### PR TITLE
fix #11096: ensure that new %time% directory is unique (rebased from dev_5_0)

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -54,6 +54,7 @@ import ome.services.blitz.repo.path.ClientFilePathTransformer;
 import ome.services.blitz.repo.path.FilePathNamingValidator;
 import ome.services.blitz.repo.path.FilePathRestrictionInstance;
 import ome.services.blitz.repo.path.FsFile;
+import ome.services.blitz.repo.path.MakeNextDirectory;
 import ome.services.blitz.util.ChecksumAlgorithmMapper;
 import ome.system.Roles;
 import ome.system.ServiceFactory;
@@ -668,7 +669,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
             final MakeNextDirectory directoryMaker = new MakeNextDirectory() {
 
                 @Override
-                List<String> getPathFor(long index) {
+                public List<String> getPathFor(long index) {
                     final int hour = now.get(Calendar.HOUR_OF_DAY);
                     final int minute = now.get(Calendar.MINUTE);
                     final int second = now.get(Calendar.SECOND);
@@ -678,12 +679,12 @@ public class ManagedRepositoryI extends PublicRepositoryI
                 }
 
                 @Override
-                boolean isAcceptable(List<String> path) throws ServerError {
+                public boolean isAcceptable(List<String> path) throws ServerError {
                     return !checkPath(getFullPathWith(path), null, current).exists();
                 }
 
                 @Override
-                void usePath(List<String> path) throws ServerError {
+                public void usePath(List<String> path) throws ServerError {
                     makeDir(getFullPathWith(path), false, current);
                 }
             };
@@ -848,17 +849,17 @@ public class ManagedRepositoryI extends PublicRepositoryI
             final MakeNextDirectory directoryMaker = new MakeNextDirectory() {
 
                 @Override
-                List<String> getPathFor(long index) {
+                public List<String> getPathFor(long index) {
                     return Collections.singletonList(prefix + Strings.padStart(Long.toString(index + 1), padding, '0') + suffix);
                 }
 
                 @Override
-                boolean isAcceptable(List<String> path) throws ServerError {
+                public boolean isAcceptable(List<String> path) throws ServerError {
                     return !checkPath(getFullPathWith(path), null, current).exists();
                 }
 
                 @Override
-                void usePath(List<String> path) throws ServerError {
+                public void usePath(List<String> path) throws ServerError {
                     makeDir(getFullPathWith(path), false, current);
                 }
             };
@@ -951,17 +952,17 @@ public class ManagedRepositoryI extends PublicRepositoryI
             final MakeNextDirectory directoryMaker = new MakeNextDirectory() {
 
                 @Override
-                List<String> getPathFor(long index) {
+                public List<String> getPathFor(long index) {
                     return getExtraSubdirectories(prefix, suffix, digits, index);
                 }
 
                 @Override
-                boolean isAcceptable(List<String> path) throws ServerError {
+                public boolean isAcceptable(List<String> path) throws ServerError {
                     return directoryContentsCount(getFullPathWith(path)) < limit;
                 }
 
                 @Override
-                void usePath(List<String> path) throws ServerError {
+                public void usePath(List<String> path) throws ServerError {
                     makeDir(getFullPathWith(path), true, current);
                 }
             };

--- a/components/blitz/src/ome/services/blitz/repo/path/MakeNextDirectory.java
+++ b/components/blitz/src/ome/services/blitz/repo/path/MakeNextDirectory.java
@@ -17,7 +17,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package ome.services.blitz.repo;
+package ome.services.blitz.repo.path;
 
 import java.util.List;
 import java.util.Random;
@@ -32,7 +32,7 @@ import omero.ServerError;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.0.3
  */
-abstract class MakeNextDirectory {
+public abstract class MakeNextDirectory {
     private Random rng = new Random();
 
     /**
@@ -41,7 +41,7 @@ abstract class MakeNextDirectory {
      * @param index a non-negative index
      * @return the subdirectories for that index
      */
-    abstract List<String> getPathFor(long index);
+    public abstract List<String> getPathFor(long index);
 
     /**
      * If the circumstances (filesystem, etc.) are such that it is okay to use the given subdirectories.
@@ -49,14 +49,14 @@ abstract class MakeNextDirectory {
      * @return if the path may be used
      * @throws ServerError if the path could not be tested
      */
-    abstract boolean isAcceptable(List<String> path) throws ServerError;
+    public abstract boolean isAcceptable(List<String> path) throws ServerError;
 
     /**
      * Actually use the path. For instance, may create the directory or ensure that it exists.
      * @param path the subdirectories to use
      * @throws ServerError if the path could not be used
      */
-    abstract void usePath(List<String> path) throws ServerError;
+    public abstract void usePath(List<String> path) throws ServerError;
 
     /**
      * Use the first acceptable path (that with the lowest {@code index} for {@link #getPathFor(long)})
@@ -64,7 +64,7 @@ abstract class MakeNextDirectory {
      * @return the used subdirectories
      * @throws ServerError if the first acceptable path could not be found or used
      */
-    List<String> useFirstAcceptable() throws ServerError {
+    public List<String> useFirstAcceptable() throws ServerError {
         /* highest unacceptable index found so far */
         Long inclusiveLower = null;
         /* lowest acceptable index found so far */


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11096 and https://github.com/openmicroscopy/openmicroscopy/pull/2751#issuecomment-48183153 and substantially refactors the implementation of `%time%`, `%increment%`, `%subdirs%` so re-test according to http://www.openmicroscopy.org/site/support/omero5-staging/sysadmins/fs-upload-configuration.html.

--rebased-from #2773 omitting Ice 3.3 fix
