### PR TITLE
Simplify Travis environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: java
 
 env:
-    - BUILD=all BUILD_TARGET="build-all" TEST_TARGET="-p"
-    - BUILD=py BUILD_TARGET="build-default test-compile" TEST_TARGET="-py test -Dtest.with.fail=true"
-    - BUILD=cpp BUILD_TARGET="build-all test-compile-all" TEST_TARGET="-cpp test -Dtest.with.fail=true"
+    - BUILD=java BUILD_TARGET="build-default test-compile" TEST_TARGET="-p"
+    - BUILD=py BUILD_TARGET="build-default" TEST_TARGET="-py test -Dtest.with.fail=true"
 
 jdk:
   - openjdk7


### PR DESCRIPTION
- Remove cpp build as it reaches the timeout limit too often
- Use build-default rather than build-all
- Do not run test-compile as part of the py BUILD
