### PR TITLE
Remove duplicate postgres startup #11793 (rebased onto dev_4_4)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -100,10 +100,8 @@ export PYTHONPATH=$(bin/brew --prefix omero)/lib/python:$ICE_HOME/python
 export PATH=$(bin/brew --prefix)/bin:$(bin/brew --prefix)/sbin:/usr/local/lib/node_modules:$ICE_HOME/bin:$PATH
 export DYLD_LIBRARY_PATH=$ICE_HOME/lib:$ICE_HOME/python:${DYLD_LIBRARY_PATH-}
 
-# There may be an old postgres process still running, but its working directory
-# may have been deleted so pg_ctl won't work.
-killall postgres || echo No existing postgres running
-
+# Note: If postgres startup fails it's probably because there was an old
+# process still running.
 # Create PostgreSQL database
 if [ -d "$PSQL_DIR" ]; then
     rm -rf $PSQL_DIR


### PR DESCRIPTION
This is the same as gh-1873 but rebased onto dev_4_4.

---

[OMERO-homebrew-develop](http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-develop) and [OMERO-homebrew-STABLE](http://hudson.openmicroscopy.org.uk/job/OMERO-homebrew-stable) regularly failed because Postgres was being started twice.

Note this requires changes to the jenkins job- since the postgres data dir is explicitly set it is necessary to run `/usr/local/bin/pg_ctl -D$PSQL_DIR -m fast stop` instead of `/usr/local/bin/brew services stop postgres`. Try runnning this job a few times to check it works.
