### PR TITLE
Do not flush all thumbnails when refreshing.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
@@ -199,8 +199,8 @@ public class ThumbnailProvider
      */
     public void setFullScaleThumb(BufferedImage t)
     {
+    	flush();
     	fullScaleThumb = t;
-        fullSizeImage = null;
         if (fullScaleThumb != null) scale(scalingFactor);
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -1047,12 +1047,6 @@ class DataBrowserComponent
 			case NEW:
 				return;
 		}
-		//flush the previous one first
-		Browser browser = model.getBrowser();
-		if (browser != null) {
-			browser.accept(new FlushVisitor(),
-					ImageDisplayVisitor.IMAGE_NODE_ONLY);
-		}
 		model.loadData(true, ids);
 		fireStateChange();
 	}


### PR DESCRIPTION
The flush will only happen before the thumbnail is updated
and when the browser is discarded.
