### PR TITLE
#12323 mousewheel (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -429,6 +429,7 @@ jQuery.fn.viewportImage = function(options) {
             
             PanoJS.CREATE_CONTROL_MAXIMIZE = true;
             PanoJS.PRE_CACHE_AMOUNT = 2;
+            PanoJS.USE_WHEEL_FOR_ZOOM = true;
             viewerBean = new PanoJS('weblitz-viewport-tiles', {
                 tileUrlProvider : myProvider,
                 xTileSize       : myPyramid.xtilesize,


### PR DESCRIPTION
This is the same as gh-2657 but rebased onto dev_5_0.

---

**Cross OS & web browsers testing**

ticket http://trac.openmicroscopy.org/ome/ticket/12323

For some reason PanoJS has that off on Mac

```
// The dafault is to pan with wheel events on a mac and zoom on other systems
PanoJS.USE_WHEEL_FOR_ZOOM = (navigator.userAgent.indexOf("Mac OS X")>0 ? false: true);
```

I cannot find any explanations why, but this PR should unify it.
