### PR TITLE
default script value (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.util.ScriptingDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This is the same as gh-2340 but rebased onto develop.

---

To Test:
- Log in.
- Do not select any item. 
- Click on the script button to display the available script.
- Go to `export scripts>Batch image export`
- Check that The default data type is `Image`. Close dialog
- Repeat the previous steps and select dataset then an image then a project.

see gh-2306
