### PR TITLE
Owner: do not edit group (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
@@ -121,9 +121,7 @@ class GroupProfile
     	permissionsPane.addPropertyChangeListener(this);
     	namePane.setText(ref.getName());
     	descriptionPane.setText(ref.getDescription());
-    	canEdit = false;
-    	if (!canEdit) canEdit = model.isAdministrator();
-    	if (canEdit) canEdit = !model.isSystemGroup(ref.getId());
+    	canEdit = model.isAdministrator() && !model.isSystemGroup(ref.getId());
     	namePane.setEditable(canEdit);
     	namePane.setEnabled(canEdit);
     	descriptionPane.setEditable(canEdit);


### PR DESCRIPTION
This is the same as gh-2092 but rebased onto develop.

---

 To test:
- Log in as user-4. 
- Go to the admin tab.
- Make sure you cannot edit the group name.
