### PR TITLE
Add omero.pixeldata.dispose for static config (See #11675)

### DIFF
--- a/components/model/src/ome/util/PixelData.java
+++ b/components/model/src/ome/util/PixelData.java
@@ -10,6 +10,9 @@ package ome.util;
 import java.nio.ByteOrder;
 import java.nio.ByteBuffer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Represents a block of pixel data.
  *
@@ -21,6 +24,21 @@ import java.nio.ByteBuffer;
  */
 public class PixelData
 {
+    public static final String CONFIG_KEY;
+
+    private static final Logger LOG = LoggerFactory.getLogger(PixelData.class);
+
+    private static final boolean DISPOSE;
+    static {
+        CONFIG_KEY = "omero.pixeldata.dispose";
+        String p = System.getProperties().getProperty(CONFIG_KEY);
+        if (Boolean.valueOf(p)) {
+            DISPOSE = true;
+        } else {
+            DISPOSE = false;
+        }
+        LOG.debug("{} set to {}", CONFIG_KEY, DISPOSE);
+    }
     /** Identifies the type used to store pixel values. */
     public static final int BYTE = 0;
 
@@ -402,6 +420,11 @@ public class PixelData
      * If not called, the resources should eventually be freed anyway by garbage collection and finalization.
      */
     public void dispose() {
+
+        if (!DISPOSE) {
+            return; // EARLY EXIT
+        }
+
         if (this.data instanceof sun.nio.ch.DirectBuffer) {
             ((sun.nio.ch.DirectBuffer) this.data).cleaner().clean();
             this.data = null;

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -109,6 +109,13 @@ omero.pixeldata.repetitions=1
 # should wait for an image to be ready to view.
 omero.pixeldata.backoff=ome.io.nio.SimpleBackOff
 
+# Whether the PixelData.dispose() method should
+# try to clean up ByteBuffer instances which may
+# lead to memory exceptions. See ticket #11675
+# for more information. Note: the property is
+# set globally for the JVM.
+omero.pixeldata.dispose=false
+
 # Default sizes for tiles are provided by a
 # ome.io.nio.TileSizes implementation. By default
 # the bean ("configuredTileSizes") uses the properties


### PR DESCRIPTION
Since the cleaning should only be necessary under certain conditions
(most likely a 32-bit JVM), the disposing of the ByteBuffers held by
PixelData instances can be en-/disabled with omero.pixeldata.dispose

See: http://trac.openmicroscopy.org.uk/ome/ticket/11675

Testing:
- Up the logging for `ome.util.PixelData` in `etc/logback.xm`l to `DEBUG`
- Import `a.fake` or similar.
- Check the log for `2013-12-10 08:38:21,839 DEBUG [                      ome.util.PixelData] (l.Server-3) omero.pixeldata.dispose set to true`
- If you have a 32-bit JVM, possibly test on very large images. (This is **very** hard to reproduce)

--no-rebase
