### PR TITLE
Prefix the unzipped OMERO.matlab toolbox with version number (rebased onto develop)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -465,7 +465,9 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         </zip>
 
         <iterate buildpathref="OmeroMatlab.buildpath" target="release-zip"/>
-	<copy file="components/tools/OmeroM/target/OmeroMatlab.zip" tofile="target/OMERO.matlab-${omero.version}.zip"/>
+        <zip destfile="${omero.home}/target/OMERO.matlab-${omero.version}.zip">
+            <zipfileset dir="components/tools/OmeroM/target/matlab/" prefix="OMERO.matlab-${omero.version}" includes="**/*"/>
+        </zip>
 
 	<copy todir="target">
             <fileset dir="components/tools/OmeroPy/dist" includes="*.egg"/>


### PR DESCRIPTION
This is the same as gh-1991 but rebased onto develop.

---

The release-clients target used to directly copy the zip file generated by the
release-zip target under components/tools/OmeroM/build.xml. This caused the
unzipped OMERO.matlab toolbox to lose its version number. This commit fixes
this by re-zipping the Matlab target components with a versioned prefix in
release-clients.

To test this PR:
- download the OMERO.matlab artifact from the latest merge build
- unzip it using either a graphical application or command-line using `unzip`
- make sure the unzipped folder contains the version number in both cases
- check all components are included (comparing it with the latest released toolbox for instance)
