### PR TITLE
Extract Django when it's missing or is the wrong version

### DIFF
--- a/components/tools/OmeroWeb/build.xml
+++ b/components/tools/OmeroWeb/build.xml
@@ -53,6 +53,9 @@
                         </filtermapper>
                     </mapper>
                 </untar>
+                <touch>
+                    <fileset dir="${basedir}/../target/lib/python/django"/>
+                </touch>
             </then>
         </if>
         <if><not><available file="${basedir}/../target/lib/python/flup"/></not>


### PR DESCRIPTION
Small improvement to the build script to re-extract Django when switching between dev_4_4 and develop, so it's not necessary to run `python build.py clean`
