### PR TITLE
Ignore JetBrains project folders. (rebased onto develop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ temp-testng-customsuite.xml
 omero_version.py
 eclipse.log
 velocity.log*
+.idea


### PR DESCRIPTION
This is the same as gh-2343 but rebased onto develop.

---

This minuscule change makes Git ignore `.idea` folders created when working with the codebase in JetBrains IDEs (PyCharm or IntelliJ IDEA). To test, open a part of the codebase in one of those IDEs and verify that `git status` doesn't show new untracked folders named `.idea`.
