### PR TITLE
Group security violation 11479 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -5,7 +5,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2014 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -4,7 +4,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2014 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -3,7 +3,7 @@
 # 
 # 
 # 
-# Copyright (c) 2008-2013 University of Dundee. 
+# Copyright (c) 2008-2014 University of Dundee.
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
This is the same as gh-2485 but rebased onto develop.

---

See #2369 and https://trac.openmicroscopy.org.uk/ome/ticket/11479

If Admin tries to change a 'read-annoate' group to 'private', this will fail if any links have been created between users' data (see #2369) and this PR handles the Exception thrown.

To test:
- Pick or create a read-annotate group that has links between one user's data and another user's tags.
- As Admin, edit the group, trying to set it to 'priavate'
- Should see an appropriate warning that this may fail.
- It should fail and you get a warning.

![screen shot 2014-05-13 at 00 04 48](https://cloud.githubusercontent.com/assets/900055/2951584/e8a843ec-da29-11e3-9977-5fd0d7e5b388.png)
