### PR TITLE
Install genshi before OMERO/Bio-Formats installation using Homebrew

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -117,17 +117,16 @@ if [ $TESTING_MODE ]; then
     $VENV_DIR/bin/scc merge master
 fi
 
-# Install Genshi (OMERO and Bio-Formats requirement)
-$VENV_DIR/bin/pip install -U genshi
-
-# Add Virtualenv site-packages path to PYTHONPATH
-export PYTHONPATH=$($VENV_DIR/bin/python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
-
 cd /usr/local
+
+# Install Genshi (OMERO and Bio-Formats requirement)
+bin/brew install python
+bin/pip install -U genshi
 
 ###################################################################
 # Bio-Formats installation
 ###################################################################
+
 
 # Install Bio-Formats
 bin/brew install bioformats $BREW_OPTS


### PR DESCRIPTION
This commit should fix the failing Homebrew job on the develop branch. Genshi
is required on this branch for both formulas but cannot be installed by
Homebrew itself. Installation is managed in the installation script itself
(independently of the testing mode status since it is required for all users)/
