### PR TITLE
Fix FS moves (10380)

### DIFF
--- a/components/server/resources/ome/services/spec.xml
+++ b/components/server/resources/ome/services/spec.xml
@@ -297,7 +297,7 @@
         <constructor-arg>
             <list>
                 <value>/Dataset/DatasetImageLink;FORCE</value>
-                <value>/Image+Only;SOFT;/Dataset/DatasetImageLink</value>
+                <value>/Image+FS;SOFT;/Dataset/DatasetImageLink</value>
                 <value>/Dataset/DatasetAnnotationLink;FORCE</value>
                 <value>/Annotation;SOFT;/Dataset/DatasetAnnotationLink</value>
                 <value>/Dataset+Only</value>


### PR DESCRIPTION
Under FS, there are more links attached to an imported
Image, making every action on that Image more complicated.
Petr has outlined the behavior between Datasets and Images
in http://trac.openmicroscopy.org.uk/ome/ticket/10380 but
there may be similar issues under SPW.

NB: This is a work-in-progress due to the possible usability
issues of data moving unexpectedly.

/cc @pwalczysko @gusferguson @jburel @will-moore
