### PR TITLE
Bugfix: Weird behaviour after switching users

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.DataServicesFactory
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
After switching users new service adapter instances were created but never passed on to the registry, so subsequent calls to the server picked up old service adapter instances, with the old OMEROGateway which still used the session created by the previous user.

Fix for: https://trac.openmicroscopy.org.uk/ome/ticket/12055
Should also fix other issues due to switching users

To Test: Follow the scenario mentioned in the ticket above; 
