### PR TITLE
Composite zips

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -331,8 +331,12 @@ java component.
         </copy>
         <!-- These should eventually be removed in favor of an ivy-based approach -->
         <copy todir="target">
-            <fileset dir="components/insight/target" includes="*.zip"/>
+            <fileset dir="components/insight/target" includes="insight*.zip"/>
             <mapper type="regexp" from="insight(.*).zip"  to="OMERO.insight-${omero.version}\1.zip"/>
+        </copy>
+        <copy todir="target">
+            <fileset dir="components/insight/target" includes="editor*.zip"/>
+            <mapper type="regexp" from="editor(.*).zip"  to="OMERO.editor-${omero.version}\1.zip"/>
         </copy>
     </target>
 

--- a/components/insight/build.xml
+++ b/components/insight/build.xml
@@ -64,28 +64,36 @@
         </description>
         <!-- Hard coding paths for the moment to work around hudson regex issues -->
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*.zip" excludes="*-mac*.zip,*-win*.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*.zip" excludes="*-mac*.zip,*-win*.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight.zip"/>
         </copy>
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*-win.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win.zip"/>
         </copy>
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*-win-openGL.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win-openGL.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win-openGL.zip"/>
         </copy>
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*-win64-openGL.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win64-openGL.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win64-openGL.zip"/>
         </copy>
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*-mac.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-mac.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-mac.zip"/>
         </copy>
         <copy todir="${target.dir}">
-            <fileset dir="${basedir}/OUT/dist" includes="*-mac-openGL.zip"/>
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-mac-openGL.zip"/>
             <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-mac-openGL.zip"/>
+        </copy>
+        <copy todir="${target.dir}">
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.editor*-mac.zip"/>
+            <mapper type="regexp" from="OMERO.editor-[^-]+(.*).zip"  to="editor-mac.zip"/>
+        </copy>
+        <copy todir="${target.dir}">
+            <fileset dir="${basedir}/OUT/dist" includes="OMERO.editor*-win.zip"/>
+            <mapper type="regexp" from="OMERO.editor-[^-]+(.*).zip"  to="editor-win.zip"/>
         </copy>
     </target>
 

--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -197,7 +197,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~--> 
   <target name="dist"
           depends="jar, jar-util, dist-osx-openGL, dist-osx, dist-win, 
-  	dist-win-openGL,dist-win64-openGL"
+  	dist-win-openGL,dist-win64-openGL,distEditor-win,distEditor-osx"
           description="Build and package the app for distribution."> 
 
     <!-- Main zip -->

--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -15,6 +15,8 @@
     <artifact name="insight-win64-openGL" type="zip"/>
     <artifact name="insight-mac" type="zip"/>
     <artifact name="insight-mac-openGL" type="zip"/>
+    <artifact name="editor-mac" type="zip"/>
+    <artifact name="editor-win" type="zip"/>
   </publications>
   <dependencies defaultconfmapping="build,client->default">
     <!-- Internal -->

--- a/lib/composite.py
+++ b/lib/composite.py
@@ -45,6 +45,8 @@ IMPORTER = 'OMERO.importer'
 
 INSIGHT = 'OMERO.insight'
 
+EDITOR = 'OMERO.editor'
+
 # The following libraries are duplicated in Insight and Importer:
 # IGNORE = "bio-formats.jar jai_imageio.jar loci-common.jar mdbtools-java.jar ome-xml.jar poi-loci.jar".split()
 # IGNORE'ing them, however, causes Insight to not start.
@@ -120,6 +122,7 @@ def compress(target, base):
 # Create the composite Windows client build
 #
 target_artifacts = list()
+target_artifacts += find(EDITOR + "*win.zip")
 target_artifacts += find(INSIGHT + "*win.zip")
 target_artifacts += find(IMPORTER + "*win.zip")
 target = '%s.win' % TARGET_PREFIX
@@ -135,6 +138,7 @@ compress('%s.zip' % target, target)
 # Create the composite Mac OS X client build
 #
 target_artifacts = list()
+target_artifacts += find(EDITOR + "*mac.zip")
 target_artifacts += find(INSIGHT + "*mac.zip")
 target_artifacts += find(IMPORTER + "*mac.zip")
 target = '%s.mac' % TARGET_PREFIX
@@ -149,7 +153,7 @@ compress('%s.zip' % target, target)
 #
 target_artifacts = list()
 target_artifacts += find("%s-%s.zip" % (INSIGHT, VERSION))
-target_artifacts += find("%s-%s.zip" % (INSIGHT, VERSION))
+target_artifacts += find("%s-%s.zip" % (IMPORTER, VERSION))
 target = '%s.linux' % TARGET_PREFIX
 # Since Insight relies on its MANIFEST to start via the JAR, we're leaving
 # libs/OmeroImporter-Beta-4.1.0-DEV.jar in the ZIP.


### PR DESCRIPTION
With insight now built by the main build, we can get rid of the `INSIGHT-*` and `OMERO-*-clients` builds. For this to work, `lib/composite.py` should use the files under `target/` rather than downloads from hudson. Commits to do that are included in this branch.

This would be a good candidate for early include into "merge-blue" so that we can have all the zips as they would be in release form.

After running `./build.py clean build-default release-zip`, `./build.py release-clents` can be run to produce:

```
jmoore@necromancer ~/git/target/pkg $ ls OMERO.clients-4.3.3.linux
INSTALL.txt  OMEROeditor_macosx.sh  OMEROeditor_windows.bat  OMEROimporter_unix.sh      OMEROinsight_macosx.sh  OMEROinsight_windows.bat  libs
LICENSE      OMEROeditor_unix.sh    OMEROimporter_macosx.sh  OMEROimporter_windows.bat  OMEROinsight_unix.sh    config                    omero.insight.jar
jmoore@necromancer ~/git/target/pkg $ ls OMERO.clients-4.3.3.mac  
INSTALL  LICENSE  OMERO.importer.app  OMERO.insight.app  config
jmoore@necromancer ~/git/target/pkg $ ls OMERO.clients-4.3.3.win
LICENSE  OMERO.importer.exe  OMERO.insight.exe  OmeroImporter.jar  config  libs  omero.insight.jar
```

When `OMERO_BUILD` is specified, products look like this:

```
jmoore@necromancer ~/git $ unzip -l target/pkg/OMERO.clients-4.3.3-b123.linux.zip | head -n 10
Archive:  target/pkg/OMERO.clients-4.3.3-b123.linux.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
     1361  01-03-12 14:55   OMERO.clients-4.3.3-b123.linux/OMEROimporter_windows.bat
    15145  01-03-12 14:55   OMERO.clients-4.3.3-b123.linux/LICENSE
     1282  01-03-12 14:55   OMERO.clients-4.3.3-b123.linux/OMEROeditor_macosx.sh
     1319  01-03-12 14:55   OMERO.clients-4.3.3-b123.linux/OMEROimporter_macosx.sh
```

but a next step could be to either filter that out in composite.py or to remove it for production builds in jenkins.
