### PR TITLE
Remove Bio-Formats common directory from eclipse template

### DIFF
--- a/.classpath-template
+++ b/.classpath-template
@@ -32,6 +32,8 @@
 	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/ome-xml/test"/>
 	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/scifio/src"/>
 	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/scifio/test"/>
+	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/scifio-devel/src"/>
+	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/scifio-devel/test"/>
 	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/stubs/lwf-stubs/src"/>
 	<classpathentry kind="src" output="target/eclipse-bioformats" path="components/bioformats/components/test-suite/src"/>
 	<!-- Broken.


### PR DESCRIPTION
These directories are no longer present, so that a fresh build
or ./build.py build-dev will end with Eclipse having build errors
(missing directories)

/cc @melissalinkert
