### PR TITLE
Update timestamp when signing JARs (See #9370)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -885,7 +885,7 @@ omero.version=${omero.version}
     </target>
 
     <target name="webstart-sign">
-        <signjar alias="${jarsign.alias}" keystore="${jarsign.keystore}" storepass="${jarsign.storepass}" preservelastmodified="true">
+        <signjar alias="${jarsign.alias}" keystore="${jarsign.keystore}" storepass="${jarsign.storepass}" preservelastmodified="false">
             <path>
                 <fileset dir="${dist.dir}/lib/insight" includes="*.jar"/>
             </path>


### PR DESCRIPTION
A rebase of https://github.com/openmicroscopy/openmicroscopy/pull/415 onto 'develop'.

A general test case would be to sign webstart JARs with a self-signed certificate and see if restarting web updates the JAR files on the server. When starting webstart, the certificate details should be updated (i.e. they shouldn't say 'omedev').
