### PR TITLE
Publishing grey out (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
@@ -277,17 +277,18 @@ class PublishingDialog
     			data = img.getDefaultPixels();
     			boolean b = !model.isLargeImage();
     			exportAsOmeTiffButton.setEnabled(b);
-    			if (model.isSingleMode()) {
-    			    movieButton.setEnabled(data.getSizeT() > 1 || 
-                            data.getSizeZ() > 1);
-                    splitViewFigureButton.setEnabled(data.getSizeC() > 1);
-                    exportAsOmeTiffItem.setEnabled(b);
-                    movieItem.setEnabled(data.getSizeT() > 1 || 
-                            data.getSizeZ() > 1);
-                    splitViewFigureItem.setEnabled(b && data.getSizeC() > 1);
-                    splitViewROIFigureItem.setEnabled(b && data.getSizeC() > 1);
-                    movieFigureItem.setEnabled(true);
+    			exportAsOmeTiffItem.setEnabled(b);
+    			if (!model.isSingleMode()) {
+    			    exportAsOmeTiffItem.setEnabled(false);
     			}
+    			movieButton.setEnabled(data.getSizeT() > 1 ||
+                        data.getSizeZ() > 1);
+                splitViewFigureButton.setEnabled(data.getSizeC() > 1);
+                movieItem.setEnabled(data.getSizeT() > 1 ||
+                        data.getSizeZ() > 1);
+                splitViewFigureItem.setEnabled(b && data.getSizeC() > 1);
+                splitViewROIFigureItem.setEnabled(b && data.getSizeC() > 1);
+                movieFigureItem.setEnabled(true);
 			} catch (Exception e) {}
     	} else {
     		if (refObject instanceof DatasetData)


### PR DESCRIPTION
This is the same as gh-2458 but rebased onto develop.

---

Roll back some modifications introduced while working between version 4 and version 5.
To test:
- Select 2 images with more than one channels
- Go to the publishing menu
- Check that split view is not greyed out.
- Select the split view item
- Run the script.
- Check that the generated .jpg has the 2 images "split"

see https://trac.openmicroscopy.org.uk/ome/ticket/12251
