### PR TITLE
Reuse microns string in image viewer information pane.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/InfoPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/InfoPane.java
@@ -35,6 +35,7 @@ import info.clearthought.layout.TableLayout;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import org.openmicroscopy.shoola.util.ui.UnitsObject;
 
 
 
@@ -56,7 +57,7 @@ class InfoPane
 {
 	
     /** String to represent the micron symbol. */
-    private static final String MICRONS = "(in µ)";
+    private static final String MICRONS = "(in " + UnitsObject.MICRONS + ")";
     
     /** Identifies the <code>SizeX</code> field. */
     private static final String SIZE_X = "Size X";


### PR DESCRIPTION
Rebase of last commit of #758 from develop to dev_4_4, arising from @jburel's comment.
