### PR TITLE
big_image_link_xy_11844 (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -307,6 +307,16 @@ jQuery._WeblitzViewport = function (container, server, options) {
           zoom_levels = _this.loadedImg.levels,
           zoomLevelScaling = _this.loadedImg.zoomLevelScaling;  // may be 'undefined'
           nominalMagnification = _this.loadedImg.nominalMagnification;  // may be 'undefined'
+          // If zm set in query, see if this is a supported zoom level
+          if (typeof _this.loadedImg.query_zoom != "undefined") {
+            var query_zm = _this.loadedImg.query_zoom / 100;
+            for (var zm=0; zm<zoom_levels; zm++) {
+              if (zoomLevelScaling[zm] == query_zm) {
+                init_zoom = (zoom_levels-1) - zm;
+                break;
+              }
+            }
+          }
           // If init_zoom not defined, Zoom out until we fit in the viewport (window)
           if (typeof init_zoom === "undefined") {
             init_zoom = zoom_levels-1;   // fully zoomed in
@@ -816,7 +826,11 @@ jQuery._WeblitzViewport = function (container, server, options) {
 
   this.getZoom = function () {
     if (_this.loadedImg.tiles) {
-      return _this.viewportimg.get(0).getBigImageContainer().currentScale()*100;
+      var viewerBean = _this.viewportimg.get(0).getBigImageContainer();
+      if (viewerBean) {
+        return viewerBean.currentScale()*100;
+      }
+      return 100;
     }
     return _this.loadedImg.current.zoom;
   };
@@ -958,8 +972,8 @@ jQuery._WeblitzViewport = function (container, server, options) {
     if (this.loadedImg.current.quality) {
       query.push('q=' + this.loadedImg.current.quality);
     }
-    /* Zoom */
-    query.push('zm=' + this.loadedImg.current.zoom);
+    /* Zoom - getZoom() also handles big images */
+    query.push('zm=' + this.getZoom());
     /* Slider positions */
     if (include_slider_pos) {
       query.push('t=' + (this.loadedImg.current.t+1));
@@ -1021,7 +1035,10 @@ jQuery._WeblitzViewport = function (container, server, options) {
     query.q && this.setQuality(query.q, true);
     query.p && this.setProjection(query.p, true);
     query.p && this.setInvertedAxis(query.ia, true);
-    query.zm && this.setZoom(parseInt(query.zm, 10));
+    if (query.zm) {
+      this.loadedImg.query_zoom = query.zm;  // for big images
+      this.setZoom(parseInt(query.zm, 10));
+    }
     if (query.t) {
       this.loadedImg.current.t = parseInt(query.t, 10)-1;
     }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -506,7 +506,14 @@ jQuery.fn.viewportImage = function(options) {
             PanoJS.MSG_BEYOND_MAX_ZOOM = null;
             viewerBean.init();
             if ((typeof init_cx != 'undefined') && (typeof init_cy != 'undefined')) {
-                viewerBean.recenter({'x':parseInt(init_cx, 10), 'y':parseInt(init_cy, 10)}, true, true);
+                var scale = viewerBean.currentScale();
+                viewerBean.recenter({
+                    'x':parseInt(init_cx, 10)*scale,
+                    'y':parseInt(init_cy, 10)*scale}, true, true);
+                // Seems that if we're on the edge of image, blank tiles are not cleared...
+                setTimeout(function() {
+                  viewerBean.positionTiles();
+                }, 5000);   // clear AFTER they have loaded (not ideal!)
             }
             if (viewerBean.thumbnail_control) {
                 viewerBean.thumbnail_control.update();


### PR DESCRIPTION
This is the same as gh-1926 but rebased onto dev_5_0.

---

This fixes the "Image Link" creation and processing, so that you can 'bookmark' a location and zoom level on a Big Image (see https://trac.openmicroscopy.org.uk/ome/ticket/11844).

To test, 
- open a Big image in web viewer
- pan and zoom to a chosen location (note zoom and remember what feature you're looking at)
- copy "Image Link" from left of window
- paste Link into another window (or another browser - login if needed) and check that you are directed to same location and zoom level.
- Regression test - check that simply loading image (without following link) loads at centre of image and zoomed out.
