### PR TITLE
Fix getLabel() bug from channel_name_tweaks PR

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5499,7 +5499,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         rv = lc.name
         if rv is None or len(rv.strip())==0:
             rv = lc.emissionWave
-        if rv is None or len(rv.strip())==0:
+        if rv is None or len(unicode(rv).strip())==0:
             rv = self._idx
         return unicode(rv)
 


### PR DESCRIPTION
Critical fix for 4.4.6

To test:
- Choose an image with no channel names, but _with_ channel wavelengths. (Can also choose an image with channel excitation wavelength and save a new name as empty string).
- This should still display in the right panel. 
