### PR TITLE
Fix long-missing DELETE EventLogs

### DIFF
--- a/components/server/src/ome/services/graphs/GraphStep.java
+++ b/components/server/src/ome/services/graphs/GraphStep.java
@@ -312,7 +312,7 @@ public abstract class GraphStep {
 
         // If this is the last map, i.e. the truly processed ones, then
         // raise the EventLogMessage
-        if (cb.size() == 0) {
+        if (cb.size() == 1) {
             for (Map.Entry<String, Set<Long>> entry : cb.entrySet()) {
                 String key = entry.getKey();
                 Class<IObject> k = cb.getClass(key);


### PR DESCRIPTION
This check has been wrong throughout the 4.4 series.
If this is the last element, then EventLogs should be
raised for every OriginalFile deleted. This has not
been happening. (Very sadly)

---

Commit from gh-638 that was intended to be rebased. There should be "DELETE" entries in the eventlog table after a successful delete.

--rebased-from #638 one commit
