### PR TITLE
fix #11693: prevent rename of user's current group (rebased)

### DIFF
--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -273,7 +273,8 @@ public interface IAdmin extends ServiceInterface {
     /**
      * Updates an experimenter group if admin or owner of group.
      * Only string fields on the object are taken into account.
-     * The root, system and guest groups may not be renamed.
+     * The root, system and guest groups may not be renamed,
+     * nor may the user's current group.
      * 
      * @param group
      *            the ExperimenterGroup to update.

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -587,6 +587,9 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             } else if (fixedGroupNames.contains(newName)) {
                 throw new ValidationException("cannot change name to special group '" + newName + "'");
             }
+            if (group.getId().equals(getEventContext().getCurrentGroupId())) {
+                throw new ValidationException("cannot rename the current group context '" + origName + "'");
+            }
         }
         orig.setName(newName);
         orig.setDescription(group.getDescription());


### PR DESCRIPTION
This attempts to ameliorate https://trac.openmicroscopy.org.uk/ome/ticket/11693 but do note https://trac.openmicroscopy.org.uk/ome/ticket/11693#comment:8 (responding to the previous) which may mean that this PR is taking the wrong approach. Still, hopefully it at least stimulates useful discussion.

--rebased-from #1861
