### PR TITLE
script_ui ignores defaults if omero.model objects. See #11243 develop

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2389,6 +2389,8 @@ def script_ui(request, scriptId, conn=None, **kwargs):
             i["options"] = [v.getValue() for v in param.values.getValue()]
         if param.useDefault:
             i["default"] = unwrap(param.prototype)
+            if isinstance(i["default"], omero.model.IObject):
+                i["default"] = None
         pt = unwrap(param.prototype)
         if pt.__class__.__name__ == 'dict':
             i["map"] = True


### PR DESCRIPTION
This is in dev_4_4 as https://github.com/openmicroscopy/openmicroscopy/pull/1337, now for develop...

---

--rebased-from #1337 
