### PR TITLE
Fix "omero admin restart --foreground" (assist #12467).

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -352,10 +352,12 @@ present, the user will enter a console""")
             "--nodeonly", action="store_true",
             help="If set, then only tests if the icegridnode is running")
 
-        for name in ("start", "startasync", "restart", "restartasync"):
+        for name in ("start", "restart"):
             self.actions[name].add_argument(
                 "--foreground", action="store_true",
                 help="Start server in foreground mode (no daemon/service)")
+
+        for name in ("start", "startasync", "restart", "restartasync"):
             self.actions[name].add_argument(
                 "-u", "--user",
                 help="Windows Service Log On As user name.")
@@ -640,9 +642,10 @@ present, the user will enter a console""")
 
         command = None
         descript = self._descript(args)
+        foreground = hasattr(args, "foreground") and args.foreground
 
         if self._isWindows():
-            if args.foreground:
+            if foreground:
                 command = """icegridnode.exe "%s" --deploy "%s" %s\
                 """ % (self._icecfg(), descript, args.targets)
             else:
@@ -651,7 +654,7 @@ present, the user will enter a console""")
                 svc_name = "OMERO.%s" % args.node
                 self._start_service(config, descript, svc_name, pasw, user)
         else:
-            if args.foreground:
+            if foreground:
                 command = ["icegridnode", "--nochdir", self._icecfg(),
                            "--deploy", str(descript)] + args.targets
             else:


### PR DESCRIPTION
This PR fixes two issues from the ticket (https://trac.openmicroscopy.org.uk/ome/ticket/12467):
- whitespace in the output of `bin\omero admin start -h`,
- error on `bin\omero restart --foreground`.

To test:
- see if `bin\omero restart --foreground` and `bin\omero restartasync --foreground` work (with a running and stopped server),
- see if the help text for `restart`, `restartasync`, `start` and `startasync` makes sense (the shorter form of the parameter description).
