### PR TITLE
limit webtest getObjects() to 10

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webtest/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webtest/views.py
@@ -56,18 +56,18 @@ def index(request, conn=None, **kwargs):
         images = list(conn.getObjects("Image", ids))
     else:
         # OR find a random image and dataset to display & can be used in links to other pages
-        all_images = list(conn.getObjects("Image", params=params))
-        img = random.choice(all_images)
+        some_images = list(conn.getObjects("Image", params=params))
+        img = random.choice(some_images)
         images = [img]
     
     imgIds = ",".join([str(img2.getId()) for img2 in images])
     
     # get a random dataset (making sure we get one that has some images in it)
-    all_datasets = list(conn.getObjects("Dataset", params=params))
-    dataset = random.choice(all_datasets)
+    some_datasets = list(conn.getObjects("Dataset", params=params))
+    dataset = random.choice(some_datasets)
     attempts = 0
     while (dataset.countChildren() == 0 and attempts < 10):
-        dataset = random.choice(all_datasets)
+        dataset = random.choice(some_datasets)
         attempts += 1
 
     return render_to_response('webtest/index.html', {'images': images, 'imgIds': imgIds, 'dataset': dataset})


### PR DESCRIPTION
This fixes getObjects("Image") and getObjects("Dataset") on the webtest homepage, which were attempting to get ALL objects available to that user. Now this is limited to 10 each.

This has no effect on functionality, but should mean that running this on a server with a large number of available images causes no performance problems or server crash.
