### PR TITLE
Handle InternalException from null StatsInfo (Fix #9655)

### DIFF
--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1622,7 +1622,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
         Channel newChannel = new ShallowCopy().copy(channel);
         newChannel.setLogicalChannel(new ShallowCopy().copy(channel
                 .getLogicalChannel()));
-        newChannel.setStatsInfo(new ShallowCopy().copy(channel.getStatsInfo()));
+        if (channel.getStatsInfo() != null) {
+            newChannel.setStatsInfo(new ShallowCopy().copy(channel.getStatsInfo()));
+        }
         return newChannel;
     }
 

--- a/components/tools/OmeroPy/test/integration/pixelsService.py
+++ b/components/tools/OmeroPy/test/integration/pixelsService.py
@@ -6,12 +6,13 @@
 """
 
 import omero
+import omero.gateway
 import unittest
 import integration.library as lib
 
 
 class TestPixelsService(lib.ITest):
-            
+
     def testCreateImage(self):
         """
         Create a new image 
@@ -28,6 +29,31 @@ class TestPixelsService(lib.ITest):
         sizeT = 1
         channelList = range(1, 4)
         iId = pixelsService.createImage(sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType, "testCreateImage", description=None)
+
+    def test9655(self):
+        # Create an image without statsinfo objects and attempt
+        # to retrieve it from the Rendering service.
+
+        # Get the pixels
+        image_id = self.testCreateImage()
+        gateway = omero.gateway.BlitzGateway(client_obj=self.client)
+        image = gateway.getObject("Image", image_id)
+        pixels_id = image.getPrimaryPixels().id
+
+        # Save the pixels
+        rps = self.client.sf.createRawPixelsStore()
+        rps.setPixelsId(pixels_id, False)
+        rps.setPlane([0], 0, 0, 0)
+        rps.save()
+        rps.close()
+
+        # Now use the RE to load
+        re = self.client.sf.createRenderingEngine()
+        re.lookupPixels(pixels_id)
+        re.resetDefaults()
+        re.lookupPixels(pixels_id)
+        re.lookupRenderingDef(pixels_id)
+        re.getPixels()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ShallowCopy.copy is not intended to handle nulls. Though
it could be changed to do so, that would require a larger
review than I'd like to do at the moment. Handling nulls
inside of RE.getPixels.
