### PR TITLE
Adding 5.1.0-m1 to version history doc

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,30 @@
 OMERO version history
 =====================
 
+5.1.0-m1 (October 2014)
+-----------------------
+
+Developer preview release - 1 of 3 development milestones being released in
+the lead up to 5.1.0. **Only intended as a developer preview for updating code
+before the full public release of 5.1.0. Use at your own risk**.
+
+Model changes include:
+
+-  channel value has changed from an int to a float
+-  acquisitionDate on Image is now optional
+-  Pixels and WellSample types are no longer annotatable
+-  the following types are now annotatable: Detector, Dichroic, Filter,
+   Instrument, LightSource, Objective, Shape
+-  introduction of a "Map" type which permits storing key-value pairs, and a
+   Map annotation type which allows linking a Map on any annotatable object
+
+Other changes that may affect developers include:
+
+-  strict flake8'ing of all Python code
+-  C++ build is now based on CMake and is hopefully much more user-friendly
+-  new APIs: SendEmail and DiskUsage
+-  the password table now has a "changed" field
+
 5.0.5 / 4.4.12 (September 2014)
 -------------------------------
 


### PR DESCRIPTION
Updating the OMERO version history - uses an autogen job to update the docs.

See https://trello.com/c/uBORwN9X/20-update-omero-version-history

cc @joshmoore @sbesson 

--no-rebase
