### PR TITLE
Use the reflected network check on non-Linux platforms (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/NetworkChecker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/NetworkChecker.java
@@ -256,5 +256,17 @@ public class NetworkChecker {
 	    if (logger.isDebugEnabled()) {
 	        logger.debug(String.format(msg, objs));
 	    }
+  }
+
+	/**
+	 * Testing main that allows for the usage of the NetworkChecker
+	 * without running the entire software stack.
+	 */
+	public static void main(String[] args) throws Exception {
+		String address = args.length == 1? args[0] : null;
+		NetworkChecker nc = new NetworkChecker(address);
+		System.err.println("Using explicit server address: " + address);
+		System.err.println("Java version: " + System.getProperty("java.version"));
+		System.err.println("isNetworkup()?: " + nc.isNetworkup());
 	}
 }


### PR DESCRIPTION
Same as gh-1345, but rebased onto develop.

Please follow the same testing procedure as outlined in gh-1345.

---

--rebased-from #1345 
