### PR TITLE
adjust results parameter in flaky testInputs integration test

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -110,7 +110,7 @@ class TestInputs(lib.ITest):
                     count -= 1
                     assert count != 0
                 rc = process.poll()
-                results = process.getResults(0)
+                results = process.getResults(1)
                 self.output(results, "stdout")
                 self.output(results, "stderr")
                 assert rc is not None


### PR DESCRIPTION
Does not fix http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.0-merge-integration-python/lastCompletedBuild/testReport/test.integration.scriptstest.test_inputs/ but probably gets us closer.
