### PR TITLE
Auto-updating copyright date via Django. See #11937

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -136,7 +136,7 @@
 	
 	<p>
 		OMERO.web {{ version }}.<br/>
-		&copy; 2007-2014 University of Dundee &amp; Open Microscopy Environment<br/>
+		&copy; 2007-{% now "Y" %} University of Dundee &amp; Open Microscopy Environment<br/>
 		OMERO is distributed under the terms of the GNU GPL.
 		For more information, visit <a href="http://www.openmicroscopy.org">openmicroscopy.org</a><br/>
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -5,7 +5,7 @@
 <!--
  omero_image - django html template
 
- Copyright (c) 2007-2013 Glencoe Software, Inc. All rights reserved.
+ Copyright (c) 2007-2014 Glencoe Software, Inc. All rights reserved.
 
  This software is distributed under the terms described by the LICENCE file
  you can find at the root of the distribution bundle, which states you are
@@ -1186,7 +1186,7 @@
     </div>
     <div id="footer">
     {% block footer_content %}
-      &copy; 2007-2013 Glencoe Software Inc. All rights reserved.
+      &copy; 2007-{% now "Y" %} Glencoe Software Inc. All rights reserved.
     {% endblock %}
     </div>
 {% endblock full_body %}


### PR DESCRIPTION
Use a simple Django template to show the current year in copyright statements on webclient login page and main image viewer footer.

To test, check that the login page and image viewer copyrights both show current year.
