### PR TITLE
Handle null state on close in FileMaker (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/FileMaker.java
+++ b/components/blitz/src/ome/services/blitz/repo/FileMaker.java
@@ -129,19 +129,25 @@ public class FileMaker {
             }
 
             try {
-                lock.release();
+                if (lock != null) {
+                    lock.release();
+                }
             } catch (IOException e) {
                 log.warn("Failed to release lock");
             }
 
             try {
-                repoUuidRaf.close();
+                if (repoUuidRaf != null) {
+                    repoUuidRaf.close();
+                }
             } catch (IOException e) {
                 log.warn("Failed to close repo_uuid");
             }
 
             try {
-                dotLockRaf.close();
+                if (dotLockRaf != null) {
+                    dotLockRaf.close();
+                }
             } catch (IOException e) {
                 log.warn("Failed to close .lock");
             }


### PR DESCRIPTION
This is the same as gh-935 but rebased onto develop.

---

If getLine() is not called due to some other exception in AbstractRepositoryI,
then FileMaker.close() should not blindly try to close the lock.

To reproduce, make the "lib/scripts" directory read-only for the
omero user, and restart the server. Rather than a NPE, there should
be an error in the log stating:

```
013-03-21 16:24:40,880 ERROR [.services.blitz.repo.AbstractRepositoryI]
(2-thread-3) Failed during repository takeover
java.io.FileNotFoundException: ./lib/scripts/.omero/repository/71dfdc54-d5f3-4be7-86ef-6f19c9397e8c/repo_uui
d (No such file or directory)
    at java.io.RandomAccessFile.open(Native Method)
    at java.io.RandomAccessFile.<init>(Unknown Source)
    at ome.services.blitz.repo.FileMaker.init(FileMaker.java:82)
```

Currently debating how best to handle the read-only lib/scripts dir.

/cc @will-moore
