### PR TITLE
Fix method naming in checksum provider test class (rebased onto develop)

### DIFF
--- a/components/common/test/ome/util/checksum/AbstractChecksumProviderIntegrationTest.java
+++ b/components/common/test/ome/util/checksum/AbstractChecksumProviderIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.EnumMap;
 
 import org.springframework.util.ResourceUtils;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -163,7 +162,7 @@ public abstract class AbstractChecksumProviderIntegrationTest {
     }
 
     @Test
-    public void testChecksumAsStringChecksumWithBigFilePathString() {
+    public void testChecksumAsStringWithBigFilePathString() {
         String actual = this.checksumProvider
                 .putFile(this.bigFile.getAbsolutePath())
                 .checksumAsString();


### PR DESCRIPTION
This is the same as gh-956 but rebased onto develop.

---

This is just a code consistency fix. Doesn't change any logic, so should be quick to review and merge.
