### PR TITLE
Remove sorting from cli choices usage.

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -151,6 +151,7 @@ class Parser(ArgumentParser):
         self._positionals.title = "Positional Arguments"
         self._optionals.title = "Optional Arguments"
         self._optionals.description = "In addition to any higher level options"
+        self._sort_args = True
 
     def sub(self):
         return self.add_subparsers(title = "Subcommands", description = OMEROSUBS, metavar = OMEROSUBM)
@@ -201,11 +202,16 @@ class Parser(ArgumentParser):
             help="Quiet mode. Causes most warning and diagnostic messages to "
             "be suppressed.")
 
+    def set_args_unsorted(self):
+        self._sort_args = False
+
     def _check_value(self, action, value):
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
             msg = 'invalid choice: %r\n\nchoose from:\n' % value
             choices = list(action.choices)
+            if self._sort_args:
+                choices = sorted(choices)
             msg += self._format_list(choices)
             raise ArgumentError(action, msg)
 


### PR DESCRIPTION
This PR removes the sorting from the cli usage when an incorrect option is given. The order of the choices can be significant. See:

https://github.com/openmicroscopy/openmicroscopy/pull/2945#issuecomment-53043576

Reviewing this PR probably means looking at most cli commands that have options and reviewing its impact.
