### PR TITLE
Avoid file handle exhaustion during sessions listing (see #9331).

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -533,7 +533,7 @@ class SessionsControl(BaseControl):
                     if rv is None and args.purge:
                         try:
                             self.ctx.dbg("Purging %s / %s / %s"
-                                        % (server, name, uuid))
+                                         % (server, name, uuid))
                             store.remove(server, name, uuid)
                         except IOError, ioe:
                             self.ctx.dbg("Aborting session purging. %s" % ioe)


### PR DESCRIPTION
This PR is an initial attempt at fixing an `IOError` that appeared when too many sessions were being purged (during `bin/omero sessions list`). See https://trac.openmicroscopy.org.uk/ome/ticket/9331 for specific testing scenarios.
