### PR TITLE
Support for collapsing unique light paths

### DIFF
--- a/components/server/src/ome/formats/OMEROMetadataStore.java
+++ b/components/server/src/ome/formats/OMEROMetadataStore.java
@@ -1682,6 +1682,7 @@ public class OMEROMetadataStore
      * <ul>
      *   <li>Image --> ObjectiveSettings</li>
      *   <li>Image --> Channel --> LogicalChannel --> LightSettings</li>
+     *   <li>Image --> Channel --> LogicalChannel --> LightPath</li>
      *   <li>Image --> Channel --> LogicalChannel --> DetectorSettings</li>
      * </ul>
      */

--- a/components/server/src/ome/formats/OMEROMetadataStore.java
+++ b/components/server/src/ome/formats/OMEROMetadataStore.java
@@ -1683,7 +1683,7 @@ public class OMEROMetadataStore
      *   <li>Image --> Channel --> LogicalChannel --> DetectorSettings</li>
      * </ul>
      */
-    private void checkAndCollapseGraph()
+    public void checkAndCollapseGraph()
     {
     	// Ensure we're working with an SPW data set.
     	if (plateList.size() == 0)

--- a/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
+++ b/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
@@ -25,79 +25,79 @@ import junit.framework.TestCase;
 
 public class DetectorSettingsDetectorTest extends TestCase
 {
-	private OMEROMetadataStore store;
-	
-	private static final int INSTRUMENT_INDEX = 0;
-	
-	private static final int DETECTOR_INDEX = 0;
-	
-	private static final int OBJECTIVE_INDEX = 0;
-	
-	private static final int CHANNEL_INDEX = 0;
-	
-	private static final int IMAGE_INDEX = 0;
-	
-	@Override
-	protected void setUp() throws Exception
-	{
+    private OMEROMetadataStore store;
+
+    private static final int INSTRUMENT_INDEX = 0;
+
+    private static final int DETECTOR_INDEX = 0;
+
+    private static final int OBJECTIVE_INDEX = 0;
+
+    private static final int CHANNEL_INDEX = 0;
+
+    private static final int IMAGE_INDEX = 0;
+
+    @Override
+    protected void setUp() throws Exception
+    {
         store = new OMEROMetadataStore();
 
         String imageLSID = "Image:0";
         Image image = new Image();
-        Map<String, Integer> imageIndexes = 
+        Map<String, Integer> imageIndexes =
             new LinkedHashMap<String, Integer>();
         imageIndexes.put("imageIndex", IMAGE_INDEX);
-        
+
         String pixelsLSID = "Pixels:0";
         Pixels pixels = new Pixels();
-        Map<String, Integer> pixelsIndexes = 
+        Map<String, Integer> pixelsIndexes =
             new LinkedHashMap<String, Integer>();
         pixelsIndexes.put("imageIndex", IMAGE_INDEX);
-        
+
         String channelLSID = "Channel:0";
         Channel channel = new Channel();
-        Map<String, Integer> channelIndexes = 
+        Map<String, Integer> channelIndexes =
             new LinkedHashMap<String, Integer>();
         channelIndexes.put("imageIndex", IMAGE_INDEX);
         channelIndexes.put("channelIndex", CHANNEL_INDEX);
-        
+
         String logicalChannelLSID = "LogicalChannel:0";
         LogicalChannel logicalChannel = new LogicalChannel();
-        Map<String, Integer> logicalChannelIndexes = 
+        Map<String, Integer> logicalChannelIndexes =
             new LinkedHashMap<String, Integer>();
         logicalChannelIndexes.put("imageIndex", IMAGE_INDEX);
         logicalChannelIndexes.put("channelIndex", CHANNEL_INDEX);
-        
+
         String instrumentLSID = "Instrument:0";
         Instrument instrument = new Instrument();
-        Map<String, Integer> instrumentIndexes = 
+        Map<String, Integer> instrumentIndexes =
             new LinkedHashMap<String, Integer>();
         instrumentIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
-        
+
         String detectorLSID = "Detector:0";
         Detector detector = new Detector();
-        Map<String, Integer> detectorIndexes = 
+        Map<String, Integer> detectorIndexes =
             new LinkedHashMap<String, Integer>();
         detectorIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         detectorIndexes.put("detectorIndex", DETECTOR_INDEX);
-        
+
         String objectiveLSID = "Objective:0";
         Objective objective = new Objective();
-        Map<String, Integer> objectiveIndexes = 
+        Map<String, Integer> objectiveIndexes =
             new LinkedHashMap<String, Integer>();
         objectiveIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         objectiveIndexes.put("objectiveIndex", OBJECTIVE_INDEX);
-        
+
         String detectorSettingsLSID = "DetectorSettings:0";
         DetectorSettings detectorSettings = new DetectorSettings();
-        Map<String, Integer> detectorSettingsIndexes = 
+        Map<String, Integer> detectorSettingsIndexes =
             new LinkedHashMap<String, Integer>();
         detectorSettingsIndexes.put("imageIndex", IMAGE_INDEX);
         detectorSettingsIndexes.put("channelIndex", CHANNEL_INDEX);
         
         String objectiveSettingsLSID = "ObjectiveSettings:0";
         ObjectiveSettings objectiveSettings = new ObjectiveSettings();
-        Map<String, Integer> objectiveSettingsIndexes = 
+        Map<String, Integer> objectiveSettingsIndexes =
             new LinkedHashMap<String, Integer>();
         objectiveSettingsIndexes.put("imageIndex", IMAGE_INDEX);
 
@@ -106,52 +106,52 @@ public class DetectorSettingsDetectorTest extends TestCase
         store.updateObject(instrumentLSID, instrument, instrumentIndexes);
         store.updateObject(channelLSID, channel, channelIndexes);
         store.updateObject(logicalChannelLSID, logicalChannel,
-        		           logicalChannelIndexes);
+                           logicalChannelIndexes);
         store.updateObject(detectorLSID, detector, detectorIndexes);
         store.updateObject(objectiveLSID, objective, objectiveIndexes);
         store.updateObject(detectorSettingsLSID, detectorSettings,
-        		           detectorSettingsIndexes);
+                           detectorSettingsIndexes);
         store.updateObject(objectiveSettingsLSID, objectiveSettings,
-		                   objectiveSettingsIndexes);
-	}
-	
-	public void testAddDetectorSettingsDetectorReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("DetectorSettings:0", new String[] { "Detector:0" });
-	    store.updateReferences(referenceCache);
-	    DetectorSettings detectorSettings = (DetectorSettings)
-	    	store.getObjectByLSID(new LSID("DetectorSettings:0"));
-	    assertNotNull(detectorSettings.getDetector());
-	}
-	
-	public void testAddObjectiveSettingsObjectiveReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("ObjectiveSettings:0",
-	    		           new String[] { "Objective:0" });
-	    store.updateReferences(referenceCache);
-	    ObjectiveSettings objectiveSettings = (ObjectiveSettings)
-	    	store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
-	    assertNotNull(objectiveSettings.getObjective());
-	}
-	
-	public void testAddDetectorAndObjectiveSettingsReferences()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    
-	    referenceCache.put("DetectorSettings:0", new String[] { "Detector:0"});
-	    store.updateReferences(referenceCache);
-	    DetectorSettings detectorSettings = (DetectorSettings)
-	    	store.getObjectByLSID(new LSID("DetectorSettings:0"));
-	    
-	    referenceCache.put("ObjectiveSettings:0",
-	    		           new String[] { "Objective:0"});
-	    store.updateReferences(referenceCache);
-	    ObjectiveSettings objectiveSettings = (ObjectiveSettings)
-	    	store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
-	    
-	    assertNotNull(objectiveSettings.getObjective());
-	    assertNotNull(detectorSettings.getDetector());
-	}
+                           objectiveSettingsIndexes);
+    }
+
+    public void testAddDetectorSettingsDetectorReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("DetectorSettings:0", new String[] { "Detector:0" });
+        store.updateReferences(referenceCache);
+        DetectorSettings detectorSettings = (DetectorSettings)
+            store.getObjectByLSID(new LSID("DetectorSettings:0"));
+        assertNotNull(detectorSettings.getDetector());
+    }
+
+    public void testAddObjectiveSettingsObjectiveReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("ObjectiveSettings:0",
+                           new String[] { "Objective:0" });
+        store.updateReferences(referenceCache);
+        ObjectiveSettings objectiveSettings = (ObjectiveSettings)
+            store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
+        assertNotNull(objectiveSettings.getObjective());
+    }
+
+    public void testAddDetectorAndObjectiveSettingsReferences()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+
+        referenceCache.put("DetectorSettings:0", new String[] { "Detector:0"});
+        store.updateReferences(referenceCache);
+        DetectorSettings detectorSettings = (DetectorSettings)
+            store.getObjectByLSID(new LSID("DetectorSettings:0"));
+
+        referenceCache.put("ObjectiveSettings:0",
+                           new String[] { "Objective:0"});
+        store.updateReferences(referenceCache);
+        ObjectiveSettings objectiveSettings = (ObjectiveSettings)
+            store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
+
+        assertNotNull(objectiveSettings.getObjective());
+        assertNotNull(detectorSettings.getDetector());
+    }
 }

