### PR TITLE
fix #12552: include extra annotations in disk usage calculation

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.api.IQuery;
+import ome.io.bioformats.BfPyramidPixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.io.nio.ThumbnailService;
 import ome.parameters.Parameters;
@@ -407,6 +408,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
                     final String pixelsPath = pixelsService.getPixelsPath(id);
                     usage.bumpTotals().add(className, getFileSize(pixelsPath));
                     usage.bumpTotals().add(className, getFileSize(pixelsPath + PixelsService.PYRAMID_SUFFIX));
+                    usage.bumpTotals().add(className, getFileSize(pixelsPath + PixelsService.PYRAMID_SUFFIX +
+                            BfPyramidPixelBuffer.PYR_LOCK_EXT));
                 }
             } else if ("Thumbnail".equals(className)) {
                 /* Thumbnails may have /OMERO/Thumbnails/<id> files */


### PR DESCRIPTION
Adds to the disk usage request described in #2919 (see that for basic testing instructions) coverage of the extra annotations introduced in #2412 which may of course be file annotations. Cc: @ximenesuk regarding #3009 which may also be useful for testing. Also now includes pyramid lock files in disk usage count.

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12552.
--no-rebase
