### PR TITLE
Cast exception (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/ManageRndSettingsAction.java
@@ -5,7 +5,7 @@
  *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -128,12 +128,11 @@ public class ManageRndSettingsAction
     private void handleTreeTimeNode(TreeImageDisplay[] nodes)
     {
         int count = 0;
-        TreeImageTimeSet node;
+        TreeImageDisplay node;
         for (int i = 0; i < nodes.length; i++) {
-            node = (TreeImageTimeSet) nodes[i];
-            if (node.getNumberItems() > 0) {
-                if (model.canAnnotate(node))
-                    count++;
+            node = nodes[i];
+            if (node.getNumberOfItems() > 0 && model.canAnnotate(node)) {
+                count++;
             }
         }
         setEnabled(count == nodes.length);


### PR DESCRIPTION
This is the same as gh-2630 but rebased onto develop.

---

Do not cast object.
See https://trac.openmicroscopy.org.uk/ome/ticket/12374

The problem is difficult to reproduce see ticket for details.
