### PR TITLE
Use "pid" instead of "state" for checking service. (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1498,7 +1498,7 @@ OMERO Diagnostics %s
 
     def check_service(self, name):
         command = self._cmd()
-        command.extend(["-e", "server state %s" % name])
+        command.extend(["-e", "server pid %s" % name])
         p = self.ctx.popen(command)  # popen
         rc = p.wait()
         return rc == 0


### PR DESCRIPTION
This is the same as gh-2815 but rebased onto develop.

---

This fixes the situation where "state" would return "0"
as the return code for a started and stopped service (Ice 3.4).
"pid" returns "1" if the service isn't running.

To test, check on Ice 3.4 and Ice 3.5:
- start the server, import an image,
- try `bin/omero admin reindex —reset 0` - you should get a message about Indexer-0 still running,
- run `bin/omero admin reindex --prepare` - this will stop the indexing service,
- try again `bin/omero admin reindex —reset 0` - this time it should start reindexing.
