### PR TITLE
DB: Annotation link insert triggers for search

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -278,6 +278,7 @@ CREATE TRIGGER annotation_trigger
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_update_event_trigger();
 
+-- Note: not adding an annotation insert trigger since that would be handled by any links on insert
 
 CREATE OR REPLACE FUNCTION annotation_link_event_trigger() RETURNS "trigger"
     AS '
@@ -298,6 +299,10 @@ LANGUAGE plpgsql;
 #if( ${type.annotated} && !${type.superclass})
 CREATE TRIGGER ${type.tableName()}_annotation_link_event_trigger
         AFTER UPDATE ON ${type.tableName()}annotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('${type.id}');
+CREATE TRIGGER ${type.tableName()}_annotation_link_event_trigger_insert
+        AFTER INSERT ON ${type.tableName()}annotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('${type.id}');
 #end

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -108,6 +108,12 @@ public interface SqlAction {
     String createIdsTempTable(Collection<Long> ids);
 
     /**
+     * Creates an insert trigger of the given name, for the given table,
+     * with the given procedure. No error handling is performed.
+     */
+    void createInsertTrigger(String name, String table, String procedure);
+
+    /**
      * Returns true if the given string is the UUID of a session that is
      * currently active.
      *
@@ -512,6 +518,14 @@ public interface SqlAction {
             t.printStackTrace(pw);
             pw.close();
             return sw.toString();
+        }
+
+        public void createInsertTrigger(String name, String table, String procedure) {
+            _jdbc().update(String.format("DROP TRIGGER IF EXISTS %s ON %s",
+                    name, table));
+            _jdbc().update(String.format("CREATE TRIGGER %s AFTER INSERT ON " +
+                    "%s FOR EACH ROW EXECUTE PROCEDURE %s",
+                    name, table, procedure));
         }
 
         public String rewriteHql(String query, String key, Object value) {

--- a/components/server/resources/ome/services/startup.xml
+++ b/components/server/resources/ome/services/startup.xml
@@ -67,6 +67,13 @@
      <constructor-arg ref="roles"/>
   </bean>
 
+  <bean id="dbInsertTriggerCheck" depends-on="dbPatchCheck"
+     class="ome.services.util.DBInsertTriggerCheck"
+     init-method="start" lazy-init="false">
+     <constructor-arg ref="executor"/>
+     <constructor-arg ref="simpleSqlAction"/>
+  </bean>
+
   <!--
 
   Disabling DropBox directory creation for 4.1. The directories

--- a/components/server/src/ome/services/util/DBInsertTriggerCheck.java
+++ b/components/server/src/ome/services/util/DBInsertTriggerCheck.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.util;
+
+import ome.util.SqlAction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spring bean run on start-up to make sure that there the necessary insert
+ * triggers are in place for search. Each change to an annotation or an
+ * annotation link should generate a REINDEX to the appropriate type.
+ *
+ * A SQL upgrade script handles this issue for 5.1 and beyond.
+ *
+ * @since 5.0.3
+ */
+public class DBInsertTriggerCheck extends BaseDBCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(DBInsertTriggerCheck.class);
+
+    private static final String[][] triggers = new String[][]{
+        // Skipping insert trigger on annotation itself.
+        new String[]{"annotation_annotation_link_event_trigger_insert", "annotationannotationlink", "annotation_link_event_trigger('ome.model.annotations.Annotation')"},
+        new String[]{"channel_annotation_link_event_trigger_insert", "channelannotationlink", "annotation_link_event_trigger('ome.model.core.Channel')"},
+        new String[]{"dataset_annotation_link_event_trigger_insert", "datasetannotationlink", "annotation_link_event_trigger('ome.model.containers.Dataset')"},
+        new String[]{"experimenter_annotation_link_event_trigger_insert", "experimenterannotationlink", "annotation_link_event_trigger('ome.model.meta.Experimenter')"},
+        new String[]{"experimentergroup_annotation_link_event_trigger_insert", "experimentergroupannotationlink", "annotation_link_event_trigger('ome.model.meta.ExperimenterGroup')"},
+        new String[]{"fileset_annotation_link_event_trigger_insert", "filesetannotationlink", "annotation_link_event_trigger('ome.model.fs.Fileset')"},
+        new String[]{"image_annotation_link_event_trigger_insert", "imageannotationlink", "annotation_link_event_trigger('ome.model.core.Image')"},
+        new String[]{"namespace_annotation_link_event_trigger_insert", "namespaceannotationlink", "annotation_link_event_trigger('ome.model.meta.Namespace')"},
+        new String[]{"node_annotation_link_event_trigger_insert", "nodeannotationlink", "annotation_link_event_trigger('ome.model.meta.Node')"},
+        new String[]{"originalfile_annotation_link_event_trigger_insert", "originalfileannotationlink", "annotation_link_event_trigger('ome.model.core.OriginalFile')"},
+        new String[]{"pixels_annotation_link_event_trigger_insert", "pixelsannotationlink", "annotation_link_event_trigger('ome.model.core.Pixels')"},
+        new String[]{"planeinfo_annotation_link_event_trigger_insert", "planeinfoannotationlink", "annotation_link_event_trigger('ome.model.core.PlaneInfo')"},
+        new String[]{"plate_annotation_link_event_trigger_insert", "plateannotationlink", "annotation_link_event_trigger('ome.model.screen.Plate')"},
+        new String[]{"plateacquisition_annotation_link_event_trigger_insert", "plateacquisitionannotationlink", "annotation_link_event_trigger('ome.model.screen.PlateAcquisition')"},
+        new String[]{"project_annotation_link_event_trigger_insert", "projectannotationlink", "annotation_link_event_trigger('ome.model.containers.Project')"},
+        new String[]{"reagent_annotation_link_event_trigger_insert", "reagentannotationlink", "annotation_link_event_trigger('ome.model.screen.Reagent')"},
+        new String[]{"roi_annotation_link_event_trigger_insert", "roiannotationlink", "annotation_link_event_trigger('ome.model.roi.Roi')"},
+        new String[]{"screen_annotation_link_event_trigger_insert", "screenannotationlink", "annotation_link_event_trigger('ome.model.screen.Screen')"},
+        new String[]{"session_annotation_link_event_trigger_insert", "sessionannotationlink", "annotation_link_event_trigger('ome.model.meta.Session')"},
+        new String[]{"well_annotation_link_event_trigger_insert", "wellannotationlink", "annotation_link_event_trigger('ome.model.screen.Well')"},
+        new String[]{"wellsample_annotation_link_event_trigger_insert", "wellsampleannotationlink", "annotation_link_event_trigger('ome.model.screen.WellSample')"},
+    };
+
+    private final SqlAction sql;
+
+    public DBInsertTriggerCheck(Executor executor, SqlAction sql) {
+        super(executor);
+        this.sql = sql;
+    }
+
+    @Override
+    protected void doCheck() {
+        for (String[] trigger : triggers) {
+            try {
+                String name = trigger[0];
+                String table = trigger[1];
+                String procedure = trigger[2];
+                sql.createInsertTrigger(name, table, procedure);
+            } catch (Exception e) {
+                log.error("Failed to create trigger: {}", trigger, e);
+            }
+        }
+    }
+}

