### PR TITLE
Update OMERO-homebrew-install.sh to install archived formulas

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -85,7 +85,7 @@ bin/brew install postgres
 bash bin/omero_python_deps
 
 # Set environment variables
-ICE_VERSION=$(bin/brew deps omero44 $BREW_OPTS | grep ice)
+ICE_VERSION=$(bin/brew deps omero44 | grep ice)
 export ICE_CONFIG=$(bin/brew --prefix omero44)/etc/ice.config
 export ICE_HOME=$(bin/brew --prefix $ICE_VERSION)
 export PYTHONPATH=$(bin/brew --prefix omero44)/lib/python:$ICE_HOME/python


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/11891

This PR will be tested by http://ci.openmicroscopy.org/job/OME-4.4-merge-homebrew/ in conjunction with https://github.com/ome/homebrew-alt/pull/53. The Homebrew install script in the `dev_4_4` line is updated to install the archived versions of the OMERO and Bio-Formats formulas.

---

--no-rebase
