### PR TITLE
fix #10617: clickable MIF import thumbnails

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -643,6 +643,7 @@ public class FileImportComponent
 				label.setFont(f.deriveFont(f.getStyle(), f.getSize()-2));
 			}
 			label.setVisible(false);
+			label.addPropertyChangeListener(this);
 			imageLabels.add(label);
 		}
 		fileNameLabel = new JLabel(getFile().getName());


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/10617. To test, try importing a MIF; when the multiple images appear in the import window tab, try clicking them to summon the corresponding full image view.
