### PR TITLE
Pytest target (rebased onto develop)

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -63,12 +63,14 @@ ice_compatibility="${versions.ice}"
     </target>
 
     <target name="python-integration" unless="env.NOPYTHON">
-        <property name="suite_file" value="${basedir}/test/integration/integration_suite.py"/>
-        <run_py failonerror="${test.with.fail}">
+        <setup_py failonerror="${test.with.fail}">
             <env key="ICE_CONFIG" value="${env.ICE_CONFIG}"/>
-            <env key="PYTHONPATH" path="test:build/lib:${basedir}/../target/lib/python:${env.PYTHONPATH}"/>
-            <arg file="${suite_file}"/>
-        </run_py>
+            <arg value="test"/>
+            <arg value="-v"/>
+            <arg value="-s"/>
+            <arg file="${basedir}/test"/>
+            <!-- Could be made configurable via python-test-single -->
+        </setup_py>
     </target>
 
     <target name="python-install" unless="env.NOPYTHON">


### PR DESCRIPTION
This is the same as gh-1493 but rebased onto develop.

---

Enable all pytests (`OmeroPy/test`) including gatewaytests via the "integration" target. This means all of the following should now run Python:

```
 ome.git$ ./build.py test-integration
 ome.git$ cd components/tools/OmeroPy
 OmeroPy$ ../../../build.py integration
 OmeroPy$ ../../../build.py python-integration
```
