### PR TITLE
Add omero.web.page_size to settings

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -231,6 +231,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.application_server.port": ["APPLICATION_SERVER_PORT", "4080", str],
     "omero.web.application_server.max_requests": ["APPLICATION_SERVER_MAX_REQUESTS", 400, int],
     "omero.web.ping_interval": ["PING_INTERVAL", 60000, int],
+    "omero.web.page_size": ["PAGE", 200, int],      # pagination of images in datasets and 'orphaned'
     "omero.web.force_script_name": ["FORCE_SCRIPT_NAME", None, leave_none_unset],
     "omero.web.static_url": ["STATIC_URL", "/static/", str],
     "omero.web.staticfile_dirs": ["STATICFILES_DIRS", '[]', json.loads],
@@ -619,11 +620,6 @@ DEFAULT_USER = os.path.join(os.path.dirname(__file__), 'webgateway', 'static', '
 # SEND_BROKEN_LINK_EMAILS=True.
 MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 
-# PAGE: Used in varous locations where large number of data is retrieved from the server.
-try:
-    PAGE  # noqa
-except:
-    PAGE = 200
 
 EMAIL_TEMPLATES = {
     'create_share': {


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7595&start=10

We can now configure the number of images in a 'page' for dataset and 'orphaned' pagination:

Documentation for this https://github.com/openmicroscopy/ome-documentation/pull/972

To test:
- Check that default page size is still 200 (need Dataset / orphaned with > 200 images).
- Check documentation PR above.
- `$ bin/omero config set omero.web.page_size 50`
- `$ bin/omero web stop` and `$ bin/omero web start`
- Check updated page size.

--no-rebase
