### PR TITLE
testGetTile() checks against getPlane(). See #11315

### DIFF
--- a/components/tools/OmeroPy/test/gatewaytest/pixels.py
+++ b/components/tools/OmeroPy/test/gatewaytest/pixels.py
@@ -95,6 +95,11 @@ class PixelsTest (lib.GTest):
         stacked = hstack((tile1, tile2))
         self.assertEqual(str(tile3), str(stacked))  # bit of a hacked way to compare arrays, but seems to work
 
+        # See whether a 2x2 tile is the same as the same region of a Plane. See #11315
+        testTile = pixels.getTile(0,0,0, tile=(0,0,2,2))
+        croppedPlane = pixels.getPlane(0,0,0)[0:2,0:2]
+        self.assertEqual(str(testTile), str(croppedPlane), "Tile and croppedPlane not equal")
+
     def testGetPlane(self):
         image = self.TESTIMG
         pixels = image.getPrimaryPixels()


### PR DESCRIPTION
Extend gatewaytest/pixels.py testGetTile() to check that we get the same pixel values for getTile() and the corresponding region of a plane, using getPlane().

This fails in FS but passes in dev_4_4: See ticket #11315.

To run test:

```
$ python gatewaytest/pixels.py PixelsTest.testGetTile
F
======================================================================
FAIL: testGetTile (__main__.PixelsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "gatewaytest/pixels.py", line 101, in testGetTile
    self.assertEqual(str(testTile), str(croppedPlane), "Tile and croppedPlane not equal")
AssertionError: Tile and croppedPlane not equal
```
