### PR TITLE
remove some empty CSS clutter (rebased from develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/calendar.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/calendar.css
@@ -25,14 +25,9 @@
 	    -moz-box-shadow: 0 1px 1px rgba(0,0,0,0.1); /* FF3.5+ */
 	         box-shadow: 0 1px 1px rgba(0,0,0,0.1); /* Opera 10.5, IE 9.0 */
  }
- 
- 
- 
- 
- .cal_nav {
-}
 
-    
+
+
 
     .cal_nav input {
 		border:none;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/calendar_ie.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/calendar_ie.css
@@ -25,12 +25,6 @@
 	    -moz-box-shadow: 0 1px 1px rgba(0,0,0,0.1); /* FF3.5+ */
 	         box-shadow: 0 1px 1px rgba(0,0,0,0.1); /* Opera 10.5, IE 9.0 */
  }
- 
- 
- 
- 
- .cal_nav {
-}
 
     
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -734,11 +734,7 @@ button::-moz-focus-inner {
 
 
 		/* Numbers */
-	
-		.ui-datepicker tbody td:hover {
 
-		}
-	
 			.ui-datepicker tbody td:hover a{
 			    background-color:hsl(205,40%,50%);
 				color:white;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.gs_slider.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.gs_slider.css
@@ -15,9 +15,6 @@
 /***********************************/
 /* Horizontal Slider generic rules */
 
-.hslider { 
-}
-
 .hslider .slider-line { 
   cursor: pointer;
   font-size: 1px;
@@ -71,9 +68,6 @@
 
 /*********************************/
 /* Vertical Slider generic rules */
-
-.vslider { 
-}
 
 .vslider .slider-line { 
   cursor: pointer;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
@@ -17,11 +17,6 @@
   table-layout: fixed;
 }
 
-
-.weblitz-plateview tr {
-
-}
-
 .weblitz-plateview td {
   padding: 5px;
   border: 1px solid;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table.css
@@ -110,10 +110,7 @@ table#drivespaceTable tbody tr:hover{
 		 .tablesorter tbody tr:nth-child(even) {
 			 background-color:hsl(210,3%,94%);
 		 }
-		 
-		  .tablesorter_basic tbody tr {
-		  }
-		  
+
 		 .tablesorter_basic tbody tr:hover {
 			 background:none;
 		 }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table_ie.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.table_ie.css
@@ -82,10 +82,7 @@
 		 .tablesorter tbody tr:nth-child(even) {
 			 background-color: #EFF0F0;
 		 }
-		 
-		  .tablesorter_basic tbody tr {
-		  }
-		  
+
  		 .tablesorter tbody tr:nth-child(even) {
  			 background-color:#EFF0F0;
  		 }


### PR DESCRIPTION
Removed a little empty CSS; should make no difference at all, apart from reducing clutter.

There is still plenty around, but I left those in as possibly being useful memos about page structure.

--rebased-from #2717
