### PR TITLE
Read only flag

### DIFF
--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -104,6 +104,9 @@ module omero {
         ["java:type:java.util.ArrayList<omero.model.ChecksumAlgorithm>:java.util.List<omero.model.ChecksumAlgorithm>"]
             sequence<omero::model::ChecksumAlgorithm> ChecksumAlgorithmList;
 
+        ["java:type:java.util.ArrayList<omero.sys.EventContext>:java.util.List<omero.sys.EventContext>"]
+            sequence<omero::sys::EventContext> EventContextList;
+
         // Arrays
 
         sequence<bool> BoolArray;

--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -66,6 +66,7 @@ module omero {
       long   groupId;
       string groupName;
       bool   isAdmin;
+      bool   isReadOnly;
       long   eventId;
       string eventType;
       LongList memberOfGroups;

--- a/components/blitz/resources/omero/api/ISession.ice
+++ b/components/blitz/resources/omero/api/ISession.ice
@@ -48,6 +48,7 @@ module omero {
 
                 omero::model::Session getSession(string sessionUuid) throws ServerError;
                 int getReferenceCount(string sessionUuid) throws ServerError;
+                omero::api::EventContextList getOpenSessions() throws ServerError;
                 int closeSession(omero::model::Session sess) throws ServerError;
 
                 // Listing

--- a/components/blitz/src/ome/services/blitz/impl/SessionI.java
+++ b/components/blitz/src/ome/services/blitz/impl/SessionI.java
@@ -22,6 +22,7 @@ import omero.api.AMD_ISession_getInputs;
 import omero.api.AMD_ISession_getMyOpenAgentSessions;
 import omero.api.AMD_ISession_getMyOpenClientSessions;
 import omero.api.AMD_ISession_getMyOpenSessions;
+import omero.api.AMD_ISession_getOpenSessions;
 import omero.api.AMD_ISession_getOutput;
 import omero.api.AMD_ISession_getOutputKeys;
 import omero.api.AMD_ISession_getOutputs;
@@ -157,6 +158,11 @@ public class SessionI extends AbstractAmdServant implements _ISessionOperations 
     }
 
     public void getMyOpenSessions_async(AMD_ISession_getMyOpenSessions __cb,
+            Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current);
+    }
+
+    public void getOpenSessions_async(AMD_ISession_getOpenSessions __cb,
             Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current);
     }

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -536,8 +536,7 @@ public class IceMapper extends ome.util.ModelMapper implements
         ec.leaderOfGroups = ctx.getLeaderOfGroupsList();
         ec.memberOfGroups = ctx.getMemberOfGroupsList();
         ec.isAdmin = ctx.isCurrentUserAdmin();
-        // ticket:2265 Removing from public interface
-        // ec.isReadOnly = ctx.isReadOnly();
+        ec.isReadOnly = ctx.isReadOnly();
         ec.groupPermissions = convert(ctx.getCurrentGroupPermissions());
         return ec;
     }
@@ -729,6 +728,17 @@ public class IceMapper extends ome.util.ModelMapper implements
         }
 
         return filter;
+    }
+
+    /**
+     * Overrides findTarget to handle contents of collections
+     */
+    @Override
+    public Object findTarget(Object current) {
+        if (current instanceof ome.system.EventContext) {
+            return convert((ome.system.EventContext)current); 
+        }
+        return super.findTarget(current);
     }
 
     /**

--- a/components/common/src/ome/api/ISession.java
+++ b/components/common/src/ome/api/ISession.java
@@ -19,6 +19,7 @@ import ome.conditions.SecurityViolation;
 import ome.conditions.SessionTimeoutException;
 import ome.model.internal.Permissions;
 import ome.model.meta.Session;
+import ome.system.EventContext;
 import ome.system.Principal;
 
 /**
@@ -142,6 +143,14 @@ public interface ISession extends ServiceInterface {
      * started by official OMERO clients.
      */
     List<Session> getMyOpenClientSessions();
