### PR TITLE
Fix heap_dump=tmp for jvmcfg

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/jvmcfg.py
+++ b/components/tools/OmeroPy/src/omero/install/jvmcfg.py
@@ -255,13 +255,8 @@ class Strategy(object):
         hd = self.settings.heap_dump
         if hd == "off":
             return ""
-        elif hd in ("on", "cwd"):
+        elif hd in ("on", "cwd", "tmp"):
             return "-XX:+HeapDumpOnOutOfMemoryError"
-        elif hd in ("tmp",):
-            import tempfile
-            tmp = tempfile.gettempdir()
-            return ("-XX:+HeapDumpOnOutOfMemoryError "
-                    "-XX:HeapDumpPath=%s") % tmp
 
     def get_perm_gen(self):
         pg = self.settings.perm_gen
@@ -271,7 +266,12 @@ class Strategy(object):
             return "-XX:MaxPermSize=%s" % pg
 
     def get_append(self):
-        return split(self.settings.append)
+        values = []
+        if self.settings.heap_dump == "tmp":
+            import tempfile
+            tmp = tempfile.gettempdir()
+            values.append("-XX:HeapDumpPath=%s" % tmp)
+        return values + split(self.settings.append)
 
     def get_memory_settings(self):
         values = [

--- a/components/tools/OmeroPy/test/unit/test_jvmcfg.py
+++ b/components/tools/OmeroPy/test/unit/test_jvmcfg.py
@@ -161,6 +161,24 @@ class TestStrategy(object):
         assert table[0] == 2**15
         assert table[1] == 2**15*15/100
 
+    def test_heap_dump_on(self):
+        settings = Settings({"heap_dump": "on"})
+        strategy = PercentStrategy("blitz", settings)
+        hd = strategy.get_heap_dump()
+        append = strategy.get_append()
+        assert " " not in hd
+        assert "HeapDumpPath" not in hd
+        assert not append
+
+    def test_heap_dump_tmp(self):
+        settings = Settings({"heap_dump": "tmp"})
+        strategy = PercentStrategy("blitz", settings)
+        hd = strategy.get_heap_dump()
+        append = strategy.get_append()
+        assert " " not in hd
+        assert "HeapDumpPath" not in hd
+        assert "HeapDumpPath" in "".join(append)
+
 
 class AdjustFixture(object):
 


### PR DESCRIPTION
Use of `bin/omero config set omero.jvmcfg.heap_dump tmp`
was broken shortly before release and apparently never
worked. Rather than change the return value of get_heap_dump
to a list, the `tmp` shortcut now does the same that a user
could do, namely includes the HeapDumpPath argument in the
append section, though possibly with easier white-space
handling than the user could perform themselves.

Reported by Seb Simard
http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2014-October/003021.html

/cc @zeb Note: candidate for rebase.
