### PR TITLE
Fix web attachment error msg develop

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
@@ -187,6 +187,7 @@
                     },
                     error: function(data){
                         $("#fileann_spinner").hide();
+                        alert("Upload failed [" + data.status + " " + data.statusText + "]");
                     }
                 });
                 // prepare dialog for choosing file to attach...

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -262,7 +262,7 @@
                     },
                     error: function(data){
                         $("#fileann_spinner").hide();
-                        alert(data.response);
+                        alert("Upload failed [" + data.status + " " + data.statusText + "]");
                     }
                 });
                 // prepare dialog for choosing file to attach...


### PR DESCRIPTION
This PR attempts to make alert messages more explicit in case of failed file annotations upload in OMERO.web.

Testing requires nginx with a config such that:
* either no `client_max_body_size` is configured, hence using the default 1MB value
* or explicitly set to `client_max_body_size 1M;`

Test cases:
* Standard file annotation:
  * create a dataset and attach a file larger than 1MB via the webclient from the local filesystem
  * the browser's alert popup should display "Upload failed [413 Request body too large]" instead of "undefined"
* Batch file annotation:
  * create two datasets, select both in the left panel and repeat the file upload >1M
  * an alert popup should be displayed with a message as above instead of the error being silently ignored

Note: 
the issue is reproducible on `5.0.6` but testing on `develop` currently depends on https://trac.openmicroscopy.org/ome/ticket/12663 first (see #3231).

