### PR TITLE
Tables set all metadata 12606

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -31,6 +31,8 @@ from omero_ext.functional import wraps
 sys = __import__("sys")  # Python sys
 tables = __import__("tables")  # Pytables
 
+VERSION = 2
+
 
 def slen(rv):
     """
@@ -327,10 +329,11 @@ class HdfStorage(object):
         self.__hdf_file.createArray(
             self.__ome, "ColumnDescriptions", self.__descriptions)
 
-        self.__mea.attrs.version = "v1"
-        self.__mea.attrs.initialized = time.time()
         if metadata:
             self._add_meta_map(metadata)
+
+        self.__mea.attrs.__version = VERSION
+        self.__mea.attrs.__initialized = time.time()
 
         self.__hdf_file.flush()
         self.__initialized = True

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -421,9 +421,9 @@ class HdfStorage(object):
     @modifies
     def add_meta_map(self, m, replace=False):
         self.__initcheck()
-        self._add_meta_map(m)
+        self._add_meta_map(m, replace)
 
-    def _add_meta_map(self, m):
+    def _add_meta_map(self, m, replace):
         for k in m.keys():
             if internal_attr(k):
                 raise omero.ApiUsageException(

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -22,7 +22,7 @@ import omero.callbacks
 
 # For ease of use
 from omero.columns import columns2definition
-from omero.rtypes import rfloat, rint, rlong, rstring, unwrap, wrap
+from omero.rtypes import rfloat, rint, rlong, rstring, unwrap
 from omero.util.decorators import remoted, locked, perf
 from omero_ext import portalocker
 from omero_ext.functional import wraps
@@ -393,13 +393,13 @@ class HdfStorage(object):
         keys = list(self.__mea.attrs._v_attrnamesuser)
         for key in keys:
             val = attr[key]
-            if type(val) == numpy.float64:
+            if isinstance(val, float):
                 val = rfloat(val)
-            elif type(val) == numpy.int32:
+            elif isinstance(val, int):
                 val = rint(val)
-            elif type(val) == numpy.int64:
+            elif isinstance(val, long):
                 val = rlong(val)
-            elif type(val) == numpy.string_:
+            elif isinstance(val, str):
                 val = rstring(val)
             else:
                 raise omero.ValidationException("BAD TYPE: %s" % type(val))

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -329,11 +329,12 @@ class HdfStorage(object):
         self.__hdf_file.createArray(
             self.__ome, "ColumnDescriptions", self.__descriptions)
 
+        md = {}
         if metadata:
-            self.add_meta_map(metadata, replace=True, init=True)
-
-        self.__mea.attrs.__version = VERSION
-        self.__mea.attrs.__initialized = time.time()
+            md = metadata.copy()
+        md['__version'] = VERSION
+        md['__initialized'] = time.time()
+        self.add_meta_map(md, replace=True, init=True)
 
         self.__hdf_file.flush()
         self.__initialized = True
@@ -422,14 +423,14 @@ class HdfStorage(object):
     def add_meta_map(self, m, replace=False, init=False):
         if not init:
             self.__initcheck()
-        for k, v in m.iteritems():
-            if internal_attr(k):
-                raise omero.ApiUsageException(
-                    None, None, "Reserved attribute name: %s" % k)
-            if not init and not isinstance(v, (
-                    omero.RString, omero.RLong, omero.RInt, omero.RFloat)):
-                raise omero.ValidationException(
-                    "Unsupported type: %s" % type(v))
+            for k, v in m.iteritems():
+                if internal_attr(k):
+                    raise omero.ApiUsageException(
+                        None, None, "Reserved attribute name: %s" % k)
+                if not isinstance(v, (
+                        omero.RString, omero.RLong, omero.RInt, omero.RFloat)):
+                    raise omero.ValidationException(
+                        "Unsupported type: %s" % type(v))
 
         attr = self.__mea.attrs
         if replace:

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -31,7 +31,7 @@ from omero_ext.functional import wraps
 sys = __import__("sys")  # Python sys
 tables = __import__("tables")  # Pytables
 
-VERSION = 2
+VERSION = '2'
 
 
 def slen(rv):
@@ -283,19 +283,18 @@ class HdfStorage(object):
     def __getversion(self):
         """
         In OMERO.tables v2 the version attribute name was changed to __version
