### PR TITLE
Disable keyboard navigation (up, down, left, right) for jquery tabs

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/includes/jquery-ui.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/includes/jquery-ui.html
@@ -20,3 +20,17 @@
 
 <link rel="stylesheet" href="{% static "3rdparty/jquery-ui-1.10.4/themes/base/jquery.ui.base.css" %}" type="text/css" />
 <script type="text/javascript" src="{% static "3rdparty/jquery-ui-1.10.4/js/jquery-ui-1.10.4.js" %}"></script>
+
+<!-- Disable JQuery UI Tabs Keyboard Navigation -->
+<script type="text/javascript">
+    $.widget("ui.tabs", $.ui.tabs, {
+        _tabKeydown: function (event) {
+            if (event.keyCode !== 37 &&
+                event.keyCode !== 38 &&
+                event.keyCode !== 39 &&
+                event.keyCode !== 40) {
+                this._super(event);
+            }
+        }
+    });
+</script>


### PR DESCRIPTION
Address issue with jquery ui tabs navigation reported in #3094.

Big cludgy, but jquery-ui does not give any way to disable this behaviour. We might want to disable the visual selection (the box selection halo when you click something) of the jquery tabs as well as that is a bit confusing/messy now.
