### PR TITLE
assist #11250: manage transfer buffer size

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -67,6 +67,7 @@ import omero.model.Screen;
 import omero.sys.Parameters;
 import omero.sys.ParametersI;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -335,7 +336,7 @@ public class ImportLibrary implements IObservable
                     null, length, null));
 
             // "touch" the file otherwise zero-length files
-            rawFileStore.write(new byte[0], offset, 0);
+            rawFileStore.write(ArrayUtils.EMPTY_BYTE_ARRAY, offset, 0);
             estimator.stop();
             notifyObservers(new ImportEvent.FILE_UPLOAD_BYTES(
                     file.getAbsolutePath(), index, srcFiles.length,


### PR DESCRIPTION
At least 5Mb were being transferred from client to server for every file imported; this is enormous overhead for plates with many small files. This PR attempts to remedy the situation.

See http://trac.openmicroscopy.org.uk/ome/ticket/11250 and mostly test that import still works at least as well. Improvements should be most obvious over slow connections. Try importing small files, large files (at least several megabytes), and many-file plates.

Cc: @jburel, @joshmoore, @rleigh-dundee, @ximenesuk.

--no-rebase as dev_4_4 writes raw pixel data using very different code.
