### PR TITLE
accommodate PL/pgSQL that logs deletes

### DIFF
--- a/sql/psql/OMERO5.0DEV__6/OMERO4.4__0.sql
+++ b/sql/psql/OMERO5.0DEV__6/OMERO4.4__0.sql
@@ -482,12 +482,12 @@ CREATE TRIGGER _fs_dir_delete
 CREATE TABLE _fs_deletelog (
     event_id BIGINT NOT NULL,
     file_id BIGINT NOT NULL,
-    group_id BIGINT NOT NULL,
-    name VARCHAR(255) NOT NULL,
     owner_id BIGINT NOT NULL,
-    params TEXT[2][],
-    path TEXT NOT NULL,
-    repo VARCHAR(36) NOT NULL
+    group_id BIGINT NOT NULL,
+    "path" TEXT NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    repo VARCHAR(36) NOT NULL,
+    params TEXT[2][]
 );
 
 CREATE FUNCTION _fs_log_delete() RETURNS TRIGGER AS $_fs_log_delete$


### PR DESCRIPTION
`_fs_deletelog()` makes brittle assumptions about table column ordering. To test, make sure that you can delete images from a 4.4 → 5.0 upgraded DB (upgrade using `sql/psql/OMERO5.0DEV__6/OMERO4.4__0.sql`). After upgrade delete images that were imported both before and after upgrade.

--no-rebase as is FS model specific.
