### PR TITLE
Allow fast finish up travis builds (rebased onto dev_4_4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 env:
-    - BUILD=java BUILD_TARGET="build-default test-compile" TEST_TARGET="-p"
     - BUILD=py BUILD_TARGET="build-default" TEST_TARGET="-py test -Dtest.with.fail=true"
+    - BUILD=java BUILD_TARGET="build-default test-compile" TEST_TARGET="-p"
 
 matrix:
       fast_finish: true


### PR DESCRIPTION
This is the same as gh-1847 but rebased onto dev_4_4.

---

As soon as one part of the build has failed,
the job will be marked as a failure and appear
red in github.

See: http://about.travis-ci.org/blog/2013-11-27-fast-finishing-builds
