### PR TITLE
Add scc travis-merge to the Travis before_install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ before_install:
     - sudo apt-get install -qq git
     - sudo apt-get install -qq zeroc-ice34
     - sudo apt-get install -qq python-imaging python-numpy python-tables python-genshi
+    - git config github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
+    - sudo pip install scc --use-mirrors
+    - scc travis-merge
 
 install: python build.py build-all test-compile-all
 


### PR DESCRIPTION
This PR integrates the scc features added in openmicroscopy/snoopycrimecop#77, openmicroscopy/snoopycrimecop#79 and openmicroscopy/snoopycrimecop#81 into the openmicroscopy Travis build.

Before Travis builds the server and runs `test-compile`, `scc travis-merge` should be called which performs the following actions:
- bumps the submodules to the HEAD of `origin/$branch`
- merges all the PRs specified by `--depends-on #prnumber` or `--depends-on repo/name#prnumber` in the comments of the PR
