### PR TITLE
Check for duplicate pixels IDs when adding to list. (rebased)

### DIFF
--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+#
+# Copyright (C) 2008-2014 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 """
    Library for integration tests
-
-   Copyright 2008-2013 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
 
 """
 
@@ -195,7 +210,9 @@ class ITest(object):
             if x and x.find("Created") < 0 and x.find("#") < 0:
                 try:    # if the line has an image ID...
                     imageId = str(long(x.strip()))
-                    pix_ids.append(imageId)
+                    # Occasionally during tests an id is duplicated on stdout
+                    if imageId not in pix_ids:
+                        pix_ids.append(imageId)
                 except: pass
         return pix_ids
 


### PR DESCRIPTION
This is rebased from #2192, testing is pretty much that impacted integration tests pass.

--rebased-from #2192
