### PR TITLE
ImportCandidates: catch Throwable instead of Exception

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -457,9 +457,16 @@ public class ImportCandidates extends DirectoryWalker
         } catch (MissingLibraryException mle)
         {
             safeUpdate(new ErrorHandler.MISSING_LIBRARY(path, mle, usedFiles, format));
-        } catch (Throwable e)
+        } catch (Throwable t)
         {
-            safeUpdate(new ErrorHandler.FILE_EXCEPTION(path, new Exception(e), usedFiles, format));
+            Exception e = null;
+            if (t instanceof Exception) {
+                e = (Exception) t;
+            }
+            else {
+                e = new Exception(t);
+            }
+            safeUpdate(new ErrorHandler.FILE_EXCEPTION(path, e, usedFiles, format));
         }
 
         return null;


### PR DESCRIPTION
This allows us to continue if, for instance, an OOM is thrown during setId.

Fixes #9872.

I tested this by copying `8kx8k.jpg` and `Iron Plate.al3d` into a directory `9872-test`, and then running `./importer-cli -f 9872-test/*` with 128 MB allocated.
