### PR TITLE
Error handling of tile image loading in PanoJS See #11709

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
@@ -525,12 +525,12 @@ PanoJS.prototype.assignTileImage = function(tile) {
         var $this = $(this);
         // only try to reload if this is the first failure
         if (!$this.hasClass('failed')) {
+          $this.addClass('failed');
           setTimeout(function(){
             var s = tileImg.src;
             tileImg.src = s;    // no change, but is enough to trigger reload
           }, 1000); // try to reload src after timeout - 1 sec seems to work OK
         }
-        $(this).addClass('failed');
       };
 
     if ( tileImg.done || !tileImg.delayed_loading &&


### PR DESCRIPTION
This has not yet been merged into develop #1818 but I'm back-porting to make testing easier, and it might address a critical issue in dev_4_4. E.g. see https://nightshade.openmicroscopy.org/webgateway/img_detail/3946831/

For testing and more info see #1818

--rebased-from #1818
--rebased-to #1940
