### PR TITLE
Orphan folder dev 4 4

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageTimeSet.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageTimeSet.java
@@ -328,14 +328,14 @@ public class TreeImageTimeSet
     			group = (GroupData) gp.getUserObject();
     			path = "gid"+group.getId()+TEXT+"eid"+exp.getId()+TEXT+path;
     		}
-    		
+
     		return path;
     	}
     	if (ho instanceof GroupData) {
-			group = (GroupData) ho;
-			path = "gid"+group.getId()+TEXT+path;
-			return path;
-		}
+    		group = (GroupData) ho;
+    		path = "gid"+group.getId()+TEXT+path;
+    		return path;
+    	}
     	path = ho.toString()+TEXT+path;
     	return createPath(parent, path);
     }


### PR DESCRIPTION
Same as #1265 now onto `dev_4_4`

The `Orphaned Images` folder displayed did not correspond to the correct group context. 
The problem was highlighted when testing the move of MIF (see https://trac.openmicroscopy.org.uk/ome/ticket/11089)

To test:
- Log in as user-4
- Add to the display 2 groups user-4 is a member of.
- Expand the `Orphaned Images` folder for the first group.
- Expand the `Orphaned Images` folder for the second group.
- Go back to the `Orphaned Images` folder, The central panel should display the correct images.
