### PR TITLE
Fix menu size when the group has >50 users. (see #10070) (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -425,11 +425,10 @@ class ToolBar
 				Dimension d = usersMenu.getPreferredSize();
 				Point p1 = c.getLocation();
 				SwingUtilities.convertPointToScreen(p1, c);
-				int h = p1.y+d.height;
-				int diff = h-size.height;
-				if (diff > 0)  {
-					usersMenu.setPopupSize(d.width+20, diff+30);
-				}
+				int h = size.height-p1.y-30; //max size.
+				int diff = p1.y+d.height;
+				if (diff > h)
+					usersMenu.setPopupSize(d.width+20, h);
 				//Set the location
 				usersMenu.show(e.getComponent(), r.width, 0);
 			}


### PR DESCRIPTION
This is the same as gh-568 but rebased onto develop.

---

Fix menu issue described in https://trac.openmicroscopy.org.uk/ome/ticket/10070

To test: 
- log in as petr password ome
  with 19/12/12 build, you will see 
  ![menuBefore](https://f.cloud.github.com/assets/1022396/23112/24d590ae-4a25-11e2-90b6-ec0b426afd6c.png)

with 20/12/12 build you will see
![menuAfter](https://f.cloud.github.com/assets/1022396/23120/8626712a-4a25-11e2-9127-f8d9d2944cff.png)
