### PR TITLE
Fix typo in stamped decorator.

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -66,7 +66,7 @@ def stamped(func, update=False):
         finally:
             if update:
                 self._stamp = time.time()
-    # checked_and_update_stamp = wraps(func)(check_and_update_stamp)
+    check_and_update_stamp = wraps(func)(check_and_update_stamp)
     return locked(check_and_update_stamp)
 
 


### PR DESCRIPTION
This PR fixes a typo that was found while fixing the file for `flake8`, see gh-3040. In that PR the line was commented out to pass `flake8`; here it is restored and corrected. This may have an effect on the functionality of `tables.py`

/cc @manics 
