### PR TITLE
Update webadmin_utils.py with downloads.o.org link instead of trac.o.org 

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -28,7 +28,7 @@ def upgradeCheck():
         check = UpgradeCheck("web", url=settings.UPGRADES_URL)
         check.run()
         if check.isUpgradeNeeded():
-            logger.error("Upgrade is available. Please visit http://www.openmicroscopy.org/site/products/omero/downloads.\n")
+            logger.error("Upgrade is available. Please visit http://downloads.openmicroscopy.org/latest/omero/.\n")
         else:
             logger.debug("Up to date.\n")
     except Exception, x:


### PR DESCRIPTION
http://trac.openmicroscopy.org.uk/ome/wiki/MilestoneDownloads has a big red sign stating "deprecated page", with a link to donwloads.o.org. Might as well direct users to downloads.o.org from the application in the first place.
