### PR TITLE
jobHandle.setMessage(message) does not work, as null status is not allowed

### DIFF
--- a/components/server/src/ome/services/JobBean.java
+++ b/components/server/src/ome/services/JobBean.java
@@ -301,10 +301,6 @@ public class JobBean extends AbstractStatefulBean implements JobHandle,
     @RolesAllowed("user")
     public String setStatusAndMessage(String status, String message) {
 
-        if (status != null) {
-             JobStatus s = iTypes.getEnumeration(JobStatus.class, status);
-        }
-
         // status can only be null if this is invoked locally, otherwise
         // the @NotNull will prevent that. therefore the return value
         // will only be the message when called by setMessage()
@@ -317,6 +313,7 @@ public class JobBean extends AbstractStatefulBean implements JobHandle,
             job.setMessage(message);
         }
         if (status != null) {
+            JobStatus s = iTypes.getEnumeration(JobStatus.class, status);
             rv = job.getStatus().getValue();
             job.setStatus(s);
             Timestamp t = new Timestamp(System.currentTimeMillis());


### PR DESCRIPTION
This originates from discussion at 
http://www.openmicroscopy.org/community/viewtopic.php?f=6&t=7544&start=10

Calling jobHandle.setMessage(message) will call jobHandle.setStatusAndMessage(null, message). But this will fail as status is actually not allowed to be null. Here is the exeception:

```
omero.ApiUsageException: exception ::omero::ApiUsageException
 {
 serverStackTrace = ome.conditions.ApiUsageException: An ome.model.jobs.JobStatus enum does not exist with the value: null
at ome.logic.TypesImpl.getEnumeration(TypesImpl.java:128)
at ome.services.JobBean.setStatusAndMessage(JobBean.java:304)
at ome.services.JobBean.setMessage(JobBean.java:297)
```

I think this is fixed if the status is first checked for not being null.
