### PR TITLE
vm fixes

### DIFF
--- a/docs/install/VM/nginx-control.sh
+++ b/docs/install/VM/nginx-control.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# $Id$
+
+OMERO_HOME=${OMERO_HOME:-"/home/omero/OMERO.server"}
+
+case $1 in
+  start)
+    /usr/sbin/nginx -c $OMERO_HOME/omero-web-nginx.conf
+    ;;
+  stop)
+    /usr/sbin/nginx -s stop -c $OMERO_HOME/omero-web-nginx.conf
+    ;;
+  restart)
+    /usr/sbin/nginx -t $OMERO_HOME/omero-web-nginx.conf && \
+      /usr/sbin/nginx -s reopen -c $OMERO_HOME/omero-web-nginx.conf
+    ;;
+  reload)
+    /usr/sbin/nginx -s reload -c $OMERO_HOME/omero-web-nginx.conf
+    ;;
+  force-stop)
+    /usr/sbin/nginx -s quit -c $OMERO_HOME/omero-web-nginx.conf
+    ;;
+  status)
+    ps -Fw -C nginx
+    ;;
+  *)
+    echo "$0 (start|stop|restart|reload|force-stop|status)"
+    exit 1
+    ;;
+esac
+

--- a/docs/install/VM/omero-init.d
+++ b/docs/install/VM/omero-init.d
@@ -3,13 +3,27 @@
 # /etc/init.d/omero
 # Subsystem file for "omero" server
 #
+### BEGIN INIT INFO
+# Provides:             omero-server
+# Required-Start:       $local_fs $remote_fs $network $time postgresql
+# Required-Stop:        $local_fs $remote_fs $network $time
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    OMERO.server
+### END INIT INFO
 
 RETVAL=0
 prog="omero"
 
+# Read configuration variable file if it is present
+[ -r /etc/default/$prog ] && . /etc/default/$prog
+
+OMERO_HOME=${OMERO_HOME:-"/home/omero/OMERO.server"}
+OMERO_USER=${OMERO_USER:-"omero"}
+
 start() {	
 	echo -n $"Starting $prog:"
-	sudo -u omero /home/omero/OMERO.server/bin/omero admin start
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin start
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]
 	echo
