### PR TITLE
Simplify VM scripts for release (rebased onto dev_5_0) (rebased onto develop)

### DIFF
--- a/docs/install/VM/omerovm.sh
+++ b/docs/install/VM/omerovm.sh
@@ -41,6 +41,7 @@ function installvm ()
 	SCP="scp -2 -o NoHostAuthenticationForLocalhost=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=no -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o PreferredAuthentications=publickey -i omerovmkey -P $SSH_PF"
 	SSH="ssh -2 -o StrictHostKeyChecking=no -i omerovmkey -p $SSH_PF -t"
 	echo "Copying scripts to VM"
+	$SCP ../../../target/OMERO.server*zip omero@localhost:~/
 	$SCP driver.sh omero@localhost:~/
 	$SCP setup_userspace.sh omero@localhost:~/
 	$SCP setup_postgres.sh omero@localhost:~/
@@ -132,7 +133,7 @@ function deletevm ()
 function createvm ()
 {
 		$VBOX list vms | grep "$VMNAME" || {
-		VBoxManage clonehd "$HARDDISKS"omero-base-img_2011-08-08.vdi"" "$HARDDISKS$VMNAME.vdi"
+		VBoxManage clonehd "$OMERO_BASE_IMAGE" "$HARDDISKS$VMNAME.vdi"
 		VBoxManage createvm --name "$VMNAME" --register --ostype "Debian"
 		VBoxManage storagectl "$VMNAME" --name "SATA CONTROLLER" --add sata
 		VBoxManage storageattach "$VMNAME" --storagectl "SATA CONTROLLER" --port 0 --device 0 --type hdd --medium $HARDDISKS$VMNAME.vdi

--- a/docs/install/VM/setup_omero.sh
+++ b/docs/install/VM/setup_omero.sh
@@ -19,25 +19,9 @@ readAPIValue() {
     wget -q -O- $URL | sed 's/^<.*>\([^<].*\)<.*>$/\1/'
     }
 
-echo "Grabbing last successful QA Build of OMERO.server"
-DL_ARCHIVE=""
-if [ "x$DL_ARCHIVE" == "x" ]; then
-
-    URL=`readAPIValue $OMERO_BUILD_URL"/api/xml?xpath=/freeStyleBuild/url"`
-    FILE=`readAPIValue $OMERO_BUILD_URL"/api/xml?xpath=//relativePath[contains(.,'server')]"`
-
-    wget -q "$URL"artifact/$FILE
-
-    DL_ARCHIVE=`basename $FILE`
-    DL_FOLDER=${DL_ARCHIVE%.zip}
-else
-    DL_LOC=$OMERO_BUILD_URL"/artifact/"
-    DL_FOLDER=${DL_ARCHIVE%.zip}
-
-    wget $DL_LOC$DL_ARCHIVE
-fi
-unzip $DL_ARCHIVE
-mv $DL_FOLDER $INSTALL_FOLDER
+unzip OMERO.server*.zip
+rm -rf OMERO.server*.zip
+mv OMERO.server* $INSTALL_FOLDER
 
 mkdir OMERO.data
 

--- a/docs/install/VM/setup_postgres.sh
+++ b/docs/install/VM/setup_postgres.sh
@@ -9,14 +9,15 @@ sudo -u omero cat > ${FILE} << EOF
 localhost:5432:omero:omero:omero
 EOF
 chmod 600 .pgpass
+chown omero:omero .pgpass
 
 echo "CREATE USER omero PASSWORD 'omero'" | sudo -u postgres psql
 sudo -u postgres createdb -O omero omero
-sudo -u postgres createlang plpgsql omero
+sudo -u postgres createlang plpgsql omero || echo Already installed
 
 echo `psql -h localhost -U omero -l`
 
-sudo sed '/127.0.0.1/s/md5/trust/' /etc/postgresql/8.4/main/pg_hba.conf > pg_hba.conf && sudo mv pg_hba.conf /etc/postgresql/8.4/main/pg_hba.conf
+sudo sed '/127.0.0.1/s/md5/trust/' /etc/postgresql/9.1/main/pg_hba.conf > pg_hba.conf && sudo mv pg_hba.conf /etc/postgresql/9.1/main/pg_hba.conf
 
 sudo /etc/init.d/postgresql restart
 


### PR DESCRIPTION
This is the same as gh-1968 but rebased onto develop.

---

This is the same as gh-1950 but rebased onto dev_5_0.

---

4.4 and 5.0 release jobs have been using
https://gist.github.com/joshmoore/6902157
for some time. Primarily, this patch uses
an existing server zip rather than attempting
to download from a job.

/cc @manics @sbesson

The release job will need to be updated once this is merged.
