### PR TITLE
fix #10894: input window start = min, end = max (rebased)

### DIFF
--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -334,8 +334,8 @@ public class StatsFactory {
             locationStats = new double[NB_BIN];
         }
         //value will be reset when calculating data.
-        inputStart = gMax;
-        inputEnd = gMin;
+        inputEnd = gMax;
+        inputStart = gMin;
         final double globalMin = gMin;
         Utils.forEachTile(new TileLoopIteration() {
             public void run(int z, int c, int t, int x, int y, int tileWidth,

--- a/components/server/test/omeis/providers/re/utests/BaseRenderingTest.java
+++ b/components/server/test/omeis/providers/re/utests/BaseRenderingTest.java
@@ -128,9 +128,7 @@ public class BaseRenderingTest extends TestCase
 	protected byte[] getPlane()
 	{
 		byte[] plane = new byte[getSizeX() * getSizeY() * getBytesPerPixel()];
-		// FIXME: causes "Interval not supported"
-		// random.nextBytes(plane);
-		// See https://trac.openmicroscopy.org.uk/ome/ticket/10894
+		random.nextBytes(plane);
 		return plane;
 	}
 	


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/10894 : check that the server's `BaseRenderingTest`-subclass unit tests no longer have the reported issue, and that there aren't regressions in the renderer.
--rebased-from #1598
