### PR TITLE
script_utils.getObjects() sorts by IDs

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -366,6 +366,11 @@ def getObjects(conn, params):
     else:
         if not len(objects) == len(ids):
             message += "Found %s out of %s %s%s(s). " % (len(objects), len(ids), dataType[0].lower(), dataType[1:])
+
+        # Sort the objects according to the order of IDs
+        idMap = dict( [(o.id, o) for o in objects] )
+        objects = [idMap[i] for i in ids if i in idMap]
+
     return objects, message
 
 def addAnnotationToImage(updateService, image, annotation):


### PR DESCRIPTION
See bug #10745. We now sort objects by IDs in script_utils.getObjects().

To test:
- Select a bunch of images and open split view figure dialog in Web.
- Re-order the images by dragging & dropping rows (handle to left of each row) 
- Grab a screen-shot (makes comparing easier)
- Run script and check that the figure generated has the same order of rows as the preview.
