### PR TITLE
Also mark TestTables.testErrorInGet as xfail

### DIFF
--- a/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
@@ -368,6 +368,7 @@ class TestTables(lib.TestCase):
         pytest.raises(omero.ValidationException, tables.getTable, of, self.sf,
                       self.current)
 
+    @pytest.mark.xfail(reason="See ticket #12372")
     def testErrorInGet(self):
         self.repofile(self.sf.db_uuid)
         f = omero.model.OriginalFileI(1, True)


### PR DESCRIPTION
Follow up of #2618. Transient failures have been observed in this test which also uses `table.addData()`

/cc @will-moore
