### PR TITLE
Make the OMERO.server autostart on Windows (see #11448)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -414,7 +414,7 @@ Examples:
                 try:
                     self.ctx.out("Installing %s Windows service." % svc_name)
                     hs = win32service.CreateService(hscm, svc_name, svc_name, win32service.SERVICE_ALL_ACCESS,
-                            win32service.SERVICE_WIN32_OWN_PROCESS, win32service.SERVICE_DEMAND_START,
+                            win32service.SERVICE_WIN32_OWN_PROCESS, win32service.SERVICE_AUTO_START,
                             win32service.SERVICE_ERROR_NORMAL, binpath, None, 0, None, user, pasw)
                     self.ctx.out("Successfully installed %s Windows service." % svc_name)
                     win32service.CloseServiceHandle(hs)


### PR DESCRIPTION
To be consistent with the docs, the server service installed by `bin\omero admin start` should be configured initially to automatic startup mode. This PR updates the call to the Windows service manager API.

To test, deploy OMERO.server on Windows and verify that the `OMERO.server` service has the startup mode as "Automatic".

This will have to be rebased to `develop`.
--rebased-to #1516
