### PR TITLE
Use getThumbnail() to speed up import. (see #11783)

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -2277,9 +2277,10 @@ public class OMEROMetadataStoreClient
                     log.debug("resetDefaultsAndGenerateThumbnails exception", ie);
                 }
             }
-            thumbnailStore.close();
         } catch (ServerError e) {
             throw new RuntimeException(e);
+        } finally {
+            closeQuietly(thumbnailStore);
         }
     }
 


### PR DESCRIPTION
This PR aims at increasing import speed by using a different method server-side for thumbnail generation. This is one of the import steps and for bigger datasets can take up some time.

Rough measurements didn't point to this being the best solution, but testing with Leica image file sets or other multi-file images should succeed.

This can be rebased, as `dev_4_4` is also using the `createThumbnailsByLongestSideSet` method.
