### PR TITLE
Group was excluded.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -615,8 +615,9 @@ public class DataServicesFactory
         Set<GroupData> available;
         List<ExperimenterData> exps = new ArrayList<ExperimenterData>();
         try {
-        	SecurityContext ctx = new SecurityContext(
-        			exp.getDefaultGroup().getId());
+            GroupData defaultGroup = null;
+            long gid = exp.getDefaultGroup().getId();
+        	SecurityContext ctx = new SecurityContext(gid);
         	groups = omeroGateway.getAvailableGroups(ctx, exp);
         	registry.bind(LookupNames.SYSTEM_ROLES,
                     omeroGateway.getSystemRoles(ctx));
@@ -626,6 +627,7 @@ public class DataServicesFactory
         	available = new HashSet<GroupData>();
         	while (i.hasNext()) {
         		g = i.next();
+        		if (gid == g.getId()) defaultGroup = g;
         		if (!admin.isSecuritySystemGroup(g.getId())) {
         			available.add(g);
         		} else {
@@ -636,7 +638,12 @@ public class DataServicesFactory
         			}
         		}
         	}
-        	
+        	//to be on the safe side.
+        	if (available.size() ==  0) {
+        	    //group with loaded users.
+        	    if (defaultGroup != null) available.add(defaultGroup);
+        	    else available.add(exp.getDefaultGroup());
+        	}
         	registry.bind(LookupNames.USER_GROUP_DETAILS, available);
         	List<Long> ids = new ArrayList<Long>();
         	i = available.iterator();


### PR DESCRIPTION
Make sure that we always at least one group available for a user.

The problem was due to the fact that the "default" group is a "system" group. The Roles on nighthade are not correctly set

see https://trac.openmicroscopy.org.uk/ome/ticket/11813