--- a/sql/psql/OMERO5.0__0/insert-triggers.sql
+++ b/sql/psql/OMERO5.0__0/insert-triggers.sql
@@ -1,0 +1,85 @@
+-- Note: no annotation insert trigger
+CREATE TRIGGER annotation_annotation_link_event_trigger_insert
+        AFTER INSERT ON annotationannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.annotations.Annotation');
+CREATE TRIGGER channel_annotation_link_event_trigger_insert
+        AFTER INSERT ON channelannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Channel');
+CREATE TRIGGER dataset_annotation_link_event_trigger_insert
+        AFTER INSERT ON datasetannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Dataset');
+CREATE TRIGGER experimenter_annotation_link_event_trigger_insert
+        AFTER INSERT ON experimenterannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Experimenter');
+CREATE TRIGGER experimentergroup_annotation_link_event_trigger_insert
+        AFTER INSERT ON experimentergroupannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.ExperimenterGroup');
+CREATE TRIGGER fileset_annotation_link_event_trigger_insert
+        AFTER INSERT ON filesetannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.fs.Fileset');
+CREATE TRIGGER image_annotation_link_event_trigger_insert
+        AFTER INSERT ON imageannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Image');
+CREATE TRIGGER namespace_annotation_link_event_trigger_insert
+        AFTER INSERT ON namespaceannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Namespace');
+CREATE TRIGGER node_annotation_link_event_trigger_insert
+        AFTER INSERT ON nodeannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Node');
+CREATE TRIGGER originalfile_annotation_link_event_trigger_insert
+        AFTER INSERT ON originalfileannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.OriginalFile');
+CREATE TRIGGER pixels_annotation_link_event_trigger_insert
+        AFTER INSERT ON pixelsannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Pixels');
+CREATE TRIGGER planeinfo_annotation_link_event_trigger_insert
+        AFTER INSERT ON planeinfoannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.PlaneInfo');
+CREATE TRIGGER plate_annotation_link_event_trigger_insert
+        AFTER INSERT ON plateannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Plate');
+CREATE TRIGGER plateacquisition_annotation_link_event_trigger_insert
+        AFTER INSERT ON plateacquisitionannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.PlateAcquisition');
+CREATE TRIGGER project_annotation_link_event_trigger_insert
+        AFTER INSERT ON projectannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Project');
+CREATE TRIGGER reagent_annotation_link_event_trigger_insert
+        AFTER INSERT ON reagentannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Reagent');
+CREATE TRIGGER roi_annotation_link_event_trigger_insert
+        AFTER INSERT ON roiannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.roi.Roi');
+CREATE TRIGGER screen_annotation_link_event_trigger_insert
+        AFTER INSERT ON screenannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Screen');
+CREATE TRIGGER session_annotation_link_event_trigger_insert
+        AFTER INSERT ON sessionannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Session');
+CREATE TRIGGER well_annotation_link_event_trigger_insert
+        AFTER INSERT ON wellannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Well');
+CREATE TRIGGER wellsample_annotation_link_event_trigger_insert
+        AFTER INSERT ON wellsampleannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.WellSample');

