### PR TITLE
Set global min/max according to pixel type. (see #11840)

### DIFF
--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -309,8 +309,8 @@ public abstract class QuantumStrategy {
      */
     public void setWindow(double start, double end) {
         verifyInterval(start, end);
-        if (start < globalMin) start = globalMin;
-        if (end < globalMax) end = globalMax;
+        if (start < pixelsTypeMin) start = pixelsTypeMin;
+        if (end > pixelsTypeMax) end = pixelsTypeMax;
         windowStart = start;
         windowEnd = end;
         onWindowChange();


### PR DESCRIPTION
Fix array out of bounds when viewing image.
See https://trac.openmicroscopy.org.uk/ome/ticket/11840
- Log as (see testing sheet)
- Open images SenP6 siRNA > Hec1/Aca/Tub II > image ID 3777835, 3777836, 
