### PR TITLE
Fixed Search by Tag NPEs (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
@@ -681,6 +681,8 @@ public class SelectionWizardUI
             TagAnnotationData t = (TagAnnotationData) item.getUserObject();
             if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(t.getNameSpace())) {
                 Set<TagAnnotationData> tags = t.getTags();
+                if (CollectionUtils.isEmpty(tags))
+                    continue;
                 for (TagAnnotationData n : tags) {
                     if (n.getId() == tag.getId()) {
                         parents.add(t);
@@ -815,6 +817,8 @@ public class SelectionWizardUI
                 if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(
                         tag.getNameSpace())) {
                     Set<TagAnnotationData> children = tag.getTags();
+                    if (CollectionUtils.isEmpty(children))
+                        continue;
                     Iterator<TagAnnotationData> j = children.iterator();
                     DataObject o;
                     while (j.hasNext()) {


### PR DESCRIPTION
This is the same as gh-2605 but rebased onto develop.

---

See Ticket https://trac.openmicroscopy.org.uk/ome/ticket/12368
If there are empty tagsets Insight crashed with a NPE after a tag was selected in the tag selection dialog (search panel).
Test:
Make sure there is at least one empty tagset; Open the search panel; Open the tag selection dialog by clicking on the tag icon; select some tags to search for.
