### PR TITLE
Close the RFS and kill the root session.

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+#
+# Copyright (C) 2008-2014 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 """
    Tests of the permissions
-
-   Copyright 2008-2013 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
 
 """
 


### PR DESCRIPTION
This should get `testUseOfRawFileBeanScriptReadCorrectGroup` to pass consistently due to an error arising from the preceding test `testUseOfRawFileBeanScriptReadGroupMinusOne`. The integration build results should be enough of a check.
