### PR TITLE
Change warn to debug

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -428,7 +428,9 @@ public class PixelsService extends AbstractFileSystemService
     public PixelBuffer getPixelBuffer(Pixels pixels, boolean write)
     {
         PixelBuffer pb = _getPixelBuffer(pixels, write);
-        log.warn(pb +" for " + pixels);
+        if (log.isDebugEnabled()) {
+            log.debug(pb +" for " + pixels);
+        }
         return pb;
     }
 


### PR DESCRIPTION
In f5a3bb85f26ec011012ee6cd356fae403df8efe9, a `log.warn` statement
snuck in that should really have been at `debug()`.
