### PR TITLE
Fixed NPE

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2228,9 +2228,13 @@ class ImViewerModel
 	 */
 	boolean isOriginalPlane()
 	{
-		if (originalDef.getDefaultZ() != getDefaultZ()) return false;
-		if (originalDef.getDefaultT() != getDefaultT()) return false;
-		return true;
+            if (originalDef != null) {
+                if (originalDef.getDefaultZ() != getDefaultZ())
+                    return false;
+                if (originalDef.getDefaultT() != getDefaultT())
+                    return false;
+            }
+            return true;
 	}
 	
 	/**


### PR DESCRIPTION
Just fixed a NPE, see https://trac.openmicroscopy.org.uk/ome/ticket/12365
Don't know how to test (how to get into the state that originalDef is not set), maybe a code review is sufficient?
Just applied the same logic to isOriginalPlane() as isOriginalSettings(), i. e. originalDef==null implies nothing has changed, return true.
