### PR TITLE
Fix deprecation warning for mimetype keyword argument

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -445,7 +445,7 @@ class render_response(object):
             # allows us to return the dict as json  (NB: BlitzGateway objects don't serialize)
             if template is None or template == 'json':
                 json_data = json.dumps(context)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
             else:
                 # allow additional processing of context dict
                 ctx.prepare_context(request, context, *args, **kwargs)

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -729,7 +729,7 @@ def my_account(request, action=None, conn=None, **kwargs):
 @login_required()
 def myphoto(request, conn=None, **kwargs):
     photo = conn.getExperimenterPhoto()
-    return HttpResponse(photo, mimetype='image/jpeg')
+    return HttpResponse(photo, content_type='image/jpeg')
 
 
 @login_required()
@@ -785,4 +785,4 @@ def drivespace(request, conn=None, **kwargs):
 def load_drivespace(request, conn=None, **kwargs):
     offset = request.REQUEST.get('offset', 0)
     rv = usersData(conn, offset)
-    return HttpResponse(json.dumps(rv),mimetype='application/json')
+    return HttpResponse(json.dumps(rv), content_type='application/json')

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1408,14 +1408,14 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
                 oid = manager.createDataset(name, description)
                 rdict = {'bad':'false', 'id': oid}
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
             else:
                 d = dict()
                 for e in form.errors.iteritems():
                     d.update({e[0]:unicode(e[1])}) 
                 rdict = {'bad':'true','errs': d }
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
         elif request.REQUEST.get('folder_type') in ("project", "screen", "dataset"):
             # No parent specified. We can create orphaned 'project', 'dataset' etc.
             form = ContainerForm(data=request.REQUEST.copy())
@@ -1430,14 +1430,14 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
                     oid = getattr(manager, "create"+folder_type.capitalize())(name, description)
                 rdict = {'bad':'false', 'id': oid}
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
             else:
                 d = dict()
                 for e in form.errors.iteritems():
                     d.update({e[0]:unicode(e[1])}) 
                 rdict = {'bad':'true','errs': d }
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
         else:
             return HttpResponseServerError("Object does not exist")
     elif action == 'edit':
@@ -1513,14 +1513,14 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
                     o_type = "image"
                 manager.updateName(o_type, name)
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
             else:
                 d = dict()
                 for e in form.errors.iteritems():
                     d.update({e[0]:unicode(e[1])}) 
                 rdict = {'bad':'true','errs': d }
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
         else:
             return HttpResponseServerError("Object does not exist")
     elif action == 'editdescription':
@@ -1549,14 +1549,14 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
                 manager.updateDescription(o_type, description)
                 rdict = {'bad':'false' }
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
             else:
                 d = dict()
                 for e in form.errors.iteritems():
                     d.update({e[0]:unicode(e[1])}) 
                 rdict = {'bad':'true','errs': d }
                 json_data = json.dumps(rdict, ensure_ascii=False)
-                return HttpResponse(json_data, mimetype='application/javascript')
+                return HttpResponse(json_data, content_type='application/javascript')
         else:
             return HttpResponseServerError("Object does not exist")
     elif action == 'paste':
@@ -1566,11 +1566,11 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
         if rv:
             rdict = {'bad':'true','errs': rv }
             json_data = json.dumps(rdict, ensure_ascii=False)
-            return HttpResponse(json_data, mimetype='application/javascript')
+            return HttpResponse(json_data, content_type='application/javascript')
         else:
             rdict = {'bad':'false' }
             json_data = json.dumps(rdict, ensure_ascii=False)
-            return HttpResponse(json_data, mimetype='application/javascript')
+            return HttpResponse(json_data, content_type='application/javascript')
     elif action == 'move':
         # Handles drag-and-drop moving of objects in jsTree. 
         # Also handles 'remove' of Datasets (moves to 'Experimenter' parent)
@@ -1591,7 +1591,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
             else:
                 rdict = {'bad':'false' }
         json_data = json.dumps(rdict, ensure_ascii=False)
-        return HttpResponse(json_data, mimetype='application/javascript')
+        return HttpResponse(json_data, content_type='application/javascript')
     elif action == 'remove':
         # Handles 'remove' of Images from jsTree, removal of comment, tag from Object etc.
         parents = request.REQUEST['parent']     # E.g. image-123  or image-1|image-2
