### PR TITLE
Fix PIL installation under OSX 10.9 with Homebrew freetype

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -96,6 +96,9 @@ else
 fi
 bin/brew install postgres
 
+# Fix for PIL installation
+ln -s /usr/local/include/freetype2 /usr/local/include/freetype
+
 # Install OMERO Python dependencies
 bash bin/omero_python_deps
 


### PR DESCRIPTION
Should fix http://ci.openmicroscopy.org/job/OME-4.4-merge-homebrew/ under OS X 10.9

--no-rebase
