### PR TITLE
Tables too many files 9996

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -543,8 +543,6 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
             self.logger.debug("Client session not found: %s" % idname)
             return False
 
-        return True
-
     def cleanup(self):
         """
         Decrements the counter on the held storage to allow it to


### PR DESCRIPTION
Fixes the following issues related to [9996](https://trac.openmicroscopy.org.uk/ome/ticket/9996):
- Table files not closed when session ends. If a client didn't call `table.close()` the file handle remained open indefinitely, now `TableI.check()` checks whether the session is still active and returns `False` so that it will be destroyed by `Resources.checkAll()`.
- `TableI` not destroyed after file closed. If a client called `table.close()` the file handle was closed but the `TableI` instance remained, as seen by enabling `DEBUG` logging and observing the regular `check()` calls from closed tables.

To test: open a load of tables until `Tables-0.log` contains a too many open files error, e.g.

```
n = 0
res = session.sharedResources()
while res.newTable(0, '/test.h5'):
        n += 1
        print n

```

And check how many files are open (`lsof +D /OMERO_DATA_DIR/Files`) a minute or two after either `client.closeSession()` is called or the session times out .

Needs reviewing by someone familiar with client/server session handling.
