### PR TITLE
Insight thumbnail white border

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tpane/TinyPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tpane/TinyPaneUI.java
@@ -158,7 +158,7 @@ class TinyPaneUI
      */
     protected FrameBorder makeBorder()
     {
-        return new FrameBorder(BORDER_COLOR, DESKTOP_COLOR, BORDER_MARGIN);
+        return new FrameBorder(BORDER_COLOR, null, BORDER_MARGIN);
     }
     
     /**


### PR DESCRIPTION
The thumbnail borders are already made white after deselection from `Colors.getDeselectedHighlight` returning `null` which `FrameBorder` interprets as being `DEFAULT_COLOR` so they may as well not start off differently (nearly white) in the first place.

---

--rebased-to #1381 
