### PR TITLE
Java8

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -318,6 +318,7 @@ public class client {
         id.properties.setProperty("Ice.Default.EndpointSelection", "Ordered");
         id.properties.setProperty("Ice.Default.PreferSecure", "1");
         id.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
+        id.properties.setProperty("IceSSL.Protocols", "ssl3, tls");
         id.properties.setProperty("IceSSL.Ciphers", "NONE (DH_anon)");
         id.properties.setProperty("IceSSL.VerifyPeer", "0");
 


### PR DESCRIPTION
Allow connection to some servers when using Java 1.8 client side. see https://trac.openmicroscopy.org.uk/ome/ticket/12339

To test:
- Make sure that Java 8 is used.
- try to connect to various servers: localhost, trout (develop), or Windows server

if testing this on a Mac opening the Insight client from the Desktop uses the default system java even if you've installed a more recent java, so to test this you should download the Linux client package and use the scripts from the command line.

General question: Do we also want to adjust `client.cpp`, `client.py` etc.?
