### PR TITLE
Update AssumeNG version

### DIFF
--- a/components/blitz/test.xml
+++ b/components/blitz/test.xml
@@ -13,7 +13,7 @@
     <dependency name="blitz" rev="${omero.version}" changing="true"/>
     <dependency name="common-test" rev="${omero.version}" changing="true"/>
     <dependency org="omero" name="omero-icemock" rev="${versions.ice}"/>
-    <dependency org="bf-deps" name="assumeng" rev="1.2.3-jdk15"/>
+    <dependency org="bf-deps" name="assumeng" rev="1.2.3"/>
   </dependencies>
 </ivy-module>
 


### PR DESCRIPTION
This PR can be merged together with https://github.com/openmicroscopy/bioformats/pull/377. It updates the AssumeNG version in components/blitz/test.xml.

Nothing to test as long as the build isn't broken.
