### PR TITLE
Search id order bug 12310 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -47,8 +47,8 @@
                 }
             });
             
-            
-            $("#dataTable").tablesorter( {sortList: [[1,0]]} ); 
+            // We init sorting (not cols 0 & 3) but don't sort by default
+            $("#dataTable").tablesorter({headers: { 0: { sorter: false}, 3: {sorter: false} } });
 
             $('input#id_search').quicksearch('table#dataTable tbody tr', {
                 'delay': 300,


### PR DESCRIPTION
This is the same as gh-2543 but rebased onto develop.

---

See http://trac.openmicroscopy.org.uk/ome/ticket/12310

To test:
Search for images / datasets etc by ID: The data found by ID should always appear at the top of the search results, with data found by other attributes below.
