### PR TITLE
Fix #12537: Add target/test-classes to test classpath.

### DIFF
--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -544,6 +544,7 @@
             </path>
             <path id="omero.test.classpath">
               <path refid="omero.classpath" />
+              <path location="${target.dir}/test-classes" />
               <fileset dir="${deps.lib.dir}/test" />
             </path>
             </sequential>

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -253,7 +253,7 @@ omero.version=${omero.version}
         <!-- may be overridden by fail-on-error -->
         <property name="test.with.fail" value="false"/>
         <property name="emma.enabled"   value="true"/>
-            <property name="unit.suite" value="unit.testng.xml"/>
+        <property name="unit.suite" value="unit.testng.xml"/>
         <copyTestResources/>
         <myjavac
             destdir="${testclasses.dir}"


### PR DESCRIPTION
This PR fixes the issue noticed by @qidane. After this change, the class files created by `test-compile` are also on the classpath for subsequent invocations of `test-compile`. If ant picks out source files for compilation based on modification time, it will be able to compile the full test jar, as the other required classes will be on the classpath.

To test:
- verify that the 5.1 main integration job is green (when calling the `test-compile` target),
- verify that the failure scenario from http://trac.openmicroscopy.org.uk/ome/ticket/12530 is fixed (i.e. try compiling the tests for any module under `components`, touch a test file or create a new test, try running the `test` target for that component).

--no-rebase
