### PR TITLE
Travis: do not use --use-mirrors  (rebased onto dev_4_4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - git config --global user.name 'Snoopy Crime Cop'
     - sudo pip install scc
     - scc travis-merge
-    - if [[ $BUILD == 'py' ]]; then sudo pip install flake8 --use-mirrors; fi
+    - if [[ $BUILD == 'py' ]]; then sudo pip install flake8; fi
     - if [[ $BUILD == 'py' ]]; then flake8 -v components/tools/OmeroPy/src/omero/plugins;  fi
     - if [[ $BUILD == 'py' ]]; then flake8 -v components/tools/OmeroPy/test/unit/clitest;  fi
 


### PR DESCRIPTION
This is the same as gh-2061 but rebased onto dev_4_4.

---

This PR should fix the recent failing Travis builds. The latter seemed to be related to our using of `pip install … --use-mirrors` in .travis.yml.

See also https://github.com/travis-ci/docs-travis-ci-com/pull/10
