### PR TITLE
Export as OME-TIFF.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2583,6 +2583,7 @@ class EditorModel
 	{ 
 		boolean b = isSameObject(this.refObject);
 		set = null;
+		largeImage = false;
 		this.refObject = refObject;
 		if (existingTags != null) existingTags.clear();
 		existingTags = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -266,8 +266,11 @@ class ToolBar
         exportAsOmeTiffItem.addActionListener(controller);
         exportAsOmeTiffItem.setActionCommand(
                 ""+EditorControl.EXPORT_AS_OMETIFF);
-        b = model.getRefObject() instanceof ImageData && 
-                !model.isLargeImage();
+        if (model.isMultiSelection()) b = false;
+        else {
+            b = model.getRefObject() instanceof ImageData &&
+                    !model.isLargeImage();
+        }
         exportAsOmeTiffItem.setEnabled(b);
         saveAsMenu.add(exportAsOmeTiffItem);
         JMenu menu = new JMenu();


### PR DESCRIPTION
see https://trac.openmicroscopy.org.uk/ome/ticket/11940

To test
- Select an image (not big)
  - Go to the right-hand side. 
  - Click on menu "Display Save Options"
  - Export as OME-TIFF should be not greyed out.
- Select a big image. 
  - Go to the right-hand side. 
  - Click on menu "Display Save Options"
  - Export as OME-TIFF should be greyed out.
  - Select both images
  - Go to the right-hand side. 
  - Click on menu "Display Save Options"
  - Export as OME-TIFF should be greyed out.

--rebased-from #2031
