### PR TITLE
Fix test_model51.py on Ice 3.4

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -69,7 +69,12 @@ class TestModel51(lib.ITest):
         assert omero.model.enums.UnitsLength.MM == unit
 
     UL = omero.model.enums.UnitsLength
-    UL = sorted(UL._enumerators.values())
+    try:
+        UL = sorted(UL._enumerators.values())
+    except:
+        # TODO: this occurs on Ice 3.4 and can be removed
+        # once it has been dropped.
+        UL = [getattr(UL, x) for x in sorted(UL._names)]
 
     @pytest.mark.parametrize("ul", UL)
     def testAllLengths(self, ul):

--- a/components/tools/OmeroPy/test/unit/test_model.py
+++ b/components/tools/OmeroPy/test/unit/test_model.py
@@ -331,3 +331,15 @@ class TestModel(object):
         link = DatasetImageLinkI()
         link.setParent("Dataset:1")
         link.setChild("Image:1")
+
+    UL = omero.model.enums.UnitsLength
+    try:
+        UL = sorted(UL._enumerators.values())
+    except:
+        # TODO: this occurs on Ice 3.4 and can be removed
+        # once it has been dropped.
+        UL = [getattr(UL, x) for x in sorted(UL._names)]
+
+    @pytest.mark.parametrize("ul", UL)
+    def testEnumerators(self, ul):
+        assert hasattr(omero.model.enums.UnitsLength, str(ul))


### PR DESCRIPTION
Ice 3.5 generates an _enumerators collection to
access the members of an enum. Ice 3.4 generates
a _names collection of the string values of the
enums instead. For the moment, handling this only
in the tests. We will likely want to provide some
helper methods for working with these.

Note: my intent had been to inject a _enumerators
collection in the Ice 3.4 code, but there's not a
good hook for doing so.
