### PR TITLE
Fixed a problem with the MoviePlayerDialog (rebased onto develop)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.util.player.MoviePlayer
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayerUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.util.player.MoviePlayerUI
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This is the same as gh-2755 but rebased onto develop.

---

There were some inconsistencies between t-scale of the MoviePlayerDialog and the ImageViewer.
See ticket https://trac.openmicroscopy.org.uk/ome/ticket/12389

To Test:
Have a play with a multi-z/multi-t image and make sure, that the frames shown match your settings in the MoviePlayerDialog. E.g. octopus, user-4, read-only-1/test fff/TestImages/multi-channel-4d-series.ome.tiff
