### PR TITLE
Fix for crash when user only has 1 group

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -674,15 +674,17 @@ class ImporterComponent
 	{
 		Collection<GroupData> m = loadGroups();
 
-		Iterator i = m.iterator();
+		if (m == null) {
+			ExperimenterData exp = ImporterAgent.getUserDetails();
+			return exp.getDefaultGroup();
+		}
 
 		long id = model.getGroupId();
-		
+
 		for (GroupData group : m) {
 			if (group.getId() == id)
 				return group;
 		}
-		
 		ExperimenterData exp = ImporterAgent.getUserDetails();
 		return exp.getDefaultGroup();
 	}


### PR DESCRIPTION
@jburel The code in ImporterComponent was not consistent with the changes made in PR #536.

This resolves the issue and patches the bug caused when a user is only in 1 group.
