### PR TITLE
Enable test_cmdcallback.py

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_cmdcallback.py
+++ b/components/tools/OmeroPy/test/integration/test_cmdcallback.py
@@ -34,14 +34,14 @@ from omero.rtypes import *
 from omero.util.concurrency import get_event
 
 
-class TestCB(omero.callbacks.CmdCallbackI):
+class CmdCallback(omero.callbacks.CmdCallbackI):
 
     def __init__(self, client, handle):
-        super(TestCB, self).__init__(client, handle)
+        super(CmdCallback, self).__init__(client, handle)
         self.t_lock = threading.RLock()
         self.t_steps = 0
         self.t_finished = 0
-        self.t_event = get_event("TestCB")
+        self.t_event = get_event("CmdCallback")
 
     def step(self, complete, total, current=None):
         self.t_lock.acquire()
@@ -94,15 +94,15 @@ class TestCB(omero.callbacks.CmdCallbackI):
             self.t_lock.release()
 
 
-class CmdCallbackTest(lib.ITest):
+class TestCmdCallback(lib.ITest):
 
     def mktestcb(self, req):
         """
-        returns a testCB instance for testing
+        returns a CmdCallback instance for testing
         """
         client = self.new_client(perms="rw----")
         handle = client.getSession().submit(req)
-        return TestCB(client, handle)
+        return CmdCallback(client, handle)
 
     # Timing
     # =========================================================================


### PR DESCRIPTION
Due to an error in the names of the two classes this test module was being skipped altogether. Without this PR:

```
jrs-macbookpro-25031:OmeroPy cblackburn$ ./setup.py test -s test/integration/test_cmdcallback.py 
[...]
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 2.7.4 -- pytest-2.5.0
collected 0 items / 1 skipped 

======================================================================== 1 skipped in 2.67 seconds ========================================================================

```

With this PR the tests should run, and hopefully, pass:

```
jrs-macbookpro-25031:OmeroPy cblackburn$ ./setup.py test -s test/integration/test_cmdcallback.py 
[...]
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 2.7.4 -- pytest-2.5.0
collected 6 items 

test/integration/test_cmdcallback.py ......

======================================================================== 6 passed in 6.41 seconds =========================================================================
```

--rebased-to #1911 
