### PR TITLE
Remove duplicate setting of uint16 bit size

### DIFF
--- a/sql/psql/OMERO5.0__0/psql-footer.sql
+++ b/sql/psql/OMERO5.0__0/psql-footer.sql
@@ -2021,7 +2021,6 @@ update pixelstype set bitsize = 8 where value = 'uint8';
 update pixelstype set bitsize = 16 where value = 'int16';
 update pixelstype set bitsize = 16 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'int32';
-update pixelstype set bitsize = 32 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'uint32';
 update pixelstype set bitsize = 32 where value = 'float';
 update pixelstype set bitsize = 64 where value = 'double';


### PR DESCRIPTION
See http://trac.openmicroscopy.org.uk/ome/ticket/12126.  The correct bit depth for uint16 is 16; for some reason, the bit depth was being set twice for uint16 (first to 16, then to 32).
