### PR TITLE
Remove archiving workflow for Screens

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -1510,15 +1510,11 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * Populates archive flags on all images currently processed links
-     * relevant original metadata files as requested and performs graph logic
-     * to have the scafolding in place for later original file upload if
+     * Links relevant companion files for later original file upload if
      * we are of the HCS domain.
-     * @param archive Whether or not the user requested the original files to
-     * be archived.
      * @return A list of the temporary metadata files created on local disk.
      */
-    public List<File> setArchiveScreeningDomain(boolean archive)
+    public List<File> setArchiveScreeningDomain()
     {
 	List<File> metadataFiles = new ArrayList<File>();
 	String[] usedFiles = reader.getUsedFiles();
@@ -1529,55 +1525,34 @@ public class OMEROMetadataStoreClient
 	formatString = formatString.replace("class loci.formats.in.", "");
 	formatString = formatString.replace("Reader", "");
 	LSID plateKey = new LSID(Plate.class, 0);
-		// Populate the archived flag on the image. This inadvertently
-		// ensures that an Image object (and corresponding container)
-		// exists.
+	// Set the archived flag to false as archiving is disabled for screens
 	for (int series = 0; series < reader.getSeriesCount(); series++)
 	{
 		LinkedHashMap<Index, Integer> imageIndexes =
 			new LinkedHashMap<Index, Integer>();
 		imageIndexes.put(Index.IMAGE_INDEX, series);
 		Image image = getSourceObject(Image.class, imageIndexes);
-		image.setArchived(toRType(archive));
+		image.setArchived(toRType(false));
 	}
-	// Create all original file objects for later population based on
-	// the existence or abscence of companion files and the archive
-	// flag. This increments the original file count by the number of
-	// files to actually be created.
+	// Create original file objects for later population for companion
+	// files. This increments the original file count by the
+	// number of files to actually be created.
 	int originalFileIndex = 0;
 	for (String usedFilename : usedFiles)
 	{
 		File usedFile = new File(usedFilename);
 		boolean isCompanionFile = companionFiles == null? false :
-			companionFiles.contains(usedFilename);
-		if (archive || isCompanionFile)
-		{
-			LinkedHashMap<Index, Integer> indexes =
+			    companionFiles.contains(usedFilename);
+		LinkedHashMap<Index, Integer> indexes =
 				new LinkedHashMap<Index, Integer>();
-			indexes.put(Index.ORIGINAL_FILE_INDEX, originalFileIndex);
-			if (isCompanionFile)
-			{
-				// PATH 1: The file is a companion file, create it,
-				// and increment the next original file's index.
-				String format = "Companion/" + formatString;
-				createOriginalFileFromFile(usedFile, indexes, format);
-				addCompanionFileAnnotationTo(plateKey, indexes,
-						                     originalFileIndex);
-				originalFileIndex++;
-			}
-			else
-			{
-				// PATH 2: We're archiving and the file is not a
-				// companion file, create it, and increment the next
-				// original file's index.
-				createOriginalFileFromFile(usedFile, indexes,
-						formatString);
-				LSID originalFileKey =
-					new LSID(OriginalFile.class, originalFileIndex);
-				addReference(plateKey, originalFileKey);
-				originalFileIndex++;
-			}
-		}
+		indexes.put(Index.ORIGINAL_FILE_INDEX, originalFileIndex);
+		// The file is a companion file, create it,
+		// and increment the next original file's index.
+		String format = "Companion/" + formatString;
+		createOriginalFileFromFile(usedFile, indexes, format);
+		addCompanionFileAnnotationTo(plateKey, indexes,
+		        originalFileIndex);
+		originalFileIndex++;
 	}
 	return metadataFiles;
     }

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -527,7 +527,7 @@ public class ImportLibrary implements IObservable
             {
                 log.info("Reader is of HCS domain, disabling metafile.");
 
-                metadataFiles = store.setArchiveScreeningDomain(archive);
+                metadataFiles = store.setArchiveScreeningDomain();
             }
             else
             {


### PR DESCRIPTION
This PR removes the archiving workflow for screens so that even if the archive flag is passed in (via the cli or ImportLibrary api) no attempt will be made to archive screens.

To test:
- the key test is that cli import of a screen with and without the archive flag '-a' should succeed.

Additionally:
- importing a screen via Insight, with and without archiving checked, should be unaffected (ie should succeed).
- importing of images via cli or Insight, with or without archiving, should be unaffected.
