### PR TITLE
Long line wrapping (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -673,8 +673,8 @@
             overflow:hidden;
             float:left;
             width:90%;
-			color:#666;
-			display:inline-block;
+            color:#666;
+            word-wrap: break-word;
         }
             
         .description img {


### PR DESCRIPTION
This is the same as gh-3026 but rebased onto dev_5_0.

---

It looks like that long lines in the description where there are only letters and underline chars are unwrapped.
![firefoxscreensnapz004](https://cloud.githubusercontent.com/assets/1065155/4232538/2a36b7c0-399e-11e4-838d-fb1ee21af434.png)

Testing on all possible web browsers: IE, FF, Safari, Opera, including mobile devices, tablets, etc.

To test please try to paste the following text in the description and see if is wrapped.

```
This_is_a_very_long_text_that_should_break_on_any_letter_This_is_a_very_long_text_that_should_break_on_any_letter_This_is_a_very_long_text_that_should_break_on_any_letter_This_is_a_very_long_text_that_should_break_on_any_letter_
```

![firefoxscreensnapz003](https://cloud.githubusercontent.com/assets/1065155/4232523/f9991298-399d-11e4-8072-db8d9144ef98.png)
