### PR TITLE
Simple well field selection on full viewer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1159,6 +1159,17 @@
                 {% endifnotequal %}
           </div>
 {% endblock roi_buttons %}
+{% block well_fields %}
+  {% if wellFields %}
+          <div class="odd row">
+            <select id="wblitz-wellfields" onchange="viewport.load($(this).val())">
+            {% for f in wellFields %}
+              <option{% ifequal f image.id %} selected="selected"{% endifequal %} value="{{ f }}">Field #{{ forloop.counter }}</option>
+            {% endfor %}
+            </select>
+          </div>
+  {% endif %}
+{% endblock well_fields %}
           {% block current_image_tools %}{% endblock %}
         </div>
             


### PR DESCRIPTION
This changeset adds a simple dropdown selector for field selection for images that are contained in wells. The field selector roughly mimics the one in the plate grid view of omero webclient.

Things to look for when testing:
- Images not from wells (dataset children or orphans) should not show the field selector at all
- Opening the full viewer for an image in a well should show the field selector, with the correct field selected for the opened image
- Changing the selected field will open the new image and all controls should show the new information, including Image Details and Image Link.

![fullviewer_fields](https://cloud.githubusercontent.com/assets/1065156/2666122/dd7b69e6-c097-11e3-8d8d-478f5e61cb91.png)
