### PR TITLE
fix NPE in indexing file annotations

### DIFF
--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -340,7 +340,12 @@ public class FullTextBridge extends BridgeHelper {
             // None of these values can be null
             add(document, "file.name", file.getName(), opts);
             add(document, "file.path", file.getPath(), opts);
-            add(document, "file.hash", file.getHash(), opts);
+            if (file.getHasher() != null) {
+                add(document, "file.hasher", file.getHasher().getValue(), opts);
+            }
+            if (file.getHash() != null) {
+                add(document, "file.hash", file.getHash(), opts);
+            }
             if (file.getMimetype() != null) {
                 add(document, "file.format", file.getMimetype(), opts);
                 // ticket:2211 - duplicating for backwards compatibility


### PR DESCRIPTION
To test, try adding file annotations and make sure that errors no longer appear in `var/log/Indexer-0.log`.

cc @bpindelski 

---

--no-rebase FS-only
