### PR TITLE
fix #11693: prevent rename of user's current group

### DIFF
--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -273,7 +273,8 @@ public interface IAdmin extends ServiceInterface {
     /**
      * Updates an experimenter group if admin or owner of group.
      * Only string fields on the object are taken into account.
-     * The root, system and guest groups may not be renamed.
+     * The root, system and guest groups may not be renamed,
+     * nor may the user's current group.
      * 
      * @param group
      *            the ExperimenterGroup to update.

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -599,6 +599,9 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             } else if (fixedGroupNames.contains(newName)) {
                 throw new ValidationException("cannot change name to special group '" + newName + "'");
             }
+            if (group.getId().equals(getEventContext().getCurrentGroupId())) {
+                throw new ValidationException("cannot rename the current group context '" + origName + "'");
+            }
         }
         orig.setName(newName);
         orig.setDescription(group.getDescription());

--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -950,6 +950,72 @@ public class AdminServiceTest extends AbstractServerTest {
     }
 
     /**
+     * Test that a user cannot rename the group that is currently their context.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testCurrentGroupRenameProhibition() throws Exception {
+        IAdminPrx proxy;
+        proxy = root.getSession().getAdminService();
+
+        final Roles roles = proxy.getSecurityRoles();
+        ExperimenterGroup userGroup   = proxy.getGroup(roles.userGroupId);
+        ExperimenterGroup systemGroup = proxy.getGroup(roles.systemGroupId);
+
+        final String normalGroupName1α = UUID.randomUUID().toString();
+        final String normalGroupName1β = UUID.randomUUID().toString();
+        ExperimenterGroup normalGroup1 = new ExperimenterGroupI();
+        normalGroup1.setName(omero.rtypes.rstring(normalGroupName1α));
+        normalGroup1 = proxy.getGroup(proxy.createGroup(normalGroup1));
+
+        final String normalGroupName2 = UUID.randomUUID().toString();
+        ExperimenterGroup normalGroup2 = new ExperimenterGroupI();
+        normalGroup2.setName(omero.rtypes.rstring(normalGroupName2));
+        normalGroup2 = proxy.getGroup(proxy.createGroup(normalGroup2));
+
+        final String userName1 = UUID.randomUUID().toString();
+        Experimenter experimenter1 = createExperimenterI(userName1, "1", "user");
+        final long experimenterId1 = proxy.createUser(experimenter1, normalGroupName1α);
+        experimenter1 = proxy.getExperimenter(experimenterId1);
+        proxy.addGroups(experimenter1, ImmutableList.of(userGroup, systemGroup, normalGroup1, normalGroup2));
+        experimenter1 = proxy.getExperimenter(experimenterId1);
+
+        final String userName2 = UUID.randomUUID().toString();
+        Experimenter experimenter2 = createExperimenterI(userName2, "2", "user");
+        final long experimenterId2 = proxy.createUser(experimenter2, normalGroupName1α);
+        experimenter2 = proxy.getExperimenter(experimenterId2);
+        proxy.addGroups(experimenter2, ImmutableList.of(userGroup, normalGroup1, normalGroup2));
+        experimenter2 = proxy.getExperimenter(experimenterId2);
+
+        final omero.client client1 = newOmeroClient();
+        final omero.client client2 = newOmeroClient();
+
+        client1.createSession(userName1, null);
+        client2.createSession(userName2, null);
+
+        proxy = client1.getSession().getAdminService();
+        try {
+            /* test that the current group cannot be renamed */
+            normalGroup1.setName(omero.rtypes.rstring(normalGroupName1β));
+            proxy.updateGroup(normalGroup1);
+            fail("the current group may not be renamed");
+        } catch (ValidationException e) { }
+        /* switch current group */
+        proxy.setDefaultGroup(experimenter1, normalGroup2);
+        client1.closeSession();
+        client1.createSession(userName1, null);
+        proxy = client1.getSession().getAdminService();
+        /* test that the same group can be renamed if no longer current */
+        proxy.updateGroup(normalGroup1);
+        /* test the viability of another user still logged in with the renamed group as current */
+        proxy = client2.getSession().getAdminService();
+        proxy.setDefaultGroup(experimenter2, normalGroup2);
+
+        client1.closeSession();
+        client2.closeSession();
+    }
+
+    /**
      * Test the group removal prohibitions of
      * {@link ome.api.IAdmin#removeGroups(ome.model.meta.Experimenter, ome.model.meta.ExperimenterGroup...)}.
      * Specifically, test this claim from the Javadoc:
@@ -998,7 +1064,7 @@ public class AdminServiceTest extends AbstractServerTest {
 
         final omero.client client = newOmeroClient();
 
-        client.createSession(userName1, normalGroupName);
+        client.createSession(userName1, null);
         proxy = client.getSession().getAdminService();
 
         try {
@@ -1065,7 +1131,7 @@ public class AdminServiceTest extends AbstractServerTest {
 
         final omero.client client = newOmeroClient();
 
-        client.createSession(userName1, normalGroupName);
+        client.createSession(userName1, null);
         proxy = client.getSession().getAdminService();
 
         try {


### PR DESCRIPTION
This attempts to ameliorate https://trac.openmicroscopy.org.uk/ome/ticket/11693 but do note https://trac.openmicroscopy.org.uk/ome/ticket/11693#comment:8 (responding to the previous) which may mean that this PR is taking the wrong approach. Still, hopefully it at least stimulates useful discussion. Cc: @dpwrussell.