--- a/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
+++ b/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
@@ -10,6 +10,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import ome.util.LSID;
 import ome.formats.OMEROMetadataStore;
 import ome.model.acquisition.Detector;
@@ -21,9 +25,9 @@ import ome.model.core.Channel;
 import ome.model.core.Image;
 import ome.model.core.LogicalChannel;
 import ome.model.core.Pixels;
-import junit.framework.TestCase;
 
-public class DetectorSettingsDetectorTest extends TestCase
+@Test
+public class DetectorSettingsDetectorTest
 {
     private OMEROMetadataStore store;
 
@@ -37,7 +41,7 @@ public class DetectorSettingsDetectorTest extends TestCase
 
     private static final int IMAGE_INDEX = 0;
 
-    @Override
+    @BeforeMethod
     protected void setUp() throws Exception
     {
         store = new OMEROMetadataStore();
@@ -122,7 +126,7 @@ public class DetectorSettingsDetectorTest extends TestCase
         store.updateReferences(referenceCache);
         DetectorSettings detectorSettings = (DetectorSettings)
             store.getObjectByLSID(new LSID("DetectorSettings:0"));
-        assertNotNull(detectorSettings.getDetector());
+        Assert.assertNotNull(detectorSettings.getDetector());
     }
 
     public void testAddObjectiveSettingsObjectiveReference()
@@ -133,7 +137,7 @@ public class DetectorSettingsDetectorTest extends TestCase
         store.updateReferences(referenceCache);
         ObjectiveSettings objectiveSettings = (ObjectiveSettings)
             store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
-        assertNotNull(objectiveSettings.getObjective());
+        Assert.assertNotNull(objectiveSettings.getObjective());
     }
 
     public void testAddDetectorAndObjectiveSettingsReferences()
@@ -151,7 +155,7 @@ public class DetectorSettingsDetectorTest extends TestCase
         ObjectiveSettings objectiveSettings = (ObjectiveSettings)
             store.getObjectByLSID(new LSID("ObjectiveSettings:0"));
 
-        assertNotNull(objectiveSettings.getObjective());
-        assertNotNull(detectorSettings.getDetector());
+        Assert.assertNotNull(objectiveSettings.getObjective());
+        Assert.assertNotNull(detectorSettings.getDetector());
     }
 }

--- a/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
+++ b/components/server/test/ome/formats/utests/DetectorSettingsDetectorTest.java
@@ -59,14 +59,14 @@ public class DetectorSettingsDetectorTest extends TestCase
         Map<String, Integer> channelIndexes = 
             new LinkedHashMap<String, Integer>();
         channelIndexes.put("imageIndex", IMAGE_INDEX);
-        channelIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        channelIndexes.put("channelIndex", CHANNEL_INDEX);
         
         String logicalChannelLSID = "LogicalChannel:0";
         LogicalChannel logicalChannel = new LogicalChannel();
         Map<String, Integer> logicalChannelIndexes = 
             new LinkedHashMap<String, Integer>();
         logicalChannelIndexes.put("imageIndex", IMAGE_INDEX);
-        logicalChannelIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        logicalChannelIndexes.put("channelIndex", CHANNEL_INDEX);
         
         String instrumentLSID = "Instrument:0";
         Instrument instrument = new Instrument();
@@ -93,7 +93,7 @@ public class DetectorSettingsDetectorTest extends TestCase
         Map<String, Integer> detectorSettingsIndexes = 
             new LinkedHashMap<String, Integer>();
         detectorSettingsIndexes.put("imageIndex", IMAGE_INDEX);
-        detectorSettingsIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        detectorSettingsIndexes.put("channelIndex", CHANNEL_INDEX);
         
         String objectiveSettingsLSID = "ObjectiveSettings:0";
         ObjectiveSettings objectiveSettings = new ObjectiveSettings();

