### PR TITLE
Fix omero.data.dir ignored in current develop branch (see #10828)

### DIFF
--- a/components/common/src/ome/system/PreferenceContext.java
+++ b/components/common/src/ome/system/PreferenceContext.java
@@ -78,8 +78,10 @@ public class PreferenceContext extends PropertyPlaceholderConfigurer {
             while (names.hasMoreElements()) {
                 String key = names.nextElement().toString();
                 String value = properties.getProperty(key);
-                System.setProperty(key, value);
-                log.debug("Set property: {}={}", key, value);
+                if (System.getProperty(key) == null) {
+                    System.setProperty(key, value);
+                    log.debug("Set property: {}={}", key, value);
+                }
             }
         } catch (IOException ioe) {
             log.error("Error on mergeProperties()", ioe);


### PR DESCRIPTION
Some folks have been waiting for this, so here's the PR.

To test, run the server locally and set `omero.data.dir` to anything else than `/OMERO`. Also remove the `/OMERO` directory before starting up the server. Everything should start nicely and data should land in the `omero.data.dir` configured folder.
