### PR TITLE
Remove metadata-only flag from dropbox import command.

### DIFF
--- a/components/tools/OmeroFS/fsDropBoxMonitorClient.py
+++ b/components/tools/OmeroFS/fsDropBoxMonitorClient.py
@@ -607,7 +607,7 @@ class MonitorClientI(monitors.MonitorClient):
 
             cli = omero.cli.CLI()
             cli.loadplugins()
-            cmd = ["-s", self.host, "-p", str(self.port), "-k", key, "import", "-m"]
+            cmd = ["-s", self.host, "-p", str(self.port), "-k", key, "import"]
             cmd.extend([str("---errs=%s"%t), str("---file=%s"%to), "--", "--agent=dropbox"])
             cmd.extend(shlex.split(self.importArgs))
             cmd.append(fileName)


### PR DESCRIPTION
Under the experimental fslite branch DropBox files were imported as metadata-only as the original files  were accessible to the repository service. However, for the time being it would be safer to upload the files to the ManagedRepository thus allowing the users' DropBox directories to be cleared if necessary. The metadata-only import could be restored later as an option if necessary.

To test:
- copy an image file(s) into a user's DropBox folder
- after import check that the file(s) have been copied to the user's ManagedRepository folder
- after deleting the file(s) in the DropBox directory the image should still accessible to the client
