### PR TITLE
ImportLibrary: read from each used file's mapped ID

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import loci.common.Location;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import ome.formats.OMEROMetadataStoreClient;
@@ -321,7 +322,7 @@ public class ImportLibrary implements IObservable
                 ChecksumAlgorithmMapper.getChecksumType(
                         proc.getImportSettings().checksumAlgorithm));
         String digestString = null;
-        File file = new File(srcFiles[index]);
+        File file = new File(Location.getMappedId(srcFiles[index]));
         long length = file.length();
         FileInputStream stream = null;
         RawFileStorePrx rawFileStore = null;


### PR DESCRIPTION
The vast majority of the time, the mapped ID will be identical to the
path returned by getUsedFiles().  For Flex datasets with server mapping
enabled client-side, however, the mapped ID will be different to allow
all files to end up in the same directory.  This eliminates the need for
server-side server mappings.

See https://trac.openmicroscopy.org.uk/ome/ticket/11781 and https://github.com/openmicroscopy/bioformats/pull/819.

To test, move the .flex file from test_images_good/flex/ to a different directory and add the following to `~/omero/importer.ini`:

```
[FlexReaderServerMaps]
CIA-1=/path/to/dir/containing/flex/
```

Then import the .mea file from test_images_good/flex/.  Verify that the import succeeds, the image can be viewed, and that the .flex, .mea, and .res file all appear in the same directory on the server.  Without this and https://github.com/openmicroscopy/bioformats/pull/819, the same import should fail (and/or result in an unreadable image).
