### PR TITLE
Re-raise javac.maxmem to 600m (Fix #10688)

### DIFF
--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -22,8 +22,8 @@ javac.debug=on
 javac.debuglevel=lines,vars,source
 # "300m" suffices on 32 bit machines
 # "600m" should suffice on 64 bit for Ice 3.4
-javac.maxmem=750m
-javadoc.maxmem=750m
+javac.maxmem=1050m
+javadoc.maxmem=1050m
 exe4j.home=/opt/exe4j
 
 # Which version of Ice this build of OMERO is


### PR DESCRIPTION
`develop` builds are now frequently failing due to memory constraints. `javac` may default to using the `-client` option which would prevent the 1/4 memory from being used.

/cc @chris-allan, @mtbc, @sbesson, @bpindelski, @rleigh-dundee
