### PR TITLE
Fix TestReimportArchivedFiles.

### DIFF
--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -184,7 +184,8 @@ class ITest(object):
         img.acquisitionDate = rtime(0)
         return img
 
-    def import_image(self, filename=None, client=None, extra_args=None):
+    def import_image(self, filename=None, client=None, extra_args=None,
+                     **kwargs):
         if filename is None:
             filename = self.OmeroPy / ".." / ".." / ".." / \
                 "components" / "common" / "test" / "tinyTest.d3d.dv"

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -223,7 +223,7 @@ class TestReimportArchivedFiles(lib.ITest):
             fileset in order to prevent import.
             It can be safely deleted.
             """)
-        readme_obj = self.client.upload(readme_path,
+        readme_obj = self.client.upload(str(readme_path),
                                         name="README.txt")
 
         new_img = self.createSynthetic()


### PR DESCRIPTION
This fix makes sure we check for a string where one
is expected and fixes the declaration of a method in library.py
(missing argument).

To test, make sure that http://ci.openmicroscopy.org/job/OMERO-5.0-merge-integration-python/ is green and in particular http://ci.openmicroscopy.org/job/OMERO-5.0-merge-integration-python/lastCompletedBuild/testReport/test.integration.test_reimport/TestReimportArchivedFiles/testConvertSynthetic/
