### PR TITLE
Move kill session to global teardown

### DIFF
--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -722,4 +722,6 @@ class ITest(object):
         return rsp
 
     def teardown_method(self, method):
+        self.root.killSession()
+        self.root = None
         self.__clients.__del__()

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -825,9 +825,8 @@ class TestPermissions(lib.ITest):
         assert script.size.val ==  len(data)
         try:
             store.close()
-        finally:
-            self.root.killSession()
-            self.root = None
+        except:
+            pass
 
     def testUseOfRawFileBeanScriptReadGroupMinusOne(self):
         self.assertValidScript(lambda v: {'omero.group': '-1'})


### PR DESCRIPTION
This is an investigative PR and doesn't need any specific review.

Several Python integration tests fail intermittently with the reason:

```
No valid permissions available! DUMMY permissions are not intended for copying.
```

This is entirely reproducible locally and can be fixed with gh-2188. However, that PR did not have the same effect on Jenkins and intermittent fails of this type have continued. As mentioned in https://github.com/openmicroscopy/openmicroscopy/pull/2188#issuecomment-38259556, killing the root session after every test method may be worth investigating. This PR does that. It may have an effect on the time taken for the whole suite to run, it may have effects on other tests, both of those aspects will be investigated by this PR being in the build for a few days.

If this PR causes any serious problems or prevents other PRs being merged then it can be closed.

--rebased-to #2568 
