### PR TITLE
Disabled MoveToAction for Tags/TagSets (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewerControl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This is the same as gh-2382 but rebased onto dev_5_0.

---

Just disables the 'Move to Group' menu item when Tags/TagSets are selected; until it's sorted out what exactly should happen, when Tags are moved to another group.
See https://trac.openmicroscopy.org.uk/ome/ticket/12226

Test: You should still see the 'Move to Group' context menu item when selecting Projects, Datasets, etc. but not on selection of Tags or TagSets.
