### PR TITLE
fix #11360: get the servant holder from the session factory into the raw file store

### DIFF
--- a/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
+++ b/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
@@ -300,6 +300,7 @@ public final class SessionManagerI extends Glacier2._SessionManagerDisp
                 if (sf != null) {
                     Ice.Identity newId = new Ice.Identity(UUID.randomUUID().toString(), id.name);
                     msg.setProxy(sf.registerServant(newId, msg.getServant()));
+                    msg.setHolder(sf.holder);
                 }
             } else if (event instanceof DestroySessionMessage) {
                 DestroySessionMessage msg = (DestroySessionMessage) event;

--- a/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
@@ -31,6 +31,7 @@ import omero.grid.RepositoryPrx;
 import omero.grid.RepositoryPrxHelper;
 import omero.model.OriginalFile;
 import omero.util.IceMapper;
+import omero.util.ServantHolder;
 import omero.util.TieAware;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -172,6 +173,7 @@ _RawFileStoreOperations, ServiceFactoryAware, TieAware {
         final RawFileStorePrx rfsPrx = repoPrx.file(fileId, adjustedCtx);
         OpsDelegate ops = new OpsDelegate(be, rfsTie, this, rfsPrx);
         ops.setApplicationContext(ctx);
+        ops.setHolder(holder);
         tie.ice_delegate(ops);
         return true;
     }

--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -61,6 +61,7 @@ import ome.formats.importer.OMEROWrapper;
 import ome.parameters.Parameters;
 import ome.services.blitz.util.RegisterServantMessage;
 import ome.services.util.Executor;
+import ome.system.OmeroContext;
 import ome.system.Principal;
 import ome.system.ServiceFactory;
 import ome.util.SqlAction;
@@ -721,7 +722,10 @@ public class PublicRepositoryI extends _RepositoryDisp {
         _RawFileStoreTie tie = new _RawFileStoreTie(rfs);
         RegisterServantMessage msg = new RegisterServantMessage(this, tie, adjustedCurr);
         try {
-            this.executor.getContext().publishMessage(msg);
+            final OmeroContext ctx = this.executor.getContext();
+            ctx.publishMessage(msg);
+            rfs.setHolder(msg.getHolder());
+            rfs.setApplicationContext(ctx);
         } catch (Throwable t) {
             if (t instanceof ServerError) {
                 throw (ServerError) t;

--- a/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
+++ b/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
@@ -8,6 +8,7 @@
 package ome.services.blitz.util;
 
 import ome.util.messages.InternalMessage;
+import omero.util.ServantHolder;
 
 /**
  * {@link InternalMessage} raised when a servant should be registered for clean.
@@ -27,6 +28,14 @@ public class RegisterServantMessage extends InternalMessage {
 
     private transient Ice.ObjectPrx prx;
 
+    private transient ServantHolder holder;
+
+    /**
+     * Create a new message
+     * @param source the source of the message
+     * @param servant the servant that is to be registered
+     * @param current the Ice context
+     */
     public RegisterServantMessage(Object source, Ice.Object servant,
             Ice.Current current) {
         super(source);
@@ -34,22 +43,51 @@ public class RegisterServantMessage extends InternalMessage {
         this.curr = current;
     }
 
+    /**
+     * @return the servant to register
+     */
     public Ice.Object getServant() {
         return this.servant;
     }
 
+    /**
+     * @return the Ice context
+     */
     public Ice.Current getCurrent() {
         return this.curr;
     }
 
+    /**
+     * @param prx the proxy object to set
+     */
     public void setProxy(Ice.ObjectPrx prx) {
         if (this.prx != null) {
-            throw new RuntimeException("Proxy can only be set once!");
+            throw new RuntimeException("Proxy can be set only once!");
         }
         this.prx = prx;
     }
 
+    /**
+     * @return the proxy object
+     */
     public Ice.ObjectPrx getProxy() {
         return this.prx;
+    }
+
+    /**
+     * @param holder the servant holder to set
+     */
+    public void setHolder(ServantHolder holder) {
+        if (this.holder != null) {
+            throw new RuntimeException("Holder can be set only once!");
+        }
+        this.holder = holder;
+    }
+
+    /**
+     * @return the servant holder
+     */
+    public ServantHolder getHolder() {
+        return this.holder;
     }
 }

--- a/components/tools/OmeroJava/test/integration/RawFileStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawFileStoreTest.java
@@ -87,7 +87,6 @@ public class RawFileStoreTest extends AbstractServerTest {
      *             Thrown if an error occurred.
      * @see #testUploadFile()
      */
-    @Test(groups = "broken")
     public void testDownloadScript() throws Exception {
         IScriptPrx svc = factory.getScriptService();
         List<OriginalFile> scripts = svc.getScripts();
@@ -108,5 +107,4 @@ public class RawFileStoreTest extends AbstractServerTest {
             store.close();
         }
     }
-
 }


### PR DESCRIPTION
fixes http://trac.openmicroscopy.org.uk/ome/ticket/11360

Check that the appropriate OMERO integration test Jenkins job passes or try running tests locally. A quick start would be,

```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/RawFileStoreTest
```

but run the other non-broken ones too if Jenkins didn't do it for you (timeouts, whatever).
