### PR TITLE
Fix bug in `bin/omero admin diagnostics`

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1079,7 +1079,8 @@ OMERO Diagnostics %s
                 dir_size = self.getdirsize(omero_temp_dir)
                 dir_size = "   (Size: %s)" % dir_size
             self.ctx.out("OMERO %s dir: '%s'\tExists? %s\tIs writable? %s%s" %
-                         (dir_name, dir_path, exists, is_writable, dir_size))
+                         (dir_name, dir_path, dir_path_exists, is_writable,
+                          dir_size))
 
         from omero.plugins.web import WebControl
         try:


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11665

To test this PR, call `bin/omero admin diagnostics` and make sure the command outputs either `Exists: True` or `Exists: false` for the OMERO data directory and the OMERO temp directory.

```
$ bin/omero admin diagnostics
…
OMERO data dir: '/OMERO'    Exists? True    Is writable? True
OMERO temp dir: '/Users/sebastien/omero/tmp'    Exists? True    Is writable? True   (Size: 3358)
```
