### PR TITLE
Fix dual dirs in the mac zip for insight (rebased onto develop)

### DIFF
--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -473,7 +473,7 @@
     <property name="dist.zip.prefix.osx"
               value="${dist.bundle.name}-${dist.bundle.version}-mac"/>
     <zip destfile="${dist.dir}/${dist.zip.prefix.osx}.zip">
-      <zipfileset refid="dist.launch.scripts" prefix="${main-dist-prefix}" filemode="775"/>
+      <zipfileset refid="dist.launch.scripts" prefix="${dist.zip.prefix.osx}" filemode="775"/>
       <zipfileset prefix="${dist.zip.prefix.osx}/${dist.app.config.dir.name}"
                   dir="${app.config.dir}"/>
       <zipfileset prefix="${dist.zip.prefix.osx}" dir="${dist.dir}"


### PR DESCRIPTION
This is the same as gh-2073 but rebased onto develop.

---

gh-1994 re-introduced importer-cli but at the same
time used `${main-dist-prefix}` rather than
`${dist.zip.prefix.osx}` leading to split directories.
