### PR TITLE
Fix table display for Unicode characters (see #9646)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -73,7 +73,7 @@ class Column(list):
     def __init__(self, name, data, align=ALIGN.LEFT):
         list.__init__(self, data)
         self.name = name
-        self.width = max(len(str(x)) for x in data + [name])
+        self.width = max(len(str(x).decode("utf-8")) for x in data + [name])
         self.format = ' %%%s%ds ' % (align, self.width)
 
 
@@ -88,7 +88,14 @@ class Table:
             if i is None:
                 yield x.format % x.name
             else:
-                yield x.format % x[i]
+                try:
+                    x[i].decode("ascii")
+                except UnicodeDecodeError: # Unicode characters are present
+                    yield (x.format % x[i].decode("utf-8")).encode("utf-8")
+                except AttributeError: # Unicode characters are present
+                    yield x.format % x[i]
+                else:
+                    yield x.format % x[i]
 
     def get_rows(self):
         yield '|'.join(self.get_row(None))


### PR DESCRIPTION
To test this PR,
- login as root and modify some users to insert Unicode characters
- run `bin/omero user list`
- check the tables render correctly, e.g

```
sbesson:openmicroscopy sebastien$ dist/bin/omero user list
Using session 1f0e09f8-d72d-4631-84c5-20a326505390 (sebastien@localhost:4064). Idle timeout: 10.0 min. Current group: read-annotate-1
 id  | omeName      | firstName | lastName | email | active | admin | member of | leader of 
-----+--------------+-----------+----------+-------+--------+-------+-----------+-----------
 0   | root         | root      | root     |       | Yes    | Yes   |           |           
 1   | guest        | Guest     | Account  |       |        |       | 2         |           
 2   | sebastien    | Sebastien | Besson   |       | Yes    |       |           | 3         
 52  | test         | test      | test     |       | Yes    |       | 3         |           
 102 | éîøπµß´óµß´ó | Unicode   | test     |       | Yes    |       | 3         |           
 103 | ßébaßtien    | ßébaßtien | Béßon    |       | Yes    |       | 3         |           
(6 rows)
```
