### PR TITLE
-1 was still specified instead of groupId. (see #9997)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
@@ -248,7 +248,7 @@ public class ImporterAgent
     	Map<Long, Map<Long, List<TreeImageDisplay>>> map = evt.getData();
     	objects = map;
     	if (!ImporterFactory.doesImporterExist()) return;
-    	Importer importer = ImporterFactory.getImporter(-1);
+    	Importer importer = ImporterFactory.getImporter(groupId);
     	if (importer == null || map == null || map.size() == 0) return;
     	GroupData group = importer.getSelectedGroup();
     	if (group == null) return;


### PR DESCRIPTION
#537 now on `develop`
