### PR TITLE
Changed export routines to use long variables to perform position arithme

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -6975,15 +6975,14 @@ class OMEROGateway
 					
 					try {
 						long size = store.generateTiff();
-						int offset = 0;
-						int length = (int) size;
+						long offset = 0;
 						try {
 							for (offset = 0; (offset+INC) < size;) {
 								stream.write(store.read(offset, INC));
 								offset += INC;
 							}	
 						} finally {
-							stream.write(store.read(offset, length-offset)); 
+							stream.write(store.read(offset, (int)(size-offset))); 
 							stream.close();
 						}
 					} catch (Exception e) {

--- a/components/tools/OmeroImageJ/Omero_ImageJ/src/ome/ij/data/Gateway.java
+++ b/components/tools/OmeroImageJ/Omero_ImageJ/src/ome/ij/data/Gateway.java
@@ -698,8 +698,7 @@ class Gateway
 					store = getExporterService();
 					store.addImage(imageID);
 					long size = store.generateTiff();
-					int offset = 0;
-					int length = (int) size;
+					long offset = 0;
 					try {
 						try {
 							for (offset = 0; (offset+INC) < size;) {
@@ -707,7 +706,7 @@ class Gateway
 								offset += INC;
 							}	
 						} finally {
-							stream.write(store.read(offset, length-offset)); 
+							stream.write(store.read(offset, (int)(size-offset))); 
 							stream.close();
 						}
 					} catch (Exception e) {


### PR DESCRIPTION
Changed export routines to use long variables to perform position arithmetic. This fixes a bug when exporting OME-TIFF files over 4GB in size.

See http://www.openmicroscopy.org/community/viewtopic.php?f=4&t=785
