### PR TITLE
Make checksum safe against raw file store save() returning null (rebase)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -4364,7 +4364,8 @@ class OMEROGateway
 		}
 		byte[] buf = new byte[INC]; 
 		FileInputStream stream = null;
-		final ChecksumProvider hasher = checksumProviderFactory.getProvider(ChecksumType.SHA1);
+		final ChecksumProvider hasher = checksumProviderFactory.getProvider(
+				ChecksumType.SHA1);
 		try {
 			stream = new FileInputStream(file);
 			long pos = 0;
@@ -4380,12 +4381,16 @@ class OMEROGateway
 			stream.close();
 			OriginalFile f = store.save();
 			closeService(ctx, store);
-			if (f != null) save = f;
-			final String clientHash = hasher.checksumAsString();
-			final String serverHash = save.getSha1().getValue();
-			if (!clientHash.equals(serverHash)) {
-			    throw new ImportException("file checksum mismatch on upload: " + file +
-			            " (client has " + clientHash + ", server has " + serverHash + ")");
+			if (f != null) {
+				save = f;
+				final String clientHash = hasher.checksumAsString();
+				final String serverHash = save.getSha1().getValue();
+				if (!clientHash.equals(serverHash)) {
+				    throw new ImportException("file checksum mismatch on " +
+				    		"upload: " + file +
+				            " (client has " + clientHash + ", " +
+				            		"server has " + serverHash + ")");
+				}
 			}
 		} catch (Exception e) {
 			try {


### PR DESCRIPTION
This shouldn't change behavior, but do test that importing a file still works and that attaching a file and a non-empty file still works okay and that they can be downloaded intact.

This rebases #1047 and #1121.
