### PR TITLE
Rnd test (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
@@ -48,10 +48,8 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
     private void moveImage(String src, String target, int memberRole, int
             moveMemberRole) throws Exception
     {
-        //Create 2 users in the source group.
+        //Create one user in the source group.
         EventContext ctx = newUserAndGroup(src);
-        
-
         //Create an image
         Image img = mmFactory.createImage();
         img = (Image) iUpdate.saveAndReturnObject(img);
@@ -112,8 +110,10 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
 
         disconnect();
         // Log in to other group
-        loginUser(ctx); //require if log as root.
-        disconnect();
+        if (moveMemberRole == AbstractServerTest.ADMIN) {
+            loginUser(ctx); //require if log as root.
+            disconnect();
+        }
         loginUser(g);
 
         //Check that image has been moved.


### PR DESCRIPTION
This is the same as gh-1588 but rebased onto develop.

---

Add more tests to move image with rendering settings. The tests should all pass.

To run the tests

```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/chgrp/RenderingSettingsMoveTest
```
