### PR TITLE
Image metadata dev 4 4

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AcquisitionDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AcquisitionDataUI.java
@@ -620,7 +620,7 @@ class AcquisitionDataUI
 		imagePane.setCollapsed(true);
 		*/
 	}
-	
+
 	/**
 	 * Loads the acquisition data.
 	 * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OriginalMetadataComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OriginalMetadataComponent.java
@@ -55,6 +55,7 @@ import javax.swing.table.DefaultTableModel;
 
 //Third-party libraries
 
+import org.apache.commons.collections.CollectionUtils;
 //Application-internal dependencies
 import org.apache.commons.io.FilenameUtils;
 import org.jdesktop.swingx.JXBusyLabel;
@@ -213,7 +214,7 @@ class OriginalMetadataComponent
 			entry = i.next();
 			key = entry.getKey();
 			l = entry.getValue();
-			if (l != null && l.size() > 0) {
+			if (!CollectionUtils.isEmpty(l)) {
 				label = UIUtilities.setTextFont(key);
 				label.setBackground(UIUtilities.BACKGROUND_COLOR);
 				row = UIUtilities.buildComponentPanel(label);
@@ -225,6 +226,8 @@ class OriginalMetadataComponent
 		removeAll();
 		add(toolBar, BorderLayout.NORTH);
 		add(p, BorderLayout.CENTER);
+		revalidate();
+		repaint();
 	}
 	
 	/**
@@ -377,11 +380,13 @@ class OriginalMetadataComponent
 						}
 					}
 				}
-				buildGUI(components);
 			} finally {
 				input.close();
 			}
+			buildGUI(components);
+			file.delete();
 		} catch (IOException e) {
+			e.printStackTrace();
 			file.delete();
 			JLabel l = new JLabel("Loading metadata");
 			l.setBackground(UIUtilities.BACKGROUND_COLOR);


### PR DESCRIPTION
Few commits from #1145 applied onto `dev_4_4` to avoid issues later on.

To test:
- Import an image
- Select the image.
- Go to the Acquisition tab and make the the Original metadata task pane is available
- Expand. The data should be loaded.
- Click on the download button to download the file
