### PR TITLE
Add a plugin for determining disk usage.

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/usage.py
+++ b/components/tools/OmeroPy/src/omero/plugins/usage.py
@@ -29,6 +29,7 @@ class UsageControl(CmdControl):
 
     def _configure(self, parser):
         super(UsageControl, self)._configure(parser)
+        parser.add_login_arguments()
         parser.add_style_argument()
         parser.add_argument(
             "--size_only", action="store_true",


### PR DESCRIPTION
This plugin utilises the work in gh-2919 to provide a summary of disk usage by object type:

```
bin/omero usage Image:1,2,3  --report
Using session b011dfc4-2d21-4898-b72b-0a366891414a (user-0@localhost:4064). Idle timeout: 10.0 min. Current group: pg-0
Total disk usage: 153629 bytes
 component    | size  
--------------+-------
 Job          | 59124 
 Annotation   | 8     
 FilesetEntry | 90432 
 Thumbnail    | 4065  
(4 rows)
```

This is very much work in progress in both the name, `usage` is not that good, the object arguments and the output styles, more for discussion than review at this stage.

/cc @mtbc @joshmoore @sbesson

--depends-on #2919
