### PR TITLE
remove erroneous bitsize update

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -428,7 +428,6 @@ update pixelstype set bitsize = 8 where value = 'uint8';
 update pixelstype set bitsize = 16 where value = 'int16';
 update pixelstype set bitsize = 16 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'int32';
-update pixelstype set bitsize = 32 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'uint32';
 update pixelstype set bitsize = 32 where value = 'float';
 update pixelstype set bitsize = 64 where value = 'double';

--- a/sql/psql/OMERO5.0__0/psql-footer.sql
+++ b/sql/psql/OMERO5.0__0/psql-footer.sql
@@ -2021,7 +2021,6 @@ update pixelstype set bitsize = 8 where value = 'uint8';
 update pixelstype set bitsize = 16 where value = 'int16';
 update pixelstype set bitsize = 16 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'int32';
-update pixelstype set bitsize = 32 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'uint32';
 update pixelstype set bitsize = 32 where value = 'float';
 update pixelstype set bitsize = 64 where value = 'double';

--- a/sql/psql/OMERO5.1DEV__3/psql-footer.sql
+++ b/sql/psql/OMERO5.1DEV__3/psql-footer.sql
@@ -2021,7 +2021,6 @@ update pixelstype set bitsize = 8 where value = 'uint8';
 update pixelstype set bitsize = 16 where value = 'int16';
 update pixelstype set bitsize = 16 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'int32';
-update pixelstype set bitsize = 32 where value = 'uint16';
 update pixelstype set bitsize = 32 where value = 'uint32';
 update pixelstype set bitsize = 32 where value = 'float';
 update pixelstype set bitsize = 64 where value = 'double';


### PR DESCRIPTION
See #2261: this PR is a trivial change arising from conversation in the comments of http://trac.openmicroscopy.org.uk/ome/ticket/12126.

The upgrade script for 5.1 is in the breaking queue in https://github.com/joshmoore/openmicroscopy/commit/13750928eef094cdd05803d2d397b49d86e39e70 and the corresponding changes for `dev_5_0` are covered by #2315.
