### PR TITLE
Use official OMERO.matlab name when loading toolbox with loadOmero() (rebased onto develop)

### DIFF
--- a/components/tools/OmeroM/src/loadOmero.m
+++ b/components/tools/OmeroM/src/loadOmero.m
@@ -63,7 +63,7 @@ if exist('omero.client','class') == 0
     
     disp('');
     disp('--------------------------');
-    disp('OmeroMatlab Toolbox ');
+    disp('OMERO.matlab Toolbox ');
     disp(omeroVersion);
     disp('--------------------------');
     disp('');


### PR DESCRIPTION
This is the same as gh-2196 but rebased onto develop.

---

Noticed while answering https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=7469. This is a trivial change which unifies the displayed name of the toolbox with the documentation/downloads.

To test the PR, download the merge OMERO.matlab toolbox, load it with

```
>> loadOmero()
```

and check the displayed name is correct, i.e. `OMERO.matlab $VERSION`
