### PR TITLE
Flake8 omero.cli

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -24,7 +24,6 @@ See LICENSE for details.
 sys = __import__("sys")
 cmd = __import__("cmd")
 
-import string
 import re
 import os
 import subprocess
@@ -881,7 +880,7 @@ class CLI(cmd.Cmd, Context):
         class LS(BaseControl):
             def __call__(self, args):
                 for p in sorted(path(os.getcwd()).listdir(
-                    unreadable_as_empty=True)):
+                        unreadable_as_empty=True)):
                     self.ctx.out(str(p.basename()))
 
         class CD(BaseControl):

--- a/components/tools/OmeroPy/src/setup.cfg
+++ b/components/tools/OmeroPy/src/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-exclude=gateway,omero/api,omero/install,omero/model,omero_ext,omero/all.py,omero/columns.py,omero/cli.py,omero/java.py,omero/min.py,flim-omero.py,killableprocess.py,omero_fuse.py,omero_web_iis.py,omero/tables.py,path.py,portalocker.py,runProcessor.py,runTables.py,shellserver.py,winprocess.py
+exclude=gateway,omero/api,omero/install,omero/model,omero_ext,omero/all.py,omero/columns.py,omero/java.py,omero/min.py,flim-omero.py,killableprocess.py,omero_fuse.py,omero_web_iis.py,omero/tables.py,path.py,portalocker.py,runProcessor.py,runTables.py,shellserver.py,winprocess.py


### PR DESCRIPTION
See https://trello.com/c/vnojR45Q/43-flake8-omeropy. This PR modifies `components/tools/OmeroPy/src/omero/cli.py` to let it comply with the PEP-8 style.
This PR will need coordination with #2902 to unexclude `omero/cli.py` from `setup.cfg`. Nevertheless I am opening it so that we test it extensively in the merge build in the upcoming weeks.

To review this PR:
- run flake8 on the file (overriding `components/tools/OmeroPy/src/setup.cfg`) and check it is clean
- check the integration tests are still passing
- test the CLI commands (should I list them?)

/cc @ximenesuk

--no-rebase
