### PR TITLE
Replacing trac links in readmes

### DIFF
--- a/components/blitz/README.txt
+++ b/components/blitz/README.txt
@@ -1,6 +1,6 @@
 OmeroBlitz
-http://trac.openmicroscopy.org.uk/ome/wiki/OmeroBlitz
--------------------------------------------------------
+http://www.openmicroscopy.org/site/support/omero4/developers/server-blitz.html
+------------------------------------------------------------------------------
 
 The Blitz server is based on Ice (http://zeroc.com)
 
@@ -8,4 +8,4 @@ Contained in this directory are server implementation, code
 generation for the client implementation, and configuration
 for an IceGrid application.
 
-See also http://trac.openmicroscopy.org.uk/ome/wiki/OmeroGrid
+See also http://www.openmicroscopy.org/site/support/omero4/sysadmins/grid.html

--- a/examples/OmeroClients/README.txt
+++ b/examples/OmeroClients/README.txt
@@ -1,6 +1,6 @@
 These examples complement the documentation at:
 
-http://trac.openmicroscopy.org.uk/ome/wiki/OmeroClients
+http://www.openmicroscopy.org/site/support/omero4/developers/GettingStarted/AdvancedClientDevelopment.html
 
 Please read there further for information on how to write
 your own client to talk to the OMERO server.

--- a/examples/TreeList/README.txt
+++ b/examples/TreeList/README.txt
@@ -1,8 +1,8 @@
 These files form a simple command-line application which
 prints out the current users projects, datasets, and
-images. Primarily, this is an example for us by:
+images. Primarily, this is an example referenced by:
 
-http://trac.openmicroscopy.org.uk/ome/wiki/OmeroClients
+http://www.openmicroscopy.org/site/support/omero4/developers/GettingStarted/AdvancedClientDevelopment.html
 
 Note: the design of the application with largely static
 methods is to keep the example files brief for displaying


### PR DESCRIPTION
Fix for ticket 11648 - updating readme.txt files in the codebase to point at current docs rather than trac links which are then redirected.

To be rebased to develop with doc version numbers changed to 5.
