### PR TITLE
Fix download original file in web. #10266

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3913,9 +3913,12 @@ class _OriginalFileWrapper (BlitzObjectWrapper):
         @return:    Data from file in chunks
         @rtype:     Generator
         """
+        group_id = self.getDetails().group.id.val
+        ctx = self._conn.SERVICE_OPTS.copy()
+        ctx.setOmeroGroup(group_id)     # Shouldn't be needed, but '-1' causes a bug in FS
 
         store = self._conn.createRawFileStore()
-        store.setFileId(self._obj.id.val, self._conn.SERVICE_OPTS)
+        store.setFileId(self._obj.id.val, ctx)
         size = self._obj.size.val
         if size <= buf:
             yield store.read(0,long(size))


### PR DESCRIPTION
This is a work-around for the fact that `rawFileStore.setFileId(id,{'omero.group':'-1')` is causing a stack trace (see ticket). 

NB: This may be the same issue as stderr and stdout not being returned from Scripts (https://trac.openmicroscopy.org.uk/ome/ticket/10216). 
