### PR TITLE
Add upload_rm to cli importer help.

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -344,6 +344,7 @@ public class CommandLineImporter {
             + "    --transfer=ARG          \tFile transfer method\n\n"
             + "        General options:    \t\n"
             + "          upload          \t# Default\n"
+            + "          upload_rm       \t# Caution! File upload followed by source deletion.\n"
             + "          some.class.Name \t# Use a class on the CLASSPATH.\n\n"
             + "        Server-side options:\t\n"
             + "          ln              \t# Use hard-link.\n"


### PR DESCRIPTION
The `upload_rm` option should now appear for both:

```
bin/omero import --advanced-help
```

and

```
./importer-cli --advanced-help
```

--no-rebase
