### PR TITLE
Add unit tests for CLI connection string parser

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -623,7 +623,7 @@ class SessionsControl(BaseControl):
         """Parse a connection string of form (user@)server(:port)"""
 
         import re
-        pat = '^((?P<name>.+)@)?(?P<server>.*?)(:(?P<port>.*))?$'
+        pat = '^((?P<name>.+)@)?(?P<server>.*?)(:(?P<port>\d{1,5}))?$'
         match = re.match(pat, server)
         server = match.group('server')
         name = match.group('name')

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -428,7 +428,18 @@ class TestParseConn(object):
         assert not out_port
 
     @pytest.mark.parametrize('default_user', [None, 'default_user'])
-    @pytest.mark.parametrize('user_prefix', ['', 'user@', 'üser-1£@'])
+    @pytest.mark.parametrize('port', ['bad_port', '12323414232'])
+    def testBadPort(self, default_user, port):
+        out_server, out_name, out_port = SessionsControl._parse_conn(
+            'localhost:%s' % port, default_user)
+
+        assert out_server == 'localhost:%s' % port
+        assert out_name == default_user
+        assert not out_port
+
+    @pytest.mark.parametrize('default_user', [None, 'default_user'])
+    @pytest.mark.parametrize(
+        'user_prefix', ['', 'user@', 'üser-1£@', 'user:4@email@'])
     @pytest.mark.parametrize('server', ['localhost', 'server.domain'])
     @pytest.mark.parametrize('port_suffix', ['', ':4064', ':14064'])
     def testConnectionString(self, default_user, user_prefix, server,


### PR DESCRIPTION
As a follow up of https://github.com/openmicroscopy/openmicroscopy/pull/2358#issuecomment-41378688, this PR:
- converts `SessionsControl._parse_conn()` into a static method
- adds unit tests for the parsing of connection string of the form `(user@)server(:port)`
- adds cosmetic improvements to the matching logic in `_parse_conn`
