### PR TITLE
Case-insensitive matching of errors/warnings in admin diagnostics

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -673,8 +673,9 @@ OMERO Diagnostics %s
                     err = 0
                     for l in p.lines():
                         # ensure errors/warnings search is case-insensitive
-                        found_err = l.find("ERROR") >= 0 or l.find("error") >= 0
-                        found_warn = l.find("WARN") >= 0 or l.find("warn") >= 0
+                        lcl = l.lower()
+                        found_err = lcl.find("error") >= 0
+                        found_warn = lcl.find("warn") >= 0
                         
                         if found_err:
                             err += 1


### PR DESCRIPTION
To test the change (assuming a stopped server):
- invalidate Ice grid configuration : `echo "RaiseAnIceXMLParserExceptionAtStartup" >> $OMERO_HOME/etc/grid/templates.xml`
- run `omero admin start` : server starts up despite invalid XML syntax
- run `omero admin diagnostics` : log files report for `master.err` should now display positive errors and warnings counts
