### PR TITLE
Fix for 11674 - script doc links

### DIFF
--- a/components/blitz/resources/omero/API.ice
+++ b/components/blitz/resources/omero/API.ice
@@ -182,7 +182,7 @@ module omero {
              * Returns a reference to a back-end manager. The [omero::grid::SharedResources]
              * service provides look ups for various facilities offered by OMERO:
              * <ul>
-             *   <li><a href="http://www.openmicroscopy.org/site/community/scripts">OMERO.scripts</a>
+             *   <li><a href="http://www.openmicroscopy.org/site/support/omero5/developers/scripts/">OMERO.scripts</a>
              *   <li><a href="http://www.openmicroscopy.org/site/support/omero5/developers/Tables.html">OMERO.tables</a>
              * </ul>
              * These facilities may or may not be available on first request.

--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -19,7 +19,7 @@
  * implementation, for use by the server and via the
  * InteractiveProcessor wrapper by clients.
  *
- * See http://www.openmicroscopy.org/site/community/scripts
+ * See http://www.openmicroscopy.org/site/support/omero5/developers/scripts/
  */
 
 module omero {

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -48,7 +48,7 @@ module omero {
          *     proc.close(False)
          *
          * </pre>
-	 * See <a href="http://www.openmicroscopy.org/site/community/scripts">OMERO.scripts</a> for more information.
+	 * See <a href="http://www.openmicroscopy.org/site/support/omero5/developers/scripts/">OMERO.scripts</a> for more information.
 	 **/
 	["ami","amd"] interface IScript extends ServiceInterface
 	    {


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/11674 - updates script doc links in the code repo to point at the developer docs rather than the community scripts page (change already made on 4.4 branch, the 5 docs were moving on release when the community page link was used).
