### PR TITLE
Fix OMERO.matlab delete functions using omero.cmd.DoAll

### DIFF
--- a/components/tools/OmeroM/src/delete/deleteObjects.m
+++ b/components/tools/OmeroM/src/delete/deleteObjects.m
@@ -42,10 +42,14 @@ ip.parse(session, ids, type);
 objectType = objectTypes(strcmp(type, objectNames));
 
 % Create a list of delete commands
-list = javaArray('omero.api.delete.DeleteCommand', numel(ids));
+deleteCommands(1 : numel(ids)) = omero.cmd.Delete();
 for i = 1 : numel(ids)
-    list(i) = omero.api.delete.DeleteCommand(objectType.delete, ids(i), []);
+    deleteCommands(i) = omero.cmd.Delete(objectType.delete, ids(i), []);
 end
 
-%Delete the object queue
-session.getDeleteService().queueDelete(list);
+% Create DoAll command object and add delete commands to the requests
+doAll = omero.cmd.DoAll();
+doAll.requests = toJavaList(deleteCommands);
+
+% Submit the delete commands
+session.submit(doAll);


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/11168

Replace deprecated queueDelete() list using omero.cmd.DoAll() and add list of
delete commands to the DoAll requests

To test this PR, retest the `deleteImages`, `deleteDatasets`, `deleteProjects`... functions by passing either one or multiple object identifiers to be deleted.

---

--rebased-to #1387 
