### PR TITLE
Fix build-all-dev target (rebased onto develop)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -192,7 +192,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         depends="clean,init,build-default,test-compile,build-eclipse"/>
 
     <target name="build-all-dev" description="build-all, then test-compile and build-eclipse"
-        depends="clean,init,build-default,test-compile,build-eclipse"/>
+        depends="clean,init,build-all,test-compile-all,build-eclipse"/>
 
     <target name="build-blitz" description="Alias for 'build-server'" depends="build-server"/>
 


### PR DESCRIPTION
This is the same as gh-1561 but rebased onto develop.

---

The `build-all-dev` ant target should call only `*-all` targets internally (or more importantly, no target which sets `NOMAKE=1`)
