### PR TITLE
Fix permissions in bulk annotation script (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -440,11 +440,10 @@ class ParsingContext(object):
     def write_to_omero(self):
         sf = self.client.getSession()
         group = str(self.value_resolver.target_object.details.group.id.val)
-        sf.setSecurityContext(omero.model.ExperimenterGroupI(group, False))
         sr = sf.sharedResources()
         update_service = sf.getUpdateService()
         name = 'bulk_annotations'
-        table = sr.newTable(1, name)
+        table = sr.newTable(1, name, {'omero.group': group})
         if table is None:
             raise MetadataError(
                 "Unable to create table: %s" % name)
@@ -463,7 +462,7 @@ class ParsingContext(object):
         link = self.create_annotation_link()
         link.parent = self.target_object
         link.child = file_annotation
-        update_service.saveObject(link)
+        update_service.saveObject(link, {'omero.group': group})
 
 def parse_target_object(target_object):
     type, id = target_object.split(':')


### PR DESCRIPTION
This is the same as gh-2420 but rebased onto develop.

---

See https://trac.openmicroscopy.org.uk/ome/ticket/12210

It looks like the OriginalFile is being created in the user's _default_ group but the update of the AnnotationLink is explicitly using the group of the target Plate or Screen. For a simple user with one group this is fine, for other group combinations the link may fail or may be across groups.

Testing is tricky. You need a user who has several groups, one read-only and one read-write at least. A Plate should be imported into the read-only group as per https://www.openmicroscopy.org/private/ome-internal/testing_scenarios/BulkAnnotations.html  That scenario should complete without a SecurityViolation exception.
