### PR TITLE
Add jar to classpath. (rebased onto develop)

### DIFF
--- a/components/tests/ui/build.xml
+++ b/components/tests/ui/build.xml
@@ -27,7 +27,7 @@
         <attribute name="output"/>
         <sequential>
             <exec executable="jybot" failonerror="@{failonerror}" dir="${reports.insight}">
-                <env key="CLASSPATH" value="${insight.dir}/app/libs/*:${insight.dir}/dist/omero.insight.jar:${target.dir}/java-ui-libraries-${omero.version}.jar:${lib.dir}/repository/swinglibrary-${versions.robotframework.swinglibrary}.jar"/>
+                <env key="CLASSPATH" value="${insight.dir}/app/libs/*:${insight.dir}/dist/omero.insight.jar:${target.dir}/java-ui-libraries-${omero.version}.jar:${lib.dir}/repository/swinglibrary-${versions.robotframework.swinglibrary}.jar:${lib.dir}/repository/xercesImpl-${versions.xercesImpl}.jar"/>
                     <arg value="-d"/>
                     <arg value="@{output}"/>
                     <arg value="--loglevel"/>


### PR DESCRIPTION
This is the same as gh-1628 but rebased onto develop.

---

Add missing jar to classpath. The jar used to be an dependency of insight. This is no longer the case since we removed the doc section.

Nothing to test check that http://hudson.openmicroscopy.org.uk/view/All/job/OMERO-merge-robotframework-stable/ is green.
