### PR TITLE
Add a script for running all of the necessary xsd-fu commands

### DIFF
--- a/components/xsd-fu/xsd-fu-generate
+++ b/components/xsd-fu/xsd-fu-generate
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# stop if BF_HOME is not defined
+
+if [ -z $BF_HOME ]; then
+  echo "The 'BF_HOME' environment variable must be set to the location of a clone of:
+  
+  git://github.com/openmicroscopy/bioformats.git"
+  exit 1;
+fi
+
+# define the path to the latest schemas
+
+export SCHEMA_VERSION=2012-06
+export SCHEMA_PATH=../specification/Released-Schema/$SCHEMA_VERSION/V1/
+#export SCHEMA_PATH=../specification/InProgress/
+export OME=$SCHEMA_PATH/ome.xsd
+export BINARY_FILE=$SCHEMA_PATH/BinaryFile.xsd
+export ROI=$SCHEMA_PATH/ROI.xsd
+export SA=$SCHEMA_PATH/SA.xsd
+export SPW=$SCHEMA_PATH/SPW.xsd
+
+# generate the OME model object classes
+./xsd-fu java_classes -p 'ome.xml.model' -o $BF_HOME/components/ome-xml/src/ome/xml/model/ $OME $BINARY_FILE $ROI $SA $SPW
+
+# generate the OME model enumeration classes
+
+./xsd-fu enum_types -p 'ome.xml.model.enums' -o $BF_HOME/components/ome-xml/src/ome/xml/model/enums/ $OME $BINARY_FILE $ROI $SA $SPW
+
+# generate the handlers for the OME model enumeration classes
+
+./xsd-fu enum_handlers -p 'ome.xml.model.enums.handlers' -o $BF_HOME/components/ome-xml/src/ome/xml/model/enums/handlers/ $OME $BINARY_FILE $ROI $SA $SPW
+
+# generate the metadata interfaces
+
+./xsd-fu metadata_store $OME $BINARY_FILE $ROI $SA $SPW
+./xsd-fu metadata_retrieve $OME $BINARY_FILE $ROI $SA $SPW
+
+# generate the metadata implementations
+
+./xsd-fu omexml_metadata $OME $BINARY_FILE $ROI $SA $SPW
+./xsd-fu metadata_aggregate $OME $BINARY_FILE $ROI $SA $SPW
+./xsd-fu dummy_metadata $OME $BINARY_FILE $ROI $SA $SPW
+./xsd-fu filter_metadata $OME $BINARY_FILE $ROI $SA $SPW
+
+# move resulting classes to the correct locations
+
+mv MetadataStore.java MetadataRetrieve.java AggregateMetadata.java DummyMetadata.java FilterMetadata.java $BF_HOME/components/scifio/src/loci/formats/meta/
+mv OMEXMLMetadataImpl.java $BF_HOME/components/scifio/src/loci/formats/ome/


### PR DESCRIPTION
The BF_HOME environment variable must be set first; this should be the
full path to a working clone of bioformats.git.  Then it is just a
matter of running './xsd-fu-generate', as all of the resulting files
will be copied to the correct location in bioformats.git.
