### PR TITLE
Initialize table before file chooser.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -608,6 +608,8 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		partialName.setSelected(true);
 		group.add(partialName);
 
+		table = new FileSelectionTable(this);
+		table.addPropertyChangeListener(this);
 		chooser = new GenericFileChooser();
 		JList list = (JList) UIUtilities.findComponent(chooser, JList.class);
 		KeyAdapter ka = new KeyAdapter() {
@@ -677,8 +679,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			chooser.setAcceptAllFileFilterUsed(true);
 		}
 		
-		table = new FileSelectionTable(this);
-		table.addPropertyChangeListener(this);
+
 		closeButton = new JButton(TEXT_CLOSE);
 		closeButton.setToolTipText(TOOLTIP_CLOSE);
 		closeButton.setActionCommand("" + CMD_CLOSE);


### PR DESCRIPTION
Same as gh-1823 but on develop

Modifies the initialization sequence of the component composing the ImportDialog
To test the PR, use Linux

Open the importer.