--- a/components/server/test/ome/formats/utests/GenericReferenceTest.java
+++ b/components/server/test/ome/formats/utests/GenericReferenceTest.java
@@ -36,145 +36,145 @@ import junit.framework.TestCase;
 
 public class GenericReferenceTest extends TestCase
 {
-	private OMEROMetadataStore store;
-	
-	private static final int IMAGE_INDEX = 0;
+    private OMEROMetadataStore store;
 
-	private static final int CHANNEL_INDEX = 0;
-	
-	private static final int INSTRUMENT_INDEX = 0;
-	
-	private static final int EXPERIMENT_INDEX = 0;
-	
-	private static final int LASER_INDEX = 0;
-	
-	private static final int FILTER_INDEX = 0;
-	
-	private static final int FILTER_SET_INDEX = 0;
-	
-	private static final int DETECTOR_INDEX = 0;
-	
-	private static final int DICHROIC_INDEX = 0;
-	
-	private static final int SCREEN_INDEX = 0;
-	
-	private static final int PLATE_INDEX = 0;
-	
-	private static final int WELL_INDEX = 0;
-	
-	private static final int REAGENT_INDEX = 0;
-	
-	private Image image;
-	
-	private Pixels pixels;
-	
-	private Channel channel;
-	
-	private LogicalChannel logicalChannel;
-	
-	private Instrument instrument;
-	
-	private Experiment experiment;
-	
-	private Laser laser;
-	
-	private Filter filter;
-	
-	private FilterSet filterSet;
-	
-	private Detector detector;
-	
-	private Dichroic dichroic;
-	
-	private LightSettings lightSettings;
-	
-	private DetectorSettings detectorSettings;
-	
-	private Screen screen;
-	
-	private Plate plate;
-	
-	private Well well;
-	
-	private Reagent reagent;
-	
-	@Override
-	protected void setUp() throws Exception
-	{
+    private static final int IMAGE_INDEX = 0;
+
+    private static final int CHANNEL_INDEX = 0;
+
+    private static final int INSTRUMENT_INDEX = 0;
+
+    private static final int EXPERIMENT_INDEX = 0;
+
+    private static final int LASER_INDEX = 0;
+
+    private static final int FILTER_INDEX = 0;
+
+    private static final int FILTER_SET_INDEX = 0;
+
+    private static final int DETECTOR_INDEX = 0;
+
+    private static final int DICHROIC_INDEX = 0;
+
+    private static final int SCREEN_INDEX = 0;
+
+    private static final int PLATE_INDEX = 0;
+
+    private static final int WELL_INDEX = 0;
+
+    private static final int REAGENT_INDEX = 0;
+
+    private Image image;
+
+    private Pixels pixels;
+
+    private Channel channel;
+
+    private LogicalChannel logicalChannel;
+
+    private Instrument instrument;
+
+    private Experiment experiment;
+
+    private Laser laser;
+
+    private Filter filter;
+
+    private FilterSet filterSet;
+
+    private Detector detector;
+
+    private Dichroic dichroic;
+
+    private LightSettings lightSettings;
+
+    private DetectorSettings detectorSettings;
+
+    private Screen screen;
+
+    private Plate plate;
+
+    private Well well;
+
+    private Reagent reagent;
+
+    @Override
+    protected void setUp() throws Exception
+    {
         store = new OMEROMetadataStore();
-        
-		// Update Image
+
+        // Update Image
         image = new Image();
-        Map<String, Integer> imageIndexes = 
+        Map<String, Integer> imageIndexes =
             new LinkedHashMap<String, Integer>();
         imageIndexes.put("imageIndex", IMAGE_INDEX);
         String imageLSID = "Image:0";
         store.updateObject(imageLSID, image, imageIndexes);
-        
-		// Update Pixels
+
+        // Update Pixels
         pixels = new Pixels();
-        Map<String, Integer> pixelsIndexes = 
+        Map<String, Integer> pixelsIndexes =
             new LinkedHashMap<String, Integer>();
         pixelsIndexes.put("imageIndex", IMAGE_INDEX);
         String pixelsLSID = "Pixels:0";
         store.updateObject(pixelsLSID, pixels, pixelsIndexes);
-        
-		// Update Channel
+
+        // Update Channel
         channel = new Channel();
-        Map<String, Integer> channelIndexes = 
+        Map<String, Integer> channelIndexes =
             new LinkedHashMap<String, Integer>();
         channelIndexes.put("imageIndex", IMAGE_INDEX);
         channelIndexes.put("channelIndex", CHANNEL_INDEX);
         String channelLSID = "Channel:0:0";
         store.updateObject(channelLSID, channel, channelIndexes);
-        
-		// Update LogicalChannel
+
+        // Update LogicalChannel
         logicalChannel = new LogicalChannel();
-        Map<String, Integer> logicalChannelIndexes = 
+        Map<String, Integer> logicalChannelIndexes =
             new LinkedHashMap<String, Integer>();
         logicalChannelIndexes.put("imageIndex", IMAGE_INDEX);
         logicalChannelIndexes.put("channelIndex", CHANNEL_INDEX);
         String logicalChannelLSID = "LogicalChannel:0:0";
         store.updateObject(logicalChannelLSID, logicalChannel,
-        		           logicalChannelIndexes);
-        
+                           logicalChannelIndexes);
+
         // Update Instrument
         instrument = new Instrument();
-        Map<String, Integer> instrumentIndexes = 
+        Map<String, Integer> instrumentIndexes =
             new LinkedHashMap<String, Integer>();
         instrumentIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         String instrumentLSID = "Instrument:0";
         store.updateObject(instrumentLSID, instrument, instrumentIndexes);
-        
+
         // Update Experiment
         experiment = new Experiment();
-        Map<String, Integer> experimentIndexes = 
+        Map<String, Integer> experimentIndexes =
             new LinkedHashMap<String, Integer>();
         experimentIndexes.put("experimentIndex", EXPERIMENT_INDEX);
         String experimentLSID = "Experiment:0";
-        store.updateObject(experimentLSID, experiment, experimentIndexes);        
-        
+        store.updateObject(experimentLSID, experiment, experimentIndexes);
+
         // Update Laser
         laser = new Laser();
-        Map<String, Integer> laserIndexes = 
+        Map<String, Integer> laserIndexes =
             new LinkedHashMap<String, Integer>();
         laserIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         laserIndexes.put("lightSourceIndex", LASER_INDEX);
         String laserLSID = "Laser:0:0";
         store.updateObject(laserLSID, laser, laserIndexes);
-        
+
         // Update Filter
         filter = new Filter();
-        Map<String, Integer> filterIndexes = 
+        Map<String, Integer> filterIndexes =
             new LinkedHashMap<String, Integer>();
         filterIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         filterIndexes.put("filterIndex", FILTER_INDEX);
         String filterLSID = "Filter:0:0";
         store.updateObject(filterLSID, filter, filterIndexes);
-        
+
         // Update FilterSet
         filterSet = new FilterSet();
-        Map<String, Integer> filterSetIndexes = 
+        Map<String, Integer> filterSetIndexes =
             new LinkedHashMap<String, Integer>();
         filterSetIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         filterSetIndexes.put("filterSetIndex", FILTER_SET_INDEX);
@@ -183,186 +183,186 @@ public class GenericReferenceTest extends TestCase
 
         // Update Detector
         detector = new Detector();
-        Map<String, Integer> detectorIndexes = 
+        Map<String, Integer> detectorIndexes =
             new LinkedHashMap<String, Integer>();
         detectorIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         detectorIndexes.put("detectorIndex", DETECTOR_INDEX);
         String detectorLSID = "Detector:0:0";
         store.updateObject(detectorLSID, detector, detectorIndexes);
-        
+
         // Update Dichroic
         dichroic = new Dichroic();
-        Map<String, Integer> dichroicIndexes = 
+        Map<String, Integer> dichroicIndexes =
             new LinkedHashMap<String, Integer>();
         dichroicIndexes.put("instrumentIndex", INSTRUMENT_INDEX);
         dichroicIndexes.put("dichroicIndex", DICHROIC_INDEX);
         String dichroicLSID = "Dichroic:0:0";
         store.updateObject(dichroicLSID, dichroic, dichroicIndexes);
-        
+
         // Update LightSettings
         lightSettings = new LightSettings();
-        Map<String, Integer> lightSettingsIndexes = 
+        Map<String, Integer> lightSettingsIndexes =
             new LinkedHashMap<String, Integer>();
         lightSettingsIndexes.put("imageIndex", IMAGE_INDEX);
         lightSettingsIndexes.put("channelIndex", CHANNEL_INDEX);
         String lightSettingsLSID = "LightSourceSettings:0:0";
         store.updateObject(lightSettingsLSID, lightSettings,
-        		           lightSettingsIndexes);
-        
+                           lightSettingsIndexes);
+
         // Update DetectorSettings
         detectorSettings = new DetectorSettings();
-        Map<String, Integer> detectorSettingsIndexes = 
+        Map<String, Integer> detectorSettingsIndexes =
             new LinkedHashMap<String, Integer>();
         detectorSettingsIndexes.put("imageIndex", IMAGE_INDEX);
         detectorSettingsIndexes.put("channelIndex",
-        		                    CHANNEL_INDEX);
+                                    CHANNEL_INDEX);
         String detectorSettingsLSID = "DetectorSettings:0:0";
         store.updateObject(detectorSettingsLSID, detectorSettings,
-        		           detectorSettingsIndexes);
-        
-		// Update Screen
-		screen = new Screen();
-        Map<String, Integer> screenIndexes = 
+                           detectorSettingsIndexes);
+
+        // Update Screen
+        screen = new Screen();
+        Map<String, Integer> screenIndexes =
             new LinkedHashMap<String, Integer>();
         screenIndexes.put("screenIndex", SCREEN_INDEX);
         store.updateObject("Screen:0", screen, screenIndexes);
