### PR TITLE
Fix indirect import in webgateway

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -24,8 +24,6 @@ import ConfigParser
 import omero
 import omero.clients
 from omero.util.decorators import timeit
-# not used here, but imported from here in other places:
-from omero.util.decorators import TimeIt  # noqa
 from omero.cmd import DoAll
 from omero.api import Save
 from omero.gateway.utils import ServiceOptsDict, GatewayConfig

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -37,7 +37,7 @@ except:
 from cStringIO import StringIO
 
 from omero import ApiUsageException
-from omero.gateway import timeit, TimeIt
+from omero.util.decorators import timeit, TimeIt
 from omeroweb.http import HttpJavascriptResponse, HttpJsonResponse, \
     HttpJavascriptResponseServerError
 


### PR DESCRIPTION
Remove unused import from gateway and fix indirect imports of that name

This is a follow-up to #2251 that had initially removed the import from `omero.gateway` without fixing the reference in `omeroweb.webgateway.views`.
