### PR TITLE
Use Homebrew Python rather than virtualenv (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -47,6 +47,9 @@ bin/brew doctor
 # dependencies may require sudo
 bin/brew install python
 
+# Install Genshi (OMERO and Bio-Formats requirement)
+bin/pip install -U genshi
+
 # Tap ome-alt library
 bin/brew tap ome/alt || echo "Already tapped"
 


### PR DESCRIPTION
This is the same as gh-1274 but rebased onto develop.

---

With recent changes brought to the main Homebrew repository, virtualenv Python
cannot be used by the Formula installer. To reduce maintenance burden, this
commit now installs Homebrew Python instead of a virtual environment. All
Python dependencies should be installed there during testing.
