### PR TITLE
fix #11654: adjust try / catch around import library operations

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -404,15 +404,18 @@ public class ImportLibrary implements IObservable
             FileInputStream stream) throws ServerError {
         try {
             if (rawFileStore != null) {
-                rawFileStore.close();
+                try {
+                    rawFileStore.close();
+                } catch (Exception e) {
+                    log.error("error in closing raw file store", e);
+                }
             }
         } finally {
             if (stream != null) {
                 try {
                     stream.close();
-                }
-                catch (Exception e) {
-                    log.error("I/O error closing stream.", e);
+                } catch (IOException e) {
+                    log.error("I/O in error closing stream", e);
                 }
             }
         }
@@ -654,9 +657,12 @@ public class ImportLibrary implements IObservable
 
     public void clear()
     {
-        store.setGroup(null);
-        store.setCurrentLogFile(null);
-        store.createRoot();
+        try {
+            store.setGroup(null);
+            store.setCurrentLogFile(null);
+            store.createRoot();
+        } catch (Throwable t) {
+            log.error("failed to clear metadata store", t);
+        }
     }
-
 }


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11654, catching and logging `store.createRoot()` errors; that code path seems unused in 5.x, so also catches and logs failure of `rawFileStore.close()` from `finally` clause of `uploadFile`.
