### PR TITLE
Modify default Homebrew installation directory to /usr/local (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -60,7 +60,7 @@ cd $BREW_DIR
 rm -rf $(bin/brew --cache)
 
 # Install git if not already installed
-bin/brew list | grep git || bin/brew install git
+bin/brew list | grep "\bgit\b" || bin/brew install git
 
 # Update homebrew and run brew doctor
 bin/brew update


### PR DESCRIPTION
This is the same as gh-711 but rebased onto develop.

---

This PR should allow to fix regular failures in the OMERO-homebrew-stable job by using the default (and recommended) path
