### PR TITLE
Don't require additional omeroweb apps to be within omeroweb

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -448,11 +448,23 @@ INSTALLED_APPS = (
 
 # ADDITONAL_APPS: We import any settings.py from apps. This allows them to modify settings.
 for app in ADDITIONAL_APPS:
-    INSTALLED_APPS += ('omeroweb.%s' % app,)
+    # Previously the app was added to INSTALLED_APPS as 'omeroweb.app', which
+    # then required the app to reside within or be symlinked from within
+    # omeroweb, instead of just having to be somewhere on the python path.
+    # To allow apps to just be on the path, but keep it backwards compatible,
+    # try to import as omeroweb.app, if it works, keep that in INSTALLED_APPS,
+    # otherwise add it to INSTALLED_APPS just with its own name.
+    try:
+        __import__('omeroweb.%s' % app)
+        INSTALLED_APPS += ('omeroweb.%s' % app,)
+    except ImportError:
+        INSTALLED_APPS += (app,)
     try:
         a = __import__('%s.settings' % app)
     except ImportError:
         logger.debug("Couldn't import settings from app: %s" % app)
+
+logger.debug('INSTALLED_APPS=%s' % [INSTALLED_APPS])
 
 
 # FEEDBACK_URL: Used in feedback.sendfeedback.SendFeedback class in order to submit 

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -72,8 +72,14 @@ urlpatterns = patterns('',
 urlpatterns += redirect_urlpatterns()
 
 for app in settings.ADDITIONAL_APPS:
+    # Depending on how we added the app to INSTALLED_APPS in settings.py,
+    # include the urls the same way
+    if 'omeroweb.%s' % app in settings.INSTALLED_APPS:
+        urlmodule = 'omeroweb.%s.urls' % app
+    else:
+        urlmodule = '%s.urls' % app
     regex = '(?i)^%s/' % app
-    urlpatterns += patterns('', (regex, include('omeroweb.%s.urls' % app)),)
+    urlpatterns += patterns('', (regex, include(urlmodule)),)
 
 if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Allow apps in ADDITIONAL_APPS to be anywhere on the python path instead of requiring them to be within the omeroweb directory
