### PR TITLE
Allow 'Cut' instead of 'Copy' when orphaned Dataset selected

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -1230,8 +1230,8 @@
 			
 			<li class="seperator"></li>
 			
-			<li><input id="copyButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_copy.png" %}" alt="Copy Link" title="Copy a link to the selected object" /> </li>
 			<li><input id="cutButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_cut.png" %}" alt="Cut Link" title="Cut Link" /> </li>
+            <li><input id="copyButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_copy.png" %}" alt="Copy Link" title="Copy a link to the selected object" /> </li>
 			<li><input id="pasteButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_paste.png" %}" alt="Paste Link" title="Paste the copied link" /> </li>
 			
 			<li class="seperator">


### PR DESCRIPTION
When #2310 was rebased to dev_5_0 it had some extra commits added. This backports them to develop.

To test, check that the Copy/Cut options are the same for Insight and Web when orphaned Datasets are selected. Should be able to Cut only in right-click menu and toolbar.
