### PR TITLE
Fix Class cast Exception (see #9960) (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -1094,7 +1094,6 @@ class ImViewerControl
 				klass = ImageData.class;
 				p = view.getParentObject();
 				if (!(p instanceof DatasetData)) p = null;
-				if (p == null) p = model.getImageName();
 				if (p != null) param.setAnchor((DataObject) p);
 			}
 			ids.add(view.getImageID());


### PR DESCRIPTION
This is the same as gh-882 but rebased onto develop.

---

Fix exception when object selected was not a dataset.
see https://trac.openmicroscopy.org.uk/ome/ticket/9960
