### PR TITLE
Delete projected image (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -6,6 +6,9 @@
  */
 package integration.delete;
 
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
This is the same as gh-1586 but rebased onto develop.

---

Not directly related to https://trac.openmicroscopy.org.uk/ome/ticket/10262

But necessary to test the deletion of projected image, source image etc.

To test
- Run `./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/delete/DeleteProjectedImageTest`

This will probably take around 4mins. (40 tests, image is projected)
