### PR TITLE
Homebrew hudson script: CURL fix

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -90,7 +90,7 @@ then
 else
     rm -rf virtualenv.py
     $CURL "$VENV_URL"
-    python virtualenv.py --no-site-packages .
+    /usr/bin/python virtualenv.py --no-site-packages .
 fi
 
 # Install scc tools


### PR DESCRIPTION
This PR fixes a but reported by @nikola. When no `bin/pip` exists under `$BREW_DIR` the `CURL` variable used for downloading virtualenv was missing.

In the OMERO-homebrew-install.sh script, `$BREW_DIR/bin/pip` is now systematically deleted in order to test this cURL operation.
