### PR TITLE
Fix background processes after gh-106 (Fix #8267)

### DIFF
--- a/components/server/resources/ome/services/indexer.xml
+++ b/components/server/resources/ome/services/indexer.xml
@@ -62,6 +62,7 @@
     <constructor-arg ref="roles"/>
     <constructor-arg ref="internalServiceFactory"/>
     <constructor-arg ref="tokenHolder"/>
+    <constructor-arg ref="securityFilterHolder"/>
   </bean>
 
   <bean id="eventHandler" class="ome.security.basic.NullEventHandler">

--- a/components/server/resources/ome/services/pixeldata.xml
+++ b/components/server/resources/ome/services/pixeldata.xml
@@ -61,6 +61,7 @@
     <constructor-arg ref="roles"/>
     <constructor-arg ref="internalServiceFactory"/>
     <constructor-arg ref="tokenHolder"/>
+    <constructor-arg ref="securityFilterHolder"/>
   </bean>
 
   <bean id="eventHandler" class="ome.security.basic.NullEventHandler">


### PR DESCRIPTION
Indexer and PixelData have been broken for the past week. @cneves ran into this while testing his migration. Change is very minor and should go in ASAP.
