### PR TITLE
Fix hanging of diagnostics on Windows (see #10155) (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -791,7 +791,6 @@ OMERO Diagnostics %s
                 applications.sort()
                 for s in applications:
                     p2 = self.ctx.popen(self._cmd("-e", "application describe %s" % s)) # popen
-                    rv2 = p2.wait()
                     io2 = p2.communicate()
                     if io2[1]:
                         self.ctx.err(io2[1].strip())


### PR DESCRIPTION
This is the same as gh-715 but rebased onto develop.

---

This PR fixes https://trac.openmicroscopy.org.uk/ome/ticket/10155. To test, deploy the server on Windows and verify that `bin\omero admin diagnostics` shows all the information and doesn't stop halfway.
