### PR TITLE
render_fs_speed_10183 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webtest/templates/webtest/demo_viewers/render_performance.html
+++ b/components/tools/OmeroWeb/omeroweb/webtest/templates/webtest/demo_viewers/render_performance.html
@@ -1,0 +1,111 @@
+{% extends "webgateway/base/base_main.html" %}
+
+{% block title %}Render Performance{% endblock %}
+
+
+{% block link %}
+{% endblock %}
+
+{% block script %}
+{{ block.super }}
+
+
+<script>
+$(document).ready(function() {
+
+    var $planes = $("img.plane"),
+        $planeCount = $("#planeCount"),
+        $planesLoaded = $("#planesLoaded"),
+        $duration = $("#duration"),
+        $secsPerPlane = $("#secsPerPlane"),
+        planeCount = $planes.length,
+        loadedCount = 0,
+        start = 0,
+        duration = 0,
+        perPlane = 0;
+
+    $planeCount.text(planeCount);
+
+    var initLoadCallbacks = function() {
+        // When a plane has loaded, update count and time
+        $planes.load(function() {
+            loadedCount += 1;
+            $planesLoaded.text(loadedCount);
+            duration = (Date.now() - start) / 1000;
+            perPlane = duration / loadedCount;
+            $duration.text(duration.toPrecision(3));
+            $secsPerPlane.text(perPlane.toPrecision(3));
+        });
+    }
+
+
+    $("#loadSequential").click(function() {
+
+        initLoadCallbacks();
+
+        $planes.load(function() {
+            var thisId = +$(this).attr('id');
+            thisId += 1;
+            $nextPlane = $("#" + thisId);
+            // load the next Plane
+            var src = $nextPlane.attr('href');
+            $nextPlane.attr('src', src);
+        });
+
+        start = Date.now();
+
+        // Kick off loading of first image.
+        $("#0").attr('src', $("#0").attr('href'));
+    });
+
+
+    $("#loadAll").click(function(){
+
+        initLoadCallbacks();
+
+        start = Date.now();
+
+        // Set the src to start all planes loading
+        $planes.each(function(){
+            var src = $(this).attr('href');
+            $(this).attr('src', src);
+        })
+    });
+
+});
+</script>
+
+<style type="text/css">
+    img.plane {
+        max-width: 50px;
+        max-height: 50px
+    }
+</style>
+{% endblock %}
+
+
+
+{% block body %}
+
+Usage: Refresh page, then click button below to EITHER load all images at once OR load sequentially. 
+
+<hr />
+
+<button id="loadAll" value="Load All">Load All</button>
+<button id="loadSequential" value="Load Sequential">Load Sequentially</button>
+
+Planes Loaded: <span id="planesLoaded">0</span> / <span id="planeCount">0</span> |
+Duration: <span id="duration">0</span> secs |
+Per Plane: <span id="secsPerPlane">0</span> secs.
+
+<hr />
+
+{% for zct in zctList %}
+
+        <img id="{{ forloop.counter0 }}" class="plane"
+            src="{% url webgateway.views.render_image image.id 0 0 %}?c=0"
+            href="{% url webgateway.views.render_image image.id zct.z zct.t %}?c={{ zct.c }}"/>
+
+{% endfor %}
+
+{% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webtest/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webtest/urls.py
@@ -50,4 +50,7 @@ urlpatterns = patterns('django.views.generic.simple',
     url(r'^webclient_templates/(?P<base_template>[a-z0-9_]+)/', views.webclient_templates, name='webclient_templates'),
     
     url( r'^img_detail/(?:(?P<iid>[0-9]+)/)?$', views.image_viewer, name="webtest_image_viewer"),
+
+    # Test the speed of rendering all planes in an image (E.g. to compare FS)
+    url( r'^render_performance/(?P<imageId>[0-9]+)/', views.render_performance, name='webtest_render_performance' ),
 )

--- a/components/tools/OmeroWeb/omeroweb/webtest/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webtest/views.py
@@ -584,3 +584,14 @@ def stack_preview (request, imageId, conn=None, **kwargs):
     sizeZ = image.getSizeZ()
     z_indexes = [0, int(sizeZ*0.25), int(sizeZ*0.5), int(sizeZ*0.75), sizeZ-1]
     return render_to_response('webtest/stack_preview.html', {'imageId':imageId, 'image_name':image_name, 'z_indexes':z_indexes})
+
+@login_required()
+def render_performance (request, imageId, conn=None, **kwargs):
+    """ Test rendering performance for all planes in an image """
+    image = conn.getObject("Image", imageId)
+    zctList = []
+    for z in range(image.getSizeZ()):
+        for c in range(image.getSizeC()):
+            for t in range(image.getSizeT()):
+                zctList.append({'z':z, 'c':c+1, 't':t})
+    return render_to_response('webtest/demo_viewers/render_performance.html', {'image':image, 'zctList':zctList})


### PR DESCRIPTION
This is the same as gh-616 but rebased onto develop.

---

Simple page in /webtest/ to look at performance for rendering every plane in an Image.

Once this is in dev_4_4 and develop, we can use it to compare speed of rendering in FS.

To test: go to /webtest/render_performance/<imageId>/ and click button. Refresh to repeat.
