### PR TITLE
Fix URL to permissions page

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/help/help.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/help/help.html
@@ -72,7 +72,7 @@
                 <img alt="feature icon" src="http://www.openmicroscopy.org.uk/site/products/feature-list/omero/FeatureIcons/ledorange.png">
             </div>
             <div class="feature-text">
-                OMERO permissions functionality allows users to share data within groups of scientists and collaborate on their data. <a target="_blank" href="http://www.openmicroscopy.org.uk/site/support/omero4/server/permissions/">More Info</a>.
+                OMERO permissions functionality allows users to share data within groups of scientists and collaborate on their data. <a target="_blank" href="http://www.openmicroscopy.org.uk/site/support/omero4/sysadmins/server-permissions.html">More Info</a>.
                     </div>
                     <div class="feature-link">Movies: 
                 <a target="_blank" href="http://cvs.openmicroscopy.org.uk/snapshots/movies/omero-4-2/mov/Permissions1.mov">Intro</a> |


### PR DESCRIPTION
Two of the three changes made by "Correcting the URL for permissions page" on dev_4_4 made it onto develop. see https://github.com/openmicroscopy/openmicroscopy/pull/541

This new PR corrects the third URL.
