### PR TITLE
Tile failed moved from pr1839 dev 5 0

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/3rdparty/panojs/PanoJS.js
@@ -525,12 +525,12 @@ PanoJS.prototype.assignTileImage = function(tile) {
         var $this = $(this);
         // only try to reload if this is the first failure
         if (!$this.hasClass('failed')) {
+          $this.addClass('failed');
           setTimeout(function(){
             var s = tileImg.src;
             tileImg.src = s;    // no change, but is enough to trigger reload
           }, 1000); // try to reload src after timeout - 1 sec seems to work OK
         }
-        $(this).addClass('failed');
       };
 
     if ( tileImg.done || !tileImg.delayed_loading &&


### PR DESCRIPTION
Extra commit in #1839 when it was rebased to dev_4_4 now needs backporting to develop.

Can't imagine that this needs much testing, but wouldn't hurt to check that big image viewer is still working OK.

--rebased-from #1940
