### PR TITLE
Blitz listParents() query fix

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5803,7 +5803,7 @@ class _WellSampleWrapper (BlitzObjectWrapper):
         """
         rv = self._conn.getQueryService().findAllByQuery(
             ("select w from Well w "
-             "left outer join fetch w.wellSamples as ws"
+             "left outer join fetch w.wellSamples as ws "
              "where ws.id=%d" % self.getId()),
             None, self._conn.SERVICE_OPTS)
         if not len(rv):


### PR DESCRIPTION
This fixes a tiny error from 85ccaabd.
To test, simply choose an Image (in Project & Dataset), click the link button in right panel toolbar, copy link and test the link works.
--no-rebase