-        
-		// Update Plate
+
+        // Update Plate
         plate = new Plate();
-        Map<String, Integer> plateIndexes = 
+        Map<String, Integer> plateIndexes =
             new LinkedHashMap<String, Integer>();
         plateIndexes.put("screenIndex", SCREEN_INDEX);
         plateIndexes.put("plateIndex", PLATE_INDEX);
         store.updateObject("Plate:0:0", plate, plateIndexes);
-        
-		// Update Well
+
+        // Update Well
         well = new Well();
-        Map<String, Integer> wellIndexes = 
+        Map<String, Integer> wellIndexes =
             new LinkedHashMap<String, Integer>();
         wellIndexes.put("screenIndex", SCREEN_INDEX);
         wellIndexes.put("plateIndex", PLATE_INDEX);
         wellIndexes.put("wellIndex", WELL_INDEX);
         store.updateObject("Well:0:0:0", well, wellIndexes);
-        
-		// Update Reagent
+
+        // Update Reagent
         reagent = new Reagent();
-        Map<String, Integer> reagentIndexes = 
+        Map<String, Integer> reagentIndexes =
             new LinkedHashMap<String, Integer>();
         reagentIndexes.put("screenIndex", SCREEN_INDEX);
         reagentIndexes.put("reagentIndex", REAGENT_INDEX);
         store.updateObject("Reagent:0:0", reagent, reagentIndexes);
-	}
-	
-	public void testImageInstrumentReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("Image:0", new String[] { "Instrument:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(image.getInstrument(), instrument);
-	}
+    }
 
