### PR TITLE
Fix for non-existing Pixels directory in bin/omero admin cleanse (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -206,7 +206,7 @@ def cleanse(data_dir, query_service, dry_run=False, config_service=None):
         cleanser = ""
         for directory in SEARCH_DIRECTORIES:
             full_path = os.path.join(data_dir, directory)
-            if directory == 'Pixels'  and not os.path.exists(full_path):
+            if not os.path.exists(full_path):
                 print "%s does not exist. Skipping..." % full_path
                 continue
             if dry_run:


### PR DESCRIPTION
This is the same as gh-2631 but rebased onto develop.

---

See https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7540 for a description of the exception

To test this PR, run

```
bin/omero admin cleanse --dry-run
```
1. against a fresh 5.0.x server (no `Pixels` directory) and check the `Pixels` directory is skipped
2. against a 5.0.x server with a 4.4 DB upgrade, e.g. octopus.openmicroscopy.org and check the `Pixels` directory is still scanned.
   should not fail with an exception
