### PR TITLE
Fix crash when creating new tags in Insight 9812

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/util/FilteringDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/util/FilteringDialog.java
@@ -219,10 +219,10 @@ public class FilteringDialog
 				selected.add(tag);
 			else available.add(tag);
 		}
-		long id = DataBrowserAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(
 				DataBrowserAgent.getRegistry().getTaskBar().getFrame(), 
-				available, selected, TagAnnotationData.class, false, id);
+				available, selected, TagAnnotationData.class, false,
+				DataBrowserAgent.getUserDetails());
 		wizard.setTitle(title, text, icons.getIcon(IconManager.TAG_FILTER_48));
 		wizard.addPropertyChangeListener(this);
 		UIUtilities.centerAndShow(wizard);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -133,10 +133,9 @@ class DataBrowserComponent
 		String title = "Datasets Selection";
 		String text = "Select the Datasets to add the images to";
 		Icon icon = icons.getIcon(IconManager.DATASET_48);
-		long userID = DataBrowserAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(
 				DataBrowserAgent.getRegistry().getTaskBar().getFrame(),
-				datasets, DatasetData.class, userID);
+				datasets, DatasetData.class, DataBrowserAgent.getUserDetails());
 		wizard.setTitle(title, text, icon);
 		wizard.addPropertyChangeListener(controller);
 		UIUtilities.centerAndShow(wizard);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserToolBar.java
@@ -246,10 +246,10 @@ class DataBrowserToolBar
 				selected.add(tag);
 			else available.add(tag);
 		}
-		long id = DataBrowserAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(
 				DataBrowserAgent.getRegistry().getTaskBar().getFrame(), 
-				available, selected, TagAnnotationData.class, false, id);
+				available, selected, TagAnnotationData.class, false,
+				DataBrowserAgent.getUserDetails());
 		wizard.setTitle(title, text, icons.getIcon(IconManager.TAG_FILTER_48));
 		wizard.addPropertyChangeListener(this);
 		UIUtilities.centerAndShow(wizard);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -673,9 +673,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			text = "Select the Tags to add or remove, \nor Create new Tags";
 			icon = icons.getIcon(IconManager.TAGS_48);
 		}
-		long userID = ImporterAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(reg.getTaskBar()
-				.getFrame(), available, selected, type, addCreation, userID);
+				.getFrame(), available, selected, type, addCreation,
+				ImporterAgent.getUserDetails());
 		wizard.setAcceptButtonText("Save");
 		wizard.setTitle(title, text, icon);
 		wizard.addPropertyChangeListener(this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -142,10 +142,9 @@ class EditorComponent
 			text = "Select the Attachments to add or remove.";
 			icon = icons.getIcon(IconManager.ATTACHMENT_48);
 		}
-		long userID = MetadataViewerAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(
 				reg.getTaskBar().getFrame(), available, selected, type,
-				addCreation, userID);
+				addCreation, MetadataViewerAgent.getUserDetails());
 		wizard.setImmutableElements(model.getImmutableAnnotation());
 		if (model.isMultiSelection())
 			wizard.setAcceptButtonText("Save");

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/ExperimenterPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/ExperimenterPane.java
@@ -144,9 +144,8 @@ class ExperimenterPane
 		groupOwner.setToolTipText("Select an existing user as owner");
 		groupOwner.setVisible(passwordRequired);
 		if (available == null && selected == null) return;
-		long userID = TreeViewerAgent.getUserDetails().getId();
 		selectionComponent = new SelectionWizardUI(available, selected,
-				GroupData.class, userID);
+				GroupData.class, TreeViewerAgent.getUserDetails());
 		selectionComponent.addPropertyChangeListener(this);
 		addPropertyChangeListener(this);
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1761,23 +1761,14 @@ class TreeViewerComponent
 		}
 		fireStateChange();
 		SelectionWizard d = new SelectionWizard(view, available, selected,
-				objects.get(0).getClass(), 
-				TreeViewerAgent.getUserDetails().getId());
+				objects.get(0).getClass(), TreeViewerAgent.getUserDetails());
 		IconManager icons = IconManager.getInstance();
 		String title = "Experimenters Selection";
 		String text = "Select the Experimenters to add to the selected group.";
 		Icon icon = icons.getIcon(IconManager.OWNER_48);
 		d.setTitle(title, text, icon);
 		d.addPropertyChangeListener(controller);
-		UIUtilities.centerAndShow(d);  
-		/*
-		Set n = TreeViewerTranslator.transformIntoCheckNodes(nodes, 
-				getUserDetails().getId(), model.getUserGroupID());
-		model.setState(LOADING_SELECTION);
-		AddExistingObjectsDialog dialog = new AddExistingObjectsDialog(view, n);
-		dialog.addPropertyChangeListener(controller);
-		UIUtilities.centerAndShow(dialog);  
-		*/
+		UIUtilities.centerAndShow(d);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/DataObjectListCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/DataObjectListCellRenderer.java
@@ -171,8 +171,8 @@ public class DataObjectListCellRenderer
 			icons.getIcon(IconManager.TAG_SET_OTHER_OWNER);
 	}
 	
