### PR TITLE
Restore 3rd-party "overriden" misspelling.

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/jquery-ui-1.8.19/ui/jquery-ui-1.8.19.custom.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/jquery-ui-1.8.19/ui/jquery-ui-1.8.19.custom.js
@@ -746,7 +746,7 @@ $.widget("ui.mouse", {
 		return this.mouseDelayMet;
 	},
 
-	// These are placeholder methods, to be overridden by extending plugin
+	// These are placeholder methods, to be overriden by extending plugin
 	_mouseStart: function(event) {},
 	_mouseDrag: function(event) {},
 	_mouseStop: function(event) {},

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/jquery-ui-1.8.19/ui/jquery.ui.mouse.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/jquery-ui-1.8.19/ui/jquery.ui.mouse.js
@@ -155,7 +155,7 @@ $.widget("ui.mouse", {
 		return this.mouseDelayMet;
 	},
 
-	// These are placeholder methods, to be overridden by extending plugin
+	// These are placeholder methods, to be overriden by extending plugin
 	_mouseStart: function(event) {},
 	_mouseDrag: function(event) {},
 	_mouseStop: function(event) {},


### PR DESCRIPTION
rebases #993 reverting parts of #977 following discussion in #975
