### PR TITLE
NPE Thumbnails

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -115,9 +115,10 @@ public class ThumbnailLoader
      * @param pxd The image the thumbnail for.
      * @param userID The id of the user the thumbnail is for.
      * @param store The thumbnail store to use.
+     * @param imageID The id of the image associated to the pixels set.
      */
     private void loadThumbail(PixelsData pxd, long userID,
-    		ThumbnailStorePrx store, boolean last)
+    		ThumbnailStorePrx store, boolean last, long imageID)
     {
     	BufferedImage thumbPix = null;
         boolean valid = true;
@@ -159,7 +160,7 @@ public class ThumbnailLoader
         	valid = false;
         	thumbPix = Factory.createDefaultImageThumbnail(sizeX, sizeY);
         }
-        currentThumbnail = new ThumbnailData(pxd.getImage().getId(), thumbPix,
+        currentThumbnail = new ThumbnailData(imageID, thumbPix,
         		userID, valid);
     }
     
@@ -222,18 +223,24 @@ public class ThumbnailLoader
         		final ThumbnailStorePrx value = store;
         		int size = images.size()-1;
         		int k = 0;
+        		long imageID = -1;
         		while (i.hasNext()) {
         			image = (DataObject) i.next();
-        			if (image instanceof ImageData)
-        				pxd = ((ImageData) image).getDefaultPixels();
-        			else pxd = (PixelsData) image;
+        			if (image instanceof ImageData) {
+        			    pxd = ((ImageData) image).getDefaultPixels();
+        			    imageID = image.getId();
+        			} else {
+        			    pxd = (PixelsData) image;
+        			    if (pxd != null) imageID = pxd.getImage().getId();
+        			}
         			description = "Loading thumbnail";
         			final PixelsData index = pxd;
         			final boolean last = size == k;
         			k++;
+        			final long iid = imageID;
         			add(new BatchCall(description) {
         				public void doCall() {
-        					loadThumbail(index, userID, value, last);
+        					loadThumbail(index, userID, value, last, iid);
         				}
         			});
         		}


### PR DESCRIPTION
This possible NPE when no pixels associated to an image. 
This is already in develop
To test:
- Log as root
- expand the "orphaned images" smart folder
- No error.

see https://trac.openmicroscopy.org.uk/ome/ticket/11879

--no-rebase
