### PR TITLE
Don't use rstring on null values (fix #12056). (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 
 import ome.formats.importer.transfers.FileTransfer;
 import ome.formats.importer.transfers.UploadFileTransfer;
@@ -276,12 +275,10 @@ public class ImportContainer
         // ImportUserSettings rather than misusing ImportContainer.
         settings.doThumbnails = rbool(getDoThumbnails());
         settings.userSpecifiedTarget = getTarget();
-        settings.userSpecifiedName = StringUtils
-                .isNotEmpty(getUserSpecifiedName()) ? rstring(getUserSpecifiedName())
-                : null;
-        settings.userSpecifiedDescription = StringUtils
-                .isNotEmpty(getUserSpecifiedDescription()) ? rstring(getUserSpecifiedDescription())
-                : null;
+        settings.userSpecifiedName = getUserSpecifiedName() == null ? null
+                : rstring(getUserSpecifiedName());
+        settings.userSpecifiedDescription = getUserSpecifiedDescription() == null ? null
+                : rstring(getUserSpecifiedDescription());
         settings.userSpecifiedAnnotationList = getCustomAnnotationList();
 
         if (getUserPixels() != null) {


### PR DESCRIPTION
This is the same as gh-2407 but rebased onto develop.

---

This PR fixes image description preservation between exporting/importing to the server. To test, verify that setting an image description on an image doesn't get lost when that image is exported as OME-TIFF and the re-imported to the server (see https://trac.openmicroscopy.org.uk/ome/ticket/12056).

~~\cc @joshmoore: Is that the best place the null check can be placed? Or can it be done even earlier in the code?~~
