### PR TITLE
Print win service info in admin diagnostics

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -712,6 +712,21 @@ OMERO Diagnostics %s
                         self.ctx.out(io2[0].strip())
                     else:
                         self.ctx.err("UNKNOWN!")
+        if self._isWindows():
+            # Print the OMERO server Windows service details
+            hscm = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
+            services = win32service.EnumServicesStatus(hscm)
+            omesvcs = tuple((sname, fname) for sname,fname,status in services if "OMERO" in fname)
+            for sname,fname in omesvcs:
+                item("Server", fname)
+                hsc = win32service.OpenService(hscm, sname, win32service.SC_MANAGER_ALL_ACCESS)
+                logonuser = win32service.QueryServiceConfig(hsc)[7]
+                if win32service.QueryServiceStatus(hsc)[1] == win32service.SERVICE_RUNNING:
+                    self.ctx.out("active (running as %s)" % logonuser)
+                else:
+                    self.ctx.out("inactive")
+                win32service.CloseServiceHandle(hsc)
+            win32service.CloseServiceHandle(hscm)
 
         def log_dir(log, cat, cat2, knownfiles):
             self.ctx.out("")


### PR DESCRIPTION
As an RFE from PR #539, this PR adds an additional line in the `bin\omero admin diagnostics` output. It describes the status of the OMERO Windows service (active/inactive) and the Log On as user.
