### PR TITLE
Remove openGL from the build system

### DIFF
--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -136,12 +136,6 @@
     <zip destfile="${dist.dir}/${main-dist-prefix}-win.zip">
       <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
     </zip>
-    <zip destfile="${dist.dir}/${main-dist-prefix}-win-openGL.zip">
-      <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
-    </zip>
-    <zip destfile="${dist.dir}/${main-dist-prefix}-win64-openGL.zip">
-      <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
-    </zip>
     <zip destfile="${dist.dir}/${distEditor.bundle.name}-${dist.bundle.version}-win.zip">
       <zipfileset file="${base.licensefile}" fullpath="${main-dist-prefix}/LICENSE"/>
     </zip>
@@ -242,8 +236,8 @@
    *   + The license file, ${base.licensefile}.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
   <target name="dist"
-          depends="jar, jar-util, jar-ij, dist-osx-openGL, dist-osx, dist-win,
-	dist-win-openGL,dist-win64-openGL,distEditor-osx, distEditor-win,
+          depends="jar, jar-util, jar-ij, dist-osx, dist-win,
+	distEditor-osx, distEditor-win,
 	distEditor-linux, dist-ij, distImporter-osx, distImporter-win,
 	distImporter-linux"
           description="Build and package the app for distribution.">
@@ -405,83 +399,6 @@
 	                  includes="${dist.jar.file}"/>
 	    </zip>
 	  </target>
-
-  <target name="dist-win-openGL" depends="jar,exe4j-init"
-          if="dist.exe4j.exists"
-          description="Build and package the app for Windows distribution with OpenGL support.">
-    <make-windows-executables type="Insight" do-64-bit="false"/>
-    <copy file="${app.config.dir}/imviewer.xml"
-      tofile="${dist.dir}/opengl-imviewer.xml"/>
-    <replace file="${dist.dir}/opengl-imviewer.xml"
-        token='entry name="/library/opengl" type="boolean"&gt;false&lt;/entry'
-        value='entry name="/library/opengl" type="boolean"&gt;true&lt;/entry'>
-    </replace>
-    <property name="dist.zip.prefix.win.openGL"
-              value="${dist.bundle.name}-${dist.bundle.version}-win-openGL"/>
-    <zip destfile=
-           "${dist.dir}/${dist.zip.prefix.win.openGL}.zip">
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}/${dist.app.config.dir.name}"
-                  dir="${app.config.dir}"
-                  includes="**"
-                  excludes="imviewer.xml"/>
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}/libs" dir="${app.lib.dir}"
-                  includes="*"/>
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}"
-                  file="${app.dir}/${distInsight.win.exename}.exe"/>
-      <zipfileset fullpath="${dist.zip.prefix.win.openGL}/LICENSE"
-                  file="${base.licensefile}"/>
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}" dir="${dist.dir}"
-                  includes="${dist.jar.file}"/>
-      <zipfileset prefix="${dist.zip.prefix.win.openGL}/libs"
-                  dir="${native.lib.dir}/win-native" includes="*"/>
-      <zipfileset file="${dist.dir}/opengl-imviewer.xml"
-                  fullpath="${dist.zip.prefix.win.openGL}/${dist.app.config.dir.name}/imviewer.xml"/>
-    </zip>
-  </target>
-
-  <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	* Creates the Windows distribution bundle under ${dist.dir}.
-	* This is a zip file whose name is set to
-	* ${dist.bundle.name}-${dist.bundle.version}-win.zip
-	* and whose contents are:
-	*   + A config dir, containing all the app.config files.  The dir name is
-	*     set to the name of the ${app.config.dir}.
-	*   + The OMERO.insight application.  That is, the .app dir embedding the app
-	*     jar file, all the the app.libs files, and Windows exe.
-	*   + The license file, ${base.licensefile}.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-   <target name="dist-win64-openGL" depends="jar,exe4j-init"
-	          if="dist.exe4j.exists"
-	          description="Build and package the app for Windows 64 distribution with OpenGL support.">
-      <make-windows-executables type="Insight" do-32-bit="false"/>
-      <copy file="${app.config.dir}/imviewer.xml"
-        tofile="${dist.dir}/opengl-imviewer.xml"/>
-      <replace file="${dist.dir}/opengl-imviewer.xml"
-          token='entry name="/library/opengl" type="boolean"&gt;false&lt;/entry'
-          value='entry name="/library/opengl" type="boolean"&gt;true&lt;/entry'>
-      </replace>
-	    <property name="dist.zip.prefix.win64.openGL"
-                value="${dist.bundle.name}-${dist.bundle.version}-win64-openGL"/>
-	    <zip destfile="${dist.dir}/${dist.zip.prefix.win64.openGL}.zip">
-	      <zipfileset prefix="${dist.zip.prefix.win64.openGL}/${dist.app.config.dir.name}"
-                    dir="${app.config.dir}"
-                    includes="**"
-                    excludes="imviewer.xml"/>
-	      <zipfileset prefix="${dist.zip.prefix.win64.openGL}/libs" dir="${app.lib.dir}"
-	                  includes="*"/>
-	      <zipfileset prefix="${dist.zip.prefix.win64.openGL}"
-	                  file="${app.dir}/${distInsight.win64.exename}.exe"/>
-	      <zipfileset file="${base.licensefile}"
-	                  fullpath="${dist.zip.prefix.win64.openGL}/LICENSE"/>
-	      <zipfileset prefix="${dist.zip.prefix.win64.openGL}" dir="${dist.dir}"
-	                  includes="${dist.jar.file}"/>
-	      <zipfileset prefix="${dist.zip.prefix.win64.openGL}/libs"
-	                  dir="${native.lib.dir}/win64-native"
-	                  includes="*"/>
-        <zipfileset file="${dist.dir}/opengl-imviewer.xml"
-                    fullpath="${dist.zip.prefix.win64.openGL}/${dist.app.config.dir.name}/imviewer.xml"/>
-	    </zip>
-	  </target>
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * Creates the Mac OS X distribution bundle under ${dist.dir}.
    * This is a zip file whose name is set to
