### PR TITLE
Image link hash bug 12304 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1179,8 +1179,8 @@
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
                 {% ifnotequal roiCount 0 %}
-                    <a href="#" onclick="show_rois()">Show ROIs</a> |
-                    <a href="#" onclick="hide_rois()">Hide</a>
+                    <a href="#" onclick="show_rois(); return false;">Show ROIs</a> |
+                    <a href="#" onclick="hide_rois(); return false;">Hide</a>
                 {% endifnotequal %}
           </div>
 {% endblock roi_buttons %}


### PR DESCRIPTION
This is the same as gh-2531 but rebased onto develop.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12304.

To test, open image viewer and either click the "Show ROIs" link or manually add a `#` to the end of the url. Then click "Image Link" and check that the link is valid (works when copied and pasted into browser). Check the url doesn't have the imageId duplicated: E.g. `...img_detail/<imageId>/#/<imageId>/?c=...`
