### PR TITLE
Allow to set feedback URL via environment variable

### DIFF
--- a/components/insight/build.xml
+++ b/components/insight/build.xml
@@ -39,6 +39,8 @@
             <ant antfile="${basedir}/build/build.xml" inheritAll="false" inheritRefs="false" target="@{target}">
                 <property name="dont.run.tests" value="true"/>
                 <property name="omero.display_version" value="${omero.version}"/>
+                <property environment="env"/>
+                <property name="env.QA_BASEURL" value="http://qa.openmicroscopy.org.uk/qa"/>
             </ant>
         </sequential>
     </macrodef>

--- a/components/insight/build/app.xml
+++ b/components/insight/build/app.xml
@@ -112,7 +112,9 @@
     <replace dir="${app.config.dir}"
         token="@OMERO_DISPLAY_VERSION@"
         value="${omero.display_version}"/>
-
+    <replace dir="${app.config.dir}"
+        token="@QA_BASEURL@"
+        value="${env.QA_BASEURL}"/>
     <copy todir="${app.lib.dir}">
       <fileset refid="app.libs"/>
     </copy>

--- a/components/insight/config/container.xml
+++ b/components/insight/config/container.xml
@@ -167,8 +167,8 @@
          This entry specifies the name of the server and 
          and e-mail address to submit comment.
     -->
-    <entry name="/services/DEBUGGER/hostnameToken">http://qa.staging.openmicroscopy.org/qa/initial/</entry>
-    <entry name="/services/DEBUGGER/hostnameProcessing">http://qa.staging.openmicroscopy.org/qa/upload_processing/</entry>
+    <entry name="/services/DEBUGGER/hostnameToken">@QA_BASEURL@/initial/</entry>
+    <entry name="/services/DEBUGGER/hostnameProcessing">@QA_BASEURL@/upload_processing/</entry>
     <entry name="/services/DEBUGGER/applicationNameBug">4</entry>
     <entry name="/services/DEBUGGER/applicationNameComment">3</entry>
     <entry name="/services/DEBUGGER/postTimeout" type="integer">2000</entry>

--- a/components/insight/config/containerImporter.xml
+++ b/components/insight/config/containerImporter.xml
@@ -158,8 +158,8 @@
          This entry specifies the name of the server and
          and e-mail address to submit comment.
     -->
-    <entry name="/services/DEBUGGER/hostnameToken">http://qa.staging.openmicroscopy.org/qa/initial/</entry>
-    <entry name="/services/DEBUGGER/hostnameProcessing">http://qa.staging.openmicroscopy.org/qa/upload_processing/</entry>
+    <entry name="/services/DEBUGGER/hostnameToken">@QA_BASEURL@/initial/</entry>
+    <entry name="/services/DEBUGGER/hostnameProcessing">@QA_BASEURL@/upload_processing/</entry>
     <entry name="/services/DEBUGGER/applicationNameBug">2</entry>
     <entry name="/services/DEBUGGER/applicationNameComment">1</entry>
     <entry name="/services/DEBUGGER/postTimeout" type="integer">2000</entry>


### PR DESCRIPTION
With this PR:
- the default Insight build should be unmodified and produce Insight artifacts which connect to http://qa.openmicroscopy.org.uk/ when sending feedback
- it is now possible to configure the base url of the QA feedback by setting the `QA_BASEURL` environment variable in the build command, e.g.
  
  ```
  QA_BASEURL=http://qa.staging.openmicroscopy.org/qa ./build.py -f components/insight/build.xml dist
  ```

--no-rebase
