### PR TITLE
Travis build: environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 env:
     - BUILD="build-all" TEST="-p"
     - BUILD="build-default test-compile" TEST="-py test -Dtest.with.fail=true"
-    - BUILD="build-default build-cpp test-compile-all" TEST="-cpp test -Dtest.with.fail=true"
+    - BUILD="build-all test-compile-all" TEST="-cpp test -Dtest.with.fail=true"
 
 jdk:
   - openjdk7


### PR DESCRIPTION
Some of the commits from #1200 were not properly cherry-picked in #1316. Thus the Travis build was inconsistent between branches. 

This PR should restore the multiple environment Travis builds in the dev_4_4 branch

---

--rebased-from #1200 .travis.yml commits only
