### PR TITLE
homebrew improvements to match new formula (See #8810)

### DIFF
--- a/docs/install/homebrew/README.md
+++ b/docs/install/homebrew/README.md
@@ -148,6 +148,14 @@ Edit your .profile as appropriate. NB. The following are indicators of required 
     export PATH=$BREW_DIR/bin:$BREW_DIR/sbin:$OMERO_HOME/bin:/usr/local/lib/node_modules:$ICE_HOME/bin:$PATH
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib:$ICE_HOME/python:$DYLD_LIBRARY_PATH
 
+NB: On Mac OS.X Lion, a version of postgres is already installed. If you get an error like the following:
+    
+    psql: could not connect to server: Permission denied
+    Is the server running locally and accepting
+    connections on Unix domain socket "/var/pgsql_socket/.s.PGSQL.5432"?
+   
+make sure `$BREW_DIR/bin` is at the beginning of your PATH (see also [[here](http://nextmarvel.net/blog/2011/09/brew-install-postgresql-on-os-x-lion/)]).
+
 CONFIG
 ======
 

--- a/docs/install/homebrew/omero_homebrew.sh
+++ b/docs/install/homebrew/omero_homebrew.sh
@@ -6,7 +6,7 @@ set -u
 OMERO_ALT=${OMERO_ALT:-openmicroscopy/alt}
 VENV_URL=${VENV_URL:-https://raw.github.com/pypa/virtualenv/master/virtualenv.py}
 TABLES_GIT=${TABLES_GIT:-git+https://github.com/PyTables/PyTables.git@master}
-if [[ "$GIT_SSL_NO_VERIFY" == "1" ]]; then
+if [[ "${GIT_SSL_NO_VERIFY-}" == "1" ]]; then
     CURL_OPTS=${CURL_OPTS:-"--insecure"}
 fi
 


### PR DESCRIPTION
openmicroscopy/homebrew-alt#1 changed the name of the
omero formula from "omero43" to "omero". This updates
the read with that change as well as fixes some small
issues and includes platform information for OSX 10.5
