### PR TITLE
Turning off cross-group search. See 9526

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -519,7 +519,7 @@ def load_chgrp_target(request, group_id, target_type, conn=None, **kwargs):
     context = {'manager': manager, 'target_type': target_type, 'show_projects':show_projects, 'template': template}
     return context
 
-@login_required()
+@login_required(setGroupContext=True)
 @render_response()
 def load_searching(request, form=None, conn=None, **kwargs):
     """


### PR DESCRIPTION
Turning off cross-group search for now (fixes 404s currently possible when trying to display search results from other groups).

To test: search in one group for images that are in another group. Shouldn't be returned. Check that all images returned can be displayed in right-hand panel when selected. 
