### PR TITLE
503rc1 fixes

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -217,6 +217,8 @@ class PropertyParser(object):
             if x.key is None:
                 raise Exception("Bad key: %s" % x)
             parts = x.key.split(".")
+            if parts[0] == "Ice":
+                continue
             if parts[0] != "omero":
                 raise Exception("Bad key: %s" % x)
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -282,7 +282,7 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out='[]')
 
     @pytest.mark.parametrize("data", (
-        ("omero.a=b\nomero.c=d\n##igmore=me\n",
+        ("omero.a=b\nomero.c=d\n##ignore=me\n",
          "omero.a=b\nomero.c=d",
          "a (1)\n\t\nc (1)"),
         ("omero.whitelist=\\\nome.foo,\\\nome.bar\n### END",
@@ -297,6 +297,9 @@ class TestPrefs(object):
         ("omero.user_mapping=\\\na=b,c=d",
          "omero.user_mapping=a=b,c=d",
          "user_mapping (1)"),
+        ("omero.whitelist=ome.foo\nIce.c=d\n",
+         "Ice.c=d\nomero.whitelist=ome.foo",
+         "whitelist (1)"),
     ))
     def testDefaultsParsing(self, tmpdir, capsys, data):
         input, defaults, keys = data

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -49,9 +49,22 @@ omero.security.filter.bitand=(int8and(permissions,%s) = %s)
 omero.security.password_provider=chainedPasswordProvider
 omero.security.login_failure_throttle_count=1
 omero.security.login_failure_throttle_time=3000
+# A keystore is a database of private keys and their associated X.509
+# certificate chains authenticating the corresponding public keys.
+# A keystore is mostly needed if you are doing client-side certificates
+# for authentication against your LDAP server.
 omero.security.keyStore=
+# Sets the password of the keystore
 omero.security.keyStorePassword=
+
+# A truststore is a database of trusted entities and their associated X.509
+# certificate chains authenticating the corresponding public keys. The
+# truststore contains the Certificate Authority (CA) certificates and the
+# certificate(s) of the other party to which this entity intends to send
+# encrypted (confidential) data. This file must contain the public key
+# certificates of the CA and the client's public key certificate.
 omero.security.trustStore=
+# Sets the password of the truststore
 omero.security.trustStorePassword=
 
 
@@ -218,6 +231,9 @@ omero.pixeldata.max_plane_height=3192
 
 #############################################
 ## Search properties
+
+## For more information, see
+## http://www.openmicroscopy.org/site/support/omero/developers/Modules/Search.html
 #############################################
 
 # To disable search indexing, leave blank.
@@ -315,9 +331,6 @@ omero.search.locking_strategy=native
 omero.search.merge_factor=25
 omero.search.ram_buffer_size=64
 
-# For more information, see:
-# http://www.openmicroscopy.org/site/support/omero/developers/Modules/Search.html
-
 #############################################
 ## FS properties
 #############################################
@@ -346,8 +359,7 @@ omero.search.ram_buffer_size=64
 #    /              path separator
 #    //             end of root-owned directories
 #
-# These are described further at:
-# http://www.openmicroscopy.org/site/support/omero/sysadmins/fs-upload-configuration.html
+# These are described further at :doc:`fs-upload-configuration`
 #
 # The path must be unique per fileset to prevent upload conflicts,
 # which is why %time% includes milliseconds.
@@ -356,17 +368,17 @@ omero.search.ram_buffer_size=64
 # it are created with root ownership, the remainder are the user's.
 # At least one user-owned directory must be included in the path.
 #
-# The template path is created below <omero.managed.dir>,
+# The template path is created below :term:`omero.managed.dir`,
 # e.g. /OMERO/ManagedRepository/<omero.fs.repo.path>/
 omero.fs.repo.path=%user%_%userId%//%year%-%month%/%day%/%time%
 
 # Rules to apply to judge the acceptability of FS paths for writing into
-# omero.managed.dir, being any comma-separated non-empty subset of:
+# :term:`omero.managed.dir`, being any comma-separated non-empty subset of:
 #
-#  - Windows required
-#  - Windows optional
-#  - UNIX required
-#  - UNIX optional
+# - Windows required
+# - Windows optional
+# - UNIX required
+# - UNIX optional
 #
 # Minimally, the "required" appropriate for the server is recommended.
 # Also applying optional rules may make sysadmin tasks easier,
@@ -376,13 +388,13 @@ omero.fs.repo.path_rules=Windows required, UNIX required
 # Checksum algorithms supported by the server for new file uploads,
 # being any comma-separated non-empty subset of:
 #
-#  - Adler-32
-#  - CRC-32
-#  - MD5-128
-#  - Murmur3-32
-#  - Murmur3-128
-#  - SHA1-160
-#  - File-Size-64
+# - Adler-32
+# - CRC-32
+# - MD5-128
+# - Murmur3-32
+# - Murmur3-128
+# - SHA1-160
+# - File-Size-64
 #
 # In negotiation with clients, this list is interpreted as being in
 # descending order of preference.
@@ -421,6 +433,7 @@ omero.threads.cancel_timeout=5000
 ## comparison with start/finish values more
 ## straightforward
 ##
+## For more information, see
 ## http://www.openmicroscopy.org/site/support/omero/developers/Server/Throttling.html
 #############################################
 omero.throttling.objects_read_interval=1000
@@ -438,7 +451,7 @@ omero.throttling.method_time.error.indexer=86400000
 #############################################
 ## cluster configuration
 ##
-##
+## For more information, see
 ## http://www.openmicroscopy.org/site/support/omero/developers/Server/Clustering.html
 #############################################
 omero.cluster.redirector=nullRedirector
@@ -446,6 +459,8 @@ omero.cluster.read_only=false
 
 #############################################
 ## grid configuration
+##
+## For more information, see
 ##
 ## http://www.openmicroscopy.org/site/support/omero/sysadmins/grid.html
 #############################################
@@ -573,12 +588,12 @@ omero.ldap.new_user_group=default
 ## full listing see:
 ##
 ##   http://doc.zeroc.com/display/Ice/Property+Reference
-##
+## For more information see
+## https://www.openmicroscopy.org/site/support/omero/sysadmins/troubleshooting.html#server-fails-to-start
 #############################################
 
 # Disable IPv6 by setting to 0. Only needed in
-# certain situations. For more information see
-# https://www.openmicroscopy.org/site/support/omero/sysadmins/troubleshooting.html#server-fails-to-start
+# certain situations.
 Ice.IPv6=1
 
 ### END


### PR DESCRIPTION
Minor issues seen during rc1 testing, mostly related to the configuration improvements.
- `bin/omero config parse` no longer shows `omero.search.excludes=\me.model.annotations...`
