### PR TITLE
Show chgrp target tree if Projects OR Datasets exist. See #10917

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/chgrp_target_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/chgrp_target_tree.html
@@ -25,7 +25,7 @@
 
 <link rel="stylesheet" href="{% static "3rdparty/jquery.jstree/themes/default/style.css" %}" type="text/css" media="screen"/>
 
-{% if manager.containers.projects %}
+{% if manager.containers.projects or manager.containers.datasets %}
 <h1>Choose target {{ target_type|capfirst }} in new Group</h1>
 
 <div id="hierarchyTree" class="jstree jstree-default">


### PR DESCRIPTION
To test, choose to move an Image to a group that only has Datasets (no Projects). The chgrp dialog should present this list of Datasets (Previously just showed 'No Projects'). Pick a Dataset and check the chgrp puts the image in that Dataset.
