### PR TITLE
set Javadoc encoding to UTF-8 for release-javadoc ant target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -646,6 +646,8 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 version="true"
                 use="true"
                 breakiterator="true"
+                encoding="UTF-8"
+                docencoding="UTF-8"
                 windowtitle="OMERO (OME Remote Objects) Server"
                 overview="target/docs/overview.html"
                 stylesheetfile="docs/javadocsstyle.css">


### PR DESCRIPTION
Should make builds green again after #1710 caused, "unmappable character for encoding ASCII".
