### PR TITLE
Customise Windows service name: omero.windows.servicename

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -58,6 +58,7 @@ Environment variables:
 Configuration properties:
  omero.windows.user
  omero.windows.pass
+ omero.windows.servicename
 
 """ + "\n" + "="*50 + "\n"
 
@@ -389,6 +390,12 @@ present, the user will enter a console""")
     # Windows utility methods
     #
     if has_win32:
+        def _get_service_name(unused, config):
+            try:
+                return config.as_map()["omero.windows.servicename"]
+            except KeyError:
+                return 'OMERO'
+
         def _query_service(unused, svc_name):
             hscm = win32service.OpenSCManager(
                 None, None, win32service.SC_MANAGER_ALL_ACCESS)
@@ -651,7 +658,8 @@ present, the user will enter a console""")
             else:
                 user = args.user
                 pasw = args.password
-                svc_name = "OMERO.%s" % args.node
+                svc_name = "%s.%s" % (
+                    self._get_service_name(config), args.node)
                 self._start_service(config, descript, svc_name, pasw, user)
         else:
             if foreground:
@@ -815,7 +823,7 @@ present, the user will enter a console""")
             self.ctx.err("Server not running")
             return True
         elif self._isWindows():
-            svc_name = "OMERO.%s" % args.node
+            svc_name = "%s.%s" % (self._get_service_name(config), args.node)
             output = self._query_service(svc_name)
             if 0 <= output.find("DOESNOTEXIST"):
                 self.ctx.die(203, "%s does not exist. Use 'start' first."


### PR DESCRIPTION
This is needed to allow multiple server deployments on the same Windows system.

```
C:\OMERO.server>bin\omero config set omero.windows.servicename toast

C:\OMERO.server>bin\omero config get
omero.data.dir=\OMERO
omero.windows.servicename=toast

C:\OMERO.server>bin\omero admin start
Found default value: c:\omero_dist\var\master
Attempting to correct...
Converting from c:\omero_dist to C:\OMERO.server
Changes made: 6
Creating C:\OMERO.server\var\master
Creating C:\OMERO.server\var\registry
No descriptor given. Using etc\grid\windefault.xml
Installing toast.master Windows service.
Successfully installed toast.master Windows service.
Starting toast.master Windows service.
Waiting on startup. Use CTRL-C to exit
..................
C:\OMERO.server>
```

This is currently deployed as a merge-deploy on Hake (OMERO-5.1-merge-deploy-win, port 4064, servicename: OMEROmerge) alongside latest-deploy (OMERO-5.1-latest-deploy-win, port 14064, default servicename since PR isn't merged). Note multiple web/IIS isn't working for other reasons so ignore web for now.

Test locally on your own VM if you're feeling brave.
