### PR TITLE
Make hql output more consistent

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -174,6 +174,10 @@ class TableBuilder(object):
                 raise KeyError("%s not in %s" % (k, self.headers))
             idx = self.headers.index(k)
             self.results[idx][-1] = by_name[self.headers[idx]]
+            # Now fill any empty values with "" for consistency with col()
+            for idx in range(len(self.headers)):
+                if self.results[idx][-1] is None:
+                    self.results[idx][-1] = ""
 
     def build(self):
         columns = []


### PR DESCRIPTION
This is an attempt to fix the issue raised in http://trac.openmicroscopy.org.uk/ome/ticket/12500

As elements in a new row are populated by `None` by default these elements can be change to empty strings as in the methods `col()`. The alternative would be to backfill with `None` in `col()` though empty elements look neater.

To test do something like this:

```
bin/omero obj new Dataset name=foo
bin/omero obj new Dataset name=bar description="A description"
bin/omero obj new Dataset name=foo2
bin/omero hql "from Dataset"
```

The output with this fix should be:

```
 # | Class    | Id | name | details         | description   
---+----------+----+------+-----------------+---------------
 0 | DatasetI | 1  | foo  | owner=2;group=3 |               
 1 | DatasetI | 2  | bar  | owner=2;group=3 | A description 
 2 | DatasetI | 3  | foo2 | owner=2;group=3 |               
```

Prior to this PR the final element of row 2 would have been `None`.

/cc @joshmoore @mtbc
