### PR TITLE
Thumbs table text white on selection

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -1463,6 +1463,7 @@
             }
 
             #dataIcons .ui-selected { 
+                color: white;
                 background-color:#3875d7;
                 border:solid 1px #3875d7;
                 -webkit-box-shadow: 0 1px 1px rgba(0,0,0,.2); 


### PR DESCRIPTION
In the table view of thumbnails in the center panel, the text of the selected item is white (shows better against the new blue selection background).

To test, check that text is white in table.

![screen shot 2013-05-22 at 11 36 56](https://f.cloud.github.com/assets/900055/547705/956e3dd8-c2cb-11e2-873e-ce36b78c0d4e.png)
