### PR TITLE
Unsuppress fs rename --no-move option.

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -27,8 +27,6 @@ import sys
 
 from collections import namedtuple
 
-from omero_ext.argparse import SUPPRESS
-
 from omero import client as Client
 from omero import CmdError
 from omero import ServerError


### PR DESCRIPTION
Unsuppresses a previously suppressed option. Option should be visible and understandable from,

```
bin/omero fs rename -h
```
