### PR TITLE
mark testInputs integration test as failing (rebased from dev_5_0)

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -25,6 +25,7 @@
 """
 
 import test.integration.library as lib
+import pytest
 import omero
 import omero.processor
 import omero.scripts
@@ -92,6 +93,7 @@ class TestInputs(lib.ITest):
             finally:
                 rfs.close()
 
+    @pytest.mark.xfail(reason="ticket #12314")
     def testInputs(self):
         import logging
         logging.basicConfig(level=10)


### PR DESCRIPTION
Fixes http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-python/lastCompletedBuild/testReport/test.integration.scriptstest.test_inputs/

--rebased-from #2744
