### PR TITLE
Insight thumbnail white border (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tpane/TinyPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tpane/TinyPaneUI.java
@@ -158,7 +158,7 @@ class TinyPaneUI
      */
     protected FrameBorder makeBorder()
     {
-        return new FrameBorder(BORDER_COLOR, DESKTOP_COLOR, BORDER_MARGIN);
+        return new FrameBorder(BORDER_COLOR, null, BORDER_MARGIN);
     }
     
     /**


### PR DESCRIPTION
This is the same as gh-1375 but rebased onto develop.

---

The thumbnail borders are already made white after deselection from `Colors.getDeselectedHighlight` returning `null` which `FrameBorder` interprets as being `DEFAULT_COLOR` so they may as well not start off differently (nearly white) in the first place.

---

--rebased-from #1375 
