### PR TITLE
Fix line length in web.py

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -3,7 +3,7 @@
 """
    Plugin for our configuring the OMERO.web installation
 
-   Copyright 2009 University of Dundee. All rights reserved.
+   Copyright 2009-2013 University of Dundee. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """


### PR DESCRIPTION
Following the merge of #1798, this commit fixes the line length in web.py so that flake8 does not exit with a return code of 1. To test this PR, check that Travis is green again and that the functionality is not altered.

/cc @aleksandra-tarkowska
