### PR TITLE
try/finally after store.attach to close sessions (See 9331)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -413,10 +413,13 @@ class SessionsControl(BaseControl):
                     try:
                         if props: port = props.get("omero.port", port)
                         rv = store.attach(server, name, uuid)
-                        grp = rv[0].sf.getAdminService().getEventContext().groupName
-                        started = rv[0].sf.getSessionService().getSession(uuid).started.val
-                        started = time.ctime(started / 1000.0)
-                        rv[0].closeSession()
+                        try:
+                            grp = rv[0].sf.getAdminService().getEventContext().groupName
+                            started = rv[0].sf.getSessionService().getSession(uuid).started.val
+                            started = time.ctime(started / 1000.0)
+                        finally:
+                            if rv:
+                                rv[0].closeSession()
                     except PermissionDeniedException, pde:
                         msg = pde.reason
                     except exceptions.Exception, e:


### PR DESCRIPTION
See ticket for an example of an attempt to reproduce. As long
as `bin/omero sessions list` still functions normally, this
change can't really cause any issues, and should hopefully
prevent the issue in 9331.
