### PR TITLE
making Group/User dropdown menu configurable, close #11120 (rebased onto dev_4_4)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -258,6 +258,9 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # Add links to the top header: links are ['Link Text', 'link'], where the url is reverse("link") OR simply 'link' (for external urls)
     "omero.web.ui.top_links": ["TOP_LINKS", '[]', json.loads],  # E.g. '[["Webtest", "webtest_index"]]'
     
+    # Shows/hides users in dropdown menu; default: '{"LEADERS": "Owners", "COLLEAGUES": "Members", "ALL": "All members"}'
+    "omero.web.ui.menu.dropdown": ["UI_MENU_DROPDOWN",'{"LEADERS": "Owners", "COLLEAGUES": "Members", "ALL": "All members"}', json.loads],
+    
     # Add plugins to the right-hand & center panels: plugins are ['Label', 'include.js', 'div_id']. The javascript loads data into $('#div_id').
     "omero.web.ui.right_plugins": ["RIGHT_PLUGINS", '[["Acquisition", "webclient/data/includes/right_plugin.acquisition.js.html", "metadata_tab"],'\
             #'["ROIs", "webtest/webclient_plugins/right_plugin.rois.js.html", "image_roi_tab"],'\

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown.html
@@ -1,3 +1,5 @@
+{% load common_tags %}
+
 {% comment %}
 <!--
   Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
@@ -144,19 +146,21 @@
                         {% endif %} />
                         {{ grp.getName }}
                     </a>
-                    <ul title="Switch to this Group and User">
-                        <li>
-                            {% ifequal grp.id active_group.id %}
-                            <a href="{{ current_url }}?experimenter=-1">
-                                <!-- otherwise we switch group too -->
-                            {% else %}
-                            <a href="{% url change_active_group %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1">
-                            {% endifequal %}
-                                All members
-                            </a>
-                        </li>
+                    <ul title="Switch to this Group and User" style="top:0px">
+                        {% if grp.all %}
+							<li>
+	                            {% ifequal grp.id active_group.id %}
+	                            <a href="{{ current_url }}?experimenter=-1">
+	                                <!-- otherwise we switch group too -->
+	                            {% else %}
+	                            <a href="{% url change_active_group %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1">
+	                            {% endifequal %}
+	                                {% setting UI_MENU_DROPDOWN.ALL %}
+	                            </a>
+	                        </li>
+						{% endif %}
                         {% if grp.leaders %}
-                            <li class="non_selectable"><strong>Owners</strong></li>
+                            <li class="non_selectable"><strong>{% setting UI_MENU_DROPDOWN.LEADERS %}</strong></li>
                             {% for user in grp.leaders %}
                                 <li {% ifequal user.id experimenter %}class="current_user"{% endifequal %}>
                                     <!-- if this user is in current group, we just switch user -->
@@ -173,7 +177,7 @@
                         {% endif %}
                         
                         {% if grp.colleagues %}
-                            <li class="non_selectable"><strong>Members</strong></li>
+                            <li class="non_selectable"><strong>{% setting UI_MENU_DROPDOWN.COLLEAGUES %}</strong></li>
                             {% for user in grp.colleagues %}
                                 <li {% ifequal user.id experimenter %}class="current_user"{% endifequal %}>
                                     {% ifequal grp.id active_group.id %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2051,11 +2051,16 @@ class ExperimenterGroupWrapper (OmeroWebObjectWrapper, omero.gateway.Experimente
         @return:    {'leaders': list L{ExperimenterWrapper}, 'colleagues': list L{ExperimenterWrapper}}
         @rtype:     dict
         """
+        
         summary = self._conn.groupSummary(self.getId())
-        self.leaders = summary["leaders"]
-        self.leaders.sort(key=lambda x: x.getLastName().lower())
-        self.colleagues = summary["colleagues"]
-        self.colleagues.sort(key=lambda x: x.getLastName().lower())
+        if settings.UI_MENU_DROPDOWN.get("LEADERS", None):
+            self.leaders = summary["leaders"]
+            self.leaders.sort(key=lambda x: x.getLastName().lower())
+        if settings.UI_MENU_DROPDOWN.get("COLLEAGUES", None):
+            self.colleagues = summary["colleagues"]
+            self.colleagues.sort(key=lambda x: x.getLastName().lower())
+        if settings.UI_MENU_DROPDOWN.get("ALL", None):
+            self.all = True
 
     def getOwners(self):
         for gem in self.copyGroupExperimenterMap():

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_tags.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_tags.py
@@ -37,23 +37,35 @@ logger = logging.getLogger(__name__)
 
 # makes settings available in template
 @register.tag
-def setting ( parser, token ): 
+def setting ( parser, token ):
     try:
         tag_name, option = token.split_contents()
     except ValueError:
         raise template.TemplateSyntaxError, "%r tag requires a single argument" % token.contents[0]
     return SettingNode( option )
 
-class SettingNode ( template.Node ): 
-    def __init__ ( self, option ): 
+class SettingNode ( template.Node ):
+    def __init__ ( self, option ):
         self.option = option
 
-    def render ( self, context ): 
-        # if FAILURE then FAIL silently
+    def render ( self, context ):
         try:
-            return str(settings.__getattr__(self.option))
+            setting = settings
+            for name in self.option.split('.'):
+                if name.isdigit():
+                    setting = setting[int(name)]
+                else:
+                    if type(setting) == dict:
+                        setting = setting.get(name)
+                    else:
+                        setting = setting.__getattr__(name)
+            
+            return str(setting)
         except:
+            # if FAILURE then FAIL silently
             return ""
+
+
 
 class PluralNode(template.Node):
     def __init__(self, quantity, single, plural):


### PR DESCRIPTION
This is the same as gh-1294 but rebased onto dev_4_4.

---

This PR covers [ticket 11120](http://trac.openmicroscopy.org.uk/ome/ticket/11120).
Additional configuration allows to manipulate drop down menu, as shown on the picture
![firefoxscreensnapz004](https://f.cloud.github.com/assets/1065155/653887/7143601c-d4e8-11e2-86fd-238a54a7d70b.jpg).

`bin/omero config set omero.web.ui.menu.dropdown '{"LEADERS": "Owners", "COLLEAGUES": "Members", "ALL": "All members"}'`
