### PR TITLE
Add distEditor-win to insight's dist target (Fix #9546)

### DIFF
--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -237,7 +237,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~--> 
   <target name="dist"
           depends="jar, jar-util, jar-ij, dist-osx-openGL, dist-osx, dist-win, 
-  	dist-win-openGL,dist-win64-openGL,distEditor-osx, dist-ij, 
+  	dist-win-openGL,dist-win64-openGL,distEditor-osx, distEditor-win, dist-ij, 
   	distImporter-osx, distImporter-win"
           description="Build and package the app for distribution."> 
 


### PR DESCRIPTION
This was accidentally removed in ef46fbf19 so that no insight/OUT/Editor.exe4j executable was produced. To test, download the clients daily build for Windows and try to start the editor.
