### PR TITLE
Calculate hash digests on a per plane basis (Fixes #10073)

### DIFF
--- a/components/romio/src/ome/io/nio/RomioPixelBuffer.java
+++ b/components/romio/src/ome/io/nio/RomioPixelBuffer.java
@@ -760,12 +760,16 @@ public class RomioPixelBuffer extends AbstractBuffer implements PixelBuffer {
         }
 
         for (int t = 0; t < getSizeT(); t++) {
-            try {
-                ByteBuffer buffer = getTimepoint(t).getData();
-                md.update(buffer);
-            } catch (DimensionsOutOfBoundsException e) {
-                // This better not happen. :)
-                throw new RuntimeException(e);
+            for (int c = 0; c < getSizeC(); c++) {
+                for (int z = 0; z < getSizeZ(); z++) {
+                    try {
+                        ByteBuffer buffer = getPlane(z, c, t).getData();
+                        md.update(buffer);
+                    } catch (DimensionsOutOfBoundsException e) {
+                        // This better not happen. :)
+                        throw new RuntimeException(e);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
There are some edge cases, such as electron microscopy, where the stack
size is huge.  Often 1000's of planes, which causes the byte size of a
timepoint to be larger than 2.1GB.  As the hash digest algoritms we use
are CPU limited anyway there is very little justification for reading
the entire timepoint anyway.  Calculating it on a per plane basis is
much safer and should have no performance implications at all.

To test we need to import a file with a stack size <2.1GB and a file with a stack size >2.1GB. It would also be a good idea to compare the import performance of the former before and after.
