### PR TITLE
Fix MRepoITest for JDK 5

### DIFF
--- a/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
@@ -227,7 +227,7 @@ public class ManagedRepositoryITest extends MockObjectTestCase {
     @Test
     public void testGetStringFromTokenReturnsEmptyStringOnNullToken() {
         String actual = this.tmri.getStringFromToken("", null, null);
-        Assert.assertEquals(actual.length(), 0);
+        Assert.assertEquals(0, actual.length());
     }
 
     @Test


### PR DESCRIPTION
Test case:
- 1st option: verify that OMERO-trunk-jdk5 job in hudson (http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-JDK5/) doesn't fail (is not "red") - that's only testable after the merge.
- 2nd option: merge locally into develop and try building with a JDK5. It should succeed.
