### PR TITLE
Fix insight zips in build

### DIFF
--- a/components/insight/build.xml
+++ b/components/insight/build.xml
@@ -66,47 +66,47 @@
         <!-- Hard coding paths for the moment to work around hudson regex issues -->
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*.zip" excludes="*-mac*.zip,*-win*.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}.zip"  to="insight.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}-+(.*).zip"  to="insight-win.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win-openGL.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win-openGL.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}-+(.*).zip"  to="insight-win-openGL.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-win64-openGL.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-win64-openGL.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}-+(.*).zip"  to="insight-win64-openGL.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-mac.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-mac.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}-+(.*).zip"  to="insight-mac.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight*-mac-openGL.zip"/>
-            <mapper type="regexp" from="OMERO.insight-[^-]+(.*).zip"  to="insight-mac-openGL.zip"/>
+            <mapper type="regexp" from="OMERO.insight-${omero.version}-+(.*).zip"  to="insight-mac-openGL.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.editor*-mac.zip"/>
-            <mapper type="regexp" from="OMERO.editor-[^-]+(.*).zip"  to="editor-mac.zip"/>
+            <mapper type="regexp" from="OMERO.editor-${omero.version}-+(.*).zip"  to="editor-mac.zip"/>
         </copy>
         <copy todir="${target.dir}">
             <fileset dir="${basedir}/OUT/dist" includes="OMERO.editor*-win.zip"/>
-            <mapper type="regexp" from="OMERO.editor-[^-]+(.*).zip"  to="editor-win.zip"/>
+            <mapper type="regexp" from="OMERO.editor-${omero.version}-+(.*).zip"  to="editor-win.zip"/>
         </copy>
     	<copy todir="${target.dir}">
     	    <fileset dir="${basedir}/OUT/dist" includes="OMERO.insight-ij*.zip"/>
-    	    <mapper type="regexp" from="OMERO.insight-ij-[^-]+(.*).zip"  to="insight-ij.zip"/>
+            <mapper type="regexp" from="OMERO.insight-ij-${omero.version}.zip"  to="insight-ij.zip"/>
     	</copy>
     	<copy todir="${target.dir}">
     	    <fileset dir="${basedir}/OUT/dist" includes="OMERO.importer*-win.zip"/>
-    	    <mapper type="regexp" from="OMERO.importer-[^-]+(.*).zip"  to="importer-win.zip"/>
+            <mapper type="regexp" from="OMERO.importer-${omero.version}-+(.*).zip"  to="importer-win.zip"/>
     	</copy>
     	<copy todir="${target.dir}">
     	    <fileset dir="${basedir}/OUT/dist" includes="OMERO.importer*-mac.zip"/>
-    	    <mapper type="regexp" from="OMERO.importer-[^-]+(.*).zip"  to="importer-mac.zip"/>
+            <mapper type="regexp" from="OMERO.importer-${omero.version}-+(.*).zip"  to="importer-mac.zip"/>
     	</copy>
     </target>
 


### PR DESCRIPTION
The recent renaming of the OMERO.ij zip to
OMERO.insight-ij made both zips match the
regex "OMERO.insight-[^-]*" which on copy
meant one clobbered the other.

Now using the specific version as a part
of the regex to prevent confusion.
