### PR TITLE
Bugfix: Image import: File naming settings were ignored

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -6381,12 +6381,14 @@ class OMEROGateway
 			String[] paths = new String[1];
 			paths[0] = file.getAbsolutePath();
 			ImportCandidates icans = new ImportCandidates(reader, paths, status);
-			for(ImportContainer ic : icans.getContainers()) {
-    			    if (object.isOverrideName()) {
-                                int depth = object.getDepthForName();
-                                ic.setUserSpecifiedName(UIUtilities.getDisplayedFileName(file.getAbsolutePath(), depth));
-                            }
+			
+			if(object.isOverrideName()) {
+			    String name = UIUtilities.getDisplayedFileName(file.getAbsolutePath(), object.getDepthForName());
+			    for(ImportContainer ic : icans.getContainers()) {
+			        ic.setUserSpecifiedName(name);
+			    }
 			}
+			
 			return icans;
 		} catch (Throwable e) {
 			throw new ImportException(e);


### PR DESCRIPTION
See Ticket #12030: https://trac.openmicroscopy.org.uk/ome/ticket/12030
When importing images setting specific file naming options didn't have any effect.
