### PR TITLE
EventLog Query (trac-12279)

### DIFF
--- a/components/server/src/ome/services/eventlogs/EventLogLoader.java
+++ b/components/server/src/ome/services/eventlogs/EventLogLoader.java
@@ -101,7 +101,9 @@ public abstract class EventLogLoader implements Iterator<EventLog>,
 
     /**
      * Build a query string based on the current {@link #excludes} {@link List}.
-     * The query expects a single :id parameter to be set on execution.
+     * The query expects a single :id parameter to be set on execution. The
+     * {@link #excludes} list is used to filter out unwanted {@link EventLog}
+     * instances.
      */
     private void initQueryString() {
         List<String> copy = excludes; // Instead of synchronizing
@@ -220,8 +222,7 @@ public abstract class EventLogLoader implements Iterator<EventLog>,
     /**
      * Returns the {@link EventLog} with the next id after the given argument or
      * null if none exists. This method will only return "true" {@link EventLog}
-     * instances, with a valid id. The {@link #excludes} list is used to filter
-     * out unwanted {@link EventLog} isntances.
+     * instances, with a valid id.
      */
     public final EventLog nextEventLog(long id) {
         if (query == null) {


### PR DESCRIPTION
See: https://trac.openmicroscopy.org.uk/ome/ticket/12279

The memory dump from the demo server had over 800MB tied up
in `char[]` all belonging to the `Launcher$AppClassLoader`.
Nearly all of them (>400K instances) were of the form:

  `select el from EventLog el where el.id > SOMEID`

That change is from roughly 2009 yet I've never seen
precisely this issue. Perhaps the recent move of the
`flush()` invocation was leaving more instances dangling.
In any event, this should collapse all 400K instances
down to one.

To test, check that the indexer process is progressing normally and that there is no undue memory growth. A snapshot of the heap (using `jmap -dump:file=somefilename.hprof $PID`) might be taken to look for growing numbers.
