### PR TITLE
Mark three further further failing tests.

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -48,6 +48,7 @@ class TestScripts(lib.ITest):
         self.client.setInput("a", rstring("a"));
         self.client.getInput("a");
 
+    @pytest.mark.xfail(reason="See ticket #11539")
     def testUploadAndPing(self):
         name = str(self.pingfile())
         file = self.client.upload(name, type="text/x-python")

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -202,6 +202,7 @@ class TestSearch(lib.ITest):
                 if not s.hasNext(all) or len(s.results(all)) != 1:
                     assert False, msg % ("SearchPrx", uuid, who, x)
 
+    @pytest.mark.xfail(reason="See ticket #11539")
     def test8846(self):
         # Wildcard search
 

--- a/components/tools/OmeroPy/test/integration/test_tickets2000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets2000.py
@@ -60,6 +60,7 @@ class TestTickets2000(lib.ITest):
         uuid = self.client.sf.getAdminService().getEventContext().sessionUuid
         self.client.sf.getAdminService().lookupLdapAuthExperimenters()
 
+    @pytest.mark.xfail(reason="See ticket #11539")
     def test1069(self):
         unique = rstring(self.uuid())
         project = ProjectI()


### PR DESCRIPTION
This PR marks three further tests that did not have a 100% stability record on hudson. I'm not sure it needs testing but if so then on a local server:

```
./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=xfail
```

should confirm the three tests are among those marked as xfail.
