### PR TITLE
fix #10894: input window start = min, end = max

### DIFF
--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -334,8 +334,8 @@ public class StatsFactory {
             locationStats = new double[NB_BIN];
         }
         //value will be reset when calculating data.
-        inputStart = gMax;
-        inputEnd = gMin;
+        inputEnd = gMax;
+        inputStart = gMin;
         final double globalMin = gMin;
         Utils.forEachTile(new TileLoopIteration() {
             public void run(int z, int c, int t, int x, int y, int tileWidth,


### PR DESCRIPTION
Investigating https://trac.openmicroscopy.org.uk/ome/ticket/10894 revealed a probable mix-up in `StatsFactory`: the other code in `StatsFactory` and `RenderingSettingsImpl` seems to assume that the input window has a start smaller than its end. In reviewing this PR, make sure that the change seems consistent with the related code and that it doesn't newly break anything in the renderer. (@joshmoore and @jburel can probably answer questions about the code.)
