### PR TITLE
Disable hql.PARSER logging

### DIFF
--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -115,7 +115,7 @@
   <logger name="org.hibernate.cfg" level="ERROR"/>
   <logger name="org.hibernate.engine" level="ERROR"/>
   <logger name="org.hibernate.hql" level="WARN"/> <!-- for first/max in memory -->
-  <logger name="org.hibernate.hql.PARSER" level="ERROR"/>
+  <logger name="org.hibernate.hql.PARSER" level="OFF" additivity="false"/>
   <logger name="org.hibernate.loader" level="ERROR"/>
   <logger name="org.hibernate.persister" level="ERROR"/>
   <logger name="org.hibernate.pretty" level="ERROR"/>


### PR DESCRIPTION
Previously (3bd6af6d5661d433f032d07ab9527a9c7c3e7bb8) PARSER logging was
set to FATAL. With logback, that was not possible (defaulted to DEBUG).
Rather than ERROR, however, this needs to be completely prevent since
every error in HQL parsing, will also later through an exception.
