### PR TITLE
Intensity view add

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityResultsView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityResultsView.java
@@ -645,8 +645,12 @@ class IntensityResultsView
 				}
 			}
 		}
-		if (shapeList.size() > 0) {
-			view.calculateStats(shapeList);
+		if (shapeList.isEmpty()) {
+		    if (!analysisResults.isEmpty()) {
+		        displayAnalysisResults();
+		    }
+		} else {
+		    view.calculateStats(shapeList);
 		}
 	}
 	


### PR DESCRIPTION
Problem noticed during Montpellier workshop.
To test the PR.
- Open an image with several z-section or timepoints.
- Open the measurement tool
- Draw a line and propagate it across z or t.
- Select the shape
- Go to "Intensity Results Tab" and add the selected shape
- When the results of the shapes composing the ROI  are displayed in the table 
- scroll to a new plane where the shape has been propagated. Check that the results of the shapes composing the RO are not added again to the table.
- Draw another line. Save. Select and Add it. Make sure that only rows corresponding to the new line are added
