### PR TITLE
Do not allow to copy/paste rnd settings across groups (see #7927)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/DataBrowserAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/DataBrowserAgent.java
@@ -220,7 +220,7 @@ public class DataBrowserAgent
      */
     private void handleCopyRndSettings(CopyRndSettings evt)
     {
-    	DataBrowserFactory.setRndSettingsToCopy(evt.getImage() != null);
+    	DataBrowserFactory.setRndSettingsToCopy(evt.getImage());
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/ManageRndSettingsAction.java
@@ -39,6 +39,7 @@ import org.openmicroscopy.shoola.agents.dataBrowser.browser.Browser;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageDisplay;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ImageData;
 import pojos.PlateAcquisitionData;
@@ -220,10 +221,14 @@ public class ManageRndSettingsAction
 						ho instanceof ImageData || ho instanceof DatasetData ||
 						ho instanceof PlateAcquisitionData) {
 						i = selected.iterator();
+						DataObject data;
 						while (i.hasNext()) {
 							obj = i.next();
+							data = (DataObject) obj;
 							//if (model.isUserOwner(obj)) count++;
-							if (model.isWritable(obj)) count++;
+							if (model.isWritable(obj) &&
+								model.areSettingsCompatible(data.getGroupId()))
+								count++;
 						}
 						setEnabled(count == selected.size());
 					} else setEnabled(true);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowser.java
@@ -730,5 +730,14 @@ public interface DataBrowser
 	 * @return See above.
 	 */
 	SecurityContext getSecurityContext();
+	
+	/**
+	 * Returns <code>true</code> if the image to copy the rendering settings
+	 * from is in the specified group, <code>false</code> otherwise.
+	 * 
+	 * @param groupID The group to handle.
+	 * @return See above.
+	 */
+	boolean areSettingsCompatible(long groupID);
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -1320,6 +1320,15 @@ class DataBrowserComponent
 
 	/**
 	 * Implemented as specified by the {@link DataBrowser} interface.
+	 * @see DataBrowser#areSettingsCompatible(long)
+	 */
+	public boolean areSettingsCompatible(long groupID)
+	{
+		return DataBrowserFactory.areSettingsCompatible(groupID);
+	}
+	
+	/**
+	 * Implemented as specified by the {@link DataBrowser} interface.
 	 * @see DataBrowser#hasDataToCopy()
 	 */
 	public Class hasDataToCopy()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
@@ -282,12 +282,11 @@ public class DataBrowserFactory
 	}
 	
 	/**
-	 * Sets to <code>true</code> if some rendering settings have to be copied.
-	 * <code>false</code> otherwise.
+	 * Sets the image to copy the settings from.
 	 * 
 	 * @param rndSettingsToCopy The value to set.
 	 */
