### PR TITLE
Pyramid reader: do not override initFile (rebased onto develop)

### DIFF
--- a/components/romio/src/ome/io/bioformats/OmeroPixelsPyramidReader.java
+++ b/components/romio/src/ome/io/bioformats/OmeroPixelsPyramidReader.java
@@ -102,40 +102,6 @@ public class OmeroPixelsPyramidReader extends MinimalTiffReader {
         super.close();
     }
 
-    /* (non-Javadoc)
-     * @see loci.formats.in.MinimalTiffReader#initFile(java.lang.String)
-     */
-    @Override
-    protected void initFile(String id) throws FormatException, IOException
-    {
-        super.initFile(id);
-        IFDList newIFDs = new IFDList();
-        for (IFD ifd : ifds)
-        {
-            Integer resolutionLevel = (Integer) 
-                    ifd.get(OmeroPixelsPyramidWriter.IFD_TAG_SERIES);
-            Integer imageNumber = (Integer)
-                    ifd.get(OmeroPixelsPyramidWriter.IFD_TAG_PLANE_NUMBER);
-            if (resolutionLevel != null)
-            {
-                subResolutionIFDs.get(imageNumber).set(resolutionLevel, ifd);
-                for (CoreMetadata coreMetadata : core)
-                {
-                    coreMetadata.sizeT--;
-                    coreMetadata.imageCount--;
-                }
-            }
-            else
-            {
-                newIFDs.add(ifd);
-            }
-        }
-        ifds = newIFDs;
-    }
-
-    /* (non-Javadoc)
-     * @see loci.formats.in.MinimalTiffReader#setResolutionLevel(loci.formats.tiff.IFD)
-     */
     @Override
     protected void setResolutionLevel(IFD ifd)
     {


### PR DESCRIPTION
This is the same as gh-478 but rebased onto develop.

---

With the new subresolutions support, MinimalTiffReader's initFile
implementation performs all of the necessary steps for dealing with
pyramid files.

This PR plus https://github.com/openmicroscopy/bioformats/pull/211 should resolve ticket #9871.
