### PR TITLE
Do not enter interactive mode if hql command output is piped (rebased onto dev_4_4)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/hql.py
+++ b/components/tools/OmeroPy/src/omero/plugins/hql.py
@@ -58,7 +58,7 @@ class HqlControl(BaseControl):
         p.page(args.offset, args.limit)
         rv = self.project(q, args.query, p, ice_map)
         has_details = self.display(rv)
-        if args.quiet:
+        if args.quiet or not sys.stdout.isatty():
             return
 
         input = """


### PR DESCRIPTION
This is the same as gh-1244 but rebased onto dev_4_4.

---

Return the output if `sys.stdout.isatty()` is `False`, i.e. when the hql command
is either piped or redirected to a file.

Can be tested using the command in the ticket [#11036](https://134.36.65.55/ome/ticket/11036) :

```
bin/omero hql --admin "select i.fileset.id, 'F' from Image i where i.wellSamples is empty order by i.fileset.id desc"
```

should still enter interative mode while

```
bin/omero hql --admin "select i.fileset.id, 'F' from Image i where i.wellSamples is empty order by i.fileset.id desc" --quiet
bin/omero hql --admin "select i.fileset.id, 'F' from Image i where i.wellSamples is empty order by i.fileset.id desc" | grep F
bin/omero hql --admin "select i.fileset.id, 'F' from Image i where i.wellSamples is empty order by i.fileset.id desc" > output
```

should not hang and properly return the output (or redirect it to a file in the last case)
