### PR TITLE
Hibernate mapping of Event object

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -1,5 +1,5 @@
 --
--- Copyright 2006 University of Dundee. All rights reserved.
+-- Copyright 2006-2014 University of Dundee. All rights reserved.
 -- Use is subject to license terms supplied in LICENSE.txt
 --
 
@@ -355,6 +355,12 @@ alter table dbpatch alter message set default 'Updating';
 --
 insert into dbpatch (currentVersion, currentPatch, previousVersion, previousPatch, message)
              values ('@DBVERSION@',  @DBPATCH@,    '@DBVERSION@',   0,             'Initializing');
+
+--
+-- Temporarily make event columns nullable; restored below.
+--
+alter table event alter column "type" drop not null;
+alter table event alter column experimentergroup drop not null;
 
 --
 -- Here we will create the root account and the necessary groups

--- a/components/model/resources/mappings/meta.ome.xml
+++ b/components/model/resources/mappings/meta.ome.xml
@@ -2,9 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# $Id$
-#
-# Copyright 2006 University of Dundee. All rights reserved.
+# Copyright 2006-2014 University of Dundee. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,13 +90,11 @@
 	<type id="ome.model.meta.Event" immutable="true" global="true">
 		<!-- Note: Event is not in model-->
 		<properties>
-<!-- Type & Group are not really optional. Needed to bootstrap.
-        Constraints are added later -->
 			<optional name="status" type="string"/>
 			<required name="time" type="timestamp"/>
 			<required name="experimenter" type="ome.model.meta.Experimenter"/>
-			<optional name="experimenterGroup" type="ome.model.meta.ExperimenterGroup"/>
-			<optional name="type" type="ome.model.enums.EventType"/>
+			<required name="experimenterGroup" type="ome.model.meta.ExperimenterGroup"/>
+			<required name="type" type="ome.model.enums.EventType"/>
 			<optional name="containingEvent" type="ome.model.meta.Event"/>
             <onemany name="logs" type="ome.model.meta.EventLog" inverse="event"/>
 			<manyone name="session" type="ome.model.meta.Session"/>

--- a/sql/psql/OMERO5.0__0/psql-footer.sql
+++ b/sql/psql/OMERO5.0__0/psql-footer.sql
@@ -1,5 +1,5 @@
 --
--- Copyright 2006 University of Dundee. All rights reserved.
+-- Copyright 2006-2014 University of Dundee. All rights reserved.
 -- Use is subject to license terms supplied in LICENSE.txt
 --
 
@@ -1250,6 +1250,12 @@ alter table dbpatch alter message set default 'Updating';
 --
 insert into dbpatch (currentVersion, currentPatch, previousVersion, previousPatch, message)
              values ('OMERO5.0',  0,    'OMERO5.0',   0,             'Initializing');
+
+--
+-- Temporarily make event columns nullable; restored below.
+--
+alter table event alter column "type" drop not null;
+alter table event alter column experimentergroup drop not null;
 
 --
 -- Here we will create the root account and the necessary groups

--- a/sql/psql/OMERO5.0__0/schema.sql
+++ b/sql/psql/OMERO5.0__0/schema.sql
@@ -590,9 +590,9 @@
         containingEvent int8,
         external_id int8 unique,
         experimenter int8 not null,
-        experimenterGroup int8,
+        experimenterGroup int8 not null,
         "session" int8 not null,
-        type int8,
+        type int8 not null,
         primary key (id)
     );;
 


### PR DESCRIPTION
This PR should leave the resulting DB schema unchanged. To be sure of this, have a look at the definition of the `event` table as created from `bin/omero db script` both without and with this PR. Also make sure that, even with this PR, after the DB is created, the server starts and works fine.

The point of this PR is to remove inaccuracy in the Hibernate mapping of the Event object.

--rebased-to #2633