@@ -1601,11 +1601,11 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
             logger.error(traceback.format_exc())
             rdict = {'bad':'true','errs': str(x) }
             json_data = json.dumps(rdict, ensure_ascii=False)
-            return HttpResponse(json_data, mimetype='application/javascript')
+            return HttpResponse(json_data, content_type='application/javascript')
         
         rdict = {'bad':'false' }
         json_data = json.dumps(rdict, ensure_ascii=False)
-        return HttpResponse(json_data, mimetype='application/javascript')
+        return HttpResponse(json_data, content_type='application/javascript')
     elif action == 'removefromshare':
         image_id = request.REQUEST.get('source')
         try:
@@ -1614,10 +1614,10 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
             logger.error(traceback.format_exc())
             rdict = {'bad':'true','errs': str(x) }
             json_data = json.dumps(rdict, ensure_ascii=False)
-            return HttpResponse(json_data, mimetype='application/javascript')
+            return HttpResponse(json_data, content_type='application/javascript')
         rdict = {'bad':'false' }
         json_data = json.dumps(rdict, ensure_ascii=False)
-        return HttpResponse(json_data, mimetype='application/javascript')
+        return HttpResponse(json_data, content_type='application/javascript')
     elif action == 'delete':
         # Handles delete of a file attached to object.
         child = toBoolean(request.REQUEST.get('child'))
@@ -1633,7 +1633,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
         else:
             rdict = {'bad':'false' }
         json_data = json.dumps(rdict, ensure_ascii=False)
-        return HttpResponse(json_data, mimetype='application/javascript')
+        return HttpResponse(json_data, content_type='application/javascript')
     elif action == 'deletemany':
         # Handles multi-delete from jsTree.
         object_ids = {'Image':request.REQUEST.getlist('image'), 'Dataset':request.REQUEST.getlist('dataset'), 'Project':request.REQUEST.getlist('project'), 'Screen':request.REQUEST.getlist('screen'), 'Plate':request.REQUEST.getlist('plate'), 'Well':request.REQUEST.getlist('well'), 'PlateAcquisition':request.REQUEST.getlist('acquisition')}
@@ -1660,7 +1660,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
         else:
             rdict = {'bad':'false' }
         json_data = json.dumps(rdict, ensure_ascii=False)
-        return HttpResponse(json_data, mimetype='application/javascript')
+        return HttpResponse(json_data, content_type='application/javascript')
     context['template'] = template
     return context
 
@@ -2216,7 +2216,7 @@ def activities(request, conn=None, **kwargs):
         rv['inprogress'] = in_progress
         rv['failure'] = failure
         rv['jobs'] = len(request.session['callback'])
-        return HttpResponse(json.dumps(rv),mimetype='application/javascript') # json
+        return HttpResponse(json.dumps(rv), content_type='application/javascript') # json
         
     jobs = []
     new_errors = False
@@ -2266,7 +2266,7 @@ def activities_update (request, action, **kwargs):
                 rv['removed'] = True
             else:
                 rv['removed'] = False
-            return HttpResponse(json.dumps(rv),mimetype='application/javascript')
+            return HttpResponse(json.dumps(rv), content_type='application/javascript')
         else:
             for key, data in request.session['callback'].items():
                 if data['status'] != "in progress":
@@ -2280,7 +2280,7 @@ def activities_update (request, action, **kwargs):
 def avatar(request, oid=None, conn=None, **kwargs):
     """ Returns the experimenter's photo """
     photo = conn.getExperimenterPhoto(oid)
-    return HttpResponse(photo, mimetype='image/jpeg')
+    return HttpResponse(photo, content_type='image/jpeg')
 
 ####################################################################################
 # webgateway extention
@@ -2662,7 +2662,7 @@ def script_run(request, scriptId, conn=None, **kwargs):
         if x.message and x.message.startswith("No processor available"):
             # Delegate to run_script() for handling 'No processor available'
             rsp = run_script(request, conn, sId, inputMap, scriptName='Script')
-            return HttpResponse(json.dumps(rsp), mimetype='json')
+            return HttpResponse(json.dumps(rsp), content_type='json')
         else:
             raise
     params = scriptService.getParams(sId)
@@ -2742,7 +2742,7 @@ def script_run(request, scriptId, conn=None, **kwargs):
 
     logger.debug("Running script %s with params %s" % (scriptName, inputMap))
     rsp = run_script(request, conn, sId, inputMap, scriptName)
