### PR TITLE
Zoom reset

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserStatusBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserStatusBar.java
@@ -104,6 +104,8 @@ class DataBrowserStatusBar
 		zoomSlider.addChangeListener(this);
 		zoomSlider.setToolTipText("Magnifies the thumbnails.");
 		fieldsZoomSlider.addChangeListener(this);
+		addPropertyChangeListener(
+		        MagnificationComponent.MAGNIFICATION_UPDATE_PROPERTY, mag);
 		refSlider = zoomSlider;
 		progressBar = new JProgressBar();
         status = new JLabel();
@@ -204,6 +206,9 @@ class DataBrowserStatusBar
 			int v = zoomSlider.getValue();
 	    	double f = (double) v/FACTOR;
 			view.setMagnificationFactor(f);
+			firePropertyChange(
+			        MagnificationComponent.MAGNIFICATION_UPDATE_PROPERTY,
+			        null, f);
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MagnificationComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MagnificationComponent.java
@@ -26,6 +26,8 @@ package org.openmicroscopy.shoola.util.ui;
 //Java imports
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 import javax.swing.Box;
 import javax.swing.Icon;
@@ -49,12 +51,16 @@ import javax.swing.JToolBar;
  */
 public class MagnificationComponent
 	extends JPanel
-	implements ActionListener
+	implements ActionListener, PropertyChangeListener
 {
 
 	/** Bound property indicating that the magnification has been changed. */
 	public static final String MAGNIFICATION_PROPERTY = "magnification";
 	
+	/** Bound property indicating that the magnification has been changed. */
+    public static final String MAGNIFICATION_UPDATE_PROPERTY =
+            "magnificationUpdate";
+    
 	/** Default minimum value. */
 	public static final double MINIMUM = 0.1;
 	
@@ -257,5 +263,16 @@ public class MagnificationComponent
 				firePropertyChange(MAGNIFICATION_PROPERTY, v, currentValue);
 		}
 	}
+
+    /**
+     * Updates the current value if modified by another component.
+     * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)
+     */
+    public void propertyChange(PropertyChangeEvent evt) {
+        String name = evt.getPropertyName();
+        if (MAGNIFICATION_UPDATE_PROPERTY.equals(name)) {
+            currentValue = (Double) evt.getNewValue();
+        }
+    }
 
 }


### PR DESCRIPTION
Restore default thumbnail when clicking on the reset button

To test:
- Browse a dataset.
- go to the status bar of the browser (central panel)
- Click on the +/- button to zoom in/out
- Click reset. The size should be reset.
- Now modify the size using the slider
  - Click reset. The size should be reset.

See https://trac.openmicroscopy.org.uk/ome/ticket/11312
