### PR TITLE
Single ch split 2923 lineplot 2924

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -409,7 +409,8 @@
       // disable line-plot for max projection, split-view etc
       $('#wblitz-lp-enable').attr('disabled', p != 'normal');
       //$('#wblitz-channels-box button').attr('disabled', p == 'split');
-        $('[name="wblitz-proj"][value=intmax]').attr('disabled', viewport.loadedImg.rdefs.invertAxis);
+      var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
+      $('[name="wblitz-proj"][value=intmax]').attr('disabled', disable_intmax);
     }
     
     //nosync || syncRDCW();


### PR DESCRIPTION
A couple of minor tickets addressed:

https://trac.openmicroscopy.org.uk/ome/ticket/2923 Open a single-channel image in the main web image viewer. Check that the "Split Channel" option is disabled. Check it is not disabled for multi-channel images. 
Also check that "Max Intensity" option is disabled for single-Z images.

https://trac.openmicroscopy.org.uk/ome/ticket/2924 Don't allow the Line Plot to be shown in split-view or max-intensity projection. This was already fixed in the code (no changes) but just check it's working now that I'm closing the ticket: Choose "Split Channel" or "Max Intensity" view and check that the Line Plot is disabled. 
