### PR TITLE
Replace accented character in unknown charset with unicode equivalent (#10251)

### DIFF
--- a/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
@@ -402,9 +402,9 @@ public class ManagedRepositoryITest extends MockObjectTestCase {
 
     @Test
     public void testExpandTemplateUnknown() {
-        String expected = "%bj\u00F6rk%";
+        String expected = "%björk%";
         newEventContext();
-        String actual = this.tmri.expandTemplate("%bj\u00F6rk%", curr);
+        String actual = this.tmri.expandTemplate("%björk%", curr);
         Assert.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
To test: find a system where `./build.py build-all-dev` fails in the test-compile target due to a charset encoding error. This should fix it.
