### PR TITLE
Make BfPixelBufferTest run against a remote server. (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/test/integration/BfPixelBufferTest.java
+++ b/components/tools/OmeroJava/test/integration/BfPixelBufferTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import loci.formats.ImageReader;
 import ome.io.bioformats.BfPixelBuffer;
@@ -43,16 +42,7 @@ public class BfPixelBufferTest extends AbstractServerTest {
     private void setUpTestFile(String fileName) throws Throwable,
             NoSuchAlgorithmException {
         File srcFile = ResourceUtils.getFile("classpath:" + fileName);
-        String dataDirName = root.getSession().getConfigService()
-                .getConfigValue("omero.data.dir");
-        String destPathName = UUID.randomUUID().toString();
-        File dataDir = new File(dataDirName);
-        destPath = new File(dataDir, destPathName);
-        File destFile = new File(destPath, fileName);
-        destPath.mkdir();
 
-        // Copy file into repo
-        FileUtils.copyFile(srcFile, destFile);
         // Import file
         List<Pixels> pixList = importFile(srcFile, fileName);
         log.debug(String.format("Imported: %s, pixid: %d", srcFile, pixList
@@ -63,7 +53,7 @@ public class BfPixelBufferTest extends AbstractServerTest {
         rps.setPixelsId(pixList.get(0).getId().getValue(), false);
 
         // Access the data from file via BfPixelBuffer
-        destFileName = destFile.getCanonicalPath();
+        destFileName = srcFile.getCanonicalPath();
         bf = new BfPixelBuffer(destFileName, new ImageReader());
     }
 
@@ -223,10 +213,6 @@ public class BfPixelBufferTest extends AbstractServerTest {
         bf.getTimepointDirect(midT, buff1);
         buff2 = rps.getTimepoint(midT);
         assertEquals(sha1(buff1), sha1(buff2));
-    }
-
-    private void testMessageDigest() throws IOException, ServerError {
-        assertEquals(bf.calculateMessageDigest(), rps.calculateMessageDigest());
     }
 
     private void testOtherGetters() {


### PR DESCRIPTION
This is the same as gh-1594 but rebased onto develop.

---

This PR removes code from BfPixelBufferTest that makes the test look for files in a local binary repository. This breaks the test when executing the `integration` target on a local system with ICE_CONFIG pointing to a remote server.

This PR doesn't break any test methods. To verify it's validity, check the http://hudson.openmicroscopy.org.uk/view/2.%20Stable/job/OmeroJava-integration-stable/ job.

Also one can try setting `omero.host` to howe.openmicroscopy.org.uk, `omero.user` to user-1 and `omero.pass` to the usual and run the test with:

```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/BfPixelBufferTest
```
