### PR TITLE
Fix Hibernate error on Web user creation.

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -48,7 +48,7 @@ import Ice
 import omero.gateway
 import omero.scripts
 
-from omero.rtypes import rint, rstring, rlong, rlist, rtime, unwrap
+from omero.rtypes import rbool, rint, rstring, rlong, rlist, rtime, unwrap
 from omero.model import \
                         ExperimenterI, ExperimenterGroupI
 
@@ -886,6 +886,7 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
         experimenter.lastName = rstring(str(lastName))
         experimenter.email = rstring(str(email))
         experimenter.institution = (institution!="" and institution is not None) and rstring(str(institution)) or None
+        experimenter.ldap = rbool(False)
 
         listOfGroups = list()
         # system group


### PR DESCRIPTION
This PR fixes an issue where the new "ldap" field wasn't filled in when a user was created through the Web UI. This was the only place I missed from my previous LDAP PR.

To test:
- verify that the Python integration tests are still green,
- verify that no error is thrown when you create a user in the Webadmin part of OMERO.web.
