### PR TITLE
Add simple method to check if image was imported prior to FS

### DIFF
--- a/components/blitz/src/pojos/ImageData.java
+++ b/components/blitz/src/pojos/ImageData.java
@@ -523,4 +523,16 @@ public class ImageData extends DataObject {
     	return instrument.getId().getValue();
     }
 
+    /**
+     * Returns <code>true</code> is the image has been imported the new
+     * import strategy known as FS import, <code>false</code> if imported
+     * using the previous import approach (data duplication).
+     * 
+     * @return See above.
+     */
+    public boolean isFSImage()
+    {
+    	return asImage().getFileset() != null;
+    }
+
 }


### PR DESCRIPTION
Simple PR to identify image imported prior to FS. So if we change the way to identify we should have one location to update. 

---

--no-rebase FS only
