### PR TITLE
removing check for already loaded orphaned, close #12446 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -91,10 +91,8 @@ $(document).ready(function() {
         if ($.inArray(orel, ["experimenter", "project", "screen"])>-1) {
             update['empty'] = true;
         } else if (oid.indexOf("orphaned")>=0) {
-            if (oid!==crel) {           // check we've not already loaded orphaned
-                update['rel'] = oid;
-                update['url'] = prefix+'load_data/'+orel+'/?view=icon';
-            }
+            update['rel'] = oid;
+            update['url'] = prefix+'load_data/'+orel+'/?view=icon';
         } else if(orel == "plate") {
             if (datatree.is_leaf(selected)) {   // Load Plate if it's a 'leaf' (No PlateAcquisition)...
                 update['rel'] = oid;


### PR DESCRIPTION
This is the same as gh-2754 but rebased onto develop.

---

This should resolve issues with pagination in orphaned container. To test just click on the Orphaned Container and see if you can browse through pages back and forth. 

Note: you may wish to lower the value in setting.PAGE in case there is less then 200 orphaned images.
