### PR TITLE
Add LeicaSCN to fs-lite-readers in config and ImportLibrary

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -141,6 +141,7 @@ public class ImportLibrary implements IObservable
             fsLiteReaders.add(loci.formats.in.APNGReader.class.getName());
             fsLiteReaders.add(loci.formats.in.JPEG2000Reader.class.getName());
             fsLiteReaders.add(loci.formats.in.JPEGReader.class.getName());
+            fsLiteReaders.add(loci.formats.in.LeicaSCNReader.class.getName());
             fsLiteReaders.add(loci.formats.in.TiffDelegateReader.class.getName());
         }
         else

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -123,6 +123,7 @@ loci.formats.in.SVSReader,\
 loci.formats.in.APNGReader,\
 loci.formats.in.JPEG2000Reader,\
 loci.formats.in.JPEGReader,\
+loci.formats.in.LeicaSCNReader,\
 loci.formats.in.TiffDelegateReader
 
 # To disable search indexing, leave blank.


### PR DESCRIPTION
This PR adds Leica SCN to the list of formats to be treated as a big image and thus imported via fs-lite. See https://trac.openmicroscopy.org.uk/ome/ticket/9563

The easiest way to test this is to import a Leica SCN using Insight or Importer and monitor the progress. If the file is imported as a big image the status should go:

`prepping -> analyzing -> archiving ->` (clock icons)

The archiving step may take some minutes.

If the image fails to import as a big image then the status would be:

`prepping -> analyzing -> 1/7 1/3 -> 1/7 2/3` ...

and would take a very long time.

Note that this tests the import process and not whether the image has actually been imported correctly. That's for another PR!