--- a/sql/psql/OMERO5.0__0/psql-footer.sql
+++ b/sql/psql/OMERO5.0__0/psql-footer.sql
@@ -1021,6 +1021,7 @@ CREATE TRIGGER annotation_trigger
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_update_event_trigger();
 
+-- Note: not adding an annotation insert trigger since that would be handled by any links on insert
 
 CREATE OR REPLACE FUNCTION annotation_link_event_trigger() RETURNS "trigger"
     AS '
@@ -1041,84 +1042,168 @@ CREATE TRIGGER annotation_annotation_link_event_trigger
         AFTER UPDATE ON annotationannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.annotations.Annotation');
+CREATE TRIGGER annotation_annotation_link_event_trigger_insert
+        AFTER INSERT ON annotationannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.annotations.Annotation');
 CREATE TRIGGER channel_annotation_link_event_trigger
         AFTER UPDATE ON channelannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Channel');
+CREATE TRIGGER channel_annotation_link_event_trigger_insert
+        AFTER INSERT ON channelannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Channel');
 CREATE TRIGGER dataset_annotation_link_event_trigger
         AFTER UPDATE ON datasetannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Dataset');
+CREATE TRIGGER dataset_annotation_link_event_trigger_insert
+        AFTER INSERT ON datasetannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Dataset');
 CREATE TRIGGER experimenter_annotation_link_event_trigger
         AFTER UPDATE ON experimenterannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Experimenter');
+CREATE TRIGGER experimenter_annotation_link_event_trigger_insert
+        AFTER INSERT ON experimenterannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Experimenter');
 CREATE TRIGGER experimentergroup_annotation_link_event_trigger
         AFTER UPDATE ON experimentergroupannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.ExperimenterGroup');
+CREATE TRIGGER experimentergroup_annotation_link_event_trigger_insert
+        AFTER INSERT ON experimentergroupannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.ExperimenterGroup');
 CREATE TRIGGER fileset_annotation_link_event_trigger
         AFTER UPDATE ON filesetannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.fs.Fileset');
+CREATE TRIGGER fileset_annotation_link_event_trigger_insert
+        AFTER INSERT ON filesetannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.fs.Fileset');
 CREATE TRIGGER image_annotation_link_event_trigger
         AFTER UPDATE ON imageannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Image');
+CREATE TRIGGER image_annotation_link_event_trigger_insert
+        AFTER INSERT ON imageannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Image');
 CREATE TRIGGER namespace_annotation_link_event_trigger
         AFTER UPDATE ON namespaceannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Namespace');
