### PR TITLE
Fix hover for .tablesorter (see Basket) (rebased from develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table.css
@@ -107,20 +107,6 @@ table#drivespaceTable tbody tr:hover{
 		 
 	 	
 	 
-	 
-	 
-		 
-		 
-		 .tablesorter tbody tr:hover {
-		 	background-color:hsl(210,15%,85%);
-			-webkit-transition: background .2s linear;
-			-webkit-transition:background .2s linear  ;		
-			   -moz-transition:background .2s linear  ;
-			     -o-transition:background .2s linear  ;
-			        transition:background .2s linear  ; 	
-		 }
-	 	
-
 		 .tablesorter tbody tr:nth-child(even) {
 			 background-color:hsl(210,3%,94%);
 		 }
@@ -130,6 +116,15 @@ table#drivespaceTable tbody tr:hover{
 		  
 		 .tablesorter_basic tbody tr:hover {
 			 background:none;
+		 }
+		 
+ 		 .tablesorter tbody tr:hover {
+		 	background-color:hsl(210,15%,85%);
+			-webkit-transition: background .2s linear;
+			-webkit-transition:background .2s linear  ;		
+			   -moz-transition:background .2s linear  ;
+			     -o-transition:background .2s linear  ;
+			        transition:background .2s linear  ; 	
 		 }
 		 
 		 


### PR DESCRIPTION
The basket table was not showing hover on even rows. Also removed double rule.
--rebased-from #2694 from @PaulVanSchayck
