### PR TITLE
Install Python dependencies using Homebrew Python (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -9,7 +9,6 @@ export PSQL_DIR=${PSQL_DIR:-/usr/local/var/postgres}
 export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/tmp/var/OMERO.data}
 export BREW_OPTS=${BREW_OPTS:-}
 export SCRIPT_NAME=${SCRIPT_NAME:-OMERO.sql}
-VENV_DIR=${VENV_DIR:-/usr/local/virtualenv}
 
 # Test whether this script is run in a job environment
 JOB_NAME=${JOB_NAME:-}
@@ -82,15 +81,6 @@ showinf -version
 # Install PostgreSQL and OMERO
 bin/brew install omero $BREW_OPTS
 bin/brew install postgres
-
-# Create a virtual environment for Python dependencies
-bin/pip install virtualenv
-bin/virtualenv $VENV_DIR
-
-# Activate the virtual environment
-set +u
-source $VENV_DIR/bin/activate
-set -u
 
 # Install OMERO Python dependencies
 bash bin/omero_python_deps


### PR DESCRIPTION
This is the same as gh-1932 but rebased onto develop.

---

With recent changes to pip 1.5, insecure external URLs need an extra `--allow-external` flag to be installed. This change directly affects the OMERO dependencies especially PIL and caused the Jenkins job to be unstable in the last couple of days.

This commit provides a workaround  to this situation by using Homebrew pip to install the Python dependencies. Homebrew pip version is still 1.4 and should install PIL without problem while virtualenv created using Home-brew `virtualenv` install pip-1.5. This PR is expected to restore OMERO installation via Homebrew and pip 1.4 to normal for the imminent 4.4.10 release. To test it, check the OMERO-homebrew job turns green again.

More generally, for OMERO 5.0 and later, we may want to consider replacing the dependency on PIL by a dependency on [Pillow](http://pillow.readthedocs.org/en/latest/) which is a maintained fork of PIL.

/cc @will-moore, @aleksandra-tarkowska
