### PR TITLE
DB 4.1-4.4 upgrade script fix from Bernhard Hollaender

### DIFF
--- a/sql/psql/OMERO4.4__0/OMERO4.1__0.sql
+++ b/sql/psql/OMERO4.4__0/OMERO4.1__0.sql
@@ -803,7 +803,7 @@ BEGIN
 
     INSERT INTO plateacquisitionannotationlink (id, permissions, version, child, creation_id, external_id, group_id, owner_id, update_id, parent)
     SELECT id, permissions, version, child, creation_id, external_id, group_id, owner_id, update_id, parent FROM screenacquisitionannotationlink
-     WHERE id IN (SELECT id FROM plateacquisition);
+     WHERE parent IN (SELECT id FROM plateacquisition);
 
     PERFORM setval(''seq_plateacquisition'', nextval(''seq_plateacquisition''));
     PERFORM setval(''seq_plateacquisitionannotationlink'', nextval(''seq_plateacquisitionannotationlink''));


### PR DESCRIPTION
"There is bug in the screen-plate-well model migration function in the
SQL script for the Omero4.1 to 4.4 database migration.

There is a statement that converts the annotationlinks from
screenacquisitionannotationlink to plateacquisitionannotationlink. The
where clause is wrong, it needs to be the
screenacquisitionannotaionlink.parent field that is looked up in the
plateacquistion table as id."
