### PR TITLE
Fix typo in Ice grid template to enable remote JMX connections

### DIFF
--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -202,10 +202,11 @@
         <target name="jmx">
             <!-- Be sure to understand the consequences of enabling JMX.
                  It allows calling remote methods on your JVM -->
-            <option>-Dcom.sun.management.jmxremote=${jmxhost}</option>
+            <option>-Dcom.sun.management.jmxremote</option>
             <option>-Dcom.sun.management.jmxremote.port=${jmxport}</option>
             <option>-Dcom.sun.management.jmxremote.authenticate=false</option>
             <option>-Dcom.sun.management.jmxremote.ssl=false</option>
+            <option>-Djava.rmi.server.hostname=${jmxhost}</option>
         </target>
         <option>-jar</option>
         <option>${OMERO_JARS}blitz.jar</option>


### PR DESCRIPTION
To test the change (assuming a running server):
- fill in `jmxhost` parameter with your server's IP address in $OMERO_HOME/etc/grid/templates.xml
- run `omero admin deploy jmx`
- check for listening java process on TCP port 3001
- connect JMX agent - eg. `jconsole <server_ip>:3001`
