### PR TITLE
OmeroCpp: Ignore compiler.log in status.

### DIFF
--- a/components/tools/OmeroCpp/.gitignore
+++ b/components/tools/OmeroCpp/.gitignore
@@ -13,6 +13,7 @@ slice_generated*
 Makefile
 aclocal.m4
 autom4te.cache
+compiler.log
 config.guess
 config.h
 config.log


### PR DESCRIPTION
This removes `compiler.log` from the output of `git status`.
