### PR TITLE
Homebrew nginx (rebased onto develop)

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -26,7 +26,7 @@ TESTING_MODE=${TESTING_MODE:-$DEFAULT_TESTING_MODE}
 ###################################################################
 
 # Install Homebrew in /usr/local
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 cd /usr/local
 
 # Install git if not already installed


### PR DESCRIPTION
This is the same as gh-2816 but rebased onto develop.

---

Following PRs opened by @aleksandra-tarkowska  for the nginx config template improvement, this PR simply adds nginx installation, configuration and OMERO.web deployment to the daily Homebrew job.
