### PR TITLE
Add Sphinx documentation build to hudson script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -546,6 +546,14 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         <zip destfile="${omero.home}/target/OMERO.docs-${omero.version}.zip">
             <zipfileset dir="${dist.dir}/docs" prefix="OMERO.docs-${omero.version}"/>
         </zip>
+
+        <gitdescribe select="\2"> </gitdescribe>
+
+        <exec executable="make" failonerror="true" dir="${sphinx.dir}">
+            <env key="OMERO_RELEASE" value="${version.describe}"/>
+            <arg line="clean html latexpdf"/>
+        </exec>
+        <copy file="${sphinx.dir}/_build/latex/OMERO-${version.describe}.pdf" tofile="${omero.home}/target/OMERO-${version.describe}.pdf" overwrite="true"/>
     </target>
 
     <target name="release-slice2html" description="The Ice API Documentation">
@@ -933,15 +941,4 @@ omero.version=${omero.version}
             javadoc.maxmem=${javadoc.maxmem}
         </echo>
     </target>
-
-    <target name="sphinx">
-        <gitdescribe select="\2">
-        </gitdescribe>
-
-        <exec executable="make" failonerror="true" dir="${sphinx.dir}">
-            <env key="OMERO_RELEASE" value="${version.describe}"/>
-            <arg line="clean html latexpdf"/>
-        </exec>
-    </target>
-
 </project>

--- a/docs/hudson/OMERO.sh
+++ b/docs/hudson/OMERO.sh
@@ -15,7 +15,6 @@ echo Building $OMERO_BRANCH
 ./build.py clean
 ./build.py build-default test-compile release-src release-webstart release-zip release-clients
 ./build.py release-docs
-./build.py sphinx
 
 # Log information
 echo BUILD_NUMBER=$BUILD_NUMBER > target/$OMERO_BRANCH.log


### PR DESCRIPTION
Allow documentation PDF to be generated as part of the OMERO-trunk-\* job.

Can be tested by running `./build.py release-docs`. 
- HTML & PDF should be compiled under `docs/sphinx/_build` 
- documenation PDF should be copied into `target/`
