### PR TITLE
Homebrew 4.4 installation (#9203)

### DIFF
--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -40,11 +40,12 @@
 	<dirname property="antlib.dir"     file="${import.dir}"/>
 	<dirname property="components.dir" file="${antlib.dir}"/>
 	<dirname property="root.dir"       file="${components.dir}"/>
-
+	<dirname property="config.dir"     file="${root.dir}/etc"/>
+	
         <!-- Reading local.properties here to allow overwriting
         dist.dir since this is no longer possible with insight.
         See other property files below. -->
-        <property file="${root.dir}/etc/local.properties" />
+        <property file="${config.dir}/local.properties" />
 
 	<!-- Absolute paths: same for all components -->
 	<property name="omero.home"    value="${root.dir}"/>


### PR DESCRIPTION
Build is currently failing when using the following syntax

```
./build.py -Ddist.dir=...
```

A workaround is to edit local.properties located under etc/. However, during install, Homebrew does not allow to edit any file outside the prefix. 

To solve this, the home brew formula could:
- create a custom local.properties file under prefix/etc
- use this file to set dist.dir to prefix.

Then the omero formula would just need to call

```
./build.py -Dconfig.dir=(#prefix+etc)
```
