### PR TITLE
NPE when loading tiles

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1261,6 +1261,12 @@ public interface ImViewer
 	boolean isCompressed();
 
 	/**
+         * Checks if the {@link Renderer} is loaded
+         * @return <code>true</code> if the Renderer is loaded, <code>false</code> otherwise
+         */
+	boolean isRendererLoaded();
+	
+	/**
 	 * Returns the security context.
 	 * 
 	 * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -767,6 +767,14 @@ class ImViewerComponent
 	 */
 	public boolean isZoomFitToWindow() { return model.isZoomFitToWindow(); }
 
+	/**
+         * Implemented as specified by the {@link ImViewer} interface.
+         * @see ImViewer#isRendererLoaded()
+         */
+	public boolean isRendererLoaded() {
+	    return model.isRendererLoaded();
+	}
+	
 	/** 
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#setColorModel(int)
@@ -3331,10 +3339,6 @@ class ImViewerComponent
     	if (tiles == null) return;
     	//invalidate images.
     	Dimension d = model.getTileSize();
-    	if (d == null) {
-    	    // i. e. the Renderer has not been loaded yet
-    	    return;
-    	}
     	int width = d.width;
     	int height = d.height;
     	int cs = region.x/width;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.iviewer.view.ImViewerControl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -1115,7 +1115,7 @@ class ImViewerControl
 	public void componentResized(ComponentEvent e) 
 	{ 
 		//Review that code.
-		if (model.isBigImage()) {
+		if (model.isBigImage() && model.isRendererLoaded() ) {
 			model.loadTiles(null);
 		} else {
 			if (model.isZoomFitToWindow()) 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -622,6 +622,14 @@ class ImViewerModel
 	}
 	
 	/**
+	 * Checks if the {@link Renderer} is loaded
+	 * @return <code>true</code> if the Renderer is loaded, <code>false</code> otherwise
+	 */
+	boolean isRendererLoaded() {
+	    return metadataViewer.getRenderer() != null;
+	}
+	
+	/**
 	 * Returns the current user's details.
 	 * 
 	 * @return See above.


### PR DESCRIPTION
There is a NPE occasionally (seems to happen on nightshade only) when tiles are loaded; I have not been able to reproduce it. This PR doesn't fix the issue, but at least it gives us information about what image(s) is affected, when it happens next time.
There's nothing to test for this PR.
