### PR TITLE
set the compression to high for big images (see #10759) (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -2755,7 +2755,8 @@ class ImViewerComponent
 		int index = view.getUICompressionLevel();
 		if (old == index) return;
 		view.setCompressionLevel(index);
-		ImViewerFactory.setCompressionLevel(index);
+		if (!model.isBigImage())
+			ImViewerFactory.setCompressionLevel(index);
 		renderXYPlane();
 	}
 
@@ -2903,6 +2904,8 @@ class ImViewerComponent
 		model.onRndLoaded();
 		if (!reload) {
 			if (model.isBigImage()) {
+				view.setCompressionLevel(ToolBar.LOW);
+				view.resetCompressionLevel(view.convertCompressionLevel());
 				model.fireBirdEyeViewRetrieval();
 				fireStateChange();
 				return;
@@ -3125,6 +3128,7 @@ class ImViewerComponent
 			default:
 				controller.setPreferences();
 				//tmp store compression
+				if (!model.isBigImage())
 				ImViewerFactory.setCompressionLevel(
 						view.getUICompressionLevel());
 				if (!saveOnClose(notifyUser)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -2653,6 +2653,16 @@ class ImViewerUI
     	controlPane.onChannelUpdated();
     }
     
+    /**
+    * Sets the compression index.
+    * 
+    * @param index
+    */
+   void resetCompressionLevel(int index)
+    {
+    	toolBar.setCompressionLevel(index);
+    }
+   
 	/** 
 	 * Overridden to the set the location of the {@link ImViewer}.
 	 * @see TopWindow#setOnScreen() 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
@@ -385,8 +385,8 @@ class ToolBar
 			ImViewerAgent.getRegistry().lookup(LookupNames.CONNECTION_SPEED);
 		int setUp = view.convertCompressionLevel(value);
 		if (compression != setUp) compression = setUp;
-		if (view.isBigImage() && compression == ImViewer.UNCOMPRESSED) {
-			compression = ImViewer.MEDIUM;
+		if (view.isBigImage()) {
+			compression = ImViewer.LOW;
 		}
 		int index = view.convertCompressionLevel();
 		if (compression >= UNCOMPRESSED && compression <= LOW)
@@ -395,6 +395,20 @@ class ToolBar
 		compressionBox.addActionListener(
     			controller.getAction(ImViewerControl.COMPRESSION));
     	buildGUI(); 
+    }
+    
+    /**
+     * Sets the compression index.
+     * 
+     * @param index
+     */
+    void setCompressionLevel(int index)
+    {
+    	compressionBox.removeActionListener(
+    			controller.getAction(ImViewerControl.COMPRESSION));
+    	compressionBox.setSelectedIndex(index);
+    	compressionBox.addActionListener(
+    			controller.getAction(ImViewerControl.COMPRESSION));
     }
     
     /** Selects or deselects the {@link #rndButton}. */


### PR DESCRIPTION
This is the same as gh-1074 but rebased onto develop.

---

Set the compression level to high. This should speed up the retrieval of big images
https://trac.openmicroscopy.org.uk/ome/ticket/10759
