### PR TITLE
1007 search plugin

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -79,7 +79,9 @@ class SearchControl(HqlControl):
                     if not search.hasNext():
                         self.ctx.die(433, "No results found.")
                     while search.hasNext():
-                        self.display([search.results()])
+                        results = search.results()
+                        results = [[x] for x in results]
+                        self.display(results)
                 except omero.ApiUsageException, aue:
                     self.ctx.die(434, aue.message)
 


### PR DESCRIPTION
Search plugin for use via "bin/omero search". Currently output is similar to "bin/omero hql" however initial user feedback (JC) points to this being confusing. Perhaps just printing the ids to standard out would be more useful. No options are currently implemented.

Is this useful for develop in this state or do we need to do further evaluation?
