### PR TITLE
Tap homebrew/science formulae to install OMERO via Homebrew (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -50,6 +50,9 @@ bin/brew install python
 # Install Genshi (OMERO and Bio-Formats requirement)
 bin/pip install -U genshi
 
+# Tap homebrew-science library (HDF5)
+bin/brew tap homebrew/science || echo "Already tapped"
+
 # Tap ome-alt library
 bin/brew tap ome/alt || echo "Already tapped"
 


### PR DESCRIPTION
This is the same as gh-1540 but rebased onto develop.

---

HDF5 formula has been recently moved to homebrew-science. Thus tapping this
repository is now required to install all of OMERO dependencies.

This PR should turn the OMERO-homebrew-stable green again. A rebased PR will be opened to fix the OMERO-homebrew-develop job.
Once jobs are green, 2 documentation PRs will be opened to document this new tap requirement.
