### PR TITLE
Fix missing negation in ExportActivity.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ExportActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ExportActivity.java
@@ -87,7 +87,7 @@ public class ExportActivity
 					extension = "."+OMETIFFFilter.OME_TIFF;
 				break;
 		}
-		if (StringUtils.isBlank(extension)) return path+extension;
+		if (!StringUtils.isBlank(extension)) return path+extension;
 		return path;
     }
     


### PR DESCRIPTION
This wouldn't cause any problems as the higher-layer logic already appends the .ome.tiff extension to the file name. To test, try exporting images as OME-TIFF.
