### PR TITLE
Jnlp 10598 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -32,6 +32,8 @@ from django.template import RequestContext as Context
 from django.shortcuts import render_to_response
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
+from django.views.decorators.cache import never_cache
+
 from omero_version import omero_version
 
 def index(request):
@@ -45,6 +47,7 @@ def index(request):
     
     return render_to_response(template,{'insight_url':insight_url, "version": omero_version})
 
+@never_cache
 def insight(request):
     t = template_loader.get_template('webstart/insight.xml')
     
@@ -81,3 +84,4 @@ def insight(request):
 
     c = Context(request, context)
     return HttpResponse(t.render(c), content_type="application/x-java-jnlp-file")
+    


### PR DESCRIPTION
This is the same as gh-1521 but rebased onto develop.

---

In order to test it you would have to build the server with webstart, and then modify a jar and rebuild and see if you download the new JNLP. OSX / Chrome / Java 1.6

https://trac.openmicroscopy.org.uk/ome/ticket/10598
