### PR TITLE
Fix intermittent test failures in OmeroPy-integration-stable. (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -87,7 +87,7 @@ class TestTickets3000(lib.ITest):
               "from EventLog evl join evl.event ev join ev.session s"
 
         # This was never supported
-        with pytest.raises(Ice.UnmarshalOutOfBoundsException or Ice.UnknownUserException):
+        with pytest.raises((Ice.UnmarshalOutOfBoundsException, Ice.UnknownUserException)):
             q.findAllByQuery(sql, None)
 
         p1 = omero.sys.Parameters()


### PR DESCRIPTION
This is the same as gh-1799 but rebased onto develop.

---

This PR updates the exceptions expected in `OmeroPy/test/integration/test_tickets3000.py`. This way `test2628` should pass all the time now.

To test this PR, verify that the exception seen in http://hudson.openmicroscopy.org.uk/view/2.%20Stable/job/OmeroPy-integration-stable/67/testReport/junit/test.integration.test_tickets3000/TestTickets3000/test2628/ doesn't happen again for a few next builds.

This PR can be rebased onto `develop` to keep the code inline.
