### PR TITLE
doc: fix incorrect documentation for ImageWrapper.getPixelsType (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5422,20 +5422,27 @@ class _PixelsWrapper (BlitzObjectWrapper):
 
     def getPixelsType (self):
         """
-        This simply wraps the PixelsType object in a BlitzObjectWrapper.
-        Shouldn't be needed when this is done automatically
+        This simply wraps the omero::model::PixelsType object in a
+        BlitzObjectWrapper. Shouldn't be needed when this is done automatically.
+
+        It has the methods `getValue' and `getBitSize'.
         """
         return BlitzObjectWrapper(self._conn, self._obj.getPixelsType())
 
     def copyPlaneInfo (self, theC=None, theT=None, theZ=None):
         """
-        Loads plane infos and returns sequence of omero.model.PlaneInfo objects wrapped in BlitzObjectWrappers
-        ordered by planeInfo.deltaT.
+        Loads plane infos and returns sequence of omero.model.PlaneInfo objects
+        wrapped in BlitzObjectWrappers ordered by planeInfo.deltaT.
         Set of plane infos can be filtered by C, T or Z
 
         @param theC:    Filter plane infos by Channel index
+        @type  theC:    int or None
         @param theT:    Filter plane infos by Time index
+        @type  theT:    int or None
         @param theZ:    Filter plane infos by Z index
+        @type  theT:    int or None
+
+        @return:  Generator of PlaneInfo wrapped in BlitzObjectWrappers
         """
 
         params = omero.sys.Parameters()
@@ -7362,10 +7369,10 @@ class _ImageWrapper (BlitzObjectWrapper):
     @assert_pixels
     def getPixelsType (self):
         """
-        Gets the physical size X of pixels in microns
+        Gets name of pixel data type.
 
-        @return:    Size of pixel in x or O
-        @rtype:     float
+        @return:    name of the image precision, e.g., float, uint8, etc.
+        @rtype:     String
         """
         rv = self._obj.getPrimaryPixels().getPixelsType().value
         return rv is not None and rv.val or 'unknown'


### PR DESCRIPTION
This is the same as gh-2548 but rebased onto dev_5_0.

---

The documentation for getPixelsType was incorrect (copy and paste from getPixelSizeX).

While doing it I added a bit more detail to what getPixelsType can be used for (otherwise one has to follow into the Java documentation which is not so obvious for someone without java knowledge).
