### PR TITLE
Specify source version for compilation with Java 7 (see #9781)

### DIFF
--- a/components/insight/build/app.xml
+++ b/components/insight/build/app.xml
@@ -133,6 +133,7 @@
           depends="app-init" 
           description="Compile the whole app.">
     <javac srcdir="${base.src.dir}" target="1.5"
+           source="1.5"
            destdir="${app.compiled.dir}"
            includeantruntime="no"  
            deprecation="yes"
@@ -142,6 +143,7 @@
       <patternset refid="app.sources"/>
     </javac> 
   	<javac srcdir="${base.src.util.dir}" target="1.5"
+  	           source="1.5"
   	           destdir="${app.compiled.util.dir}"
   	           includeantruntime="no"  
   	           deprecation="yes"
@@ -151,6 +153,7 @@
   	      <patternset refid="app.sources"/>
   	    </javac> 
   	<javac srcdir="${base.src.svc.dir}" target="1.5"
+  	  	           source="1.5"
   	  	           destdir="${app.compiled.util.dir}"
   	  	           includeantruntime="no"  
   	  	           deprecation="yes"


### PR DESCRIPTION
Fixes compilation error with Java 7

Testing: Insight should compile and run with Java 1.5, 1.6, 1.7
