### PR TITLE
Distorted 'Send feedback' dialog

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MessengerDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MessengerDialog.java
@@ -422,6 +422,7 @@ public class MessengerDialog
         JScrollPane areaScrollPane = new JScrollPane(commentArea);
         areaScrollPane.setVerticalScrollBarPolicy(
         		JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        commentArea.setPreferredSize(new Dimension(300,100));
         JLabel label = new JLabel(comment);
         label.setOpaque(false);
         label.setDisplayedMnemonic(mnemonic);
@@ -819,4 +820,9 @@ public class MessengerDialog
 	 */
 	public void changedUpdate(DocumentEvent e) {}
 	
+	@Override
+	public void setVisible(boolean b) {
+		super.setVisible(b);
+		pack();
+	}
 }


### PR DESCRIPTION
See: https://trac.openmicroscopy.org.uk/ome/ticket/12375

It's a bit tricky to hit this bug, apparently you need to run Insight compiled with Java 8 and run with Java 7 on OSX (at least that's my setup for reproducing the bug).
Test without this PR: Try to import a 'bad' image in order to get a failed import; click on Failed -> Submit; Make sure you get the distorted 'Send feedback' dialog (see screenshot1 ).
Test with this PR: Repeat above procedure, and make sure you now see a proper 'Send feedback' dialog (see screenshot 2)

Without PR:
![screen shot 2014-11-06 at 11 15 31](https://cloud.githubusercontent.com/assets/6575139/4935197/8ff6d4d2-65a9-11e4-8183-18d0672ad90e.png)

With PR:
![screen shot 2014-11-06 at 11 37 03](https://cloud.githubusercontent.com/assets/6575139/4935200/99715276-65a9-11e4-874b-864e8756b968.png)

--no-rebase
