### PR TITLE
Fix #11588 Settings containing Python string formatting are not displayed correctly

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -143,24 +143,6 @@ class TestPrefs(object):
         # ticket:7273
         pytest.raises(NonZeroReturnCode, self.invoke, "load THIS_FILE_SHOULD_NOT_EXIST")
 
-    def testLoadMultiLine(self):
-        to_load = create_path()
-        to_load.write_text("A=B\\\nC")
-        self.invoke("load %s" % to_load)
-        self.invoke("get")
-        self.assertStdout(["A=BC"])
-
-    def testSetFromFile(self):
-        to_load = create_path()
-        to_load.write_text("Test")
-        self.invoke("set -f %s A" % to_load)
-        self.invoke("get")
-        self.assertStdout(["A=Test"])
-        to_load.write_text("Placeholder %s")
-        self.invoke("set -f %s A" % to_load)
-        self.invoke("get")
-        self.assertStdout(["A=Placeholder %s"])
-
     def testDrop(self):
         self.invoke("def x")
         self.invoke("def")


### PR DESCRIPTION
`omero config get` uses `safePrint` to display values, which interpolated any Python string formatting, e.g.

```
$ omero config set A %s
$ omero config get A
{'program_name': '/Users/andreas/omero/openmicroscopy/dist/bin/omero'}
```

https://trac.openmicroscopy.org.uk/ome/ticket/11588
