### PR TITLE
Fix getResolutionDescriptions for pyramid-based files

### DIFF
--- a/components/romio/src/ome/io/bioformats/BfPyramidPixelBuffer.java
+++ b/components/romio/src/ome/io/bioformats/BfPyramidPixelBuffer.java
@@ -1188,12 +1188,13 @@ public class BfPyramidPixelBuffer implements PixelBuffer {
         return delegate().getResolutionLevels();
     }
 
-    public List<List<Integer>> getResolutionDescriptions()
+    public synchronized List<List<Integer>> getResolutionDescriptions()
     {
-        List<Integer> sizes = Arrays.asList(getSizeX(), getSizeY());
-        List<List<Integer>> rv = new ArrayList<List<Integer>>();
-        rv.add(sizes);
-        return rv;
+        if (isWrite())
+        {
+            throw new ApiUsageException("In write mode!");
+        }
+        return delegate().getResolutionDescriptions();
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
The dummy implementation from the ROMIO pixel buffer and the in-memory pixel
buffer was also copied into the BfPyramidPixelBuffer implementation causing
the return values of getResolutionLevels and getResolutionDescriptions to be
out of sync. BfPPB now delegates to the internal BfPB for the descriptions.

/cc @melissalinkert @jburel