-	public void testImageExperimentReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("Image:0", new String[] { "Experiment:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(image.getExperiment(), experiment);
-	}
-	
-	public void testWellReagentReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("Well:0:0:0", new String[] { "Reagent:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertNotNull(well.linkedReagentList());
-	    assertEquals(1, well.linkedReagentList().size());
-	    assertEquals(well.linkedReagentList().get(0), reagent);
-	}
-	
-	public void testLaserLaserReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("Laser:0:0", new String[] { "Laser:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(laser.getPump(), laser);
-	}
-	
-	public void testLightSettingsLightSourceReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("LightSourceSettings:0:0", 
-	    		           new String[] { "Laser:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(lightSettings.getLightSource(), laser);
-	}
-	
-	public void testDetectorSettingsDetectorReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("DetectorSettings:0:0", 
-	    		           new String[] { "Detector:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(detectorSettings.getDetector(), detector);
-	}
-	
-	public void testLogicalChannelFilterSetReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("LogicalChannel:0:0", 
-	    		           new String[] { "FilterSet:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(logicalChannel.getFilterSet(), filterSet);
-	}
-	
-	public void testLogicalChannelFilterReference()
-	{
-		try
-		{
-			Map<String, String[]> referenceCache =
-				new HashMap<String, String[]>();
-			referenceCache.put("LogicalChannel:0:0", 
-					new String[] { "Filter:0:0" });
-			store.updateReferences(referenceCache);
-			fail("Did not throw ApiUsageException.");
-		}
-		catch (ApiUsageException e)
-		{
-			return;
-		}
-	}
-	
-	public void testLogicalChannelSecondaryEmissionFilterReference()
-	{
-		Map<String, String[]> referenceCache =
-			new HashMap<String, String[]>();
-		referenceCache.put("LogicalChannel:0:0", 
-				new String[] { "Filter:0:0:OMERO_EMISSION_FILTER" });
-		store.updateReferences(referenceCache);
-		LightPath lightPath = logicalChannel.getLightPath();
-		assertEquals(0, lightPath.sizeOfExcitationFilterLink());
-		assertEquals(1, lightPath.sizeOfEmissionFilterLink());
-		assertEquals(lightPath.linkedEmissionFilterIterator().next(), filter);
-	}
-	
-	public void testLogicalChannelSecondaryExcitationFilterReference()
-	{
-		Map<String, String[]> referenceCache =
-			new HashMap<String, String[]>();
-		referenceCache.put("LogicalChannel:0:0", 
-				new String[] { "Filter:0:0:OMERO_EXCITATION_FILTER" });
-		store.updateReferences(referenceCache);
+    public void testImageInstrumentReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("Image:0", new String[] { "Instrument:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(image.getInstrument(), instrument);
+    }
+
+    public void testImageExperimentReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("Image:0", new String[] { "Experiment:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(image.getExperiment(), experiment);
+    }
+
+    public void testWellReagentReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("Well:0:0:0", new String[] { "Reagent:0:0" });
+        store.updateReferences(referenceCache);
+        assertNotNull(well.linkedReagentList());
+        assertEquals(1, well.linkedReagentList().size());
+        assertEquals(well.linkedReagentList().get(0), reagent);
+    }
+
+    public void testLaserLaserReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("Laser:0:0", new String[] { "Laser:0:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(laser.getPump(), laser);
+    }
+
+    public void testLightSettingsLightSourceReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("LightSourceSettings:0:0",
+                           new String[] { "Laser:0:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(lightSettings.getLightSource(), laser);
+    }
+
+    public void testDetectorSettingsDetectorReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("DetectorSettings:0:0",
+                           new String[] { "Detector:0:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(detectorSettings.getDetector(), detector);
+    }
+
+    public void testLogicalChannelFilterSetReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("LogicalChannel:0:0",
+                           new String[] { "FilterSet:0:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(logicalChannel.getFilterSet(), filterSet);
+    }
+
+    public void testLogicalChannelFilterReference()
+    {
+        try
+        {
+            Map<String, String[]> referenceCache =
+                new HashMap<String, String[]>();
+            referenceCache.put("LogicalChannel:0:0",
+                    new String[] { "Filter:0:0" });
+            store.updateReferences(referenceCache);
+            fail("Did not throw ApiUsageException.");
+        }
+        catch (ApiUsageException e)
+        {
+            return;
+        }
+    }
+
+    public void testLogicalChannelSecondaryEmissionFilterReference()
+    {
+        Map<String, String[]> referenceCache =
+            new HashMap<String, String[]>();
+        referenceCache.put("LogicalChannel:0:0",
+                new String[] { "Filter:0:0:OMERO_EMISSION_FILTER" });
+        store.updateReferences(referenceCache);
+        LightPath lightPath = logicalChannel.getLightPath();
+        assertEquals(0, lightPath.sizeOfExcitationFilterLink());
+        assertEquals(1, lightPath.sizeOfEmissionFilterLink());
+        assertEquals(lightPath.linkedEmissionFilterIterator().next(), filter);
+    }
+
+    public void testLogicalChannelSecondaryExcitationFilterReference()
+    {
+        Map<String, String[]> referenceCache =
+            new HashMap<String, String[]>();
+        referenceCache.put("LogicalChannel:0:0",
+                new String[] { "Filter:0:0:OMERO_EXCITATION_FILTER" });
+        store.updateReferences(referenceCache);
         LightPath lightPath = logicalChannel.getLightPath();
         assertEquals(1, lightPath.sizeOfExcitationFilterLink());
         assertEquals(0, lightPath.sizeOfEmissionFilterLink());
         assertEquals(lightPath.linkedExcitationFilterIterator().next(), filter);
-	}
-	
-	public void testFilterSetDichroicReference()
-	{
-	    Map<String, String[]> referenceCache = new HashMap<String, String[]>();
-	    referenceCache.put("FilterSet:0:0", 
-	    		           new String[] { "Dichroic:0:0" });
-	    store.updateReferences(referenceCache);
-	    assertEquals(filterSet.getDichroic(), dichroic);
-	}
+    }
+
+    public void testFilterSetDichroicReference()
+    {
+        Map<String, String[]> referenceCache = new HashMap<String, String[]>();
+        referenceCache.put("FilterSet:0:0",
+                           new String[] { "Dichroic:0:0" });
+        store.updateReferences(referenceCache);
+        assertEquals(filterSet.getDichroic(), dichroic);
+    }
 }

--- a/components/server/test/ome/formats/utests/GenericReferenceTest.java
+++ b/components/server/test/ome/formats/utests/GenericReferenceTest.java
@@ -278,7 +278,7 @@ public class GenericReferenceTest
         referenceCache.put("Well:0:0:0", new String[] { "Reagent:0:0" });
         store.updateReferences(referenceCache);
         Assert.assertNotNull(well.linkedReagentList());
-        Assert.assertEquals(1, well.linkedReagentList().size());
+        Assert.assertEquals(well.linkedReagentList().size(), 1);
         Assert.assertEquals(well.linkedReagentList().get(0), reagent);
     }
 
@@ -342,8 +342,8 @@ public class GenericReferenceTest
                 new String[] { "Filter:0:0:OMERO_EMISSION_FILTER" });
         store.updateReferences(referenceCache);
         LightPath lightPath = logicalChannel.getLightPath();
-        Assert.assertEquals(0, lightPath.sizeOfExcitationFilterLink());
-        Assert.assertEquals(1, lightPath.sizeOfEmissionFilterLink());
+        Assert.assertEquals(lightPath.sizeOfExcitationFilterLink(), 0);
+        Assert.assertEquals(lightPath.sizeOfEmissionFilterLink(), 1);
         Assert.assertEquals(
                 lightPath.linkedEmissionFilterIterator().next(), filter);
     }
@@ -356,8 +356,8 @@ public class GenericReferenceTest
                 new String[] { "Filter:0:0:OMERO_EXCITATION_FILTER" });
         store.updateReferences(referenceCache);
         LightPath lightPath = logicalChannel.getLightPath();
-        Assert.assertEquals(1, lightPath.sizeOfExcitationFilterLink());
-        Assert.assertEquals(0, lightPath.sizeOfEmissionFilterLink());
+        Assert.assertEquals(lightPath.sizeOfExcitationFilterLink(), 1);
+        Assert.assertEquals(lightPath.sizeOfEmissionFilterLink(), 0);
         Assert.assertEquals(
                 lightPath.linkedExcitationFilterIterator().next(), filter);
     }

--- a/components/server/test/ome/formats/utests/GenericReferenceTest.java
+++ b/components/server/test/ome/formats/utests/GenericReferenceTest.java
@@ -124,7 +124,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, Integer> channelIndexes = 
             new LinkedHashMap<String, Integer>();
         channelIndexes.put("imageIndex", IMAGE_INDEX);
-        channelIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        channelIndexes.put("channelIndex", CHANNEL_INDEX);
         String channelLSID = "Channel:0:0";
         store.updateObject(channelLSID, channel, channelIndexes);
         
@@ -133,7 +133,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, Integer> logicalChannelIndexes = 
             new LinkedHashMap<String, Integer>();
         logicalChannelIndexes.put("imageIndex", IMAGE_INDEX);
-        logicalChannelIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        logicalChannelIndexes.put("channelIndex", CHANNEL_INDEX);
         String logicalChannelLSID = "LogicalChannel:0:0";
         store.updateObject(logicalChannelLSID, logicalChannel,
         		           logicalChannelIndexes);
@@ -150,7 +150,7 @@ public class GenericReferenceTest extends TestCase
         experiment = new Experiment();
         Map<String, Integer> experimentIndexes = 
             new LinkedHashMap<String, Integer>();
-        instrumentIndexes.put("experimentIndex", EXPERIMENT_INDEX);
+        experimentIndexes.put("experimentIndex", EXPERIMENT_INDEX);
         String experimentLSID = "Experiment:0";
         store.updateObject(experimentLSID, experiment, experimentIndexes);        
         
@@ -204,7 +204,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, Integer> lightSettingsIndexes = 
             new LinkedHashMap<String, Integer>();
         lightSettingsIndexes.put("imageIndex", IMAGE_INDEX);
-        lightSettingsIndexes.put("logicalChannelIndex", CHANNEL_INDEX);
+        lightSettingsIndexes.put("channelIndex", CHANNEL_INDEX);
         String lightSettingsLSID = "LightSourceSettings:0:0";
         store.updateObject(lightSettingsLSID, lightSettings,
         		           lightSettingsIndexes);
@@ -214,7 +214,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, Integer> detectorSettingsIndexes = 
             new LinkedHashMap<String, Integer>();
         detectorSettingsIndexes.put("imageIndex", IMAGE_INDEX);
-        detectorSettingsIndexes.put("logicalChannelIndex",
+        detectorSettingsIndexes.put("channelIndex",
         		                    CHANNEL_INDEX);
         String detectorSettingsLSID = "DetectorSettings:0:0";
         store.updateObject(detectorSettingsLSID, detectorSettings,

--- a/components/server/test/ome/formats/utests/GenericReferenceTest.java
+++ b/components/server/test/ome/formats/utests/GenericReferenceTest.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.testng.Assert;
+
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import ome.conditions.ApiUsageException;
@@ -32,9 +35,9 @@ import ome.model.screen.Plate;
 import ome.model.screen.Reagent;
 import ome.model.screen.Screen;
 import ome.model.screen.Well;
-import junit.framework.TestCase;
 
-public class GenericReferenceTest extends TestCase
+@Test
+public class GenericReferenceTest
 {
     private OMEROMetadataStore store;
 
@@ -98,7 +101,7 @@ public class GenericReferenceTest extends TestCase
 
     private Reagent reagent;
 
-    @Override
+    @BeforeMethod
     protected void setUp() throws Exception
     {
         store = new OMEROMetadataStore();
@@ -258,7 +261,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, String[]> referenceCache = new HashMap<String, String[]>();
         referenceCache.put("Image:0", new String[] { "Instrument:0" });
         store.updateReferences(referenceCache);
-        assertEquals(image.getInstrument(), instrument);
+        Assert.assertEquals(image.getInstrument(), instrument);
     }
 
     public void testImageExperimentReference()
@@ -266,7 +269,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, String[]> referenceCache = new HashMap<String, String[]>();
         referenceCache.put("Image:0", new String[] { "Experiment:0" });
         store.updateReferences(referenceCache);
-        assertEquals(image.getExperiment(), experiment);
+        Assert.assertEquals(image.getExperiment(), experiment);
     }
 
     public void testWellReagentReference()
@@ -274,9 +277,9 @@ public class GenericReferenceTest extends TestCase
         Map<String, String[]> referenceCache = new HashMap<String, String[]>();
         referenceCache.put("Well:0:0:0", new String[] { "Reagent:0:0" });
         store.updateReferences(referenceCache);
-        assertNotNull(well.linkedReagentList());
-        assertEquals(1, well.linkedReagentList().size());
-        assertEquals(well.linkedReagentList().get(0), reagent);
+        Assert.assertNotNull(well.linkedReagentList());
+        Assert.assertEquals(1, well.linkedReagentList().size());
+        Assert.assertEquals(well.linkedReagentList().get(0), reagent);
     }
 
     public void testLaserLaserReference()
@@ -284,7 +287,7 @@ public class GenericReferenceTest extends TestCase
         Map<String, String[]> referenceCache = new HashMap<String, String[]>();
         referenceCache.put("Laser:0:0", new String[] { "Laser:0:0" });
         store.updateReferences(referenceCache);
-        assertEquals(laser.getPump(), laser);
+        Assert.assertEquals(laser.getPump(), laser);
     }
 
     public void testLightSettingsLightSourceReference()
@@ -293,7 +296,7 @@ public class GenericReferenceTest extends TestCase
         referenceCache.put("LightSourceSettings:0:0",
                            new String[] { "Laser:0:0" });
         store.updateReferences(referenceCache);
-        assertEquals(lightSettings.getLightSource(), laser);
+        Assert.assertEquals(lightSettings.getLightSource(), laser);
     }
 
     public void testDetectorSettingsDetectorReference()
@@ -302,7 +305,7 @@ public class GenericReferenceTest extends TestCase
         referenceCache.put("DetectorSettings:0:0",
                            new String[] { "Detector:0:0" });
         store.updateReferences(referenceCache);
-        assertEquals(detectorSettings.getDetector(), detector);
+        Assert.assertEquals(detectorSettings.getDetector(), detector);
     }
 
     public void testLogicalChannelFilterSetReference()
@@ -311,7 +314,7 @@ public class GenericReferenceTest extends TestCase
         referenceCache.put("LogicalChannel:0:0",
                            new String[] { "FilterSet:0:0" });
         store.updateReferences(referenceCache);
-        assertEquals(logicalChannel.getFilterSet(), filterSet);
+        Assert.assertEquals(logicalChannel.getFilterSet(), filterSet);
     }
 
     public void testLogicalChannelFilterReference()
@@ -323,7 +326,7 @@ public class GenericReferenceTest extends TestCase
             referenceCache.put("LogicalChannel:0:0",
                     new String[] { "Filter:0:0" });
             store.updateReferences(referenceCache);
-            fail("Did not throw ApiUsageException.");
+            Assert.fail("Did not throw ApiUsageException.");
         }
         catch (ApiUsageException e)
         {
@@ -339,9 +342,10 @@ public class GenericReferenceTest extends TestCase
                 new String[] { "Filter:0:0:OMERO_EMISSION_FILTER" });
         store.updateReferences(referenceCache);
         LightPath lightPath = logicalChannel.getLightPath();
-        assertEquals(0, lightPath.sizeOfExcitationFilterLink());
-        assertEquals(1, lightPath.sizeOfEmissionFilterLink());
-        assertEquals(lightPath.linkedEmissionFilterIterator().next(), filter);
+        Assert.assertEquals(0, lightPath.sizeOfExcitationFilterLink());
+        Assert.assertEquals(1, lightPath.sizeOfEmissionFilterLink());
+        Assert.assertEquals(
+                lightPath.linkedEmissionFilterIterator().next(), filter);
     }
 
     public void testLogicalChannelSecondaryExcitationFilterReference()
