### PR TITLE
Switch reindexer to use slf4j.

### DIFF
--- a/components/server/src/ome/services/fulltext/Main.java
+++ b/components/server/src/ome/services/fulltext/Main.java
@@ -1,7 +1,7 @@
 /*
  *   $Id$
  *
- *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
+ *   Copyright 2008-14 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -18,8 +18,9 @@ import ome.services.util.Executor;
 import ome.system.OmeroContext;
 import ome.services.eventlogs.*;
 
-import org.apache.log4j.xml.DOMConfigurator;
 import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.ResourceUtils;
 
@@ -72,26 +73,14 @@ public class Main {
 
     public static void usage() {
         StringBuilder sb = new StringBuilder();
-        sb
-                .append("usage: ome.service.fulltext.Main [help|standalone|events|full|reindex class1 class2 class3 ...]\n");
+        sb.append("usage: [-Dlogback.configurationFile=stderr.xml] ");
+        sb.append("ome.service.fulltext.Main [help|standalone|events|full|");
+        sb.append("reindex class1 class2 class3 ...]\n");
         System.out.println(sb.toString());
         System.exit(-2);
     }
 
     public static void main(String[] args) throws Throwable {
-
-        // Copied from blitz Entry
-        try {
-            String log4j_xml = System.getProperty("log4j.configuration", "");
-            if (log4j_xml.length() == 0) {
-                File file = ResourceUtils.getFile("classpath:log4j.xml");
-                log4j_xml = file.getAbsolutePath();
-            }
-            DOMConfigurator.configureAndWatch(log4j_xml);
-        } catch (Exception e) {
-            String msg = "CANNOT INITIALIZE LOGGING. Set -Dlog4j.configuration=...";
-            throw new RuntimeException(msg, e);
-        }
 
         int rc = 0;
         try {

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -8,7 +8,7 @@
  This is a python wrapper around icegridregistry/icegridnode for master
  and various other tools needed for administration.
 
- Copyright 2008 Glencoe Software, Inc.  All Rights Reserved.
+ Copyright 2008-14 Glencoe Software, Inc.  All Rights Reserved.
  Use is subject to license terms supplied in LICENSE.txt
 
 """
@@ -165,10 +165,11 @@ machine where /OMERO/FullText is located.
 
 Examples:
   bin/omero admin reindex --full                                             \
-  # All objects
+          # All objects
   bin/omero admin reindex --class ome.model.core.Image                       \
-  # Only images
-  JAVA_OPTS="-Dlog4j.configuration=stderr.xml" bin/omero admin reindex --full\
+          # Only images
+  JAVA_OPTS="-Dlogback.configurationFile=stderr.xml" \
+  bin/omero admin reindex --full\
   # Passing arguments to Java
 
 
@@ -1229,9 +1230,10 @@ OMERO Diagnostics %s
         self.check_access(config=config)
         import omero.java
         server_dir = self.ctx.dir / "lib" / "server"
-        log4j = "-Dlog4j.configuration=log4j-cli.properties"
+        log_config_file = self.ctx.dir / "etc" / "logback-indexing-cli.xml"
+        logback = "-Dlogback.configurationFile=%s" % log_config_file
         classpath = [file.abspath() for file in server_dir.files("*.jar")]
-        xargs = [log4j, "-Xmx1024M", "-cp", os.pathsep.join(classpath)]
+        xargs = [logback, "-Xmx1024M", "-cp", os.pathsep.join(classpath)]
 
         cfg = config.as_map()
         config.close()  # Early close. See #9800

--- a/etc/logback-indexing-cli.xml
+++ b/etc/logback-indexing-cli.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="stderr" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- INTERNAL /////////////////////////////////////////////////////////////// -->
+  <logger name="ome" level="INFO"/>
+  <logger name="ome.formats" level="INFO"/>
+  <logger name="omero" level="INFO"/>
+  <logger name="OMERO" level="INFO"/>
+  <!-- Quieter indexing -->
+  <logger name="ome.security.basic.EventHandler" level="WARN"/>
+  <logger name="ome.services.util.ServiceHandler" level="WARN"/>
+  <logger name="ome.services.sessions.state" level="WARN"/>
+  <!-- Inherit from Spring/etc and so are a bit verbose -->
+  <logger name="ome.system.OmeroContext" level="WARN"/>
+  <logger name="ome.system.PreferenceContext" level="WARN"/>
+  <logger name="ome.security.basic.BasicEventContext" level="WARN"/>
+  <logger name="ome.security.basic.CurrentDetails" level="INFO"/>
+  <logger name="ome.services.blitz.impl.ServiceFactoryI" level="INFO"/>
+  <logger name="ome.services.blitz.impl.OmeroMetadata" level="DEBUG"/>
+  <logger name="ome.services.blitz.util.ShutdownSafeEhcacheManagerFactoryBean" level="WARN"/>
+  <!-- Adapters are also too so is a bit verbose -->
+  <logger name="ome.adapters" level="ERROR"/>
+
+  <!-- THIRD PARTY //////////////////////////////////////////////////////////// -->
+  <logger name="org.apache" level="WARN"/>
+  <logger name="org.jgroups" level="WARN"/>
+  <logger name="org.quartz" level="WARN"/>
+  <logger name="org.hibernate" level="WARN"/>
+  <logger name="org.springframework" level="WARN"/>
+  <!-- Suppressing "Warning missing properties files" -->
+  <logger name="org.springframework.beans" level="ERROR"/>
+  <!-- Whether or not to print jamon timing INFO. ERROR or TRACE -->
+  <logger name="org.springframework.aop.interceptor.JamonPerformanceMonitorInterceptor" level="TRACE"/>
+  <!-- Quieting blitz startup -->
+  <logger name="net.sf.ehcache" level="ERROR"/>
+  <logger name="loci" level="INFO"/><!-- Bio-Formats -->
+  <logger name="ucar" level="WARN"/><!-- NetCDF -->
+
+  <!-- DATABASE /////////////////////////////////////////////////////////////// -->
+  <logger name="bitronix" level="WARN"/>
+  <!-- Limit memory WARNing -->
+  <logger name="org.hibernate.hql.ast.QueryTranslatorImpl" level="ERROR"/>
+  <!-- Limit fail-safe cleanup -->
+  <logger name="org.hibernate.engine.loading.LoadContexts" level="ERROR"/>
+  <!-- This is bogus, and will be caught by our exception handlers anyway -->
+  <logger name="org.hibernate.util.JDBCExceptionReporter" level="ERROR"/>
+  <!-- Printed on startup -->
+  <logger name="org.hibernate.search.engine.DocumentBuilderContainedEntity" level="ERROR"/>
+  <!-- Other overly verbose messages -->
+  <logger name="org.hibernate.SQL" level="ERROR"/>
+  <logger name="org.hibernate.cfg" level="ERROR"/>
+  <logger name="org.hibernate.engine" level="ERROR"/>
+  <logger name="org.hibernate.hql" level="WARN"/> <!-- for first/max in memory -->
+  <logger name="org.hibernate.hql.PARSER" level="ERROR"/>
+  <logger name="org.hibernate.loader" level="ERROR"/>
+  <logger name="org.hibernate.persister" level="ERROR"/>
+  <logger name="org.hibernate.pretty" level="ERROR"/>
+  <logger name="org.hibernate.type" level="ERROR"/>
+  <logger name="org.hibernate.validator" level="ERROR"/>
+
+  <root level="warn">
+    <appender-ref ref="stderr"/>
+  </root>
+</configuration>


### PR DESCRIPTION
The reindexer as as accessed by:

```
bin/omero admin reindex
```

should log using logback to `stderr`. This command works with a local server and using a fresh database the `--full` option should generate about 40 lines of logging. An alternative console log config file can be used:

```
JAVA_OPTS="-Dlogback.configurationFile=etc/logback-cli.xml" bin/omero admin reindex --full
```

should produce a little more output.

--rebased-to #2098 
