### PR TITLE
Icons cleanup (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -145,7 +145,7 @@
                                 "tagset-locked" : {
                                     "valid_children" : [ "tag", "tag-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_tags_locked.png" %}'
+                                        "image" : '{% static "webclient/image/left_sidebar_icon_tags.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -166,7 +166,7 @@
                                 "tag-locked" : {
                                     "valid_children" : [ "project", "project-locked", "dataset", "dataset-locked", "image", "image-locked", "screen", "screen-locked", "plate", "plate-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_tag_locked.png" %}'
+                                        "image" : '{% static "webclient/image/left_sidebar_icon_tag.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -186,7 +186,7 @@
                                 "project-locked" : {
                                     "valid_children" : [ "dataset", "dataset-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -206,7 +206,7 @@
                                 "dataset-locked" : {
                                     "valid_children" : [ "image", "image-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_image_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder_image16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -226,7 +226,7 @@
                                 "image-locked" : {
                                     "valid_children" : "none",
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/image_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/image16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -246,7 +246,7 @@
                                 "screen-locked" : {
                                     "valid_children" : [ "plate", "plate-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_screen_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder_screen16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -266,7 +266,7 @@
                                 "plate-locked" : {
                                     "valid_children" : "none",
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_plate_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder_plate16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -128,7 +128,7 @@
                                 "share-locked" : {
                                     "valid_children" : [ "image", "image-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_html_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder_html16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -138,7 +138,7 @@
                                 "share-disabled" : {
                                     "valid_children" : [ "image", "image-locked" ],
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/folder_html_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/folder_html16.png" %}'
                                     },
                                     "select_node" : false,
                                     "create_node" : false,
@@ -159,7 +159,7 @@
                                 "discussion-locked" : {
                                     "valid_children" :  "none",
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/wp_protocol_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/wp_protocol16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
@@ -179,7 +179,7 @@
                                 "image-locked" : {
                                     "valid_children" : "none",
                                     "icon" : {
-                                        "image" : '{% static "webclient/image/image_locked16.png" %}'
+                                        "image" : '{% static "webclient/image/image16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,


### PR DESCRIPTION
This is the same as gh-1957 but rebased onto dev_5_0.

---

it turned out that there were still places where icons for shared data were indicating the difference. in order to test it check all tabs: data, tags, public whether ownership is not indicated by either 'red dot' or 'lock'
