### PR TITLE
fix for #9237

### DIFF
--- a/docs/install/VM/omero-init.d
+++ b/docs/install/VM/omero-init.d
@@ -4,9 +4,9 @@
 # Subsystem file for "omero" server
 #
 ### BEGIN INIT INFO
-# Provides:             omero-server
+# Provides:             omero
 # Required-Start:       $local_fs $remote_fs $network $time postgresql
-# Required-Stop:        $local_fs $remote_fs $network $time
+# Required-Stop:        $local_fs $remote_fs $network $time postgresql
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 # Short-Description:    OMERO.server
@@ -23,7 +23,7 @@ OMERO_USER=${OMERO_USER:-"omero"}
 
 start() {	
 	echo -n $"Starting $prog:"
-	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin start
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin start &> /dev/null && echo -n ' OMERO.server'
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]
 	echo
@@ -31,7 +31,7 @@ start() {
 
 stop() {
 	echo -n $"Stopping $prog:"
-	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin stop
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero admin stop &> /dev/null && echo -n ' OMERO.server'
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]
 	echo

--- a/docs/install/VM/omero-web-init.d
+++ b/docs/install/VM/omero-web-init.d
@@ -5,8 +5,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:             omero-web
-# Required-Start:       $local_fs $remote_fs $network $time omero
-# Required-Stop:        $local_fs $remote_fs $network $time
+# Required-Start:       $local_fs $remote_fs $network $time omero postgresql
+# Required-Stop:        $local_fs $remote_fs $network $time omero postgresql
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 # Short-Description:    OMERO.web
@@ -25,7 +25,7 @@ OMERO_USER=${OMERO_USER:-"omero"}
 
 start() {	
 	echo -n $"Starting $prog:"
-	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web start
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web start &> /dev/null && echo -n ' OMERO.web'
   sudo -iu ${OMERO_USER} bash ${OMERO_HOME%OMERO.server}/nginx-control.sh start
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]
@@ -33,7 +33,7 @@ start() {
 
 stop() {
 	echo -n $"Stopping $prog:"
-	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web stop
+	sudo -iu ${OMERO_USER} ${OMERO_HOME}/bin/omero web stop &> /dev/null && echo -n ' OMERO.web'
   sudo -iu ${OMERO_USER} bash ${OMERO_HOME%OMERO.server}/nginx-control.sh stop
 	RETVAL=$?
 	[ "$RETVAL" = 0 ]


### PR DESCRIPTION
Appears to be an order problem with shutting down postgres when there
are active sessions/logins.

To reproduce (prior to fix).
- start vm
- login to web
- immediately issue a shutdown after the page loads

This forces a dependency on postgres as well as omero for omero web to
ensure postgres is the last thing shutdown.  Debian's LSB initscripts
are run concurrently so a race condition can occur when they run at the
same time.
