### PR TITLE
Fix #11682: Screening plate rows with empty wells are too tall

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2159,6 +2159,9 @@ div.paging input.button_pagination {
     width: 0;
     table-layout: auto;
 }
+#spw table th {
+    vertical-align: middle;
+}
 #spw table td {
     padding: 1px;
     border: 1px solid #ccc;
@@ -2166,6 +2169,9 @@ div.paging input.button_pagination {
 }
 #spw table td.well {
     background: #eee;
+}
+#spw table td.placeholder {
+    vertical-align: top;
 }
 
 #spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -132,7 +132,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       tr.append('<th>'+data.rowlabels[i]+'</th>');
       for (j in data.grid[i]) {
         if (data.grid[i][j] == null) {
-        tr.append('<td><div class="placeholder" style="width:'+opts.width+'px;height:'+opts.height+'px;line-height:'+opts.height+'px;">&nbsp;</div></td>');
+        tr.append('<td class="placeholder"><div class="placeholder" style="width:'+opts.width+'px;height:'+opts.height+'px;line-height:'+opts.height+'px;">&nbsp;</div></td>');
         } else {
           data.grid[i][j]._wellpos = data.rowlabels[i]+data.collabels[j];
           var parentPrefix = '';


### PR DESCRIPTION
When a row in a plate contains both images and empty wells, the row is too tall with extra whitespace below all the images

![screen shot 2013-11-14 at 10 18 52 am](https://f.cloud.github.com/assets/197099/1539704/dc72b770-4d10-11e3-8e87-8da92a3a921a.png)
