### PR TITLE
Use absolute paths when referring to config files

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/AgentsInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/AgentsInit.java
@@ -24,6 +24,7 @@
 package org.openmicroscopy.shoola.env.init;
 
 //Java imports
+import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 
@@ -123,8 +124,9 @@ public final class AgentsInit
 	private Registry createAgentRegistry(String configFile)
 		throws Exception
 	{
-		String relPathName = container.getConfigFileRelative(configFile);
-		Registry agentReg = RegistryFactory.makeNew(relPathName),
+		String absPathName = container.getHomeDir() + File.separator +
+					container.getConfigFileRelative(configFile);
+		Registry agentReg = RegistryFactory.makeNew(absPathName),
 					containerReg = container.getRegistry();
 		RegistryFactory.linkEventBus(containerReg.getEventBus(), agentReg);
 		RegistryFactory.linkLogger(containerReg.getLogger(), agentReg);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
@@ -78,7 +78,8 @@ public final class ContainerConfigInit
 	void execute() 
 		throws StartupException
 	{
-		String file = container.getConfigFileRelative();
+		String file = container.getHomeDir() + File.separator +
+				container.getConfigFileRelative();
 		Registry reg = container.getRegistry();
 		try {
 			RegistryFactory.fillFromFile(file, reg);
@@ -109,4 +110,3 @@ public final class ContainerConfigInit
 	void rollback() {}
 	
 }
-		


### PR DESCRIPTION
This prevents exceptions due to the configuration files not being found
when running Insight as an ImageJ plugin.

See #9308.
