### PR TITLE
match BioFormats bump of AssumeNG up from 1.2.3 to 1.2.4

### DIFF
--- a/components/blitz/test.xml
+++ b/components/blitz/test.xml
@@ -13,7 +13,7 @@
     <dependency name="blitz" rev="${omero.version}" changing="true"/>
     <dependency name="common-test" rev="${omero.version}" changing="true"/>
     <dependency org="omero" name="omero-icemock" rev="${versions.ice}"/>
-    <dependency org="bf-deps" name="assumeng" rev="1.2.3"/>
+    <dependency org="bf-deps" name="assumeng" rev="1.2.4"/>
   </dependencies>
 </ivy-module>
 


### PR DESCRIPTION
Depends upon https://github.com/openmicroscopy/bioformats/pull/442 (probably why the Travis build failed) and allows OMERO to fully build afterward, including the test classes.

At the least, make sure that from a clean build the Blitz unit tests compile and pass. (Well, actually some of them will probably fail, just make sure that it's no more than usual -- that none of the errors look to be related to AssumeNG!)
