### PR TITLE
Zoom display (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2012 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2012-2014 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -4,7 +4,7 @@
  * Depends on jquery, jquery-plugin-viewportImage, gs_utils, gs_slider
  * Uses weblitz.css
  *
- * Copyright (c) 2007, 2008, 2009 Glencoe Software, Inc. All rights reserved.
+ * Copyright (c) 2007-2014 Glencoe Software, Inc. All rights reserved.
  *
  * This software is distributed under the terms described by the LICENCE file
  * you can find at the root of the distribution bundle, which states you are

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -3,7 +3,7 @@
  *
  * Depends on jquery
  *
- * Copyright (c) 2007, 2008, 2009 Glencoe Software, Inc. All rights reserved.
+ * Copyright (c) 2007-2014 Glencoe Software, Inc. All rights reserved.
  *
  * This software is distributed under the terms described by the LICENCE file
  * you can find at the root of the distribution bundle, which states you are


### PR DESCRIPTION
This is the same as gh-2291 but rebased onto dev_5_0.

---

This PR should display correctly nominal magnification in big image viewer (x40) rather then scale (100%).
In order to test this PR import big image that has AppMag set (for example SVS) and check if you see `Magnification: x10`. Then go to big image that has been imported before changes in https://github.com/openmicroscopy/bioformats/pull/1007 and check if you still see `Scale: 25%`
