### PR TITLE
Handle correctly duplicate thumbnails (see #10225) (rebased onto dev_4_4)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -76,6 +76,7 @@ import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StatusLabel;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import pojos.DataObject;
@@ -328,6 +329,20 @@ public class FileImportComponent
 	
 	/** Flag indicating the the user is member of one group only.*/
 	private boolean singleGroup;
+	
+	/**
+	 * Logs the exception.
+	 * 
+	 * @param e The error to log.
+	 */
+	private void logException(Exception e)
+	{
+		String s = "Error during import: ";
+        LogMessage msg = new LogMessage();
+        msg.print(s);
+        msg.print(e);
+		ImporterAgent.getRegistry().getLogger().warn(this, msg);
+	}
 	
 	/** Displays the error box at the specified location.
 	 * 
@@ -808,7 +823,7 @@ public class FileImportComponent
 	 * @return See above.
 	 */
 	public StatusLabel getStatus() { return statusLabel; }
-
+	
 	/**
 	 * Sets the result of the import.
 	 * 
@@ -829,6 +844,7 @@ public class FileImportComponent
 			try {
 				img.getDefaultPixels();
 			} catch (Exception e) {
+				logException(e);
 				error = e;
 				toReImport = true;
 			}
@@ -908,6 +924,7 @@ public class FileImportComponent
 				errorButton.setVisible(false);
 				errorBox.setVisible(false);
 				groupLabel.setVisible(!singleGroup);
+				logException(thumbnail.getError());
 			}
 		} else if (image instanceof PlateData) {
 			imageLabel.setData((PlateData) image);
@@ -992,6 +1009,7 @@ public class FileImportComponent
 					errorButton.setToolTipText(
 							UIUtilities.formatExceptionForToolTip(e));
 					exception = e;
+					logException(e);
 					errorButton.setVisible(false);
 					cancelButton.setVisible(false);
 					if (e instanceof ImportException) {


### PR DESCRIPTION
This is the same as gh-631 but rebased onto dev_4_4.

---

First test the ticket against develop, the PR should then be rebased onto dev_4_4 (hard to trigger there)

To test 
- select the folder `al3d`
- Click import, 2 images should show up in the import queue

Follow 2 thumbnails before and after the fix
![10225_before](https://f.cloud.github.com/assets/1022396/79262/960ffa9e-61a8-11e2-8e5e-b7d7894820d5.png)
![10225_after](https://f.cloud.github.com/assets/1022396/79263/99e1cd78-61a8-11e2-9ac2-968df1e26226.png)
