### PR TITLE
Make sure @omero_host@ is never present (fix #12555).

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -337,7 +337,8 @@ class BaseClient(object):
                 if router is not None:
                     for endpoint in router.ice_getEndpoints():
                         host = endpoint.getInfo().host
-                    insecure = insecure.replace("@omero.host@", str(host))
+                    if host != "":
+                        insecure = insecure.replace("@omero.host@", str(host))
                 props["Ice.Default.Router"] = insecure
             else:
                 self.__logger.warn(


### PR DESCRIPTION
This fixes the issue when an insecure connection is
requested and the connection string still contains
@omero_host@.

To test:
- verify that scripts still work,
- check that a sample script from the ticket description (https://trac.openmicroscopy.org.uk/ome/ticket/12555) works. Save the code to a file, send it to the server as a script and execute (`bin/omero script launch <id>`). No errors should be present.

/cc @joshmoore, @sbesson 

--no-rebase
