### PR TITLE
Create image by tiling 12459

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -24,6 +24,7 @@ import ConfigParser
 import omero
 import omero.clients
 from omero.util.decorators import timeit
+from omero.util.tiles import RPSTileLoop, TileLoopIteration, TileLoop
 from omero.cmd import DoAll
 from omero.api import Save
 from omero.gateway.utils import ServiceOptsDict, GatewayConfig
@@ -2895,8 +2896,6 @@ class _BlitzGateway (object):
         def createImage():
             return self.createImage(sizeX, sizeY, sizeZ, sizeC, sizeT, channelList, dType, imageName, sourceImageId, description)
 
-        from omero.util.tiles import RPSTileLoop, TileLoopIteration
-
         # Create image and init rawPixelsStore etc.
         image, convertToType = createImage()
         pid = image.getPrimaryPixels().getId().val
@@ -2919,6 +2918,24 @@ class _BlitzGateway (object):
             pixelsService.setChannelGlobalMinMax(pid, theC, float(0), float(255), self.SERVICE_OPTS)
 
         return ImageWrapper(self, image)
+
+
+    def getTileSequence(self, sizeX, sizeY, sizeZ, sizeC, sizeT, tileWidth, tileHeight):
+        """
+        Provides a list of tile coodinates as dict: {'z': z, 'c': c, 't': t, 'x': x, 'y': y, 'w': w, 'h': h}
+        for use in providing a tile generator to createImageFromTileSeq().
+
+        :param sizeX:           SizeX of the new image
+        :param sizeY:           SizeY of the new image
+        :param sizeZ:           SizeZ of the new image
+        :param sizeC:           SizeC of the new image
+        :param sizeT:           SizeT of the new image
+        :param tileWidth:       Width of desired tiles
+        :param tileHeight:      Height of desired tiles
+        :return:                List of dicts with keys z, c, t, x, y, w, h
+        :rtype:                 List
+        """
+        return TileLoop().getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT, tileWidth, tileHeight)
 
 
     def createImageFromNumpySeq (self, zctPlanes, imageName, sizeZ=1, sizeC=1, sizeT=1, description=None, dataset=None, sourceImageId=None, channelList=None):

--- a/components/tools/OmeroPy/src/omero/util/tiles.py
+++ b/components/tools/OmeroPy/src/omero/util/tiles.py
@@ -62,7 +62,7 @@ class TileLoop(object):
         raise NotImplementedError()
 
     def getTileSequence(self, sizeX, sizeY, sizeZ, sizeC, sizeT,
-                    tileWidth, tileHeight):
+                        tileWidth, tileHeight):
 
         """
         Provides a list of tile coordinates as used by forEachTile()
@@ -82,7 +82,6 @@ class TileLoop(object):
         <code>y + tileHeight > sizeY</code>.
         :returns: List of dicts with keys: z, c, t, x, y, w, h.
         """
-
 
         tiles = []
         for t in range(0, sizeT):
@@ -109,9 +108,8 @@ class TileLoop(object):
                                 h = sizeY - y
 
                             tiles.append({'z': z, 'c': c, 't': t,
-                                              'x': x, 'y': y, 'w': w, 'h': h,})
+                                          'x': x, 'y': y, 'w': w, 'h': h})
         return tiles
-
 
     def forEachTile(self, sizeX, sizeY, sizeZ, sizeC, sizeT,
                     tileWidth, tileHeight, iteration):
@@ -139,10 +137,10 @@ class TileLoop(object):
         try:
             tileCount = 0
             for t in self.getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT,
-                    tileWidth, tileHeight):
+                                          tileWidth, tileHeight):
 
                 iteration.run(data, t['z'], t['c'], t['t'],
-                        t['x'], t['y'], t['w'], t['h'], tileCount)
+                              t['x'], t['y'], t['w'], t['h'], tileCount)
                 tileCount += 1
 
             return tileCount

