### PR TITLE
Fix remaining Colour in title.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
@@ -77,7 +77,7 @@ public class ColourPicker
     public static final String CANCEL_PROPERTY = "closeColourPicker";
     
     /** The title of the window. */
-    private static final String TITLE = "Colour Picker Window";
+    private static final String TITLE = "Color Picker Window";
     
     /** The default color. */
     private static final Color DEFAULT_COLOR = Color.red;


### PR DESCRIPTION
This is a follow-up of gh-2666
Remove Colour from the title of Color picker dialog.
To test 
- Open an image 
- Open the Color picker by, for example, right click on a channel button and modify the color.
