### PR TITLE
Ignore units on FontSize in shapeMarshall

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -262,7 +262,8 @@ def shapeMarshal(shape):
         # only populate json with font styles if we have some text
         rv['textValue'] = text_value
         # FIXME: units ignored for font size
-        set_if('fontSize', shape.getFontSize().getValue())
+        if shape.getFontSize() is not None:
+            set_if('fontSize', shape.getFontSize().getValue())
         set_if('fontStyle', shape.getFontStyle())
         set_if('fontFamily', shape.getFontFamily())
 


### PR DESCRIPTION
This fixes an issue reported by @aleksandra-tarkowska where text label ROIs break ROI display in web (due to font size units). https://github.com/openmicroscopy/openmicroscopy/pull/3245#issuecomment-65805182

To test, add a text label Shape to an image in Insight, then test that it displays in web.

--no-rebase
