### PR TITLE
ExporterI: set tile size for exported files to 128x128 (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/ExporterI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ExporterI.java
@@ -28,6 +28,7 @@ import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
+import loci.formats.tiff.IFD;
 import ome.api.RawPixelsStore;
 import ome.conditions.ApiUsageException;
 import ome.conditions.InternalException;
@@ -410,7 +411,13 @@ public class ExporterI extends AbstractCloseableAmdServant implements
                                         planeCount, i);
                                     int readerIndex = reader.getIndex(zct[0], zct[1], zct[2]);
                                     reader.openBytes(readerIndex, plane);
-                                    writer.saveBytes(i, plane);
+
+
+                                    IFD ifd = new IFD();
+                                    ifd.put(IFD.TILE_WIDTH, 128);
+                                    ifd.put(IFD.TILE_LENGTH, 128);
+
+                                    writer.saveBytes(i, plane, ifd);
                                 }
                                 retrieve = null;
 


### PR DESCRIPTION
This is the same as gh-2029 but rebased onto develop.

---

This prevents the OME-TIFF writer from writing each row of pixels as a
separate strip, which should improve performance upon re-importing the
exported file.

See http://trac.openmicroscopy.org.uk/ome/ticket/11850.  In the test case outlined in the ticket, the import times should now be roughly similar for the original file and the exported OME-TIFF.

Whether or not we really want to use 128x128 as the tile size across the board is up for debate, but it seemed like a reasonable value to use for now.
