### PR TITLE
Clean session 'active_group' if invalid. See #9448

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -147,7 +147,11 @@ def login(request):
                 if userGroupId in conn.getEventContext().memberOfGroups:
                     request.session['connector'] = connector
                     upgradeCheck()
-                
+
+                    # if 'active_group' remains in session from previous login, check it's valid for this user
+                    if request.session.get('active_group'):
+                        if request.session.get('active_group') not in conn.getEventContext().memberOfGroups:
+                            del request.session['active_group']
                     # do we ned to display server version ?
                     # server_version = conn.getServerVersion()
                     if request.REQUEST.get('noredirect'):


### PR DESCRIPTION
Single tiny fix for if you login with an old request.session['active_group'] from a previous user's login. Now we clean this on login if invalid. 
