### PR TITLE
Exclude failing table tests from Travis (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
@@ -325,6 +325,7 @@ class TestTables(lib.TestCase):
         assert not storage.uptodate(table.stamp)
         table.cleanup()
 
+    @pytest.mark.xfail(reason="See ticket #12372")
     def testTableAddData(self, newfile=True, cleanup=True):
         mocktable = self.testTables(newfile)
         table = mocktable.table
@@ -341,6 +342,7 @@ class TestTables(lib.TestCase):
             table.cleanup()
         return table
 
+    @pytest.mark.xfail(reason="See ticket #12372")
     def testTableSearch(self):
         table = self.testTableAddData(True, False)
         rv = list(table.getWhereList('(a==1)', None, None, None, None, None))


### PR DESCRIPTION
This is the same as gh-2618 but rebased onto develop.

---

As recently reported by @dominikl, @jburel and others, Travis intermittently fails with 2 of the table tests with an `Internal Exception`. This intermittent failure is captured by https://trac.openmicroscopy.org.uk/ome/ticket/12372. 

Until someone takes the time to investigate what goes wrong there, this PR marks these tests as `xfail` so that these intermittent failures do not affect our workflow as they do now.
