### PR TITLE
Add wsgi.py for OMERO.web (develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/wsgi.py
+++ b/components/tools/OmeroWeb/omeroweb/wsgi.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+   WSGI config for the OMERO.web project.
+
+   Copyright 2014 Glencoe Software, Inc. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+
+"""
+
+"""
+This module contains the WSGI application used by Django's development server
+and any production WSGI deployments. It should expose a module-level variable
+named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
+this application via the ``WSGI_APPLICATION`` setting.
+
+Usually you will have the standard Django WSGI application here, but it also
+might make sense to replace the whole Django WSGI application with a custom one
+that later delegates to the Django one. For example, you could introduce WSGI
+middleware here, or combine a Django application with an application of another
+framework.
+
+"""
+import os
+import sys
+
+# OMERO.web is set up with the "omeroweb" package also on the PYTHONPATH
+sys.path.append(os.path.dirname(__file__))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
+
+# This application object is used by any WSGI server configured to use this
+# file. This includes Django's development server, if the WSGI_APPLICATION
+# setting points here.
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+
+# Apply WSGI middleware here.
+# from helloworld.wsgi import HelloWorldApplication
+# application = HelloWorldApplication(application)


### PR DESCRIPTION
`develop` version of #2352 

Since Django 1.4 the wsgi.py has been included in all new Django
projects to ease integration with WSGI aware web servers.  Adding this
allows the alternative ways of deploying OMERO.web such as:
- Gunicorn (http://gunicorn.org/)
- uWSGI (http://uwsgi-docs.readthedocs.org/en/latest/)

As well as many others.  Static content serving is also supported in
multi-process mode with automatic restarts after changes.
