### PR TITLE
Refuse LDAP login on empty username/password

### DIFF
--- a/components/server/src/ome/logic/LdapImpl.java
+++ b/components/server/src/ome/logic/LdapImpl.java
@@ -544,15 +544,18 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
 
         Hashtable<String, String> env = new Hashtable<String, String>(5, 0.75f);
         try {
+
+            // See discussion on anonymous bind in LdapPasswordProvider
+            if (username == null || username.equals("") ||
+                    password == null || password.equals("")) {
+                throw new SecurityViolation(
+                        "Refused to authenticate without username and password!");
+            }
+
             env = (Hashtable<String, String>) ctx.getReadOnlyContext()
                     .getEnvironment();
-
-            if (username != null && !username.equals("")) {
-                env.put(Context.SECURITY_PRINCIPAL, username);
-                if (password != null) {
-                    env.put(Context.SECURITY_CREDENTIALS, password);
-                }
-            }
+            env.put(Context.SECURITY_PRINCIPAL, username);
+            env.put(Context.SECURITY_CREDENTIALS, password);
             new InitialLdapContext(env, null);
         } catch (AuthenticationException authEx) {
             throw new SecurityViolation("Authentication falilure! "

--- a/components/server/src/ome/security/auth/LdapPasswordProvider.java
+++ b/components/server/src/ome/security/auth/LdapPasswordProvider.java
@@ -78,6 +78,29 @@ public class LdapPasswordProvider extends ConfigurablePasswordProvider {
             return null; // EARLY EXIT!
         }
 
+        // Note: LDAP simple authentication defaults to anonymous
+        // binding if the password is blank:
+        //
+        // 5.1.2. Unauthenticated Authentication Mechanism of Simple Bind
+        //
+        //  An LDAP client may use the unauthenticated authentication mechanism
+        //  of the simple Bind method to establish an anonymous authorization
+        //  state by sending a Bind request with a name value (a distinguished
+        //  name in LDAP string form [RFC4514] of non-zero length) and specifying
+        //  the simple authentication choice containing a password value of zero
+        //  length.
+        //
+        //  Since an anonymous bind proves nothing about the validity of this
+        //  user, we disable all attempts to login with an empty password.
+        //
+        //  The same check takes place in LdapImpl.isAuthContext method.
+        //
+        if (password == null || password.equals("")) {
+            log.warn("Empty password for user: " + user);
+            loginAttempt(user, false);
+            return false;
+        }
+
         Long id = util.userId(user);
 
         // Unknown user. First try to create.


### PR DESCRIPTION
This is the issue which lead to two security vulnerabilities (or the same one twice):
- once in 4.3.x
  - Commit: dbcbce5
  - Forum: https://www.openmicroscopy.org/community/viewtopic.php?f=11&t=
  - Email: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2012-January/002918.html
- once in 4.4.x:
  - Commit: 63c11de
  - Forum: https://www.openmicroscopy.org/community/viewtopic.php?f=11&t=1458
  - Email: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2012-August/003228.html

This commit gets it on the mainline so that this doesn't occur again.
