### PR TITLE
Download crash dev 4 4

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.ui.DownloadArchivedActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -25,21 +25,22 @@ package org.openmicroscopy.shoola.env.ui;
 
 
 //Java imports
-
-//Third-party libraries
-
-//Application-internal dependencies
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 
+//Third-party libraries
+
+//Application-internal dependencies
+
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.DownloadArchivedActivityParam;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.util.file.IOUtil;
-import org.springframework.util.CollectionUtils;
 
 /** 
  * Downloads the archived image.


### PR DESCRIPTION
Manually fix issue already in develop cf. gh-1889. A previous PR has not been rebased (zip)

Fix NPE when downloading the archived file see http://trac.openmicroscopy.org.uk/ome/ticket/11810
- Log in as (see sheet)
- Select an image with archived flag (see screenshot attached to ticket)
- Click on the "Download archived"
- Message indicating that no archived available should be displayed.

--rebased-from #1889
