### PR TITLE
Handle trans. range before filter (Fix #11017) (rebased onto dev_4_4)

### DIFF
--- a/components/server/resources/ome/services/spec.xml
+++ b/components/server/resources/ome/services/spec.xml
@@ -178,8 +178,8 @@
             <list>
                 <value>/Instrument/Detector</value>
                 <value>/Instrument/Dichroic</value>
-                <value>/Instrument/Filter/TransmittanceRange</value>
                 <value>/Instrument/Filter</value>
+                <value>/Instrument/Filter/TransmittanceRange</value>
                 <value>/LightSource;SOFT;/Instrument</value>
                 <value>/Instrument/OTF</value> <!--  related to filterSet and Objective -->
                 <value>/Instrument/Objective</value>


### PR DESCRIPTION
This is the same as gh-1299 but rebased onto dev_4_4.

---

Under the `/Instrument` graph spec, `TransmittanceRange` was listed before `Filter` whereas under `/Image/Pixels/Channel` the order was reversed:

```
                <value>/Image/Pixels/Channel/LogicalChannel/LightPath/LightPathEmissionFilterLink/Filter;SOFT</value>
                <value>/Image/Pixels/Channel/LogicalChannel/LightPath/LightPathEmissionFilterLink/Filter/TransmittanceRange;SOFT</value>
```

This has been reversed, with which `zeiss-lsm-martin/051215-j-tf.mdb` should now be properly chgrp'able and link'able.

More generally, though, this points to an increased need to test the listing of `Instruments` in the graph specs (i.e. for chgrp and delete), and quite possibly a complete review of the `SOFT` handling.

/cc @will-moore, @pwalczysko, @mtbc

---

--rebased-from #1299 
