### PR TITLE
Eclipse OmeroJava src (rebased onto develop)

### DIFF
--- a/.classpath-template
+++ b/.classpath-template
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="examples/Delete"/>
-	<classpathentry kind="src" path="components/tools/OmeroJava/src"/>
 	<classpathentry kind="src" path="components/tools/OmeroJava/test"/>
 	<classpathentry kind="src" path="components/dsl/test"/>
 	<classpathentry kind="src" path="components/dsl/resources"/>


### PR DESCRIPTION
This is the same as gh-1470 but rebased onto develop.

---

After @bpindelski's recent changes to tools/OmeroJava,
there is no longer any source under OmeroJava, but build-eclipse
produced a .classpath file which referenced it leaving the workspace
broken.

Re-running `./build.py build-dev` with this change should produce
a new working Eclipse classpath file.
