### PR TITLE
Tagging dialog null description fix (dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
@@ -331,7 +331,7 @@ var tagging_form = function(
 
         var process_desc = function() {
             for (var id in all_tags) {
-                all_tags[id].d = raw_desc[id];
+                all_tags[id].d = raw_desc[id] || "";
             }
             update_html();
             finalize_load();


### PR DESCRIPTION
Sometimes tag descriptions are returned as `null` instead of empty strings.

This fix is already part of #2336 for develop.

--rebased-from #2336 partial
