### PR TITLE
dev_4_4: Add Annotation and OriginalFile IDs to OMERO.web FileAnnotation tooltip

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileann.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileann.html
@@ -67,7 +67,7 @@
                 <br/><b>Namespace:</b> {{ fileann.getNs }}
             {% endif %}
             {% if fileann.file %}
-                <br/><b>File ID:</b> {{ fileann.file.id }}
+                <br/><b>File ID:</b> {{ fileann.file.id.val }}
             {% endif %}
         </span>
     {% endif %}


### PR DESCRIPTION
It is useful to see the `Annotation` and `OriginalFile` IDs in the `FileAnnotation` tooltip. This is especially true when the `FileAnnotation` links to an OMERO.tables instance where the `OriginalFile` ID is used to retrieve a reference to the the table via the API.

Before:

![screen shot 2013-11-18 at 10 18 14](https://f.cloud.github.com/assets/487082/1561799/19463b68-503b-11e3-9af2-221b15d29004.png)

After:

![screen shot 2013-11-18 at 10 18 31](https://f.cloud.github.com/assets/487082/1561800/1df248aa-503b-11e3-80aa-6237f42113b2.png)

The added **Namespace** in the screenshot is from 4.4.9 and was added in f669a15b0d7009ad54a0eb895336f82c64c7cb77. The before screenshot is from 4.4.8p1. Please ignore.
## To Test
1. Pick any container or Image
2. Attach a file
3. Mouse over the annotation in the right hand panel
4. Confirm that the IDs are displayed
