### PR TITLE
Thumbnails import

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -2133,8 +2133,8 @@ public class OMEROMetadataStoreClient
             {
                 pixels.unloadCollections();
                 pixels.unloadDetails();
-                unloadedImage = new ImageI(pixels.getImage().getId(), false);
-                pixels.setImage(unloadedImage);
+                //unloadedImage = new ImageI(pixels.getImage().getId(), false);
+                //pixels.setImage(unloadedImage);
                 objectList.add(pixels);
             }
             iUpdate.saveArray(objectList);

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -399,7 +399,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             store.updatePixels(pixList);
         }
 
-        if (reader.isMinMaxSet() == false)
+        if (!reader.isMinMaxSet())
         {
             store.populateMinMax();
         }


### PR DESCRIPTION
Review the import sequence. 
See https://trac.openmicroscopy.org.uk/ome/ticket/10112

What to do:
- Go to the importer
- Select al3d folder, add it to the queue and click import
- 2 images should be added to the importer tab
- first one import and display
- Second one (.xml) import and now display a black image (expected). Before the change a "message" cannot create thumbnail was displayed.
