### PR TITLE
Don't show green tick if delete Error. See #10900

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -136,7 +136,7 @@
                             {% ifequal j.status "in progress" %}
                                 <img alt="Deleting" src="{% static "webgateway/img/spinner.gif" %}" />
                             {% else %}
-                                {% if j.error %}
+                                {% if j.derror %}
                                     <div class='script_error' title="{{ j.error }}">
                                         <img src="{% static "webgateway/img/failed.png" %}" />
                                     </div>


### PR DESCRIPTION
To test, try to delete Dataset containing partial MIF. This should fail (for an unknown reason) as described https://trac.openmicroscopy.org/ome/ticket/10900 BUT you should see a red triangle in the activities dialog instead of a green tick.
