### PR TITLE
Add test for trac:11939 #3228

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
@@ -111,6 +111,8 @@ class TestDelete (object):
         fileAnnLink.link(omero.model.ProjectI(pid, False), fileAnn)
         fileAnnLink = us.saveAndReturnObject(fileAnnLink)
 
+        faid = unwrap(fileAnnLink.getChild().getId())
+
         # Delete the file
         handle = gatewaywrapper.gateway.deleteObjects(
             'OriginalFile', [oid], True, True)
@@ -118,4 +120,4 @@ class TestDelete (object):
         handle.close()
 
         assert qs.find('OriginalFile', oid) is None
-        assert qs.find('FileAnnotation', unwrap(fileAnn.getId())) is None
+        assert qs.find('FileAnnotation', faid) is None


### PR DESCRIPTION
@mtbc says #3228 fixes the bug reported in http://trac.openmicroscopy.org/ome/ticket/11939#comment:9 and suggests copying the test. Here it is.

--depends-on #3228

Assuming this test passes are there any other assertions that should be made?
