### PR TITLE
Modify version.xml to support vRELEASE tags

### DIFF
--- a/components/antlib/resources/version.xml
+++ b/components/antlib/resources/version.xml
@@ -26,7 +26,7 @@
     </description>
 
     <property name="gitmatch" value="v*[0-9]*.[0-9]*.[0-9]*"/>
-    <property name="omero.v.regexp" value="^(v*)?(.*?)(-[0-9]+)?((-)g(.*?))?$"/>
+    <property name="omero.v.regexp" value="^(v\.?)?(.*?)(-[0-9]+)?((-)g(.*?))?$"/>
 
     <!-- Unset from etc/local.properties -->
     <if>


### PR DESCRIPTION
This commit should add support for tags prefixed with v (as opposed to v. previously)

To test it:
- [ ] check the merge build (using the existing `v.5.1.0-m0.3` tag)
- [ ] create an annotated  `vx.y.z` tag on a previous commit
- [ ] create an annotated  `vx.y.z` tag on the current commit

In all scenarios
- make sure `./build.py version-info` returns the correct version (i.e. uses the latest tag)
- build the server/clients and check the version number are correct

--no-rebase
