### PR TITLE
Admin move to group 12305 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -410,11 +410,12 @@ def load_template(request, menu, conn=None, url=None, **kwargs):
     request.session['user_id'] = user_id
 
     myGroups = list(conn.getGroupsMemberOf())
+    myGroups.sort(key=lambda x: x.getName().lower())
     if conn.isAdmin():  # Admin can see all groups
         groups = [g for g in conn.getObjects("ExperimenterGroup") if g.getName() not in ("user", "guest")]
+        groups.sort(key=lambda x: x.getName().lower())
     else:
         groups = myGroups
-    myGroups.sort(key=lambda x: x.getName().lower())
     new_container_form = ContainerForm()
 
     context = {'init':init, 'myGroups':myGroups, 'new_container_form':new_container_form, 'global_search_form':global_search_form}


### PR DESCRIPTION
This is the same as gh-2541 but rebased onto develop.

---

This fixes the list of Groups available for an Admin when they right-click and "Move to Group". Now we only show the groups that the Admin is a member of.

This is a partial fix for http://trac.openmicroscopy.org.uk/ome/ticket/12305

To test, log in as Admin, right click on Dataset or Image -> Move to Group.
List of groups should only be the ones that the Admin is a member of.
