### PR TITLE
Revert "Change error responses to 404 in query API"

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -17,7 +17,7 @@ import re
 
 import omero
 import omero.clients
-from django.http import HttpResponse, HttpResponseServerError, HttpResponseRedirect, Http404, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseServerError, HttpResponseRedirect, Http404
 from django.utils import simplejson
 from django.utils.encoding import smart_str
 from django.utils.http import urlquote
@@ -1821,10 +1821,11 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
         obj = q.findByQuery(query, omero.sys.ParametersI().addId(objid),
                             conn.createServiceOptsDict())
     except omero.QueryException, ex:
-        return HttpResponseNotFound('%s cannot be queried' % objtype)
+        return dict(error='%s cannot be queried' % objtype,
+                    query=query)
 
     if not obj:
-        return HttpResponseNotFound('%s with id %s not found' % (objtype, objid))
+        return dict(error='%s with id %s not found' % (objtype, objid))
 
     return dict(data=[
         dict(id=annotation.id.val,
@@ -1922,7 +1923,7 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
                         (an array of rows, each an array of values)
     """
     a = _annotations(request, objtype, objid, conn, **kwargs)
-    if isinstance(a, HttpResponse) or a.has_key('error'):
+    if (a.has_key('error')):
         return a
 
     if len(a['data']) < 1:


### PR DESCRIPTION
This reverts commit 1f3f8d1354444445a23c337be315252c156b9e01.

Per suggestion from will-moore, removing 404 responses from AJAX calls
and returning a dictionary with an error field instead.

This change was already merged into develop (PR 898), porting to dev_4_4.
