### PR TITLE
fix #10727, so raw file bean can create empty files

### DIFF
--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -147,7 +147,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public synchronized OriginalFile save() {
-        if (isModified()) {
+        if (isModified() || size() == 0) {
             Long id = (file == null) ? null : file.getId();
             if (id == null) {
                 return null;


### PR DESCRIPTION
To test, in Insight try attaching a file of zero size to an image and see if it works and downloads okay. See notes on https://trac.openmicroscopy.org.uk/ome/ticket/10712 and https://trac.openmicroscopy.org.uk/ome/ticket/10727

Also check that `originalfile.sha1` in the database has the correct hash for an empty file, viz.,

```
$ shasum /dev/null
da39a3ee5e6b4b0d3255bfef95601890afd80709  /dev/null
```

---

--rebased-to #1103 
