### PR TITLE
Do not include Win64 executable in the win-openGL client

### DIFF
--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -385,8 +385,6 @@
                   includes="*"/>
       <zipfileset prefix="${dist.zip.prefix.win.openGL}"
                   file="${app.dir}/${distInsight.win.exename}.exe"/>
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}"
-                  file="${app.dir}/${distInsight.win64.exename}.exe"/>
       <zipfileset fullpath="${dist.zip.prefix.win.openGL}/LICENSE"
                   file="${base.licensefile}"/> 
       <zipfileset prefix="${dist.zip.prefix.win.openGL}" dir="${dist.dir}"


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11900

To test this PR, open the various Windows artifacts  produced by the merge builds for each Ice version. Both the `win-openGL` and the `win64-openGL` clients should only contain one single Insight executable. Make sure each of these executables work as expected (log in, browse, open image).
