### PR TITLE
Have raw file bean flush file metadata.

### DIFF
--- a/components/romio/src/ome/io/nio/FileBuffer.java
+++ b/components/romio/src/ome/io/nio/FileBuffer.java
@@ -62,12 +62,15 @@ public class FileBuffer extends AbstractBuffer {
     }
     
     /**
-     * Flush the buffer, writing any pending content to the underlying storage device.
+     * Flush the buffer, writing any pending content to the underlying storage device,
+     * optionally also the file's metadata.
+     * @param includeMetadata flushes also the file metadata, not just the content
      * @throws IOException an I/O error that occurred
      */
-    public void flush() throws IOException {
-        if (channel != null)
-            channel.force(false);
+    public void flush(boolean includeMetadata) throws IOException {
+        if (channel != null) {
+            channel.force(includeMetadata);
+        }
     }
 
     /**

--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -29,7 +29,6 @@ import ome.util.Utils;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumType;
 
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.HibernateException;
@@ -158,7 +157,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
             try {
 
                 try {
-                    buffer.flush();
+                    buffer.flush(true);
                 } catch (IOException ie) {
                     final String msg = "cannot flush " + buffer.getPath() + ": " + ie;
                     log.warn(msg);


### PR DESCRIPTION
This commit is https://github.com/mtbc/openmicroscopy/commit/32d510cf8e096cdbb5cdcd395870e8ca12e99d4e rebased back from develop. The main thing to check is probably that imports still work and that the file information in the `originalfile` table ends up correct.

---

--rebased-from #997 
