### PR TITLE
Orphaned missing

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -1333,7 +1333,7 @@ class BrowserUI
 				bottom.add(object);
 			else if (object instanceof SmartFolder ||
 			        object instanceof TreeFileSet)
-				bottom.add(object);
+				bottom2.add(object);
 		}
 		List<TreeImageDisplay> all = new ArrayList<TreeImageDisplay>();
 		if (top.size() > 0) all.addAll(top);


### PR DESCRIPTION
To test this PR
- Go to the Project tabs
- Click toggle between order alphabetically and by date.
- The orphaned folder should still be visible and should be the last one. 
- Check that objects are correctly ordered.

see https://trac.openmicroscopy.org.uk/ome/ticket/12294
