### PR TITLE
Reset Image.archived flag where necessary (Fix #11810)

### DIFF
--- a/sql/psql/OMERO5.0__0/OMERO4.4__0.sql
+++ b/sql/psql/OMERO5.0__0/OMERO4.4__0.sql
@@ -600,6 +600,13 @@ CREATE TRIGGER prevent_experimenter_group_rename
     BEFORE UPDATE ON experimentergroup
     FOR EACH ROW EXECUTE PROCEDURE prevent_experimenter_group_rename();
 
+-- #11810 Fix Image.archived flag
+UPDATE image set archived = false where id in (
+    SELECT i.id FROM pixels p, image i
+     WHERE p.image = i.id
+       AND i.archived
+       AND NOT EXISTS ( SELECT 1 FROM pixelsoriginalfilemap m WHERE m.child = p.id));
+
 --
 -- FINISHED
 --

--- a/sql/psql/OMERO5.0__0/OMERO5.0DEV__6.sql
+++ b/sql/psql/OMERO5.0__0/OMERO5.0DEV__6.sql
@@ -140,6 +140,13 @@ CREATE TRIGGER prevent_experimenter_group_rename
     BEFORE UPDATE ON experimentergroup
     FOR EACH ROW EXECUTE PROCEDURE prevent_experimenter_group_rename();
 
+-- #11810 Fix Image.archived flag
+UPDATE image set archived = false where id in (
+    SELECT i.id FROM pixels p, image i
+     WHERE p.image = i.id
+       AND i.archived
+       AND NOT EXISTS ( SELECT 1 FROM pixelsoriginalfilemap m WHERE m.child = p.id));
+
 --
 -- FINISHED
 --


### PR DESCRIPTION
During the upgrade testing of nightshade for 5.0.0-beta2-rc3,
images were found which had incorrect `archived`. This won't
prevent the flags from being mis-set again, but for starting
with `5.0__0` it will at least be consistent.
