### PR TITLE
Travis author fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
     - sudo apt-get install -qq zeroc-ice34
     - sudo apt-get install -qq python-imaging python-numpy python-tables python-genshi
     - git config github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
-    - git config —global user.email snoopycrimecop@gmail.com
-    - git config —global user.name 'Snoopy Crime Cop'
+    - git config --global user.email snoopycrimecop@gmail.com
+    - git config --global user.name 'Snoopy Crime Cop'
     - sudo pip install scc --use-mirrors
     - scc travis-merge
 


### PR DESCRIPTION
Both commits cherry-picked from #1200 allow Git to be configured in the Travis worker and commits to be added during the script.

Note the submodule pointer of this branch is already behind `origin/develop`. As a self-test mechanism, `scc travis-merge` should 1- not fail and 2- properly bump the submodules in the Travis build.
