### PR TITLE
release-clients must follow release-zip

### DIFF
--- a/docs/hudson/OMERO.sh
+++ b/docs/hudson/OMERO.sh
@@ -13,7 +13,7 @@ source docs/hudson/functions.sh
 echo Building $OMERO_BRANCH
 
 ./build.py clean
-./build.py build-default test-compile release-src release-clients release-webstart release-zip
+./build.py build-default test-compile release-src release-webstart release-zip release-clients
 ./build.py release-docs
 
 # Log information


### PR DESCRIPTION
Otherwise the composite.py can't find the appropriate zips.
