### PR TITLE
Admin user develop

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
@@ -530,7 +530,7 @@ class UserProfile
         GroupData g;
         while (i.hasNext()) {
             g = i.next();
-            if (model.isSystemGroup(g.getId()))
+            if (model.isSystemGroup(g.getId(), GroupData.SYSTEM))
                 return true;
         }
         return false;
@@ -954,7 +954,7 @@ class UserProfile
                 field = items.get(key);
                 if (field != null) {
                     v = field.getText();
-                    if (v != null && v.trim().length() == 0) {
+                    if (StringUtils.isBlank(v)) {
                         if (EditorUtil.FIRST_NAME.equals(key) ||
                                 EditorUtil.LAST_NAME.equals(key)) {
                             return false;


### PR DESCRIPTION
To test: 
- Log in as root. 
- Go to the admin tab
- Select root in the tree
- Check that the administrator box is selected on right-hand side.
- Select another user e.g. user-1.  Check that the administrator box is NOT selected
- Expand the Guest group.
- Select the Guest user. Check that the administrator box is NOT selected

--rebased-from #2054
