### PR TITLE
Only transform element nodes in the XMLAnnotation.

### DIFF
--- a/components/xsd-fu/templates/Pojo_XMLAnnotation_update_Value.template
+++ b/components/xsd-fu/templates/Pojo_XMLAnnotation_update_Value.template
@@ -29,9 +29,12 @@
 				NodeList childNodeList = Value_nodeList.get(0).getChildNodes();
 				for (int i = 0; i < childNodeList.getLength(); i++)
 				{
-					if (childNodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
+					try {
 						t.transform(new javax.xml.transform.dom.DOMSource(
 							childNodeList.item(i)), sr);
+					}
+					catch (javax.xml.transform.TransformerException te) {
+						LOGGER.warn("Failed to transform node #" + i, te);
 					}
 				}
 				setValue(sw.toString().trim());


### PR DESCRIPTION
When using Saxon (as is the default in MATLAB), empty non-element nodes
may be present.  Attempting to transform these nodes will fail, thus
causing the entire OME-XML parsing step to fail.

Reported on ome-devel by Heinrich Grabmayr.
