### PR TITLE
Use numpy.float32 for PixelsType 'float' (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5511,7 +5511,7 @@ class _PixelsWrapper (BlitzObjectWrapper):
                 "int32":['i',numpy.int32],
                 "uint32":['I',numpy.uint32],
                 "float":['f',numpy.float32],
-                "double":['d', numpy.double]}
+                "double":['d', numpy.float64]}
 
         rawPixelsStore = self._prepareRawPixelsStore()
         sizeX = self.sizeX


### PR DESCRIPTION
This is the same as gh-2572 but rebased onto develop.

---

See: https://github.com/openmicroscopy/openmicroscopy/issues/2547

Fixes numpy type to use with 32-bit 'float' datatype, explicitly specifying float32 type.

To test, import an image of 'float' datatype, and check we get 'float32' when we do:

```
>>> i = conn.getObject("Image", 8502)
>>> p = i.getPrimaryPixels()
>>> plane = p.getPlane()
>>> plane.dtype
dtype('float32')
```
