### PR TITLE
Make sure the reference to the connector is removed (see #10333)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -8444,6 +8444,7 @@ class OMEROGateway
 		if (c == null) return;
 		isNetworkUp();
 		try {
+			connectors.remove(c);
 			c.close(networkup);
 		} catch (Throwable e) {
 			new Exception("Cannot close the connector", e);


### PR DESCRIPTION
This PR fixes the second part of https://trac.openmicroscopy.org.uk/ome/ticket/10333
