### PR TITLE
OMERO.matlab agent

### DIFF
--- a/components/tools/OmeroM/src/connectOmero.m
+++ b/components/tools/OmeroM/src/connectOmero.m
@@ -64,6 +64,7 @@ end
 
 % Create client object
 client = javaObject('omero.client', connArgs{:});
+client.setAgent('OMERO.matlab');
 
 if nargout > 1,
     % Create session


### PR DESCRIPTION
This trivial PR sets the agent to `OMERO.matlab` instead of the default `OMERO.java` when initializing a client using `connectOmero`.

Since there is no property to read the `__agent` value in the client, to test this PR, create a client/session from MATLAB using `loadOmero()` and check the agent is correctly in `Blitz-0.log`  e.g.

```
2014-05-04 02:01:29,185 INFO  [ ome.services.blitz.fire.SessionManagerI] (l.Server-4) Created session ServiceFactoryI(session-1ebd489e-8e1f-49c6-9d57-e6f5fa1c5097/183b2b5d-5af7-44b7-9edd-a190eaba511d) for user user-1 (agent=OMERO.matlab)
```