+
+    /**
+     * Administration method for loading all open sessions. The
+     * {@link EventContext#isReadOnly()} flag is useful for determining
+     * if any transactions can be taking place. If all open sessions are
+     * read-only, then the server can be safely restarted.
+     */
+    List<EventContext> getOpenSessions();
 
     // void addNotification(String notification);
     // void removeNotification(String notification);

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -119,9 +119,9 @@ public interface SecuritySystem {
      * Prepares the current {@link EventContext} instance with the current
      * {@link Principal}. An exception is thrown if there is none.
      * 
-     * @param isReadyOnly
+     * @param isReadOnly
      */
-    void loadEventContext(boolean isReadyOnly);
+    void loadEventContext(boolean isReadOnly);
 
     /**
      * Clears the content of the {@link EventContext}so that the

--- a/components/server/src/ome/security/sharing/SharingSecuritySystem.java
+++ b/components/server/src/ome/security/sharing/SharingSecuritySystem.java
@@ -120,7 +120,7 @@ public class SharingSecuritySystem implements SecuritySystem {
         return false;
     }
 
-    public void loadEventContext(boolean isReadyOnly) {
+    public void loadEventContext(boolean isReadOnly) {
         // TODO Auto-generated method stub
 
     }

--- a/components/server/src/ome/services/sessions/SessionBean.java
+++ b/components/server/src/ome/services/sessions/SessionBean.java
@@ -28,6 +28,7 @@ import ome.model.internal.Permissions;
 import ome.model.meta.Session;
 import ome.security.basic.CurrentDetails;
 import ome.services.util.Executor;
+import ome.system.EventContext;
 import ome.system.Principal;
 
 import org.slf4j.Logger;
@@ -189,6 +190,15 @@ public class SessionBean implements ISession {
             public List<Session> call() throws Exception {
                 return mgr.findByUserAndAgent(user, "OMERO.insight",
                         "OMERO.web", "OMERO.importer");
+            }});
+        return ex.get(future);
+    }
+
+    @RolesAllowed("system")
+    public java.util.List<EventContext> getOpenSessions() {
+        Future<List<EventContext>> future = ex.submit(new Callable<List<EventContext>>(){
+            public List<EventContext> call() throws Exception {
+                return mgr.getOpenSessions();
             }});
         return ex.get(future);
     }

--- a/components/server/src/ome/services/sessions/SessionContextImpl.java
+++ b/components/server/src/ome/services/sessions/SessionContextImpl.java
@@ -17,7 +17,8 @@ import ome.services.sessions.stats.SessionStats;
 import ome.system.Roles;
 
 public class SessionContextImpl implements SessionContext {
-    
+
+    private final boolean isReadOnly;
     private final Count count;
     private final Roles _roles;
     private final Session session;
@@ -37,6 +38,7 @@ public class SessionContextImpl implements SessionContext {
     public SessionContextImpl(Session session, List<Long> lGroups,
             List<Long> mGroups, List<String> roles, SessionStats stats,
             Roles _roles, SessionContext previous) {
+        this.isReadOnly = false;
         this._roles = _roles;
         this.stats = stats;
         this.session = session;
@@ -89,7 +91,7 @@ public class SessionContextImpl implements SessionContext {
     }
 
     public Long getCurrentEventId() {
-        throw new UnsupportedOperationException();
+        return -1L;
     }
 
     public String getCurrentEventType() {
@@ -136,10 +138,10 @@ public class SessionContextImpl implements SessionContext {
     }
 
     public boolean isReadOnly() {
-        throw new UnsupportedOperationException();
+        return isReadOnly;
     }
 
     public Permissions getCurrentUmask() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 }

--- a/components/server/src/ome/services/sessions/SessionManager.java
+++ b/components/server/src/ome/services/sessions/SessionManager.java
@@ -141,6 +141,11 @@ public interface SessionManager {
     List<Session> findByUserAndAgent(String user, String... agent);
 
     /**
+     * Returns a snapshot of all the open sessions.
+     */
+    List<EventContext> getOpenSessions();
+
+    /**
      * If reference count for the session is less than 1, close the session.
      * Otherwise decrement the reference count. The current reference count is
      * returned. If -1, then no such session existed. If -2, then the session

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -525,8 +525,10 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
         return ctx.stats();
     }
 
-    /*
-     */
+    public List<EventContext> getOpenSessions() {
+        return new ArrayList<EventContext>(cache.getSnapshot());
+    }
+
     public int close(String uuid) {
         SessionContext ctx;
         try {

--- a/components/server/src/ome/services/sessions/state/SessionCache.java
+++ b/components/server/src/ome/services/sessions/state/SessionCache.java
@@ -26,6 +26,7 @@ import ome.services.sessions.SessionContext;
 import ome.services.sessions.SessionManager;
 import ome.services.sessions.events.UserGroupUpdateEvent;
 import ome.services.sessions.state.SessionCache.StaleCacheListener;
+import ome.system.EventContext;
 import ome.system.OmeroContext;
 
 import org.slf4j.Logger;
@@ -484,8 +485,22 @@ public class SessionCache implements ApplicationContextAware {
      * significantly effected.
      */
     public Set<String> getIds() {
-        // waitForUpdate();
         return sessions.keySet();
+    }
+
+    /**
+     * Returns a collection of all the active sessions currently in the
+     * system. Timed out sessions are silently ignored.
+     */
+    public Set<EventContext> getSnapshot() {
+        Set<EventContext> rv = new HashSet<EventContext>();
+        for (String uuid : sessions.keySet()) {
+            Data data = getDataNullOrThrowOnTimeout(uuid, false);
+            if (data != null) {
+                rv.add(data.sessionContext);
+            }
+        }
+        return rv;
     }
 
     // State

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -95,6 +95,12 @@ class CallContextFixture(object):
 
 class TestPermissions(lib.ITest):
 
+    def testNoInsertInReadOnly(self):
+        client = self.new_client(perms="r-----")
+        tag = TagAnnotationI()
+        with pytest.raises(omero.SecurityViolation):
+            client.sf.getUpdateService().saveObject(tag)
+
     def testLoginToPublicGroupTicket1940(self):
         # As root create a new group
         uuid = self.uuid()


### PR DESCRIPTION
First steps toward a proper "read-only" (or "published") state. With this, the `EventContext` object properly records whether or not any write action (i.e. INSERT, UPDATE, DELETE) is possible. Further PRs can make use of this state to set the server into shutdown-mode.

There is little to no use currently of the `r-----` flag, so this branch as it stands should have no impact on existing tests or functionality. As the one integration test shows, though, any newly created group starting with `r-` will be locked, or published, in that no database INSERTs can take place.

As it stands, this branch may not be compatible with the `dev_5_0` branch because of the change in the model objections. If the general functional is considered to be correct, we can evaluate how best to achieve `5.0`-compatibility.