### PR TITLE
Use FORCE_SCRIPT_NAME and STATIC_URL in `web iis`

### DIFF
--- a/components/tools/OmeroPy/src/omero_web_iis.py
+++ b/components/tools/OmeroPy/src/omero_web_iis.py
@@ -32,6 +32,8 @@ STATICS = os.path.realpath(STATICS)
 sys.path.append(str(CWD))
 sys.path.append(str(os.path.join(CWD, 'omeroweb')))
 
+from omeroweb import settings
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'omeroweb.settings'
 import django.core.handlers.wsgi
 import threading
@@ -82,6 +84,12 @@ def permit_iis(filename):
 
 if __name__ == '__main__':
 
+    static_prefix = settings.STATIC_URL.rstrip("/")
+    try:
+        web_prefix = settings.FORCE_SCRIPT_NAME.rstrip("/")
+    except:
+        web_prefix = "/omero"
+
     permit_iis(CONFIG)
     permit_iis(LOGS)
 
@@ -96,12 +104,12 @@ if __name__ == '__main__':
     sm = [
         ScriptMapParams(Extension="*", Flags=0)
     ]
-    vd1 = VirtualDirParameters(Name="/omero",
+    vd1 = VirtualDirParameters(Name=web_prefix,
                                Description="ISAPI-WSGI OMERO.web",
                                ScriptMaps=sm,
                                ScriptMapUpdate="replace"
                                )
-    vd2 = VirtualDirParameters(Name="/static",
+    vd2 = VirtualDirParameters(Name=static_prefix,
                                Description="OMERO.web static files",
                                Path=STATICS,
                                AccessRead=True,


### PR DESCRIPTION
Example:

```
C:\tmp>OMERO.server\bin\omero config set omero.web.force_script_name /test-omero

C:\tmp>OMERO.server\bin\omero config set omero.web.static_url /test-static/

C:\tmp>OMERO.server\bin\omero web iis

0 static files copied, 816 unmodified.
Configured Virtual Directory: /test-omero
Configured Virtual Directory: /test-static
Installation complete.
```

OMERO.web should be running under http://localhost/test-omero/

Ideally test this with two side-by-side OMERO instances running on the same machine under different ports and web prefixes (and make sure it's not just the same OMERO.web appearing under two different prefixes). Note only top-level prefixes work.
