### PR TITLE
Servants per session (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
+++ b/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
@@ -184,7 +184,7 @@ public final class SessionManagerI extends Glacier2._SessionManagerDisp
             Principal sp = new Principal(s.getUuid(), group, event);
             // Event raised to add to Ring
 
-            ServantHolder holder = new ServantHolder(s.getUuid());
+            ServantHolder holder = new ServantHolder(s.getUuid(), servantsPerSession);
             ServantHolder previous = sessionToHolder.putIfAbsent(s.getUuid(), holder);
             if (previous != null) {
                 holder = previous;


### PR DESCRIPTION
This is the same as gh-2468 but rebased onto develop.

---

While looking into an `OverUsageException` issue for @bramalingam, I noticed that the property set in `etc/omero.properties` was not being passed to `ServantHolder`. This fix should simply make changes via `bin/omero config set` propagate. Setting an abnormally low value (e.g. 10) should cause errors quite quickly. Setting to a more reasonable but yet low value (100) might also help find leak issues sooner.
