### PR TITLE
Fix PYTHONPATH whitespace issue on Windows (see #11989).

### DIFF
--- a/components/tools/OmeroPy/bin/setpythonpath.bat
+++ b/components/tools/OmeroPy/bin/setpythonpath.bat
@@ -1,0 +1,24 @@
+@echo off
+REM
+REM  Prepends the OMERO distribution containing this bat file
+REM  to the PYTHONPATH environment variable if necessary.
+REM
+REM  Copyright (c) 2009, University of Dundee
+REM  See LICENSE for details.
+
+for %%i in ("%~dp0\..\") do (set dist=%%~dpi)
+set found=0
+FOR /F "usebackq delims=; tokens=*" %%i in (`echo %PYTHONPATH%`) do call :PARSE %%i
+goto :EOF
+
+:PARSE
+if "%1"=="" goto OMERO
+if /I %1 EQU %dist%lib\python goto FOUND
+Shift
+goto :PARSE
+
+:FOUND
+set found=1
+
+:OMERO
+if %found% EQU 0 set PYTHONPATH=%dist%lib\python;%PYTHONPATH%


### PR DESCRIPTION
This PR fixes http://trac.openmicroscopy.org.uk/ome/ticket/11989 by removing the call to `setpythonpath.bat` from `omero.bat`. There are [numerous](http://stackoverflow.com/questions/535975/dealing-with-quotes-in-windows-batch-scripts), [hard-to-predict](http://stackoverflow.com/questions/473117/pass-path-with-spaces-as-parameter-to-bat-file) [behaviours](http://chrisoldwood.blogspot.co.uk/2013/06/handling-paths-with-spaces-parenthesis.html) with the `FOR` construct and paths containing spaces and parentheses. There might be scope for improving the error reported by `setpythonpath.bat`.

To test: verify that the server starts up on Windows and that all services (thumbnail generation, search etc.) work as expected.
