### PR TITLE
View the imported image using click (see #9753)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1486,6 +1486,12 @@ public class FileImportComponent
 			noContainer = true;
 		} else if (StatusLabel.DEBUG_TEXT_PROPERTY.equals(name)) {
 			firePropertyChange(name, evt.getOldValue(), evt.getNewValue());
+		} else if (ThumbnailLabel.VIEW_IMAGE_PROPERTY.equals(name)) {
+			//use the group
+			SecurityContext ctx = new SecurityContext(group.getId());
+			EventBus bus = ImporterAgent.getRegistry().getEventBus();
+			ImageData img = (ImageData) evt.getNewValue();
+			bus.post(new ViewImage(ctx, new ViewImageObject(img), null));
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/ThumbnailLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/ThumbnailLabel.java
@@ -39,13 +39,9 @@ import javax.swing.border.Border;
 //Third-party libraries
 
 //Application-internal dependencies
-import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
-import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
-import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.util.ui.RollOverThumbnailManager;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
-import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import pojos.ImageData;
 import pojos.PlateData;
@@ -70,6 +66,9 @@ class ThumbnailLabel
 	/** Bound property indicating to browse the specified plate. */
 	static final String BROWSE_PLATE_PROPERTY = "browsePlate";
 	
+	/** Bound property indicating to view the image. */
+	static final String VIEW_IMAGE_PROPERTY = "viewImage";
+	
 	/** The border of the thumbnail label. */
 	private static final Border	LABEL_BORDER = 
 							BorderFactory.createLineBorder(Color.black, 1);
@@ -86,20 +85,16 @@ class ThumbnailLabel
 	/** Posts an event to view the object. */
 	private void view()
 	{
-		/* TODO: review
-		EventBus bus = ImporterAgent.getRegistry().getEventBus();
 		if (data instanceof ThumbnailData) {
 			ThumbnailData thumbnail = (ThumbnailData) data;
 			if (thumbnail.getImage() != null)
-				bus.post(new ViewImage(new ViewImageObject(
-						thumbnail.getImage()), null));
+				firePropertyChange(VIEW_IMAGE_PROPERTY, null,
+						thumbnail.getImage());
 		} else if (data instanceof ImageData) {
-			ImageData image = (ImageData) data;
-			bus.post(new ViewImage(new ViewImageObject(image), null));
+			firePropertyChange(VIEW_IMAGE_PROPERTY, null, (ImageData) data);
 		} else if (data instanceof PlateData) {
 			firePropertyChange(BROWSE_PLATE_PROPERTY, null, data);
 		}
-		*/
 	}
 	
 	/** Rolls over the node. */


### PR DESCRIPTION
Fix https://trac.openmicroscopy.org.uk/ome/ticket/9753

To test:
- Import an image e.g. jpeg
- when the thumbnail is displayed
- click on the thumbnail
- The full viewer should open up
