### PR TITLE
Remove ERROR log on non-CloseableServant (Fix #11378) (rebased onto dev_4_4)

### DIFF
--- a/components/blitz/src/omero/cmd/SessionI.java
+++ b/components/blitz/src/omero/cmd/SessionI.java
@@ -441,9 +441,10 @@ public class SessionI implements _SessionOperations {
                         __curr.ctx.put(CLIENTUUID.value, clientId);
                         CloseableServant cs = (CloseableServant) servant;
                         cs.close(__curr);
-                    } else {
-                        log.error("Unknown servant type: " + servant);
                     }
+                    // Now ignoring all non-CloseableServants, since
+                    // that is *the* interface that should be used
+                    // for any cleanup. See #11378
                 } catch (Exception e) {
                     log.error("Error destroying servant: " + idName + "="
                             + servant, e);


### PR DESCRIPTION
This is the same as gh-1401 but rebased onto dev_4_4.

---

Since the refactoring the close methods out of
`AbstractAmdServant` and into `CloseableServant`,
an ERROR has been printed for each stateless
service.

As mentioned in the ticket, without this patch

```
import omero
cli=omero.client('localhost')
sess=cli.createSession('root','ome')
sess.getAdminService()
cli.__del__()
```

suffices to print an ERROR to var/log/Blitz-0.log. With
it, there should be none.

See: http://trac.openmicroscopy.org.uk/ome/ticket/11378#comment:6

---

--rebased-from #1401 
