### PR TITLE
add checksum verification for web file attachment

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/upload.py
+++ b/components/tools/OmeroPy/src/omero/plugins/upload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-   upoad plugin
+   upload plugin
 
    Plugin read by omero.cli.Cli during initialization. The method(s)
    defined here will be added to the Cli class for later use.

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # 
-# 
+# container
 # 
 # Copyright (c) 2008-2011 University of Dundee.
 # 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -25,6 +25,7 @@
 #
 
 import cStringIO
+import exceptions
 import traceback
 import logging
 
@@ -69,6 +70,13 @@ from django.core.mail import send_mail
 from django.core.mail import EmailMultiAlternatives
 
 from omeroweb.connector import Server
+
+try:
+    import hashlib
+    hash_sha1 = hashlib.sha1
+except:
+    import sha
+    hash_sha1 = sha.new
 
 try:
     PAGE = settings.PAGE
@@ -1323,13 +1331,26 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
         store.setFileId(oFile_id, self.SERVICE_OPTS);
         pos = 0
         rlen = 0
-        
+        hash = hash_sha1()
+
         for chunk in binary.chunks():
             rlen = len(chunk)
             store.write(chunk, pos, rlen)
+            hash.update(chunk)
             pos = pos + rlen
-        return store.save(self.SERVICE_OPTS)
-    
+        ofile = store.save(self.SERVICE_OPTS)
+        store.close()
+
+        serverhash = ofile.sha1.val
+        clienthash = hash.hexdigest()
+
+        if serverhash != clienthash:
+            msg = "SHA-1 checksums do not match in file upload: client has %s but server has %s" % (clienthash, serverhash)
+            logger.error(msg)
+            raise Exception(msg)
+
+        return ofile
+
     ##############################################
     ##   IShare
     


### PR DESCRIPTION
To test this,
1. choose a file
2. find out its SHA1 hash (e.g., use `shasum` on it)
3. attach it to an image using the web client
4. check that it has the correct hash in the `sha1` column of the `originalfile` table
5. download it
6. check that the file locally still has the same hash as before.
