### PR TITLE
Reduce memoizer wait to 0 (Fix #10337)

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -122,7 +122,7 @@ omero.pixeldata.backoff=ome.io.nio.SimpleBackOff
 # Maximum time in milliseconds that file parsing
 # can take without the parsed metadata being
 # cached to BioFormatsCache.
-omero.pixeldata.memoizer_wait=100
+omero.pixeldata.memoizer_wait=0
 
 # Whether the PixelData.dispose() method should
 # try to clean up ByteBuffer instances which may


### PR DESCRIPTION
See http://trac.openmicroscopy.org.uk/ome/ticket/10337

For relatively fast setId alls, no bfmemo file
was being produced. Lowering this value to zero
shaved off 1/3 of the setId time, though, even
for fast files.

This should also prevent discrepancies when the
system is underload: now a memo file will always
be produced.

_To test, check the `DEBUG` messages for the `loci.formats.Memoizer` in the Blitz-0.log. There should be no memo file creations which are skipped. Even a fake file import should create one._
