### PR TITLE
HQL binary data (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -72,9 +72,16 @@ class ALIGN:
 class Column(list):
 
     def __init__(self, name, data, align=ALIGN.LEFT):
-        list.__init__(self, data)
+        def tostring(x):
+            try:
+                return str(x).decode("utf-8")
+            except UnicodeDecodeError:
+                return '<Invalid UTF-8>'
+
+        decoded = [tostring(d) for d in data]
+        list.__init__(self, decoded)
         self.name = name
-        self.width = max(len(str(x).decode("utf-8")) for x in data + [name])
+        self.width = max(len(x) for x in decoded + [name])
         self.format = ' %%%s%ds ' % (align, self.width)
 
 


### PR DESCRIPTION
This is the same as gh-2190 but rebased onto develop.

---

Run a hql query that returns binary data (for instance the cached script params). Instead of an exception you should see `<Invalid UTF-8>`.
See https://trac.openmicroscopy.org.uk/ome/ticket/12115
