### PR TITLE
Blackthumbnails dev 4 4

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/BirdEyeLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/BirdEyeLoader.java
@@ -79,7 +79,7 @@ public class BirdEyeLoader
      * @param ratio The ratio by with to scale the image.
      */
     public BirdEyeLoader(ImViewer viewer, SecurityContext ctx, ImageData image,
-            PlaneDef plane, double ratio)
+            double ratio)
     {
         super(viewer, ctx);
         if (image == null)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -5,7 +5,7 @@
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -47,7 +47,6 @@ import java.util.Map;
 
 import omero.model.PlaneInfo;
 import omero.romio.PlaneDef;
-import omero.romio.RegionDef;
 
 import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.agents.events.iviewer.CopyRndSettings;
@@ -112,15 +111,13 @@ import com.sun.opengl.util.texture.TextureData;
 * them back to this class and fires state transitions as appropriate.
 * 
 * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
-* 				<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
-* @author	Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
-* 				<a href="mailto:a.falconi@dundee.ac.uk">a.falconi@dundee.ac.uk</a>
-* @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
-* 				<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+*         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+* @author Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+*         <a href="mailto:a.falconi@dundee.ac.uk">a.falconi@dundee.ac.uk</a>
+* @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
+*         <a href="mailto:donald@lifesci.dundee.ac.uk">
+*         donald@lifesci.dundee.ac.uk</a>
 * @version 3.0
-* <small>
-* (<b>Internal version:</b> $Revision: $ $Date: $)
-* </small>
 * @since OME2.2
 */
 class ImViewerModel
@@ -2591,32 +2588,10 @@ class ImViewerModel
 		// use the lowest resolution
 		Renderer rnd = metadataViewer.getRenderer();
 		if (rnd == null) return;
-		PlaneDef pDef = createPlaneDef();
 		ResolutionLevel level = getResolutionDescription();
 		Dimension d = level.getTileSize();
 		int w = d.width;
 		int h = d.height;
-		int edgeWidth = w;
-		int edgeHeight = h;
-		int size = level.getImageSize().width;
-		edgeWidth = w;
-		int n = size/w;
-		int tiledImageSizeX = n*w;
-		if (n*w < size) {
-			edgeWidth = size-n*w;
-			tiledImageSizeX += edgeWidth;
-			n++;
-		}
-		size = level.getImageSize().height;
-		edgeHeight = h;
-		n = size/h;
-		int tiledImageSizeY = n*h;
-		if (n*h < size) {
-			edgeHeight = size-n*h;
-			tiledImageSizeY += edgeHeight;
-			n++;
-		}
-		pDef.region = new RegionDef(0, 0, tiledImageSizeX, tiledImageSizeY);
 		double ratio = 1;
 		w = tiledImageSizeX;
 		h = tiledImageSizeY;
@@ -2634,7 +2609,7 @@ class ImViewerModel
 		ratio = (double) ref/Factory.THUMB_DEFAULT_WIDTH;
 		state = ImViewer.LOADING_BIRD_EYE_VIEW;
 		BirdEyeLoader loader = new BirdEyeLoader(component, ctx, getImage(),
-				pDef, ratio);
+				ratio);
 		loader.load();
 		loaders.put(BIRD_EYE_VIEW, loader);
 	}


### PR DESCRIPTION
Same as gh-1871

log in as user-6 group read-only -1 (omero4-demo.openmicroscopy.org port 14064)
- add user-9 to the tree
- open one of the gatan image owned by user-9
- the thumbnail should no longer be black 

see https://trac.openmicroscopy.org.uk/ome/ticket/11776
