### PR TITLE
Disable concurrent Quartz scheduling of indexer (rebased onto develop)

### DIFF
--- a/components/server/resources/ome/services/service-ome.api.Search.xml
+++ b/components/server/resources/ome/services/service-ome.api.Search.xml
@@ -83,10 +83,13 @@
   <bean id="fullTextThreadRun" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
     <property name="targetObject" ref="fullTextThread" />
     <property name="targetMethod" value="run" />
-    <!-- FullTextThread now handles locking properly itself, so we will allow
-    concurrent execution. Quartz will now let multiple jobs through and each 
-    FullTextThread can discard itself as it sees fit (via construction) -->
-    <property name="concurrent" value="true" />
+    <!-- FullTextThread now handles locking properly itself, however when Quartz
+         runs multiple threads concurrently and one or more experiences a fatal
+         error (e.g. OOM) it seems that we can still get into a deadlock
+         situation. Since we can only perform actual indexing work on one thread
+         at a time anyway, we will disable concurrency until the deadlock issue
+         can be resolved. -->
+    <property name="concurrent" value="false" />
   </bean>
 
   <!-- FullText trigger moved to indexer.xml for running as separate process -->


### PR DESCRIPTION
This is the same as gh-2049 but rebased onto develop.

---

When Quartz schedules indexer threads concurrently and one or more
experiences an OOM error, this can lead to a deadlock on the indexer.
Disabling concurrency should fix this issue.

To test, import at least one image and then attach 1000 text attachments
of ~20 KB each. (These can be generated with a quick script like: `for i
in {1..1000}; do printf 'This is only a test... %.0s' {1..1000} >
test_$i.txt; done` inside of a directory.) If the first import of 1000
doesn't cause OOM, repeat them import. Watch the Indexer log files for
OOM. When it occurs, the Indexer should discard the OOM thread but
continue processing.
