### PR TITLE
Reload channel data after edit.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -4276,6 +4276,9 @@ class EditorModel
 	 */
 	void updateChannels(List<ChannelData> channels)
 	{
+	    if (channelAcquisitionDataMap != null) {
+	        channelAcquisitionDataMap.clear();
+	    }
 		List l = sorter.sort(channels); 
 		emissionsWavelengths = new LinkedHashMap();
 		Iterator i = l.iterator();


### PR DESCRIPTION
This PR fixes a problem noticed while testing the display of channel.
To Test:
- Select an image e.g. dv
- Go to the acquisition tab. Expand one channel
- Go back to the General tab
- Change the name of the channel you expanded and Save
- Go back to the Acquisition tab
- Expand the channel you just edited. The channel info should be displayed (This was the bug, info not displayed)
