### PR TITLE
Do not allow to run the split figures on big images.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
@@ -277,15 +277,17 @@ class PublishingDialog
     			data = img.getDefaultPixels();
     			boolean b = !model.isLargeImage();
     			exportAsOmeTiffButton.setEnabled(b);
-    			movieButton.setEnabled(data.getSizeT() > 1 || 
-    					data.getSizeZ() > 1);
-    			splitViewFigureButton.setEnabled(data.getSizeC() > 1);
-    			exportAsOmeTiffItem.setEnabled(b);
-    			movieItem.setEnabled(data.getSizeT() > 1 || 
-    					data.getSizeZ() > 1);
-    			splitViewFigureItem.setEnabled(data.getSizeC() > 1);
-    			splitViewROIFigureItem.setEnabled(data.getSizeC() > 1);
-    			movieFigureItem.setEnabled(true);
+    			if (model.isSingleMode()) {
+    			    movieButton.setEnabled(data.getSizeT() > 1 || 
+                            data.getSizeZ() > 1);
+                    splitViewFigureButton.setEnabled(data.getSizeC() > 1);
+                    exportAsOmeTiffItem.setEnabled(b);
+                    movieItem.setEnabled(data.getSizeT() > 1 || 
+                            data.getSizeZ() > 1);
+                    splitViewFigureItem.setEnabled(b && data.getSizeC() > 1);
+                    splitViewROIFigureItem.setEnabled(b && data.getSizeC() > 1);
+                    movieFigureItem.setEnabled(true);
+    			}
 			} catch (Exception e) {}
     	} else {
     		if (refObject instanceof DatasetData)


### PR DESCRIPTION
The split view is not available in the viewer for big image
The option to run the split view figure and other scripts involving the rendering engine is still available
This leads to some errors since the code is not implemented to handle such case.
Turn the option off.

To test:
- Select a big image. Make sure you cannot run "Split" script
- Select a non-big image.  Make sure you can run "Split" script
- Select both. Make sure you cannot run "Split" script
