### PR TITLE
Fix test_reporawfilestore

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
+++ b/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
@@ -54,10 +54,8 @@ class TestRepoRawFileStore(AbstractRepoTest):
         rfs = self.repoPrx.file(self.repo_filename, "r")
         assert rfs.size() == 0
         wbytes = "0123456789"
-        try:
+        with pytest.raises(omero.SecurityViolation):
             rfs.write(wbytes,0,len(wbytes))
-        except:
-            pass
         assert rfs.size() == 0
 
     def testFailedWriteNoFile(self):
@@ -113,14 +111,9 @@ class TestRepoRawFileStore(AbstractRepoTest):
         assert rfs.size() == len(wbytes)
         rbytes = rfs.read(0,len(wbytes))
         assert wbytes == rbytes
-        try:
-            rfs.close()
-        except:
-            pass #FIXME: close throws an NPE but should close the filehandle...
-        try:
+        rfs.close()
+        with pytest.raises(Ice.ObjectNotExistException):
             rbytes = rfs.read(0,len(wbytes))
-        except:
-            pass #FIXME: ... so an exception should be thrown here now.
         rfs = self.repoPrx.file(self.repo_filename, "r")
         assert rfs.size() == len(wbytes)
 


### PR DESCRIPTION
This certainly gets the previously failing test to pass though it might be that the test is not the problem.

In the failing test, `testFailedWriteNoFile` calling a method on a closed rfs throws an exception but not an open one. In addition, the exception raised when trying to write to a read-only rfs is not the one originally expected.

In the other tests `rfs.close()` does not throw an NPE (as evidenced in other tests). Also a couple of `try` blocks used for exceptions have been converted to `with` blocks.

The only testing this PR needs is a clean pass in the integration tests. However, a review of what is expected by `testFailedWriteNoFile` by someone who know what the `RepoRawFileStore` is meant to do would be welcomed.

--no-rebase as this is develop-only
