### PR TITLE
Fix bug that causes _treeList to only return last directory entry

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -251,6 +251,7 @@ public class RepositoryDaoImpl implements RepositoryDao {
             // Now we recurse
             List<ome.model.core.OriginalFile> subFiles
                 = getOriginalFiles(sf, sql, repoUuid, checked);
+            final RMap subFilesRv = omero.rtypes.rmap();
 
             for (ome.model.core.OriginalFile subFile : subFiles) {
                 CheckedPath child = null;
@@ -269,10 +270,9 @@ public class RepositoryDaoImpl implements RepositoryDao {
                     throw new ome.conditions.ValidationException(ve.getMessage());
                 }
 
-                final RMap subFilesRv = omero.rtypes.rmap();
                 _treeList(subFilesRv, repoUuid, child, sf, sql);
-                subVal.put("files", subFilesRv);
             }
+            subVal.put("files", subFilesRv);
         }
     }
 


### PR DESCRIPTION
One effect of this was that repository.deletePaths(...) would only delete directories with at most one file in them, two or more files caused an exception.
