### PR TITLE
Remove unused groups/user dropdown imports

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -437,10 +437,7 @@
 
         });
     </script>
-	
-	
-	{% include "webclient/base/includes/group_user_dropdown.html" %}
-	
+
 </div>
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -319,10 +319,7 @@
 
         });
     </script>
-	
-	
-	{% include "webclient/base/includes/group_user_dropdown.html" %}
-	
+
 </div>
 
 <div id="left_panel_tabs" class="absolute_fill">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -204,14 +204,6 @@
 
 {% block left %}
 
-
-<div id="user_selection">
-
-{% include "webclient/base/includes/group_user_dropdown.html" %}
-	
-</div>
-
-
 <div id="searching">
 	
 	


### PR DESCRIPTION
The groups/user menu has been abstracted to a higher level, but several files were still importing what is now a placeholder html file which accomplishes nothing.
## Testing Instructions

None really given that this change can't really have any effect.
