### PR TITLE
Update RawFileStoreTest.java: Remove "broken" annotation from test.

### DIFF
--- a/components/tools/OmeroJava/test/integration/RawFileStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawFileStoreTest.java
@@ -90,7 +90,7 @@ public class RawFileStoreTest extends AbstractServerTest {
      *             Thrown if an error occurred.
      * @see #testUploadFile()
      */
-    @Test(groups = "broken")
+    @Test
     public void testDownloadScript() throws Exception {
         IScriptPrx svc = factory.getScriptService();
         List<OriginalFile> scripts = svc.getScripts();


### PR DESCRIPTION
http://hudson.openmicroscopy.org.uk/job/OmeroJava-broken-develop/lastCompletedBuild/testngreports/integration/integration.RawFileStoreTest/testDownloadScript/ is constantly green. This PR removes the "broken" group from the "@Test" annotation.

To test - verify that OmeroJava-integration-develop gained one passing test.
