### PR TITLE
Fix Sphinx documentation directory post doc reorganization

### DIFF
--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -52,7 +52,7 @@
 	<property name="lib.dir"       value="${root.dir}/lib" />
 	<property name="tools.dir"     value="${root.dir}/lib/tools" />
 	<property name="dist.dir"      value="${root.dir}/dist" />
-	<property name="sphinx.dir"    value="${root.dir}/docs/sphinx" />
+	<property name="sphinx.dir"    value="${root.dir}/docs/sphinx/omero" />
 
 	<!-- Components -->
 	<property name="dsl.comp"       value="${components.dir}/dsl"/>


### PR DESCRIPTION
With openmicroscopy/ome-documentation#315 merged and the `docs/sphinx` submodule updated, the path to the OMERO Sphinx documentation directory is now incorrect.

This PR should fix the behaviour of the `release-docs` target.
