### PR TITLE
Add fork=true to insight's build

### DIFF
--- a/components/insight/build/app.xml
+++ b/components/insight/build/app.xml
@@ -139,7 +139,8 @@
            deprecation="yes"
            encoding="UTF-8"
            debug="yes"
-           debuglevel="lines,vars,source">
+           debuglevel="lines,vars,source"
+           fork="true">
       <classpath refid="app.compile.classpath"/>
       <patternset refid="app.sources"/>
     </javac>
@@ -150,7 +151,8 @@
            deprecation="yes"
            encoding="UTF-8"
            debug="yes"
-           debuglevel="lines,vars,source">
+           debuglevel="lines,vars,source"
+           fork="true">
       <classpath refid="app.compile.classpath"/>
       <patternset refid="app.sources"/>
     </javac>
@@ -161,7 +163,8 @@
            deprecation="yes"
            encoding="UTF-8"
            debug="yes"
-           debuglevel="lines,vars,source">
+           debuglevel="lines,vars,source"
+           fork="true">
       <classpath refid="app.compile.classpath"/>
       <patternset refid="app.sources"/>
     </javac>

--- a/components/insight/build/test.xml
+++ b/components/insight/build/test.xml
@@ -195,7 +195,8 @@
            deprecation="yes"
            encoding="UTF-8"
            debug="yes"
-           debuglevel="lines,vars,source">
+           debuglevel="lines,vars,source"
+           fork="true">
       <classpath refid="test.compile.classpath" />
       <patternset refid="test.sources" />
     </javac>


### PR DESCRIPTION
Under Windows, the error:

 `com.sun.tools.javac.Main is not on the classpath`

can be printed depending on the Java installation.

John Webber (NBI) suggested adding fork=true.

See: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-May/003699.html
