### PR TITLE
Fix IOOB when searching in Insight (see #9787)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1094,7 +1094,7 @@ class TreeViewerComponent
 		int n = l.size();
 		List selection = (List) l.get(0);
 		Object parent = null;
-		if (n == 1) parent = l.get(1);
+		if (n == 2) parent = l.get(1);
 		if (selection == null || selection.size() == 0) return;
 		MetadataViewer mv = model.getMetadataViewer();
 		if (hasDataToSave()) {


### PR DESCRIPTION
Selection of images returned by search caused Insight to crash
with an Index Out Of Bounds exception. This change fixes that.

Test case:
- Start Insight,
- Log in,
- Make sure some images are present,
- Use Search to find any results,
- Drag-select some of the images in the results window.

Expected result:
- Insight doesn't crash.
