### PR TITLE
Set SOURCE_BRANCH when using top-level release-docs build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -550,6 +550,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         <gitdescribe select="\2"> </gitdescribe>
 
         <exec executable="make" failonerror="true" dir="${sphinx.dir}">
+            <env key="SOURCE_BRANCH" value="v.${version.describe}"/>
             <env key="OMERO_RELEASE" value="${version.describe}"/>
             <arg line="clean html latexpdf"/>
         </exec>


### PR DESCRIPTION
This PR,  combined with openmicroscopy/ome-documentation#122, sets the `SOURCE_BRANCH` environment variable using the `git-describe` tag when using the top-level `release-docs` target.

To test it, 
- merge locally the `merge-doc-target` branch of ome-documentation.git: 

```
cd docs/sphinx
git remote add sbesson git://github.com/sbesson/ome-documentation.git
git merge sbesson/merge-doc-target
```
- build the docs

```
cd ../../
 ./build.py release-docs
```
- look at the output in `docs/sphinx/_build/html/*` \* `docs/sphinx/_builds/latex/*`. Source code links sould now point at the tag, e.g. [server/resources/ome/services](https://github.com/openmicroscopy/openmicroscopy/tree/v.4.4.4/components/server/resources/ome/services).
