### PR TITLE
Improvements to windows service user (see #10095) (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -386,15 +386,18 @@ Examples:
                     except KeyError:
                         user = None
                 if user is not None and len(user) > 0:
-                    # See #9967, code based on http://mail.python.org/pipermail/python-win32/2010-October/010791.html
                     if not "\\" in user:
                         computername = win32api.GetComputerName()
                         user = "\\".join([computername, user])
-                    self.ctx.out("Granting SeServiceLogonRight to service user \"%s\"" % user)
-                    policy_handle = win32security.LsaOpenPolicy(None, win32security.POLICY_ALL_ACCESS)
-                    sid_obj, domain, tmp = win32security.LookupAccountName(None, user)
-                    win32security.LsaAddAccountRights(policy_handle, sid_obj, ('SeServiceLogonRight',))
-                    win32security.LsaClose(policy_handle)
+                    try:
+                        # See #9967, code based on http://mail.python.org/pipermail/python-win32/2010-October/010791.html
+                        self.ctx.out("Granting SeServiceLogonRight to service user \"%s\"" % user)
+                        policy_handle = win32security.LsaOpenPolicy(None, win32security.POLICY_ALL_ACCESS)
+                        sid_obj, domain, tmp = win32security.LookupAccountName(None, user)
+                        win32security.LsaAddAccountRights(policy_handle, sid_obj, ('SeServiceLogonRight',))
+                        win32security.LsaClose(policy_handle)
+                    except pywintypes.error, details:
+                        self.ctx.die(200, "Error during service user set up: (%s) %s" % (details[0], details[2]))
                     if not pasw:
                         try:
                             pasw = config.as_map()["omero.windows.pass"]


### PR DESCRIPTION
This is the same as gh-589 but rebased onto develop.

---

This is a final round of changes to admin.py, only in the code executed on Windows.
This PR tackles the following issues:
1) Removal of the OMERO Windows service when incorrect password for the Log On as user provided,
2) Add option (`-w`) to specify the password for the Log On as user on the command line and not only through a config value,
3) Remove the dependency on sc.exe - all service interactions are now done by Win32 API calls,
4) Add output messages informing the user about the startup status.

To test:
- Deploy OMERO on Windows,
- Create a separate user account,
- Verify that the OMERO.master service gets created with proper credentials when using either the CLI options (`-u` and `-w`) or the config values,
- Verify that the service is removed when an incorrect password is provided for the separate user account.

Relevant doc PR: https://github.com/openmicroscopy/ome-documentation/pull/198
