### PR TITLE
Use Python 2.5/2.6 compatible syntax with bz2.BZ2File (#10403)

### DIFF
--- a/components/tools/OmeroPy/test/tablestest/backwards_compatibility.py
+++ b/components/tools/OmeroPy/test/tablestest/backwards_compatibility.py
@@ -49,8 +49,9 @@ class BackwardsCompatibilityTest(lib.ITest):
         file = os.path.join(dir, file)
 
         tmpf = tempfile.NamedTemporaryFile(delete=False)
-        with bz2.BZ2File(file) as bzf:
-            tmpf.write(bzf.read())
+        bzf = bz2.BZ2File(file)
+        tmpf.write(bzf.read())
+        bzf.close()
         tmpf.close()
 
         ofile = self.client.upload(


### PR DESCRIPTION
Make OMERO.tables integration tests compatible with Python 2.5 and 2.6:
https://github.com/openmicroscopy/openmicroscopy/pull/728#issuecomment-13545014

Testing: Run tests on a Python 2.5/2.6 system.

---

--rebased-from #728
