### PR TITLE
Fix build by referencing UNSIGNED jar (Fix #9359)

### DIFF
--- a/components/tools/OmeroImageJ/Omero_ImageJ/build.xml
+++ b/components/tools/OmeroImageJ/Omero_ImageJ/build.xml
@@ -35,7 +35,7 @@
 		</copy>
 		<!-- include plugin -->
 		<copy flatten="true" todir="${pluginsDir}/OmeroImageJ">
-			<fileset dir="${target.dir}" includes="${ivy.module}.jar"/>
+			<fileset dir="${target.dir}" includes="${ivy.module}-UNSIGNED.jar"/>
 		</copy>
 		<!-- convert jar with "_" -->
 		<copy flatten="true" todir="${pluginsDir}/OmeroImageJ">
@@ -65,7 +65,7 @@
     <target name="findbugs"/>
     <!-- LIFECYCLE OVERRIDE -->
     <target name="package" depends="lifecycle.package">
-        <jar destfile="${target.dir}/${ivy.module}.jar" update="true">
+        <jar destfile="${target.dir}/${ivy.module}-UNSIGNED.jar" update="true">
             <fileset dir="${resrc.dir}" includes="*.config"/>
         </jar>
     </target>

--- a/components/tools/OmeroImporter/build.xml
+++ b/components/tools/OmeroImporter/build.xml
@@ -67,7 +67,7 @@
         <chmod perm="a+x">
             <fileset dir="${target.dir}" includes="importer-*,test-engine,metadata-validator"/>
         </chmod>
-        <jar destfile="${target.dir}/${ivy.module}.jar" update="true">
+        <jar destfile="${target.dir}/${ivy.module}-UNSIGNED.jar" update="true">
             <fileset dir="${resrc.dir}" includes="*.icns"/>
             <fileset dir="${src.dir}" includes="**/*.png"/>
             <fileset dir="${src.dir}" includes="**/*.gif"/>


### PR DESCRIPTION
During the "package" phase of the build, the regular
jar does not exist. Only `${ivy.module}-UNSIGNED`
exists. The "install" phase turns the unsigned version
into the final version.
