### PR TITLE
Pass Image IDs to script when Wells selected. See #11835 (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2435,6 +2435,19 @@ def script_ui(request, scriptId, conn=None, **kwargs):
                 Data_TypeParam["default"] = dtype
                 IDsParam["default"] = request.REQUEST.get(dtype, "")
                 break       # only use the first match
+        # if we've not found a match, check whether we have "Well" selected
+        if len(IDsParam["default"]) == 0 and request.REQUEST.get("Well", None) is not None:
+            if "Image" in Data_TypeParam["options"]:
+                wellIds = [long(i) for i in request.REQUEST.get("Well", None).split(",")]
+                wellIdx = 0
+                try:
+                    wellIdx = int(request.REQUEST.get("Index", 0))
+                except:
+                    pass
+                wells = conn.getObjects("Well", wellIds)
+                imgIds = [str(w.getImage(wellIdx).getId()) for w in wells]
+                Data_TypeParam["default"] = "Image"
+                IDsParam["default"] = ",".join(imgIds)
 
     # try to determine hierarchies in the groupings - ONLY handle 1 hierarchy level now (not recursive!)
     for i in range(len(inputs)):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
@@ -171,7 +171,14 @@ OME.openScriptWindow = function(event, width, height) {
             sel_types[type].push(oid);
         }
         var args = [];
-        for (key in sel_types) {
+        for (var key in sel_types) {
+            // If in SPW with wells selected, handy to know what 'field'
+            if (key === "well") {
+                // grab the index select value:
+                if ($("#id_index").length > 0) {
+                    args.push("Index=" + $("#id_index").val());
+                }
+            }
             if (sel_types.hasOwnProperty(key)){
                 args.push(key.capitalize() + "=" + sel_types[key].join(","));
             }


### PR DESCRIPTION
This is the same as gh-2138 but rebased onto dev_5_0.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11835
When Wells are selected in HCS data and we launch a script that only takes Image IDs, we get the Image IDs from the wells and pass to script.

To test:
- Select one or more wells
- Launch script that takes Image IDs (E.g. Batch Image Export)
- Check that IDs field is populated with correct Image IDs for the currently selected Field (and Data Type is "Image").
- Check that a different Field gives different Image IDs in the script.
