### PR TITLE
Fix 'compile error' in processor.py (Fix #9497)

### DIFF
--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -786,9 +786,12 @@ class ProcessorI(omero.grid.Processor, omero.util.Servant):
             cb = omero.grid.ProcessorCallbackPrx.uncheckedCast(cb)
             servants = list(self.ctx.servant_map.values())
             rv = []
+
             for x in servants:
-                if hasattr(x, "properties"):
-                    rv.append(long(x))
+                try:
+                    rv.append(long(x.properties["omero.job"]))
+                except:
+                    pass
             cb.responseRunning(rv)
         except exceptions.Exception, e:
             self.logger.warn("callback failed on requestRunning: %s Exception:%s", cb, e)


### PR DESCRIPTION
Minor issue that was found in Processor log. This method
is only called by CheckAllJobs:

```
@9497-proc-bug ~/git $ git grep requestRunning
components/blitz/resources/omero/Scripts.ice:            void requestRunning(ProcessorCallback* cb);
components/blitz/src/ome/services/blitz/util/CheckAllJobs.java:                "requestRunning", cbPrx));
components/tools/OmeroPy/src/omero/processor.py:    def requestRunning(self, cb, current = None):
components/tools/OmeroPy/src/omero/processor.py:            self.logger.warn("callback failed on requestRunning: %s Exception:%s", cb, e)
@9497-proc-bug ~/git $ git grep CheckAllJobs
components/blitz/resources/ome/services/blitz-config.xml:  <bean class="ome.services.blitz.util.CheckAllJobs" lazy-init="false">
components/blitz/src/ome/services/blitz/util/CheckAllJobs.java:public class CheckAllJobs extends OnContextRefreshedEventListener {
components/blitz/src/ome/services/blitz/util/CheckAllJobs.java:    private static final Log log = LogFactory.getLog(CheckAllJobs.class);
components/blitz/src/ome/services/blitz/util/CheckAllJobs.java:    public CheckAllJobs(Executor ex, ObjectAdapter oa, TopicManager tm) {
components/blitz/src/ome/services/blitz/util/CheckAllJobs.java:    public CheckAllJobs(Executor ex, ObjectAdapter oa, TopicManager tm,

```

and so would be fiendishly difficult to test. It also is surrounded by an `except Exception` block, which is why this was previously only logged at "WARN".

The only likely noticeable effect of fixing this is certain statements may get printed sooner in the log during startup (since the background thread will complete faster).
