### PR TITLE
Don't use omero.group=-1 when not required (Fixes #11427)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5908,7 +5908,7 @@ class _ImageWrapper (BlitzObjectWrapper):
             if not re.lookupRenderingDef(pid, ctx):
                 re.resetDefaults(ctx)
                 re.lookupRenderingDef(pid, ctx)
-            self._onResetDefaults(re.getRenderingDefId(self._conn.SERVICE_OPTS))
+            self._onResetDefaults(re.getRenderingDefId(ctx))
         else:
             re.loadRenderingDef(rdid, ctx)
         re.load(ctx)
@@ -6180,9 +6180,9 @@ class _ImageWrapper (BlitzObjectWrapper):
                 except omero.ConcurrencyException, ce:
                     logger.info( "ConcurrencyException: resetDefaults() failed in _prepareTB with backOff: %s" % ce.backOff)
                     return tb
-                tb.setPixelsId(pid, self._conn.SERVICE_OPTS)
+                tb.setPixelsId(pid, ctx)
                 try:
-                    rdid = tb.getRenderingDefId(self._conn.SERVICE_OPTS)
+                    rdid = tb.getRenderingDefId(ctx)
                 except omero.ApiUsageException:         # E.g. No rendering def (because of missing pyramid!)
                     logger.info( "ApiUsageException: getRenderingDefId() failed in _prepareTB")
                     return tb


### PR DESCRIPTION
Ticket for reference with more overarching explanation:
- https://trac.openmicroscopy.org.uk/ome/ticket/11427

Testing requirements:
1. Read-Write group (at least two users present in the group)
2. One or more images

Expectations before:
- If a user who is not the owner of the the image is examining an image for the first time in OMERO.web a broken image thumbnail will be shown

Expectations after:
- Thumbnail and image viewing as normal when examining an image for the first time in OMERO.web

Could potentially be exposed to full permissions testing but at this point given that all the other remote method calls in these methods use a context where `omero.group=object.details.group.id.val` I can't see any issues with the changes overall.
