### PR TITLE
Fix multi-selection in data manager (see #11037)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserModel.java
@@ -282,7 +282,8 @@ class BrowserModel
     				selectedDisplay.getUserObject().getClass()))
     			selectedNodes.clear();
     	}
-    	selectedNodes.add(selectedDisplay);
+    	if (!selectedNodes.contains(selectedDisplay))
+    		selectedNodes.add(selectedDisplay);
     }
     
     /**


### PR DESCRIPTION
Fix issue with multi-selection. The easiest to validate the PR is
- select 2 images in the data manager (i.e. Tree)
- Go to the script menu and Select the Channel offset script for example
- The 2 ids of the selected images should be displayed.

Screenshot before (check with yesterday's build)
![11037_before](https://f.cloud.github.com/assets/1022396/601909/e74035ec-cc8c-11e2-969f-1f679e142121.png)

Screenshot after (check with Today's build)
![11037_after](https://f.cloud.github.com/assets/1022396/601912/f5232f70-cc8c-11e2-906f-d3f8df909b48.png)

This PR will have to be rebased.
