### PR TITLE
Add append/remove subcommands to `bin/omero config`

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -286,10 +286,7 @@ class PrefsControl(BaseControl):
                          % (args.VALUE, args.KEY))
 
         list_value.remove(json.loads(args.VALUE))
-        if list_value:
-            config[args.KEY] = json.dumps(list_value)
-        else:
-            del config[args.KEY]
+        config[args.KEY] = json.dumps(list_value)
 
     @with_config
     def keys(self, args, config):

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -226,4 +226,13 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out='[1]')
         self.invoke("remove A 1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='')
+        self.assertStdoutStderr(capsys, out='[]')
+
+    def testRemoveIdenticalValues(self, capsys):
+        self.invoke("set A [1,1]")
+        self.invoke("remove A 1")
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[1]')
+        self.invoke("remove A 1")
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[]')


### PR DESCRIPTION
This PR addresses https://trac.openmicroscopy.org.uk/ome/ticket/11201

Changes included are:
- addition of `bin/omero config append` and `bin/omero config remove` so that configuration using lists of strings can easily be manipulated, e.g.
  
  ```
  bin/omero config append omero.web.apps webfigure
  bin/omero config append omero.web.apps webtagging
  …
  bin/omero config remove omero.web.apps webfigure
  ```
- addition of corresponding unit tests under `test_prefs.py`

/cc @dpwrussell, @will-moore, @manics
