### PR TITLE
License updates

### DIFF
--- a/components/xsd-fu/templates/AggregateMetadata.template
+++ b/components/xsd-fu/templates/AggregateMetadata.template
@@ -180,7 +180,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/Class.template
+++ b/components/xsd-fu/templates/Class.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/DummyMetadata.template
+++ b/components/xsd-fu/templates/DummyMetadata.template
@@ -103,7 +103,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/Enum.template
+++ b/components/xsd-fu/templates/Enum.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/EnumHandler.template
+++ b/components/xsd-fu/templates/EnumHandler.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/FilterMetadata.template
+++ b/components/xsd-fu/templates/FilterMetadata.template
@@ -95,7 +95,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/MetadataRetrieve.template
+++ b/components/xsd-fu/templates/MetadataRetrieve.template
@@ -48,7 +48,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/MetadataStore.template
+++ b/components/xsd-fu/templates/MetadataStore.template
@@ -48,7 +48,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/OMEXMLMetadataImpl.template
+++ b/components/xsd-fu/templates/OMEXMLMetadataImpl.template
@@ -217,7 +217,7 @@ ${customContent[obj.name][prop.name]}
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/Pojo.template
+++ b/components/xsd-fu/templates/Pojo.template
@@ -13,7 +13,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates/SPW.template
+++ b/components/xsd-fu/templates/SPW.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2012 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2013 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee


### PR DESCRIPTION
This updates the xsd-fu template license headers to include 2013. It goes hand in hand with [Bio-Formats PR #356](https://github.com/openmicroscopy/bioformats/pull/356).