+CREATE TRIGGER namespace_annotation_link_event_trigger_insert
+        AFTER INSERT ON namespaceannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Namespace');
 CREATE TRIGGER node_annotation_link_event_trigger
         AFTER UPDATE ON nodeannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Node');
+CREATE TRIGGER node_annotation_link_event_trigger_insert
+        AFTER INSERT ON nodeannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Node');
 CREATE TRIGGER originalfile_annotation_link_event_trigger
         AFTER UPDATE ON originalfileannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.OriginalFile');
+CREATE TRIGGER originalfile_annotation_link_event_trigger_insert
+        AFTER INSERT ON originalfileannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.OriginalFile');
 CREATE TRIGGER pixels_annotation_link_event_trigger
         AFTER UPDATE ON pixelsannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Pixels');
+CREATE TRIGGER pixels_annotation_link_event_trigger_insert
+        AFTER INSERT ON pixelsannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.Pixels');
 CREATE TRIGGER planeinfo_annotation_link_event_trigger
         AFTER UPDATE ON planeinfoannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.PlaneInfo');
+CREATE TRIGGER planeinfo_annotation_link_event_trigger_insert
+        AFTER INSERT ON planeinfoannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.core.PlaneInfo');
 CREATE TRIGGER plate_annotation_link_event_trigger
         AFTER UPDATE ON plateannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Plate');
+CREATE TRIGGER plate_annotation_link_event_trigger_insert
+        AFTER INSERT ON plateannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Plate');
 CREATE TRIGGER plateacquisition_annotation_link_event_trigger
         AFTER UPDATE ON plateacquisitionannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.PlateAcquisition');
+CREATE TRIGGER plateacquisition_annotation_link_event_trigger_insert
+        AFTER INSERT ON plateacquisitionannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.PlateAcquisition');
 CREATE TRIGGER project_annotation_link_event_trigger
         AFTER UPDATE ON projectannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Project');
+CREATE TRIGGER project_annotation_link_event_trigger_insert
+        AFTER INSERT ON projectannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.containers.Project');
 CREATE TRIGGER reagent_annotation_link_event_trigger
         AFTER UPDATE ON reagentannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Reagent');
+CREATE TRIGGER reagent_annotation_link_event_trigger_insert
+        AFTER INSERT ON reagentannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Reagent');
 CREATE TRIGGER roi_annotation_link_event_trigger
         AFTER UPDATE ON roiannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.roi.Roi');
+CREATE TRIGGER roi_annotation_link_event_trigger_insert
+        AFTER INSERT ON roiannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.roi.Roi');
 CREATE TRIGGER screen_annotation_link_event_trigger
         AFTER UPDATE ON screenannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Screen');
+CREATE TRIGGER screen_annotation_link_event_trigger_insert
+        AFTER INSERT ON screenannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Screen');
 CREATE TRIGGER session_annotation_link_event_trigger
         AFTER UPDATE ON sessionannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Session');
+CREATE TRIGGER session_annotation_link_event_trigger_insert
+        AFTER INSERT ON sessionannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.meta.Session');
 CREATE TRIGGER well_annotation_link_event_trigger
         AFTER UPDATE ON wellannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Well');
+CREATE TRIGGER well_annotation_link_event_trigger_insert
+        AFTER INSERT ON wellannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.Well');
 CREATE TRIGGER wellsample_annotation_link_event_trigger
         AFTER UPDATE ON wellsampleannotationlink
+        FOR EACH ROW
+        EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.WellSample');
+CREATE TRIGGER wellsample_annotation_link_event_trigger_insert
+        AFTER INSERT ON wellsampleannotationlink
         FOR EACH ROW
         EXECUTE PROCEDURE annotation_link_event_trigger('ome.model.screen.WellSample');
 


### PR DESCRIPTION
REINDEX event logs were only being created for annotation
and annotationlink UPDATE and DELETE actions meaning that
on new tag creation created, re-indexing of the annotated
object was not happening.

This commit adds DBInsertTriggerCheck which adds triggers
once on startup. If this fails (due to permissions, etc.)
only ERRORs will be printed to the log. An admin can then
try executing the included insert-triggers.sql file again
