### PR TITLE
Eclipse OmeroJava src

### DIFF
--- a/.classpath-template
+++ b/.classpath-template
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="examples/Delete"/>
-	<classpathentry kind="src" path="components/tools/OmeroJava/src"/>
 	<classpathentry kind="src" path="components/tools/OmeroJava/test"/>
 	<classpathentry kind="src" path="components/tools/OmeroImporter/test"/>
 	<classpathentry kind="src" path="components/tools/OmeroImporter/src"/>


### PR DESCRIPTION
After @bpindelski's recent changes to tools/OmeroJava,
there is no longer any source under OmeroJava, but build-eclipse
produced a .classpath file which referenced it leaving the workspace
broken.

Re-running `./build.py build-dev` with this change should produce
a new working Eclipse classpath file.
