### PR TITLE
Roi results

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.agents.measurement.view.MeasurementResults 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.agents.measurement.view.MeasurementViewerComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -40,6 +40,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.filechooser.FileFilter;
 
+import org.apache.commons.collections.CollectionUtils;
 //Third-party libraries
 import org.jhotdraw.draw.AttributeKey;
 import org.jhotdraw.draw.Drawing;
@@ -889,7 +890,7 @@ class MeasurementViewerComponent
 				if (i.hasNext())
 				{
 					roiResult = i.next();
-					if (roiResult.getROIs().size() != 0)
+					if (CollectionUtils.isNotEmpty(roiResult.getROIs()))
 						hasResult = true;
 				}
 			}
@@ -910,6 +911,7 @@ class MeasurementViewerComponent
 		}
 		view.refreshToolBar();
 		view.rebuildManagerTable();
+		view.refreshResultsTable();
 		view.updateDrawingArea();
 		view.setReadyStatus();
 		fireStateChange();
@@ -930,6 +932,7 @@ class MeasurementViewerComponent
 		try {
 			model.removeAllROI();
 			view.rebuildManagerTable();
+			view.refreshResultsTable();
 			view.updateDrawingArea();
 		} catch (NoSuchROIException e) {
 			reg.getLogger().error(this, "Cannot save the ROI "+e.getMessage());


### PR DESCRIPTION
Problem noticed by @will-moore  while preparing material for workshop
The results tab was not populated until you select a ROI.

To test:
- Draw few shapes on an image. Save.
- Close the measurement tool and the viewer.
- Re-open the viewer and the measurement tool.
- Check that the Manage tab and the Results tab are populated.
