### PR TITLE
Set the color to grey if one channel.

### DIFF
--- a/components/blitz/src/ome/formats/model/ChannelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ChannelProcessor.java
@@ -106,6 +106,35 @@ public class ChannelProcessor implements ModelProcessor
 	}
 
 	/**
+	 * Sets the default color if it is a single channel image.
+	 *
+	 * @param channelData Channel data to use to set the color.
+	 */
+	private void setSingleChannel(ChannelData channelData)
+	{
+	    int channelIndex = channelData.getChannelIndex();
+	    Channel channel = channelData.getChannel();
+	    Integer red = getValue(channel.getRed());
+        Integer green = getValue(channel.getGreen());
+        Integer blue = getValue(channel.getBlue());
+        Integer alpha = getValue(channel.getAlpha());
+        RString name;
+        //color already set by Bio-formats
+        if (red != null && green != null && blue != null && alpha != null) {
+            return;
+        }
+        int[] defaultColor = ColorsFactory.newGreyColor();
+        channel.setRed(
+                rint(defaultColor[ColorsFactory.RED_INDEX]));
+        channel.setGreen(
+                rint(defaultColor[ColorsFactory.GREEN_INDEX]));
+        channel.setBlue(
+                rint(defaultColor[ColorsFactory.BLUE_INDEX]));
+        channel.setAlpha(
+                rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
+	}
+
+	/**
      * Populates the default color for the channel if one does not already
      * exist.
      *
@@ -119,6 +148,7 @@ public class ChannelProcessor implements ModelProcessor
 	int channelIndex = channelData.getChannelIndex();
 	Channel channel = channelData.getChannel();
 	LogicalChannel lc = channelData.getLogicalChannel();
+	int[] defaultColor;
 	if (isGraphicsDomain)
 		{
 	    log.debug("Setting color channel to RGB.");
@@ -162,6 +192,7 @@ public class ChannelProcessor implements ModelProcessor
 		}
 		return;
         }
+        //not set by 
         //First we check the emission wavelength.
 	Double valueWavelength = getValue(lc.getEmissionWave());
 	if (valueWavelength != null) {
@@ -484,22 +515,27 @@ public class ChannelProcessor implements ModelProcessor
 		//Think of strategy for images with high number of channels
 		//i.e. > 6
 		sizeC = pixels.getSizeC().getValue();
-		for (int c = 0; c < sizeC; c++)
-		{
-			channelData = ChannelData.fromObjectContainerStore(store, i, c);
-			//Color section
-			populateDefault(channelData, isGraphicsDomain);
+		if (sizeC == 1) {
+		    channelData = ChannelData.fromObjectContainerStore(store, i, 0);
+		    setSingleChannel(channelData);
+		} else {
+		    for (int c = 0; c < sizeC; c++)
+	        {
+	            channelData = ChannelData.fromObjectContainerStore(store, i, c);
+	            //Color section
+	            populateDefault(channelData, isGraphicsDomain);
 
-                //only retrieve if not graphics
-                if (!isGraphicsDomain) {
-			//Determine if the channel same emission wavelength.
-			v = ColorsFactory.hasEmissionData(channelData);
-			if (!v)
-			{
-				count++;
-			}
-                    m.put(channelData, v);
-                }
+	                //only retrieve if not graphics
+	                if (!isGraphicsDomain) {
+	            //Determine if the channel same emission wavelength.
+	            v = ColorsFactory.hasEmissionData(channelData);
+	            if (!v)
+	            {
+	                count++;
+	            }
+	                    m.put(channelData, v);
+	                }
+	        }
 		}
 
 		//Need to reset the color of transmitted light


### PR DESCRIPTION
To test this PR
- Import an image with one channel e.g. DICOM
- The channel should now be grey instead of red (see screenshot before and after)
  before
  ![singlechannel](https://cloud.githubusercontent.com/assets/1022396/4794518/2c8ac45a-5df5-11e4-9c60-adf7c93d8d05.png)
  after
  ![singlechannelafter](https://cloud.githubusercontent.com/assets/1022396/4794520/2ea1ccd4-5df5-11e4-90df-0095faf6e272.png)
