### PR TITLE
Fixed quality initial selection on full-preview load

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -308,7 +308,7 @@
 
         var q = viewport.getQuality();
         if (q) {
-            var qr = $('#wblitz-quality > [value="+q.toFixed(1)+"]');
+            var qr = $('#wblitz-quality > option[value="' + q.toFixed(1) + '"]');
             if (qr.length) {
                 qr.attr('selected','selected');
             }


### PR DESCRIPTION
When full-preview was loaded the jquery selector was incorrect so quality would never be updated and always remain at the default of 'Normal'.
## Testing Instructions

If testing the merge build then these instructions will work, otherwise you will need: https://github.com/openmicroscopy/openmicroscopy/pull/3039/ because otherwise the full-viewer does not work in its own tab.

Copy the URL of the full-viewer window and pase into a new tab in your regular browser window. Then add a different quality to the end of the url like so:

```
http://localhost:8000/webclient/img_detail/1/?q=0.5
```

In this case, in my example, the quality will switch from 'normal' to 'low'.
