### PR TITLE
big_image_link_xy_11844

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -497,7 +497,14 @@ jQuery.fn.viewportImage = function(options) {
             PanoJS.MSG_BEYOND_MAX_ZOOM = null;
             viewerBean.init();
             if ((typeof init_cx != 'undefined') && (typeof init_cy != 'undefined')) {
-                viewerBean.recenter({'x':parseInt(init_cx, 10), 'y':parseInt(init_cy, 10)}, true, true);
+                var scale = viewerBean.currentScale();
+                viewerBean.recenter({
+                    'x':parseInt(init_cx, 10)*scale,
+                    'y':parseInt(init_cy, 10)*scale}, true, true);
+                // Seems that if we're on the edge of image, blank tiles are not cleared...
+                setTimeout(function() {
+                  viewerBean.positionTiles();
+                }, 5000);   // clear AFTER they have loaded (not ideal!)
             }
             if (viewerBean.thumbnail_control) {
                 viewerBean.thumbnail_control.update();


### PR DESCRIPTION
This fixes the "Image Link" creation and processing, so that you can 'bookmark' a location and zoom level on a Big Image (see https://trac.openmicroscopy.org.uk/ome/ticket/11844).

To test, 
- open a Big image in web viewer
- pan and zoom to a chosen location (note zoom and remember what feature you're looking at)
- copy "Image Link" from left of window
- paste Link into another window (or another browser - login if needed) and check that you are directed to same location and zoom level.
- Regression test - check that simply loading image (without following link) loads at centre of image and zoomed out.
