### PR TITLE
Bio-Formats dependency on lwf-stubs JAR for lurawave

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -73,6 +73,7 @@
         <artifact name="bio-formats"/>
         <artifact name="jai_imageio"/>
         <artifact name="loci-common"/>
+        <artifact name="lwf-stubs"/>
         <artifact name="mdbtools-java"/>
         <artifact name="metakit"/>
         <artifact name="ome-io"/>

--- a/components/romio/ivy.xml
+++ b/components/romio/ivy.xml
@@ -19,6 +19,7 @@
         <artifact name="bio-formats"/>
         <artifact name="jai_imageio"/>
         <artifact name="loci-common"/>
+        <artifact name="lwf-stubs"/>
         <artifact name="mdbtools-java"/>
         <artifact name="metakit"/>
         <artifact name="ome-io"/>


### PR DESCRIPTION
This should prevent exceptions in thumbnail generation that interfere with reader serialization.

Depends on https://github.com/openmicroscopy/bioformats/pull/812.
