### PR TITLE
No longer remove tabs if big images. (close #10035)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -2644,10 +2644,6 @@ class ImViewerUI
 		if (model.isBigImage()) index = model.getSelectedResolutionLevel();
 		setMagnificationStatus(model.getZoomFactor(), index);
 		controlPane.resetZoomValues();
-		if (model.isBigImage()) {
-			tabs.remove(ImViewer.GRID_INDEX);
-			tabs.remove(ImViewer.PROJECTION_INDEX);
-		}
 	}
 	
 	/** Sets the image data.*/


### PR DESCRIPTION
The init sequence has previously been modified
No longer required to remove the split and projection tabs.
see https://trac.openmicroscopy.org.uk/ome/ticket/10035

To test:
- Log in as user-3
- browse the jpeg dataset
- open a 2kx2k image
- open a 8kx8k image
