### PR TITLE
QA feedback url configurable (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -214,6 +214,7 @@ def leave_none_unset_int(s):
 
 CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 CUSTOM_SETTINGS_MAPPINGS = {
+    "omero.qa.feedback" : ["FEEDBACK_URL", "http://qa.openmicroscopy.org.uk", str],
     "omero.web.login_logo": ["LOGIN_LOGO", None, leave_none_unset],
     "omero.web.apps": ["ADDITIONAL_APPS", '[]', json.loads],
     "omero.web.public.enabled": ["PUBLIC_ENABLED", "false", parse_boolean],
@@ -498,9 +499,11 @@ for app in ADDITIONAL_APPS:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 logger.debug('INSTALLED_APPS=%s' % [INSTALLED_APPS])
 
 
-# FEEDBACK_URL: Used in feedback.sendfeedback.SendFeedback class in order to submit 
-# error or comment messages to https://qa.openmicroscopy.org.
-FEEDBACK_URL = "http://qa.openmicroscopy.org.uk"
+# # FEEDBACK - DO NOT MODIFY!
+# FEEDBACK_URL: Is now configurable for testing purpuse only. Used in
+# feedback.sendfeedback.SendFeedback class in order to submit errors or
+# comment messages to http://qa.openmicroscopy.org.uk.
+# FEEDBACK_APP: 6 = OMERO.web
 FEEDBACK_APP = 6
 
 # IGNORABLE_404_STARTS: 


### PR DESCRIPTION
This is the same as gh-2992 but rebased onto dev_5_0.

---

To perform better testing we need to make QA feedback URL configurable

to test set `bin/omero config set omero.qa.feedback URL`

cc: @sbesson @jburel @pwalczysko 
