### PR TITLE
Fix omero.client classpath error (see #10487) (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -57,6 +57,7 @@
             <fileset dir="${common.comp}/target/classes">
                 <include name="ome/system/UpgradeCheck.class"/>
                 <include name="ome/system/OmeroContext.class"/>
+                <include name="ome/util/checksum/*.class"/>
             </fileset>
             <fileset dir="${model.comp}/target/classes">
                 <include name="ome/model/**/*.class"/>
@@ -104,6 +105,7 @@
                 <include name="tiny*dv"/>
                 <include name="test.bmp"/>
                 <include name="test.jpg"/>
+                <include name="test.txt"/>
             </patternset>
         </unjar>
     </target>


### PR DESCRIPTION
This is the same as gh-805 but rebased onto develop.

---

This PR fixes http://trac.openmicroscopy.org.uk/ome/ticket/10487. To test, download the OMERO.matlab zip file and try using it in Matlab. @sbesson already reported successful preliminary tests.
