### PR TITLE
Workaround for compile error in DeleteBox

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -86,5 +86,8 @@
     <!-- importer -->
     <dependency org="importer" name="slf4j-api" rev="${versions.slf4j}"/>
     <dependency org="importer" name="slf4j-log4j12" rev="${versions.slf4j}"/>
+
+    <!-- temporary fix for o.s.u.CollectionUtils-->
+    <dependency org="org.springframework" name="org.springframework.core" rev="${versions.spring}" conf="build,client->default"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Add spring.core dependency to insight in order to fix develop and develop2 builds. `o.s.u.CollectionUtils` was imported in `DeleteBox` from gh-1161.
