### PR TITLE
Fix NPE during Editor startup in AutosaveRecovery.java (Fix #10235) (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/editor/view/AutosaveRecovery.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/editor/view/AutosaveRecovery.java
@@ -107,9 +107,12 @@ public class AutosaveRecovery {
 				return false;
 			}
 		});
-		
-		int fileCount = recoveredFiles.length;
-		
+
+		int fileCount = 0;
+		if (recoveredFiles != null) {
+			fileCount = recoveredFiles.length;
+		}
+
 		// if there are any files found...
 		if (fileCount > 0) {
 			


### PR DESCRIPTION
This is the same as gh-1135 but rebased onto develop.

---

From the original report:

```
*3. Launching problem with OMERO.editor on a Windows system*

OMERO.editor can't be launched. The problem looks similar to this one : 
http://trac.openmicroscopy.org.uk/ome/ticket/10235
The user really wants to try the application. Any help ?
/Error Log attached to this mail as //_OMERO.editor_Error.log_/
```

Follow-up:

```
The editor client was running Windows 7 (32 bit) with a non-administrator
local account (also the %USERPROFILE%\omero directory seemed to be missing
for some reason, but without breaking other clients).
```

/cc @zeb