@@ -526,54 +443,6 @@
       <zipfileset prefix="${dist.zip.prefix.osx}" file="${dist.osx.installfile}"/>
       <zipfileset file="${base.licensefile}"
                   fullpath="${dist.zip.prefix.osx}/LICENSE"/>
-    </zip>
-  </target>
-
-  <target name="dist-osx-openGL"
-          depends="jar"
-          description="Build and package the app for OS X distribution with OpenGL support.">
-    <delete dir="${dist.dir}/OMERO.insight.app"/>
-    <jarbundler dir="${dist.dir}"
-                name="${distInsight.name}"
-                mainclass="${app.mainclass}"
-                version="${dist.bundle.version}"
-                infostring="${distInsight.name} Java Client, ${dist.bundle.version}"
-                aboutmenuname="${distInsight.name}"
-                screenmenu="true"
-                icon="${dist.osx.icon}"
-                stubfile="${dist.osx.stub}"
-                jvmversion="1.6+"
-                vmoptions="${dist.vmparameters}">
-      <jarfileset refid="app.libs"/>
-      <javaproperty name="java.library.path" value="$JAVAROOT"/>
-      <jarfileset dir="${dist.dir}" includes="${dist.jar.file}"/>
-      <jarfileset dir="${native.lib.dir}/osx-native" includes="*"/>
-    </jarbundler>
-    <copy file="${app.config.dir}/imviewer.xml"
-      tofile="${dist.dir}/opengl-imviewer.xml"/>
-    <replace file="${dist.dir}/opengl-imviewer.xml"
-        token='entry name="/library/opengl" type="boolean"&gt;false&lt;/entry'
-        value='entry name="/library/opengl" type="boolean"&gt;true&lt;/entry'>
-    </replace>
-
-    <property name="dist.zip.prefix.osx.openGL"
-              value="${dist.bundle.name}-${dist.bundle.version}-mac-openGL"/>
-    <zip destfile="${dist.dir}/${dist.zip.prefix.osx.openGL}.zip">
-      <zipfileset prefix="${dist.zip.prefix.osx.openGL}/${dist.app.config.dir.name}"
-                  dir="${app.config.dir}"
-                  includes="**"
-                  excludes="imviewer.xml"/>
-      <zipfileset prefix="${dist.zip.prefix.osx.openGL}" dir="${dist.dir}"
-               includes="OMERO.insight.app/**"
-               excludes="**/${dist.osx.stub.name}"/>
-      <zipfileset file="${dist.osx.stub}"
-                  fullpath="${dist.zip.prefix.osx.openGL}/OMERO.insight.app/Contents/MacOS/${dist.osx.stub.name}"
-                  filemode="775"/>
-      <zipfileset prefix="${dist.zip.prefix.osx.openGL}" file="${dist.osx.installfile}"/>
-      <zipfileset file="${base.licensefile}"
-                  fullpath="${dist.zip.prefix.osx.openGL}/LICENSE"/>
-      <zipfileset file="${dist.dir}/opengl-imviewer.xml"
-                  fullpath="${dist.zip.prefix.osx.openGL}/${dist.app.config.dir.name}/imviewer.xml"/>
     </zip>
   </target>
 
@@ -765,9 +634,6 @@ Distribution targets:
   dist: Creates the distribution bundle under ${dist.dir}.
   dist-osx: Creates the Mac OS X distribution bundle under ${dist.dir}.
   dist-win: Creates the Windows distribution bundle under ${dist.dir}.
-  dist-osx-openGL: Creates the Mac OS X distribution bundle under ${dist.dir} with OpenGL support.
-  dist-win-openGL: Creates the Windows distribution bundle under ${dist.dir} with OpenGL support.
-  dist-win64-openGL: Creates the Windows 64-bit distribution bundle under ${dist.dir} with OpenGL support.
   dist.clean: Remove ${dist.dir}.
     </echo>
   </target>

--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -15,10 +15,7 @@
     <artifact name="insight" type="javadoc" ext="jar" m:classifier="javadoc"/>
     <artifact name="insight" type="zip" conf="release"/>
     <artifact name="insight-win" type="zip" conf="release"/>
-    <artifact name="insight-win-openGL" type="zip" conf="release"/>
-    <artifact name="insight-win64-openGL" type="zip" conf="release"/>
     <artifact name="insight-mac" type="zip" conf="release"/>
-    <artifact name="insight-mac-openGL" type="zip" conf="release"/>
     <artifact name="editor-mac" type="zip" conf="release"/>
     <artifact name="editor-win" type="zip" conf="release"/>
     <artifact name="insight-ij" type="zip" conf="release"/>


### PR DESCRIPTION
This PR removes the openGL Insights components from the build for 5.1.0.
To test it, check the artifacts built by the `release-clients` target do not include any OpenGL zips anymore.

--no-rebase