@@ -17,7 +31,7 @@ start() {
 
 stop() {
 	echo -n $"Stopping $prog:"
-	sudo -u omero /home/omero/OMERO.server/bin/omero admin stop
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin stop
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]
 	echo
@@ -25,16 +39,28 @@ stop() {
 
 status() {
 	echo -n $"Status $prog:"
-	sudo -u omero /home/omero/OMERO.server/bin/omero admin status
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin status && echo -n ' OMERO.server running'
 	RETVAL=$?
 	echo
 }
 
 diagnostics() {
 	echo -n $"Diagnostics $prog:"
-	sudo -u omero /home/omero/OMERO.server/bin/omero admin diagnostics
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin diagnostics
 	RETVAL=$?
 	echo
+}
+
+clearlogs() {
+  LOGDIR=${LOGDIR:-${OMERO_HOME}/var/log}
+  TARFILE=${TARFILE:-omero-logs-$(date '+%F').tar.bz2}
+  echo -n $"Clearing logs $prog:"
+  cd $LOGDIR && tar -caf $TARFILE *.{err,out,log} && \
+	(for x in ${LOGDIR}/*.{err,out,log}; do : > $x ;done) && \
+	chown $OMERO_USER ${LOGDIR}/${TARFILE} && \
+	echo -n $" saved to $LOGFILE/$TARFILE:"
+  RETVAL=$?
+  echo
 }
 
 case "$1" in
@@ -56,8 +82,12 @@ case "$1" in
 		diagnostics
 		RETVAL=$?
 		;;
+  clearlogs)
+    clearlogs
+    RETVAL=$?
+    ;;
 	*)	
-		echo $"Usage: $0 {start|stop|restart|status|diagnostics}"
+		echo $"Usage: $0 {start|stop|restart|status|diagnostics|clearlogs}"
 		RETVAL=1
 esac
 exit $RETVAL

--- a/docs/install/VM/omero-web-init.d
+++ b/docs/install/VM/omero-web-init.d
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# /etc/init.d/omero
+# Subsystem file for "omero" server
+#
+### BEGIN INIT INFO
+# Provides:             omero-web
+# Required-Start:       $local_fs $remote_fs $network $time omero
+# Required-Stop:        $local_fs $remote_fs $network $time
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    OMERO.web
+### END INIT INFO
+
+RETVAL=0
+prog="omero-web"
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$prog ] && . /etc/default/$prog
+# also read the omero config
+[ -r /etc/default/omero ] && . /etc/default/omero
+
+OMERO_HOME=${OMERO_HOME:-"/home/omero/OMERO.server"}
+OMERO_USER=${OMERO_USER:-"omero"}
+
+start() {	
+	echo -n $"Starting $prog:"
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web start
+	RETVAL=$?
+	[ "$RETVAL" = 0 ]
+}
+
+stop() {
+	echo -n $"Stopping $prog:"
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web stop
+	RETVAL=$?
+	[ "$RETVAL" = 0 ]
+}
+
+status() {
+	echo -n $"Status $prog:"
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web status
+	RETVAL=$?
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop
+		start
+		;;
+	status)
+		status
+		RETVAL=$?
+		;;
+	*)	
+		echo $"Usage: $0 {start|stop|restart|status}"
+		RETVAL=1
+esac
+exit $RETVAL

--- a/docs/install/VM/omerovm.sh
+++ b/docs/install/VM/omerovm.sh
@@ -47,6 +47,8 @@ function installvm ()
 	$SCP setup_omero.sh omero@localhost:~/
 	$SCP setup_omero_daemon.sh omero@localhost:~/
 	$SCP omero-init.d omero@localhost:~/
+	$SCP omero-web-init.d omero@localhost:~/
+  $SCP nginx-control.sh omero@localhost:~/
 	echo "ssh : exec driver.sh"
 	$SSH omero@localhost 'bash /home/omero/driver.sh'
 	sleep 10
@@ -137,7 +139,7 @@ function createvm ()
 		VBoxManage modifyvm "$VMNAME" --natpf1 "ssh,tcp,127.0.0.1,2222,10.0.2.15,22"
 		VBoxManage modifyvm "$VMNAME" --natpf1 "omero-unsec,tcp,127.0.0.1,4063,10.0.2.15,4063"
 		VBoxManage modifyvm "$VMNAME" --natpf1 "omero-ssl,tcp,127.0.0.1,4064,10.0.2.15,4064"
-		VBoxManage modifyvm "$VMNAME" --natpf1 "omero-web,tcp,127.0.0.1,4080,10.0.2.15,4080"
+		VBoxManage modifyvm "$VMNAME" --natpf1 "omero-web,tcp,127.0.0.1,8080,10.0.2.15,8080"
 	}
 }
 

--- a/docs/install/VM/setup_nginx.sh
+++ b/docs/install/VM/setup_nginx.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e -u -x
+
+sudo apt-get update && sudo apt-get install nginx
+# ugly -- but required for nginx to start
+# as of version 0.7.53, nginx will use a compiled-in default error log
+# location until it has read the config file. If the user running nginx
+# doesn't have write permission to this log location, nginx will raise
+# an alert
+sudo chown -R omero:omero /var/log/nginx
+/home/omero/OMERO.server/bin/omero web config nginx > /home/omero/OMERO.server/omero-web-nginx.conf
+/usr/sbin/nginx -c /home/omero/OMERO.server/omero-web-nginx.conf

--- a/docs/install/VM/setup_omero_daemon.sh
+++ b/docs/install/VM/setup_omero_daemon.sh
@@ -8,3 +8,8 @@ echo $PASSWORD | sudo -S cp /home/omero/omero-init.d /etc/init.d/omero
 echo $PASSWORD | sudo -S chmod a+x /etc/init.d/omero
 echo $PASSWORD | sudo -S update-rc.d -f omero remove
 echo $PASSWORD | sudo -S update-rc.d -f omero defaults 98 02
+
+echo $PASSWORD | sudo -S cp /home/omero/omero-web-init.d /etc/init.d/omero-web
+echo $PASSWORD | sudo -S chmod a+x /etc/init.d/omero-web
+echo $PASSWORD | sudo -S update-rc.d -f omero-web remove
+echo $PASSWORD | sudo -S update-rc.d -f omero-web defaults 98 02

--- a/docs/install/VM/setup_port_forwarding.sh
+++ b/docs/install/VM/setup_port_forwarding.sh
@@ -17,6 +17,6 @@ $VBOX list vms | grep "$VMNAME" && {
 	VBoxManage modifyvm "$VMNAME" --natpf1 "ssh,tcp,127.0.0.1,2222,10.0.2.15,22"
 	VBoxManage modifyvm "$VMNAME" --natpf1 "omero-unsec,tcp,127.0.0.1,4063,10.0.2.15,4063"
 	VBoxManage modifyvm "$VMNAME" --natpf1 "omero-ssl,tcp,127.0.0.1,4064,10.0.2.15,4064"
-	VBoxManage modifyvm "$VMNAME" --natpf1 "omero-web,tcp,127.0.0.1,4080,10.0.2.15,4080"
+	VBoxManage modifyvm "$VMNAME" --natpf1 "omero-web,tcp,127.0.0.1,8080,10.0.2.15,4080"
 
 }


### PR DESCRIPTION
Fixes for vm:

Correctly setup omero to autostart after postgres, this fixes a problem where
postgres and omero would initialize at the same time and omero would time out
trying to talk to postgres and mark it as failed.

Init script and support files for setting up OMERO.web.  Install and setup an
initscript for OMERO.web.  Additionally a setup script and control script for
nginx (running as the omero user).

Changes to omerovm.sh to support extra files and changes.
