### PR TITLE
group rename

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
@@ -370,6 +370,10 @@ class GroupProfile
 		if (namePane == null) return false;
 		String v = namePane.getText();
 		v = v.trim();
+		if (v.length() == 0) {
+			saveButton.setEnabled(false);
+			return false;
+		}
 		if (!ref.getName().equals(v)) {
 			if (saveButton != null) saveButton.setEnabled(true);
 			return true;


### PR DESCRIPTION
Do not allow to enter empty string for group's name see
https://trac.openmicroscopy.org.uk/ome/ticket/9911
