### PR TITLE
fix #10727, so raw file bean can create empty files (rebased)

### DIFF
--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -177,7 +177,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public synchronized OriginalFile save() {
-        if (isModified()) {
+        if (isModified() || buffer != null && size() == 0) {
             Long id = (file == null) ? null : file.getId();
             if (id == null) {
                 return null;


### PR DESCRIPTION
To test, try attaching normal files and empty ones to images or datasets or whatever and make sure they go without errors and after download arrive intact, the same as they went.

---

--rebased-from #1076 
--rebased-from #1102 
