### PR TITLE
OMERO-qa-upgrade.py fixes

### DIFF
--- a/docs/hudson/OMERO-qa-upgrade.py
+++ b/docs/hudson/OMERO-qa-upgrade.py
@@ -3,52 +3,52 @@
 import os
 import platform
 import subprocess
-WINDOWS = platform.system() == "Windows"
-###########################################################################
-# CONFIGURATION
-###########################################################################
+
 
 def DEFINE(key, value):
     m = globals()
     m[key] = os.environ.get(key, value)
     print key, "=>", m[key]
 
+
+###########################################################################
+# DETECTION
+###########################################################################
+WINDOWS = platform.system() == "Windows"
+p = subprocess.Popen(["hostname"], stdout=subprocess.PIPE)
+h = p.communicate()[0].strip()
+DEFINE("HOSTNAME", h)
+
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
 # Most likely to be changed
-DEFINE("SKIPEMAIL", "false")
-if WINDOWS:
+DEFINE("NAME", HOSTNAME)
+if HOSTNAME == "gretzky":
+    DEFINE("ADDRESS", "gretzky.openmicroscopy.org.uk")
+elif HOSTNAME == "howe":
+    DEFINE("ADDRESS", "howe.openmicroscopy.org.uk")
+elif HOSTNAME == "ome-dev-svr":
     DEFINE("NAME", "win-2k8")
     DEFINE("ADDRESS", "bp.openmicroscopy.org.uk")
-    DEFINE("MEM", "Xmx1024M")
+else:
+    DEFINE("ADDRESS", HOSTNAME)
+    # Don't send emails if we're not on a known host.
+    DEFINE("SKIPEMAIL", "true")
+if "SKIPEMAIL" not in globals():
+    DEFINE("SKIPEMAIL", "false")
+
+if WINDOWS:
     DEFINE("UNZIP", "C:\\Program Files (x86)\\7-Zip\\7z.exe")
     DEFINE("UNZIPARGS", "x")
 else:
-    DEFINE("NAME", "gretzky")
-    DEFINE("ADDRESS", "gretzky.openmicroscopy.org.uk")
-    DEFINE("MEM", "Xmx1024M")
     DEFINE("UNZIP", "unzip")
     DEFINE("UNZIPARGS", "")
 
-# Also run detection here, since these values are
-# re-used during DEFINITION
-p = subprocess.Popen(["hostname"], stdout=subprocess.PIPE)
-hostname = p.communicate()[0].strip()
-
-# If this is the default linux situation, then we want
-# to also handle howe. Other servers will need to be
-# handled better later.
-if NAME == "gretzky" and NAME != hostname:
-    if hostname == "howe":
-        print "Detected hostname == 'howe'"
-        DEFINE("NAME", "howe")
-        DEFINE("ADDRESS", "howe.openmicroscopy.org.uk")
-    else:
-        print "Setting hostname to '%s'" % hostname
-        DEFINE("NAME", hostname)
-        DEFINE("ADDRESS", "localhost")
-        # Don't send emails if we're not on a known host.
-        DEFINE("SKIPEMAIL", "true")
-
 # new_server.py
+DEFINE("MEM", "Xmx1024M")
 DEFINE("SYM", "OMERO-CURRENT")
 DEFINE("CFG", os.path.join(os.path.expanduser("~"), "config.xml"))
 DEFINE("WEB", """'[["localhost", 4064, "%s"], ["gretzky.openmicroscopy.org.uk", 4064, "gretzky"], ["howe.openmicroscopy.org.uk", 4064, "howe"]]'""" % NAME)


### PR DESCRIPTION
Previous version had the hostname check too late, after other DEFINE commands had used "gretzky" (for example).
Now adding various cleanups to make this more robust on a number of different servers.
