### PR TITLE
Rdef slider range 8758

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -766,6 +766,10 @@
     for (i in channels) {
       $('#rd-wblitz-ch'+i).get(0).checked = channels[i].active;
       $('#wblitz-ch'+i+'-cwslider .ui-slider-range').css('background-color', toRGB(channels[i].color));
+      var w = channels[i].window;
+      $('#wblitz-ch'+i+'-cwslider')
+          .slider( "option", "min", Math.min(w.min, w.start) )   // extend range if needed
+          .slider( "option", "max", Math.max(w.max, w.end) );
       $('#wblitz-ch'+i+'-color').css('background-color', toRGB(channels[i].color));//$('#wblitz-ch'+i).css('background-color'));
       $('#wblitz-ch'+i+'-cw-start').val(channels[i].window.start).change();
       $('#wblitz-ch'+i+'-cw-end').val(channels[i].window.end).change();


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/8758

To test, open image in web image viewer, click 'Edit' channel rendering.
Note that the sliders only go to the 'min' / 'max' pixel intensity range.
Now try manually editing the values above the sliders. If you put in a value outside the min/max range, the slider will expand it's range accordingly.
When you hit Apply or Save, the range is validated to be within the Pixel range, E.g. 0 - 255 for int8 image.
