### PR TITLE
Remove /tmp/memo from OMEROWrapper (Fix #10836)

### DIFF
--- a/components/blitz/src/ome/formats/importer/OMEROWrapper.java
+++ b/components/blitz/src/ome/formats/importer/OMEROWrapper.java
@@ -99,7 +99,7 @@ public class OMEROWrapper extends MinMaxCalculator {
         this.reader = null;
         filler = new ChannelFiller(iReader);
         separator  = new ChannelSeparator(filler);
-        memoizer = new Memoizer(separator, 100, new java.io.File("/tmp/memo")) {
+        memoizer = new Memoizer(separator) { // Disabled
             public Deser getDeser() {
                 KryoDeser k = new KryoDeser();
                 k.kryo.register(OMEXMLModelComparator.class);


### PR DESCRIPTION
The /tmp/memo directory was still present on the one
testing server that the plate import was not working
on which led to plates not being imported. Moving the
directory away allowed plates to be imported. My guess
is that this will fix the issue.

---

--no-rebase FS only
