### PR TITLE
Check for duplicate pixels IDs when adding to list.

### DIFF
--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+#
+# Copyright (C) 2008-2014 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 """
    Library for integration tests
-
-   Copyright 2008-2013 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
 
 """
 
@@ -195,7 +210,9 @@ class ITest(object):
             if x and x.find("Created") < 0 and x.find("#") < 0:
                 try:    # if the line has an image ID...
                     imageId = str(long(x.strip()))
-                    pix_ids.append(imageId)
+                    # Occasionally during tests an id is duplicated on stdout
+                    if imageId not in pix_ids:
+                        pix_ids.append(imageId)
                 except: pass
         return pix_ids
 


### PR DESCRIPTION
Occasionally during testing a CLI import produces duplicate pixels IDs which then causes a test to fail:

http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-python/88/testReport/test.integration.test_chgrp/TestChgrp/testChgrpImportedImage/

This is probably down to a glitch on `stdout` on the node running the integration tests rather than a fault in the import code. This commit should ensure that duplicates are not present.

As this was a very intermittent fail the test should be that a failure like this doesn't occur again. Equally this commit shouldn't break any other tests.

--rebased-to #2267
