### PR TITLE
make sleep timer's shutdown method less likely to hold thread

### DIFF
--- a/components/server/src/ome/services/util/SleepTimer.java
+++ b/components/server/src/ome/services/util/SleepTimer.java
@@ -58,10 +58,18 @@ public class SleepTimer {
         final Semaphore semaphoreCopy = SHARED_SEMAPHORE;
         if (semaphoreCopy != null) {
             SHARED_SEMAPHORE = null;
-            Thread.yield();
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // does not matter
+            }
             while (semaphoreCopy.hasQueuedThreads()) {
                 semaphoreCopy.release();
-                Thread.yield();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    // does not matter
+                }
             }
         }
     }


### PR DESCRIPTION
Code inspection probably suffices here: this is just about making it more likely that the JVM will schedule another thread. (`Thread.yield()` really may just do nothing whatsoever.) The code is executed when the server is shutting down.
--rebased-to #2733
