### PR TITLE
Refactor OMERO.matlab write data example (rebased onto develop)

### DIFF
--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -15,20 +15,17 @@
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-% Information to edit
-fileToUpload= char('mydata.txt'); % file should exist.
-generatedSha1 = char('pending');
-fileMimeType = char('application/octet-stream');
+% File annotation constants
+filePath = 'mydata.txt';
+fileContent = 'file annotation content';
+fileMimeType = 'application/octet-stream';
+fileDescription = 'file annotation example';
+fileNamespace = 'examples.training.matlab';
+fileOutputPath = 'mydataBack.txt';
 
-description = char(java.util.UUID.randomUUID());
-NAME_SPACE_TO_SET = char('imperial.training.demo');
-
-% How to create a file annotation and link to an image.
-
-% To attach a file to an object e.g. an image, few objects need to be created:
-%  1. an `OriginalFile`
-%  1. a `FileAnnotation`
-%  1. a link between the `Image` and the `FileAnnotation`.
+% Tag annotation constants
+tagName = 'example';
+tagDescription = 'tag annotation example';
 
 try
     % Create a connection
@@ -41,117 +38,66 @@ try
     % Information to edit
     imageId = str2double(client.getProperty('image.id'));
     projectId = str2double(client.getProperty('project.id'));
+    
     % Load image
     fprintf(1, 'Reading image: %g\n', imageId);
     image = getImages(session, imageId);
     assert(~isempty(image), 'OMERO:WriteData', 'Image Id not valid');
 
-    
-    iUpdate = session.getUpdateService(); % service used to write object
-    % create the original file object.
-    file = java.io.File(fileToUpload);
-    name = file.getName();
-    absolutePath = file.getAbsolutePath();
-	path = absolutePath.substring(0, absolutePath.length()-name.length());
-    
-    
-    originalFile = omero.model.OriginalFileI;
-    originalFile.setName(omero.rtypes.rstring(name));
-    originalFile.setPath(omero.rtypes.rstring(path));
-    originalFile.setSize(omero.rtypes.rlong(file.length()));
-    originalFile.setSha1(omero.rtypes.rstring(generatedSha1));
-    originalFile.setMimetype(omero.rtypes.rstring(fileMimeType));
-    % now we save the originalFile object
-    originalFile = iUpdate.saveAndReturnObject(originalFile);
-  
-    % Initialize the service to load the raw data
-    rawFileStore = session.createRawFileStore();
-    rawFileStore.setFileId(originalFile.getId().getValue());
-    % open file and read stream
-    % works for small file
-    fid = fopen(fileToUpload);
-    byteArray = fread(fid,[1, file.length()], 'uint8');
-    rawFileStore.write(byteArray, 0, file.length());
+    % Create a local file
+    fprintf(1, 'Creating local file with content: %s\n', fileContent);
+    fid = fopen(filePath, 'w');
+    fwrite(fid, fileContent);
     fclose(fid);
     
-    originalFile = rawFileStore.save();
-    originalFile.getSize().getValue()
-    % Important to close the service
-    rawFileStore.close();
-    % now we have an original File in DB and raw data uploaded.
-    % We now need to link the Original file to the image using the File annotation object. That's the way to do it.
-    fa = omero.model.FileAnnotationI;
-    fa.setFile(originalFile);
-    fa.setDescription(omero.rtypes.rstring(description)); % The description set above e.g. PointsModel
-    fa.setNs(omero.rtypes.rstring(NAME_SPACE_TO_SET)) % The name space you have set to identify the file annotation.
-
-    % save the file annotation.
-    fa = iUpdate.saveAndReturnObject(fa);
-
-    % now link the image and the annotation
-    link = omero.model.ImageAnnotationLinkI;
-    link.setChild(fa);
-    link.setParent(image);
-    % save the link back to the server.
-    link = iUpdate.saveAndReturnObject(link);
-
-
-    % Load all the annotations with a given namespace linked to the images.
-
-
-    userId = session.getAdminService().getEventContext().userId;
-    nsToInclude = java.util.ArrayList;
-    nsToInclude.add(NAME_SPACE_TO_SET);
-    nsToExclude = java.util.ArrayList;
-    options = omero.sys.ParametersI;
-    options.exp(omero.rtypes.rlong(userId)); %load the annotation for a given user.
-    metadataService = session.getMetadataService();
-    % retrieve the annotations linked to images, for datasets use: omero.model.Dataset.class
-    annotations = metadataService.loadSpecifiedAnnotations(omero.model.Image.class, nsToInclude, nsToExclude, options);
-    for j = 0:annotations.size()-1,
-        annotations.get(j).getId().getValue();
-    end
-
-    % Read the attachment. First load the annotation, cf. above.
-
-    % Let's call fa the file annotation
-    originalFile = fa.getFile();
-    rawFileStore = session.createRawFileStore();
-    rawFileStore.setFileId(originalFile.getId().getValue());
-    % read data
+    % Create a file annotation
+    fprintf(1, 'Creating file annotation with namespace %s\n', fileNamespace);
+    fa = writeFileAnnotation(session, filePath,...
+        'mimetype', fileMimeType, 'description', fileDescription,...
+        'namespace', fileNamespace);
+    fprintf(1, 'Created file annotation %g ', fa.getId().getValue());
     
