### PR TITLE
Add a hook so additional scripts can be run after creating VM

### DIFF
--- a/docs/install/VM/driver.sh
+++ b/docs/install/VM/driver.sh
@@ -22,5 +22,10 @@ bash setup_nginx.sh
 
 $OMERO_BIN/omero admin start
 
+#OMERO_POST_INSTALL_SCRIPTS
+for cmd in "$@"; do
+    bash "`basename $cmd`"
+done
+
 echo $PASSWORD | sudo -S halt
 #echo $PASSWORD | sudo -S reboot

--- a/docs/install/VM/omerovm.sh
+++ b/docs/install/VM/omerovm.sh
@@ -11,6 +11,8 @@ export OMEROS_PORT=${OMEROS_PORT:-"4064"}
 export OMEROS_PF=${OMEROS_PF:-"4064"}
 export OMERO_JOB=${OMERO_JOB:-"OMERO-stable"}
 
+export OMERO_POST_INSTALL_SCRIPTS=${OMERO_POST_INSTALL_SCRIPTS}
+
 set -e
 set -u
 set -x
@@ -53,10 +55,16 @@ function installvm ()
 	$SCP virtualbox-network-fix-init.d omero@localhost:~/
   $SCP virtualbox_fix.sh omero@localhost:~/
   $SCP nginx-control.sh omero@localhost:~/
+
+	if [ -n "$OMERO_POST_INSTALL_SCRIPTS" ];
+	then
+		$SCP $OMERO_POST_INSTALL_SCRIPTS omero@localhost:~/
+	fi
+
 	echo "ssh : exec driver.sh"
-	$SSH omero@localhost "export OMERO_JOB=$OMERO_JOB; bash /home/omero/driver.sh"
+	$SSH omero@localhost "export OMERO_JOB=$OMERO_JOB; bash /home/omero/driver.sh $OMERO_POST_INSTALL_SCRIPTS"
 	sleep 10
-	
+
 	echo "ALL DONE!"
 }
 


### PR DESCRIPTION
Allow additional scripts to be run as part of the OMERO Virtualbox build.

For example, to include OMERO.searcher as part of the VM (note this is using the manual-scc-merge-all branch for convenience, and assumes you can build the standard VM in the first place):

```
PARENTDIR=$PWD
git clone git@github.com:openmicroscopy/omero_searcher.git
cd omero_searcher
git checkout origin/manual-scc-merge-all
```

or alternatively just download `setup_omero_searcher.sh` from
https://github.com/manics/omero_searcher/blob/omero_searcher_vm-11240/docs/vm/setup_omero_searcher.sh

Then in the openmicroscopy checkout:

```
export OMERO_POST_INSTALL_SCRIPTS=$PARENTDIR/omero_searcher/docs/vm/setup_omero_searcher.sh
./build.py build-vm
```

If you're lucky you'll now have a VM image with OMERO.searcher pre-installed and configured. Import some images, calculate some features, and search :).

See also
http://trac.openmicroscopy.org.uk/ome/ticket/11240
https://github.com/openmicroscopy/omero_searcher/pull/12

Note the actual OMERO.searcher VM setup script `setup_omero_searcher.sh` is a bit of a mess (or rather quite a big mess) due to the ancient pip version which is missing a lot of functionality. There's also the question of where it should go- its not part of the core omero distribution, but it is specific to the OME build infrastructure so is the omero_searcher repo the right place for it?
