### PR TITLE
Use the reflected network check on non-Linux platforms

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/NetworkChecker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/NetworkChecker.java
@@ -201,4 +201,16 @@ public class NetworkChecker {
 		}
 		return networkup;
 	}
+
+	/**
+	 * Testing main that allows for the usage of the NetworkChecker
+	 * without running the entire software stack.
+	 */
+	public static void main(String[] args) throws Exception {
+		String address = args.length == 1? args[0] : null;
+		NetworkChecker nc = new NetworkChecker(address);
+		System.err.println("Using explicit server address: " + address);
+		System.err.println("Java version: " + System.getProperty("java.version"));
+		System.err.println("isNetworkup()?: " + nc.isNetworkup());
+	}
 }


### PR DESCRIPTION
If it has been determined that the reflected check (i.e. using Java 1.6+
code) can be used, then try that first on non-Linux systems.  If it
returns false or cannot be run, then the original Java 1.5 is still
used.

This prevents the network from being detected as down on many non-Linux
systems with Java 1.7.0-b27.

See #10824, #10838, and #11244.

Please do note the following:
- This worked for me on a Windows XP VM with 1.7.0-b27 installed, but please double check that this works across as broad a range of systems as possible.  1.7.0-b27 really must be tested on all platforms, but please do check older Java versions on non-Linux systems as well.
- This is in no way intended to be a comprehensive "make NetworkChecker perfect" PR.  It is a bandage for ticket 11244.  If there is something fundamentally wrong with what is in this PR, I will fix it, but I do not intend to fully address ticket 10824 here.
- Any comments to the effect that this PR does not solve ticket 11244 must be accompanied by the Java version and OS version.

/cc @chris-allan, @jburel, @joshmoore, @bpindelski, @mtbc, @will-moore, @zeb, @rleigh-dundee

---

--rebased-to #1348 
