### PR TITLE
Call setMetadataFiltered(true) for all Memoizer uses (rebased onto develop)

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -786,6 +786,7 @@ public class PixelsService extends AbstractFileSystemService
         reader = new ChannelSeparator(reader);
         reader = new Memoizer(reader, getMemoizerWait(), getMemoizerDirectory());
         reader.setFlattenedResolutions(false);
+        reader.setMetadataFiltered(true);
         return reader;
     }
 


### PR DESCRIPTION
This is the same as gh-2758 but rebased onto develop.

---

The fact that OMEROWrapper was using `setMetadataFilter(true)`
but the `PixelsService` was not led to the `equalReaders` method
to return false which essentially deactivated Memoizer speed
ups for `resetDefaultsInSet`!

The primary result of this is that during `IRenderingSettings.resetDefaultsInSet()` a new memoizer file should not be generated. `loci.formats.Memoizer` logging at `DEBUG` should be checked for the import of a simple file (like PNG).

/cc @jburel @melissalinkert

This is also a related cause of the file leak seen in openmicroscopy/bioformats#1196
