### PR TITLE
Matlab examples fix

### DIFF
--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -7,6 +7,11 @@
 try
     disp('Creating connection');
     [client, session] = loadOmero();
+    fprintf(1, 'Created session for  %s', char(client.getProperty('omero.host')));
+    fprintf(1, ' for user %s',...
+        char(session.getAdminService().getEventContext().userName));
+    fprintf(1, ' using group %s\n',...
+        char(session.getAdminService().getEventContext().groupName));
     
     % Information to edit
     datasetId = str2double(client.getProperty('dataset.id'));


### PR DESCRIPTION
First round of changes for the Matlab examples scripts in preparation for the Paris workshop
- refactor `ReadData.m` to make use of the most recent OMERO.matlab functions (getImages, getProjects...)
- use `loadOmero()` to create a connection. assuming `ice.config` is in the path or `ICE_CONFIG` is defined and all the parameters have been defined. This should be further improved to explain how to create a connection without ice.config. This changes allow the script to be tested in a job for now. 
- read `image.id`, `dataset.id` from the `ice.config` file
- add some verbose output to the various read operations

Should be tested by the `OMERO-merge-training-stable` job

/cc @will-moore, @jburel
