### PR TITLE
Fix CLI `omero group perms` subcommmand

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -169,7 +169,7 @@ More information is available at:
         c = self.ctx.conn(args)
         a = c.sf.getAdminService()
 
-        gid, g = self.find_group(a, args.id_or_name)
+        gid, g = self.parse_groupid(a, args)
 
         old_perms = str(g.details.permissions)
         if old_perms == str(perms):


### PR DESCRIPTION
Propagate the recent changes made to the group arguments using --id/--name
options to the perms() method using parse_groupid() to return the group and
group identifier.

To test this PR, try out the various signatures of the `bin/omero group perms` subcommand, i.e.

```
bin/omero group perms --id 4 --type read-only
bin/omero group perms --name private-1 --perms 'rw----'
bin/omero group perms --id 4 --perms 'rwr---'
bin/omero group perms --name private-1 --type read-only
```

and check the permissions are updated using `bin/omero group list`

/cc @ximenesuk

---

--rebased-to #1353 
