### PR TITLE
Correct typo in spec.xml OriginalfileAnnotationLink

### DIFF
--- a/components/server/resources/ome/services/spec.xml
+++ b/components/server/resources/ome/services/spec.xml
@@ -405,7 +405,7 @@
     <bean parent="graphSpec" name="/ImageAnnotationLink"> <constructor-arg> <list> <value>/ImageAnnotationLink</value> </list> </constructor-arg> </bean>
     <bean parent="graphSpec" name="/NamespaceAnnotationLink"> <constructor-arg> <list> <value>/NamespaceAnnotationLink</value> </list> </constructor-arg> </bean>
     <bean parent="graphSpec" name="/NodeAnnotationLink"> <constructor-arg> <list> <value>/NodeAnnotationLink</value> </list> </constructor-arg> </bean>
-    <bean parent="graphSpec" name="/OriginalfileAnnotationLink"> <constructor-arg> <list> <value>/OriginalfileAnnotationLink</value> </list> </constructor-arg> </bean>
+    <bean parent="graphSpec" name="/OriginalFileAnnotationLink"> <constructor-arg> <list> <value>/OriginalFileAnnotationLink</value> </list> </constructor-arg> </bean>
     <bean parent="graphSpec" name="/PixelsAnnotationLink"> <constructor-arg> <list> <value>/PixelsAnnotationLink</value> </list> </constructor-arg> </bean>
     <bean parent="graphSpec" name="/PlaneinfoAnnotationLink"> <constructor-arg> <list> <value>/PlaneinfoAnnotationLink</value> </list> </constructor-arg> </bean>
     <bean parent="graphSpec" name="/PlateAcquisitionAnnotationLink"> <constructor-arg> <list> <value>/PlateAcquisitionAnnotationLink</value> </list> </constructor-arg> </bean>


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/11944

Testing: Should be able to delete an OriginalFileAnnotationLink using omero.cmd.Delete:

```
us = conn.getUpdateService()

f = omero.model.OriginalFileI()
f.setName(wrap('name'))
f.setPath(wrap('path'))
f = self.sess.getUpdateService().saveAndReturnObject(f)

tag = omero.model.TagAnnotationI()
tag.setTextValue(wrap('text'));
tag = us.saveAndReturnObject(tag);

link = omero.model.OriginalFileAnnotationLinkI()
link.setChild(tag)
link.setParent(f)
link = us.saveAndReturnObject(link)
print link.getId()

linkClassd = '/OriginalFileAnnotationLink'
dcs = [omero.cmd.Delete(linkClassd, unwrap(link.getId()), None)]
doall = omero.cmd.DoAll()
doall.requests = dcs
handle = conn.c.sf.submit(doall, conn.SERVICE_OPTS)
conn._waitOnCmd(handle)
```
