### PR TITLE
Short-circuit canEdit and canAnnotate for admin

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -476,7 +476,7 @@ class BlitzObjectWrapper (object):
         @rtype:     Boolean
         @return:    True if user can Edit this object Delete, link etc.
         """
-        return self.getDetails().getPermissions().canEdit()
+        return self.getDetails().getPermissions().canEdit() or self._conn.isAdmin()
 
     def canDelete(self):
         """
@@ -504,7 +504,7 @@ class BlitzObjectWrapper (object):
         @rtype:     Boolean
         @return:    True if user can Annotate this object
         """
-        return self.getDetails().getPermissions().canAnnotate()
+        return self.getDetails().getPermissions().canAnnotate() or self._conn.isAdmin()
 
     def canChgrp(self):
         """


### PR DESCRIPTION
admins can edit and annotate anything, but the tests from omeropy gateway don't currently state that.

Needed at the very least for unittesting (see #7202)