-    return HttpResponse(json.dumps(rsp), mimetype='json')
+    return HttpResponse(json.dumps(rsp), content_type='json')
 
 
 @login_required(setGroupContext=True)
@@ -2762,7 +2762,7 @@ def ome_tiff_script(request, imageId, conn=None, **kwargs):
     inputMap = {'Data_Type': wrap('Image'), 'IDs': wrap(imageIds)}
     inputMap['Format'] = wrap('OME-TIFF')
     rsp = run_script(request, conn, sId, inputMap, scriptName='Create OME-TIFF')
-    return HttpResponse(json.dumps(rsp), mimetype='json')
+    return HttpResponse(json.dumps(rsp), content_type='json')
 
 
 def run_script(request, conn, sId, inputMap, scriptName='Script'):

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_http.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_http.py
@@ -29,7 +29,7 @@ class HttpJavascriptRedirect(HttpResponse):
 
 class HttpJavascriptResponse(HttpResponse):
     def __init__(self,content):
-        HttpResponse.__init__(self,content,mimetype="text/javascript")
+        HttpResponse.__init__(self, content, content_type="text/javascript")
 
 
 class HttpLoginRedirect(HttpResponse):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -310,7 +310,7 @@ def render_thumbnail (request, iid, w=None, h=None, conn=None, _defcb=None, **kw
             webgateway_cache.setThumb(request, server_id, user_id, iid, jpeg_data, size)
     else:
         pass
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
 @login_required()
@@ -508,7 +508,7 @@ def get_shape_thumbnail (request, conn, image, s, compress_quality):
         draw.text((10,30), "Shape too large to \ngenerate thumbnail", fill=(255,0,0))
         rv = StringIO()
         dummy.save(rv, 'jpeg', quality=90)
-        return HttpResponse(rv.getvalue(), mimetype='image/jpeg')
+        return HttpResponse(rv.getvalue(), content_type='image/jpeg')
 
     xOffset = (newW - w)/2
     yOffset = (newH - h)/2
@@ -607,7 +607,7 @@ def get_shape_thumbnail (request, conn, image, s, compress_quality):
     img.save(rv, 'jpeg', quality=int(compression*100))
     jpeg = rv.getvalue()
 
-    return HttpResponse(jpeg, mimetype='image/jpeg')
+    return HttpResponse(jpeg, content_type='image/jpeg')
 
 
 def _get_signature_from_request (request):
@@ -728,7 +728,7 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
         if jpeg_data is None:
             raise Http404
         webgateway_cache.setImage(request, server_id, img, z, t, jpeg_data)
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
 @login_required()
@@ -757,7 +757,7 @@ def render_image (request, iid, z=None, t=None, conn=None, **kwargs):
             raise Http404
         webgateway_cache.setImage(request, server_id, img, z, t, jpeg_data)
 
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     if 'download' in kwargs and kwargs['download']:
         rsp['Content-Type'] = 'application/force-download'
         rsp['Content-Length'] = len(jpeg_data)
@@ -825,7 +825,7 @@ def render_ome_tiff (request, ctx, cid, conn=None, **kwargs):
         c = request.REQUEST.get('callback', None)
         if c is not None and not kwargs.get('_internal', False):
             rv = '%s(%s)' % (c, rv)
-        return HttpResponse(rv, mimetype='application/javascript')
+        return HttpResponse(rv, content_type='application/javascript')
 
     if len(imgs) == 0:
         raise Http404
@@ -850,7 +850,7 @@ def render_ome_tiff (request, ctx, cid, conn=None, **kwargs):
                 raise Http404
             webgateway_cache.setOmeTiffImage(request, server_id, imgs[0], tiff_data)
         if fobj is None:
-            rsp = HttpResponse(tiff_data, mimetype='image/tiff')
+            rsp = HttpResponse(tiff_data, content_type='image/tiff')
             rsp['Content-Disposition'] = 'attachment; filename="%s.ome.tiff"' % (str(obj.getId()) + '-'+objname)
             rsp['Content-Length'] = len(tiff_data)
             return rsp
@@ -884,7 +884,7 @@ def render_ome_tiff (request, ctx, cid, conn=None, **kwargs):
             zobj.close()
             if fpath is None:
                 zip_data = fobj.getvalue()
-                rsp = HttpResponse(zip_data, mimetype='application/zip')
+                rsp = HttpResponse(zip_data, content_type='application/zip')
                 rsp['Content-Disposition'] = 'attachment; filename="%s.zip"' % name
                 rsp['Content-Length'] = len(zip_data)
                 return rsp
@@ -948,7 +948,7 @@ def render_movie (request, iid, axis, pos, conn=None, **kwargs):
         if fpath is None:
             movie = open(fn).read()
             os.close(fo)
-            rsp = HttpResponse(movie, mimetype=mimetype)
+            rsp = HttpResponse(movie, content_type=mimetype)
             rsp['Content-Disposition'] = 'attachment; filename="%s"' % (img.getName()+ext)
             rsp['Content-Length'] = len(movie)
             return rsp
@@ -986,7 +986,7 @@ def render_split_channel (request, iid, z, t, conn=None, **kwargs):
         if jpeg_data is None:
             raise Http404
         webgateway_cache.setSplitChannelImage(request, server_id, img, z, t, jpeg_data)
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
 def debug (f):
@@ -1036,16 +1036,16 @@ def jsonp (f):
                 rv = '%s(%s)' % (c, rv)
             if kwargs.get('_internal', False):
                 return rv
-            return HttpResponse(rv, mimetype='application/javascript')
+            return HttpResponse(rv, content_type='application/javascript')
         except omero.ServerError:
             if kwargs.get('_raw', False) or kwargs.get('_internal', False):
                 raise
-            return HttpResponseServerError('("error in call","%s")' % traceback.format_exc(), mimetype='application/javascript')
+            return HttpResponseServerError('("error in call","%s")' % traceback.format_exc(), content_type='application/javascript')
         except:
             logger.debug(traceback.format_exc())
             if kwargs.get('_raw', False) or kwargs.get('_internal', False):
                 raise
-            return HttpResponseServerError('("error in call","%s")' % traceback.format_exc(), mimetype='application/javascript')
+            return HttpResponseServerError('("error in call","%s")' % traceback.format_exc(), content_type='application/javascript')
     wrap.func_name = f.func_name
     return wrap
 
@@ -1081,7 +1081,7 @@ def render_row_plot (request, iid, z, t, y, conn=None, w=1, **kwargs):
         raise
     if gif_data is None:
         raise Http404
-    rsp = HttpResponse(gif_data, mimetype='image/gif')
+    rsp = HttpResponse(gif_data, content_type='image/gif')
     return rsp
 
 @debug
@@ -1112,7 +1112,7 @@ def render_col_plot (request, iid, z, t, x, w=1, conn=None, **kwargs):
     gif_data = img.renderColLinePlotGif(int(z),int(t),int(x), int(w))
     if gif_data is None:
         raise Http404
-    rsp = HttpResponse(gif_data, mimetype='image/gif')
+    rsp = HttpResponse(gif_data, content_type='image/gif')
     return rsp
 
 @login_required()
@@ -1132,7 +1132,7 @@ def imageData_json (request, conn=None, _internal=False, **kwargs):
     key = kwargs.get('key', None)
     image = conn.getObject("Image", iid)
     if image is None:
-        return HttpResponseServerError('""', mimetype='application/javascript')
+        return HttpResponseServerError('""', content_type='application/javascript')
     rv = imageMarshal(image, key)
     return rv
 
@@ -1152,7 +1152,7 @@ def wellData_json (request, conn=None, _internal=False, **kwargs):
     wid = kwargs['wid']
     well = conn.getObject("Well", wid)
     if well is None:
-        return HttpResponseServerError('""', mimetype='application/javascript')
+        return HttpResponseServerError('""', content_type='application/javascript')
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     def urlprefix(iid):
         return reverse(prefix, args=(iid,))
@@ -1171,7 +1171,7 @@ def plateGrid_json (request, pid, field=0, conn=None, **kwargs):
     except ValueError:
         field = 0
     if plate is None:
-        return HttpResponseServerError('""', mimetype='application/javascript')
+        return HttpResponseServerError('""', content_type='application/javascript')
     grid = []
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     thumbsize = int(request.REQUEST.get('size', 64))
@@ -1221,7 +1221,7 @@ def listImages_json (request, did, conn=None, **kwargs):
 
     dataset = conn.getObject("Dataset", did)
     if dataset is None:
-        return HttpResponseServerError('""', mimetype='application/javascript')
+        return HttpResponseServerError('""', content_type='application/javascript')
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     def urlprefix(iid):
         return reverse(prefix, args=(iid,))
@@ -1244,7 +1244,7 @@ def listWellImages_json (request, did, conn=None, **kwargs):
 
     well = conn.getObject("Well", did)
     if well is None:
-        return HttpResponseServerError('""', mimetype='application/javascript')
+        return HttpResponseServerError('""', content_type='application/javascript')
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     def urlprefix(iid):
         return reverse(prefix, args=(iid,))
@@ -1267,7 +1267,7 @@ def listDatasets_json (request, pid, conn=None, **kwargs):
     project = conn.getObject("Project", pid)
     rv = []
     if project is None:
-        return HttpResponse('[]', mimetype='application/javascript')
+        return HttpResponse('[]', content_type='application/javascript')
     return [x.simpleMarshal(xtra={'childCount':0}) for x in project.listChildren()]
 
 @login_required()
@@ -1386,7 +1386,7 @@ def search_json (request, conn=None, **kwargs):
         else:
             sr = conn.searchObjects(None, opts['search'], conn.SERVICE_OPTS)  # searches P/D/I
     except ApiUsageException:
-        return HttpResponseServerError('"parse exception"', mimetype='application/javascript')
+        return HttpResponseServerError('"parse exception"', content_type='application/javascript')
     def marshal ():
         rv = []
         if (opts['grabData'] and opts['ctx'] == 'imgs'):
@@ -1436,7 +1436,7 @@ def save_image_rdef_json (request, iid, conn=None, **kwargs):
         json_data = 'true'
     if r.get('callback', None):
         json_data = '%s(%s)' % (r['callback'], json_data)
-    return HttpResponse(json_data, mimetype='application/javascript')
+    return HttpResponse(json_data, content_type='application/javascript')
 
 @login_required()
 def list_compatible_imgs_json (request, iid, conn=None, **kwargs):
@@ -1486,7 +1486,7 @@ def list_compatible_imgs_json (request, iid, conn=None, **kwargs):
 
     if r.get('callback', None):
         json_data = '%s(%s)' % (r['callback'], json_data)
-    return HttpResponse(json_data, mimetype='application/javascript')
+    return HttpResponse(json_data, content_type='application/javascript')
 
 @login_required()
 @jsonp
@@ -1635,7 +1635,7 @@ def reset_image_rdef_json (request, iid, conn=None, **kwargs):
 #        return json_data == 'true'      # TODO: really return a boolean? (not json)
 #    if r.get('callback', None):
 #        json_data = '%s(%s)' % (r['callback'], json_data)
-#    return HttpResponse(json_data, mimetype='application/javascript')
+#    return HttpResponse(json_data, content_type='application/javascript')
 
 @login_required()
 def full_viewer (request, iid, conn=None, **kwargs):
@@ -1774,7 +1774,7 @@ def get_shape_json(request, roiId, shapeId, conn=None, **kwargs):
         logger.debug('No such shape: %r' % shapeId)
         raise Http404
     return HttpResponse(json.dumps(shapeMarshal(shape)),
-            mimetype='application/javascript')
+            content_type='application/javascript')
 
 @login_required()
 def get_rois_json(request, imageId, conn=None, **kwargs):
@@ -1803,7 +1803,7 @@ def get_rois_json(request, imageId, conn=None, **kwargs):
 
     rois.sort(key=lambda x: x['id']) # sort by ID - same as in measurement tool.
 
-    return HttpResponse(json.dumps(rois), mimetype='application/javascript')
+    return HttpResponse(json.dumps(rois), content_type='application/javascript')
 
 @login_required(isAdmin=True)
 @jsonp

--- a/components/tools/OmeroWeb/omeroweb/webtest/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webtest/views.py
@@ -228,7 +228,7 @@ def render_channel_overlay (request, conn=None, **kwargs):
     merge.save(rv, 'jpeg', quality=int(compression*100))
     jpeg_data = rv.getvalue()
 
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
 


### PR DESCRIPTION
This applies only to develop (Django 1.6)

--no-rebase

<pre>
/omero/openmicroscopy/dist/lib/python/django/http/response.py:330: DeprecationWarning: Using mimetype keyword argument is deprecated, use content_type instead
  super(HttpResponse, self).__init__(*args, **kwargs)
</pre>
