### PR TITLE
Fix 'duplicate headers' bug in download original image

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1823,7 +1823,8 @@ def archived_files(request, iid=None, conn=None, **kwargs):
         rsp = ConnCleaningHttpResponse(orig_file.getFileInChunks())
         rsp.conn = conn
         rsp['Content-Length'] = orig_file.getSize()
-        rsp['Content-Disposition'] = 'attachment; filename=%s' % (orig_file.getName().replace(" ","_"))
+        fname = orig_file.getName().replace(" ","_").replace(",", ".")      # ',' in name causes duplicate headers
+        rsp['Content-Disposition'] = 'attachment; filename=%s' % (fname)
     else:
         import tempfile
         temp = tempfile.NamedTemporaryFile(suffix='.archive')
@@ -1853,7 +1854,7 @@ def archived_files(request, iid=None, conn=None, **kwargs):
                 shutil.rmtree(temp_zip_dir, ignore_errors=True)
 
             zipName = request.REQUEST.get('zipname', image.getName())
-            zipName = zipName.replace(" ","_")
+            zipName = zipName.replace(" ","_").replace(",", ".")        # ',' in name causes duplicate headers
             if not zipName.endswith('.zip'):
                 zipName = "%s.zip" % zipName
 


### PR DESCRIPTION
This contains the one critical bug-fix from #2971 (closed).

To test:
- pick a single image to import (not MIF) with the image name containing a comma (rename with a comma if you can't find one). E.g. image,1.tiff
- Import the image then try to download the Original file.
- Select multiple images and try to 'Download' their original files. In the download dialog, add a comma into the zip name field before downloading. Check that downloads OK (with the comma replaced in the resulting zip name).
