### PR TITLE
Unwrap namespace

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -1159,6 +1159,7 @@ def registerNamespace(iQuery, iUpdate, namespace, keywords):
 
     # Support rstring and str namespaces
     namespace = unwrap(namespace)
+    keywords = unwrap(keywords)
 
     workflow = iQuery.findByQuery("from Namespace as n where n.name = '" + namespace+"'", None);
     workflowData = WorkflowData();
@@ -1166,7 +1167,7 @@ def registerNamespace(iQuery, iUpdate, namespace, keywords):
         workflowData = WorkflowData(workflow);
     else:
         workflowData.setNamespace(namespace);
-    splitKeywords = keywords.val.split(',');
+    splitKeywords = keywords.split(',');
 
     SU_LOG.debug(workflowData.asIObject())
     for keyword in splitKeywords:


### PR DESCRIPTION
This began with a very small change to `script_utils.py`, namely fixing the following error:

```
    *** start stderr (id=202)***
    * Traceback (most recent call last):
    *   File "./script", line 80, in <module>
    *     runAsScript();
    *   File "./script", line 75, in runAsScript
    *     initialise(session)
    *   File "./script", line 65, in initialise
    *     script_utils.registerNamespace(iQuery, iUpdate, NAMESPACE, keywords);
    *   File "/opt/ome2/dist/lib/python/omero/util/script_utils.py", line 1175, in registerNamespace
    *     workflow = iQuery.findByQuery("from Namespace as n where n.name = '" + namespace.val+"'", None);
    * AttributeError: 'str' object has no attribute 'val'
    * 
    *** end stderr ***
```

when running the `FLIM_initialise.py` script.

The other commits are all tidying the file afterwards.
