### PR TITLE
Selection issue develop

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treemng.browser.BrowserControl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -358,7 +358,6 @@ class BrowserControl
         JTree tree = view.getTreeDisplay();
         TreePath[] paths = tree.getSelectionPaths();
         if (paths == null) {
-            model.setSelectedDisplay(null);
             return;
         }
         TreeImageDisplay node;


### PR DESCRIPTION
The node was reset to null after double-click
Problem described by https://trac.openmicroscopy.org.uk/ome/ticket/11853

To test
- Double-click on a project containing datasets.
- The Browse button should be active.
- Double-click again on the project 
- The Browse button should be still active. (it was not before)

--rebased-from #1964
