### PR TITLE
Wrap description text to avoid horizontal scroll bar

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -35,6 +35,8 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;
@@ -1227,7 +1229,12 @@ public class PropertiesUI
         descriptionWiki.setCaretPosition(0);
         descriptionWiki.setBackground(UIUtilities.BACKGROUND_COLOR);
         descriptionWiki.setForeground(UIUtilities.DEFAULT_FONT_COLOR);
-
+        addComponentListener(new ComponentAdapter() {
+			public void componentResized(ComponentEvent e) {
+				descriptionWiki.wrapText(getSize().width, null);
+			}
+		});
+        
         editNames();
         if (b) {
             namePane.getDocument().addDocumentListener(this);


### PR DESCRIPTION
Follow-up to PR #3133 /cc @gusferguson 
This will make the description field behave similar to the comment field. It will try to word wrap (i. e. wrap on white spaces) the description text to avoid a horizontal scroll bar. But this affects **only loaded descriptions**. If you're in editing mode there will be no automatic line wrap; once you reached the right hand side end of the description field you can continue adding characters on the same line, a horizontal scrollbar will appear (which is the same for the 'add comment' text field).
