### PR TITLE
Fix (yet another time) the Homebrew installation one-liner

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -24,7 +24,7 @@ TESTING_MODE=${TESTING_MODE:-$DEFAULT_TESTING_MODE}
 ###################################################################
 
 # Install Homebrew in /usr/local
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 cd /usr/local
 
 # Install git if not already installed


### PR DESCRIPTION
Should allow Homebrew to install in the http://ci.openmicroscopy.org/job/OME-4.4-merge-homebrew/ job
