### PR TITLE
assist #11675: do not assume sun.nio.ch.DirectBuffer

### DIFF
--- a/components/model/src/ome/util/PixelData.java
+++ b/components/model/src/ome/util/PixelData.java
@@ -1,7 +1,7 @@
 /*
  * ome.util.PixelData
  *
- *   Copyright 2007-2013 Glencoe Software Inc. All rights reserved.
+ *   Copyright 2007-2014 Glencoe Software Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -41,9 +41,9 @@ public class PixelData
         final Boolean dispose;
 
         /* parse config value and log accordingly */
-        if ("true".equals(configValue)) {
+        if ("true".equalsIgnoreCase(configValue)) {
             dispose = Boolean.TRUE;
-        } else if ("false".equals(configValue)) {
+        } else if ("false".equalsIgnoreCase(configValue)) {
             dispose = Boolean.FALSE;
         } else {
             dispose = null;


### PR DESCRIPTION
Addresses https://github.com/openmicroscopy/openmicroscopy/pull/1865#discussion_r8370560 by not assuming that `dispose()`'s,

``` java
((sun.nio.ch.DirectBuffer) this.data).cleaner().clean();
```

is even possible with the loadable classes.

To see this in action, in `etc/omero.properties` set `omero.pixeldata.dispose=true` and do,

```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/RawPixelsStoreTest
```

--no-rebase, following #1865 and #1884.
