### PR TITLE
Install scc and merge PRs opened against homebrew-alt

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -50,6 +50,13 @@ bin/brew update
 
 export PATH=$(bin/brew --prefix)/bin:$PATH
 
+# Merge hombrew-alt PRs
+bin/brew tap $OMERO_ALT || echo "Already tapped"
+bin/brew install scc
+cd Library/Taps/${OMERO_ALT/\//-}
+scc merge master
+cd $BREW_DIR
+
 # Install homebrew dependencies
 source "$JOB_WS/docs/install/homebrew/omero_homebrew.sh"
 


### PR DESCRIPTION
This PR should allow the OMERO-homebrew-stable job to simultaneously test PRs opened against openmicroscopy/openmicroscopy and ome/homebrew-alt.
See ome/homebrew-alt#20
