### PR TITLE
Fix bug #9179: OMERO-cpp.bat fails on notification

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,13 +18,11 @@ BUILD_PY = "-Dbuild.py=true"
 
 def popen(args, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
         copy = os.environ.copy()
-        shell = (sys.platform == "win32")
         return subprocess.Popen(args,
                 env=copy,
                 stdin=stdin,
                 stdout=stdout,
-                stderr=stderr,
-                shell=shell)
+                stderr=stderr)
 
 
 def execute(args):
@@ -40,7 +38,7 @@ def notification(msg, prio):
     """
 
     # May want to revert this to be OMERO_BUILD_NOTIFICATION, or whatever.
-    if "OMERO_QUIET" in os.environ:
+    if "OMERO_QUIET" in os.environ or sys.platform == "win32":
         return
 
     try:


### PR DESCRIPTION
Removing the "shell" argument from the Popen call removes the [Errno 22]
error. A check has been also added in "communicate()" to return when run
on Windows platforms, as an early exit from the function.
