### PR TITLE
bioformats: check if submodule has been checked out

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -35,9 +35,21 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
     <property name="import.dir" value="${basedir}/components/antlib/resources"/>
     <import file="${import.dir}/global.xml"/>
 
-    <target name="init" depends="check-ivy,check-scons,check-ice">
+    <target name="init" depends="check-bioformats,check-ivy,check-scons,check-ice">
         <mkdir dir="${blitz.comp}/generated"/>
         <mkdir dir="${blitz.comp}/target/generated/src"/>
+    </target>
+
+    <target name="check-bioformats" unless="bioformats.done">
+        <!-- Prevent future invocations -->
+        <property name="bioformats.check.done" value="done"/>
+        <if><not><available file="${basedir}/components/bioformats/build.xml"/></not>
+        <then>
+            <fail>No components/bioformats/build.xml!
+
+            Use 'git submodule update --init' to checkout the source code.
+            </fail>
+        </then></if>
     </target>
 
     <target name="check-ivy" unless="ivy.done">


### PR DESCRIPTION
Before we have full support for downloading bio-formats
artifacts via Ivy, this will fail the build if the proper
`git submodule` incantations have not yet been made.
