### PR TITLE
Unit issue dev 4 4

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -1333,10 +1333,10 @@ class ImViewerUI
 			buffer.append("-"+(getProjectionEndZ()+1));
 			if (d > 0 && max > 0) {
 				o = EditorUtil.transformSize(n*d);
-				units = o.getUnits();
 				buffer.append(" ("+UIUtilities.roundTwoDecimals(o.getValue()));
 				buffer.append("-");
 				o = EditorUtil.transformSize(m*d);
+				units = o.getUnits();
 				buffer.append(UIUtilities.roundTwoDecimals(o.getValue()));
 				buffer.append(" "+units+")");
 			}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2440,8 +2440,7 @@ public class UIUtilities
 	{
 		double v = value.doubleValue();
 		String units = UnitsObject.MICRONS;
-		/* TODO: check if we want to introduce that.
-		if (v < 1) {
+		if (v > 0.0 && v < 0.01) {
 			units = UnitsObject.NANOMETER;
 			v *= 1000;
 			if (v < 1) {
@@ -2450,7 +2449,6 @@ public class UIUtilities
 			}
 			return new UnitsObject(units, v);
 		}
-		*/
 		if (v > 1000) {
 			units = UnitsObject.MILLIMETER;
 			v /= 1000;


### PR DESCRIPTION
To test:
- select an image with more than one z-sections
- go to the first z-sections. Make sure the units is 0.0 microns
- Go to the projection tab. Make sure the units is correctly displayed e.g. 1.4-2.6 microns

Screenshots from eclipse build. so ignore funny character
See units in main view before and after
![units-before](https://f.cloud.github.com/assets/1022396/1732500/6b3fbc90-631f-11e3-8b0a-8a74556230f7.png)
![units-after](https://f.cloud.github.com/assets/1022396/1732502/6e1ba2c6-631f-11e3-94c3-cbf390cea9c1.png)

See units in projection view before and after
![unit-projections-before](https://f.cloud.github.com/assets/1022396/1732506/76990024-631f-11e3-96bb-3576d6339b05.png)
![unit-projection-after](https://f.cloud.github.com/assets/1022396/1732509/7d40455e-631f-11e3-99c4-b94d6ff00d58.png)
