### PR TITLE
11472 empty min max string

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/script.py
+++ b/components/tools/OmeroPy/src/omero/plugins/script.py
@@ -527,6 +527,7 @@ class ScriptControl(BaseControl):
                             proto_value = None
 
                         self.ctx.out("    Subtype: %s" % proto_value)
+
                     # ticket:11472 - string min/max need quoting
                     def min_max(x):
                         if x:
@@ -537,6 +538,7 @@ class ScriptControl(BaseControl):
                             else:
                                 return x.val
                         return ""
+
                     self.ctx.out("    Min: %s" % min_max(v.min))
                     self.ctx.out("    Max: %s" % min_max(v.max))
                     values = omero.rtypes.unwrap(v.values)


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/11472

A script which has an empty max string should show as much from the CLI. Steps to test:

**1.** Create the following script and upload it as an official script

```
import omero
import omero.scripts as _os
import omero.rtypes as _ot
c = _os.client("test", _os.String("a", max=_ot.rstring(""), optional=False))
```

**2.** List the params for that script:
```id:  14798
name:  test
...
inputs:
  a - (no description)
    Optional: False
    Type: ::omero::RString
    Min: 
    Max: ''  <--- This is the important bit
    Values: 
outputs:

```
```
