### PR TITLE
12373 grid config (rebased onto develop)

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -90,7 +90,9 @@ omero.process.matlab=omero.processor.MATLABProcessI
 #
 # For example, "0,30 * * * * ?" is equivalent to running
 # every 30 seconds. For more information, see:
-# http://quartz.sourceforge.net/javadoc/org/quartz/CronTrigger.html
+#
+# http://quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger
+#
 ############################################
 
 # To disable pixelsdata processing, leave blank.


### PR DESCRIPTION
This is the same as gh-2652 but rebased onto develop.

---

I recently asked @kennethgillen to take a glance at the properties in `etc/omero.properties` for readability etc. This PR is probably as good a place as any for suggestions for improvement. This may also go along with the recent discussion under https://github.com/openmicroscopy/ome-documentation/pull/826
- [12373](https://trac.openmicroscopy.org.uk/ome/ticket/12373) - fix urls
