### PR TITLE
Enable multi-select in Tags tree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -292,9 +292,9 @@
                         // For UI & core - the nodes to initially select and open will be overwritten by the cookie plugin
                         // the UI plugin - it handles selecting/deselecting/hovering nodes
                         "ui" : {
-                            "select_limit" : 1,
-                            "select_multiple_modifier" : false,
-                            "select_range_modifier" : false,
+                            "select_limit" : -1,
+                            "select_multiple_modifier": OME.multi_key(),
+                            "disable_selecting_children": true,
                             "initially_select" : [ {% if init.initially_select %}{% for s in init.initially_select%}"{{s}}",{% endfor %}""{% else %}"experimenter-0"{% endif %}  ],
                         },
                         // the core plugin - not many options here


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/11668
This enables multi-selection in the tree on the Tags page.

To test, browse tags that have multiple images under them, select multiple images. Right-hand panel displays "Batch Annotate" panel as normal, for annotating images.
NB: If multiple Tags are selected, right panel is blank since it doesn't support batch annotation of Tags.
