### PR TITLE
Create image from old 11426

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2774,7 +2774,7 @@ class _BlitzGateway (object):
                 # need to ensure that the plane dtype matches the pixels type of our new image
                 img = self.getObject("Image", iId.getValue())
                 newPtype = img.getPrimaryPixels().getPixelsType().getValue()
-                omeroToNumpy = {'int8':'int8', 'uint8':'uint8', 'int16':'int16', 'int32':'int32', 'uint32':'uint32', 'float':'float32', 'double':'double'}
+                omeroToNumpy = {'int8':'int8', 'uint8':'uint8', 'int16':'int16', 'uint16':'uint16', 'int32':'int32', 'uint32':'uint32', 'float':'float32', 'double':'double'}
                 if omeroToNumpy[newPtype] != firstPlane.dtype.name:
                     convertToType = getattr(numpy, omeroToNumpy[newPtype])
                 img._obj.setName(rstring(imageName))


### PR DESCRIPTION
The Blitz Gateway conn.createImageFromNumpySeq() now takes an optional 'sourceImageId' parameter and 'channelList' to allow new image to be created using metadata from existing image. This uses the pixelsService.copyAndResizeImage().

The Channel_Offsets and Images_From_ROIs util scripts have been updated to use these parameters, so that new images inherit channel and other metadata from their original images. That work is in https://github.com/ome/scripts/pull/37 - both PRs can be tested together as one:

To test:
- Run Scripts > Util Scripts > Channel Offsets, choosing 1 channel or multiple channels.
- Check that the new image gets the correct metadata etc from the correct channels of the source image.
- Run Scripts > Util Scripts > Images From ROIs on an image that has at least one Rectangle shape.
- Check the new image has the same channels and channel metadata as the original.

cc @chris-allan 
