### PR TITLE
Import delete dataset (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1255,7 +1255,8 @@ class OmeroImageServiceImpl
 							context.getLogger().error(this, msg);
 						}
 					}
-				} else ioContainer = gateway.findIObject(ctx, ioContainer);
+				} else ioContainer = gateway.findIObject(ctx,
+						container.asIObject());
 			}
 			importCandidates(ctx, hcsFiles, status, object,
 					ioContainer, customAnnotationList, userID, close, true, userName);


### PR DESCRIPTION
This is the same as gh-1477 but rebased onto develop.

---

Fix issue reported by https://trac.openmicroscopy.org.uk/ome/ticket/11430

To test:

Test 1:
- Create a dataset: toDeleteBeforeImport from Data manager
- Open the importer
- Select an image
- Select the dataset created above.
- Add the image to the import queue.
- Go to web or data manager, delete the dataset
- click import
- The image should be imported, and be orphaned.

Test 2:
- Create a project: toDeleteBeforeImport from Data manager
- Open the importer
- Select a folder
- Select the project created above.
- Select `new from folder`
- Add the folder to the import queue and select 
- Go to web or data manager, delete the project
- click import
- The folder should be imported in a dataset with name= folder's name w/o project

Test 3:
- Create a screen: toDeleteBeforeImport from Data manager
- Open the importer
- Select a plate
- Select the screen created above.
- Add the plate to the import queue.
- Go to web or data manager, delete the plate
- click import
- The plate should be imported, and be orphaned.

Test 4:
- Create a project: toDeleteBeforeImport from Data manager
- Open the importer
- Select a file
- Select the project created above.
- Select `new from folder`
- Add the file to the import queue 
- Go to web or data manager, delete the project
- click import
- The file should be imported in a dataset name = name of parent's file. The dataset w/o project
