### PR TITLE
Add batching to attachCompanionFilesToImage (See #12485)

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -768,7 +768,9 @@ public class OMEROMetadataStoreClient
             return; // EARLY EXIT
         }
 
-        final List<IObject> links = new ArrayList<IObject>();
+        final List<List<IObject>> linkBatches = new ArrayList<List<IObject>>();
+        List<IObject> links = new ArrayList<IObject>();
+        linkBatches.add(links);
         for (int i = 0; i < fs.sizeOfUsedFiles(); i++) {
             OriginalFile of = fs.getFilesetEntry(i).getOriginalFile();
             String fileName = FilenameUtils.concat(
@@ -786,12 +788,19 @@ public class OMEROMetadataStoreClient
                                 image.getId().getValue(), false));
                         iali.setChild(fa);
                         links.add(iali);
+                        if (links.size() > 1000) {
+                            log.info("Batch#{} of companion files", linkBatches.size());
+                            links = new ArrayList<IObject>();
+                            linkBatches.add(links);
+                        }
                     }
                 }
             }
         }
-        if (links.size() > 0) {
-            iUpdate.saveCollection(links);
+        for (List<IObject> batch : linkBatches) {
+            if (batch.size() > 0) {
+                iUpdate.saveCollection(batch);
+            }
         }
     }
 


### PR DESCRIPTION
As with other methods in `OMEROMetadataStoreClient` which have run into `Ice.MemoryLimitException` issues, the `attachCompanionFilesToImage` needs batching to not attempt saving too many objects at one time. This is mostly a workaround; in fact, we should no longer be generating companion annotations since that information is known by Bio-Formats as with the original metadata, but clients will need to be modified for the larger change.

To test:
- `touch /tmp/comp.fake`
- `echo series=1001 >> /tmp/comp.fake.ini`
- `bin/omero import /tmp/comp.fake`
- Check that the following is printing in the logs:

```
2014-07-22 21:17:26,327 INFO  [    ome.formats.OMEROMetadataStoreClient] (2-thread-5) Batch#1 of companion files
```

/cc @melissalinkert @jburel
