### PR TITLE
Tweak handling of acquisitionDate

### DIFF
--- a/components/server/src/ome/services/search/FullText.java
+++ b/components/server/src/ome/services/search/FullText.java
@@ -136,9 +136,8 @@ public class FullText extends SearchAction {
 
         if (LuceneQueryBuilder.DATE_ACQUISITION.equals(dateType) &&
                 !values.onlyTypes.contains(Image.class)) {
-            // Ignore acquisition ranges for non-images
-            dFrom = null;
-            dTo = null;
+            // Use import for non-images
+            dateType = LuceneQueryBuilder.DATE_IMPORT;
         }
 
         try {

--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -69,7 +69,7 @@ class SearchControl(HqlControl):
             help="End date for limiting searches (YYYY-MM-DD")
         parser.add_argument(
             "--date-type",
-            default="acquisitionDate",
+            default="import",
             choices=("acquisitionDate", "import"),
             help=("Which field to use for --from/--to "
                   "(default: acquisitionDate)"))


### PR DESCRIPTION
In order to make the choice and use of import v.
acquisition date more natural:
- import (i.e. creation date) is used by default
- for non-Image types, import date is used if the
  user requests "acquisitionDate" (server-side)
