### PR TITLE
Import screen

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1423,7 +1423,8 @@ class OmeroImageServiceImpl
 							context.getLogger().error(this, msg);
 						}
 					}
-				} else ioContainer = gateway.findIObject(ctx, ioContainer);
+				} else ioContainer = gateway.findIObject(ctx,
+						container.asIObject());
 			}
 			importCandidates(ctx, hcsFiles, status, object, archived,
 					ioContainer, list, userID, close, true, userName);


### PR DESCRIPTION
Fix error introduced while checking if object still exist before import. The problem was noticed during the review of #1498

To test

Test 1:
- Select a plate and import it into an existing screen. The plate should be linked to the screen

Test 2:
- Select a folder containing a plate and import it into an existing screen. The plate should be linked to the screen
