### PR TITLE
Crash Search (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/ImageTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/ImageTable.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.view.ImageTable 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -69,9 +69,6 @@ import pojos.ImageData;
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 class ImageTable


### PR DESCRIPTION
This is the same as gh-2120 but rebased onto develop.

---

To test
 Login as user-4. Search for image per name. Search first for *.png No results incoming. Restarted the search couple of times. After this, searched for a concrete image (an .svs) Got some search results, but they were too many to be true. Clicked on one of them.

see https://trac.openmicroscopy.org.uk/ome/ticket/11994
