### PR TITLE
Screenref fix

### DIFF
--- a/components/specification/Samples/OmeFiles/2011-06/6x4y1z1t3c8b-swatch-upgrade.ome
+++ b/components/specification/Samples/OmeFiles/2011-06/6x4y1z1t3c8b-swatch-upgrade.ome
@@ -11,14 +11,49 @@
 		<SA:AnnotationRef ID="Annotation:2"/>
 	</Dataset>
 	<SPW:Plate ID="Plate:1">
+		<SPW:Description>Wibble</SPW:Description>
+		<SPW:ScreenRef ID="Screen:1"/>
+		<SPW:ScreenRef ID="Screen:2"/>
+		<SPW:ScreenRef ID="Screen:4"/>
 		<SPW:Well ID="Well:1" Column="1" Row="1" Status="TheWellStatus" Color="-2147483648">
 			<SPW:WellSample ID="WellSample:1" Index="1">
 				<SPW:ImageRef ID="Image:0"/>
-			</SPW:WellSample></SPW:Well>
+			</SPW:WellSample>
+		</SPW:Well>
+		<SA:AnnotationRef ID="Annotation:1"/>
+		<SPW:PlateAcquisition ID="PlateAcquisition:1">
+			<SPW:Description>Wibble2</SPW:Description>
+			<SA:AnnotationRef ID="Annotation:2"/>
+		</SPW:PlateAcquisition>
 	</SPW:Plate>
-	<SPW:Screen ID="Screen:1">
+	<SPW:Plate ID="Plate:2">
+	</SPW:Plate>
+	<SPW:Screen ID="Screen:1" Name="ScreenName1" ProtocolDescription="Test" ProtocolIdentifier="TestID" ReagentSetDescription="Reagents XYZ" ReagentSetIdentifier="XYZ-ID" Type="Test3">
+		<SPW:Description>Wibble3</SPW:Description>
+		<SPW:Reagent ID="Reagent:1"/>
 		<SPW:PlateRef ID="Plate:1"/>
+		<SA:AnnotationRef ID="Annotation:2"/>
 	</SPW:Screen>
+	
+	<SPW:Screen ID="Screen:2" Name="ScreenName1" ProtocolDescription="Test" ProtocolIdentifier="TestID" ReagentSetDescription="Reagents XYZ" ReagentSetIdentifier="XYZ-ID" Type="Test3">
+		<SPW:Description>Wibble3</SPW:Description>
+		<SPW:Reagent ID="Reagent:2"/>
+		<SPW:PlateRef ID="Plate:2"/>
+		<SA:AnnotationRef ID="Annotation:2"/>
+	</SPW:Screen>
+	
+	<SPW:Screen ID="Screen:3" Name="ScreenName1" ProtocolDescription="Test" ProtocolIdentifier="TestID" ReagentSetDescription="Reagents XYZ" ReagentSetIdentifier="XYZ-ID" Type="Test3">
+		<SPW:Description>Wibble3</SPW:Description>
+		<SPW:Reagent ID="Reagent:3"/>
+		<SA:AnnotationRef ID="Annotation:2"/>
+	</SPW:Screen>
+
+	<SPW:Screen ID="Screen:4" Name="ScreenName1" ProtocolDescription="Test" ProtocolIdentifier="TestID" ReagentSetDescription="Reagents XYZ" ReagentSetIdentifier="XYZ-ID" Type="Test3">
+		<SPW:Description>Wibble3</SPW:Description>
+		<SPW:Reagent ID="Reagent:4"/>
+		<SA:AnnotationRef ID="Annotation:2"/>
+	</SPW:Screen>
+	
 	<Experimenter ID="Experimenter:1" DisplayName="Joe Bloggs">
 		<GroupRef ID="Group:1"/>
 	</Experimenter>

--- a/components/specification/Samples/OmeFiles/2012-06/6x4y1z1t1c8b-swatch-1s1p4w2ws.ome
+++ b/components/specification/Samples/OmeFiles/2012-06/6x4y1z1t1c8b-swatch-1s1p4w2ws.ome
@@ -3,7 +3,6 @@
      ../../../InProgress/ome.xsd">
 	<SPW:Plate ID="Plate:1">
 		<SPW:Description>Plate 1 description.</SPW:Description>
-		<SPW:ScreenRef ID="Screen:1"/>
 		<SPW:Well ID="Well:1.1.1" Column="1" Row="1">
 			<SPW:WellSample ID="WellSample:1.1.1.1" Index="1">
 				<ImageRef ID="Image:0"/>

