### PR TITLE
Disable MTPixelDataTest for now

### DIFF
--- a/components/server/test/ome/server/utests/MTPixelDataTest.java
+++ b/components/server/test/ome/server/utests/MTPixelDataTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  * Tests the effects of running multiple pixel data threads
  * at the same time.
  */
-@Test(groups = { "pixeldata" }, timeOut=10000)
+@Test(groups = { "pixeldata", "broken" }, timeOut=10000)
 public class MTPixelDataTest extends MockObjectTestCase {
 
     String uuid;


### PR DESCRIPTION
gh-3023 enabled unit tests for several OMERO components. Initial runs
of MTPixelDataTest passed on travis and on 2 different workstations.
Now, the NPE which was seen on one work station is "infecting" travis
as well. Disabling the test for now.
