### PR TITLE
Activities json fix for 08e94b6

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2205,7 +2205,7 @@ def activities(request, conn=None, **kwargs):
         rv['inprogress'] = in_progress
         rv['failure'] = failure
         rv['jobs'] = len(request.session['callback'])
-        return HttpJsonResponse(json.dumps(rv)) # json
+        return HttpJsonResponse(rv) # json
 
     jobs = []
     new_errors = False


### PR DESCRIPTION
Tiny fix for json for the Activities status.

To test, simply go to /webclient/activities_json/ and check that this looks like valid json. If you want to add content to the response json, simply run a script from the webclient then refresh the json.

Fixes https://github.com/aleksandra-tarkowska/openmicroscopy/commit/08e94b60886780ca01aa86211bf592fe9b39b6b1#diff-e226bce909b5b71ca51f5a26c7db1823R2201 in https://github.com/openmicroscopy/openmicroscopy/pull/1985 which is in develop only.

--no-rebase 
