### PR TITLE
Bugfix: UI elements accessed outside of EDT (ImporterAgent) (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.fsimporter.view.ImporterControl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This is the same as gh-2217 but rebased onto dev_5_0.

---

This would be a bugfix for issue: https://www.openmicroscopy.org/qa2/qa/feedback/8002/

The ClassCastException is completely misleading, as the underlieing problem is the access of UI elements of the ImporterUI's ClosedTabbedPane outside of the Event Dispatching Thread.

To Test: Start several parallel image imports, then randomly switch between the import tabs.
