### PR TITLE
Set ImportContainer.customAnnotationList (Fix #10904)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1109,7 +1109,7 @@ class OmeroImageServiceImpl
 		}
 		Object result = null;
 		Collection<TagAnnotationData> tags = object.getTags();
-		List<Annotation> list = new ArrayList<Annotation>();
+		List<Annotation> customAnnotationList = new ArrayList<Annotation>();
 		List<IObject> l;
 		//Tags
 		if (tags != null && tags.size() > 0) {
@@ -1121,7 +1121,7 @@ class OmeroImageServiceImpl
 				tag = i.next();
 				if (tag.getId() > 0) {
 					values.add(tag);
-					list.add((Annotation) tag.asIObject());
+					customAnnotationList.add((Annotation) tag.asIObject());
 				} else l.add(tag.asIObject());
 			}
 			//save the tag.
@@ -1132,7 +1132,7 @@ class OmeroImageServiceImpl
 				while (j.hasNext()) {
 					a = (Annotation) j.next();
 					values.add(new TagAnnotationData((TagAnnotation) a));
-					list.add(a);
+					customAnnotationList.add(a);
 				}
 				object.setTags(values);
 			} catch (Exception e) {}
@@ -1283,6 +1283,7 @@ class OmeroImageServiceImpl
 					status.resetFile(f);
 					if (ioContainer == null) status.setNoContainer();
 					importIc = ic.getContainers().get(0);
+					importIc.setCustomAnnotationList(customAnnotationList);
 					status.setUsedFiles(importIc.getUsedFiles());
 					result = gateway.importImage(ctx, object, ioContainer,
 							importIc, status, close,
@@ -1290,11 +1291,11 @@ class OmeroImageServiceImpl
 					if (result instanceof ImageData) {
 						image = (ImageData) result;
 						images.add(image);
-						annotatedImportedImage(ctx, list, images, userName);
+						annotatedImportedImage(ctx, customAnnotationList, images, userName);
 						return formatResult(ctx, image, userID, thumbnail);
 					} else if (result instanceof Set) {
 						ll = (Set<ImageData>) result;
-						annotatedImportedImage(ctx, list, ll, userName);
+						annotatedImportedImage(ctx, customAnnotationList, ll, userName);
 						kk = ll.iterator();
 						converted = new ArrayList<Object>(ll.size());
 						while (kk.hasNext()) {
@@ -1321,7 +1322,7 @@ class OmeroImageServiceImpl
 						
 					status.setFiles(files);
 					Boolean v = importCandidates(ctx, files, status, object,
-							ioContainer, list, userID, close, hcs, userName);
+							ioContainer, customAnnotationList, userID, close, hcs, userName);
 					if (v != null) {
 						return v.booleanValue();
 					}
@@ -1334,17 +1335,18 @@ class OmeroImageServiceImpl
 				if (icContainers.size() == 0)
 					return Boolean.valueOf(false);
 				importIc = icContainers.get(0);
+				importIc.setCustomAnnotationList(customAnnotationList);
 				status.setUsedFiles(importIc.getUsedFiles());
 				result = gateway.importImage(ctx, object, ioContainer, importIc,
 					status, close, ImportableObject.isHCSFile(file), userName);
 				if (result instanceof ImageData) {
 					image = (ImageData) result;
 					images.add(image);
-					annotatedImportedImage(ctx, list, images, userName);
+					annotatedImportedImage(ctx, customAnnotationList, images, userName);
 					return formatResult(ctx, image, userID, thumbnail);
 				} else if (result instanceof Set) {
 					ll = (Set<ImageData>) result;
-					annotatedImportedImage(ctx, list, ll, userName);
+					annotatedImportedImage(ctx, customAnnotationList, ll, userName);
 					kk = ll.iterator();
 					converted = new ArrayList<Object>(ll.size());
 					while (kk.hasNext()) {
@@ -1417,7 +1419,7 @@ class OmeroImageServiceImpl
 				} else ioContainer = container.asIObject();
 			}
 			importCandidates(ctx, hcsFiles, status, object,
-					ioContainer, list, userID, close, true, userName);
+					ioContainer, customAnnotationList, userID, close, true, userName);
 		}
 		if (otherFiles.size() > 0) {
 			folder = object.createFolderAsContainer(importable);
@@ -1494,7 +1496,7 @@ class OmeroImageServiceImpl
 			}
 			//import the files that are not hcs files.
 			importCandidates(ctx, otherFiles, status, object,
-				ioContainer, list, userID, close, false, userName);
+				ioContainer, customAnnotationList, userID, close, false, userName);
 		}
 		return Boolean.valueOf(true);
 	}


### PR DESCRIPTION
The list of annotations created from the `ImportDialog` were not being set on the `ImportContainer`. I tested via the "Add tag to images" for a simple fake import and saw that the image did appear in attached to the image. I modified the method in `OmeroImageServiceImpl` to call `ImportContainer.setCustomAnnotationList()` in as many cases as possible but it was unclear if any of the other cases was inappropriate.
