### PR TITLE
Adding support for r,g,b channel colors, see #9344

### DIFF
--- a/components/specification/InProgress/omeOxygenProject.xpr
+++ b/components/specification/InProgress/omeOxygenProject.xpr
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="13.1">
+<project version="14.0">
     <meta>
         <filters directoryPatterns="" filePatterns="" positiveFilePatterns="" showHiddenFiles="false"/>
         <options>
-            <serialized version="13.1" xml:space="preserve">
+            <serialized version="14.0" xml:space="preserve">
                 <map>
                     <entry>
                         <String>allow.dt.page.setting.to.override.general.settings</String>
@@ -94,25 +94,33 @@
                         <String>scenario.associations</String>
                         <scenarioAssociation-array>
                             <scenarioAssociation>
-                                <field name="name">
-                                    <String>2008-09 to 2009-09</String>
-                                </field>
-                                <field name="type">
-                                    <String>XSL</String>
-                                </field>
                                 <field name="url">
                                     <String>../Validator/Backend/samples/tiny2009-09-V1.ome</String>
                                 </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>2008-09 to 2009-09</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>XSL</String>
+                                    </list>
+                                </field>
                             </scenarioAssociation>
                             <scenarioAssociation>
-                                <field name="name">
-                                    <String>TEI P5(experimental) HTML</String>
-                                </field>
-                                <field name="type">
-                                    <String>XSL</String>
-                                </field>
                                 <field name="url">
                                     <String>Markdown/custom-annotations/tmpl_custom_ann.html</String>
+                                </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>TEI P5(experimental) HTML</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>XSL</String>
+                                    </list>
                                 </field>
                             </scenarioAssociation>
                         </scenarioAssociation-array>
@@ -1873,6 +1881,10 @@
                     <entry>
                         <String>scenarios.load.from.project</String>
                         <Boolean>true</Boolean>
+                    </entry>
+                    <entry>
+                        <String>validation.scenarios</String>
+                        <validationScenario-array/>
                     </entry>
                 </map>
             </serialized>

--- a/components/specification/Samples/OmeFiles/2008-09/6x4y1z1t3c8b-swatch.ome
+++ b/components/specification/Samples/OmeFiles/2008-09/6x4y1z1t3c8b-swatch.ome
@@ -4,9 +4,9 @@
       ID="Image:0" Name="6x6x1x8-swatch.tif">
       <CreationDate>2010-02-23T12:51:30</CreationDate>
       <LogicalChannel ID="LogicalChannel:0" SamplesPerPixel="3" >
-         <ChannelComponent Index="0" Pixels="Pixels:0:0"/>
-         <ChannelComponent Index="1" Pixels="Pixels:0:0"/>
-         <ChannelComponent Index="2" Pixels="Pixels:0:0"/>
+         <ChannelComponent Index="0" Pixels="Pixels:0:0" ColorDomain="r"/>
+         <ChannelComponent Index="1" Pixels="Pixels:0:0" ColorDomain="g"/>
+         <ChannelComponent Index="2" Pixels="Pixels:0:0" ColorDomain="b"/>
       </LogicalChannel>
       <Pixels BigEndian="false" DimensionOrder="XYCZT" ID="Pixels:0:0" 
          PhysicalSizeX="10000.0" PhysicalSizeY="10000.0" PhysicalSizeZ="0.0" 

--- a/components/specification/Xslt/2008-09-to-2009-09.xsl
+++ b/components/specification/Xslt/2008-09-to-2009-09.xsl
@@ -1577,9 +1577,9 @@
 	<xsl:template name="convertColorDomain">
 		<xsl:param name="cc"/>
 		<xsl:choose>
-			<xsl:when test="contains($cc,'red') or contains($cc,'r')">4278190335</xsl:when>
-			<xsl:when test="contains($cc,'green') or contains($cc,'g')">16711935</xsl:when>
-			<xsl:when test="contains($cc,'blue') or contains($cc,'b')">65535</xsl:when>
+			<xsl:when test="contains($cc,'r') or contains($cc,'R')">4278190335</xsl:when>
+			<xsl:when test="contains($cc,'g') or contains($cc,'G')">16711935</xsl:when>
+			<xsl:when test="contains($cc,'b') or contains($cc,'B')">65535</xsl:when>
 			<xsl:otherwise>4294967295</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>

--- a/components/specification/Xslt/2010-06-to-2003-FC.xsl
+++ b/components/specification/Xslt/2010-06-to-2003-FC.xsl
@@ -145,7 +145,22 @@
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
-	
+
+	<!--
+	convert the value of the Color attribute of Channel to a ColorDomain
+	attribute on ChannelComponent.
+	A limited number of colours are supported, others map to w for (white).
+	-->
+	<xsl:template name="convertToColorDomain">
+		<xsl:param name="cc"/>
+		<xsl:choose>
+			<xsl:when test="contains($cc,'-16776961')">r</xsl:when>
+			<xsl:when test="contains($cc,'16711935')">g</xsl:when>
+			<xsl:when test="contains($cc,'65535')">b</xsl:when>
+			<xsl:otherwise>w</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
 	<!-- Actual schema changes -->	
 	<xsl:template match="OME:AcquiredDate">
 		<xsl:element name="CreationDate" namespace="{$newOMENS}">
@@ -199,6 +214,11 @@
 						<xsl:attribute name="Pixels">xslt.fix:Pixels:XSLT:<xsl:for-each select=" parent::node()">
 								<xsl:value-of select="@ID"/>
 							</xsl:for-each>
+						</xsl:attribute>
+						<xsl:attribute name="ColorDomain">
+							<xsl:call-template name="convertToColorDomain">
+								<xsl:with-param name="cc" select="@Color"/>
+							</xsl:call-template>
 						</xsl:attribute>
 						<xsl:attribute name="Index"><xsl:value-of select="position()"/></xsl:attribute>
 					</xsl:element>

--- a/components/specification/Xslt/2010-06-to-2008-02.xsl
+++ b/components/specification/Xslt/2010-06-to-2008-02.xsl
@@ -130,6 +130,21 @@
 		</xsl:choose>
 	</xsl:template>
 	
+	<!--
+	convert the value of the Color attribute of Channel to a ColorDomain
+	attribute on ChannelComponent.
+	A limited number of colours are supported, others map to w for (white).
+	-->
+	<xsl:template name="convertToColorDomain">
+		<xsl:param name="cc"/>
+		<xsl:choose>
+			<xsl:when test="contains($cc,'-16776961')">r</xsl:when>
+			<xsl:when test="contains($cc,'16711935')">g</xsl:when>
+			<xsl:when test="contains($cc,'65535')">b</xsl:when>
+			<xsl:otherwise>w</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
 	<!-- Actual schema changes -->
 
 	<xsl:template match="OME:AcquiredDate">
@@ -252,6 +267,11 @@
 							<xsl:for-each select=" parent::node()">
 								<xsl:value-of select="@ID"/>
 							</xsl:for-each>
+						</xsl:attribute>
+						<xsl:attribute name="ColorDomain">
+							<xsl:call-template name="convertToColorDomain">
+								<xsl:with-param name="cc" select="@Color"/>
+							</xsl:call-template>
 						</xsl:attribute>
 						<xsl:attribute name="Index">
 							<xsl:value-of select="position()"/>


### PR DESCRIPTION
Need to be included in sync with the new version of bio-formats that has the same new transforms.

Git Conflicts:
    components/tools/OmeroPy/scripts (was folder, no submodule, action to fix: reset)
