### PR TITLE
CLI: additional fake import tests

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_import.py
@@ -54,7 +54,7 @@ class TestImport(object):
                     with_ds_store=with_ds_store)
                 for iwell in range(nwells):
                     well_dir = self.mkdir(
-                        run_dir, "WellA00%s" % str(iplate),
+                        run_dir, "WellA00%s" % str(iwell),
                         with_ds_store=with_ds_store)
                     for ifield in range(nfields):
                         fieldfile = (well_dir / ("Field00%s.fake" %


### PR DESCRIPTION
This PR adds integration tests for the CLI import:
- of fake screens as created by `mkfake` (see https://github.com/openmicroscopy/bioformats/pull/1191)
- of pattern files (see https://github.com/openmicroscopy/bioformats/pull/1123)

--depends-on https://github.com/openmicroscopy/bioformats/pull/1191
