### PR TITLE
Blitz getThumbnail() uses cached thumbs (not Direct) if possible

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6233,12 +6233,12 @@ class _ImageWrapper (BlitzObjectWrapper):
                 return self._getProjectedThumbnail(size, pos)
             if len(size) == 1:
                 if pos is None:
-                    thumb = tb.getThumbnailByLongestSideDirect
+                    thumb = tb.getThumbnailByLongestSide
                 else:
                     thumb = tb.getThumbnailForSectionByLongestSideDirect
             else:
                 if pos is None:
-                    thumb = tb.getThumbnailDirect
+                    thumb = tb.getThumbnail
                 else:
                     thumb = tb.getThumbnailForSectionDirect
             args = map(lambda x: rint(x), size)


### PR DESCRIPTION
Should improve the speed of thumbs, since we use cached thumbs if possible. 

Web should be able to use thumbs generated by Insight (and vice versa).

Therefore, shouldn't see log statements associated with BF.setId() etc when thumbs already have been generated.
