### PR TITLE
Unload ofile before linking (Fix #10216)

### DIFF
--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -411,7 +411,7 @@ class ProcessI(omero.grid.Process, omero.util.SimpleServant):
                 link.parent = omero.model.ParseJobI(rlong(jobid), False)
             else:
                 link.parent = omero.model.ScriptJobI(rlong(jobid), False)
-            link.child = ofile
+            link.child = ofile.proxy()
             client.getSession().getUpdateService().saveObject(link)
             self.status("Uploaded %s bytes of %s to %s" % (sz, filename, ofile.id.val))
         except:


### PR DESCRIPTION
Use an unlinked original file object (i.e. a proxy) for linking the stdout and
stderr. The files were previously being uploaded, just linked. This is likely
a result of the files being modified on save to calculate the sha1, but is not
directly an FS issue.

This also seems to fix the exception on batch export (see #10266),
though it's unclear why the two should be connected unless OMERO.web
was complaining about the stdout and/or stderr not being present.

/cc @will-moore, @pwalczysko
