### PR TITLE
Emergency build fix for insight

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -78,14 +78,14 @@ public interface OmeroImageService
 	
 	/** Identifies the <code>Maximum intensity</code> projection. */
 	public static final int	MAX_INTENSITY = 
-									ProjectionType.MAXIMUMINTENSITY.value();
+									ProjectionType.MAXIMUMINTENSITY.oridinal();
 	
 	/** Identifies the <code>Mean intensity</code> projection. */
 	public static final int	MEAN_INTENSITY = 
-								ProjectionType.MEANINTENSITY.value();
+								ProjectionType.MEANINTENSITY.oridinal();
 	
 	/** Identifies the <code>Sum intensity</code> projection. */
-	public static final int	SUM_INTENSITY = ProjectionType.SUMINTENSITY.value();
+	public static final int	SUM_INTENSITY = ProjectionType.SUMINTENSITY.oridinal();
 	
 	/** Identifies the type used to store pixel values. */
 	public static final String INT_8 = "int8";

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ProjectionParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ProjectionParam.java
@@ -363,11 +363,11 @@ public class ProjectionParam
 	 */
 	public static ProjectionType convertType(int type)
 	{
-		if (ProjectionType.MAXIMUMINTENSITY.value() == type)
+		if (ProjectionType.MAXIMUMINTENSITY.oridinal() == type)
 			return ProjectionType.MAXIMUMINTENSITY;
-		if (ProjectionType.MEANINTENSITY.value() == type)
+		if (ProjectionType.MEANINTENSITY.oridinal() == type)
 			return ProjectionType.MEANINTENSITY;
-		if (ProjectionType.SUMINTENSITY.value() == type)
+		if (ProjectionType.SUMINTENSITY.oridinal() == type)
 			return ProjectionType.SUMINTENSITY;
 		return null;
 	}


### PR DESCRIPTION
Now that both the insight-build and the 1260-ice34 branches are in develop, insight is no longer builder with ice3.4 due to `CONSTANT.value()` instances which need to be replaced with `CONSTANT.ordinal()`. For anyone using Ice 3.4 this is blocking, so I'm going to merge this right away. Tested with ice 3.4 and 3.3.