-    fid = fopen('mydataBack.txt', 'w');
-    fwrite(fid, rawFileStore.read(0, originalFile.getSize().getValue()), 'uint8');
+    % Link the image and the file annotation
+    link = linkAnnotation(session, fa, 'image', imageId);
+    fprintf(1, 'and linked it to image %g\n', imageId);
+
+    % Delete the local file
+    delete(filePath);
+    
+    % Load all the file annotations with a given namespace linked to the image
+    fprintf(1, 'Reading file annotations attached to image %g with namespace %s\n',...
+        imageId, fileNamespace);
+    fas = getImageFileAnnotations(session, imageId,...
+        'include', fileNamespace);
+    fprintf(1, 'Found %g file annotation(s)\n', numel(fas));
+    
+    % Download the content of the file annotation
+    fprintf(1, 'Reading content of file annotation %g\n',...
+        fa.getId().getValue());
+    getFileAnnotationContent(session, fa, fileOutputPath);
+    
+    % Read the downloaded content
+    fid = fopen(fileOutputPath, 'r');
+    readContent = fread(fid);
     fclose(fid);
-    type mydataBack.txt;
+    fprintf(1, 'File content: %s\n', readContent);
+
+    % Delete the local file
+    delete(fileOutputPath);
     
-    % close when done
-    rawFileStore.close();
-
-    %Create a dataset and link it to an existing project.
-    dataset = omero.model.DatasetI;
-    dataset.setName(omero.rtypes.rstring(char('name dataset')));
-    dataset.setDescription(omero.rtypes.rstring(char('description dataset')));
-
-    %link dataset and project
-    link = omero.model.ProjectDatasetLinkI;
-    link.setChild(dataset);
-    link.setParent(omero.model.ProjectI(projectId, false));
-
-    session.getUpdateService().saveAndReturnObject(link);
-
     % Create a tag i.e. tag annotation and link it to an existing project.
-
-    tag = omero.model.TagAnnotationI;
-    tag.setTextValue(omero.rtypes.rstring(char('name tag')));
-    tag.setDescription(omero.rtypes.rstring(char('description tag')));
-
-    %link tag and project
-    link = omero.model.ProjectAnnotationLinkI;
-    link.setChild(tag);
-    link.setParent(omero.model.ProjectI(projectId, false));
-
-    session.getUpdateService().saveAndReturnObject(link);
+    disp('Creating tag annotation');
+    ta = writeTagAnnotation(session, tagName, 'description', tagDescription);
+    fprintf(1, 'Created tag annotation %g ', ta.getId().getValue());
+    
+    % Link the image and the file annotation
+    link = linkAnnotation(session, ta, 'project', projectId);
+    fprintf(1, 'and linked it to project %g\n', projectId);
+    
+    % Load all the tag annotations linked to the project
+    fprintf(1, 'Reading tag annotations attached to project %g\n', projectId);
+    tas = getProjectTagAnnotations(session, projectId);
+    fprintf(1, 'Found %g tag annotation(s)\n', numel(tas));
     
 catch err
     disp(err.message);


### PR DESCRIPTION
This is the same as gh-1334 but rebased onto develop.

---

Use the annotation read/write functions (`writeFileAnnotation`,
`getFileAnnotationContent`...) recently merged into the OMERO.matlab toolbox.
