### PR TITLE
Remove cut link 11882 (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -1215,8 +1215,8 @@
 			
 			<li class="seperator"></li>
 			
-			<li><input id="copyButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_copy.png" %}" alt="Copy Link" title="Copy a link to the selected object" /> </li>
 			<li><input id="cutButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_cut.png" %}" alt="Cut Link" title="Cut Link" /> </li>
+            <li><input id="copyButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_copy.png" %}" alt="Copy Link" title="Copy a link to the selected object" /> </li>
 			<li><input id="pasteButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_paste.png" %}" alt="Paste Link" title="Paste the copied link" /> </li>
 			
 			<li class="seperator">


### PR DESCRIPTION
This is the same as gh-1960 but rebased onto dev_5_0.

---

This addresses https://trac.openmicroscopy.org.uk/ome/ticket/11882 and https://trac.openmicroscopy.org.uk/ome/ticket/11881. Web Cut, Copy & Paste of P/D/I & S/P should behave the same as Insight.

To test:
- "Cut Link" an Image or Dataset - should remove it from parent (become orphan).
- "Paste Link" should paste it into new parent.
- "Copy Link" and "Paste Link" should behave as normal.
- Try various copy, cut & paste actions to see if the Tree behaves in a logical way - Compare to how Insight behaves.
