### PR TITLE
Adding default value for line plot axis (see #8496)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -428,7 +428,7 @@
 
   var editLinePlot = function (show) {
     if (show) {
-      viewport.prepareLinePlot($('#wblitz-lp-axis-select option[selected]').val());
+      viewport.prepareLinePlot($('#wblitz-lp-axis-select option[selected]').val() || 'h');
     } else {
       viewport.hidePlot();
     }


### PR DESCRIPTION
IE8 doesn't allow reading the dropdown selected value for a hidden DOM element, which we have on the full viewer line plot when we click on the enable checkbox, so defaulting to horizontal if element isn't available
