### PR TITLE
fix #10561: make user object getting robust to no experimenter in tree

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2963,7 +2963,7 @@ class TreeViewerComponent
 						node = i.next();
 						parent = node.getParentDisplay();
 						expNode = BrowserFactory.getDataOwner(node);
-						exp = (ExperimenterData) expNode.getUserObject();
+						exp = expNode == null ? null : (ExperimenterData) expNode.getUserObject();
 						if (exp == null) exp = model.getUserDetails();
 						node.setExpanded(true);
 						//mv.setRootObject(node.getUserObject(), exp.getId());


### PR DESCRIPTION
To test, try reproducing http://trac.openmicroscopy.org.uk/ome/ticket/10561, switching to Group Display before generating the kymograph.
