### PR TITLE
Web image object id extension 11022 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -147,11 +147,16 @@ OME.share_selection_changed = function(share_id) {
         .trigger("selection_change.ome");
 };
 
+// Standard ids are in the form TYPE-ID, web extensions may add an
+// additional -SUFFIX
 OME.table_selection_changed = function($selected) {
     var selected_objs = [];
     if (typeof $selected != 'undefined') {
         $selected.each(function(i){
-            selected_objs.push( {"id":$(this).attr('id')} );
+            var id_split = this.id.split('-');
+            var id_obj = id_split.slice(0, 2).join('-');
+            var id_suffix = id_split.slice(2).join('-');
+            selected_objs.push( {"id":id_obj, "id_suffix":id_suffix} );
         });
     }
     $("body")


### PR DESCRIPTION
This is the same as gh-1234 but rebased onto develop.

---

Allow use of object ID suffixes in add-on webapps by ignoring everything after the second `-`. See [Trac 11022](http://trac.openmicroscopy.org.uk/ome/ticket/11022).

Testing: Check single and batch annotations work. Check right hand tabs work. Should be backwards compatible unless there's anything already using IDs with multiple `-`.

---

--rebased-from #1234 
