### PR TITLE
11462 indexer log (rebased onto develop)

### DIFF
--- a/components/server/src/ome/services/fulltext/FullTextIndexer.java
+++ b/components/server/src/ome/services/fulltext/FullTextIndexer.java
@@ -205,7 +205,10 @@ public class FullTextIndexer extends SimpleWork {
                             action = new Index(obj);
                         }
                     } else {
-                        log.error("Unknown action type: " + act);
+                        // Likely CHGRP-VALIDATION, PIXELDATA or similar.
+                        if (log.isDebugEnabled()) {
+                            log.debug("Unknown action type: " + act);
+                        }
                     }
 
                     if (action != null) {


### PR DESCRIPTION
This is the same as gh-1591 but rebased onto develop.

---

Lower purge warning from ERROR to WARN. This can be tested by creating an object and then immediately deleting it. In `var/log/Indexer-0.log` there should be a WARN message of the form: "Null returned! Purging since cannot index ... ".

Open to suggestions to lower this further to INFO or DEBUG.

/cc @manics
