### PR TITLE
Fix #12597: Update the exception handling in "login".

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -380,6 +380,8 @@ class SessionsControl(BaseControl):
                     else:
                         self.ctx.err(pde.reason)
                         pasw = None
+                except omero.RemovedSessionException, rse:
+                    self.ctx.die(525, "User account error: %s." % rse.message)
                 except Ice.ConnectionRefusedException:
                     if port:
                         self.ctx.die(554, "Ice.ConnectionRefusedException:"


### PR DESCRIPTION
This PR tries to make the exception handling in sessions.py/login more user-friendly. See https://trac.openmicroscopy.org.uk/ome/ticket/12597 and https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7656.

To test (`jdoe` must not exist in the OMERO DB):
- execute `omero login -s localhost -u jdoe --sudo=root` and verify that the error message makes sense.

/cc @joshmoore 
