### PR TITLE
Fix NPE in OMRI.java (Fix #10820)

### DIFF
--- a/components/blitz/src/omero/cmd/fs/OriginalMetadataRequestI.java
+++ b/components/blitz/src/omero/cmd/fs/OriginalMetadataRequestI.java
@@ -155,7 +155,10 @@ public class OriginalMetadataRequestI extends OriginalMetadataRequest implements
 		List<Object[]> ids = helper.getServiceFactory().getQueryService()
 				.projection(query, new Parameters().addId(imageId).page(0, 1));
 		if (ids != null && ids.size() > 0) {
-			return omero.rtypes.rlong((Long) ids.get(0)[0]);
+		    Object[] id = ids.get(0);
+		    if (id != null && id.length > 0) {
+		        return omero.rtypes.rlong((Long) id[0]);
+		    }
 		}
 		return null;
 	}


### PR DESCRIPTION
Bug found by @will-moore such that trying to load images generated by scripts causes a NPE. The `Channel_Offsets` script should be used as in the ticket https://trac.openmicroscopy.org.uk/ome/ticket/10819

---

--no-rebase FS only
