### PR TITLE
Add setup.cfg file at the root of OmeroPy test/ and simplify Travis (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/test/setup.cfg
+++ b/components/tools/OmeroPy/test/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+exclude=integration/test*.py,integration/tablestest,integration/scriptstest,integration/scriptsharness,integration/cmdtest,gatewaytest,fstest

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -22,8 +22,7 @@ build_java()
 build_python()
 {
     flake8 -v components/tools/OmeroPy/src/omero/plugins
-    flake8 -v components/tools/OmeroPy/test/integration/clitest
-    flake8 -v components/tools/OmeroPy/test/unit
+    flake8 -v components/tools/OmeroPy/test
     ./build.py build-default
     ./build.py -py test -Dtest.with.fail=true
 }


### PR DESCRIPTION
This is the same as gh-2287 but rebased onto develop.

---

As @ximenesuk is starting to validate the integration tests to comply with `flake8`, this PR proposes to add a `setup.cfg` at the root of the `components/tools/OmeroPy/test` folder. 
This way:
- `flake8` can simply be run as `flake8 -v components/tools/OmeroPy/test` 
- files validation can be  checked by updating the exclude list and re-running the command above
- no further change needs to be added to the validation of the `test` folder in the Travis script
