### PR TITLE
Increase Limit (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -72,7 +72,7 @@ public interface RenderingControl
 	public static final int		MAX_SIZE_THREE = 3*MAX_SIZE;
 	
 	/** The maximum number of channels. */
-	public static final int		MAX_CHANNELS = 10;
+	public static final int		MAX_CHANNELS = 100;
 	
 	/** Flag to indicate that the image is not compressed. */
 	public static final int		UNCOMPRESSED = 0;


### PR DESCRIPTION
This is the same as gh-3256 but rebased onto dev_5_0.

---

Increase Limit to 100.
This is mainly due to support the lifetime images
prior to the introduction of modulo.

To test:
- log in as user-2/read-only
- Check the lsm file contained in "from Daniel Banderra"
