### PR TITLE
Fix BlitzConfiguration ctor in tests

### DIFF
--- a/components/blitz/test/ome/services/blitz/test/mock/BlitzConfigurationTest.java
+++ b/components/blitz/test/ome/services/blitz/test/mock/BlitzConfigurationTest.java
@@ -39,7 +39,7 @@ public class BlitzConfigurationTest extends MockObjectTestCase {
         Ice.InitializationData id = new Ice.InitializationData();
         id.properties = Ice.Util.createProperties();
         id.properties.setProperty("BlitzAdapter.Endpoints", "default -h 127.0.0.1");
-        config = new BlitzConfiguration(id, ring, sm, ss, ex);
+        config = new BlitzConfiguration(id, ring, sm, ss, ex, 10000);
     }
     
     @Test
@@ -47,7 +47,7 @@ public class BlitzConfigurationTest extends MockObjectTestCase {
         Ice.InitializationData id = new Ice.InitializationData();
         id.properties = Ice.Util.createProperties();
         id.properties.setProperty("BlitzAdapter.Endpoints", "default -h 127.0.0.1");
-        config = new BlitzConfiguration(id, ring, sm, ss, ex);
+        config = new BlitzConfiguration(id, ring, sm, ss, ex, 10000);
         config.destroy();
     }
 

--- a/components/blitz/test/ome/services/blitz/test/mock/MockFixture.java
+++ b/components/blitz/test/ome/services/blitz/test/mock/MockFixture.java
@@ -137,7 +137,7 @@ public class MockFixture {
         this.mock("executorMock").expects(test.once()).method("execute").will(test.returnValue(true));
         this.mock("executorMock").expects(test.once()).method("execute").will(test.returnValue(Collections.EMPTY_LIST));
         */
-        blitz = new BlitzConfiguration(id, ring, mgr, ss, ex);
+        blitz = new BlitzConfiguration(id, ring, mgr, ss, ex, 10000);
         this.sm = (SessionManagerI) blitz.getBlitzManager();
         this.sm.setApplicationContext(ctx);
         this.ctx.addApplicationListener(this.sm);


### PR DESCRIPTION
gh-260 build failed during "test-compile" due to a new argument to `BlitzConfiguration`.
