### PR TITLE
CLI Import: propagate DEBUG optional argument to Java

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -120,7 +120,10 @@ class ImportControl(BaseControl):
             if arg_value:
                 login_args.append(arg_name)
                 if isinstance(arg_value, (str, unicode)):
-                    login_args.append(arg_value)
+                    if arg_name[:2] == "--":
+                        login_args[-1] += "=" + arg_value
+                    else:
+                        login_args.append(arg_value)
 
         a = self.COMMAND + login_args + args.arg
         p = omero.java.popen(a, debug=False, xargs = xargs, stdout=out, stderr=err)


### PR DESCRIPTION
This PR allows to set the debug level to both Python and Java using:

```
bin/import --debug=DEBUG file
```

To control debug levels independently, one can still use:

```
bin/import --debug=DEBUG file -- --debug=INFO
```
