### PR TITLE
Homebrew installation: virtualenv URL (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -85,10 +85,10 @@ else
 fi
 
 # Install scc tools
+bin/pip install -U scc || echo "scc installed"
+
+# Tap ome-alt library
 bin/brew tap $OMERO_ALT || echo "Already tapped"
-bin/brew install scc
-bin/pip install PyGithub || echo "PyGithub installed"
-bin/pip install argparse || echo "argparse installed"
 
 # Merge homebrew-alt PRs
 cd Library/Taps/${OMERO_ALT/\//-}


### PR DESCRIPTION
This is the same as gh-854 but rebased onto develop.

---

This PR should fix an unbound variable error in [OMERO-homebrew-stable#134](http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-stable/OSX=10.7.5/134/console).
- initialise VENV_URL to the list of variables
- use pip installation instead of Homebrew installation for sec
