### PR TITLE
remove the space from the importer artifact name (rebased onto develop)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -487,7 +487,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         </copy>
 		<copy todir="target">
             <fileset dir="components/insight/target" includes="importer*.zip"/>
-            <mapper type="regexp" from="importer(.*).zip"  to="OMERO.importer -${omero.version}\1.zip"/>
+            <mapper type="regexp" from="importer(.*).zip"  to="OMERO.importer-${omero.version}\1.zip"/>
         </copy>
        	<copy file="components/insight/target/insight-ij.zip" tofile="target/OMERO.insight-ij-${omero.version}.zip"/>
 


### PR DESCRIPTION
This is the same as gh-1331 but rebased onto develop.

---

Previously after the `release-clients` target I was getting,

```
$ ls target/*-mac.zip
target/OMERO.editor-4.4.8-DEV-ice33-mac.zip
target/OMERO.importer -4.4.8-DEV-ice33-mac.zip
target/OMERO.insight-4.4.8-DEV-ice33-mac.zip
```