-        and made an int
         """
         self.__initcheck()
         k = '__version'
         try:
             v = self.__mea.attrs[k]
-            if isinstance(v, int):
+            if isinstance(v, str):
                 return v
         except KeyError:
             k = 'version'
             v = self.__mea.attrs[k]
             if v == 'v1':
-                return 1
+                return '1'
 
         msg = "Invalid version attribute (%s=%s) in path: %s" % (
             k, v, self.__hdf_path)
@@ -444,7 +443,7 @@ class HdfStorage(object):
     @modifies
     def add_meta_map(self, m, replace=False, init=False):
         if not init:
-            if self.__getversion() < 2:
+            if int(self.__getversion()) < 2:
                 # Metadata methods were generally broken for v1 tables so
                 # the introduction of internal metadata attributes is unlikely
                 # to affect anyone.

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -435,7 +435,7 @@ class HdfStorage(object):
         attr = self.__mea.attrs
         if replace:
             for f in list(attr._v_attrnamesuser):
-                if not internal_attr(f):
+                if init or not internal_attr(f):
                     del attr[f]
         if not m:
             return

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -311,6 +311,9 @@ class HdfStorage(object):
             if not c.name:
                 raise omero.ApiUsageException(
                     None, None, "Column unnamed: %s" % c)
+            if internal_attr(c.name):
+                raise omero.ApiUsageException(
+                    None, None, "Reserved column name: %s" % c.name)
 
         self.__definition = columns2definition(cols)
         self.__ome = self.__hdf_file.createGroup("/", "OME")

--- a/components/tools/OmeroPy/test/integration/tablestest/test_backwards_compatibility.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_backwards_compatibility.py
@@ -29,8 +29,10 @@ import omero
 import omero.clients
 import omero.grid
 import library as lib
+import pytest
 
 from omero import columns
+from omero.rtypes import rint
 
 
 class TestBackwardsCompatibility(lib.ITest):
@@ -300,3 +302,19 @@ class TestBackwardsCompatibility(lib.ITest):
         testl2 = data2.columns[7].values
         assert -1 == testl2[0]
         assert 12345 == testl2[1]
+
+    def testMetadataException(self):
+        """
+        Check whether metadata set methods are blocked on a v1 (pre-5.1) table
+        """
+        ofile = self.uploadHdf5("service-reference-dev_4_4_5.h5.bz2")
+
+        grid = self.client.sf.sharedResources()
+        table = grid.openTable(ofile)
+
+        expected = 'Tables metadata is only supported for OMERO.tables >= 2'
+        with pytest.raises(omero.ApiUsageException) as exc:
+            table.setMetadata('a', rint(1))
+        with pytest.raises(omero.ApiUsageException) as exc:
+            table.setAllMetadata({'a': rint(1)})
+        assert exc.value.message == expected

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -192,6 +192,14 @@ class TestTables(lib.ITest):
             assert 1 == unwrap(table.getMetadata("f"))
             assert {"s": "b", "i": 1, "f": 1} == clean(table.getAllMetadata())
 
+            # Replace all user-metadata
+            table.setAllMetadata({})
+            assert {} == clean(table.getAllMetadata())
+
+            table.setAllMetadata({"s2": rstring("b2"), "l2": rlong(3)})
+            assert {"s2": "b2", "l2": 3} == clean(table.getAllMetadata())
+            assert table.getMetadata("s") is None
+
         finally:
             table.close()
 

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -167,10 +167,10 @@ class TestTables(lib.ITest):
             easier testing.
             """
             m = unwrap(m)
-            assert "initialized" in m
-            assert "version" in m
-            del m["initialized"]
-            del m["version"]
+            assert "__initialized" in m
+            assert "__version" in m
+            del m["__initialized"]
+            del m["__version"]
             return m
 
         try:

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -573,4 +573,44 @@ class TestTables(lib.ITest):
         assert table
         table.close()
 