@@ -352,9 +356,10 @@ public class GenericReferenceTest extends TestCase
                 new String[] { "Filter:0:0:OMERO_EXCITATION_FILTER" });
         store.updateReferences(referenceCache);
         LightPath lightPath = logicalChannel.getLightPath();
-        assertEquals(1, lightPath.sizeOfExcitationFilterLink());
-        assertEquals(0, lightPath.sizeOfEmissionFilterLink());
-        assertEquals(lightPath.linkedExcitationFilterIterator().next(), filter);
+        Assert.assertEquals(1, lightPath.sizeOfExcitationFilterLink());
+        Assert.assertEquals(0, lightPath.sizeOfEmissionFilterLink());
+        Assert.assertEquals(
+                lightPath.linkedExcitationFilterIterator().next(), filter);
     }
 
     public void testFilterSetDichroicReference()
@@ -363,6 +368,6 @@ public class GenericReferenceTest extends TestCase
         referenceCache.put("FilterSet:0:0",
                            new String[] { "Dichroic:0:0" });
         store.updateReferences(referenceCache);
-        assertEquals(filterSet.getDichroic(), dichroic);
+        Assert.assertEquals(filterSet.getDichroic(), dichroic);
     }
 }

--- a/components/server/test/ome/formats/utests/MultiplePlateTest.java
+++ b/components/server/test/ome/formats/utests/MultiplePlateTest.java
@@ -211,21 +211,21 @@ public class MultiplePlateTest
         Instrument instrument = (Instrument) store.getObjectByLSID(
                 new LSID("Instrument:0"));
         Assert.assertNotNull(instrument);
