### PR TITLE
Annotation test (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -31,7 +31,6 @@ import static org.testng.AssertJUnit.*;
  *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @version 3.0 <small> (<b>Internal version:</b> $Revision: $Date: $) </small>
  * @since 3.0-Beta4
  */
 public class AnnotationMoveTest extends AbstractServerTest {


### PR DESCRIPTION
This is the same as gh-1564 but rebased onto develop.

---

Fix the tests dealing with annotations see https://trac.openmicroscopy.org.uk/ome/ticket/11366

I have also added more tests to handle various group permissions permutations

2 new tests will fail (`rwrw--` to `rw----`). They are marked as `broken`.

To test the PR, run the following command

```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/chgrp/AnnotationMoveTest
```
