### PR TITLE
Fix path generation for 'statics' under IIS

### DIFF
--- a/components/tools/OmeroPy/src/omero_web_iis.py
+++ b/components/tools/OmeroPy/src/omero_web_iis.py
@@ -25,6 +25,7 @@ OMERO_HOME = os.path.join(CWD, os.path.pardir, os.path.pardir)
 CONFIG = os.path.join(OMERO_HOME, "etc", "grid", "config.xml")
 LOGS = os.path.join(OMERO_HOME, "var", "log")
 STATICS = os.path.join(OMERO_HOME, "lib", "python", "omeroweb", "static")
+STATICS = os.path.realpath(STATICS)
 
 sys.path.append(str(CWD))
 sys.path.append(str(os.path.join(CWD, 'omeroweb')))


### PR DESCRIPTION
IIS does not like relative paths (with ".."). This fix allows
for error-free (HTTP 500) serving of static content under IIS.
