### PR TITLE
fix #9917: adjust tile drawing for big images

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserCanvas.java
@@ -91,20 +91,21 @@ class BrowserCanvas
             TextureCoords coords = new TextureCoords(0f, 0f, 1f, 1f);
 			Color c = ImageCanvas.BACKGROUND;
     		float xStart, yStart, xEnd = 0, yEnd;
-    		drawScaleBar(gl, model.getTiledImageSizeX(),
-    				model.getTiledImageSizeY());
-        	for (int i = 0; i < rows; i++) {
+    		final int totalWidth  = model.getTiledImageSizeX();
+    		final int totalHeight = model.getTiledImageSizeY();
+    		drawScaleBar(gl, totalWidth, totalHeight);
+    		for (int i = 0; i < rows; i++) {
     			for (int j = 0; j < columns; j++) {
     				index = i*columns+j;
     				tile = tiles.get(index);
     				r = tile.getRegion();
     				img = tile.getImage();
-    				xStart = (float) r.getX()/(r.getWidth()*columns);
+    				xStart = (float) r.getX() / totalWidth;
     				xEnd = 
-    					(float) (r.getX()+r.getWidth())/(r.getWidth()*columns);
-    				yStart = (float) r.getY()/(r.getHeight()*rows);
+    					(float) (r.getX()+r.getWidth()) / totalWidth;
+    				yStart = (float) r.getY() / totalHeight;
     				yEnd =
-    					(float) (r.getY()+r.getHeight())/(r.getHeight()*rows);
+    					(float) (r.getY()+r.getHeight()) / totalHeight;
     				if (img != null) {
     					if (texture == null) 
     						texture = TextureIO.newTexture(


### PR DESCRIPTION
Try to reproduce https://trac.openmicroscopy.org.uk/ome/ticket/9917 using OpenGL Insight. `test_images_good/cellsens/brian/_BZ cfos1-2_05_/` is a great test. Make sure that all the tiles appear in the full image viewer, at the correct aspect ratio.
