### PR TITLE
Bugfix for Projection view

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
@@ -216,10 +216,10 @@ class TwoKnobsSliderUI
 		g.setColor(fontColor);
 		Map labels = model.getLabels();
 		Iterator i = labels.keySet().iterator();
-		Integer key;
+		Double key;
 		int value;
 		while (i.hasNext()) {
-			key = (Integer) i.next();
+			key = (Double) i.next();
 			value = key.intValue();
 			if (model.getOrientation() == TwoKnobsSlider.HORIZONTAL) {
 				g.translate(0, labelRect.y);


### PR DESCRIPTION
With PR #3052 I introduced a bug which causes Insight to crash with a ClassCastException when the Projection view is selected; this PR fixes the issue.

Test: Just open a multi-Z image in the full viewer and choose the Projection view
