### PR TITLE
Include fastcgi https parameter in generated nginx configuration

### DIFF
--- a/etc/nginx.conf.system.template
+++ b/etc/nginx.conf.system.template
@@ -24,8 +24,9 @@
             fastcgi_pass_header Authorization;
             fastcgi_intercept_errors on;
             fastcgi_read_timeout 300;
-            # see #10273 - requires nginx 1.1.11 or higher
-            fastcgi_param HTTPS $https;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
         }
 
         location /maintenance.html {

--- a/etc/nginx.conf.template
+++ b/etc/nginx.conf.template
@@ -50,8 +50,9 @@ http {
             fastcgi_pass_header Authorization;
             fastcgi_intercept_errors on;
             fastcgi_read_timeout 300;
-            # see #10273 - requires nginx 1.1.11 or higher
-            fastcgi_param HTTPS $https;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
         }
 
         location /maintenance.html {


### PR DESCRIPTION
As a built-in documentation for trac issue #10273, update the web server stanza generated with `omero web config nginx` and `omero web config --system nginx` 
To test the PR: 
- retrieve Insight's Web Start descriptor from `https://<server_name>/webstart/jars/insight.jnlp`
- check that the `codebase` and `href` attributes correctly use the `https` scheme in the generated `jnlp` tag
- `javaws insight.jnlp` should load the application
