### PR TITLE
Bugfix: User now must set another group than 'user' (Ticket #11926) (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
@@ -332,11 +332,7 @@ implements ActionListener, PropertyChangeListener
                 DataObject data;
                 while (i.hasNext()) {
                     data = i.next();
-                    if (data.getId() == p.getId()) {
-                        i.remove();
-                        continue;
-                    }
-                    if(svc.isSecuritySystemGroup(data.getId(), GroupData.USER)) {
+                    if(data.getId() == p.getId() || svc.isSecuritySystemGroup(data.getId(), GroupData.USER)) {
                         i.remove();
                     }
                 }


### PR DESCRIPTION
This is the same as gh-2153 but rebased onto dev_5_0.

---

Bugfix for https://trac.openmicroscopy.org.uk/ome/ticket/11926
It was possible to create users in Insight which didn't belong to any group (except to system group 'users'), because the 'users' group counted as normal group.
Now the user is forced to select a group (like it is in OMERO.web)

Test:
Open 'Create new user' dialog in Insight. 'Create' button should be disabled until a group is set.
