### PR TITLE
fix #11922: createOriginalFileFromFileObj return value is unloaded

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3051,6 +3051,7 @@ class _BlitzGateway (object):
                 fo.seek(pos)
                 block = fo.read(blockSize)
                 rawFileStore.write(block, pos, blockSize)
+            originalFile = rawFileStore.save()
         finally:
             rawFileStore.close();
         return OriginalFileWrapper(self, originalFile)


### PR DESCRIPTION
http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.0-merge-integration-python/lastSuccessfulBuild/testReport/junit/test.gatewaytest/test_annotation/testFileAnnotation/ should no longer fail.
