### PR TITLE
Fix stray quotation marks in Python docstrings

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -415,7 +415,7 @@ class Context:
 
     def out(self, text, newline = True):
         """
-        Expects as single string as argument"
+        Expects a single string as argument.
         """
         self.safePrint(text, sys.stdout, newline)
 
@@ -596,7 +596,7 @@ class BaseControl(object):
 
     def _pid(self):
         """
-        Returns a path of the form "_nodedata() / _node() + ".pid",
+        Returns a path of the form _nodedata() / (_node() + ".pid"),
         i.e. a file named NODENAME.pid in the node's data directory.
         """
         pidfile = self._nodedata() / (self._node() + ".pid")

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -981,7 +981,7 @@ def getPlaneInfo(iQuery, pixelsId, asOrderedList = True):
     @param iQuery The query service.
     @param pixelsId The pixels for Id.
     @param asOrderedList
-    @return list of planeInfoTimes or map["z:t:c:]
+    @return list of planeInfoTimes or map[z:t:c:]
     """
     query = "from PlaneInfo as Info where pixels.id='"+str(pixelsId)+"' orderby info.deltaT"
     infoList = iQuery.findAllByQuery(query,None)

--- a/components/tools/OmeroPy/src/omero/util/temp_files.py
+++ b/components/tools/OmeroPy/src/omero/util/temp_files.py
@@ -241,7 +241,7 @@ class TempFileManager(object):
         """
         Similar to tempfile.mkstemp name but immediately closes
         the file descriptor returned and passes back just the name.
-        This prevents various Windows issues"
+        This prevents various Windows issues.
         """
         fd, name = tempfile.mkstemp(prefix = prefix, suffix = suffix, dir = dir, text = text)
         self.logger.debug("Added file %s", name)

--- a/components/tools/OmeroPy/src/path.py
+++ b/components/tools/OmeroPy/src/path.py
@@ -304,7 +304,7 @@ class path(_base):
         can be used to test if one path object is contained
         within another:
 
-            p1 = path.path("/tmp)
+            p1 = path.path("/tmp")
             p2 = path.path("/tmp/foo")
             if p2.parpath(p1):
                 print "p2 is contained in p1"


### PR DESCRIPTION
Not a big deal for the docs themselves, but these wreak havoc on syntax highlighting in some editors (e.g., Emacs with python-mode).
