### PR TITLE
Initial Dockerfile for OMERO

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM omedocker/omero-build
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+ADD openmicroscopy.zip /tmp/openmicroscopy.zip
+ADD build.sh /tmp/build.sh
+RUN bash /tmp/build.sh
+
+USER root
+RUN mv /tmp/dist /opt/omero && rm /tmp/build.sh
+VOLUME /opt/omero
+
+USER omero
+CMD ["/bin/bash"]

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,30 @@
+Docker Build for OMERO
+----------------------
+
+Quickstart:
+ * Build OMERO from source with: `ant release-src release-docker`
+ * Create a container with the built code: `docker run --name=mydistro omero-dist true`
+ * Launch omero-in-a-box with that code: `docker run --volumes-from mydistro omedocker/omero-in-a-box`
+
+What you'll see:
+```
+2014-07-10 09:36:42,662 CRIT Set uid to user 0
+2014-07-10 09:36:42,665 INFO supervisord started with pid 1
+2014-07-10 09:36:43,667 INFO spawned: 'pgsql' with pid 7
+2014-07-10 09:36:43,668 INFO spawned: 'ssh' with pid 8
+2014-07-10 09:36:43,670 INFO spawned: 'nginx' with pid 9
+2014-07-10 09:36:43,671 INFO spawned: 'omero' with pid 10
+2014-07-10 09:36:43,672 INFO spawned: 'web' with pid 11
+2014-07-10 09:36:44,723 INFO success: pgsql entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+2014-07-10 09:36:44,723 INFO success: ssh entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+2014-07-10 09:36:44,723 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+2014-07-10 09:36:44,723 INFO success: omero entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+2014-07-10 09:36:44,724 INFO success: web entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+```
+
+This is the output from supervisord starting up the following:
+
+ * a PostgreSQL database with a fresh DB,
+ * a sshd daemon which you can log in to as root,
+ * a nginx instance which serves OMERO.web,
+ * and the OMERO server itself.

--- a/Docker/build.sh
+++ b/Docker/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. /home/omero/venv/bin/activate
+cd /tmp
+unzip openmicroscopy*.zip
+cd openmicroscopy*
+./build.py
+mv dist /tmp/dist
+rm -rf /tmp/openmicroscopy*

--- a/build.xml
+++ b/build.xml
@@ -468,6 +468,24 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
 
     <target name="release-src" depends="release-src-embed,release-src-git"/>
 
+    <target name="release-docker">
+        <property name="docker.cmd" value="docker"/>
+        <property name="docker.img" value="omero-dist"/>
+        <property name="docker.tag" value="latest"/>
+        <copy todir="${target.dir}/Docker">
+            <fileset dir="Docker" includes="*"/>
+        </copy>
+        <copy todir="${target.dir}/Docker">
+            <fileset dir="${target.dir}" includes="openmicroscopy*zip"/>
+        </copy>
+        <exec executable="${docker.cmd}" failonerror="true">
+            <arg value="build"/>
+            <arg value="-t"/>
+            <arg value="${docker.img}:${docker.tag}"/>
+            <arg value="${target.dir}/Docker"/>
+        </exec>
+    </target>
+
     <target name="release-clients" description="Zip the Python, Java, and Matlab zips">
         <zip destfile="${omero.home}/target/OMERO.py-${omero.version}.zip">
             <zipfileset dir="${dist.dir}" prefix="OMERO.py-${omero.version}"
@@ -488,7 +506,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <zipfileset dir="components/tools/OmeroM/target/matlab/" prefix="OMERO.matlab-${omero.version}" includes="**/*"/>
         </zip>
 
-	<copy todir="target">
+        <copy todir="target">
             <fileset dir="components/tools/OmeroPy/dist" includes="*.egg"/>
             <fileset dir="components/tools/OmeroFS/dist" includes="*.egg"/>
         </copy>


### PR DESCRIPTION
This dockerfile is used to build all of OMERO in
a repeatable way. In order to reduce the amount of
context that must be copied into docker, only the
output of the `release-src` command (openmicroscopy*zip)
is passed for building.

The image once built can be used for working with OMERO
but it does not start a server itself. Use one of the
omedocker images for starting a full stack.
