### PR TITLE
'bin/omero web start' cleans & replaces webstart jars

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -16,6 +16,7 @@ import time
 import sys
 import os
 import re
+from shutil import rmtree
 
 try:
     from omeroweb import settings
@@ -350,6 +351,10 @@ Alias /omero "%(ROOT)s/var/omero.fcgi/"
     def collectstatic(self):
         # Ensure that static media is copied to the correct location
         location = self.ctx.dir / "lib" / "python" / "omeroweb"
+        webstart_dir = location / "static" / "webstart"
+        if os.path.exists(webstart_dir):
+            self.ctx.out("Removing %s" % webstart_dir)
+            rmtree(webstart_dir)
         args = [sys.executable, "manage.py", "collectstatic", "--noinput"]
         rv = self.ctx.call(args, cwd = location)
         if rv != 0:


### PR DESCRIPTION
This is a basic 'fix' to ensure that webstart jars are copied over from dist/lib/insight/ each
time that $ bin/omero web start is run.
We simply remove the existing webstart target dir, then Django detects this and
collectstatic will replace them.
