### PR TITLE
CLI admin diagnostics: only check readability of var folder

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -894,7 +894,7 @@ present, the user will enter a console""")
 
     @with_config
     def diagnostics(self, args, config):
-        self.check_access()
+        self.check_access(os.R_OK)
         config = config.as_map()
         omero_data_dir = '/OMERO'
         try:


### PR DESCRIPTION
In a multi-user environment where group members have permissions to read but not write the var/ folder of the server, bin/omero admin diagnostics currently fails with a "Cannot access" exception. This commit relaxes the check_access() condition of the diagnostics subcommand to check the folder (and subfolders) readability only.

To test this PR, ssh to `trout.openmicroscopy.org` and check `bin/omero admin diagnostics` does not fail on the deployed server.

/cc @aleksandra-tarkowska 

--no-rebase
