### PR TITLE
Update unit.testng.xml in "rendering"

### DIFF
--- a/components/rendering/test/unit.testng.xml
+++ b/components/rendering/test/unit.testng.xml
@@ -7,7 +7,6 @@
       <run>
         <exclude name="broken"/>
         <exclude name="ignore"/>
-        <exclude name="integration"/>
       </run>
     </groups>
     <packages>


### PR DESCRIPTION
This is a small maintenance PR to get `develop` and `dev_4_4` inline. When #1601 got merged, I noticed I didn't update the file mentioned in this PR's title. This change is already in the rebased version of #1601.
--no-rebase
