### PR TITLE
Robot test fixes (rebased onto dev_5_0)

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_login.txt
+++ b/components/tests/ui/testcases/web/webadmin_login.txt
@@ -16,7 +16,7 @@ Suite Teardown      Close all browsers
 Login Page
     [Documentation]    Tests elements on the login page
     
-    Page Should Contain Image       xpath=//div[@id='login-logo']/img
+    Page Should Contain Image       xpath=//div[contains(@class, 'login-logos')]/img
     Page Should Contain Element     id_server
     Page Should Contain Checkbox    id_ssl
     Page Should Contain Element     id_username


### PR DESCRIPTION
This is the same as gh-3126 but rebased onto dev_5_0.

---

This fixes a couple of failing tests from http://ci.openmicroscopy.org/job/OMERO-5.1-merge-robotframework/47/console
They were failing due to changes in the webclient code.

Tests that are fixed are:

```
Web.Webadmin Create Group And User :: A test suite with a single test for v...
==============================================================================
Create Group :: Tests group creation                                  | FAIL |
ValueError: Element locator 'xpath=//ul[@class='chzn-choices']' did not match any elements.
```

and 

```
Web.Webadmin Login :: A test suite with a single test for valid login.\n\nT...
==============================================================================
Login Page :: Tests elements on the login page                        | FAIL |
Page should have contained image 'xpath=//div[@id='login-logo']/img' but did not
```

Other failing tests I couldn't repeat locally on Chrome or Firefox. They may have been caused by slow loading on root login (which should be fixed by https://github.com/openmicroscopy/openmicroscopy/pull/3123 or on Javascript failure in Chrome (although there is no error message and all we see in the failure to grab a screenshot when the tests fail).
