### PR TITLE
Update permission downgrade message (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.ui.PermissionsPane 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -45,7 +45,6 @@ import javax.swing.JRadioButton;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
-import org.openmicroscopy.shoola.env.ui.AbstractIconManager;
 import org.openmicroscopy.shoola.env.ui.RefWindow;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
@@ -79,9 +78,8 @@ public class PermissionsPane
 	private static final String WARNING_TITLE = "Permissions Downgrade";
 		
 	/** Warning message. */
-	private static final String WARNING = "Changing group to Private " +
-			"will remove\nany Annotations etc added under Read-Annotate " +
-			"permissions.";
+	private static final String WARNING = " Changing group to Private may fail if links"
+	        + " have been\n created under Read-Annotate permissions.";
 	
 	/** Indicate that the group has <code>RWRA--</code>. */
     //private JRadioButton		collaborativeGroupBox;


### PR DESCRIPTION
This is the same as gh-2501 but rebased onto develop.

---

Updated the warning message shown when a group is going to be downgraded to Read-Only; to match OMERO.web, see PR #2485
Showing an error dialog if downgrade really fails, has to be tackled with another PR for 5.0.3 as it is a bigger change.
