### PR TITLE
Add 2008ServerR2 support to DropBox (rebased onto develop)

### DIFF
--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -19,7 +19,7 @@ def monitorPackage():
     # At the moment a limited subset of platforms is checked for:
     #     * Mac OS 10.5 or higher
     #     * Linux kernel 2.6 then .13 or higher or kernel 3.x.y
-    #     * Windows: XP, 2003Server, 2008Server, Vista, and 7
+    #     * Windows: XP, 2003Server, 2008Server, 2008ServerR2, Vista, and 7
     #
     # Some fine-tuning may need to be applied, some additional Windows platforms added.
     # If any platform-specific stuff in the imported library fails an exception will be


### PR DESCRIPTION
This is the same as gh-2897 but rebased onto develop.

---

@kennethgillen noticed that DropBox failed to start on a Windows Server 2008 machine as it was running R2. If we want to test DropBox on that platform for 5.0.3 than this should add support for that OS version. If not then this can be closed and re-opened on develop.

To test DropBox should start successfully and images should be imported.
