### PR TITLE
Fix directory test when cleaning existing Homebrew taps (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -41,7 +41,7 @@ if [ -d "$BREW_DIR" ]; then
         rm -rf $BREW_DIR/Cellar $BREW_DIR/.git && bin/brew cleanup
     fi
 
-    if [-d "$BREW_DIR/Library/Taps"]
+    if [ -d "$BREW_DIR/Library/Taps" ]
     then
         echo "Cleaning Homebrew taps"
         rm -rf $BREW_DIR/Library/Taps


### PR DESCRIPTION
This is the same as gh-739 but rebased onto develop.

---

OMERO-homebrew-stable has been failing since the Homebrew taps folder was successfully cleaned and homebrew-alt PR weren't merged in. From the [console]((http://hudson.openmicroscopy.org.uk/view/2.%20Stable/job/OMERO-homebrew-stable/OSX=10.6.8/103/console) of #103

```
++ '[-d' '/usr/local/Library/Taps]'
docs/hudson/OMERO-homebrew-install.sh: line 44: [-d: command not found
+++ curl -fsSL https://raw.github.com/mxcl/homebrew/go
```

Commit e2e8271 should fix this `command not found` error.
