### PR TITLE
fix #10175: set FilesetEntry client path to String <256 chars

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -243,8 +243,17 @@ public class ImportContainer
         // Fill used paths
         for (String usedFile : getUsedFiles()) {
             final FilesetEntry entry = new FilesetEntryI();
-            final FsFile fsPath = sanitizer.getFsFileFromClientFile(new File(usedFile), Integer.MAX_VALUE);
-            entry.setClientPath(rstring(fsPath.toString()));
+            FsFile fsPath = sanitizer.getFsFileFromClientFile(new File(usedFile), Integer.MAX_VALUE);
+            String fsPathString;
+            while (true) {
+                fsPathString = fsPath.toString();
+                if (fsPathString.length() < 256) {
+                    break;
+                }
+                final List<String> components = fsPath.getComponents();
+                fsPath = new FsFile(components.subList(1, components.size()));
+            }
+            entry.setClientPath(rstring(fsPathString));
             fs.addFilesetEntry(entry);
         }
 


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/10175. To test, try importing images from absurdly long-named/deep paths. Cc: @manics.

--no-rebase as it's FS-specific.
