### PR TITLE
Repeat running testImageMultipleGroups 10 times.

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -195,7 +195,8 @@ class TestDownload(CLITest):
         with py.test.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    def testImageMultipleGroups(self, tmpdir):
+    @py.test.mark.parametrize('repeat', xrange(0, 10))
+    def testImageMultipleGroups(self, repeat, tmpdir):
         user, group1, group2 = self.setup_user_and_two_groups()
         client = self.new_client(user=user, password="ome")
         filename = self.OmeroPy / ".." / ".." / ".." / \


### PR DESCRIPTION
This should help identify a pattern in the failures observed on Jenkins. The code change won't make it to the codebase (don't merge).
--no-rebase
