### PR TITLE
Fix SPW delete test timeouts (see #11540). (rebased onto dev_4_4)

### DIFF
--- a/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
@@ -37,7 +37,7 @@ import spec.XMLWriter;
 @Test(groups = "ticket:2615")
 public class SpwDeleteTest extends AbstractServerTest {
 
-    @Test(groups = { "ticket:3102" })
+    @Test(groups = {"ticket:3102", "ticket:11540"})
     public void testScreen() throws Exception {
 
         newUserAndGroup("rw----");
@@ -68,10 +68,13 @@ public class SpwDeleteTest extends AbstractServerTest {
             }
         }
 
+        // In order to avoid omero.LockTimeout
+        // see XMLMockObjects.createScreen()
+        scalingFactor *= 1*2*2*2*2;
+
         delete(client, new Delete(DeleteServiceTest.REF_SCREEN, screen.getId()
                 .getValue(), null));
 
-        // assertDoesNotExist(exp);
         assertDoesNotExist(screen);
         assertNoneExist(plates.toArray(new Plate[0]));
         assertNoneExist(samples.toArray(new WellSample[0]));


### PR DESCRIPTION
This is the same as gh-1797 but rebased onto dev_4_4.

---

This PR should eliminate omero.LockTimeout-s in the `testScreen` method. It increases the time needed for the delete operation to succeed by multiplying the initial scaling factor time by the amount of plates, wells, fields and acquisitions.

To test - verify that http://hudson.openmicroscopy.org.uk/view/Failing/job/OmeroJava-integration-develop/52/testngreports/ doesn't happen for a couple of days.

This PR can be rebased to `develop` to keep the code inline.
