### PR TITLE
Parse inputs unwrap issue2439

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -1100,9 +1100,8 @@ def parseInputs(client, session, processFn=IdentityFn):
     inputKeys = client.getInputKeys();
     commandArgs = {};
     for key in inputKeys:
-        commandArgs[key]=client.getInput(key).getValue();
+        commandArgs[key] = unwrap(client.getInput(key));
     return processFn(commandArgs);
-
 
 def getROIFromImage(iROIService, imageId, namespace=None):
     """


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/issues/2439

Commit from @carandraug to fix partial unwrapping in script_utils.parseInputs().

Can be tested by updating an existing script to use this, as shown in https://github.com/MicronOxford/ome-scripts/commit/e2b9815
