### PR TITLE
9621 roi count

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7201,15 +7201,17 @@ class _ImageWrapper (BlitzObjectWrapper):
         for l in links:
             yield OriginalFileWrapper(self._conn, l.parent)
 
-    def getROICount(self, shapeType=None, eid=None):
+    def getROICount(self, shapeType=None, filterByCurrentUser=False):
         """
         Count number of ROIs associated to an image
-        
-        @param shapeType:   Filter by shape type ("Rect",...).
-        @param eid:         Filter by owner ID.
-        @return:            Number of ROIs found
+
+        @param shapeType: Filter by shape type ("Rect",...).
+        @param filterByCurrentUser: Whether or not to filter the count by the
+        currently logged in user.
+        @return: Number of ROIs found for the currently logged in user if
+        C{filterByCurrentUser} is C{True}, otherwise the total number found.
         """
-        
+
         # Create ROI shape validator (return True if at least one shape is found)
         def isValidType(shape):
             if not shapeType:
@@ -7233,17 +7235,19 @@ class _ImageWrapper (BlitzObjectWrapper):
         if shapeType is None:
             params = omero.sys.ParametersI()
             params.addLong('imageId', self.id)
-            params.addLong('ownerId', self._conn.getUserId())
+            query = 'select count(*) from Roi as roi ' \
+                    'where roi.image.id = :imageId'
+            if filterByCurrentUser:
+                query += ' and roi.details.owner.id = :ownerId'
+                params.addLong('ownerId', self._conn.getUserId())
             count = self._conn.getQueryService().projection(
-                    'select count(*) from Roi as roi ' \
-                    'where roi.image.id = :imageId ' \
-                    'and roi.details.owner.id = :ownerId', params, self._conn.SERVICE_OPTS)
+                    query, params, self._conn.SERVICE_OPTS)
             # Projection returns a two dimensional array of RType wrapped
             # return values so we want the value of row one, column one.
             return count[0][0].getValue()
 
         roiOptions = omero.api.RoiOptions()
-        if eid:
+        if filterByCurrentUser:
             roiOptions.userId = omero.rtypes.rlong(self._conn.getUserId())
         
         result = self._conn.getRoiService().findByImage(self.id, roiOptions)

--- a/components/tools/OmeroPy/test/integration/rois.py
+++ b/components/tools/OmeroPy/test/integration/rois.py
@@ -77,23 +77,29 @@ class TestRois(lib.ITest):
         roi3.setImage(img)
         roi3  = member.sf.getUpdateService().saveAndReturnObject(roi3)
         self.assertEqual(wrapper.getROICount(),3)
+        self.assertEqual(wrapper.getROICount(filterByCurrentUser=True),2)
         self.assertEqual(wrapper.getROICount("Ellipse"),2)
         self.assertEqual(wrapper.getROICount("Ellipse",None),2)
         self.assertEqual(wrapper.getROICount("Ellipse",1),1)
+        self.assertEqual(wrapper.getROICount("Ellipse",True),1)
         self.assertEqual(wrapper.getROICount("Rect"),2)
         self.assertEqual(wrapper.getROICount("Rect",None),2)
         self.assertEqual(wrapper.getROICount("Rect",1),2)
+        self.assertEqual(wrapper.getROICount("Rect",True),2)
         
         # Member gateway
         conn = BlitzGateway(client_obj = member)
         wrapper = ImageWrapper(conn, img)            
         self.assertEqual(wrapper.getROICount(),3)
+        self.assertEqual(wrapper.getROICount(filterByCurrentUser=True),1)
         self.assertEqual(wrapper.getROICount("Ellipse"),2)
         self.assertEqual(wrapper.getROICount("Ellipse",None),2)
         self.assertEqual(wrapper.getROICount("Ellipse",1),1)
+        self.assertEqual(wrapper.getROICount("Ellipse",True),1)
         self.assertEqual(wrapper.getROICount("Rect"),2)
         self.assertEqual(wrapper.getROICount("Rect",None),2)
         self.assertEqual(wrapper.getROICount("Rect",1),0)
+        self.assertEqual(wrapper.getROICount("Rect",True),0)
     
 
     def test8990(self):


### PR DESCRIPTION
This pull request should fix the issues seen in #9621 (https://trac.openmicroscopy.org.uk/ome/ticket/9621). To test:
- Open an Image in OMERO.web that has ROIs from multiple users
- Ensure that the number of ROIs displayed when clicking on "Show ROIs" is equal to the ROI count displayed

The semantics of `getROICount()` should be unchanged, and all unit tests should pass. To test:

```
./build.py -f components/tools/OmeroPy/build.xml test -DTEST=integration.rois
```

There are no uses of `getROICount()` in the current repository outside of OMERO.web so it may be useful to have @sbesson check one or more of his scripts.
