### PR TITLE
Fix location of Homebrew tap

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -60,7 +60,7 @@ if [ $TESTING_MODE ]; then
     bin/pip install -U scc || echo "scc installed"
 
     # Merge homebrew-alt PRs
-    cd Library/Taps/ome-alt
+    cd Library/Taps/ome/homebrew-alt
     /usr/local/bin/scc merge master
 
     # Repair formula symlinks after merge


### PR DESCRIPTION
With https://github.com/Homebrew/homebrew/commit/e07584e3fbdc88327bafe23b9c40c904d0fff0a1, the location of the Homebrew taps has been modified.  Consequently the local `scc merge` operation fails in the daily Homebrew job. This single commit should restore the job.
To test it, check the next occurence of the job is green.

Note: this PR will be rebased onto `develop` and `dev_4_4`.
