### PR TITLE
Rename don't recreate repos on move (Fix #12355) (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/AbstractRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/AbstractRepositoryI.java
@@ -315,17 +315,20 @@ public abstract class AbstractRepositoryI extends _InternalRepositoryDisp
                 .findByString(ome.model.core.OriginalFile.class,
                         "hash", repoUuid);
 
+                final String path = FilenameUtils.normalize(
+                        new File(fileMaker.getDir()).getAbsolutePath());
+                final String pathName = FilenameUtils.getName(path);
+                final String pathDir = FilenameUtils.getFullPath(path);
                 if (r == null) {
 
                     if (line != null) {
                         log.warn("Couldn't find repository object: " + line);
                     }
 
-                    String path = FilenameUtils.normalize(new File(fileMaker.getDir()).getAbsolutePath());
                     r = new ome.model.core.OriginalFile();
                     r.setHash(repoUuid);
-                    r.setName(FilenameUtils.getName(path));
-                    r.setPath(FilenameUtils.getFullPath(path));
+                    r.setName(pathName);
+                    r.setPath(pathDir);
                     Timestamp t = new Timestamp(System.currentTimeMillis());
                     r.setAtime(t);
                     r.setMtime(t);
@@ -339,6 +342,15 @@ public abstract class AbstractRepositoryI extends _InternalRepositoryDisp
                     log.info(String.format(
                             "Registered new repository %s (uuid=%s)", r
                                     .getName(), repoUuid));
+                } else if (!r.getPath().equals(pathDir) ||
+                        !r.getName().equals(pathName)) {
+                    final String oldPath = r.getPath();
+                    final String oldName = r.getName();
+                    r.setPath(pathDir);
+                    r.setName(pathName);
+                    r = sf.getUpdateService().saveAndReturnObject(r);
+                    log.warn("Data directory moved: {}{} updated to {}{}",
+                            oldPath, oldName, pathDir, pathName);
                 }
 
                 // ticket:1794 - only adds if necessary


### PR DESCRIPTION
This is the same as gh-2673 but rebased onto develop.

---

If a sysadmin properly moves the omero.data.dir to
a new location via:

```
  bin/omero config omero.data.dir NEW
  mv OLD NEW
```

then there's no reason that a new repository should
be created. Instead, now a WARN log statement is
printed and the new value should be visible via
`bin/omero fs repos`. Imports of files from before
and after the renaming should work identically.
