### PR TITLE
Heap dump target (rebased onto develop)

### DIFF
--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -181,6 +181,13 @@
         <target name="Blitz-hprof">
             <option>-agentlib:hprof=cpu=samples,cutoff=0,thread=y,interval=1,depth=50,force=y,file=${OMERO_LOGS}Blitz-${index}.hprof</option>
         </target>
+        <target name="heap-dump">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+        </target>
+        <target name="heap-dump-tmp">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+            <option>-XX:HeapDumpPath=/tmp</option>
+        </target>
         <option>-Xmx512M</option>
         <!--
              MaxPermSize needs to be set for most operating systems using Hibernate 3.3+
@@ -227,6 +234,13 @@
       <parameter name="index"/>
       <parameter name="config" default="default"/>
       <server id="Indexer-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
+        <target name="heap-dump">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+        </target>
+        <target name="heap-dump-tmp">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+            <option>-XX:HeapDumpPath=/tmp</option>
+        </target>
         <option>-Xmx256M</option>
         <option>-Djava.awt.headless=true</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback-indexing.xml</option>
@@ -251,6 +265,13 @@
       <parameter name="dir"/>
       <parameter name="config" default="default"/>
       <server id="PixelData-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
+        <target name="heap-dump">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+        </target>
+        <target name="heap-dump-tmp">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+            <option>-XX:HeapDumpPath=/tmp</option>
+        </target>
         <option>-Xmx256M</option>
         <option>-Djava.awt.headless=true</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback-indexing.xml</option>
@@ -276,6 +297,13 @@
       <parameter name="dir"/>
       <parameter name="config" default="default"/>
       <server id="Repository-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
+        <target name="heap-dump">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+        </target>
+        <target name="heap-dump-tmp">
+            <option>-XX:+HeapDumpOnOutOfMemoryError</option>
+            <option>-XX:HeapDumpPath=/tmp</option>
+        </target>
         <option>-Xmx400M</option>
         <option>-Djava.awt.headless=true</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback.xml</option>


### PR DESCRIPTION
This is the same as gh-1570 but rebased onto develop.

---

See: https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=6471

With these optional target blocks, it's possible to turn on heap-dumps-on-OOMs without modifying the config files. E.g.,

```
bin/omero admin start heap-dump
# or ... start heap-dump-tmp
```

If the `<target>` element is removed from around the `<option>` element, then heap-dumps will be activated by default (without passing "heap-dump").
