### PR TITLE
Add `--match v.[0-9]*` to `git describe`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,7 +52,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     </description>
 
-    <property name="gitmatch" value="v.[0-9]*"/>
+    <property name="gitmatch" value="v.[0-9]*.[0-9]*.[0-9]*"/>
     <property name="import.dir" value="${basedir}/components/antlib/resources"/>
     <import file="${import.dir}/global.xml"/>
 


### PR DESCRIPTION
In order to prevent non-official tags from causing
server/client version breakage, filter out all non
official-looking tags, i.e. "v.4.4.9"

see: http://trac.openmicroscopy.org.uk/ome/ticket/11727
#### Testing
- All jobs should remain green and version numbers should still look reasonable.
- Adding a fake ticket (`git tag -a foo_bar`) should **NOT** affect the output of `./build.py version`