+    @pytest.mark.parametrize('data', (
+        {"__version": omero.rtypes.rint(4)},
+        ("__version", omero.rtypes.rint(4)),
+    ))
+    def testCantWriteInternalMetadata(self, data):
+        grid = self.client.sf.sharedResources()
+        repoMap = grid.repositories()
+        repoObj = repoMap.descriptions[0]
+        table = grid.newTable(repoObj.id.val, "/testInternalMetadata.h5")
+        table.initialize([columns.LongColumnI('lc')])
+        with pytest.raises(omero.ApiUsageException):
+            if isinstance(data, dict):
+                table.setAllMetadata(data)
+            else:
+                table.setMetadata(*data)
+
+    @pytest.mark.parametrize('data', (
+        {"version": omero.rtypes.rint(4)},
+        ("version", omero.rtypes.rint(4)),
+    ))
+    def testCanWriteAlmostInternalMetadata(self, data):
+        grid = self.client.sf.sharedResources()
+        repoMap = grid.repositories()
+        repoObj = repoMap.descriptions[0]
+        table = grid.newTable(repoObj.id.val, "/testInternalMetadata.h5")
+        table.initialize([columns.LongColumnI('lc')])
+        if isinstance(data, dict):
+            table.setAllMetadata(data)
+        else:
+            table.setMetadata(*data)
+        assert 4 == table.getMetadata("version").val
+
+    def testCanReadInternalMetadata(self):
+        grid = self.client.sf.sharedResources()
+        repoMap = grid.repositories()
+        repoObj = repoMap.descriptions[0]
+        table = grid.newTable(repoObj.id.val, "/testInternalMetadata.h5")
+        table.initialize([columns.LongColumnI('lc')])
+        assert table.getMetadata("__version")
+
 # TODO: Add tests for error conditions

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -202,6 +202,14 @@ class TestTables(lib.ITest):
             table.setAllMetadata({})
             assert {} == clean(table.getAllMetadata())
 
+            table.setMetadata("z", rint(1))
+            with pytest.raises(omero.ApiUsageException):
+                table.setMetadata("__z", rint(2))
+            assert {"z": 1} == clean(table.getAllMetadata())
+
+            with pytest.raises(omero.ValidationException):
+                table.setMetadata("z", rint(None))
+
         finally:
             table.close()
 

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -574,8 +574,8 @@ class TestTables(lib.ITest):
         table.close()
 
     @pytest.mark.parametrize('data', (
-        {"__version": omero.rtypes.rint(4)},
-        ("__version", omero.rtypes.rint(4)),
+        {"__version": omero.rtypes.rstring("4")},
+        ("__version", omero.rtypes.rstring("4")),
     ))
     def testCantWriteInternalMetadata(self, data):
         grid = self.client.sf.sharedResources()
@@ -590,8 +590,8 @@ class TestTables(lib.ITest):
                 table.setMetadata(*data)
 
     @pytest.mark.parametrize('data', (
-        {"version": omero.rtypes.rint(4)},
-        ("version", omero.rtypes.rint(4)),
+        {"version": omero.rtypes.rstring("4")},
+        ("version", omero.rtypes.rstring("4")),
     ))
     def testCanWriteAlmostInternalMetadata(self, data):
         grid = self.client.sf.sharedResources()
@@ -603,7 +603,7 @@ class TestTables(lib.ITest):
             table.setAllMetadata(data)
         else:
             table.setMetadata(*data)
