### PR TITLE
Move kill session to global teardown (rebased)

### DIFF
--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -726,4 +726,6 @@ class ITest(object):
         return rsp
 
     def teardown_method(self, method):
+        self.root.killSession()
+        self.root = None
         self.__clients.__del__()

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -826,9 +826,8 @@ class TestPermissions(lib.ITest):
         assert script.size.val ==  len(data)
         try:
             store.close()
-        finally:
-            self.root.killSession()
-            self.root = None
+        except:
+            pass
 
     def testUseOfRawFileBeanScriptReadGroupMinusOne(self):
         self.assertValidScript(lambda v: {'omero.group': '-1'})


### PR DESCRIPTION
This is the same as gh-2428 rebased onto dev_5_0. See details there but it should be a just a case of existing tests passing.

--rebased-from #2428
