### PR TITLE
Add missing jar so insight can be launched.

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -33,6 +33,7 @@
     <dependency org="insight" name="commons-discovery" rev="${versions.commons-discovery}"/>
     <dependency org="insight" name="commons-lang" rev="${versions.commons-lang}"/>
     <dependency org="insight" name="commons-validator" rev="${versions.commons-validator}"/>
+    <dependency org="insight" name="commons-logging" rev="${versions.commons-logging}"/>
     <dependency org="insight" name="ehcache" rev="${versions.ehcache}"/>
     <dependency org="insight" name="gicentreUtils" rev="${versions.gicentreUtils}"/>
     <dependency org="insight" name="gluegen-rt" rev="${versions.jogl}"/>


### PR DESCRIPTION
Fix build. Jar was not included in ivy.xml. I will create a ticket to improve support of missing jar.
