### PR TITLE
fix #11358: set image format after import

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -1214,7 +1214,11 @@ public class OMEROMetadataStoreClient
      */
     private Format getImageFormat()
     {
-        String value = getReader().getClass().toString();
+        IFormatReader reader = getReader();
+        if (reader instanceof ImageReader) {
+            reader = ((ImageReader) reader).getReader();
+        }
+        String value = reader.getClass().toString();
         value = value.replace("class loci.formats.in.", "");
         value = value.replace("Reader", "");
         return (Format) getEnumeration(Format.class, value);


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11358. Try importing images and then,

``` sql
select image.name, format.value from image, format where image.format = format.id;
```

--no-rebase as problem reported to be 5.0-specific.
