### PR TITLE
Fix ZIP file path creation code (see #10804)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -4050,7 +4050,7 @@ class OMEROGateway
 				handleException(e, "Cannot set the file's id.");
 			}
 			if (folderPath != null) {
-				f = new File(folderPath+of.getName().getValue());
+				f = new File(folderPath, of.getName().getValue());
 			} else f = file;
 			results.add(f);
 			try {


### PR DESCRIPTION
To test, try downloading an image from a multi-file image set (like LEI). The zip file should save fine in any target folder. Check that it works with your home directory (i.e. try saving to `/Users/<username>/`). Any other file export options from Insight should be checked too.
/cc @jburel
