### PR TITLE
Use Ice.Default.Host if available (Fix #12424) (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -211,6 +211,7 @@ def leave_none_unset_int(s):
     if s is not None:
         return int(s)
 
+CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.login_logo": ["LOGIN_LOGO", None, leave_none_unset],
     "omero.web.apps": ["ADDITIONAL_APPS", '[]', json.loads],
@@ -249,7 +250,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.login_redirect": ["LOGIN_REDIRECT",'{}', json.loads],
     "omero.web.send_broken_link_emails": ["SEND_BROKEN_LINK_EMAILS", "true", parse_boolean],
     "omero.web.server_email": ["SERVER_EMAIL", None, identity],
-    "omero.web.server_list": ["SERVER_LIST", '[["localhost", 4064, "omero"]]', json.loads],
+    "omero.web.server_list": ["SERVER_LIST", '[["%s", 4064, "omero"]]' % CUSTOM_HOST, json.loads],
     # Configuration options for the viewer. -1: zoom in fully, 0: zoom out fully, unset: zoom to fit window
     "omero.web.viewer.initial_zoom_level": ["VIEWER_INITIAL_ZOOM_LEVEL", None, leave_none_unset_int],
     # the following parameters configure when to show/hide the 'Volume viewer' icon in the Image metadata panel
@@ -300,7 +301,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.webstart_jar": ["WEBSTART_JAR", "omero.insight.jar", str],
     "omero.web.webstart_icon": ["WEBSTART_ICON", "webstart/img/icon-omero-insight.png", str],
     "omero.web.webstart_heap": ["WEBSTART_HEAP", "1024m", str],
-    "omero.web.webstart_host": ["WEBSTART_HOST", "localhost", str],
+    "omero.web.webstart_host": ["WEBSTART_HOST", CUSTOM_HOST, str],
     "omero.web.webstart_port": ["WEBSTART_PORT", "4064", str],
     "omero.web.webstart_class": ["WEBSTART_CLASS", "org.openmicroscopy.shoola.Main", str],
     "omero.web.webstart_title": ["WEBSTART_TITLE", "OMERO.insight", str],
@@ -321,6 +322,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.pipeline_staticfile_storage": ["STATICFILES_STORAGE", "pipeline.storage.PipelineStorage", str],
 
 }
+del CUSTOM_HOST
 
 # DEVELOPMENT_SETTINGS_MAPPINGS - WARNING: For each setting developer MUST open
 # a ticket that needs to be resolved before a release either by moving the


### PR DESCRIPTION
This is the same as gh-2705 but rebased onto develop.

---

See:
- https://trac.openmicroscopy.org.uk/ome/ticket/12424
- https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7546&p=14200#p14200

To test:
- issue `bin/omero config set Ice.Default.Host youriphere`.
- OMERO should be listening on this interface if checked via `netstat -na | grep 4064`
- The output of `bin/omero web -h` should show `omero.web.server_list` pointing to this interface.
- It should be possible to login to the web with no special configuration.

/cc @chris-allan, @aleksandra-tarkowska, @will-moore, @dpwrussell, @manics, @bpindelski

Question: Is there any reason that the Django application host defaults to `0.0.0.0` and can't use the same interface as `server_list`?

```
    "omero.web.application_server.host": ["APPLICATION_SERVER_HOST", "0.0.0.0", str],
```
