### PR TITLE
Bugfix: Help menu not working

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.TaskBarManager
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -151,6 +151,9 @@ public class TaskBarManager
     
     /** Dialog to reconnect to server.*/
     private ScreenLoginDialog reconnectDialog;
+    
+    /** The actions for the help menu */
+    private Map<Integer, ActionListener> helpMenuActions;
     
     /**
      * Returns the icon for the splash screen if none set.
@@ -730,49 +733,104 @@ public class TaskBarManager
         }
     }
 
+    /** Instantiates the ActionListeners for the help menu */
+    private void createHelpMenuActionListeners() {
+    	
+    	helpMenuActions = new HashMap<Integer, ActionListener>();
+    	
+    	ActionListener noOp = new ActionListener() {
+			public void actionPerformed(ActionEvent ae) { 
+				notAvailable(); 
+				}
+		};
+		
+    	helpMenuActions.put(TaskBarView.WELCOME_MI, noOp);
+    	
+    	helpMenuActions.put(TaskBarView.HELP_MI, new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				 help();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.HOWTO_MI, noOp);
+    	
+    	helpMenuActions.put(TaskBarView.UPDATES_MI, new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				softwareAbout();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.ABOUT_MI, noOp);
+    	
+    	helpMenuActions.put(TaskBarView.HELP_BTN, new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				 help();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.COMMENT_MI, new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				sendComment();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.FORUM_MI, new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				forum();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.ACTIVITY_MI, new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				((UserNotifierImpl)
+	            		container.getRegistry().getUserNotifier()).showActivity();
+			}
+		});
+    	
+    	helpMenuActions.put(TaskBarView.LOG_FILE_MI, new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				logFile();
+			}
+		});
+    }
+    
+    /**
+     * Get the ActionListener for a specific help menu item
+     * @param id The Id of the action
+     * @return See above
+     */
+    public ActionListener getHelpMenuAction(int id) {
+    	return helpMenuActions.get(id);
+    }
+    
 	/**
 	 * Attaches the {@link #notAvailable() not-available} action to all buttons
 	 * whose functionality hasn't been implemented yet.
 	 */
 	private void attachMIListeners()
 	{
-		ActionListener noOp = new ActionListener() {
-			public void actionPerformed(ActionEvent ae) { notAvailable(); }
-		};
-		view.getButton(TaskBarView.WELCOME_MI).addActionListener(noOp);
+		view.getButton(TaskBarView.WELCOME_MI).addActionListener(
+				getHelpMenuAction(TaskBarView.WELCOME_MI));
 		view.getButton(TaskBarView.HELP_MI).addActionListener(
-				new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { help(); }
-        });
-		view.getButton(TaskBarView.HOWTO_MI).addActionListener(noOp);
+				getHelpMenuAction(TaskBarView.HELP_MI));
+		view.getButton(TaskBarView.HOWTO_MI).addActionListener(
+				getHelpMenuAction(TaskBarView.HOWTO_MI));
 		view.getButton(TaskBarView.UPDATES_MI).addActionListener(
-                new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { softwareAbout(); }
-        });
-		view.getButton(TaskBarView.ABOUT_MI).addActionListener(noOp);
+				getHelpMenuAction(TaskBarView.UPDATES_MI));
+		view.getButton(TaskBarView.ABOUT_MI).addActionListener(
+				getHelpMenuAction(TaskBarView.ABOUT_MI));
 		view.getButton(TaskBarView.HELP_BTN).addActionListener(
-				new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { help(); }
-        });
+				getHelpMenuAction(TaskBarView.HELP_BTN));
 		view.getButton(TaskBarView.COMMENT_MI).addActionListener(
-                new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { sendComment(); }
-        });
+				getHelpMenuAction(TaskBarView.COMMENT_MI));
 		view.getButton(TaskBarView.FORUM_MI).addActionListener(
-				new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { forum(); }
-        });
+				getHelpMenuAction(TaskBarView.FORUM_MI));
 		view.getButton(TaskBarView.ACTIVITY_MI).addActionListener(
-				new ActionListener() {
-            public void actionPerformed(ActionEvent ae) {
-            	((UserNotifierImpl)
-            		container.getRegistry().getUserNotifier()).showActivity();
-            }
-        });
+				getHelpMenuAction(TaskBarView.ACTIVITY_MI));
 		view.getButton(TaskBarView.LOG_FILE_MI).addActionListener(
-				new ActionListener() {
-            public void actionPerformed(ActionEvent ae) { logFile(); }
-        });
+				getHelpMenuAction(TaskBarView.LOG_FILE_MI));
 	}
 	
 	/**
@@ -894,6 +952,9 @@ public class TaskBarManager
 	TaskBarManager(Container c)
 	{
 		container = c;
+		// ActionListeneres for the help menu have to be created
+		// prior to the TaskBarView:
+		createHelpMenuActionListeners();
 		view = new TaskBarView(this, IconManager.getInstance(c.getRegistry()));
 		attachListeners();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/TaskBarView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/TaskBarView.java
@@ -335,12 +335,34 @@ class TaskBarView
 	{
 		JMenu help = new JMenu("Help");
 		help.setMnemonic(KeyEvent.VK_H);
-		help.add(copyItem((JMenuItem) buttons[HELP_MI]));
-		help.add(copyItem((JMenuItem) buttons[FORUM_MI]));
-		help.add(copyItem((JMenuItem) buttons[COMMENT_MI]));
+		
+		JMenuItem i = copyItem((JMenuItem) buttons[HELP_MI]);
+		if(i.getActionListeners().length==0) 
+			i.addActionListener(manager.getHelpMenuAction(HELP_MI));
+		help.add(i);
+		
+		i = copyItem((JMenuItem) buttons[FORUM_MI]);
+		if(i.getActionListeners().length==0) 
+			i.addActionListener(manager.getHelpMenuAction(FORUM_MI));
+		help.add(i);
+		
+		i = copyItem((JMenuItem) buttons[COMMENT_MI]);
+		if(i.getActionListeners().length==0) 
+			i.addActionListener(manager.getHelpMenuAction(COMMENT_MI));
+		help.add(i);
+		
 		help.add(new JSeparator(JSeparator.HORIZONTAL));
-		help.add(copyItem((JMenuItem) buttons[LOG_FILE_MI]));
-		help.add(copyItem((JMenuItem) buttons[UPDATES_MI]));
+		
+		i = copyItem((JMenuItem) buttons[LOG_FILE_MI]);
+		if(i.getActionListeners().length==0) 
+			i.addActionListener(manager.getHelpMenuAction(LOG_FILE_MI));
+		help.add(i);
+		
+		i = copyItem((JMenuItem) buttons[UPDATES_MI]);
+		if(i.getActionListeners().length==0) 
+			i.addActionListener(manager.getHelpMenuAction(UPDATES_MI));
+		help.add(i);
+		
 		return help;
 	}
 


### PR DESCRIPTION
Related to PR #3150 
Above mentioned PR fixed the issue of the disappearing help menu items, but the 'first level' help menu items (i. e. in the main application menu bar) didn't work anymore (no ActionListeners were attached to them). Sorry, didn't notice that earlier when reviewing the PR.

Test: Make sure the help menu items in the main application menu bar are working.

/cc @jburel 

--no-rebase
