### PR TITLE
Delete projected image

### DIFF
--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -612,7 +612,7 @@ public class DeleteProjectedImageTest  extends AbstractServerTest {
      *
      * @throws Exception Thrown if an error occurred.
      */
-    @Test
+    @Test(groups = "broken")
     public void testSourceImageByMemberdeleteByOwnerRWR() throws Exception {
         deleteImage("rwr---", AbstractServerTest.MEMBER,
                 -1, SOURCE_IMAGE);
@@ -625,7 +625,7 @@ public class DeleteProjectedImageTest  extends AbstractServerTest {
      *
      * @throws Exception Thrown if an error occurred.
      */
-    @Test
+    @Test(groups = "broken")
     public void testSourceImageByMemberdeleteByOwnerRWRA() throws Exception {
         deleteImage("rwra--", AbstractServerTest.MEMBER,
                 -1, SOURCE_IMAGE);


### PR DESCRIPTION
Not directly related to https://trac.openmicroscopy.org.uk/ome/ticket/10262

But necessary to test the deletion of projected image, source image etc.

To test
- Run `./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/delete/DeleteProjectedImageTest`

This will probably take around 4mins. (40 tests, image is projected)
