### PR TITLE
Move deleted tree node processing into browser component (rebase)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -45,6 +45,7 @@ import javax.swing.JTree;
 import javax.swing.tree.TreePath;
 
 //Third-party libraries
+import com.google.common.collect.Sets;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.events.treeviewer.ExperimenterLoadedDataEvent;
@@ -76,6 +77,7 @@ import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
+
 import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ExperimenterData;
@@ -1904,6 +1906,14 @@ class BrowserComponent
 				node.removeFromParent();
 				view.reloadNode(parent);
 			}
+		}
+		/* ensure that the selected displays do not include any removed nodes */
+		final Set<TreeImageDisplay> oldSelected = Sets.newHashSet(getSelectedDisplays());
+		final Set<TreeImageDisplay> newSelected = Sets.newHashSet(oldSelected);
+		newSelected.removeAll(nodes);
+		if (!newSelected.equals(oldSelected)) {
+		    setSelectedDisplay(null);
+		    setSelectedDisplays(newSelected.toArray(new TreeImageDisplay[newSelected.size()]), false);
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -117,9 +117,6 @@ import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-
 import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ExperimenterData;
@@ -3258,14 +3255,7 @@ class TreeViewerComponent
 				NodesFinder finder = new NodesFinder(klass, ids);
 				Browser browser = model.getSelectedBrowser();
 				browser.accept(finder);
-				final Set<TreeImageDisplay> nodesToRemove = finder.getNodes();
-				browser.removeTreeNodes(nodesToRemove);
-				final Set<TreeImageDisplay> oldSelected = ImmutableSet.copyOf(browser.getSelectedDisplays());
-				final Set<TreeImageDisplay> newSelected = Sets.difference(oldSelected, nodesToRemove);
-				if (!newSelected.equals(oldSelected)) {
-				    browser.setSelectedDisplay(null);
-				    browser.setSelectedDisplays(newSelected.toArray(new TreeImageDisplay[newSelected.size()]), false);
-				}
+				browser.removeTreeNodes(finder.getNodes());
 				view.removeAllFromWorkingPane();
 				DataBrowserFactory.discardAll();
 				model.getMetadataViewer().setRootObject(null, -1, null);


### PR DESCRIPTION
Rebases last commit of https://github.com/openmicroscopy/openmicroscopy/pull/1435 and should keep http://trac.openmicroscopy.org.uk/ome/ticket/11401 still fixed by https://github.com/openmicroscopy/openmicroscopy/pull/1427.

---

--rebased-from #1435 
