### PR TITLE
Version check 9524

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -36,7 +36,7 @@ def _checkVersion(host, port):
             local_cleaned = regex.match(omero_version).group(1)
             local_split = local_cleaned.split(".")
 
-            rv = (agent_split[:-1] == local_split[:-1])     # ignore point releases
+            rv = (agent_split[0:2] == local_split[0:2])     # ignore point releases
             logger.info("Client version: '%s'; Server version: '%s'"% (omero_version, agent))
         except Exception, x:
             logger.error(traceback.format_exc())


### PR DESCRIPTION
Version check to ignore point releases and getGuestConnection logs at 'debug' level (instead of 'info').

To test, try connecting to nightshade (currently 4.4.0) using gretzky (without this PR it fails).

gretzky logs should show full versions at 'info' log level and getGuestConnection should be at 'debug' level (or not show up if debug is False)
