### PR TITLE
Add call to notifyObservers before cancelling (Fix #9852)

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -289,6 +289,9 @@ public class ImportLibrary implements IObservable
                     importImage(ic, index, numDone, containers.size());
                     numDone++;
                 } catch (Throwable t) {
+                    notifyObservers(new ErrorHandler.INTERNAL_EXCEPTION(
+                        ic.getFile().toString(), new RuntimeException(t),
+                        ic.getUsedFiles(), ic.getReader()));
                     if (!config.contOnError.get()) {
                         log.info("Exiting on error");
                         return false;


### PR DESCRIPTION
This adds an INTERNAL_EXCEPTION message in case of an exception during importCandidates. There are other methods that similarly need fixing, but in order to not confuse things for 4.4.5, I'm omitted those here. (See below for an example)

To test I add a `new RuntimeException("test")` just before the `catch` block. There's likely no other easy way to be sure that the `importImage` will throw (in fact, because of the eaten exception, I still don't know what's causing it in the forum post linked to 9852).
