### PR TITLE
Fix various typos in omero.properties

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -175,12 +175,12 @@ omero.metrics.graphite=
 omero.metrics.slf4j_minutes=60
 
 # Polling frequency of the pixeldata processing. Set empty to disable
-# pixelsdata processing.
+# pixeldata processing.
 #
 # .. |cron| replace::
 #   Cron Format: seconds minutes hours day-of-month month day-of-week year
 #   (optional). For example, "0,30 * * * * ?" is equivalent to running every
-#   30 seconds. For more informatin, see the `CronTrigger Tutorial`_.
+#   30 seconds. For more information, see the `CronTrigger Tutorial`_.
 #
 # .. _CronTrigger Tutorial: http://quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger
 #
@@ -279,7 +279,7 @@ omero.search.include_actions=INSERT,UPDATE,REINDEX,DELETE
 ##
 
 # Instead, it is possible to tell the server
-# to run more indexing reptitions, each of
+# to run more indexing repetitions, each of
 # which gets completely committed before the
 # next. This will only occur when there is
 # a substantial backlog of searches to perform.
@@ -518,7 +518,7 @@ omero.ldap.urls=ldap://localhost:389
 # LDAP server bind DN (if required; can be empty)
 omero.ldap.username=
 
-# LDAP server binard password (if required; can be empty)
+# LDAP server bind password (if required; can be empty)
 omero.ldap.password=
 
 # LDAP server base search DN, i.e. the filter that is applied
@@ -531,7 +531,7 @@ omero.ldap.base=ou=example,o=com
 omero.ldap.referral=ignore
 
 # Whether or not values from LDAP will be
-# sychronized to OMERO on each login. This includes
+# synchronized to OMERO on each login. This includes
 # not just the user name, email, etc, but also the
 # groups that the user is a member of.
 #
@@ -578,7 +578,7 @@ omero.ldap.new_user_group=default
 
 ## A combination of filtered_attribute and dn_attribute,
 ## :filtered_dn_attribute: uses all of the values of the
-## specificied attribute as the DN of multipl OMERO groups
+## specified attribute as the DN of multiple OMERO groups
 ## but the attribute must pass the same filter as :query:
 ## omero.ldap.new_user_group=:filtered_dn_attribute:memberOf
 


### PR DESCRIPTION
This PR is a follow-up of https://github.com/openmicroscopy/ome-documentation/pull/923#discussion_r15804508. All changes are brought to `omero.properties, should be of orthographic nature only and meant to fix the auto-generated configuration properties page of the documentation.
