### PR TITLE
Cut menu tb

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/BrowserManageAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/BrowserManageAction.java
@@ -271,26 +271,26 @@ public class BrowserManageAction
  						if (model.canLink(selected[i].getUserObject())) 
  							count++;
  					}
- 		    		if (index == CUT) {
- 		    			if (ho instanceof DatasetData) {
- 		    				if (!(parent instanceof ProjectData)) {
- 		    					setEnabled(false);
- 		    					return;
- 		    				}
- 		    			} else if (ho instanceof ImageData) {
- 		    				if (!(parent instanceof DatasetData || 
- 		    						parent instanceof TagAnnotationData)) {
- 		    					setEnabled(false);
- 		    					return;
- 		    				}
- 		    			} else if (ho instanceof PlateData) {
- 		    				if (!(parent instanceof ScreenData)) {
- 		    					setEnabled(false);
- 		    					return;
- 		    				}
- 		    			}
- 		    		}
- 		    		setEnabled(count == selected.length);
+ 		    		if (index == COPY) {
+ 	                    if (ho instanceof DatasetData) {
+ 	                        if (!(parent instanceof ProjectData)) {
+ 	                            setEnabled(false);
+ 	                            return;
+ 	                        }
+ 	                    } else if (ho instanceof ImageData) {
+ 	                        if (!(parent instanceof DatasetData ||
+ 	                                parent instanceof TagAnnotationData)) {
+ 	                            setEnabled(false);
+ 	                            return;
+ 	                        }
+ 	                    } else if (ho instanceof PlateData) {
+ 	                        if (!(parent instanceof ScreenData)) {
+ 	                            setEnabled(false);
+ 	                            return;
+ 	                        }
+ 	                    }
+ 	                }
+ 	                setEnabled(count == selected.length);
  				} else if (ho instanceof ExperimenterData) {
  					setEnabled(model.getBrowserType() == 
  						Browser.ADMIN_EXPLORER);


### PR DESCRIPTION
Fix https://trac.openmicroscopy.org.uk/ome/ticket/12253

to test:
- Select an orphaned dataset is selected in Insight
- the toolbar gives the Copy option and Cut is greyed out
- the right-click menu gives the Edit > Cut option but the copy option is greyed out
