### PR TITLE
CLI: additional fake import tests (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_import.py
@@ -54,7 +54,7 @@ class TestImport(object):
                     with_ds_store=with_ds_store)
                 for iwell in range(nwells):
                     well_dir = self.mkdir(
-                        run_dir, "WellA00%s" % str(iplate),
+                        run_dir, "WellA00%s" % str(iwell),
                         with_ds_store=with_ds_store)
                     for ifield in range(nfields):
                         fieldfile = (well_dir / ("Field00%s.fake" %


### PR DESCRIPTION
This is the same as gh-2782 but rebased onto dev_5_0.

---

This PR adds integration tests for the CLI import:
- of fake screens as created by `mkfake` (see https://github.com/openmicroscopy/bioformats/pull/1191)
