### PR TITLE
clients builds

### DIFF
--- a/lib/composite.py
+++ b/lib/composite.py
@@ -5,7 +5,7 @@
 Creates composite builds from the various client build artifacts/platforms.
 """
 
-# Copyright (C) 2009 University of Dundee
+# Copyright (C) 2009-2013 University of Dundee
 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -44,6 +44,8 @@ TARGET_PREFIX = 'OMERO.clients-%s' % VERSION
 INSIGHT = 'OMERO.insight'
 
 EDITOR = 'OMERO.editor'
+
+IMPORTER = 'OMERO.importer'
 
 IGNORE = []
 
@@ -119,6 +121,7 @@ def compress(target, base):
 target_artifacts = list()
 target_artifacts += find(EDITOR + "*win.zip")
 target_artifacts += find(INSIGHT + "*win.zip")
+target_artifacts += find(IMPORTER + "*win.zip")
 target = '%s.win' % TARGET_PREFIX
 ignore = ['omero_client.jar',
           'omero-clients-util-r\d+-b\d+.jar'] + IGNORE
@@ -134,6 +137,7 @@ compress('%s.zip' % target, target)
 target_artifacts = list()
 target_artifacts += find(EDITOR + "*mac.zip")
 target_artifacts += find(INSIGHT + "*mac.zip")
+target_artifacts += find(IMPORTER + "*mac.zip")
 target = '%s.mac' % TARGET_PREFIX
 
 os.makedirs(target)


### PR DESCRIPTION
Add importer.app and .exe to clients build (see https://trac.openmicroscopy.org.uk/ome/ticket/11241)
To test the PR
- After a build, run `./build.py release-clients`
- Go to `target/pkg`:
  - check that the `OMERO.importer` app is in OMER.clients-xxxx.mac
  - check that the `OMERO.importer` exe is in OMER.clients-xxx.win
    (xxx is the version number)
