### PR TITLE
Batch Annotate with Read-only (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -47,10 +47,6 @@ $(function () {
             var productListQuery = new Array();
             var well_index;
             for (var i=0; i<selected.length; i++) {
-                // if any items don't have the canAnnotate class, we don't show batch annotation
-                if (typeof selected[i]['class'] != 'undefined' && selected[i]['class'].indexOf("canAnnotate") < 0) {
-                    return;
-                }
                 productListQuery[i] = selected[i]["id"].replace("-","=");
                 well_index = well_index || selected[i]["index"];
             }


### PR DESCRIPTION
This is the same as gh-3127 but rebased onto dev_5_0.

---

NB: This is critical for @imunro to allow public (read-only) data to be downloaded.

This removes the blocking of batch-annotate panel when any items that can't be annotated are selected.

It allows E.g. download of files and inspection of current annotations / paths etc. without allowing annotation.

To test:
- Select multiple P/D/I belonging to another user in a Read-only group.
- Batch annotate panel should show.
- You shouldn't be able to add annotations, but can see existing ones.
- Can download original file, inspect path on server etc.
- Banner warns that you can't annotate. Is this too aggressive?

![screen shot 2014-10-21 at 16 25 22](https://cloud.githubusercontent.com/assets/900055/4721194/036a8a50-5937-11e4-840c-4e4dd6fead24.png)
