### PR TITLE
Fix spelling mistake when copy/paste to another group (see #10263)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2009,7 +2009,7 @@ class TreeViewerComponent
 			}
 		}
 		MessageBox box = new MessageBox(view, "Change group", "Are you " +
-		"you want to move the selected items to another group?");
+		"sure you want to move the selected items to another group?");
 		if (box.centerMsgBox() != MessageBox.YES_OPTION) return;
 		//if we are here moving data.
 		i = elements.keySet().iterator();


### PR DESCRIPTION
Fix spelling mistake 
see https://trac.openmicroscopy.org.uk/ome/ticket/10263

To Test
- Copy an dataset for example
- Paste it to another group.
