### PR TITLE
Don't show red dot for non-owned P/D/I S/P/A in tree. #11039

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -566,7 +566,7 @@
                             "project-locked" : {
                                 "valid_children" : [ "dataset", "dataset-locked" ],
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/folder_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/folder16.png" %}'
                                 },
                                 "start_drag" : false
                             },
@@ -580,7 +580,7 @@
                             "dataset-locked" : {
                                 "valid_children" : [ "image", "image-locked" ],
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/folder_image_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/folder_image16.png" %}'
                                 },
                                 "start_drag" : function(obj){return obj.hasClass('canLink');}
                             },
@@ -594,7 +594,7 @@
                             "image-locked" : {
                                 "valid_children" : "none",
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/image_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/image16.png" %}'
                                 },
                                 "start_drag" : function(obj){return obj.hasClass('canLink');}
                             },
@@ -608,7 +608,7 @@
                             "screen-locked" : {
                                 "valid_children" : [ "plate", "plate-locked" ],
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/folder_screen_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/folder_screen16.png" %}'
                                 },
                                 "start_drag" : false
                             },
@@ -622,7 +622,7 @@
                             "plate-locked" : {
                                 "valid_children" : "acquisition",
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/folder_plate_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/folder_plate16.png" %}'
                                 },
                                 "start_drag" : function(obj){return obj.hasClass('canLink');}
                             },
@@ -636,7 +636,7 @@
                             "acquisition-locked" : {
                                 "valid_children" : "none",
                                 "icon" : {
-                                    "image" : '{% static "webclient/image/image_locked16.png" %}'
+                                    "image" : '{% static "webclient/image/image16.png" %}'
                                 },
                                 "start_drag" : false
                             },


### PR DESCRIPTION
See ticket http://trac.openmicroscopy.org.uk/ome/ticket/11039
We now show the same icon for owned and non-owned objects in the Tree (don't use red dot for other users' data).

To test, browse other user's data or "All Members" and check that all icons are the same (no red dots).
