### PR TITLE
Exclude Bio-Formats JARs from Insight ImageJ bundle

### DIFF
--- a/components/insight/build/app.xml
+++ b/components/insight/build/app.xml
@@ -53,6 +53,7 @@
     <include name="**/*.java"/>
   </patternset>
   <fileset id="app.libs" dir="${base.runtimelib.dir}" includes="*.jar"/>
+  <fileset id="app.libs.no-bioformats" dir="${base.runtimelib.dir}" includes="*.jar" excludes="bio-formats.jar,jai_imageio.jar,loci-common.jar,mdbtools-java.jar,metakit.jar,ome-xml.jar,poi-loci.jar,scifio.jar"/>
   <fileset id="app.libs.opengl" dir="${base.runtimelib.dir}" includes="*.jar"/>
   <fileset id="app.resources" dir="${base.src.dir}" excludes="**/*.java"/>
   <fileset id="app.config" dir="${base.config.dir}"/> 

--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -272,7 +272,8 @@
   	<property name="main-dist-ij-prefix" value="${dist.bundle.ij.name}-${dist.bundle.version}"/>
     <zip destfile="${dist.dir}/${main-dist-ij-prefix}.zip">
       <zipfileset dir="${app.config.dir}" prefix="${main-dist-ij-prefix}/${dist.app.config.dir.name}"/>
-      <zipfileset refid="app.libs" prefix="${main-dist-ij-prefix}/${dist.app.lib.dir.name}"/>
+      <zipfileset refid="app.libs.no-bioformats" prefix="${main-dist-ij-prefix}/${dist.app.lib.dir.name}">
+      </zipfileset>
       <zipfileset dir="${dist.dir}" prefix="${main-dist-ij-prefix}" includes="${dist.jar.ij.file}"/>
       <zipfileset file="${base.licensefile}" fullpath="${main-dist-ij-prefix}/LICENSE"/>
     </zip>


### PR DESCRIPTION
Do not include the .jar files that are included in loci_tools.jar.  Users are already required to have loci_tools.jar installed in ImageJ, so there is no need to include these .jars in the insight-ij bundle.
