### PR TITLE
Don't exclude 'system' from groups in drop-down

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -424,7 +424,7 @@ def load_template(request, menu, conn=None, url=None, **kwargs):
     request.session['user_id'] = user_id
 
     if conn.isAdmin():  # Admin can see all groups
-        myGroups = [g for g in conn.getObjects("ExperimenterGroup") if g.getName() not in ("system", "user", "guest")]
+        myGroups = [g for g in conn.getObjects("ExperimenterGroup") if g.getName() not in ("user", "guest")]
     else:
         myGroups = list(conn.getGroupsMemberOf())
     myGroups.sort(key=lambda x: x.getName().lower())


### PR DESCRIPTION
Fixes an annoying bug noticed by @pwalczysko today, where the 'system' group is not shown in the drop-down of groups & users in web. So you can't switch to see the data of yourself or other users in the 'system' group.

This has been the case since 4.4.0 - it's just not an issue you notice unless you have data in the 'system' group.
