### PR TITLE
Bugfix: Prevent user/group deletion (rebased onto dev_5_0)

### DIFF
--- a/components/blitz/src/pojos/ExperimenterData.java
+++ b/components/blitz/src/pojos/ExperimenterData.java
@@ -201,7 +201,7 @@ public class ExperimenterData extends DataObject {
             for (GroupExperimenterMap link : links) {
                     // if you somehow managed to delete a user's default group
                     // link can be null!
-                    if(link!=null) {
+                    if (link != null) {
                         groups.add(new GroupData(link.getParent()));
                     }
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1903,7 +1903,7 @@ class TreeViewerComponent
 		} else b = EditorUtil.isUserOwner(ho, id);
 		if (b) return b; //user is the owner.
 		GroupData group = null;
-		if(ho instanceof ExperimenterData || ho instanceof GroupData) {
+		if (ho instanceof ExperimenterData || ho instanceof GroupData) {
 		    // users and groups should not be deleted at all
 		    return false;
 		}


### PR DESCRIPTION
This is the same as gh-2426 but rebased onto dev_5_0.

---

With this PR it's not possible anymore to delete users or groups via the DEL key
See https://trac.openmicroscopy.org.uk/ome/ticket/12232