--- a/components/specification/Samples/OmeFiles/2012-06/6x4y1z1t1c8b-swatch-2s2p4w2ws.ome
+++ b/components/specification/Samples/OmeFiles/2012-06/6x4y1z1t1c8b-swatch-2s2p4w2ws.ome
@@ -2,7 +2,6 @@
      ../../../InProgress/ome.xsd">
 	<SPW:Plate ID="Plate:1">
 		<SPW:Description>Plate 1 description.</SPW:Description>
-		<SPW:ScreenRef ID="Screen:1"/>
 		<SPW:Well ID="Well:1.1.1" Column="1" Row="1">
 			<SPW:WellSample ID="WellSample:1.1.1.1" Index="1">
 				<ImageRef ID="Image:0"/>
@@ -63,7 +62,6 @@
 	</SPW:Plate>
 	<SPW:Plate ID="Plate:2" Name="twoName">
 		<SPW:Description>Plate 2 description.</SPW:Description>
-		<SPW:ScreenRef ID="Screen:1"/>
 		<SPW:Well ID="Well:2.1.1" Column="1" Row="1">
 			<SPW:WellSample ID="WellSample:2.1.1.1" Index="1">
 				<ImageRef ID="Image:11"/>

--- a/components/specification/Xslt/2011-06-to-2012-06.xsl
+++ b/components/specification/Xslt/2011-06-to-2012-06.xsl
@@ -171,6 +171,48 @@
 		</xsl:element>
 	</xsl:template>
 
+	<xsl:template match="SPW:Plate">
+		<xsl:element name="SPW:Plate" namespace="{$newSPWNS}">
+			<xsl:apply-templates select="@*"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'Description')]"/>
+			<xsl:comment>Remove ScreenRef elements and reverse </xsl:comment>
+			<xsl:apply-templates select="* [(local-name(.) = 'Well')]"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'AnnotationRef')]"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'PlateAcquisition')]"/>
+		</xsl:element>
+	</xsl:template>
+
+	<xsl:template match="SPW:Screen">
+		<xsl:element name="SPW:Screen" namespace="{$newSPWNS}">
+			<xsl:apply-templates select="@*"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'Description')]"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'Reagent')]"/>
+			<xsl:apply-templates select="* [(local-name(.) = 'PlateRef')]"/>
+			<xsl:comment>Insert reverses ScreenRef elements</xsl:comment>
+			<!-- Insert reverses ScreenRef elements -->
+			<xsl:variable name="screenID" select="@ID"/>
+			<xsl:for-each select="exsl:node-set(//SPW:Plate/SPW:ScreenRef[@ID=$screenID])">
+				<xsl:variable name="matchingPlateID"><xsl:for-each select=" parent::node()">
+					<xsl:value-of select="@ID"/>
+				</xsl:for-each></xsl:variable>
+				<xsl:if test="not(//SPW:Screen[@ID=$screenID]/SPW:PlateRef[@ID=$matchingPlateID])">
+					<xsl:comment>No existing PlateRef</xsl:comment>
+				</xsl:if>
+				<xsl:if test="//SPW:Screen[@ID=$screenID]/SPW:PlateRef[@ID=$matchingPlateID]">
+					<xsl:comment>Already matching PlateRef</xsl:comment>
+				</xsl:if>
+				<xsl:if test="not(//SPW:Screen[@ID=$screenID]/SPW:PlateRef[@ID=$matchingPlateID])">
+					<xsl:element name="SPW:PlateRef" namespace="{$newSPWNS}">
+						<xsl:attribute name="ID">
+							<xsl:value-of select="$matchingPlateID"/>
+						</xsl:attribute>
+					</xsl:element>
+				</xsl:if>
+			</xsl:for-each>
+			<xsl:apply-templates select="* [local-name(.) = 'AnnotationRef']"/>
+		</xsl:element>
+	</xsl:template>
+	
 	<xsl:template match="ROI:ROI">
 		<xsl:element name="ROI:ROI" namespace="{$newROINS}">
 			<xsl:apply-templates select="@*"/>


### PR DESCRIPTION
Sample file updated, upgrade transform not converts ScreenRef into appropriate
PlateRef on the target screen. Duplicate PlateRefs are not created. The downgrade
transform is unchanged as the step is lossy and cannot be reversed.
