### PR TITLE
Log file truncated (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -3738,11 +3738,7 @@ class OMEROGateway
 			FileOutputStream stream = new FileOutputStream(file);
 			try {
 				try {
-					if (of != null && of.getSize() != null) {
-						size = of.getSize().getValue();
-					} else {
-						size = store.size();
-					}
+				    size = store.size();
 					for (offset = 0; (offset+INC) < size;) {
 						stream.write(store.read(offset, INC));
 						offset += INC;


### PR DESCRIPTION
This is the same as gh-2434 but rebased onto develop.

---

see https://trac.openmicroscopy.org.uk/ome/ticket/12152

To test
- Import an image
- when complete Click on View Log file
  - Check that the content does not stop at step 4 but ends up with something like

```
2014-05-02 20:58:41,157 INFO  [                      omero.cmd.SessionI] (.Server-30) Unregistered servant:eed929b2-8c25-4372-ac5e-1159f5bd5e60/a485b1dc-0f57-4225-abc1-7f7d232de8bbomero.api.ThumbnailStore(omero.api._ThumbnailStoreTie@b5427ddd)
2014-05-02 20:58:41,157 DEBUG [                omero.util.ServantHolder] (.Server-31) Removed omero.api._MetadataStoreTie@9b7144cc from omero.util.ServantHolder@e8afd6c as 2b9b8806-14a3-4270-a69b-688997d5c61domero.api.MetadataStore
2014-05-02 20:58:41,157 INFO  [                      omero.cmd.SessionI] (.Server-31) Unregistered servant:eed929b2-8c25-4372-ac5e-1159f5bd5e60/2b9b8806-14a3-4270-a69b-688997d5c61domero.api.MetadataStore(omero.api._MetadataStoreTie@9b7144cc)
2014-05-02 20:58:41,158 INFO  [    o.s.blitz.repo.ManagedImportRequestI] (2-thread-5) Finalizing log file.
```
