### PR TITLE
Try to fix 'omename' not found in robotframework webadmin

### DIFF
--- a/components/tests/ui/resources/web/webadmin.txt
+++ b/components/tests/ui/resources/web/webadmin.txt
@@ -55,7 +55,7 @@ Page Should Be Open
 Page Should Contain Input Field
     [Arguments]                     ${label}  ${value}
     Page Should Contain             ${label}
-    Page Should Contain Textfield   name=${value}
+    Page Should Contain Textfield   ${value}
 
 Page Should Contain Choice Field
     [Arguments]                     ${label}  ${name}

--- a/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
+++ b/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
@@ -53,14 +53,14 @@ Check User Form
     
     Page Should Contain Input Field         Username        id_omename
     Page Should Contain Password Field      Password        xpath=//input[@name='omename']
-    Page Should Contain Password Field      Confirmation    confirmation
-    Page Should Contain Input Field         First name      first_name
-    Page Should Contain Input Field         Middle name     middle_name
-    Page Should Contain Input Field         Last name       last_name
-    Page Should Contain Input Field         Email           email
-    Page Should Contain Input Field         Institution     institution
+    Page Should Contain Password Field      Confirmation    id_confirmation
+    Page Should Contain Input Field         First name      id_first_name
+    Page Should Contain Input Field         Middle name     id_middle_name
+    Page Should Contain Input Field         Last name       id_last_name
+    Page Should Contain Input Field         Email           id_email
+    Page Should Contain Input Field         Institution     id_institution
     
-    Page Should Contain Checkbox Field      Administrator   administrator
+    Page Should Contain Checkbox Field      Administrator   id_administrator
     Page Should Contain Checkbox Field      Active          active          selected=${True}
     
     Page Should Contain Choice Field        Group           Type group names to add...


### PR DESCRIPTION
Several times we've seen robotframework test fail with:
`ValueError: Element locator 'omename' did not match any elements.`

http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.0-merge-robotframework/144/console
http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.0-merge-robotframework/155/console

Not sure if the selector by name is too slow or fragile for some reason, but it may be more robust to specify ID or to explicitly use xpath to state that we are selecting by name.

If this seems to work, we can use the same logic in other selectors on this page (more commits to this PR).
