### PR TITLE
Fix URL for Homebrew install in the hudson shell script

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -25,7 +25,7 @@ TESTING_MODE=${TESTING_MODE:-$DEFAULT_TESTING_MODE}
 ###################################################################
 
 # Install Homebrew in /usr/local
-ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go/install)"
 cd /usr/local
 
 # Install git if not already installed


### PR DESCRIPTION
This PR should fix the broken installation line in the OMERO-hombrew-install.sh script.

To test this PR, check the http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-develop/ turns green again.
