### PR TITLE
Try search repeatedly and report results

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -9,6 +9,8 @@
 
 """
 
+from collections import defaultdict
+
 import test.integration.library as lib
 import pytest
 import omero
@@ -109,7 +111,7 @@ class TestSearch(lib.ITest):
     def _3164(self, owner, searcher):
 
         images = list()
-        for i in range(0,5):
+        for i in range(0, 5):
             img = omero.model.ImageI()
             img.name = omero.rtypes.rstring("search_test_%i.tif" % i)
             img.acquisitionDate = omero.rtypes.rtime(0)
@@ -142,22 +144,18 @@ class TestSearch(lib.ITest):
         search.addOrderByAsc("name")
         search.setAllowLeadingWildcard(True)
 
-        failed = {}
-        for text in texts:
-            search.byFullText(str(text))
-            if search.hasNext():
-                sz = len(search.results())
-            else:
-                sz = 0
-            if 5 != sz:
-                failed[text] = sz
+        failed = defaultdict(list)
+        for x in range(10):
+            for text in texts:
+                search.byFullText(str(text))
+                if search.hasNext():
+                    sz = len(search.results())
+                else:
+                    sz = 0
+                if 5 != sz:
+                    failed[text].append(sz)
 
-        msg = ""
-        for k in sorted(failed):
-            msg += """\nFAILED: `%s` returned %s""" % (k, failed[k])
-
-        if msg:
-            assert False, "%s\n" % msg
+        assert not failed
 
     def test8692(self):
         # Test that group admin and system admins can


### PR DESCRIPTION
To test the hypothesis that something is going
wrong with the indexing itself, we're repeating
just the search multiple times to see what is
returned. If the search fails every time for each
of the 10 loop iterations, then the object has
not been indexed at all. If only the first search
is failing, then a small wait may be necessary.
This could be caused by the 2 different processes
(blitz's `IUpdate.indexObject()` invocation and
the background indexer) contending for the Document.
