### PR TITLE
Multi select

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
@@ -555,11 +555,12 @@ class BrowserModel
 	 */
 	public void setSelectedNodes(List<DataObject> nodes)
 	{
+		Set<ImageDisplay> oldValue = null;
+		if (selectedDisplays != null)
+			oldValue = new HashSet<ImageDisplay>(selectedDisplays);
 		if (nodes == null || nodes.isEmpty()) {
-			if (selectedDisplays == null) return;
-			List<ImageDisplay> l = new ArrayList<ImageDisplay>(selectedDisplays);
-			selectedDisplays.clear();
-			setNodesColor(null, l);
+			if (selectedDisplays != null) selectedDisplays.clear();
+			setNodesColor(null, oldValue);
 			return;
 		}
 		NodesFinder finder = new NodesFinder(nodes);
@@ -573,11 +574,10 @@ class BrowserModel
 			setSelectedDisplay(null, false, false);
 			return;
 		}
-		
-		boolean b = found.size() > 1;
-		Iterator<ImageDisplay> i = found.iterator();
-		while (i.hasNext()) 
-			setSelectedDisplay(i.next(), b, false);
+		thumbSelected = false;
+		this.multiSelection = found.size() > 1;
+		setSelectedDisplays(found);
+		setNodesColor(found, oldValue);
 	}
 	
 	/**


### PR DESCRIPTION
Fix multi-selection issue in data manager see https://trac.openmicroscopy.org.uk/ome/ticket/10855

To test:
- Expand a dataset with several images
- Use shift click and cmd click to select several images.
- Make sure the images are selected in the centre pane.
