### PR TITLE
tagging escape bug

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/tags_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/tags_form.html
@@ -100,5 +100,5 @@
 </div>
 
 <script>
-    tagging_form({{ selected_tags|escape }}, "{{ newtags_formset.prefix }}", "{{ form_tags.tags.auto_id }}", {{ ome.user.id }}, "{{ ome.user.firstName|escape }} {{ ome.user.lastName|escape }}");
+    tagging_form({{ selected_tags|safe }}, "{{ newtags_formset.prefix }}", "{{ form_tags.tags.auto_id }}", {{ ome.user.id }}, "{{ ome.user.firstName|escape }} {{ ome.user.lastName|escape }}");
 </script>


### PR DESCRIPTION
During testing of 5.0.6 rebase to develop https://github.com/openmicroscopy/openmicroscopy/pull/3187
Petr found that launching the Tagging dialog and loading tags fails if the P/D/I already has tags on it.

This is due to javascript escaping in commit:  687fe16a and is fixed by this PR.

To test, pick a tagged P/D/I and try to add additional tags. Make sure that the tagging dialog loads tags as expected.
