### PR TITLE
server_login_list_11273

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -47,13 +47,7 @@ class LoginForm(NonASCIIForm):
     
     def __init__(self, *args, **kwargs):
         super(LoginForm, self).__init__(*args, **kwargs)
-        try:
-            if reduce( (lambda x, y : x + 1), Server, 0) > 1:
-                self.fields['server'] = ServerModelChoiceField(Server, empty_label=u"---------")
-            else:
-                self.fields['server'] = ServerModelChoiceField(Server, empty_label=None)
-        except:
-            self.fields['server'] = ServerModelChoiceField(Server, empty_label=u"---------")
+        self.fields['server'] = ServerModelChoiceField(Server, empty_label=None)
         
         self.fields.keyOrder = ['server', 'username', 'password', 'ssl']
             


### PR DESCRIPTION
See #11273. Don't show the empty label '------' when you have multiple servers in the login list.

This means that the first server in the list will be chosen by default.

To test: check the list of servers in web login page, see that there's no "blank" option and the first is chosen by default.

---

--rebased-to #1356 
