### PR TITLE
fix #11401: remove deleted tree nodes from set of selected nodes (rebase)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -76,6 +76,9 @@ import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
+
+import com.google.common.collect.Sets;
+
 import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ExperimenterData;
@@ -1904,6 +1907,14 @@ class BrowserComponent
 				node.removeFromParent();
 				view.reloadNode(parent);
 			}
+		}
+		/* ensure that the selected displays do not include any removed nodes */
+		final Set<TreeImageDisplay> oldSelected = Sets.newHashSet(getSelectedDisplays());
+		final Set<TreeImageDisplay> newSelected = Sets.newHashSet(oldSelected);
+		newSelected.removeAll(nodes);
+		if (!newSelected.equals(oldSelected)) {
+		    setSelectedDisplay(null);
+		    setSelectedDisplays(newSelected.toArray(new TreeImageDisplay[newSelected.size()]), false);
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -47,9 +47,6 @@ import javax.swing.JFrame;
 //Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-
 //Application-internal dependencies
 import omero.model.OriginalFile;
 
@@ -316,14 +313,7 @@ class TreeViewerComponent
 				NodesFinder finder = new NodesFinder(klass, ids);
 				Browser browser = model.getSelectedBrowser();
 				browser.accept(finder);
-				final Set<TreeImageDisplay> nodesToRemove = finder.getNodes();
-				browser.removeTreeNodes(nodesToRemove);
-				final Set<TreeImageDisplay> oldSelected = ImmutableSet.copyOf(browser.getSelectedDisplays());
-				final Set<TreeImageDisplay> newSelected = Sets.difference(oldSelected, nodesToRemove);
-				if (!newSelected.equals(oldSelected)) {
-				    browser.setSelectedDisplay(null);
-				    browser.setSelectedDisplays(newSelected.toArray(new TreeImageDisplay[newSelected.size()]), false);
-				}
+				browser.removeTreeNodes(finder.getNodes());
 				view.removeAllFromWorkingPane();
 				DataBrowserFactory.discardAll();
 				model.getMetadataViewer().setRootObject(null, -1, null);


### PR DESCRIPTION
The four steps described at http://trac.openmicroscopy.org.uk/ome/ticket/11401 should no longer crash Insight. Play a bit with tree selection and deletion to make sure it still works properly.

---

--rebased-from #1427 
--rebased-to #1454 
