### PR TITLE
Implemented a hash on BlitzGateway objects

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -174,16 +174,16 @@ class BlitzObjectWrapper (object):
         """
         Returns a unique key for this object
         """
-        return self.getId()
+        k = self.getId()
+        if k is None:
+            return id(self)
+        return k
 
     def __hash__(self):
         """
         Returns a hash of the unique key
         """
-        h = self.__key()
-        if h is None:
-            return hash(id(self))
-        return hash(h)
+        return hash(self.__key())
 
     def __eq__ (self, a):
         """


### PR DESCRIPTION
Added a **key method to BlitzGateway objects
Used the __key method to implement __hash** method
Refactored **eq** to use __key

This is so that these objects can be used properly in sets among other things.
