### PR TITLE
Insight build fix 3: touch editor win zip

### DIFF
--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -125,6 +125,9 @@
     <zip destfile="${dist.dir}/${main-dist-prefix}-win64-openGL.zip">
       <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
     </zip>
+    <zip destfile="${dist.dir}/${distEditor.bundle.name}-${dist.bundle.version}-win.zip">
+      <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
+    </zip>
   </target>
 
   <target name="exe4j-echo-on-missing" unless="dist.exe4j.exists">


### PR DESCRIPTION
After the merge of my composite-zips branch (specifically 94c6040), builds without exe4j present were failing:

```
install:
:: delivering :: omero#insight;working@Josh-Moores-MacBook-Pro.local :: 4.3.3 :: integration :: Mon Jan 09 15:52:37 CET 2012
    delivering ivy file to /Users/moore/GlencoeSoftware.git/git/omero.git/components/insight/target/ivy.xml
:: publishing :: omero#insight

BUILD FAILED
/Users/moore/GlencoeSoftware.git/git/omero.git/components/antlib/resources/lifecycle.xml:383: The following error occurred while executing this line:
/Users/moore/GlencoeSoftware.git/git/omero.git/components/antlib/resources/global.xml:168: impossible to publish artifacts for omero#insight;working@Josh-Moores-MacBook-Pro.local: java.io.IOException: missing artifact omero#insight;4.3.3!editor-win.zip
    at org.apache.ivy.core.publish.PublishEngine.publish(PublishEngine.java:226)
    at org.apache.ivy.core.publish.PublishEngine.publish(PublishEngine.java:170)
    at org.apache.ivy.Ivy.publish(Ivy.java:600)
    at org.apache.ivy.ant.IvyPublish.doExecute(IvyPublish.java:299)
    at org.apache.ivy.ant.IvyTask.execute(IvyTask.java:277)
    at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:291)
    at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
    at org.apache.tools.ant.Task.perform(Task.java:348)
    at org.apache.tools.ant.taskdefs.Sequential.execute(Sequential.java:68)
    at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:291)
    at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
```

By touching the editor win zip like the insight win zips, this can be prevented.