--- a/components/tools/OmeroPy/src/omero/util/tiles.py
+++ b/components/tools/OmeroPy/src/omero/util/tiles.py
@@ -61,6 +61,58 @@ class TileLoop(object):
         """
         raise NotImplementedError()
 
+    def getTileSequence(self, sizeX, sizeY, sizeZ, sizeC, sizeT,
+                    tileWidth, tileHeight):
+
+        """
+        Provides a list of tile coordinates as used by forEachTile()
+        so that the order of tiles can be determined by users of this class.
+        Returns a list of dicts with keys: z, c, t, x, y, w, h.
+
+        :param sizeX: int
+        :param sizeY: int
+        :param sizeZ: int
+        :param sizeC: int
+        :param sizeT: int
+        :param tileWidth: <b>Maximum</b> width of the tile requested.
+        The tile request itself will be smaller than the original tile
+        width requested if <code>x + tileWidth > sizeX</code>.
+        :param tileHeight: <b>Maximum</b> height of the tile requested.
+        The tile request itself will be smaller if
+        <code>y + tileHeight > sizeY</code>.
+        :returns: List of dicts with keys: z, c, t, x, y, w, h.
+        """
+
+
+        tiles = []
+        for t in range(0, sizeT):
+
+            for c in range(0, sizeC):
+
+                for z in range(0, sizeZ):
+
+                    for tileOffsetY in range(
+                            0, ((sizeY + tileHeight - 1) / tileHeight)):
+
+                        for tileOffsetX in range(
+                                0, ((sizeX + tileWidth - 1) / tileWidth)):
+
+                            x = tileOffsetX * tileWidth
+                            y = tileOffsetY * tileHeight
+                            w = tileWidth
+
+                            if (w + x > sizeX):
+                                w = sizeX - x
+
+                            h = tileHeight
+                            if (h + y > sizeY):
+                                h = sizeY - y
+
+                            tiles.append({'z': z, 'c': c, 't': t,
+                                              'x': x, 'y': y, 'w': w, 'h': h,})
+        return tiles
+
+
     def forEachTile(self, sizeX, sizeY, sizeZ, sizeC, sizeT,
                     tileWidth, tileHeight, iteration):
         """
@@ -86,32 +138,13 @@ class TileLoop(object):
 
         try:
             tileCount = 0
-            for t in range(0, sizeT):
+            for t in self.getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT,
+                    tileWidth, tileHeight):
 
-                for c in range(0, sizeC):
+                iteration.run(data, t['z'], t['c'], t['t'],
+                        t['x'], t['y'], t['w'], t['h'], tileCount)
+                tileCount += 1
 
-                    for z in range(0, sizeZ):
-
-                        for tileOffsetY in range(
-                                0, ((sizeY + tileHeight - 1) / tileHeight)):
-
-                            for tileOffsetX in range(
-                                    0, ((sizeX + tileWidth - 1) / tileWidth)):
-
-                                x = tileOffsetX * tileWidth
-                                y = tileOffsetY * tileHeight
-                                w = tileWidth
-
-                                if (w + x > sizeX):
-                                    w = sizeX - x
-
-                                h = tileHeight
-                                if (h + y > sizeY):
-                                    h = sizeY - y
-
-                                iteration.run(data, z, c, t,
-                                              x, y, w, h, tileCount)
-                                tileCount += 1
             return tileCount
 
         finally:

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2014 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from numpy import fromfunction, int8
+
+class TestCreateImage (object):
+
+    def createImageAndCheck(self, conn, sizeX=125, sizeY=125, sizeZ=1, sizeC=1, sizeT=1):
+
+        def f(x, y):
+            """
+            create some fake pixel data tile (2D numpy array)
+            """
+            return (x * y)/(1 + x + y)
+
+        def planeGen(count):
+            tile_max = 255
+            dtype = int8
+            for p in range(count):
+                # perform some manipulation on each plane
+                plane = fromfunction(f, (sizeX, sizeY), dtype=dtype)
+                # plane = plane.astype(int)
+                plane[plane > tile_max] = tile_max
+                plane[plane < 0] = 0
+                yield plane
+
+        imageName = "gatewaytest.test_create_image"
+        planeCount = sizeC * sizeZ * sizeT
+        img = conn.createImageFromNumpySeq (planeGen(planeCount), imageName, sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT)
+
+        assert img is not None
+        assert img.getSizeX() == sizeX
+        assert img.getSizeY() == sizeY
+        assert img.getSizeZ() == sizeZ
+        assert img.getSizeC() == sizeC
+        assert img.getSizeT() == sizeT
+
+
+    def testCreateImages(self, gatewaywrapper):
+        gatewaywrapper.loginAsAuthor()
+        conn = gatewaywrapper.gateway
+
+        self.createImageAndCheck(conn)
+        self.createImageAndCheck(conn, sizeZ=10)
+        self.createImageAndCheck(conn, sizeC=3)
+        self.createImageAndCheck(conn, sizeT=10)
+        self.createImageAndCheck(conn, sizeT=10)
+
+    def testCreateBigImages(self, gatewaywrapper):
+        gatewaywrapper.loginAsAuthor()
+        conn = gatewaywrapper.gateway
+
+        # self.createImageAndCheck(conn)
+        self.createImageAndCheck(conn, sizeX=4096, sizeY=4096)
+

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
@@ -28,7 +28,7 @@ class TestCreateImage (object):
             """
             create some fake pixel data tile (2D numpy array)
             """
-            return (x * y)/(1 + x + y)
+            return (x * y)/(x + y) * (x + y)
 
         def planeGen(count):
             tile_max = 255

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
@@ -21,6 +21,7 @@
 from numpy import fromfunction, int8
 import pytest
 
+
 class TestCreateImage (object):
 
     @pytest.fixture(autouse=True)
@@ -28,26 +29,27 @@ class TestCreateImage (object):
         self.image = author_testimg
         assert self.image is not None, 'No test image found on database'
 