-	/** The id of the user currently logged in. */
-	private long				currentUserID;
+	/** The user currently logged in. */
+	private ExperimenterData currentUser;
 	
     /** Filter to identify protocol file. */
     private EditorFileFilter 	filter;
@@ -241,13 +241,14 @@ public class DataObjectListCellRenderer
 	/** 
 	 * Creates a new instance.
 	 * 
-	 * @param currentUserID The id of the user currently logged in.
+	 * @param currentUser The user currently logged in.
 	 * @param model Reference to the UI wizard.  
 	 */
-	DataObjectListCellRenderer(long currentUserID, SelectionWizardUI model)
+	DataObjectListCellRenderer(ExperimenterData currentUser,
+			SelectionWizardUI model)
 	{
 		this.model = model;
-		this.currentUserID = currentUserID;
+		this.currentUser = currentUser;
         filter = new EditorFileFilter();
 	}
 	
@@ -277,40 +278,44 @@ public class DataObjectListCellRenderer
 			String ns = tag.getNameSpace();
 			ExperimenterData exp;
 			if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(ns)) {
-				if (currentUserID >= 0) {
+				if (currentUser != null) {
 					try {
 						exp = tag.getOwner();
 						createTooltip(exp);
-						long id = exp.getId();
-						if (id == currentUserID)
+						if (exp.getId() == currentUser.getId())
 							setIcon(TAG_SET_ICON);
 						else
 							setIcon(TAG_SET_OTHER_OWNER_ICON);
 					} catch (Exception e) {
 						// tag.getOwner() throws when creating a new tag which
 						// doesn't have owner information
-						createTooltip(null);
+						if (tag.getId() < 0) createTooltip(currentUser);
+						else createTooltip(null);
 						setIcon(TAG_SET_ICON);
 					}
-				} else
+				} else {
+					createTooltip(null);
 					setIcon(TAG_SET_ICON);
+				}
 			} else {
-				if (currentUserID >= 0) {
+				if (currentUser != null) {
 					try {
 						exp = tag.getOwner();
 						createTooltip(exp);
-						long id = exp.getId();
-						if (id == currentUserID)
+						if (exp.getId() == currentUser.getId())
 							setIcon(TAG_ICON);
 						else
 							setIcon(TAG_OTHER_OWNER_ICON);
 					} catch (Exception e) {
 						// As above
-						createTooltip(null);
+						if (tag.getId() < 0) createTooltip(currentUser);
+						else createTooltip(null);
 						setIcon(TAG_ICON);
 					}
-				} else
+				} else {
+					createTooltip(null);
 					setIcon(TAG_ICON);
+				}
 			}
 			if (tag.getId() <= 0)
 				setForeground(NEW_FOREGROUND_COLOR);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
@@ -60,6 +60,7 @@ import org.openmicroscopy.shoola.util.ui.TitlePanel;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.search.SearchUtil;
 import pojos.DataObject;
+import pojos.ExperimenterData;
 import pojos.GroupData;
 import pojos.TagAnnotationData;
 
@@ -290,12 +291,12 @@ public class SelectionWizard
 	 * @param owner		The owner of this dialog.
 	 * @param available	The collection of available tags.
 	 * @param type		The type of object to handle.
-	 * @param userID    The if of the current user.
+	 * @param user      The current user.
 	 */
