### PR TITLE
img.getProject() no Errors if multiple parents. See #11807

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6124,8 +6124,9 @@ class _ImageWrapper (BlitzObjectWrapper):
             where i.id = %i
             """ % self._obj.id.val
             query = self._conn.getQueryService()
-            ds = query.findByQuery(q,None, self._conn.SERVICE_OPTS)
-            return ds and DatasetWrapper(self._conn, ds) or None
+            ds = query.findAllByQuery(q, None, self._conn.SERVICE_OPTS)
+            if ds and len(ds) == 1:
+                return DatasetWrapper(self._conn, ds[0])
         except: #pragma: no cover
             logger.debug('on getDataset')
             logger.debug(traceback.format_exc())


### PR DESCRIPTION
Fixes errors in the OMEROweb.log when you try image.getProject() and there are multiple projects.

To test:
 Place an image in 2 Projects (using 1 or 2 Datasets) and open the Image in Image-Viewer. Check this looks OK.
 `$ tail -f dist/var/log/OMEROweb.log` while refreshing the browser and check there's no errors (see https://trac.openmicroscopy.org.uk/ome/ticket/11807 for example of errors)

--no-rebase - too minor.
