### PR TITLE
Resolve issues with web server config generation. (Fixes #7750)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -114,27 +114,12 @@ class WebControl(BaseControl):
         unittest.add_argument("--path", action="store", help = "Path to Django-app. Must include '/'.")
 
 
-    def host_and_port(self, APPLICATION_HOST):
-        parts = APPLICATION_HOST.split(':')
-        if len(parts) != 3:
-            self.ctx.die(656, "Invalid application host: %s" % ":".join(parts))
-        try:
-            host = parts[1]
-            while host.startswith(r"/"):
-                host = host[1:]
-            port = parts[2]
-            port = re.search(r'^(\d+).*', port).group(1)
-            port = int(port)
-            return (host, port)
-        except Exception, e:
-            self.ctx.die(567, "Badly formed domain: %s -- %s" % (":".join(parts), e))
-
     def config(self, args):
         if not args.type:
             self.ctx.out("Available configuration helpers:\n - nginx, apache\n")
         else:
             server = args.type
-            host, port = self.host_and_port(settings.APPLICATION_HOST)
+            port = 8080
             if args.http:
                 port = args.http
             if settings.APPLICATION_SERVER == settings.FASTCGITCP:


### PR DESCRIPTION
Since 973ef6340e we can no longer rely on the existence of the
APPLICATION_HOST config value.  In the end this is a good thing (the
correct value is detected by OMERO.web) but it does not provide
sufficient information to the OMERO CLI web plugin.  Here we are
explicitly assigning the default HTTP port to 8080 (valid only for the
'nginx' config generation) and we continue to allow it to be changed via
the --http command line argument to 'web config <webserver>'.
