### PR TITLE
Fix import exception window layout (see #11797).

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/EditorDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/EditorDialog.java
@@ -252,8 +252,8 @@ public class EditorDialog
      */
     private JPanel buildContentPanel() {
         JPanel content = new JPanel();
-        double[][] tl = {{TableLayout.PREFERRED, TableLayout.FILL },
-                {TableLayout.PREFERRED, 5, TableLayout.FILL }};
+        double[][] tl = {{TableLayout.PREFERRED, TableLayout.FILL},
+                {TableLayout.PREFERRED, 5, TableLayout.FILL}};
         TableLayout layout = new TableLayout(tl);
         content.setLayout(layout);
         content.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));


### PR DESCRIPTION
As I've been looking at more and more exceptions, I had to finally fix this. This PR updates the layout applied to the import exception viewer. This can be easily rebased to `dev_4_4`, as the component code is the same there.

**Before:**
![screen shot 2013-12-11 at 16 01 20](https://f.cloud.github.com/assets/1692189/1725311/cb7acca0-627d-11e3-8a3a-7477a26730be.png)

**After:**
![screen shot 2013-12-11 at 16 02 20](https://f.cloud.github.com/assets/1692189/1725315/d6d68eea-627d-11e3-9a2a-c63321538830.png)