-	public static final void setRndSettingsToCopy(boolean rndSettingsToCopy)
+	public static final void setRndSettingsToCopy(ImageData rndSettingsToCopy)
 	{
 		singleton.rndSettingsToCopy = rndSettingsToCopy; 
 		Iterator v = singleton.browsers.entrySet().iterator();
@@ -376,9 +375,22 @@ public class DataBrowserFactory
 	 */
 	static boolean hasRndSettingsToCopy()
 	{
-		return singleton.rndSettingsToCopy;
+		return singleton.rndSettingsToCopy != null;
 	}
     
+	/**
+	 * Returns <code>true</code> if the image to copy the rendering settings
+	 * from is in the specified group, <code>false</code> otherwise.
+	 * 
+	 * @param groupID The group to handle.
+	 * @return See above.
+	 */
+	static boolean areSettingsCompatible(long groupID)
+	{
+		if (!hasRndSettingsToCopy()) return false;
+		return singleton.rndSettingsToCopy.getGroupId() == groupID;
+	}
+	
 	/**
 	 * Returns the type of objects to copy or <code>null</code> if no objects
 	 * selected.
@@ -397,7 +409,7 @@ public class DataBrowserFactory
 	private DataBrowser					searchBrowser;
 	
 	/** Flag indicating if some rendering settings have been copied. */
-	private boolean						rndSettingsToCopy;
+	private ImageData rndSettingsToCopy;
 	
 	/** The type identifying the object to copy. */
 	private Class						dataToCopy;
@@ -408,7 +420,7 @@ public class DataBrowserFactory
 		browsers = new HashMap<Object, DataBrowser>();
 		discardedBrowsers = new HashSet<String>();
 		searchBrowser = null;
-		rndSettingsToCopy = false;
+		rndSettingsToCopy = null;
 		dataToCopy = null;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/ManageRndSettingsAction.java
@@ -36,6 +36,8 @@ import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageTimeSet;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
+import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ImageData;
 import pojos.PlateAcquisitionData;
@@ -253,10 +255,12 @@ public class ManageRndSettingsAction
 						ho instanceof PlateAcquisitionData))
 					setEnabled(false);
 				else {
-					
+					DataObject data;
 					for (int i = 0; i < selected.length; i++) {
 						//if (model.isUserOwner(selected[i].getUserObject()))
-						if (model.isObjectWritable(selected[i].getUserObject()))
+						data = (DataObject) selected[i].getUserObject();
+						if (model.isObjectWritable(ho) && 
+								model.areSettingsCompatible(data.getGroupId()))
 							count++;
 					}
 					setEnabled(count == selected.length);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -1091,4 +1091,13 @@ public interface TreeViewer
 	 */
 	SecurityContext getSecurityContext();
 
+	/**
+	 * Returns <code>true</code> if the image to copy the rendering settings
+	 * from is in the specified group, <code>false</code> otherwise.
+	 * 
+	 * @param groupID The group to handle.
+	 * @return See above.
+	 */
+	boolean areSettingsCompatible(long groupID);
+	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2140,6 +2140,18 @@ class TreeViewerComponent
 
 	/**
 	 * Implemented as specified by the {@link TreeViewer} interface.
+	 * @see TreeViewer#AreSettingsCompatible(long)
+	 */
+	public boolean areSettingsCompatible(long groupID)
+	{
+		if (model.getState() == DISCARDED)
+			throw new IllegalStateException("This method cannot be invoked " +
+			"in the DISCARDED state.");
+		return model.areSettingsCompatible(groupID);
+	}
+	
+	/**
+	 * Implemented as specified by the {@link TreeViewer} interface.
 	 * @see TreeViewer#pasteRndSettings(List, Class)
 	 */
 	public void pasteRndSettings(List<Long> ids, Class klass)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
@@ -926,6 +926,20 @@ class TreeViewerModel
 		if (refImage == null) return null;
 		return UIUtilities.removeFileExtension(refImage.getName());
 	}
+	
+	/**
+	 * Returns <code>true</code> if the image to copy the rendering settings
+	 * from is in the specified group, <code>false</code> otherwise.
+	 * 
+	 * @param groupID The group to handle.
+	 * @return See above.
+	 */
+	boolean areSettingsCompatible(long groupID)
+	{
+		if (refImage == null) return false;
+		return refImage.getGroupId() == groupID;
+	}
+	
 	/**
 	 * Returns the type of nodes to copy or <code>null</code> if no nodes 
 	 * to copy or cut.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -4492,6 +4492,7 @@ class OMEROGateway
 		List<Long> success = new ArrayList<Long>();
 		List<Long> failure = new ArrayList<Long>();
 		isSessionAlive(ctx);
+		ctx = new SecurityContext(-1);
 		try {
 			IRenderingSettingsPrx service = getRenderingSettingsService(ctx);
 			Map m  = service.applySettingsToSet(pixelsID, 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -1532,6 +1532,8 @@ class RenderingControlProxy
 	public boolean validatePixels(PixelsData pixels)
 	{
 		if (pixels == null) return false;
+		long id = pixs.getDetails().getGroup().getId().getValue();
+		if (id != pixels.getGroupId()) return false;
 		if (getPixelsDimensionsC() != pixels.getSizeC()) return false;
 		if (getPixelsDimensionsY() != pixels.getSizeY()) return false;
 		if (getPixelsDimensionsX() != pixels.getSizeX()) return false;


### PR DESCRIPTION
Turn off the ability to copy/paste rendering settings across groups.
