### PR TITLE
Fix download of archived image (see #9850)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -545,7 +545,6 @@ class EditorComponent
 	public void download(File folder)
 	{
 		model.download(folder);
-		//setStatus(true);
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -46,7 +46,6 @@ import java.util.Map.Entry;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JTabbedPane;
-import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.filechooser.FileFilter;
@@ -313,7 +312,10 @@ class EditorControl
 		JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
 		FileChooser chooser = new FileChooser(f, FileChooser.FOLDER_CHOOSER, 
 				"Download", "Select where to download the file.", null, true);
-		chooser.setSelectedFileFull(view.getRefObjectName());
+		try {
+			File file = UIUtilities.getDefaultFolder();
+			if (file != null) chooser.setCurrentDirectory(file);
+		} catch (Exception ex) {}
 		IconManager icons = IconManager.getInstance();
 		chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
 		chooser.setApproveButtonText("Download");
@@ -342,6 +344,10 @@ class EditorControl
 		FileChooser chooser = new FileChooser(f, FileChooser.FOLDER_CHOOSER, 
 				"Save As", "Select where to save locally the images as JPEG.",
 				saveAsFilters);
+		try {
+			File file = UIUtilities.getDefaultFolder();
+			if (file != null) chooser.setCurrentDirectory(file);
+		} catch (Exception ex) {}
 		String s = UIUtilities.removeFileExtension(view.getRefObjectName());
 		if (s != null && s.trim().length() > 0) chooser.setSelectedFile(s);
 		chooser.setApproveButtonText("Save");

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -79,6 +79,7 @@ import org.openmicroscopy.shoola.env.data.util.PojoMapper;
 import org.openmicroscopy.shoola.env.data.util.SearchDataContext;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.util.filter.file.OMETIFFFilter;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 import pojos.ChannelData;
 import pojos.DataObject;
@@ -523,7 +524,8 @@ class OmeroDataServiceImpl
 		Pixels pixels = gateway.getPixels(ctx, pixelsID);
 		long imageID = pixels.getImage().getId().getValue();
 		ImageData image = gateway.getImage(ctx, imageID, null);
-		String name = image.getName()+"."+OMETIFFFilter.OME_TIF;
+		String name = UIUtilities.removeFileExtension(
+				image.getName())+"."+OMETIFFFilter.OME_TIF;
 		Map<Boolean, Object> result = 
 			gateway.getArchivedFiles(ctx, folderPath, pixelsID);
 		if (result != null) return result;


### PR DESCRIPTION
Fix critical bug https://trac.openmicroscopy.org.uk/ome/ticket/9850

To test:
- select an image with name like `/usr/foo.dv`
- Make sure the default directory is displayed and not `/usr`
- Check that the image can be downloaded
- Test with an archived image and an image not archived.
