### PR TITLE
Disable location stats calculation for big images (Fixes #11420)

### DIFF
--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -313,7 +313,17 @@ public class StatsFactory {
         
         Dimension tileSize = pixelsData.getTileSize();
         double range = gMax-gMin;
-        if (range <= RANGE_RGB) {
+        int resolutionLevels = pixelsData.getResolutionLevels();
+        if (range <= RANGE_RGB || resolutionLevels > 1) {
+            // A number of resolution levels greater than one tends to
+            // signify a big image.  We *really* do not want to be
+            // iterating through potentially GBs of data on every big image
+            // whenever a calculation of the location statistics is requested.
+            //
+            // Furthermore, as this computation is exclusively used to
+            // prime "pretty good image" rendering settings calculating
+            // them is pointless when the range does not exceed that
+            // available in the device space.
             inputEnd = gMax;
             inputStart = gMin;
             return;


### PR DESCRIPTION
## Same as #1440 but rebased on dev_4_4

Ticket for reference with more overarching explanation:
- https://trac.openmicroscopy.org.uk/ome/ticket/11420

Testing requirements:
1. Read-Annotate or Read-Write group (at least two users present in the group)
2. 8 bits per channel RGB image (Aperio SVS suggested)
3. 16 bits per channel image (Aperio AFI suggested)

Expectations before (8 bits per channel):
1. As the user who imported the image thumbnail display should be available in a few seconds
   - The scale for all three channels should be `[0, 255]`
2. As **another** user who has permissions to see the image the thumbnail display should be available in a few seconds
   - The scale for all three channels should be `[0, 255]`

Expectations after (8 bits per channel):
- Identical to those before

Expectations before (16 bits per channel):
1. As the user who imported the image thumbnail display should be available in a few seconds
   - The scale for all three channels should be some calculated values in the range `0-65535`
2. As **another** user who has permissions to see the image the thumbnail display should be take many minutes, timeout, cause the server to crash or completely not display

Expectations after (16 bits per channel):
1. As the user who imported the image thumbnail display should be available in a few seconds
   - The scale for all three channels should be `[0, 65535]`
2. As **another** user who has permissions to see the image the thumbnail display should be available in a few seconds
   - The scale for all three channels should be `[0, 65535]`

--rebased-from #1440
