### PR TITLE
fix #10399: correctly calculate row and column for wells

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
@@ -242,7 +242,7 @@ class WellsModel
 			boolean withThumbnails)
 	{
 		super(ctx);
-		if (wells == null) 
+		if (wells == null)
 			throw new IllegalArgumentException("No wells.");
 		this.withThumbnails = withThumbnails;
 		wellDimension = null;


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/10399

In testing, try different plates and see that the wells in the "map of the plate" correspond to the thumbnails visible in the data manager, and that the appropriate thumbnails have well name titles.
