### PR TITLE
Always show a created by tooltip for all tags (see #9384)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/DataObjectListCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/DataObjectListCellRenderer.java
@@ -190,8 +190,7 @@ public class DataObjectListCellRenderer
      */
     private void createTooltip(ExperimenterData exp)
     {
-    	if (exp == null) return;
-    	String s = "Created by: "+exp.getFirstName()+" "+exp.getLastName();
+    	String s = "Created by: "+EditorUtil.formatExperimenter(exp);
     	setToolTipText(s);
     }
     
@@ -279,33 +278,25 @@ public class DataObjectListCellRenderer
 			ExperimenterData exp;
 			if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(ns)) {
 				if (currentUserID >= 0) {
-					try {
-						exp = tag.getOwner();
-						createTooltip(exp);
-						long id = exp.getId();
-						if (id == currentUserID) 
-							setIcon(TAG_SET_ICON);
-						else
-							setIcon(TAG_SET_OTHER_OWNER_ICON);
-					} catch (Exception e) {
+					exp = tag.getOwner();
+					createTooltip(exp);
+					long id = exp.getId();
+					if (id == currentUserID)
 						setIcon(TAG_SET_ICON);
-					}
-				} else 
+					else
+						setIcon(TAG_SET_OTHER_OWNER_ICON);
+				} else
 					setIcon(TAG_SET_ICON);
 			} else {
 				if (currentUserID >= 0) {
-					try {
-						exp = tag.getOwner();
-						createTooltip(exp);
-						long id = exp.getId();
-						if (id == currentUserID) 
-							setIcon(TAG_ICON);
-						else
-							setIcon(TAG_OTHER_OWNER_ICON);
-					} catch (Exception e) {
+					exp = tag.getOwner();
+					createTooltip(exp);
+					long id = exp.getId();
+					if (id == currentUserID)
 						setIcon(TAG_ICON);
-					}
-				} else 
+					else
+						setIcon(TAG_OTHER_OWNER_ICON);
+				} else
 					setIcon(TAG_ICON);
 			}
 			if (tag.getId() <= 0)


### PR DESCRIPTION
The original intention appears to have been to show a tooltip for tags owned by other users, and no tooltip for tags owned by the current user. For some reason Java doesn't seem to allow a mix of elements with/without tooltips, and just uses an existing tooltip for those without. The solution is to have a tooltip for everything, in this case saying "Created by: <user name>".

Testing: Open a dataset with at least one tag owned by the current user and at least one by another user. Either add a tag (by clicking on + in the right hand pane) or click on the "Load Tags to filter by" icon, both of which will bring up a list of tags. Mouseover the tags and check the tooltips show the correct owner.

Things to consider: Would it be better if the tooltip for tags owned by the current user said "Created by you"?
