### PR TITLE
Don't show MoveToAction when WellSampleData is selected (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserControl.java
@@ -85,6 +85,7 @@ import pojos.ExperimenterData;
 import pojos.GroupData;
 import pojos.ImageData;
 import pojos.PlateAcquisitionData;
+import pojos.WellSampleData;
 
 /** 
  * The DataBrowser's Controller.
@@ -371,7 +372,8 @@ class DataBrowserControl
                 if (o instanceof DataObject) {
                     if (!(o instanceof GroupData ||
                             o instanceof ExperimenterData ||
-                            o instanceof PlateAcquisitionData)) {
+                            o instanceof PlateAcquisitionData ||
+                            o instanceof WellSampleData)) {
                         if (model.canChgrp(o)) {
                             data = (DataObject) o;
                             if (!owners.contains(data.getOwner().getId()))


### PR DESCRIPTION
This is the same as gh-2231 but rebased onto develop.

---

Fix for: https://trac.openmicroscopy.org.uk/ome/ticket/11999
Prevent users from trying to move single wells to other group.

Test:
Open a screen, right click on a well, make sure that there is no "Move To Group" in context menu.
