### PR TITLE
Re-adding the concept of GROUP-WRITE which was removed as part of #1992

### DIFF
--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -243,12 +243,10 @@ public class BasicACLVoter implements ACLVoter {
                 && o.equals(c.getOwner().getId())) {
             return true;
         }
-        /* ticket:1992 - removing concept of GROUP-WRITE
         if (p.isGranted(GROUP, WRITE) && g != null
                 && c.getMemberOfGroupsList().contains(g)) {
             return true;
         }
-        */
 
         return false;
     }


### PR DESCRIPTION
the ASCB Annotation Library permissions, as we move towards 4.3, needs to allow writes based on group permissions.

The Collaborative Group is a little too restrictive, and this commit reverts the specific restriction that is preventing our use-case. We may need another type of group or a site wide flag to allow removing the limitation. Either way this pull request is not to be merged in as-is.
