### PR TITLE
Add strict=True when invoking each line in bin/omero load

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -46,7 +46,7 @@ class LoadControl(BaseControl):
                             default=[sys.stdin])
         parser.add_argument(
             "-k", "--keep-going", action="store_true", default=False,
-            help="Continue as much as possible after an error.")
+            help="Continue processing after an error.")
         parser.set_defaults(func=self.__call__)
 
     def __call__(self, args):
@@ -56,7 +56,8 @@ class LoadControl(BaseControl):
                 self.ctx.invoke(line, strict=(not args.keep_going))
 
                 if self.ctx.rv != 0:
-                    self.ctx.err("Skipping: %s" % line)
+                    self.ctx.err("Ignoring error: %s" % line)
+                    self.ctx.rv = 0
 
 
 class ShellControl(BaseControl):

--- a/components/tools/OmeroPy/test/unit/clitest/test_cli.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_cli.py
@@ -10,8 +10,13 @@
 """
 
 import os
+import pytest
+
 from path import path
 from omero.cli import CLI
+from omero.cli import NonZeroReturnCode
+from omero.plugins.basics import LoadControl
+from omero.util.temp_files import create_path
 
 omeroDir = path(os.getcwd()) / "build"
 
@@ -50,3 +55,15 @@ class TestCli(object):
         assert len(threads) == len(set([t.cli for t in threads]))
         assert len(threads) == len(set([t.con for t in threads]))
         assert len(threads) == len(set([t.cmp for t in threads]))
+
+    def testLoad(self):
+        tmp = create_path()
+        tmp.write_text("foo")
+        self.cli = CLI()
+        self.cli.register("load", LoadControl, "help")
+
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke("load %s" % tmp, strict=True)
+
+        self.cli.invoke("load -k %s" % tmp, strict=True)
+        self.cli.invoke("load --keep-going %s" % tmp, strict=True)


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12417

Because bin/omero load does not require a valid connection, the interactive connection logic was potentially causing interferences. For instance, if an interactive server askinput was escaped with Ctrl+C, the self.ctx.invoke() call would silently fail and move to the next line of the file.
This commit fixes this issue by setting strict=True, effectively aborting the full command if such an interruption is caused.

To test this PR:
- optionally, try to reproduce the failing scenario in the ticket without this PR merged
- check that the  `bin/omero load` command without option is aborted when hitting Ctrl+C in the interactive login:
  
  ```
  $ rm -rf ~/omero/sessions/ # force new connection
  $ bin/omero logout && bin/omero load ../omego/create_users
  Server: [localhost]
  Username: [sebastien]^CCancelled
  $
  ```
- check that the `keep-going` option allow the script to keep processing when hitting Ctrl+C in the interactive login prompt but displays a warning about the skipped line
  
  ```
  $ rm -rf ~/omero/sessions/ # force new connection
  $ bin/omero logout && bin/omero load --keep-going ../omego/create_users
  Server: [localhost]
  Username: [sebastien]^CCancelled
  ...
  ```