-	public SelectionWizard(JFrame owner, Collection<Object> available, 
-						Class type, long userID)
+	public SelectionWizard(JFrame owner, Collection<Object> available,
+						Class type, ExperimenterData user)
 	{
-		this(owner, available, null, type, userID);
+		this(owner, available, null, type, user);
 	}
 	
 	/**
@@ -307,12 +308,12 @@ public class SelectionWizard
 	 * @param addCreation	Pass <code>true</code> to add a component
 	 * 						allowing creation of object of the passed type,
 	 * 						<code>false</code> otherwise.
-	 * @param userID        The id of the current user.
+	 * @param user         The current user.
 	 */
 	public SelectionWizard(JFrame owner, Collection<Object> available, 
-						Class type, boolean addCreation, long userID)
+						Class type, boolean addCreation, ExperimenterData user)
 	{
-		this(owner, available, null, type, addCreation, userID);
+		this(owner, available, null, type, addCreation, user);
 	}
 	
 	/**
@@ -322,12 +323,13 @@ public class SelectionWizard
 	 * @param available	The collection of available items.
 	 * @param selected	The collection of selected items.
 	 * @param type		The type of object to handle. 
-	 * @param userID    The if of the current user.
+	 * @param user      The current user.
 	 */
 	public SelectionWizard(JFrame owner, Collection<Object> available, 
-						Collection<Object> selected, Class type, long userID)
+						Collection<Object> selected, Class type,
+						ExperimenterData user)
 	{
-		this(owner, available, selected, type, false, userID);
+		this(owner, available, selected, type, false, user);
 	}
 	
 	/**
@@ -340,15 +342,15 @@ public class SelectionWizard
 	 * @param addCreation	Pass <code>true</code> to add a component
 	 * 						allowing creation of object of the passed type,
 	 * 						<code>false</code> otherwise.
-	 * @param userID        The if of the current user.
+	 * @param user        The the current user.
 	 */
 	public SelectionWizard(JFrame owner, Collection<Object> available, 
 							Collection<Object> selected, Class type, 
-							boolean addCreation, long userID)
+							boolean addCreation, ExperimenterData user)
 	{
 		super(owner);
 		setModal(true);
-		uiDelegate = new SelectionWizardUI(available, selected, type, userID);
+		uiDelegate = new SelectionWizardUI(available, selected, type, user);
 		uiDelegate.addPropertyChangeListener(this);
 		this.type = type;
 		initComponents();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
@@ -53,6 +53,7 @@ import info.clearthought.layout.TableLayout;
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import pojos.DataObject;
+import pojos.ExperimenterData;
 import pojos.FileAnnotationData;
 import pojos.GroupData;
 import pojos.TagAnnotationData;
@@ -179,9 +180,9 @@ public class SelectionWizardUI
 	/** 
 	 * Initializes the components composing the display. 
 	 * 
-	 * @param userID The id of the user currently logged in.
+	 * @param user The user currently logged in.
 	 */
-	private void initComponents(long userID)
+	private void initComponents(ExperimenterData user)
 	{
 		sorter = new ViewerSorter();
 		availableItemsListbox = new JList();
@@ -213,7 +214,7 @@ public class SelectionWizardUI
 				}
 			}
 		});
-		cellRendererLeft = new DataObjectListCellRenderer(userID, this);
+		cellRendererLeft = new DataObjectListCellRenderer(user, this);
 		availableItemsListbox.setCellRenderer(cellRendererLeft);
 		selectedItemsListbox = new JList();
 		selectedItemsListbox.addKeyListener(new KeyAdapter() {
@@ -244,7 +245,7 @@ public class SelectionWizardUI
 				}
 			}
 		});
-		cellRendererRight = new DataObjectListCellRenderer(userID, this);
+		cellRendererRight = new DataObjectListCellRenderer(user, this);
 		selectedItemsListbox.setCellRenderer(cellRendererRight);
 		IconManager icons = IconManager.getInstance();
 		addButton = new JButton(icons.getIcon(IconManager.RIGHT_ARROW));
@@ -518,13 +519,13 @@ public class SelectionWizardUI
 	 * Creates a new instance. 
 	 * 
 	 * @param available	The collection of available items.
-	 * @param type		The type of object to handle. 
-	 * @param userID    The if of the current user.
+	 * @param type		The type of object to handle.
+	 * @param user      The current user.
 	 */
 	public SelectionWizardUI(Collection<Object> available, Class type, 
-							long userID)
+							ExperimenterData user)
 	{
-		this(available, null, type, userID);
+		this(available, null, type, user);
 	}
 	
 	/**
@@ -533,11 +534,11 @@ public class SelectionWizardUI
 	 * @param available	The collection of available items.
 	 * @param selected	The collection of selected items.
 	 * @param type		The type of object to handle. 
-	 * @param userID    The if of the current user.
+	 * @param user      The current user.
 	 */
 	public SelectionWizardUI(Collection<Object> available, 
 							Collection<Object> selected, Class type, 
-							long userID)
+							ExperimenterData user)
 	{
 		if (selected == null) selected = new ArrayList<Object>();
 		if (available == null) available = new ArrayList<Object>();
@@ -545,7 +546,7 @@ public class SelectionWizardUI
 		this.selectedItems = selected;
 		this.type = type;
 		createOriginalSelections();
-		initComponents(userID);
+		initComponents(user);
 		sortLists();
 		buildGUI();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/AdvancedFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/AdvancedFinder.java
@@ -605,10 +605,10 @@ public class AdvancedFinder
 				selected.add(tag);
 			else available.add(tag);
 		}
-		long id = DataBrowserAgent.getUserDetails().getId();
 		SelectionWizard wizard = new SelectionWizard(
 				DataBrowserAgent.getRegistry().getTaskBar().getFrame(), 
-				available, selected, TagAnnotationData.class, false, id);
+				available, selected, TagAnnotationData.class, false, 
+				DataBrowserAgent.getUserDetails());
 		wizard.setGroups(groups);
 		wizard.setTitle(title, text, icons.getIcon(IconManager.TAG_48));
 		wizard.addPropertyChangeListener(this);


### PR DESCRIPTION
Fix regression from [PR432](https://github.com/openmicroscopy/openmicroscopy/pull/432): try-catch blocks replaced, and empty tooltip created for new tags.

Testing: Add a new tag to an object in Insight. Check that tooltip shows "Created by: "
