### PR TITLE
Update OMERO agent string in ``common`` unit test (rebased onto develop)

### DIFF
--- a/components/common/test/ome/system/utests/UpgradeCheckTest.java
+++ b/components/common/test/ome/system/utests/UpgradeCheckTest.java
@@ -42,7 +42,7 @@ public class UpgradeCheckTest extends TestCase {
 
     @Test
     public void testNoResponse() throws Exception {
-        check = new UpgradeCheck(url, "test", "server");
+        check = new UpgradeCheck(url, "test", "test");
         check.run();
         assertTrue(check.isUpgradeNeeded());
         assertFalse(check.isExceptionThrown());


### PR DESCRIPTION
This is the same as gh-1447 but rebased onto develop.

---

This PR fixes https://trac.openmicroscopy.org.uk/ome/ticket/11388. When connecting to QA to test the upgrade check class, the test was using `OMERO.test` as the user agent. That caused QA to redirect the request. After changing to `OMERO.server` (one of the valid user agents in QA's model), no HTML code is present in stdout.

To test:
verify that the output of running `./build.py -f components/common/build.xml test` doesn't have any HTML code in the output and that all tests pass.
