### PR TITLE
Object script param

### DIFF
--- a/components/tools/OmeroPy/src/omero/scripts.py
+++ b/components/tools/OmeroPy/src/omero/scripts.py
@@ -509,7 +509,7 @@ def parse_input(input_string, params):
             kls = getattr(omero.model, kls)
         except:
             raise ValueError("Format for objects: Class:id or ClassI:id. Not:%s" % val)
-        val = kls(_id, False)
+        val = omero.rtypes.robject(kls(_id, False))
     else:
         raise ValueError("No converter for: %s (type=%s)" % (key, param.prototype.__class__))
 

--- a/components/tools/OmeroPy/test/scriptstest/parse.py
+++ b/components/tools/OmeroPy/test/scriptstest/parse.py
@@ -82,8 +82,8 @@ class TestParse(unittest.TestCase):
         self.assertTrue(objParam.prototype.val is None)
 
         rv = parse_inputs(["objParam=OriginalFile:1"], params)
-        self.assertEquals(rv["objParam"].__class__, omero.model.OriginalFileI)
-        self.assertEquals(rv["objParam"].id.val, 1)
+        self.assertEquals(rv["objParam"].val.__class__, omero.model.OriginalFileI)
+        self.assertEquals(rv["objParam"].val.id.val, 1)
 
     def testObjectTypeWithDefault(self):
         SCRIPT = """if True:


### PR DESCRIPTION
Initial implementation of an Object param type for passing IObjects (wrapped with RObjects) to scripts. This allows for stringer typing than convention-based names ("Image_ID"). Instead, one can pass an omero.model.Image instance.

This branch is currently missing fine-tuning on specifying which types of objects are permitted and having bad parameters rejected at launch time. For example, on might want to specify that only images and datasets, or that images, datasets, and projects can be taken as script arguments.

Currently, this can only be tested from the command-line (by using "OriginalFile:5" as the input) or via the API.

**Note:** This PR should be merged before gh-131
