### PR TITLE
Prevent orphaned images folder deletion from crashing Insight (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1886,6 +1886,8 @@ class TreeViewerComponent
 			Browser browser = model.getSelectedBrowser();
 			if (browser == null) return false;
 			group = browser.getNodeGroup((TreeImageDisplay) ho);
+		} else {
+		    return false;
 		}
 		//Do not have enough information about the group.
 		if (group.getPermissions() == null) return false;


### PR DESCRIPTION
This is the same as gh-1481 but rebased onto develop.

---

Deletable things should still be deletable, and attempts to delete other things should not crash Insight.

The deletion was allowed by pressing the delete button -- which on a Mac keyboard is fn + backspace.