-
     def createTileImageAndCheck(self, conn, sizeX=4096, sizeY=4096,
-            sizeZ=1, sizeC=1, sizeT=1, tileWidth=256, tileHeight=256):
+                                sizeZ=1, sizeC=1, sizeT=1,
+                                tileWidth=256, tileHeight=256):
         """
         Create a large tiled image by stitching a region of a small image.
         """
 
         def planeFromImageGen(tileSeq):
-            tlist = [(0,t['c'],0, (0,0,t['w'],t['h'])) for t in tileSeq]
+            tlist = [(0, t['c'], 0, (0, 0, t['w'], t['h'])) for t in tileSeq]
             p = self.image.getPrimaryPixels()
             planes = p.getTiles(tlist)
             for tile in planes:
                 yield tile
 
         ts = conn.getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT,
-            tileWidth, tileHeight)
+                                  tileWidth, tileHeight)
 
         imageName = "gatewaytest.test_create_tiled_image"
-        img = conn.createImageFromTileSeq (planeFromImageGen(ts), imageName,
-            sizeX, sizeY, sizeZ, sizeC, sizeT, tileWidth, tileHeight)
+        img = conn.createImageFromTileSeq(planeFromImageGen(ts), imageName,
+                                          sizeX, sizeY, sizeZ, sizeC, sizeT,
+                                          tileWidth, tileHeight)
 
         assert img is not None
         assert img.getSizeX() == sizeX
@@ -64,9 +66,8 @@ class TestCreateImage (object):
         # truncated tiles right and bottom
         self.createTileImageAndCheck(conn, sizeX=4000, sizeY=3500)
 
-
     def createImageAndCheck(self, conn, sizeX=125, sizeY=125,
-        sizeZ=1, sizeC=1, sizeT=1):
+                            sizeZ=1, sizeC=1, sizeT=1):
 
         def f(x, y):
             """
@@ -87,7 +88,8 @@ class TestCreateImage (object):
 
         imageName = "gatewaytest.test_create_image"
         planeCount = sizeC * sizeZ * sizeT
-        img = conn.createImageFromNumpySeq (planeGen(planeCount), imageName,
+        img = conn.createImageFromNumpySeq(
+            planeGen(planeCount), imageName,
             sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT)
 
         assert img is not None
@@ -96,7 +98,6 @@ class TestCreateImage (object):
         assert img.getSizeZ() == sizeZ
         assert img.getSizeC() == sizeC
         assert img.getSizeT() == sizeT
-
 
     def testCreateImages(self, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
@@ -113,4 +114,3 @@ class TestCreateImage (object):
         conn = gatewaywrapper.gateway
 
         self.createImageAndCheck(conn, sizeX=4096, sizeY=4096)
-

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
@@ -72,7 +72,7 @@ class TestCreateImage (object):
             """
             create some fake pixel data tile (2D numpy array)
             """
-            return (x * y)/(x + y) * (x + y)
+            return (x * y)/(1+abs((x + y) * (x + y)))
 
         def planeGen(count):
             tile_max = 255
@@ -106,12 +106,11 @@ class TestCreateImage (object):
         self.createImageAndCheck(conn, sizeZ=10)
         self.createImageAndCheck(conn, sizeC=3)
         self.createImageAndCheck(conn, sizeT=10)
-        self.createImageAndCheck(conn, sizeT=10)
+        self.createImageAndCheck(conn, sizeT=2, sizeZ=3)
 
     def testCreateBigImages(self, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
         conn = gatewaywrapper.gateway
 
-        # self.createImageAndCheck(conn)
         self.createImageAndCheck(conn, sizeX=4096, sizeY=4096)
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_create_image.py
@@ -19,7 +19,6 @@
 #
 
 from numpy import fromfunction, int8
-from omero.util.tiles import TileLoop
 
 class TestCreateImage (object):
 
@@ -46,7 +45,7 @@ class TestCreateImage (object):
                 plane[plane < 0] = 0
                 yield plane
 
-        ts = TileLoop().getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT, tileWidth, tileHeight)
+        ts = conn.getTileSequence(sizeX, sizeY, sizeZ, sizeC, sizeT, tileWidth, tileHeight)
 
         imageName = "gatewaytest.test_create_tiled_image"
         dType = 'int8'


### PR DESCRIPTION
This adds tiling support to Blitz Gateway conn.createImageFromNumpySeq() allowing it to use numpy planes larger than 3k x 3k.
However, this is only true if the image has zero or one of dimensions Z / C / T > 1.
E.g. it can handle a multi-channel image OR a z-stack OR timelapse, but not any combination of these.

To test:
 ```
$ cd OmeroPy
$ ./setup.py test -s test/integration/gatewaytest/test_create_image.py
```

Also try creating a "BIG" ROI (over 3k x 3k) on a big image (multichannel, single Z, single C) and run the ```Images from ROIs.py``` script.
This should create a new Big tiled image.
NB: numpy arrays for each of the 3 planes will be handled as a individual 2D arrays, so this is a limitation on very big ROIs.