### PR TITLE
BF download

### DIFF
--- a/components/insight/config/container.xml
+++ b/components/insight/config/container.xml
@@ -355,7 +355,7 @@
       <dependencies>bioformats_package.jar, loci_tools.jar</dependencies>
       <conjunction>or</conjunction>
       <directory>plugins</directory>
-      <info>http://downloads.openmicroscopy.org/bio-formats/@OMERO_DISPLAY_VERSION@</info>
+      <info>http://downloads.openmicroscopy.org/latest/bio-formats5</info>
       <name>ImageJ</name>
     </plugin>
   </structuredEntry>


### PR DESCRIPTION
Point to latest B-F released version.
To test:
- Add insight-ij to ImageJ plugins folder
- Remove bf-package or loci_tools from ImageJ plugins folder
- Start ImageJ, Go to the Plugin menu and select "Connect to OMERO"
- A dialog will pop up indicating to download BF. Click on the link. The Link should redirect you to http://downloads.openmicroscopy.org/bio-formats/5.0.0-rc1/
