### PR TITLE
Don't pass invalid ICE_CONFIG to Ice (fix #10051).

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1314,7 +1314,14 @@ OMERO Diagnostics %s
         vers = Ice.stringVersion()
         _check("IcePy version", vers)
 
+        # See ticket #10051
         popen = self.ctx.popen(["icegridnode", "--version"])
+        env = self.ctx._env()
+        ice_config = env.get("ICE_CONFIG")
+        if ice_config is not None and not os.path.exists(ice_config):
+            popen = self.ctx.popen(["icegridnode", "--version"],
+                                   **{'ICE_CONFIG': ''})
+
         vers = popen.communicate()[1]
         _check("icegridnode version", vers)
 


### PR DESCRIPTION
This PR fixes https://trac.openmicroscopy.org/ome/ticket/10051.

To test, follow the steps from the ticket, with a tiny modification:
- Start the server
- Login in via `bin/omero login`
- Set the `ICE_CONFIG` env var (`export ICE_CONFIG=`bin/omero sessions file``)
- Log out (`bin/omero logout`)
- Stop the server
- Try to start the server
- Verify that no error message appears

This should also work when ICE_CONFIG is set to any invalid file/directory.
