### PR TITLE
Remove RELEASE-VERSION from docs/install/VM (Fix #9637)

### DIFF
--- a/docs/install/VM/README.md
+++ b/docs/install/VM/README.md
@@ -34,21 +34,15 @@ virtual machine.
 	
 	The OMERO.VM script will look in these locations for the VDI to kick start the VM building process.
 
-4. *OPTIONAL* In [setup_omero.sh](setup_omero.sh) you can define whether you wish to build OMERO from source, use the most recent QA build or use the release build by setting the `TARGET` variable. Valid values for `TARGET` are QA or SRC or RELEASE. Anything else will cause the latest QA build from the Hudson job to be used by default. To specify a different build you can adjust the following variables, `DL_LOC` and `DL_ARCHIVE`:	
-   - `DL_LOC` stores the URL from which to retrieve our build e.g. `DL_LOC="http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/artifact/"`
-   - `DL_ARCHIVE` stores the name of the zip archive to retrieve from `DL_LOC` because the build process could deploy many archives to that location and we must specify the particular one that we want to retrieve e.g. `DL_ARCHIVE="OMERO.server-4.3.0-DEV-bfe035dd.zip"`
-
-	If using a release build then you can also alter the `RELEASE_ARCHIVE` variable to reflect the build of OMERO.server that you want to install. 
-
-7. Run the VM build script to build a VM named omero-vm:
+4. Run the VM build script to build a VM named omero-vm:
 
 	```
 	$ bash omerovm.sh omero-vm
 	```
 
-8. This should take roughly 8-15 minutes to complete depending upon your machine.
+5. This should take roughly 8-15 minutes to complete depending upon your machine.
 
-9. When you see the message "All Done!" you should be able to either:
+6. When you see the message "All Done!" you should be able to either:
  	1. Start an OMERO client such as OMERO.insight and connect to your VM
  	2. SSH into your VM using the IP address printed at the end of the build script
 	3. Use the utility script connect.sh to open a shell into your vm named omero-vm:

--- a/docs/install/VM/driver.sh
+++ b/docs/install/VM/driver.sh
@@ -3,8 +3,6 @@
 set -e -u -x
 
 PASSWORD=${PASSWORD:-"omero"}
-TARGET=${1:-"QA"}
-export TARGET
 
 OMERO_PATH="/home/omero/OMERO.server"
 OMERO_BIN=$OMERO_PATH/bin

--- a/docs/install/VM/omerovm.sh
+++ b/docs/install/VM/omerovm.sh
@@ -2,7 +2,6 @@
 
 export VMNAME=${VMNAME:-"$1"}
 export VMNAME=${VMNAME:-"omerovm"}
-export TARGET=${2:-"QA"}
 
 export MEMORY=${MEMORY:-"1024"}
 export SSH_PF=${SSH_PF:-"2222"}
@@ -10,7 +9,6 @@ export OMERO_PORT=${OMERO_PORT:-"4063"}
 export OMERO_PF=${OMERO_PF:-"4063"}
 export OMEROS_PORT=${OMEROS_PORT:-"4064"}
 export OMEROS_PF=${OMEROS_PF:-"4064"}
-export RELEASE_VERSION="4.3.4"
 
 set -e
 set -u
@@ -55,7 +53,7 @@ function installvm ()
   $SCP virtualbox_fix.sh omero@localhost:~/
   $SCP nginx-control.sh omero@localhost:~/
 	echo "ssh : exec driver.sh"
-	$SSH omero@localhost "bash /home/omero/driver.sh ${TARGET}"
+	$SSH omero@localhost "bash /home/omero/driver.sh"
 	sleep 10
 	
 	echo "ALL DONE!"
@@ -184,9 +182,5 @@ fi
 echo "Network up after $ATTEMPTS tries"
 installvm
 
-if [ "$TARGET" == "QA" ]; then
-  EXPORTVMNAME="${VMNAME}-latest-build"
-else
-  EXPORTVMNAME="${VMNAME}-${RELEASE_VERSION}"
-fi
+EXPORTVMNAME="${VMNAME}-latest-build"
 bash export_ova.sh ${VMNAME} ${EXPORTVMNAME}

--- a/docs/install/VM/setup_omero.sh
+++ b/docs/install/VM/setup_omero.sh
@@ -3,7 +3,6 @@
 set -e -u -x
 
 PGPASSWORD=${PGPASSWORD:-"omero"}
-TARGET=${TARGET:-"QA"} # NB. Valid args are {QA | RELEASE}
 URL_RELEASE="http://cvs.openmicroscopy.org.uk/snapshots/omero/"
 RELEASE_ARCHIVE="OMERO.server-Beta-4.3.4.zip"
 RELEASE_FOLDER=${RELEASE_ARCHIVE%.zip}
@@ -13,32 +12,25 @@ OMERO_PATH="/home/omero/OMERO.server"
 OMERO_BIN=$OMERO_PATH/bin
 INSTALL_FOLDER="OMERO.server"
 
-if [[ "$TARGET" == "RELEASE" ]]; then
-	echo "Grabbing current stable release of OMERO.server: $RELEASE_ARCHIVE"
-	wget -q $URL_RELEASE$RELEASE_ARCHIVE
-	unzip $RELEASE_ARCHIVE
-	mv $RELEASE_FOLDER $INSTALL_FOLDER
+echo "Grabbing last successful QA Build of OMERO.server"
+DL_ARCHIVE=""
+if [ "x$DL_ARCHIVE" == "x" ]; then
+
+    URL=`wget -q -O- "http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/api/xml?xpath=/freeStyleBuild/url/text()"`
+    FILE=`wget -q -O- "http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/api/xml?xpath=//relativePath[contains(.,'server')]/text()"`
+
+    wget -q "$URL"artifact/$FILE
+
+    DL_ARCHIVE=`basename $FILE`
+    DL_FOLDER=${DL_ARCHIVE%.zip}
 else
-	echo "Grabbing last successful QA Build of OMERO.server"
-    DL_ARCHIVE=""
-    if [ "x$DL_ARCHIVE" == "x" ]; then
+    DL_LOC="http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/artifact/"
+    DL_FOLDER=${DL_ARCHIVE%.zip}
 
-    	URL=`wget -q -O- "http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/api/xml?xpath=/freeStyleBuild/url/text()"`
-    	FILE=`wget -q -O- "http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/api/xml?xpath=//relativePath[contains(.,'server')]/text()"`
-
-    	wget -q "$URL"artifact/$FILE
-
-        DL_ARCHIVE=`basename $FILE`
-    	DL_FOLDER=${DL_ARCHIVE%.zip}
-    else
-        DL_LOC="http://hudson.openmicroscopy.org.uk/job/OMERO-stable/lastSuccessfulBuild/artifact/"
-        DL_FOLDER=${DL_ARCHIVE%.zip}
-    
-    	wget $DL_LOC$DL_ARCHIVE
-    fi
-    unzip $DL_ARCHIVE
-    mv $DL_FOLDER $INSTALL_FOLDER
+    wget $DL_LOC$DL_ARCHIVE
 fi
+unzip $DL_ARCHIVE
+mv $DL_FOLDER $INSTALL_FOLDER
 
 mkdir OMERO.data
 


### PR DESCRIPTION
The "RELEASE" target type has been untested for sometime. Instead the "QA"
type has always been built and then renamed on release. For the moment, we'll
simplify the configuration and only use "QA" builds.

---

--rebased-to #942 
