### PR TITLE
Blitz param types 11637 develop

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6759,10 +6759,10 @@ class _ImageWrapper (BlitzObjectWrapper):
         self._pd.t = long(t)
 
         regionDef = omero.romio.RegionDef()
-        regionDef.x = long(x)
-        regionDef.y = long(y)
-        regionDef.width = long(width)
-        regionDef.height = long(height)
+        regionDef.x = int(x)
+        regionDef.y = int(y)
+        regionDef.width = int(width)
+        regionDef.height = int(height)
         self._pd.region = regionDef
         try:
             if level is not None:


### PR DESCRIPTION
Fixes a couple of errors where Blitz gateway doesn't enforce the correct parameter types, noticed on howe. See https://trac.openmicroscopy.org.uk/ome/ticket/11637

To test, this should work without throwing exceptions:

ssh to gretzky...

```
$ cd lib/python/
$ python
>>> from omero.gateway import BlitzGateway
>>> conn = BlitzGateway("username", "password", host="localhost")
>>> conn.connect()
>>> image = conn.getObject("Image", <imageId>)
>>> image.setActiveChannels([1], [[10,100]])                # previously this threw an exception
>>> image.renderJpegRegion(0, 0, 0.1, 1.0, 10.1, 10)  # previously this threw an exception
```

Not entirely sure why these methods never failed for me on my local machine.

--rebased-from #1700
