### PR TITLE
Use MIASReader.parseMasks (Fix #10170)

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -622,26 +622,15 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             try
             {
                 MIASReader miasReader = (MIASReader) baseReader;
-                String currentFile = miasReader.getCurrentFile();
-                reader.close();
-                miasReader.setAutomaticallyParseMasks(true);
                 ServiceFactoryPrx sf = store.getServiceFactory();
                 OverlayMetadataStore s = new OverlayMetadataStore();
                 s.initialize(sf, pixelsList, plateIds);
-                reader.setMetadataStore(s);
-                miasReader.close();
-                miasReader.setAutomaticallyParseMasks(true);
-                miasReader.setId(currentFile);
+                miasReader.parseMasks(s);
                 s.complete();
             }
             catch (ServerError e)
             {
                 log.warn("Error while populating MIAS overlays.", e);
-            }
-            finally
-            {
-                reader.close();
-                reader.setMetadataStore(store);
             }
         }
     }


### PR DESCRIPTION
Make use of the newly added parseMasks method which doesn't require closing
and re-opening the reader. This commit needs:

openmicroscopy/bioformats@20308cee521787e9ecab341953f84c7e0d08a9b7

/cc @pwalczysko for Thursday's round of testing.
