### PR TITLE
docs/sphinx: use git:// rather than git@

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/openmicroscopy/bioformats.git
 [submodule "docs/sphinx"]
 	path = docs/sphinx
-	url = git@github.com:openmicroscopy/ome-documentation.git
+	url = git://github.com/openmicroscopy/ome-documentation.git


### PR DESCRIPTION
docs/sphinx submodule used git@github.com (private, ssh access) rather than git:// (public access) so that hudson failed:

```
hudson.plugins.git.GitException: Error performing command: git submodule update
Command "git submodule update" returned status code 1: Initialized empty Git repository in /home/hudson/.hudson/jobs/OMERO-trunk/workspace/src/docs/sphinx/.git/
Warning: Permanently added 'github.com,207.97.227.239' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
Clone of 'git@github.com:openmicroscopy/ome-documentation.git' into submodule path 'docs/sphinx' failed

    at hudson.plugins.git.GitAPI.launchCommandIn(GitAPI.java:764)
    at hudson.plugins.git.GitAPI.launchCommand(GitAPI.java:729)
    at hudson.plugins.git.GitAPI.submoduleUpdate(GitAPI.java:376)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1217)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1178)
    at hudson.FilePath.act(FilePath.java:832)
    at hudson.FilePath.act(FilePath.java:814)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1178)
    at hudson.model.AbstractProject.checkout(AbstractProject.java:1218)
    at hudson.model.AbstractBuild$AbstractRunner.checkout(AbstractBuild.java:581)
    at hudson.model.AbstractBuild$AbstractRunner.run(AbstractBuild.java:470)
    at hudson.model.Run.run(Run.java:1421)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:238)
Caused by: hudson.plugins.git.GitException: Command "git submodule update" returned status code 1: Initialized empty Git repository in /home/hudson/.hudson/jobs/OMERO-trunk/workspace/src/docs/sphinx/.git/
Warning: Permanently added 'github.com,207.97.227.239' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
Clone of 'git@github.com:openmicroscopy/ome-documentation.git' into submodule path 'docs/sphinx' failed

```
