### PR TITLE
Add integration tests for the CLI user plugin

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -196,8 +196,7 @@ class TestUserRoot(RootCLITest):
     @pytest.mark.parametrize("user_prefix,user_attr", user_pairs)
     @pytest.mark.parametrize("group_prefix,group_attr", group_pairs)
     @pytest.mark.parametrize("is_owner", [True, False])
-    @pytest.mark.parametrize("owner_arg", [
-        pytest.mark.xfail(reason="See ticket #11687")(None), '--as-owner'])
+    @pytest.mark.parametrize("owner_arg", [None, '--as-owner'])
     def testLeaveGroup(self, user_prefix, user_attr, group_prefix, group_attr,
                        is_owner, owner_arg):
         user = self.new_user()


### PR DESCRIPTION
Similar to #1771, this PR adds integration tests for the `bin/omero group` plugin. Tests expected to fail due to https://trac.openmicroscopy.org.uk/ome/ticket/11687 are marked with `py.mark.xfail`.

To test this PR, check the output of [OmeroPy-integration-develop](http://hudson.openmicroscopy.org.uk/job/OmeroPy-integration-develop/)

---

--no-rebase
