### PR TITLE
Webclient 'Apply owner's rdef' see #12044 (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -283,7 +283,8 @@
         // Stuff to do on load...
         $(function() 
             {
-                var copy_paste_rdef_url = "{% url 'webgateway.views.copy_image_rdef_json' %}";
+                var copy_paste_rdef_url = "{% url 'webgateway.views.copy_image_rdef_json' %}",
+                    apply_owners_rdef_url = "{% url 'webgateway.views.apply_owners_rdef_json' %}";
                 // Copy the selected Image ID to the 'session' (right-click menu only allows this on 'image')
                 var copyRenderingSettings = function(selected) {
                     if (selected.length == 1) {
@@ -292,10 +293,13 @@
                     }
                 }
                 // Paste settings from 'session' to selected Images
-                var pasteRenderingSettings = function(selected) {
+                var pasteRenderingSettings = function(selected, owner) {
                     var ids = [],
                         rdef_url = copy_paste_rdef_url,
                         rel = selected.attr('rel').replace('-locked','');
+                    if (owner) {
+                        rdef_url = apply_owners_rdef_url;
+                    }
                     selected.each(function(){
                         ids.push(this.id.split('-')[1]);
                     });
@@ -307,6 +311,10 @@
                         // update thumbnails
                         OME.refreshThumbnails();
                     });
+                }
+
+                var applyOwnerRenderingSettings = function(selected) {
+                    pasteRenderingSettings(selected, true);
                 }
 
                 $("#left_panel_tabs").tabs({
@@ -888,6 +896,13 @@
                                         "icon"  : '{% static "webclient/image/icon_basic_paste_16.png" %}',
                                         "action": function() {
                                             pasteRenderingSettings(this.get_selected());
+                                        }
+                                    },
+                                    "owner_rdef": {
+                                        "label" : "Set Owner's",
+                                        "icon"  : '{% static "webclient/image/icon_basic_paste_16.png" %}',
+                                        "action": function() {
+                                            applyOwnerRenderingSettings(this.get_selected());
                                         }
                                     }
                                 }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -274,6 +274,11 @@ Copy the rendering settings from one image to a list of images, specified in req
 by 'fromid' and list of 'toids'. See L{views.copy_image_rdef_json}
 """
 
+apply_owners_rdef_json = (r'^applyOwnersRDef/$', 'webgateway.views.apply_owners_rdef_json')
+"""
+Apply the owner's rendering settings to the specified objects.
+"""
+
 webgateway_su = url(r'^su/(?P<user>[^/]+)/$', 'webgateway.views.su', name="webgateway_su")
 """
 Admin method to switch to the specified user, identified by username: <user> 
@@ -323,6 +328,7 @@ urlpatterns = patterns('',
     reset_image_rdef_json,
     list_compatible_imgs_json,
     copy_image_rdef_json,
+    apply_owners_rdef_json,
     # download archived_files
     archived_files,
     original_file_paths,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1492,6 +1492,29 @@ def list_compatible_imgs_json (request, iid, conn=None, **kwargs):
         json_data = '%s(%s)' % (r['callback'], json_data)
     return HttpResponse(json_data, mimetype='application/javascript')
 
+
+@login_required()
+@jsonp
+def apply_owners_rdef_json (request, conn=None, **kwargs):
+    """
+    Simply takes request 'to_type' and 'toids' and
+    delegates to Rendering Settings service to reset
+    settings according to the owner's settings.
+    """
+
+    r = request.REQUEST
+    toids = r.getlist('toids')
+    to_type = str(r.get('to_type', 'image'))
+
+    to_type = to_type.title()
+    toids = map(lambda x: long(x), toids)
+
+    rss = conn.getRenderingSettingsService()
+    rss.resetDefaultsByOwnerInSet(to_type, toids)
+
+    return {'OK': True}
+
+
 @login_required()
 @jsonp
 def copy_image_rdef_json (request, conn=None, **kwargs):


### PR DESCRIPTION
This is the same as gh-2229 but rebased onto dev_5_0.

---

See https://trac.openmicroscopy.org.uk/ome/ticket/12044

This allows you to apply the owner's rendering settings to images and datasets etc (I actually need to check what all the supported types are).

To test:
- Log in as owner of some images in read-annotate group. Set rendering settings to something different.
- Log is as someone else, view the images and in the tree, right-click -> Rendering settings -> Set owner's.

Thumbnails should be updated.
Open image and settings should be changed to owner's.
