### PR TITLE
Copy paste bug 12295

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -67,7 +67,7 @@
 			
 			
             {% for c in screens %}
-            <li id='screen-{{ c.id }}' rel="screen{% if not c.isOwned %}-locked{% endif %}" class="{{ c.getPermsCss }}">
+            <li id='screen-{{ c.id }}' rel="screen{% if not c.isOwned %}-locked{% endif %}" class="{{ c.permsCss }}">
 				<a href="#">{{ c.name|default:"Screen"|truncatebefor:"35" }} {% if c.childCount %}
 					<span class="children_count" id="counter-screen-{{ c.id }}">{{ c.childCount }}</span>{% endif %}</a>
                 {% if c.childCount %}


### PR DESCRIPTION
This appears to fix the blocker.
Caused by tree marshal_projects() using 'permsCss' as a key for the project dict, but the template was still using getPermsCss.

I haven't checked the extent to which this mismatch might exist in other templates using tree marshall methods. It relies on a template to 'know' whether the object is a Blitz Object Wrapper or a marshal dict. Maybe the tree marshal methods should use 'getPermsCss' as their dict key, to avoid possible conflicts.

cc @chris-allan @cneves Opinion?

Certainly need to spend a bit more time checking that this bug is not occurring elsewhere.
