### PR TITLE
Big Image levels=re.getResolutionLevels(). Fixes #10681

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -122,7 +122,7 @@ def imageMarshal (image, key=None):
     #big images
     tiles = image._re.requiresPixelsPyramid()
     width, height = image._re.getTileSize()
-    levels = image._re.getResolutionLevels()-1
+    levels = image._re.getResolutionLevels()
     zoomLevelScaling = image.getZoomLevelScaling()
     init_zoom = settings.VIEWER_INITIAL_ZOOM_LEVEL
     if init_zoom < 0:


### PR DESCRIPTION
Bug Fix: web displayed fewer Big image zoom levels than Insight.

To test, open a couple of different Big Images in Web and Insight.
- Check that you can zoom out to the same resolution level in both clients.
- Briefly check that nothing else has broken, tiles look OK, birds_eye_view shows correctly etc.
