### PR TITLE
Correct small typo in CLI group help.

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -64,7 +64,7 @@ More information is available at:
         for x in (add, perms):
             group = x.add_mutually_exclusive_group()
             group.add_argument("--perms", help="Group permissions set as string, e.g. 'rw----' ")
-            group.add_argument("--type", help="Group permission set symbollically", default="private", choices = defaultperms.keys())
+            group.add_argument("--type", help="Group permissions set symbolically", default="private", choices = defaultperms.keys())
 
         list = parser.add(sub, self.list, "List current groups")
         printgroup = list.add_mutually_exclusive_group()


### PR DESCRIPTION
Only changes help text.
