### PR TITLE
Add integration tests for the CLI group plugin

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_group.py
@@ -207,8 +207,7 @@ class TestGroupRoot(RootCLITest):
     @pytest.mark.parametrize("group_prefix,group_attr", group_pairs)
     @pytest.mark.parametrize("user_prefix,user_attr", user_pairs)
     @pytest.mark.parametrize("is_owner", [True, False])
-    @pytest.mark.parametrize("owner_arg", [
-        pytest.mark.xfail(reason="See ticket #11687")(None), '--as-owner'])
+    @pytest.mark.parametrize("owner_arg", [None, '--as-owner'])
     def testRemoveUser(self, group_prefix, group_attr, user_prefix, user_attr,
                        is_owner, owner_arg):
         user = self.new_user()


### PR DESCRIPTION
- Add integration tests for all the subcommand of `bin/omero group`
- Use parametrisation to try out all the combinations of optional arguments

To test this PR, check the corresponding test results in [OmeroPy-integration-develop](http://hudson.openmicroscopy.org.uk/job/OmeroPy-integration-develop/) are green.

NB:  all the `bin/omero group removeuser`  tests running without the `--as-owner` option are currently expected to fail due to a bug in the `AdminImpl`. See https://trac.openmicroscopy.org.uk/ome/ticket/11687. /cc @mtbc

---

--no-rebase
