### PR TITLE
Redirect to group_owner/edit. See #11911

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -653,7 +653,7 @@ def manage_group_owner(request, action, gid, conn=None, **kwargs):
         context = {'form':form, 'gid': gid, 'permissions': permissions, 'group':group, 'experimenterDefaultGroups':",".join(experimenterDefaultIds), 'ownerIds':(",".join(str(x) for x in ownerIds if x != userId)), 'userId':userId}
     elif action == "save":
         if request.method != 'POST':
-            return HttpResponseRedirect(reverse(viewname="wamyaccount", args=["edit", group.id]))
+            return HttpResponseRedirect(reverse(viewname="wamanagegroupownerid", args=["edit", group.id]))
         else:
             form = GroupOwnerForm(data=request.POST.copy(), initial={'experimenters':experimenters})
             if form.is_valid():


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11907

To test, log in as a group owner and go to: User Settings -> My groups (tab) -> Edit a group
Edit the url to replace 'edit' with 'save'. E.g. webadmin/group_owner/save/4/ and hit enter.
You should be redirected back to the 'edit' page (previously got exception - see ticket).

--no-rebase
