### PR TITLE
omero_client

### DIFF
--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -80,8 +80,10 @@
         <unjar dest="${target.dir}/generated-classes">
             <fileset dir="${target.dir}/libs">
                 <include name="ice*.jar"/>
+                <include name="ome-xml.jar"/>
             </fileset>
         </unjar>
+
     </target>
 
     <target name="package" depends="compile">


### PR DESCRIPTION
Add missing dependency directly to omero_client.jar so it can still be used as it is.
Check if matlab, training jobs are green
