### PR TITLE
Make sure the background of the PreviewCanvas is drawn

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
@@ -382,6 +382,7 @@ public class DomainPane
         	initSlider(zSlider, maxZ, model.getDefaultZ(), 
         			Z_SLIDER_DESCRIPTION, Z_SLIDER_TIPSTRING);
         	canvas = new PreviewCanvas();
+        	canvas.setBackground(UIUtilities.BACKGROUND_COLOR);
         }
         if (model.hasModuloT()) {
             lifetimeSlider = new OneKnobSlider(OneKnobSlider.HORIZONTAL,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/PreviewCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/PreviewCanvas.java
@@ -94,6 +94,13 @@ class PreviewCanvas
         int y = (d.height - scaledImage.getHeight()) / 2;
 
         Graphics2D g2D = (Graphics2D) g;
+        
+        // paint the background
+        g2D.setColor(getBackground());
+        g2D.fillRect(0, 0, getWidth(), getHeight());
+        g2D.setColor(getForeground());
+        
+        // paint the image
         ImagePaintingFactory.setGraphicRenderingSettings(g2D);
         g2D.drawImage(scaledImage, null, x, y);
         g2D.dispose();


### PR DESCRIPTION
This PR should fix the problem with the distorted PreviewCanvas @gusferguson noticed today.
Test: Open the Windows(!) build of Insight, select an Image, change some settings in the rendering settings; make sure that the preview image is shown neatly (i. e. no weird drawing artifacts in the background).
I don't know for sure if this fixes the problem, as I can't create a Windows build at the moment, but I strongly assume that the problem was the combination of double buffering and the overwritten paintComponent method (although I'm surprised, that this does not show up on OSX).
/cc @pwalczysko @jburel 

--no-rebase
