### PR TITLE
Do not append -signed to the server zip name (rebased onto develop)

### DIFF
--- a/docs/hudson/omero_insight_sign.py
+++ b/docs/hudson/omero_insight_sign.py
@@ -36,9 +36,9 @@ def usage():
   [-cf certificate-passfile] [-ts yes|no|timestamp-server] [-oz output.zip]
 
 If a zip is given and no -oz option is given a new zip will be created called
-<server>-signed.zip, if -oz is passed an empty string then no zip will be
-created. If a directory is given then no zip will be created unless an output
-zip is specified.
+<server>.zip, if -oz is passed an empty string then no zip will be created. If
+a directory is given then no zip will be created unless an output zip is
+specified.
 
 Passwords can be specified on the command line (-kp, -cp), in a file (-kf, -cf)
 or by entering at the command line when prompted (default).
@@ -298,7 +298,7 @@ def sign_server(args):
             raise Stop('Expected zip-filename to end with .zip')
         serverdir = os.path.basename(args.server[:-4])
         if args.zipout is None:
-            args.zipout = serverdir + '-signed.zip'
+            args.zipout = serverdir + '.zip'
     else:
         serverdir = args.server
 


### PR DESCRIPTION
This is the same as gh-2838 but rebased onto develop.

---

With the current setup, the signing script is returning a series of zips with `-signed` appended to the name and corresponding `md5` files. When including these zips in the downloads pages, the current protocol is:
- move the unsigned zips/md5: `mkdir unsigned && mv OMERO.server* unsigned`
- extract the signed `targ.gz` with all servers 
- rename `OMERO.server*-signed.zip`  as `OMERO.server*.zip`
- regenerate the MD5  with the correct file names without `-signed`
- regenerate the downloads page with the correct md5

The manual step of generating md5, renaming files is at odds with the md5 auto-generation and is likely to induce manual errors. With, this PR, the above could be replaced by simply:

```
mkdir unsigned && mv OMERO.server* && unzip OMERO.server-signed.tar.gz`
```

before regenerating the downloads page.

/cc @manics @kennethgillen 
