### PR TITLE
Remove cut link 11882

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -1120,6 +1120,10 @@
                     break;
                 case "cutButton":
                     $("#dataTree").jstree('cut', $.jstree._focused().get_selected());
+                    var tree = $.jstree._focused(),
+                        selected = tree.get_selected();
+                    tree.cut(selected);     // jsTree 'cut' doesn't remove...
+                    OME.remove_nodes(tree, selected);
                     break;
                 case "pasteButton":
                     $("#dataTree").jstree('paste', $.jstree._focused().get_selected());


### PR DESCRIPTION
This addresses https://trac.openmicroscopy.org.uk/ome/ticket/11882 and https://trac.openmicroscopy.org.uk/ome/ticket/11881. Web Cut, Copy & Paste of P/D/I & S/P should behave the same as Insight.

To test:
- "Cut Link" an Image or Dataset - should remove it from parent (become orphan).
- "Paste Link" should paste it into new parent.
- "Copy Link" and "Paste Link" should behave as normal.
- Try various copy, cut & paste actions to see if the Tree behaves in a logical way - Compare to how Insight behaves.