-        assert 4 == table.getMetadata("version").val
+        assert "4" == table.getMetadata("version").val
 
     def testCanReadInternalMetadata(self):
         grid = self.client.sf.sharedResources()

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -167,6 +167,8 @@ class TestTables(lib.ITest):
             easier testing.
             """
             m = unwrap(m)
+            assert "initialized" in m
+            assert "version" in m
             del m["initialized"]
             del m["version"]
             return m
@@ -193,12 +195,12 @@ class TestTables(lib.ITest):
             assert {"s": "b", "i": 1, "f": 1} == clean(table.getAllMetadata())
 
             # Replace all user-metadata
-            table.setAllMetadata({})
-            assert {} == clean(table.getAllMetadata())
-
             table.setAllMetadata({"s2": rstring("b2"), "l2": rlong(3)})
             assert {"s2": "b2", "l2": 3} == clean(table.getAllMetadata())
             assert table.getMetadata("s") is None
+
+            table.setAllMetadata({})
+            assert {} == clean(table.getAllMetadata())
 
         finally:
             table.close()

--- a/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
@@ -17,6 +17,8 @@ import logging
 import threading
 import Ice
 
+from omero.rtypes import rint
+
 from library import TestCase
 from path import path
 
@@ -176,6 +178,39 @@ class TestHdfStorage(TestCase):
         h = t / "test.h5"
         assert t.exists()
         hdf = omero.tables.HdfStorage(h, self.lock)
+        hdf.cleanup()
+
+    def testGetSetMetaMap(self):
+        hdf = omero.tables.HdfStorage(self.hdfpath(), self.lock)
+        self.init(hdf, False)
+
+        hdf.add_meta_map({'a': rint(1)})
+        m1 = hdf.get_meta_map()
+        assert len(m1) == 3
+        assert m1['__initialized'].val > 0
+        assert m1['__version'] == rint(2)
+        assert m1['a'] == rint(1)
+
+        with pytest.raises(omero.ApiUsageException) as exc:
+            hdf.add_meta_map({'b': rint(1), '__c': rint(2)})
+        assert exc.value.message == 'Reserved attribute name: __c'
+        assert hdf.get_meta_map() == m1
+
+        with pytest.raises(omero.ValidationException) as exc:
+            hdf.add_meta_map({'d': rint(None)})
+        assert exc.value.serverStackTrace.startswith('Unsupported type:')
+        assert hdf.get_meta_map() == m1
+
+        hdf.add_meta_map({}, replace=True)
+        m2 = hdf.get_meta_map()
+        assert len(m2) == 2
+        assert m2 == {
+            '__initialized': m1['__initialized'], '__version': rint(2)}
+
+        hdf.add_meta_map({'__test': 1}, replace=True, init=True)
+        m3 = hdf.get_meta_map()
+        assert m3 == {'__test': rint(1)}
+
         hdf.cleanup()
 
     def testStringCol(self):

--- a/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
@@ -148,6 +148,20 @@ class TestHdfStorage(TestCase):
         # Doesn't work yet.
         hdf.cleanup()
 
+    def testInitializeInvalidColoumnNames(self):
+        hdf = omero.tables.HdfStorage(self.hdfpath(), self.lock)
+
+        with pytest.raises(omero.ApiUsageException) as exc:
+            hdf.initialize([omero.columns.LongColumnI('')], None)
+        assert exc.value.message.startswith('Column unnamed:')
+
+        with pytest.raises(omero.ApiUsageException) as exc:
+            hdf.initialize([omero.columns.LongColumnI('__a')], None)
+        assert exc.value.message == 'Reserved column name: __a'
+
+        hdf.initialize([omero.columns.LongColumnI('a')], None)
+        hdf.cleanup()
+
     def testInitializationOnInitializedFileFails(self):
         p = self.hdfpath()
         hdf = omero.tables.HdfStorage(p, self.lock)

--- a/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
@@ -17,7 +17,7 @@ import logging
 import threading
 import Ice
 
-from omero.rtypes import rint
+from omero.rtypes import rint, rstring
 
 from library import TestCase
 from path import path
@@ -202,7 +202,7 @@ class TestHdfStorage(TestCase):
         m1 = hdf.get_meta_map()
         assert len(m1) == 3
         assert m1['__initialized'].val > 0
-        assert m1['__version'] == rint(2)
+        assert m1['__version'] == rstring('2')
         assert m1['a'] == rint(1)
 
         with pytest.raises(omero.ApiUsageException) as exc:
@@ -219,7 +219,7 @@ class TestHdfStorage(TestCase):
         m2 = hdf.get_meta_map()
         assert len(m2) == 2
         assert m2 == {
-            '__initialized': m1['__initialized'], '__version': rint(2)}
+            '__initialized': m1['__initialized'], '__version': rstring('2')}
 
         hdf.add_meta_map({'__test': 1}, replace=True, init=True)
         m3 = hdf.get_meta_map()


### PR DESCRIPTION
Fixes setAllMetadata, the last bit of https://trac.openmicroscopy.org.uk/ome/ticket/12606

Also add a workaround for numpy vs Python native types being stored in the table metadata (though I guess this means there is a danger that tables produced by different servers could use different types for the same thing).

--no-rebase