### PR TITLE
Fix public repository listFiles method that I broke with PR669.

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -154,7 +154,7 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
 
     public List<String> list(String path, Current __current) throws ServerError {
         List<OriginalFile> ofiles = listFiles(path, __current);
-        List<String> contents = new ArrayList<String>();
+        List<String> contents = new ArrayList<String>(ofiles.size());
         for (OriginalFile ofile : ofiles) {
             contents.add(ofile.getPath().getValue() + ofile.getName().getValue());
         }

--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -202,14 +202,25 @@ public class RepositoryDaoImpl implements RepositoryDao {
                      public List<ome.model.core.OriginalFile> doWork(Session session, ServiceFactory sf) {
 
                          final IQuery q = sf.getQueryService();
+                         final Long id;
 
-                         final Long id = getSqlAction().findRepoFile(repoUuid,
-                                 checked.getRelativePath(), checked.getName(),
-                                 null);
+                         if (checked.isRoot) {
+                             id = q.findByString(ome.model.core.OriginalFile.class,
+                                     "sha1", repoUuid).getId();
+                             
+                             if (id == null) {
+                                 throw new ome.conditions.SecurityViolation(
+                                         "No repository with UUID: " + repoUuid);
+                             }
+                         } else {
+                             id = getSqlAction().findRepoFile(repoUuid,
+                                     checked.getRelativePath(), checked.getName(),
+                                     null);
 
-                         if (id == null) {
-                             throw new ome.conditions.SecurityViolation(
-                                     "No such parent dir: " + checked);
+                             if (id == null) {
+                                 throw new ome.conditions.SecurityViolation(
+                                         "No such parent dir: " + checked);
+                             }
                          }
 
                          // Load parent directory to possibly cause


### PR DESCRIPTION
In #669 I broke `PublicRepositoryI.listFiles`. This attempts to fix it. Using the command-line interface to try getting a repository and listing the files would be a good test. @joshmoore will have some thoughts on testing too.
