### PR TITLE
Clear the inspector tab. (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -932,6 +932,7 @@ class MeasurementViewerComponent
 		try {
 			model.removeAllROI();
 			view.rebuildManagerTable();
+			view.clearInspector();
 			view.refreshResultsTable();
 			view.updateDrawingArea();
 		} catch (NoSuchROIException e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -1105,6 +1105,12 @@ class MeasurementViewerUI
     		roiInspector.repaint();
     } 
 
+    /** Clear the inspector after saving the data. */
+    void clearInspector()
+    {
+        roiInspector.clearData();
+    }
+
     /**
      * Handles the exception thrown by the <code>ROIComponent</code>.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -479,7 +479,14 @@ class ObjectInspector
 													"Figures selection"+e);
 		}
 	}
-	
+
+    /** Clear the inspector after saving the data. */
+	void clearData()
+	{
+	    FigureTableModel tm = (FigureTableModel) fieldTable.getModel();
+	    tm.clearData();
+	}
+
 	/**
 	 * Get the AttributeKey which is handled by a certain row
 	 * @param row The row which AttributeKey to get 


### PR DESCRIPTION
This is the same as gh-2692 but rebased onto develop.

---

To test this PR
- Open an image 
- Open the Measurement tool
- Draw few rectangle on the same plane
- Save
- Select the inspector tab
- Modify color for example and hit Save
- Check that the inspector tab is cleared up
- Select another ROI, hit save again. The inspector tab should be cleared up

See http://trac.openmicroscopy.org/ome/ticket/12393
