### PR TITLE
fix #12051: close img tag (rebased)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # 
-# 
-# 
-# Copyright (c) 2008 University of Dundee. 
+# Copyright (c) 2008-2014 University of Dundee. 
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -53,7 +51,7 @@ class LoginForm(NonASCIIForm):
             
     username = forms.CharField(max_length=50, widget=forms.TextInput(attrs={'size':22}))
     password = forms.CharField(max_length=50, widget=forms.PasswordInput(attrs={'size':22, 'autocomplete': 'off'}))
-    ssl = forms.BooleanField(required=False, help_text='<img src="%swebgateway/img/nuvola_encrypted_grey16.png" title="Real-time encrypted data transfer can be turned on by checking the box, but it will slow down the data access. Turning it off does not affect the connection to the server which is always secure." alt="SSL"' % settings.STATIC_URL)
+    ssl = forms.BooleanField(required=False, help_text='<img src="%swebgateway/img/nuvola_encrypted_grey16.png" title="Real-time encrypted data transfer can be turned on by checking the box, but it will slow down the data access. Turning it off does not affect the connection to the server which is always secure." alt="SSL"/>' % settings.STATIC_URL)
 
 class ForgottonPasswordForm(NonASCIIForm):
     


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12051.
Open the webclient login page, make sure the padlock looks okay
![nuvola_encrypted_grey16](https://f.cloud.github.com/assets/2630707/2459614/9535676c-af5e-11e3-9e06-84823834d5af.png)
and look at the source.
--rebased-from #2179
