### PR TITLE
Improve error handling during import (See #10090)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -984,42 +984,50 @@ public class FileImportComponent
 				if (image == null) setStatusText(null);
 				else if (image instanceof String) {
 					setStatusText((String) image);
-				} else if (image instanceof ImportException) {
-					ImportException ie = (ImportException) image;
+				} else if (image instanceof Exception) {
+					Exception e = (Exception) image;
 					fileNameLabel.setForeground(ERROR_COLOR);
 					resultLabel.setVisible(false);
-					toReImport = true;
+					toReImport = false;
 					errorButton.setToolTipText(
-							UIUtilities.formatExceptionForToolTip(ie));
-					exception = ie;
+							UIUtilities.formatExceptionForToolTip(e));
+					exception = e;
 					errorButton.setVisible(false);
-					int s = ie.getStatus();
-					if (s == ImportException.COMPRESSION) {
-						resultLabel.setVisible(true);
-						resultLabel.setText(COMPRESSION_ERROR_TEXT);
-						resultLabel.setToolTipText(
-								UIUtilities.formatExceptionForToolTip(ie));
-					} else if (s == ImportException.MISSING_LIBRARY) {
-						resultLabel.setVisible(true);
-						resultLabel.setText(MISSING_LIB_ERROR_TEXT);
-						resultLabel.setToolTipText(
-								UIUtilities.formatExceptionForToolTip(ie));
-					} else if (s == ImportException.FILE_ON_TAPE) {
-						resultLabel.setVisible(true);
-						resultLabel.setText(FILE_ON_TAPE_ERROR_TEXT);
-						resultLabel.setToolTipText(
-								UIUtilities.formatExceptionForToolTip(ie));
-					} else if (s == ImportException.NO_SPACE) {
-						resultLabel.setVisible(true);
-						resultLabel.setText(NO_SPACE_ERROR_TEXT);
-						resultLabel.setToolTipText(
-								UIUtilities.formatExceptionForToolTip(ie));
+					cancelButton.setVisible(false);
+					if (e instanceof ImportException) {
+						toReImport = true;
+						ImportException ie = (ImportException) image;
+						int s = ie.getStatus();
+						if (s == ImportException.COMPRESSION) {
+							resultLabel.setVisible(true);
+							resultLabel.setText(COMPRESSION_ERROR_TEXT);
+							resultLabel.setToolTipText(
+									UIUtilities.formatExceptionForToolTip(ie));
+						} else if (s == ImportException.MISSING_LIBRARY) {
+							resultLabel.setVisible(true);
+							resultLabel.setText(MISSING_LIB_ERROR_TEXT);
+							resultLabel.setToolTipText(
+									UIUtilities.formatExceptionForToolTip(ie));
+						} else if (s == ImportException.FILE_ON_TAPE) {
+							resultLabel.setVisible(true);
+							resultLabel.setText(FILE_ON_TAPE_ERROR_TEXT);
+							resultLabel.setToolTipText(
+									UIUtilities.formatExceptionForToolTip(ie));
+						} else if (s == ImportException.NO_SPACE) {
+							resultLabel.setVisible(true);
+							resultLabel.setText(NO_SPACE_ERROR_TEXT);
+							resultLabel.setToolTipText(
+									UIUtilities.formatExceptionForToolTip(ie));
+						} else {
+							errorButton.setVisible(true);
+							errorBox.setVisible(true);
+							errorBox.addChangeListener(this);
+						}
 					} else {
 						errorButton.setVisible(true);
 						errorBox.setVisible(true);
 						errorBox.addChangeListener(this);
 					}
-					cancelButton.setVisible(false);
 				}
 			}
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/ImportException.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/ImportException.java
@@ -141,6 +141,7 @@ public class ImportException
 	public int getStatus()
 	{
 		Throwable cause = getCause();
+		if (cause == null) return status;
 		if (cause instanceof UnsupportedCompressionException) {
 			return COMPRESSION;
 		} else if (cause instanceof FormatException) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2222,8 +2222,12 @@ public class UIUtilities
     {
     	if (ex == null) return "";
     	if (n <= 0) n = MAX_LINES_EXCEPTION;
-    	ex.printStackTrace();
-   		String s = UIUtilities.printErrorText(ex.getCause());
+    	//ex.printStackTrace();
+    	String s;
+    	if (ex.getCause() != null) {
+    		s = UIUtilities.printErrorText(ex.getCause());
+    	} else s = UIUtilities.printErrorText(ex);
+   		
    		String[] values = s.split("\n");
    		//Display the first 20 lines
    		String[] lines = values;


### PR DESCRIPTION
Improve error handling when an error occurs during import. Problem noticed while testing FS import.
See http://trac.openmicroscopy.org.uk/ome/ticket/10090

To test:

Choose an image that does not import see https://docs.google.com/spreadsheet/ccc?key=0AuqP9_Rq_HgldDNjT0ZIcHRSOUg1OFpjVUthdzM4cmc#gid=8
