### PR TITLE
fixing paths for test run on CI

### DIFF
--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -17,6 +17,8 @@ for tools in glob.glob("../../../lib/repository/setuptools*.egg"):
     if tools.find(".".join(map(str, sys.version_info[0:2]))) > 0:
         sys.path.insert(0, os.path.abspath(tools))
 
+os.environ.setdefault('OMERO_HOME', os.path.join("..", "..","..","dist"))
+
 LIB = os.path.join("..", "target", "lib", "python")
 sys.path.insert(0, LIB)
 OMEROWEB_LIB = os.path.join(LIB, "omeroweb")


### PR DESCRIPTION
OMERO.web integration tests are running using library under `components/tools/OmeroPy/target/lib/python` rather then dist. Unfortunately if `OMERO_HOME` is not set all omero properties are missed. With the multiple-servers deployment integration tests are failing because they run against `localhost:4064`. This fix should resolve CI failure.

cc: @sbesson, @ximenesuk, @will-moore 

Please note: we are already doing this patching all across the place, https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/library.py#L201

Test results:

```
test/integration/test_csrf.py:161: TestCsrf.test_csrf_middleware_enabled PASSED
test/integration/test_csrf.py:180: TestCsrf.test_forgot_password PASSED
test/integration/test_csrf.py:190: TestCsrf.test_add_and_rename_container PASSED
test/integration/test_csrf.py:231: TestCsrf.test_move_data PASSED
test/integration/test_csrf.py:248: TestCsrf.test_add_and_remove_comment PASSED
test/integration/test_csrf.py:263: TestCsrf.test_add_edit_and_remove_tag PASSED
test/integration/test_csrf.py:306: TestCsrf.test_attach_file PASSED
test/integration/test_csrf.py:347: TestCsrf.test_paste_move_remove_deletamany_image PASSED
test/integration/test_csrf.py:401: TestCsrf.test_basket_actions PASSED
test/integration/test_csrf.py:464: TestCsrf.test_edit_channel_names PASSED
test/integration/test_csrf.py:481: TestCsrf.test_copy_past_rendering_settings PASSED
test/integration/test_csrf.py:505: TestCsrf.test_reset_rendering_settings PASSED
test/integration/test_csrf.py:527: TestCsrf.test_apply_owners_rendering_settings PASSED
test/integration/test_csrf.py:541: TestCsrf.test_ome_tiff_script PASSED
test/integration/test_csrf.py:557: TestCsrf.test_script PASSED
test/integration/test_csrf.py:581: TestCsrf.test_myaccount PASSED
test/integration/test_csrf.py:598: TestCsrf.test_avatar PASSED
test/integration/test_csrf.py:660: TestCsrf.test_create_group PASSED
test/integration/test_csrf.py:672: TestCsrf.test_create_user PASSED
test/integration/test_csrf.py:690: TestCsrf.test_edit_group PASSED
test/integration/test_csrf.py:702: TestCsrf.test_edit_user PASSED
test/integration/test_csrf.py:717: TestCsrf.test_edit_group_by_owner PASSED
test/integration/test_csrf.py:737: TestCsrf.test_change_password PASSED
test/integration/test_csrf.py:749: TestCsrf.test_su PASSED
```
