### PR TITLE
test-compile fix in insight

### DIFF
--- a/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullRenderingService.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullRenderingService.java
@@ -283,7 +283,7 @@ public class NullRenderingService
      * long, long, boolean)
      */
 	public Object importFile(ImportableObject object,
-			ImportableFile file, long userID, long groupID, boolean close) 
+			ImportableFile file, long userID, boolean close) 
 		throws ImportException
 	{
 		return null;


### PR DESCRIPTION
NullRenderingService wasn't updated to match the change to OmeroImageService. Removing "long groupId" as an argument to the "importFile" method.
