### PR TITLE
Cannot disable active tab in web right hand panel, switch away first (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
@@ -439,11 +439,11 @@ OME.login_dialog = function(login_url, callback) {
 
                 // update enabled & selected state
                 if(!supported) {
-                    $("#annotation_tabs").tabs("disable", plugin_tab_index);
                     if (plugin_tab_index == select_tab) {
                         // if we're currently selected - switch to first tab
                         $("#annotation_tabs").tabs("select", 0);
                     }
+                    $("#annotation_tabs").tabs("disable", plugin_tab_index);
                 } else {
                     $("#annotation_tabs").tabs("enable", plugin_tab_index);
                     // update tab content


### PR DESCRIPTION
This is the same as gh-1619 but rebased onto develop.

---

To reproduce bug on OmeroWeb:
- Select image in the left tree
- Click preview tab in right hand panel
- Click the root of the left tree
- Click preview tab in right hand panel -> 404

Fix: switch away from active tab before disabling it
