### PR TITLE
Add missing deps to omero_client.jar (fix #12166) (rebased onto develop)

### DIFF
--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -67,8 +67,7 @@
                 <exclude name="omero/sys/_*Del*.class"/>
             </fileset>
             <fileset dir="${common.comp}/target/classes">
-                <include name="ome/system/UpgradeCheck.class"/>
-                <include name="ome/system/OmeroContext.class"/>
+                <include name="ome/system/*.class"/>
                 <include name="ome/util/checksum/*.class"/>
             </fileset>
             <fileset dir="${model.comp}/target/classes">


### PR DESCRIPTION
This is the same as gh-2393 but rebased onto develop.

---

 This PR updates the ant build file in `OmeroJava`. Java dependencies mentioned in https://trac.openmicroscopy.org.uk/ome/ticket/12166 should now be present.
To test, try using the JAR files mentioned in the ticket in Matlab.

/cc @joshmoore, @bramalingam
