### PR TITLE
Fix Memoizer injection (Fix #11934) (rebased onto develop)

### DIFF
--- a/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
+++ b/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
@@ -24,10 +24,15 @@
     <constructor-arg ref="simpleSqlAction"/>
   </bean>
 
+  <!-- Casting string to Long to prevent the wrong ctor from being used -->
+  <bean name="MemoizerWait" class="java.lang.Long">
+    <constructor-arg value="${omero.pixeldata.memoizer_wait}"/>
+  </bean>
+
   <bean name="/OMERO/Pixels" class="ome.io.nio.PixelsService"
         parent="filesystem">
     <!-- index=0 "path" comes from parent -->
-    <constructor-arg index="1" value="${omero.pixeldata.memoizer_wait}"/>
+    <constructor-arg index="1" ref="MemoizerWait"/>
     <constructor-arg ref="omeroFilePathResolver"/>
     <constructor-arg ref="backOff"/>
     <constructor-arg ref="tileSizes"/>

--- a/components/server/resources/ome/services/services.xml
+++ b/components/server/resources/ome/services/services.xml
@@ -137,7 +137,7 @@
   </bean>
 
   <bean name="filesystem"  abstract="true">
-    <constructor-arg value="${omero.data.dir}"/>
+    <constructor-arg index="0" value="${omero.data.dir}"/>
   </bean>
 
 <!--


### PR DESCRIPTION
This is the same as gh-2021 but rebased onto develop.

---

Once a ctor was added with the same number of arguments,
Spring was incorrectly taking the `${omero...wait}` property
as a string. Casting it first to a Long prevents this.

/cc @ximenesuk @melissalinkert
