### PR TITLE
Pass omero.db.pass via envvar to bin/omero admin reindex

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1385,6 +1385,7 @@ OMERO Diagnostics %s
             if k in cfg:
                 v = cfg[k]
                 xargs.append("-D%s=%s" % (k, v))
+
         if "omero.data.dir" in cfg:
             xargs.append("-Domero.data.dir=%s" % cfg["omero.data.dir"])
         for k, v in cfg.items():
@@ -1469,6 +1470,15 @@ OMERO Diagnostics %s
         debug = False
         if getattr(args, "jdwp"):
             debug = True
+
+        # Pass omero.db.pass using JAVA_OPTS environment variable
+        if "omero.db.pass" in cfg:
+            dbpassargs = "-Domero.db.pass=%s" % cfg["omero.db.pass"]
+            if "JAVA_OPTS" not in os.environ:
+                os.environ['JAVA_OPTS'] = dbpassargs
+            else:
+                os.environ['JAVA_OPTS'] = "%s %s" % (
+                    os.environ.get('JAVA_OPTS'), dbpassargs)
 
         self.ctx.dbg(
             "Launching Java: %s, debug=%s, xargs=%s" % (cmd, debug, xargs))


### PR DESCRIPTION
For security reasons, the DB password is not passed as an xargs to the reindex
command. This commit fixes this issue by internally setting the JAVA_OPTS
environment variable which should only be visible to the process owner (and
root).

See https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7673&p=14962#p14952

To test this PR:
- set up a server with a user/password 
- check `bin/omero admin reindex --reset 0` fails without this PR
- check `bin/omero admin reindex --reset 0` passes with this PR
- check `JAVA_OPTS="-Dlogback.configurationFile=stderr.xml" bin/omero admin reindex --reset 0` passes with this PR
- in both cases above, check the environment variable does not leak for another user than the one doing the reindex (e.g. via `ps auxe`)
