### PR TITLE
Fix Plate delete (Fix #11009, See #10776)

### DIFF
--- a/components/server/resources/ome/services/spec.xml
+++ b/components/server/resources/ome/services/spec.xml
@@ -308,7 +308,7 @@
                 <value>/Well/WellSample/WellSampleAnnotationLink;FORCE</value>
                 <value>/Annotation;SOFT;/Well/WellSample/WellSampleAnnotationLink</value>
                 <value>/Well/WellSample</value>
-                <value>/Image+WS;;/Well/WellSample</value>
+                <value>/Image;;/Well/WellSample</value>
                 <value>/Well/WellAnnotationLink;FORCE</value>
                 <value>/Annotation;SOFT;/Well/WellAnnotationLink</value>
                 <value>/Well/WellReagentLink;FORCE</value>


### PR DESCRIPTION
fc6b8340236c006c64043c22296268bddb11ea14 removed the
"+WS" suffix from Image, which broke plate delete.
Essentially, the Image subgraph was not being processed
but just the image table itself.
