### PR TITLE
omero.scripts.Type: add getter for name attr. (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroPy/src/omero/scripts.py
+++ b/components/tools/OmeroPy/src/omero/scripts.py
@@ -150,6 +150,9 @@ class Type(omero.grid.Param):
         self.prototype = wrap(arg)
         return self
 
+    def name(self):
+        return self._name
+
     def __get(self, val, func = True):
         if val is not None:
             if func:


### PR DESCRIPTION
This is the same as gh-2467 but rebased onto dev_5_0.

---

Just a simple addition to the Type class.