-        Assert.assertEquals(8, instrument.sizeOfFilter());
-        Assert.assertEquals(2, instrument.sizeOfDichroic());
+        Assert.assertEquals(instrument.sizeOfFilter(), 8);
+        Assert.assertEquals(instrument.sizeOfDichroic(), 2);
 
         for (int i = 0; i < 3; i++)
         {
             Plate plate = (Plate) store.getObjectByLSID(new LSID("Plate:" + i));
             Assert.assertNotNull(plate);
             Assert.assertEquals("Plate:" + i, plate.getName());
-            Assert.assertEquals(3, plate.sizeOfWells());
+            Assert.assertEquals(plate.sizeOfWells(), 3);
             Iterator<Well> wellIterator = plate.iterateWells();
             while (wellIterator.hasNext())
             {
                 Well well = wellIterator.next();
                 Assert.assertNotNull(well);
-                Assert.assertEquals(1, well.sizeOfWellSamples());
+                Assert.assertEquals(well.sizeOfWellSamples(), 1);
                 WellSample wellSample = well.iterateWellSamples().next();
                 Assert.assertNotNull(wellSample);
 
@@ -236,7 +236,7 @@ public class MultiplePlateTest
                 Assert.assertEquals(instrument, imageInstrument);
                 Pixels pixels = image.getPrimaryPixels();
                 Assert.assertNotNull(pixels);
-                Assert.assertEquals(2, pixels.sizeOfChannels());
+                Assert.assertEquals(pixels.sizeOfChannels(), 2);
                 for (Channel channel : pixels.<Channel>collectChannels(null)) {
                     assertChannel(channel);
                 }
@@ -255,8 +255,8 @@ public class MultiplePlateTest
         Assert.assertNotNull(logicalChannel);
         LightPath lightPath = logicalChannel.getLightPath();
         Assert.assertNotNull(lightPath);
-        Assert.assertEquals(2, lightPath.sizeOfEmissionFilterLink());
-        Assert.assertEquals(2, lightPath.sizeOfExcitationFilterLink());
+        Assert.assertEquals(lightPath.sizeOfEmissionFilterLink(), 2);
+        Assert.assertEquals(lightPath.sizeOfExcitationFilterLink(), 2);
 
         for (Filter filter : lightPath.linkedEmissionFilterList()) {
             String model = filter.getModel();

--- a/components/server/test/ome/formats/utests/MultiplePlateTest.java
+++ b/components/server/test/ome/formats/utests/MultiplePlateTest.java
@@ -76,7 +76,7 @@ public class MultiplePlateTest
             dichroic.setModel("Dichroic:" + d);
             indexes =  new LinkedHashMap<String, Integer>();
             indexes.put("instrumentIndex", 0);
-            indexes.put("dichroicIndex", 0);
+            indexes.put("dichroicIndex", d);
             store.updateObject(
                     String.format("Dichroic:0:%d", d), dichroic, indexes);
         }

--- a/components/server/test/ome/formats/utests/MultiplePlateTest.java
+++ b/components/server/test/ome/formats/utests/MultiplePlateTest.java
@@ -24,13 +24,16 @@ import ome.model.core.Pixels;
 import ome.model.screen.Plate;
 import ome.model.screen.Well;
 import ome.model.screen.WellSample;
-import junit.framework.TestCase;
 
-public class MultiplePlateTest extends TestCase
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MultiplePlateTest
 {
     private OMEROMetadataStore store;
 
-    @Override
+    @BeforeMethod
     protected void setUp() throws Exception
     {
         store = new OMEROMetadataStore();
@@ -200,44 +203,45 @@ public class MultiplePlateTest extends TestCase
      * Tests Objects and object References created in setUp();
      * Checks that object exists and are correctly linked.
      */
+    @Test
     public void testMetadata()
     {
         Instrument instrument = (Instrument) store.getObjectByLSID(
                 new LSID("Instrument:0"));
-        assertNotNull(instrument);
-        assertEquals(8, instrument.sizeOfFilter());
-        assertEquals(2, instrument.sizeOfDichroic());
+        Assert.assertNotNull(instrument);
+        Assert.assertEquals(8, instrument.sizeOfFilter());
+        Assert.assertEquals(2, instrument.sizeOfDichroic());
 
         for (int i = 0; i < 3; i++)
         {
             Plate plate = (Plate) store.getObjectByLSID(new LSID("Plate:" + i));
-            assertNotNull(plate);
-            assertEquals("Plate:" + i, plate.getName());
-            assertEquals(3, plate.sizeOfWells());
+            Assert.assertNotNull(plate);
+            Assert.assertEquals("Plate:" + i, plate.getName());
+            Assert.assertEquals(3, plate.sizeOfWells());
             Iterator<Well> wellIterator = plate.iterateWells();
             while (wellIterator.hasNext())
             {
                 Well well = wellIterator.next();
-                assertNotNull(well);
-                assertEquals(1, well.sizeOfWellSamples());
+                Assert.assertNotNull(well);
+                Assert.assertEquals(1, well.sizeOfWellSamples());
                 WellSample wellSample = well.iterateWellSamples().next();
-                assertNotNull(wellSample);
+                Assert.assertNotNull(wellSample);
 
                 Image image = wellSample.getImage();
-                assertNotNull(image);
+                Assert.assertNotNull(image);
                 Instrument imageInstrument = image.getInstrument();
-                assertNotNull(imageInstrument);
-                assertEquals(instrument, imageInstrument);
+                Assert.assertNotNull(imageInstrument);
+                Assert.assertEquals(instrument, imageInstrument);
                 Pixels pixels = image.getPrimaryPixels();
-                assertNotNull(pixels);
-                assertEquals(2, pixels.sizeOfChannels());
+                Assert.assertNotNull(pixels);
+                Assert.assertEquals(2, pixels.sizeOfChannels());
                 for (Channel channel : pixels.<Channel>collectChannels(null)) {
                     assertChannel(channel);
                 }
             }
         }
     }
-    
+
     /**
      * Checks that channel is linked to LogicalChannel and LightPath.
      * Checks that LightPath is linked to correct Filters and Dichroic.
@@ -246,27 +250,27 @@ public class MultiplePlateTest extends TestCase
     public void assertChannel(Channel channel)
     {
         LogicalChannel logicalChannel = channel.getLogicalChannel();
-        assertNotNull(logicalChannel);
+        Assert.assertNotNull(logicalChannel);
         LightPath lightPath = logicalChannel.getLightPath();
-        assertNotNull(lightPath);
-        assertEquals(2, lightPath.sizeOfEmissionFilterLink());
-        assertEquals(2, lightPath.sizeOfExcitationFilterLink());
+        Assert.assertNotNull(lightPath);
+        Assert.assertEquals(2, lightPath.sizeOfEmissionFilterLink());
+        Assert.assertEquals(2, lightPath.sizeOfExcitationFilterLink());
 
         for (Filter filter : lightPath.linkedEmissionFilterList()) {
             String model = filter.getModel();
-            assertNotNull(model);
-            assertTrue(model.startsWith("emFilter"));
+            Assert.assertNotNull(model);
+            Assert.assertTrue(model.startsWith("emFilter"));
         }
 
         for (Filter filter : lightPath.linkedExcitationFilterList()) {
             String model = filter.getModel();
-            assertNotNull(model);
-            assertTrue(model.startsWith("exFilter"));
+            Assert.assertNotNull(model);
+            Assert.assertTrue(model.startsWith("exFilter"));
         }
 
         Dichroic dichroic = lightPath.getDichroic();
-        assertNotNull(dichroic);
-        assertEquals(
+        Assert.assertNotNull(dichroic);
+        Assert.assertEquals(
                 "Dichroic:" + channel.getVersion(),
                 dichroic.getModel()
             );

--- a/components/server/test/unit.testng.xml
+++ b/components/server/test/unit.testng.xml
@@ -11,6 +11,7 @@
       </run>        
     </groups>
     <packages>
+      <package name="ome.formats.*"/>
       <package name="ome.server.*"/>
       <package name="ome.services.*"/>
       <package name="omeis.*"/>


### PR DESCRIPTION
Logic and unit test cases for collapsing unique light paths. Test cases were also expanded to cover all other existing collapse logic. Some existing, but old and non-functional, test cases have been ported to TestNG and the entire suite of `ome.formats.*` unit tests added to the server unit test suite.

Due to the amount of white space changes that were required, adding `?w=1` to the end of the GitHub "Files Changed" page may be beneficial during review.

Manual testing has been performed:
* Imported one or more Plates with `LightPath` metadata populated (Flex in particular is useful here)
* Confirmed that `LogicalChannel` and `LightPath` reduction has taken place
* Confirmed that the Plates can be deleted
* Confirmed that the Plates can be be moved between groups
* Testing also took place in the presence of a backported version of #3228

`LightPath` and `LogicalChannel` reduction can be confirmed by examining the import log for a sufficiently small number. For example:

```
2014-11-07 11:15:50,320 INFO  [          ome.formats.OMEROMetadataStore] (      main) Unique objective settings: 1
2014-11-07 11:15:50,324 INFO  [          ome.formats.OMEROMetadataStore] (      main) Unique light settings: 1
2014-11-07 11:15:50,324 INFO  [          ome.formats.OMEROMetadataStore] (      main) Unique detector settings: 1
2014-11-07 11:15:50,324 INFO  [          ome.formats.OMEROMetadataStore] (      main) Unique light paths: 2
2014-11-07 11:15:50,324 INFO  [          ome.formats.OMEROMetadataStore] (      main) Unique logical channels: 2
```

Example datasets contained 12 fields, 384 wells and 2 channels resulting in 9216 unique logical channels per Plate. Completely broken on import. With a 2GB heap, takes ~4.5 hours just to get to pixel data processing:

```
...
2014-11-05 06:12:13,751 INFO  [          ome.formats.OMEROMetadataStore] (.Server-10) Unique objective settings: 1
2014-11-05 06:12:13,751 INFO  [          ome.formats.OMEROMetadataStore] (.Server-10) Unique light settings: 2
2014-11-05 06:12:13,751 INFO  [          ome.formats.OMEROMetadataStore] (.Server-10) Unique detector settings: 0
2014-11-05 06:12:13,751 INFO  [          ome.formats.OMEROMetadataStore] (.Server-10) Unique logical channels: 9216
...
```

Reduced version with just one Well's worth of `.flex` files:

```
...
2014-11-07 05:43:23,329 INFO  [          ome.formats.OMEROMetadataStore] (erver-2027) Unique objective settings: 1
2014-11-07 05:43:23,329 INFO  [          ome.formats.OMEROMetadataStore] (erver-2027) Unique light settings: 2
2014-11-07 05:43:23,329 INFO  [          ome.formats.OMEROMetadataStore] (erver-2027) Unique detector settings: 0
2014-11-07 05:43:23,329 INFO  [          ome.formats.OMEROMetadataStore] (erver-2027) Unique logical channels: 24
...
```

After reduction with just one Well's worth of `.flex` files:

```
...
2014-11-07 05:52:44,408 INFO  [          ome.formats.OMEROMetadataStore] (l.Server-3) Unique objective settings: 1
2014-11-07 05:52:44,408 INFO  [          ome.formats.OMEROMetadataStore] (l.Server-3) Unique light settings: 2
2014-11-07 05:52:44,408 INFO  [          ome.formats.OMEROMetadataStore] (l.Server-3) Unique detector settings: 0
2014-11-07 05:52:44,408 INFO  [          ome.formats.OMEROMetadataStore] (l.Server-3) Unique light paths: 2
2014-11-07 05:52:44,408 INFO  [          ome.formats.OMEROMetadataStore] (l.Server-3) Unique logical channels: 2
...
```

Total time to import with a 2GB heap is now under <60 minutes.

```
 _____________________ 
< I love light paths! >
 --------------------- 
        \   ^__^
         \  (**)\_______
            (__)\       )\/\
             U  ||----w |
                ||     ||
```