### PR TITLE
script_ui ignores defaults if omero.model objects. See #11243

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2382,6 +2382,8 @@ def script_ui(request, scriptId, conn=None, **kwargs):
             i["options"] = [v.getValue() for v in param.values.getValue()]
         if param.useDefault:
             i["default"] = unwrap(param.prototype)
+            if isinstance(i["default"], omero.model.IObject):
+                i["default"] = None
         pt = unwrap(param.prototype)
         if pt.__class__.__name__ == 'dict':
             i["map"] = True


### PR DESCRIPTION
Don't use script parameter default E.g: `default=omero.model.OriginalFileI()` to populate the field in the script UI.

To test:
- Need to show the Make_Movie.py script in web. Need to comment out this script from the excluded scripts in omeroweb/settings.py at this line:

```
'"/omero/figure_scripts/ROI_Split_Figure.py", "/omero/export_scripts/Make_Movie.py",'\
```
- Now it should show up in the web scripts menu. Choose the script and check that the fields named: Watermark, Intro_Slide and Ending_Slide are blank.

---

--rebased-to #1343 
