### PR TITLE
Fix build target to checkout images when building Sphinx documentation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -591,7 +591,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
 
         <gitdescribe select="\2"> </gitdescribe>
 
-        <exec executable="bash" failonerror="true" dir="${sphinx.dir}"/>
+        <exec executable="bash" failonerror="true" dir="${sphinx.dir}">
             <arg line="sync_images"/>
         </exec>
 


### PR DESCRIPTION
This PR fixes the`release-docs` target to account for modification to the ome-documentation build workflow. The target now downloads the images (using `sync_images` using rsync by default) before building the Sphinx documentation.
