### PR TITLE
Add annotation ID to FileAnnotation tooltip in OMERO.insight (rebased onto dev_4_4)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -503,6 +503,11 @@ class DocComponent
 			} 
 			if (annotation.getId() > 0) {
 				buf.append("<b>");
+				buf.append("Annotation ID: ");
+				buf.append("</b>");
+				buf.append(annotation.getId());
+				buf.append("<br>");
+				buf.append("<b>");
 				buf.append("File ID: ");
 				buf.append("</b>");
 				FileAnnotationData fa = (FileAnnotationData) data;


### PR DESCRIPTION
This is the same as gh-1808 but rebased onto dev_4_4.

---

This PR is a trivial change to the File Annotation tooltip in OMERO.insight to preserve compatibility between clients.

To test it:
- Pick any container or Image
- Attach a file
- In the contextual menu next to the annotation, click on `Info`
- Confirm that the `Annotation ID` is displayed
