### PR TITLE
Both namespaces set to non-null, added cast to assertion. See #7740

### DIFF
--- a/components/server/test/ome/server/itests/query/ProjectionTest.java
+++ b/components/server/test/ome/server/itests/query/ProjectionTest.java
@@ -98,6 +98,7 @@ public class ProjectionTest extends AbstractManagedContextTest {
         FileAnnotation fa = new FileAnnotation();
         fa.setNs("OMIT");
         LongAnnotation la = new LongAnnotation();
+        la.setNs("");
         i.linkAnnotation(fa);
         i.linkAnnotation(la);
         i = iUpdate.saveAndReturnObject(i);
@@ -109,6 +110,6 @@ public class ProjectionTest extends AbstractManagedContextTest {
                 "group by i.id", null);
         Object[] values = rv.get(0);
         assertEquals(i.getId(), values[0]);
-        assertEquals(1, values[1]);
+        assertEquals((long) 1, values[1]);
     }
 }


### PR DESCRIPTION
This is a very minor bug fix in a test I came across while testing PR48. I held off issuing a PR in case I could combine any further fixes with this. None have arisen.
