### PR TITLE
Fix Group list_users function to allow root id (0) to be parsed

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -212,7 +212,7 @@ More information is available at:
         uid_list = []
         for user in users:
             [uid, u] = self.find_user(a, user, fatal = False)
-            if uid:
+            if uid is not None:
                 uid_list.append(uid)
         if not uid_list:
             self.error_no_user_found(fatal = True)


### PR DESCRIPTION
This PR should be tested by running the CLI group subcommands

```
sbesson:dist sebastien$ bin/omero group adduser --id 3 root
Using session 43bcd30e-ec19-4c8d-93ed-40c9df9e9bf6 (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
Added 0 to group 3
sbesson:dist sebastien$ bin/omero group removeuser --id 3 0
Using session 43bcd30e-ec19-4c8d-93ed-40c9df9e9bf6 (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
Removed 0 from group 3
```
