### PR TITLE
fix passing of TARGET var to subscripts

### DIFF
--- a/docs/install/VM/driver.sh
+++ b/docs/install/VM/driver.sh
@@ -4,6 +4,7 @@ set -e -u -x
 
 PASSWORD=${PASSWORD:-"omero"}
 TARGET=${1:-"QA"}
+export TARGET
 
 OMERO_PATH="/home/omero/OMERO.server"
 OMERO_BIN=$OMERO_PATH/bin


### PR DESCRIPTION
For some reason (bash_version?) under the versions of bash in linux
(specifically on howe), TARGET it not passed down to the subscripts as it is
in other environments.  exporting the var fixes this.
