### PR TITLE
Preview fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -70,7 +70,6 @@ import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.data.util.Target;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
-import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 import pojos.AnnotationData;
@@ -717,8 +716,7 @@ class EditorComponent
 				index == RenderingControlLoader.RELOAD)
 			return;
 		ImageData image = model.getImage();
-		if (image == null) return;
-		if (image.getId() < 0) return;
+		if (image == null || image.getId() < 0) return;
 		PixelsData pixels = image.getDefaultPixels();
 		if  (pixels == null) return;
 		int value;
@@ -1178,8 +1176,12 @@ class EditorComponent
 	 */
 	public void setLargeImage(Boolean value)
 	{
+	    ImageData img = model.getImage();
+	    if (img == null) return;
 		model.setLargeImage(value);
 		view.onSizeLoaded();
+		view.handleImageSelection();
+		loadRnd();
 	}
 	
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -305,7 +305,28 @@ class EditorUI
     	generalPane.setParentRootObject();
     	userUI.setParentRootObject();
     }
-    
+
+    /** Resets the selected tab when an image or well sample is selected.*/
+    void handleImageSelection()
+    {
+        ImageData img = model.getImage();
+        if (img == null) return;
+        tabPane.setEnabledAt(ACQUISITION_INDEX, img.getId() > 0);
+        boolean preview = model.isPreviewAvailable();
+        tabPane.setEnabledAt(RND_INDEX, preview);
+        if (!preview) {
+            tabPane.setToolTipTextAt(RND_INDEX, 
+                    "Only available for non big images.");
+        }
+        
+        if (getSelectedTab() == RND_INDEX) {
+            tabPane.setComponentAt(RND_INDEX, dummyPanel);
+            if (!preview && 
+                    model.getRndIndex() != 
+                        MetadataViewer.RND_SPECIFIC) 
+                tabPane.setSelectedIndex(GENERAL_INDEX);
+        }
+    }
     /**
      * Updates display when the new root node is set.
      * 
@@ -317,7 +338,7 @@ class EditorUI
 		tabPane.setComponentAt(RND_INDEX, dummyPanel);
 		setDataToSave(false);
 		toolBar.buildUI();
-		tabPane.setToolTipTextAt(RND_INDEX, "");
+		tabPane.setToolTipTextAt(RND_INDEX, RENDERER_DESCRIPTION);
 		boolean preview = false;
 		int selected = getSelectedTab();
 		if (!(uo instanceof DataObject)) {
@@ -345,52 +366,8 @@ class EditorUI
 				tabPane.setEnabledAt(ACQUISITION_INDEX, false);
 				tabPane.setEnabledAt(RND_INDEX, false);
 			} else {
-				if (uo instanceof ImageData) {
-					load = true;
-					ImageData img = (ImageData) uo;
-					tabPane.setEnabledAt(ACQUISITION_INDEX, img.getId() > 0);
-					preview = model.isPreviewAvailable();
-					tabPane.setEnabledAt(RND_INDEX, preview);
-					if (!preview) {
-						tabPane.setToolTipTextAt(RND_INDEX, 
-								"Only available for non big images.");
-					}
-					
-					if (selected == RND_INDEX) {
-						tabPane.setComponentAt(RND_INDEX, dummyPanel);
-						if (!preview && 
-								model.getRndIndex() != 
-									MetadataViewer.RND_SPECIFIC) 
-							tabPane.setSelectedIndex(GENERAL_INDEX);
-					}
-				} else if (uo instanceof WellSampleData) {
-					ImageData img = ((WellSampleData) uo).getImage();
-					if (tabPane.getSelectedIndex() == RND_INDEX) {
-						tabPane.setComponentAt(RND_INDEX, dummyPanel);
-						if (model.canEdit())
-							tabPane.setSelectedIndex(GENERAL_INDEX);
-					}
-					if (img != null && img.getId() >= 0) {
-						load = true;
-						tabPane.setEnabledAt(ACQUISITION_INDEX, true);
-						preview = model.isPreviewAvailable();
-						tabPane.setEnabledAt(RND_INDEX, preview);
-						if (!preview) {
-							tabPane.setToolTipTextAt(RND_INDEX, 
-									"Only available for image of size <= "+
-									RenderingControl.MAX_SIZE+"x"+
-									RenderingControl.MAX_SIZE);
-						}
-						if (selected == RND_INDEX) {
-							tabPane.setComponentAt(RND_INDEX, dummyPanel);
-							//tabPane.setSelectedIndex(GENERAL_INDEX);
-							if (!preview) tabPane.setSelectedIndex(GENERAL_INDEX);
-						}
-					} else {
-						tabPane.setSelectedIndex(GENERAL_INDEX);
-						tabPane.setEnabledAt(ACQUISITION_INDEX, false);
-						tabPane.setEnabledAt(RND_INDEX, false);
-					}
+				if (uo instanceof ImageData || uo instanceof WellSampleData) {
+					handleImageSelection();
 				} else {
 					tabPane.setSelectedIndex(GENERAL_INDEX);
 					tabPane.setEnabledAt(ACQUISITION_INDEX, false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -266,8 +266,6 @@ class MetadataViewerComponent
 	public void setMetadata(Map<DataObject, StructuredDataResults> results,
 			int loaderID)
 	{
-	    //load rnd.
-	    model.loadRnd();
 		if (results == null || results.size() == 0) return;
 		//Need to check the size of the results map.
 		Browser browser = model.getBrowser();


### PR DESCRIPTION
The problem was discovered by @gusferguson while reviewing gh-2722
It was possible to have access to preview even for big images. This should not happen in 5.0.3
I have also fixed the tooltip of the tab, the text could still indicate the arbitrary value

To test the PR:
- Import images from the jpeg folder if not already available. i.e. 2kx2k, 4kx4k
- First select the 2kx2k. Go to the preview tab. The image will load.
- Select the 4kx4k. Selected tab should switch back to the general one and the preview should not be accessible.
