### PR TITLE
Fix #12338: Exclude .pom files from Insight's Ivy deps. (rebased onto dev_5_0)

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -27,10 +27,16 @@
   </publications>
   <dependencies defaultconfmapping="build,client->default">
     <!-- Internal -->
-    <dependency org="omero" name="blitz" rev="${omero.version}" changing="true" conf="build->build;client->client"/>
+    <dependency org="omero" name="blitz" rev="${omero.version}" changing="true" conf="build->build;client->client">
+        <exclude ext="pom"/>
+    </dependency>
     <!-- For UpgradeCheck -->
-    <dependency org="omero" name="common" rev="${omero.version}" changing="true" conf="build->build;client->client" transitive="false"/>
-    <dependency org="omero" name="model-${omero.db.profile}" rev="${omero.version}" changing="true" conf="build->build;client->client" transitive="false"/>
+    <dependency org="omero" name="common" rev="${omero.version}" changing="true" conf="build->build;client->client" transitive="false">
+        <exclude ext="pom"/>
+    </dependency>
+    <dependency org="omero" name="model-${omero.db.profile}" rev="${omero.version}" changing="true" conf="build->build;client->client" transitive="false">
+        <exclude ext="pom"/>
+    </dependency>
     <!-- For build -->
     <dependency org="insight" name="jarbundler" rev="${versions.jarbundler}" conf="build->default"/>
     <!-- From classpath -->


### PR DESCRIPTION
This is the same as gh-2944 but rebased onto dev_5_0.

---

This PR excludes `.pom` files from `insight/ivy.xml`. The presence of those files in `insight/target/libs/runtime` caused a `java.util.zip.ZipException: error in opening zip file` during the `test-compile` build target.

To test:
- verify that `./build.py clean build test-compile` is free of the `ZipException`.
- check the 5.0 merge build logs (http://ci.openmicroscopy.org/view/5.0/job/OMERO-5.0-merge-build/) for the lack of the exception.
