### PR TITLE
CLI import help changes (rebased onto develop) (rebased onto dev_5_0)

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -361,7 +361,7 @@ public class CommandLineImporter {
             + "    --checksum_algorithm=ARG\tChoose a possibly faster algorithm for detecting file corruption,\n"
             + "                            \te.g. Adler-32 (fast), CRC-32 (fast), MD5-128,\n"
             + "                            \t     Murmur3-32, Murmur3-128, SHA1-160 (slow, default)\n\n"
-            + "  e.g. $ bin/omero import --checksum_algorithm=CRC-32 foo.tiff\n"
+            + "  e.g. $ bin/omero import -- --checksum_algorithm=CRC-32 foo.tiff\n"
             + "       $ ./importer-cli --checksum_algorithm=Murmur3-128 bar.tiff\n"
             + "\n"
             + "Report bugs to <ome-users@lists.openmicroscopy.org.uk>");


### PR DESCRIPTION
This is the same as gh-2772 but rebased onto dev_5_0.

---

This is the same as gh-2766 but rebased onto develop.

---

Another set of changes for the CLI import suggested by @manics.
To test this PR, check the ouput of
- ``bin/omero --java-help`
- `bin/omero --advanced-help`
