### PR TITLE
Robot webadmin.txt Log Out

### DIFF
--- a/components/tests/ui/resources/web/webadmin.txt
+++ b/components/tests/ui/resources/web/webadmin.txt
@@ -39,6 +39,7 @@ Open Browser To Webadmin And Log In As Root
     Page Should Be Open             ${USERS URL}                OMERO Users
 
 Log Out
+    Wait Until Page Contains Element  xpath=//div[@id='show_user_dropdown']/span
     Click Element                   xpath=//div[@id='show_user_dropdown']/span
     Click Link                      link=Logout
     Page Should Be Open             ${WEBCLIENT LOGIN URL}                OMERO.web - Login


### PR DESCRIPTION
Attempting to fix FAILS from https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-robotframework/70/console by waiting for the Log Out element to appear.

To test, check latest ci build to see if it's addressed the 'show_user_dropdown' failures above.
