### PR TITLE
fix for 8363; remove omero specific paths from system config

### DIFF
--- a/etc/nginx.conf.system.template
+++ b/etc/nginx.conf.system.template
@@ -1,8 +1,6 @@
     server {
         listen       %(HTTPPORT)d;
         server_name  $hostname;
-        fastcgi_temp_path %(ROOT)s/var/nginx_tmp;
-        proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
          # weblitz django apps serve media from here
         location /static {


### PR DESCRIPTION
running a 'system' config for nginx has no need to create temp paths
under the omero directory for fastcgi.  This causes an additional
problem in that any directory under $OMERO_HOME/var is checked for
accessibility by the omero user.  Since it gets created by nginx at a
system level (www-data/root in most cases) it causes omero to be unable
to start.
