### PR TITLE
Homebrew backport

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -90,6 +90,7 @@ if [ "$ICE" == "3.3" ]; then
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib
 elif [ "$ICE" == "3.4" ]; then
     bin/brew install omero --with-ice34
+    ICE_HOME=$(bin/brew --prefix zeroc-ice34)
     export PYTHONPATH=$OMERO_PYTHONPATH:$ICE_HOME/python
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib
 else


### PR DESCRIPTION
This PR backports some of the changes made in #2079 for the 5.0.0 formula bump
- Use the official install command for Homebrew
- Use `brew tap --repair` to fix tap symlinks
- Remove `BREW_OPTS` variable from the installation script
- Add a simple import step at the end of the OMERO installation. This should allow us to verify the import is working and that the Bio-Formats version is correctly set (see https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7409&p=13479&hilit=ilinca#p13430).
