### PR TITLE
Units cpp fixes

### DIFF
--- a/components/tools/OmeroCpp/test/omero/fixture.cpp
+++ b/components/tools/OmeroCpp/test/omero/fixture.cpp
@@ -154,7 +154,7 @@ omero::model::PixelsIPtr Fixture::pixels() {
 
     lc->setPhotometricInterpretation( pi );
 
-    UnitsLength mm = UnitsLength::MM;
+    UnitsLength mm = omero::model::enums::MM;
     LengthPtr mm1 = new LengthI();
     mm1->setUnit(mm);
     mm1->setValue(1.0);


### PR DESCRIPTION
The use of true enums throughout the OMERO stack has turned up a couple of interesting issues:
- enumerations are not always to be found at the same scope depending on GCC version (fixed here)
- enumerations can clash with public definitions in Visual Studio (not yet fixed here).

To test, check the status of the C++ tests. A follow-on run to https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-latest-cpp/342/label=gretzky35/console should now be green. 

Further runs of https://ci.openmicroscopy.org/job/OMERO-5.1-merge-cpp-win/VSARCH=x64,VSCONFIG=Debug,VSVERSION=vc110/74/console and
https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-latest-cpp-win/86/VSARCH=x64,VSCONFIG=Debug,VSVERSION=vc100/console will continue to be red for the moment.

--no-rebase
