### PR TITLE
Exit with non zero return code if a Matlab training example fails (rebased onto develop)

### DIFF
--- a/examples/Training/matlab/ConnectToOMERO.m
+++ b/examples/Training/matlab/ConnectToOMERO.m
@@ -67,16 +67,10 @@ try
         assert(groupId == adminService.getEventContext().groupId);
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/CreateImage.m
+++ b/examples/Training/matlab/CreateImage.m
@@ -112,16 +112,10 @@ try
     store.save(); %save the data
     store.close(); %close
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc = 1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/DeleteData.m
+++ b/examples/Training/matlab/DeleteData.m
@@ -51,16 +51,10 @@ try
     assert(isempty(image), 'OMERO:LoadMetadataAdvanced', 'Image not deleted');
     fprintf(1, 'Image %g deleted\n', imageId);
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc = 1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/LoadMetadataAdvanced.m
+++ b/examples/Training/matlab/LoadMetadataAdvanced.m
@@ -43,16 +43,10 @@ try
         fprintf(1, 'Reading channel %g: %g\n',j+1, channel.getId().getValue());
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc = 1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/ROIs.m
+++ b/examples/Training/matlab/ROIs.m
@@ -104,16 +104,10 @@ try
         end
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/RawDataAccess.m
+++ b/examples/Training/matlab/RawDataAccess.m
@@ -104,16 +104,10 @@ try
     % close the store
     store.close();
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -130,16 +130,10 @@ try
         end
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/ReadDataAdvanced.m
+++ b/examples/Training/matlab/ReadDataAdvanced.m
@@ -93,16 +93,10 @@ try
         end
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/RenderImages.m
+++ b/examples/Training/matlab/RenderImages.m
@@ -102,16 +102,10 @@ try
         imshow(thumbnail, []);
     end
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -123,16 +123,10 @@ try
     tas = getProjectTagAnnotations(session, projectId);
     fprintf(1, 'Found %g tag annotation(s)\n', numel(tas));
     
-    rc = 0;
 catch err
-    disp(err.message);
-    rc =  1;
+    client.closeSession();
+    throw(err);
 end
 
 % Close the session
-try
-    client.closeSession();
-catch err
-    disp(err.message);
-    rc = 2;
-end
+client.closeSession();

--- a/examples/Training/matlab/exampleSuite.m
+++ b/examples/Training/matlab/exampleSuite.m
@@ -1,0 +1,32 @@
+% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% All rights reserved.
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+try
+    ConnectToOMERO;
+    ReadData;
+    ReadDataAdvanced;
+    RawDataAccess;
+    ROIs;
+    DeleteData;
+    LoadMetadataAdvanced;
+    CreateImage;
+    RenderImages;
+    WriteData;
+catch err
+    disp(err.message);
+    exit(1);
+end


### PR DESCRIPTION
This is the same as gh-1411 but rebased onto develop.

---

We do not have any proper Matlab integration tests at the moment but daily run the training examples job against the latest server.

This PR causes all the Matlab training scripts to return a non-zero return code if an error is captured. This should cause the corresponding training example job to fail.

---

--rebased-from #1411
