### PR TITLE
Error handling of tile image loading in PanoJS See #11709

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
@@ -528,7 +528,7 @@ PanoJS.prototype.assignTileImage = function(tile) {
           setTimeout(function(){
             var s = tileImg.src;
             tileImg.src = s;    // no change, but is enough to trigger reload
-          }, 1000); // try to reload src after timeout - best value?
+          }, 1000); // try to reload src after timeout - 1 sec seems to work OK
         }
         $(this).addClass('failed');
       };
@@ -536,7 +536,7 @@ PanoJS.prototype.assignTileImage = function(tile) {
     if ( tileImg.done || !tileImg.delayed_loading &&
          (useBlankImage || !PanoJS.USE_LOADER_IMAGE || tileImg.complete || (tileImg.image && tileImg.image.complete))  ) {
       tileImg.onload = null;
-      // tileImg.onerror = null;  // thought this would work? but we need to keep it
+      // tileImg.onerror = null;  // seems we can't remove error handler here
       $(tileImg).removeClass('failed');
       if (tileImg.image) tileImg.image.onload = null;
             
@@ -573,7 +573,7 @@ PanoJS.prototype.assignTileImage = function(tile) {
           }           
         }
 
-        // since we've loaded OK, don't need error handling (not sure if this works?)
+        // since we've loaded OK, I assume this frees up memory (not confirmed)
         tileImg.onerror = null;
                 
         tileImg.onload = function() {};


### PR DESCRIPTION
PR for discussion etc - Not ready to merge yet.

This attempts to address the issue seen in https://trac.openmicroscopy.org.uk/ome/ticket/11709 where tiles fail to load (due to ConcurrencyException) but are not re-loaded.

Here, tiles that fail to load are re-loaded after 1 second.
I have added a red background to tiles that failed to load, so you can see the effect (this can be removed once reviewed).
For failing tiles, you should see a red background for 1 second, then tile is reloaded and (hopefully) the correct image appears. If it fails to load a second time then we do not try to repeat the load.

This seems to work locally. Next feature is to offer the user a chance to manually refresh tiles that fail to load a second time - if that seems necessary in this PR?

I have been reproducing the failing tiles locally by adding these lines into BlitzGateway under setActiveChannels() to randomly recreate the effect of the ConcurrencyException.

```
@@ -6487,6 +6487,9 @@ class _ImageWrapper (BlitzObjectWrapper):
         abs_channels = [abs(c) for c in channels]
         idx = 0     # index of windows/colors args above
         for c in range(len(self.getChannels())):
+            from random import random
+            if random() < 0.1:
+                self._re = None
             self._re.setActive(c, (c+1) in channels, self._conn.SERVICE_OPTS)
             if (c+1) in channels:
```
