### PR TITLE
Mt big images (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -26,7 +26,9 @@ package org.openmicroscopy.shoola.agents.measurement.util.model;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.table.AbstractTableModel;
+
 
 //Third-party libraries
 import org.jhotdraw.draw.AttributeKey;
@@ -38,6 +40,7 @@ import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKey;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
+import org.openmicroscopy.shoola.util.ui.drawingtools.canvas.DrawingCanvasView;
 
 /** 
  * The model associated to the table displaying the figures.
@@ -74,20 +77,27 @@ public class FigureTableModel
 	/** Collection of fields. */
 	private List<AttributeField>	fieldList;
 	
+	/** Reference to the canvas.*/
+	private DrawingCanvasView canvas;
+
 	/**
 	 * Creates a new instance.
 	 * 
 	 * @param fieldList The collection of fields. Mustn't be <code>null</code>.
-	 * @param columnNames The collection of column's names. 
-	 * 	Mustn't be <code>null</code>.
+	 * @param columnNames The collection of column's names.
+	 *                    Mustn't be <code>null</code>.
+	 * @param canvas Reference to the drawing canvas. Mustn't be <code>null</code>.
 	 */
 	public FigureTableModel(List<AttributeField> fieldList,
-			List<String> columnNames)
+			List<String> columnNames, DrawingCanvasView canvas)
 	{
 		if (fieldList == null) 
 			throw new IllegalArgumentException("No fields specified.");
 		if (columnNames == null) 
 			throw new IllegalArgumentException("No column's names specified.");
+		if (canvas == null) 
+            throw new IllegalArgumentException("No canvas.");
+		this.canvas = canvas;
 		this.fieldList = fieldList;
 		this.columnNames = columnNames;
 		keys = new ArrayList<AttributeKey>();
@@ -125,15 +135,18 @@ public class FigureTableModel
 				key = (AttributeKey) i.next();
 				if (key.equals(fieldName.getKey()))
 				{
+				    Object value = figure.getAttribute(key);
 					if (MeasurementAttributes.TEXT.equals(key) ||
 							MeasurementAttributes.WIDTH.equals(key) ||
 							MeasurementAttributes.HEIGHT.equals(key)) {
 						if (figure.isReadOnly())
 							fieldName.setEditable(false);
 						else fieldName.setEditable(figure.canEdit());
+					} else if (MeasurementAttributes.FONT_SIZE.equals(key)) {
+					    value = ((Double) value)*canvas.getScaleFactor();
 					}
 					keys.add(key);
-					values.add(figure.getAttribute(key));
+					values.add(value);
 					found = true;
 					break;
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -40,7 +40,6 @@ import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKey;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
-import org.openmicroscopy.shoola.util.ui.drawingtools.canvas.DrawingCanvasView;
 
 /** 
  * The model associated to the table displaying the figures.
@@ -76,9 +75,6 @@ public class FigureTableModel
 	
 	/** Collection of fields. */
 	private List<AttributeField>	fieldList;
-	
-	/** Reference to the canvas.*/
-	private DrawingCanvasView canvas;
 
 	/**
 	 * Creates a new instance.
@@ -89,15 +85,12 @@ public class FigureTableModel
 	 * @param canvas Reference to the drawing canvas. Mustn't be <code>null</code>.
 	 */
 	public FigureTableModel(List<AttributeField> fieldList,
-			List<String> columnNames, DrawingCanvasView canvas)
+			List<String> columnNames)
 	{
 		if (fieldList == null) 
 			throw new IllegalArgumentException("No fields specified.");
 		if (columnNames == null) 
 			throw new IllegalArgumentException("No column's names specified.");
-		if (canvas == null) 
-            throw new IllegalArgumentException("No canvas.");
-		this.canvas = canvas;
 		this.fieldList = fieldList;
 		this.columnNames = columnNames;
 		keys = new ArrayList<AttributeKey>();
@@ -142,8 +135,6 @@ public class FigureTableModel
 						if (figure.isReadOnly())
 							fieldName.setEditable(false);
 						else fieldName.setEditable(figure.canEdit());
-					} else if (MeasurementAttributes.FONT_SIZE.equals(key)) {
-					    value = ((Double) value)*canvas.getScaleFactor();
 					}
 					keys.add(key);
 					values.add(value);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/FigureTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/FigureTable.java
@@ -125,15 +125,6 @@ public class FigureTable
 			JTextField f = (JTextField) editor.getComponent();
 			f.getDocument().addDocumentListener(this);
 			return editor;
-		} else if (v instanceof Double || v instanceof Integer || 
-					v instanceof Long) {
-			DefaultCellEditor editor =
-				new DefaultCellEditor((NumericalTextField) renderer.
-						getTableCellRendererComponent(this,
-								getValueAt(row, col), false, false, row, col));
-			JTextField f = (JTextField) editor.getComponent();
-			f.getDocument().addDocumentListener(this);
-			return editor;
 		} else if (v instanceof Boolean) {
 			return new DefaultCellEditor((JCheckBox) renderer.
 				getTableCellRendererComponent(this,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/KeyDescription.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/KeyDescription.java
@@ -1,0 +1,45 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.measurement.util.ui;
+
+//Java imports
+
+/**
+ * 
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.0
+ */
+public class KeyDescription {
+    
+    private String key;
+    private String description;
+    
+    public KeyDescription(String key, String description)
+    {
+        this.key = key;
+        this.description = description;
+    }
+    
+    public String getKey() { return key;}
+    public String getDescription() {return description;}
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -46,6 +46,8 @@ import javax.swing.table.TableCellRenderer;
 //Third-party libraries
 
 
+
+import org.apache.commons.lang.StringUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
 import org.openmicroscopy.shoola.util.roi.model.util.FigureType;
@@ -247,9 +249,12 @@ public class ResultsCellRenderer
 		        UnitsObject object;
 	            StringBuffer buffer = new StringBuffer();
 	            object = UIUtilities.transformSize(n.doubleValue());
-	            buffer.append(twoDecimalPlaces(object.getValue()));
-	            buffer.append(object.getUnits());
-	            label.setText(buffer.toString());
+	            String s = twoDecimalPlaces(object.getValue());
+	            if (StringUtils.isNotBlank(s)) {
+	                buffer.append(s);
+	                buffer.append(object.getUnits());
+	                label.setText(buffer.toString());
+	            }
 		    } else {
 		        label.setText(UIUtilities.twoDecimalPlaces(n.doubleValue()));
 		    }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -255,7 +255,11 @@ public class ResultsCellRenderer
 	                    buffer.append(object.getUnits());
 	                }
 	                if (AnnotationKeys.AREA.getKey().equals(k)) {
-	                    buffer.append(UIUtilities.SQUARED_SYMBOL);
+	                    buffer = new StringBuffer();
+	                    object = UIUtilities.transformSquareSize(n.doubleValue());
+	                    s = twoDecimalPlaces(object.getValue());
+	                    buffer.append(s);
+	                    buffer.append(object.getUnits());
 	                }
 	                label.setText(buffer.toString());
 	            }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -43,14 +43,16 @@ import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
+
+
 //Third-party libraries
-
-
-
 import org.apache.commons.lang.StringUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
+import org.openmicroscopy.shoola.agents.measurement.view.MeasurementTableModel;
+import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.util.FigureType;
+import org.openmicroscopy.shoola.util.roi.model.util.MeasurementUnits;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.UnitsObject;
 import org.openmicroscopy.shoola.util.ui.drawingtools.figures.FigureUtil;
@@ -113,8 +115,6 @@ public class ResultsCellRenderer
 		MASK = icons.getIcon(IconManager.MASK);
 	}
 
-	/** Indicates if we display the units in microns or not.*/
-	private boolean inMicrons = false;
 
 	/**
 	 * Adds the appropriate shape icon to the label.
@@ -209,19 +209,7 @@ public class ResultsCellRenderer
 		list.setModel(model);
 		return list;
 	}
-	
-    /**
-     * Creates a new instance. Sets the opacity of the label to 
-     * <code>true</code>.
-     *
-     * @param inMicrons Pass <code>true</code> to display units in microns,
-     *                  <code>false</code> otherwise.
-     */
-    public ResultsCellRenderer(boolean inMicrons)
-    {
-        setOpaque(true);
-        this.inMicrons = inMicrons;
-    }
+
     
 	/**
 	 * Creates a new instance. Sets the opacity of the label to 
@@ -229,7 +217,7 @@ public class ResultsCellRenderer
 	 */
 	public ResultsCellRenderer()
 	{
-		this(false);
+	    setOpaque(true);
 	}
 	
 	/**
@@ -242,18 +230,28 @@ public class ResultsCellRenderer
 		Component thisComponent = new JLabel();
 		JLabel label = new JLabel();
 		label.setOpaque(true);
+		
 		if (value instanceof Number)
 		{
+		    MeasurementTableModel tm = (MeasurementTableModel) table.getModel();
+	        KeyDescription key = tm.getColumnNames().get(column);
+	        String k = key.getKey();
+	        MeasurementUnits units = tm.getUnitsType();
 		    Number n = (Number) value;
 		    String s;
-		    if (inMicrons) {
+		    if (units.isInMicrons()) {
 		        UnitsObject object;
 	            StringBuffer buffer = new StringBuffer();
 	            object = UIUtilities.transformSize(n.doubleValue());
 	            s = twoDecimalPlaces(object.getValue());
 	            if (StringUtils.isNotBlank(s)) {
 	                buffer.append(s);
-	                buffer.append(object.getUnits());
+	                if (!AnnotationKeys.ANGLE.getKey().equals(k)) {
+	                    buffer.append(object.getUnits());
+	                }
+	                if (AnnotationKeys.AREA.getKey().equals(k)) {
+	                    buffer.append(UIUtilities.SQUARED_SYMBOL);
+	                }
 	                label.setText(buffer.toString());
 	            }
 		    } else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -245,18 +245,22 @@ public class ResultsCellRenderer
 		if (value instanceof Number)
 		{
 		    Number n = (Number) value;
+		    String s;
 		    if (inMicrons) {
 		        UnitsObject object;
 	            StringBuffer buffer = new StringBuffer();
 	            object = UIUtilities.transformSize(n.doubleValue());
-	            String s = twoDecimalPlaces(object.getValue());
+	            s = twoDecimalPlaces(object.getValue());
 	            if (StringUtils.isNotBlank(s)) {
 	                buffer.append(s);
 	                buffer.append(object.getUnits());
 	                label.setText(buffer.toString());
 	            }
 		    } else {
-		        label.setText(UIUtilities.twoDecimalPlaces(n.doubleValue()));
+		        s = UIUtilities.twoDecimalPlaces(n.doubleValue());
+                if (StringUtils.isNotBlank(s)) {
+                    label.setText(s);
+                }
 		    }
     		thisComponent = label;
 		} else if (value instanceof FigureType || value instanceof String) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -45,10 +45,12 @@ import javax.swing.table.TableCellRenderer;
 
 //Third-party libraries
 
+
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
 import org.openmicroscopy.shoola.util.roi.model.util.FigureType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import org.openmicroscopy.shoola.util.ui.UnitsObject;
 import org.openmicroscopy.shoola.util.ui.drawingtools.figures.FigureUtil;
 
 /** 
@@ -108,7 +110,10 @@ public class ResultsCellRenderer
 		TEXT = icons.getIcon(IconManager.TEXT_16);
 		MASK = icons.getIcon(IconManager.MASK);
 	}
-	
+
+	/** Indicates if we display the units in microns or not.*/
+	private boolean inMicrons = false;
+
 	/**
 	 * Adds the appropriate shape icon to the label.
 	 * 
@@ -203,13 +208,26 @@ public class ResultsCellRenderer
 		return list;
 	}
 	
+    /**
+     * Creates a new instance. Sets the opacity of the label to 
+     * <code>true</code>.
+     *
+     * @param inMicrons Pass <code>true</code> to display units in microns,
+     *                  <code>false</code> otherwise.
+     */
+    public ResultsCellRenderer(boolean inMicrons)
+    {
+        setOpaque(true);
+        this.inMicrons = inMicrons;
+    }
+    
 	/**
 	 * Creates a new instance. Sets the opacity of the label to 
 	 * <code>true</code>.
 	 */
 	public ResultsCellRenderer()
 	{
-		setOpaque(true);
+		this(false);
 	}
 	
 	/**
@@ -222,15 +240,19 @@ public class ResultsCellRenderer
 		Component thisComponent = new JLabel();
 		JLabel label = new JLabel();
 		label.setOpaque(true);
-		if (value instanceof Integer || value instanceof Long ||
-				value instanceof Double ||
-				value instanceof Float)
+		if (value instanceof Number)
 		{
-			if (value instanceof Double)
-				label.setText(twoDecimalPlaces((Double) value));
-			else if (value instanceof Float)
-				label.setText(twoDecimalPlaces((Float) value));
-			else label.setText(value+"");
+		    Number n = (Number) value;
+		    if (inMicrons) {
+		        UnitsObject object;
+	            StringBuffer buffer = new StringBuffer();
+	            object = UIUtilities.transformSize(n.doubleValue());
+	            buffer.append(twoDecimalPlaces(object.getValue()));
+	            buffer.append(object.getUnits());
+	            label.setText(buffer.toString());
+		    } else {
+		        label.setText(UIUtilities.twoDecimalPlaces(n.doubleValue()));
+		    }
     		thisComponent = label;
 		} else if (value instanceof FigureType || value instanceof String) {
 			thisComponent = makeShapeIcon(label, ""+value);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -45,10 +45,12 @@ import javax.swing.table.TableCellRenderer;
 
 
 
+
 //Third-party libraries
 import org.apache.commons.lang.StringUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
+import org.openmicroscopy.shoola.agents.measurement.util.model.AnnotationDescription;
 import org.openmicroscopy.shoola.agents.measurement.view.MeasurementTableModel;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.util.FigureType;
@@ -246,7 +248,10 @@ public class ResultsCellRenderer
 	            s = twoDecimalPlaces(object.getValue());
 	            if (StringUtils.isNotBlank(s)) {
 	                buffer.append(s);
-	                if (!AnnotationKeys.ANGLE.getKey().equals(k)) {
+	                if (!(AnnotationKeys.ANGLE.getKey().equals(k) ||
+	                        AnnotationDescription.ZSECTION_STRING.equals(k) ||
+	                        AnnotationDescription.ROIID_STRING.equals(k) ||
+	                        AnnotationDescription.TIME_STRING.equals(k))) {
 	                    buffer.append(object.getUnits());
 	                }
 	                if (AnnotationKeys.AREA.getKey().equals(k)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
+
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
@@ -46,11 +47,11 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
 //Third-party libraries
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
@@ -59,7 +60,7 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnnotationDescription;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnnotationField;
 import org.openmicroscopy.shoola.agents.measurement.util.model.MeasurementObject;
-import org.openmicroscopy.shoola.agents.measurement.util.ui.AttributeUnits;
+import org.openmicroscopy.shoola.agents.measurement.util.ui.KeyDescription;
 import org.openmicroscopy.shoola.agents.measurement.util.ui.ResultsCellRenderer;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.log.Logger;
@@ -73,7 +74,6 @@ import org.openmicroscopy.shoola.util.roi.model.ROIShape;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKey;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
-import org.openmicroscopy.shoola.util.roi.model.util.MeasurementUnits;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
 
@@ -604,168 +604,8 @@ class MeasurementResults
 		 */
 		public TableCellRenderer getCellRenderer(int row, int column) 
 		{
-		    MeasurementTableModel tm = (MeasurementTableModel) getModel();
-	        return new ResultsCellRenderer(tm.isInMicrons());
+		    return new ResultsCellRenderer();
 	    }
 	}
-	
-	/** Inner class used to display the results of measurement. */
-	class MeasurementTableModel 
-		extends AbstractTableModel
-	{
-	
-		private MeasurementUnits				unitsType;
-		
-		/** The collection of column's names. */
-		private List<KeyDescription>			columnNames;
-		
-		/** Collection of <code>Object</code>s hosted by this model. */
-		private List<MeasurementObject>	values;
-		
-		/**
-		 * Creates a new instance.
-		 * 
-		 * @param colNames	The collection of column's names.
-		 * 						Mustn't be <code>null</code>.
-		 * @param units The units of measurement.
-		 */
-		MeasurementTableModel(List<KeyDescription> colNames,
-				MeasurementUnits units)
-		{
-			if (colNames == null)
-				throw new IllegalArgumentException("No column's names " +
-													"specified.");
-			this.columnNames = colNames;
-			this.values = new ArrayList<MeasurementObject>();
-			this.unitsType = units;
-		}
 
-		/**
-		 * Returns <code>true</code> if in microns, <code>false</code>
-		 * otherwise.
-		 *
-		 * @return See above.
-		 */
-		boolean isInMicrons() { return unitsType.isInMicrons(); }
-
-		/** 
-		 * Adds a new row to the model.
-		 * 
-		 * @param row The value to add.
-		 */
-		void addRow(MeasurementObject row)
-		{
-			values.add(row);
-			fireTableStructureChanged();
-		}
-		
-		/** 
-		 * Get a row from the model.
-		 * 
-		 * @param index The row to return
-		 * 
-		 * @return MeasurementObject the row.
-		 */
-		MeasurementObject getRow(int index)
-		{
-			if (index < values.size())
-				return values.get(index);
-			return null;
-		}
-		
-		/**
-		 * Returns the value of the specified cell.
-		 * @see AbstractTableModel#getValueAt(int, int)
-		 */
-		public Object getValueAt(int row, int col) 
-	    {
-			if (row < 0 || row > values.size()) return null;
-			MeasurementObject rowData = values.get(row);
-			Object value = rowData.getElement(col);
-			if (value instanceof List) {
-				List<Object> l = (List<Object>) value;
-				
-				if (l.size() == 1) return l.get(0);
-				StringBuilder buffer = new StringBuilder();
-				Iterator<Object> i = l.iterator();
-				Object v;
-				double total = 0;
-				while (i.hasNext()) {
-					v = i.next();
-					if (v instanceof Number) {
-					    double d = ((Number) v).doubleValue();
-						total += d;
-						buffer.append(UIUtilities.formatToDecimal(d));
-						buffer.append(" ");
-					}
-				}
-				if (total > 0) {
-				    buffer.append("= "+UIUtilities.formatToDecimal(total));
-				}
-				return buffer.toString();
-			}
-	    	return rowData.getElement(col);
-		}
-	    
-		/**
-		 * Sets the specified value.
-		 * @see AbstractTableModel#setValueAt(Object, int, int)
-		 */
-	    public void setValueAt(Object value, int row, int col) 
-	    {
-
-	    }
-	    
-		/**
-		 * Overridden to return the name of the specified column.
-		 * @see AbstractTableModel#getColumnName(int)
-		 */
-		public String getColumnName(int col) 
-		{
-			String s = columnNames.get(col).getKey();
-			if (AttributeUnits.getUnits(s, unitsType).equals(""))
-				return columnNames.get(col).getDescription();
-			else
-				return columnNames.get(col).getDescription()+
-			" (" + AttributeUnits.getUnits(s, unitsType)+")"; }
-	    
-	    /**
-		 * Overridden to return the number of columns.
-		 * @see AbstractTableModel#getColumnCount()
-		 */
-		public int getColumnCount() { return columnNames.size();  }
-	
-		/**
-		 * Overridden to return the number of rows.
-		 * @see AbstractTableModel#getRowCount()
-		 */
-		public int getRowCount() { return values.size(); }
-		
-		/**
-		 * Overridden so that the cell is not editable.
-		 * @see AbstractTableModel#isCellEditable(int, int)
-		 */
-		public boolean isCellEditable(int row, int col) 
-		{ 
-			return false;
-		}
-		
-	}
-
-
-	class KeyDescription
-	{
-		String key;
-		String description;
-		
-		public KeyDescription(String key, String description)
-		{
-			this.key = key;
-			this.description = description;
-		}
-		
-		public String getKey() { return key;}
-		public String getDescription() {return description;}
-	}
-	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
@@ -604,7 +604,8 @@ class MeasurementResults
 		 */
 		public TableCellRenderer getCellRenderer(int row, int column) 
 		{
-	        return new ResultsCellRenderer();
+		    MeasurementTableModel tm = (MeasurementTableModel) getModel();
+	        return new ResultsCellRenderer(tm.isInMicrons());
 	    }
 	}
 	
@@ -638,7 +639,15 @@ class MeasurementResults
 			this.values = new ArrayList<MeasurementObject>();
 			this.unitsType = units;
 		}
-		
+
+		/**
+		 * Returns <code>true</code> if in microns, <code>false</code>
+		 * otherwise.
+		 *
+		 * @return See above.
+		 */
+		boolean isInMicrons() { return unitsType.isInMicrons(); }
+
 		/** 
 		 * Adds a new row to the model.
 		 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
@@ -1,0 +1,183 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.measurement.view;
+
+
+
+//Java imports
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.swing.table.AbstractTableModel;
+
+import org.openmicroscopy.shoola.agents.measurement.util.model.MeasurementObject;
+import org.openmicroscopy.shoola.agents.measurement.util.ui.AttributeUnits;
+import org.openmicroscopy.shoola.agents.measurement.util.ui.KeyDescription;
+import org.openmicroscopy.shoola.util.roi.model.util.MeasurementUnits;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+/**
+ * 
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.0
+ */
+public class MeasurementTableModel extends AbstractTableModel
+{
+    
+    private MeasurementUnits                unitsType;
+    
+    /** The collection of column's names. */
+    private List<KeyDescription>            columnNames;
+    
+    /** Collection of <code>Object</code>s hosted by this model. */
+    private List<MeasurementObject> values;
+    
+    /**
+     * Creates a new instance.
+     * 
+     * @param colNames  The collection of column's names.
+     *                      Mustn't be <code>null</code>.
+     * @param units The units of measurement.
+     */
+    MeasurementTableModel(List<KeyDescription> colNames,
+            MeasurementUnits units)
+    {
+        if (colNames == null)
+            throw new IllegalArgumentException("No column's names " +
+                                                "specified.");
+        this.columnNames = colNames;
+        this.values = new ArrayList<MeasurementObject>();
+        this.unitsType = units;
+    }
+
+    public List<KeyDescription> getColumnNames() { return  columnNames; }
+
+    /**
+     * Returns the units type.
+     *
+     * @return See above.
+     */
+    public MeasurementUnits getUnitsType() { return unitsType; }
+
+    /** 
+     * Adds a new row to the model.
+     * 
+     * @param row The value to add.
+     */
+    void addRow(MeasurementObject row)
+    {
+        values.add(row);
+        fireTableStructureChanged();
+    }
+    
+    /** 
+     * Get a row from the model.
+     * 
+     * @param index The row to return
+     * 
+     * @return MeasurementObject the row.
+     */
+    MeasurementObject getRow(int index)
+    {
+        if (index < values.size())
+            return values.get(index);
+        return null;
+    }
+    
+    /**
+     * Returns the value of the specified cell.
+     * @see AbstractTableModel#getValueAt(int, int)
+     */
+    public Object getValueAt(int row, int col) 
+    {
+        if (row < 0 || row > values.size()) return null;
+        MeasurementObject rowData = values.get(row);
+        Object value = rowData.getElement(col);
+        if (value instanceof List) {
+            List<Object> l = (List<Object>) value;
+            
+            if (l.size() == 1) return l.get(0);
+            StringBuilder buffer = new StringBuilder();
+            Iterator<Object> i = l.iterator();
+            Object v;
+            double total = 0;
+            while (i.hasNext()) {
+                v = i.next();
+                if (v instanceof Number) {
+                    double d = ((Number) v).doubleValue();
+                    total += d;
+                    buffer.append(UIUtilities.formatToDecimal(d));
+                    buffer.append(" ");
+                }
+            }
+            if (total > 0) {
+                buffer.append("= "+UIUtilities.formatToDecimal(total));
+            }
+            return buffer.toString();
+        }
+        return rowData.getElement(col);
+    }
+    
+    /**
+     * Sets the specified value.
+     * @see AbstractTableModel#setValueAt(Object, int, int)
+     */
+    public void setValueAt(Object value, int row, int col) 
+    {
+
+    }
+    
+    /**
+     * Overridden to return the name of the specified column.
+     * @see AbstractTableModel#getColumnName(int)
+     */
+    public String getColumnName(int col) 
+    {
+        String s = columnNames.get(col).getKey();
+        if (AttributeUnits.getUnits(s, unitsType).equals(""))
+            return columnNames.get(col).getDescription();
+        else
+            return columnNames.get(col).getDescription()+
+        " (" + AttributeUnits.getUnits(s, unitsType)+")"; }
+    
+    /**
+     * Overridden to return the number of columns.
+     * @see AbstractTableModel#getColumnCount()
+     */
+    public int getColumnCount() { return columnNames.size();  }
+
+    /**
+     * Overridden to return the number of rows.
+     * @see AbstractTableModel#getRowCount()
+     */
+    public int getRowCount() { return values.size(); }
+    
+    /**
+     * Overridden so that the cell is not editable.
+     * @see AbstractTableModel#isCellEditable(int, int)
+     */
+    public boolean isCellEditable(int row, int col) 
+    { 
+        return false;
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -398,8 +398,10 @@ class MeasurementViewerComponent
 		int t = model.getDefaultT();
 		double f = model.getMagnification();
 		if (z == defaultZ && t == defaultT) {
-			if (f != magnification)
-				model.setMagnification(magnification);
+			if (f != magnification) {
+			    model.setMagnification(magnification);
+			    view.onMagnificationChanged();
+			}
 			if (!model.isBigImage()) return;
 		}
 		model.setPlane(defaultZ, defaultT);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -502,11 +502,8 @@ class MeasurementViewerModel
 		int sizeX = getSizeX();
 		int sizeY = getSizeY();
 		this.magnification = magnification;
-		if (state != MeasurementViewer.NEW)
-			getDrawingView().setScaleFactor(magnification,
-					new Dimension(sizeX, sizeY));
-		else 
-			getDrawingView().setScaleFactor(magnification);
+		getDrawingView().setScaleFactor(magnification,
+                new Dimension(sizeX, sizeY));
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -475,9 +475,9 @@ class MeasurementViewerUI
 					roiManager.getComponentIcon(), roiManager);
 		tabs.addTab(roiInspector.getComponentName(),
 			roiInspector.getComponentIcon(), roiInspector);
+		tabs.addTab(roiResults.getComponentName(),
+                roiResults.getComponentIcon(), roiResults);
 		if (!model.isBigImage()) {
-			tabs.addTab(roiResults.getComponentName(),
-				roiResults.getComponentIcon(), roiResults);
 			tabs.addTab(graphPane.getComponentName(),
 				graphPane.getComponentIcon(), graphPane);
 			tabs.addTab(intensityView.getComponentName(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -1569,7 +1569,7 @@ class MeasurementViewerUI
 	/** Updates view when the zoom factor is modified.*/
 	void onMagnificationChanged()
 	{
-	    roiInspector.onMagnificationChanged();
+	    toolBar.onMagnificationChanged();
 	}
 
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -1565,7 +1565,13 @@ class MeasurementViewerUI
 		intensityView.onAnalysed(analyse);
 		toolBar.onAnalysed(analyse);
 	}
-	
+
+	/** Updates view when the zoom factor is modified.*/
+	void onMagnificationChanged()
+	{
+	    roiInspector.onMagnificationChanged();
+	}
+
     /** 
      * Overridden to the set the location of the {@link MeasurementViewer}.
      * @see TopWindow#setOnScreen() 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -84,7 +84,6 @@ import org.openmicroscopy.shoola.util.roi.exception.NoSuchROIException;
 import org.openmicroscopy.shoola.util.roi.exception.ROICreationException;
 import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
 import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
-import org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureMaskFigure;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.ROI;
@@ -222,13 +221,7 @@ class MeasurementViewerUI
     
     /** The map holding the work-flow objects. */
     private Map<String, String> workflowsUIMap;
-    
-    /** 
-     * Flag indicating that the measurement was shown before adding 
-     * a new figure.
-     */
-    private Boolean measurementShown;
-    
+
     /**
      * Scrolls to the passed figure.
      * 
@@ -1029,16 +1022,7 @@ class MeasurementViewerUI
     		if (!isDuplicate) {
 	    		MeasurementAttributes.SHOWTEXT.set(figure,
 	    					roiInspector.isShowText());
-	    		if (figure instanceof MeasureLineFigure) {
-	    			measurementShown = roiInspector.isShowMeasurement();
-	    			MeasurementAttributes.SHOWMEASUREMENT.set(figure, true);
-	    		} else {
-	    			boolean b = roiInspector.isShowMeasurement();
-	    			if (measurementShown != null)
-	    				b = measurementShown.booleanValue();
-	    			MeasurementAttributes.SHOWMEASUREMENT.set(figure, b);
-	    			measurementShown = null;
-	    		}
+                MeasurementAttributes.SHOWMEASUREMENT.set(figure, true);
     		}
     		getDrawingView().unsetDuplicate();
     	} catch (Exception e) {
@@ -1503,12 +1487,12 @@ class MeasurementViewerUI
 	{
 		Collection<Figure> figures = model.getSelectedFigures();
 		if (figures != null) {
+		    boolean show = roiInspector.isShowMeasurement();
 			Iterator<Figure> i = figures.iterator();
 			Figure f;
 			while (i.hasNext()) {
 				f = i.next();
-				if (measurementShown != null && measurementShown.booleanValue())
-					MeasurementAttributes.SHOWMEASUREMENT.set(f, true);
+				MeasurementAttributes.SHOWMEASUREMENT.set(f, show);
 			}
 		}
 		

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.swing.BoxLayout;
 import javax.swing.Icon;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
@@ -82,6 +84,9 @@ class ObjectInspector
 	/** The name of the panel. */
 	private static final String			NAME = "Inspector";
 	
+	/** Text indicating the scaling factor.*/
+	private static final String MAGNIFICATION = "The scaling Factor";
+	
 	/** The table hosting the various fields. */
 	private FigureTable					fieldTable;
 
@@ -90,6 +95,9 @@ class ObjectInspector
 	
 	/** Reference to the model. */
 	private MeasurementViewerModel		model;
+
+	/** Magnification factor label*/
+	private JLabel infoLabel;
 
 	static {
 		COLUMN_NAMES = new ArrayList<String>(2);
@@ -136,6 +144,7 @@ class ObjectInspector
 	/** Initializes the component composing the display. */
 	private void initComponents()
 	{
+	    infoLabel = new JLabel(MAGNIFICATION+" is 1");
 		//create the table
 		fieldTable = new FigureTable(new FigureTableModel(attributeFields,
 		        COLUMN_NAMES, model.getDrawingView()));
@@ -279,6 +288,13 @@ class ObjectInspector
 	private void buildGUI()
 	{
 		setLayout(new BorderLayout());
+		JPanel p = new JPanel();
+		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
+		JLabel l = new JLabel();
+		l.setText("Information below (e.g. font size) are for a scaling factor of 1.");
+		p.add(l);
+		p.add(infoLabel);
+		add(p, BorderLayout.NORTH);
 		add(new JScrollPane(fieldTable), BorderLayout.CENTER);
 	}
 	
@@ -423,11 +439,8 @@ class ObjectInspector
 	/** Updates the display when the magnification factor changes.*/
 	void onMagnificationChanged()
 	{
-	    FigureTableModel tm = (FigureTableModel) fieldTable.getModel();
-	    ROIFigure figure = tm.getFigure();
-	    if (figure != null) {
-	        tm.setData(figure);
-	    }
+	    infoLabel.setText(MAGNIFICATION+" is "+
+	model.getDrawingView().getScaleFactor());
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -144,10 +144,11 @@ class ObjectInspector
 	/** Initializes the component composing the display. */
 	private void initComponents()
 	{
-	    infoLabel = new JLabel(MAGNIFICATION+" is 1");
+	    infoLabel = new JLabel(MAGNIFICATION+" is "+
+	model.getDrawingView().getScaleFactor());
 		//create the table
 		fieldTable = new FigureTable(new FigureTableModel(attributeFields,
-		        COLUMN_NAMES, model.getDrawingView()));
+		        COLUMN_NAMES));
 		fieldTable.getTableHeader().setReorderingAllowed(false);
 		fieldTable.setRowHeight(26);
 		fieldTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -289,13 +289,6 @@ class ObjectInspector
 	private void buildGUI()
 	{
 		setLayout(new BorderLayout());
-		JPanel p = new JPanel();
-		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
-		JLabel l = new JLabel();
-		l.setText("Information below (e.g. font size) are for a scaling factor of 1.");
-		p.add(l);
-		p.add(infoLabel);
-		add(p, BorderLayout.NORTH);
 		add(new JScrollPane(fieldTable), BorderLayout.CENTER);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -137,7 +137,8 @@ class ObjectInspector
 	private void initComponents()
 	{
 		//create the table
-		fieldTable = new FigureTable(new FigureTableModel(attributeFields, COLUMN_NAMES));
+		fieldTable = new FigureTable(new FigureTableModel(attributeFields,
+		        COLUMN_NAMES, model.getDrawingView()));
 		fieldTable.getTableHeader().setReorderingAllowed(false);
 		fieldTable.setRowHeight(26);
 		fieldTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -419,6 +420,16 @@ class ObjectInspector
 		fieldTable.repaint();
 	}
 	
+	/** Updates the display when the magnification factor changes.*/
+	void onMagnificationChanged()
+	{
+	    FigureTableModel tm = (FigureTableModel) fieldTable.getModel();
+	    ROIFigure figure = tm.getFigure();
+	    if (figure != null) {
+	        tm.setData(figure);
+	    }
+	}
+
 	/**
 	 * Removes the ROI figure.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -27,6 +27,7 @@ package org.openmicroscopy.shoola.agents.measurement.view;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -35,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -46,6 +48,7 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+
 
 //Third-party libraries
 import org.jhotdraw.draw.AttributeKey;
@@ -210,7 +213,22 @@ class ToolBar
     	button.setAction(new DrawingAction(measurementcomponent, button));	
 		button.addMouseListener(this);
     }
-    
+
+    /** The max plane size.*/
+    private static final int MAX_SIZE = 512;
+
+    private double getDefaultFontSize()
+    {
+        int sizeX = model.getSizeX();
+        int sizeY = model.getSizeY();
+        double f = ShapeSettingsData.DEFAULT_FONT_SIZE;
+        if (sizeX <= MAX_SIZE && sizeY <= MAX_SIZE){
+            return f;
+        }
+        double rx = f*(sizeX/MAX_SIZE);
+        double ry = f*(sizeY/MAX_SIZE);
+        return Math.floor(Math.max(ry, rx));
+    }
     /** Initializes the component composing the display. */
 	private void initComponents()
 	{
@@ -218,23 +236,32 @@ class ToolBar
 		
 		lineConnectionProperties = new FigureProperties(
 				defaultConnectionAttributes);
-		ellipseTool = new DrawingObjectCreationTool(new MeasureEllipseFigure(
-				false, true, true, true, true));
-		rectTool = new DrawingObjectCreationTool(new MeasureRectangleFigure(
-				false, true, true, true, true));
+		Map<AttributeKey, Object> p = new HashMap<AttributeKey, Object>();
+		double value = getDefaultFontSize();
+		Font font = ROIFigure.DEFAULT_FONT;
+		font = font.deriveFont((float) value);
+		p.put(MeasurementAttributes.FONT_SIZE, value);
+		p.put(MeasurementAttributes.FONT_FACE, font);
+		Map<AttributeKey, Object> pl = new HashMap<AttributeKey, Object>();
+		pl.put(MeasurementAttributes.FONT_SIZE, value);
+		ellipseTool = new DrawingObjectCreationTool(
+		        new MeasureEllipseFigure(false, true, true, true, true), p);
+		rectTool = new DrawingObjectCreationTool(
+		        new MeasureRectangleFigure(false, true, true, true, true), p);
 		textTool = new DrawingObjectCreationTool(
-				new MeasureTextFigure(false, true));
+				new MeasureTextFigure(false, true), p);
 		lineTool = new DrawingObjectCreationTool(
-				new MeasureLineFigure(false, true, true, true, true));
+				new MeasureLineFigure(false, true, true, true, true), pl);
+		Map<AttributeKey, Object> m = lineConnectionProperties.getProperties();
+		m.put(MeasurementAttributes.FONT_SIZE, value);
 		connectionTool = new DrawingConnectionTool(
-						new MeasureLineConnectionFigure(), 
-						lineConnectionProperties.getProperties());
+						new MeasureLineConnectionFigure(), m);
 		pointTool = new DrawingPointCreationTool(
 				new MeasurePointFigure(false, true, true, true, true));
 	    polygonTool = new DrawingBezierTool(
-	    		new MeasureBezierFigure(true, false, true, true, true, true));
+	    		new MeasureBezierFigure(true, false, true, true, true, true), pl);
 	    polylineTool = new DrawingBezierTool(
-	    		new MeasureBezierFigure(false, false, true, true, true, true));
+	    		new MeasureBezierFigure(false, false, true, true, true, true), pl);
 	    
 	    Component component;
 	    

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -145,7 +145,7 @@ class ToolBar
     private static final Dimension 		HGLUE = new Dimension(5, 5);
 
     /** The max plane size.*/
-    private static final int MAX_SIZE = 512;
+    private static final int MAX_SIZE = 1024;
 
     /** The properties figure for a line connection object. */
 	private FigureProperties 			lineConnectionProperties;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -224,15 +224,31 @@ class ToolBar
      */
     private double getDefaultFontSize()
     {
-        int sizeX = model.getSizeX();
-        int sizeY = model.getSizeY();
-        double f = ShapeSettingsData.DEFAULT_FONT_SIZE;
-        if (sizeX <= MAX_SIZE && sizeY <= MAX_SIZE){
-            return f;
+        Dimension d = model.getDrawingView().getSize();
+        int sizeX = d.width;
+        double r1 = 1;
+        if (sizeX == 0) {
+            sizeX = model.getSizeX();
         }
-        double rx = f*(sizeX/MAX_SIZE);
-        double ry = f*(sizeY/MAX_SIZE);
-        return Math.floor(Math.max(ry, rx));
+        r1 = model.getSizeX()/sizeX;
+        int sizeY = d.height;
+        if (sizeY == 0) {
+            sizeY = model.getSizeY();
+        }
+        double r2 = 1;
+        r2 = model.getSizeX()/sizeX;
+        double f = ShapeSettingsData.DEFAULT_FONT_SIZE;
+        double sx = model.getSizeX();
+        double sy = model.getSizeY();
+        if (sx > MAX_SIZE || sy  > MAX_SIZE){
+            f = 2*f;
+        }
+        double rx = f*r1;
+        double ry = f*r2;
+        f = Math.floor(Math.max(ry, rx));
+        if (f < ShapeSettingsData.DEFAULT_FONT_SIZE)
+            return ShapeSettingsData.DEFAULT_FONT_SIZE;
+        return f;
     }
 
     /** Initializes the component composing the display. */
@@ -556,7 +572,30 @@ class ToolBar
 	{
 		assistantButton.setEnabled(!analyse);
 	}
-	
+
+	/** Modifies the creation tools when changing the magnification.*/
+	void onMagnificationChanged()
+	{
+	    if (!model.isBigImage()) return;
+	    Map<AttributeKey, Object> p = new HashMap<AttributeKey, Object>();
+        double value = getDefaultFontSize();
+        Font font = ROIFigure.DEFAULT_FONT;
+        font = font.deriveFont((float) value);
+        p.put(MeasurementAttributes.FONT_SIZE, value);
+        p.put(MeasurementAttributes.FONT_FACE, font);
+        rectTool.setAttributes(p);
+        ellipseTool.setAttributes(p);
+        pointTool.setAttributes(p);
+        lineTool.setAttributes(p);
+        textTool.setAttributes(p);
+        polygonTool.setAttributes(p);
+        polylineTool.setAttributes(p);
+        Map<AttributeKey, Object> m = lineConnectionProperties.getProperties();
+        m.put(MeasurementAttributes.FONT_SIZE, value);
+        connectionTool = new DrawingConnectionTool(
+                        new MeasureLineConnectionFigure(), m);
+	}
+
 	/**
 	 * Sets the selected flag of the source of the event to 
 	 * <code>true</code> when a right click event occurs.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -143,7 +143,10 @@ class ToolBar
 	
 	/** Size of the horizontal box. */
     private static final Dimension 		HGLUE = new Dimension(5, 5);
-    
+
+    /** The max plane size.*/
+    private static final int MAX_SIZE = 512;
+
     /** The properties figure for a line connection object. */
 	private FigureProperties 			lineConnectionProperties;
 	
@@ -214,9 +217,11 @@ class ToolBar
 		button.addMouseListener(this);
     }
 
-    /** The max plane size.*/
-    private static final int MAX_SIZE = 512;
-
+    /**
+     * Determines the font size according to the image size.
+     *
+     * @return See above.
+     */
     private double getDefaultFontSize()
     {
         int sizeX = model.getSizeX();
@@ -229,6 +234,7 @@ class ToolBar
         double ry = f*(sizeY/MAX_SIZE);
         return Math.floor(Math.max(ry, rx));
     }
+
     /** Initializes the component composing the display. */
 	private void initComponents()
 	{
@@ -242,8 +248,6 @@ class ToolBar
 		font = font.deriveFont((float) value);
 		p.put(MeasurementAttributes.FONT_SIZE, value);
 		p.put(MeasurementAttributes.FONT_FACE, font);
-		Map<AttributeKey, Object> pl = new HashMap<AttributeKey, Object>();
-		pl.put(MeasurementAttributes.FONT_SIZE, value);
 		ellipseTool = new DrawingObjectCreationTool(
 		        new MeasureEllipseFigure(false, true, true, true, true), p);
 		rectTool = new DrawingObjectCreationTool(
@@ -251,7 +255,7 @@ class ToolBar
 		textTool = new DrawingObjectCreationTool(
 				new MeasureTextFigure(false, true), p);
 		lineTool = new DrawingObjectCreationTool(
-				new MeasureLineFigure(false, true, true, true, true), pl);
+				new MeasureLineFigure(false, true, true, true, true), p);
 		Map<AttributeKey, Object> m = lineConnectionProperties.getProperties();
 		m.put(MeasurementAttributes.FONT_SIZE, value);
 		connectionTool = new DrawingConnectionTool(
@@ -259,9 +263,9 @@ class ToolBar
 		pointTool = new DrawingPointCreationTool(
 				new MeasurePointFigure(false, true, true, true, true));
 	    polygonTool = new DrawingBezierTool(
-	    		new MeasureBezierFigure(true, false, true, true, true, true), pl);
+	    		new MeasureBezierFigure(true, false, true, true, true, true), p);
 	    polylineTool = new DrawingBezierTool(
-	    		new MeasureBezierFigure(false, false, true, true, true, true), pl);
+	    		new MeasureBezierFigure(false, false, true, true, true, true), p);
 	    
 	    Component component;
 	    

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -178,7 +178,7 @@ class ToolBar
     private DrawingObjectCreationTool	textTool;
 
     /** The point creation tool. */
-    private DrawingPointCreationTool	pointTool;
+    private DrawingObjectCreationTool	pointTool;
     
     /** The polygon creation tool. */
     private DrawingBezierTool 			polygonTool;
@@ -260,8 +260,8 @@ class ToolBar
 		m.put(MeasurementAttributes.FONT_SIZE, value);
 		connectionTool = new DrawingConnectionTool(
 						new MeasureLineConnectionFigure(), m);
-		pointTool = new DrawingPointCreationTool(
-				new MeasurePointFigure(false, true, true, true, true));
+		pointTool = new DrawingObjectCreationTool(
+				new MeasurePointFigure(false, true, true, true, true), p);
 	    polygonTool = new DrawingBezierTool(
 	    		new MeasureBezierFigure(true, false, true, true, true, true), p);
 	    polylineTool = new DrawingBezierTool(

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -321,14 +322,17 @@ public class MeasureBezierFigure
 		if (MeasurementAttributes.SHOWMEASUREMENT.get(this) || 
 				MeasurementAttributes.SHOWID.get(this))
 		{
+		    Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
 			if (isClosed())
 			{
 				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				String polygonArea = formatter.format(getArea());
 				polygonArea = addAreaUnits(polygonArea);
-				double sz = ((Double) this.getAttribute(
-							MeasurementAttributes.FONT_SIZE));
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				bounds = g.getFontMetrics().getStringBounds(polygonArea, g);
 				bounds = new Rectangle2D.Double(
 						this.getBounds().getCenterX()-bounds.getWidth()/2,
@@ -354,9 +358,6 @@ public class MeasureBezierFigure
 				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				String polygonLength = formatter.format(getLength());
 				polygonLength = addLineUnits(polygonLength);
-				double sz = (Double) 
-						getAttribute(MeasurementAttributes.FONT_SIZE);
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				bounds = g.getFontMetrics().getStringBounds(polygonLength, g);
 				
 				if (super.getNodeCount() > 1)

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -239,14 +239,16 @@ public class MeasureBezierFigure
 	private String formatValue(double value, boolean lineUnits)
 	{
 	    NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
-	    if (units.isInMicrons()){ 
-	        UnitsObject v = UIUtilities.transformSize(value);
+	    if (units.isInMicrons()){
+	        UnitsObject v;
+	        if (lineUnits) {
+	            v = UIUtilities.transformSize(value);
+	        } else {
+	            v = UIUtilities.transformSquareSize(value);
+	        }
 	        StringBuffer buffer = new StringBuffer();
 	        buffer.append(formatter.format(v.getValue()));
 	        buffer.append(v.getUnits());
-	        if (!lineUnits) {
-	            buffer.append(UIUtilities.SQUARED_SYMBOL);
-	        }
 	        return buffer.toString();
 	    }
 	    if (lineUnits) return addLineUnits(formatter.format(value));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -226,7 +227,32 @@ public class MeasureBezierFigure
 		}
 		total += map.size();
 	}
-	
+
+	/**
+	 * Formats the area.
+	 * 
+	 * @param value The value to format.
+	 * @param lineUnits Pass <code>true</code> to use the line units,
+	 *                  <code>false</code> otherwise.
+	 * @return See above.
+	 */
+	private String formatValue(double value, boolean lineUnits)
+	{
+	    NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
+	    if (units.isInMicrons()){ 
+	        UnitsObject v = UIUtilities.transformSize(value);
+	        StringBuffer buffer = new StringBuffer();
+	        buffer.append(formatter.format(v.getValue()));
+	        buffer.append(v.getUnits());
+	        if (!lineUnits) {
+	            buffer.append(UIUtilities.SQUARED_SYMBOL);
+	        }
+	        return buffer.toString();
+	    }
+	    if (lineUnits) return addLineUnits(formatter.format(value));
+	    return addAreaUnits(formatter.format(value));
+	}
+
 	/** Creates an instance of the Bezier figure. */
 	public MeasureBezierFigure()
 	{
@@ -330,9 +356,7 @@ public class MeasureBezierFigure
             }
 			if (isClosed())
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
-				String polygonArea = formatter.format(getArea());
-				polygonArea = addAreaUnits(polygonArea);
+				String polygonArea = formatValue(getArea(), false);
 				bounds = g.getFontMetrics().getStringBounds(polygonArea, g);
 				bounds = new Rectangle2D.Double(
 						this.getBounds().getCenterX()-bounds.getWidth()/2,
@@ -355,9 +379,7 @@ public class MeasureBezierFigure
 			}
 			else
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
-				String polygonLength = formatter.format(getLength());
-				polygonLength = addLineUnits(polygonLength);
+				String polygonLength = formatValue(getLength(), true);
 				bounds = g.getFontMetrics().getStringBounds(polygonLength, g);
 				
 				if (super.getNodeCount() > 1)

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -482,9 +482,9 @@ public class MeasureBezierFigure
 		Point2D.Double pt = getNode(i).getControlPoint(0); 
 		if (units.isInMicrons()) {
 			double tx = UIUtilities.transformSize(
-					pt.getX()*units.getMicronsPixelX()).getValue();
+					pt.getX()*units.getMicronsPixelX(), refUnits);
 			double ty = UIUtilities.transformSize(
-					pt.getY()*units.getMicronsPixelY()).getValue();
+					pt.getY()*units.getMicronsPixelY(), refUnits);
 			return new Point2D.Double(tx, ty);
 		}
 		return pt;
@@ -526,9 +526,9 @@ public class MeasureBezierFigure
 		{
 			Point2D.Double pt1 =  path.getCenter();
 			double tx = UIUtilities.transformSize(
-					pt1.getX()*units.getMicronsPixelX()).getValue();
+					pt1.getX()*units.getMicronsPixelX(), refUnits);
 			double ty = UIUtilities.transformSize(
-					pt1.getY()*units.getMicronsPixelY()).getValue();
+					pt1.getY()*units.getMicronsPixelY(), refUnits);
 			pt1.setLocation(tx, ty);
 			return pt1;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.AttributeKeys;
@@ -112,7 +113,27 @@ public class MeasureEllipseFigure
 	
 	/** The units of reference.*/
 	private String refUnits;
-	
+
+	   /**
+     * Formats the area.
+     * 
+     * @param value The value to format.
+     * @return See above.
+     */
+    private String formatValue(double value)
+    {
+        NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
+        if (units.isInMicrons()){ 
+            UnitsObject v = UIUtilities.transformSize(value);
+            StringBuffer buffer = new StringBuffer();
+            buffer.append(formatter.format(v.getValue()));
+            buffer.append(v.getUnits());
+            buffer.append(UIUtilities.SQUARED_SYMBOL);
+            return buffer.toString();
+        }
+        return addUnits(formatter.format(value));
+    }
+
 	/** Creates a new instance. */
 	public MeasureEllipseFigure()
 	{
@@ -323,9 +344,7 @@ public class MeasureEllipseFigure
 		if (MeasurementAttributes.SHOWMEASUREMENT.get(this) || 
 				MeasurementAttributes.SHOWID.get(this))
 		{
-			NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
-			String ellipseArea = formatter.format(getArea());
-			ellipseArea = addUnits(ellipseArea);
+			String ellipseArea = formatValue(getArea());
 			Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
             Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
             if (font != null) g.setFont(font.deriveFont(sz.floatValue()));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
@@ -124,11 +124,10 @@ public class MeasureEllipseFigure
     {
         NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
         if (units.isInMicrons()){ 
-            UnitsObject v = UIUtilities.transformSize(value);
+            UnitsObject v = UIUtilities.transformSquareSize(value);
             StringBuffer buffer = new StringBuffer();
             buffer.append(formatter.format(v.getValue()));
             buffer.append(v.getUnits());
-            buffer.append(UIUtilities.SQUARED_SYMBOL);
             return buffer.toString();
         }
         return addUnits(formatter.format(value));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
@@ -203,7 +203,7 @@ public class MeasureEllipseFigure
 	{
 		if (units.isInMicrons()) 
 			return UIUtilities.transformSize(
-					getX()*units.getMicronsPixelX()).getValue();
+					getX()*units.getMicronsPixelX(), refUnits);
 		return getX();
 	}
 	
@@ -217,7 +217,7 @@ public class MeasureEllipseFigure
 	{
 		if (units.isInMicrons())
 			return UIUtilities.transformSize(
-					getY()*units.getMicronsPixelY()).getValue();
+					getY()*units.getMicronsPixelY(), refUnits);
 		return getY();
 	}
 	
@@ -231,7 +231,7 @@ public class MeasureEllipseFigure
 	{
 		if (units.isInMicrons())
 			return UIUtilities.transformSize(
-					getWidth()*units.getMicronsPixelX()).getValue();
+					getWidth()*units.getMicronsPixelX(), refUnits);
 		return getWidth();
 	}
 		
@@ -245,7 +245,7 @@ public class MeasureEllipseFigure
 	{
 		if (units.isInMicrons())
 			return UIUtilities.transformSize(
-					getHeight()*units.getMicronsPixelY()).getValue();
+					getHeight()*units.getMicronsPixelY(), refUnits);
 		return getHeight();
 	}
 		
@@ -259,9 +259,9 @@ public class MeasureEllipseFigure
 	{
 		if (units.isInMicrons()) {
 			double tx = UIUtilities.transformSize(
-					getCentre().getX()*units.getMicronsPixelX()).getValue();
+					getCentre().getX()*units.getMicronsPixelX(), refUnits);
 			double ty = UIUtilities.transformSize(
-					getCentre().getY()*units.getMicronsPixelY()).getValue();
+					getCentre().getY()*units.getMicronsPixelY(), refUnits);
 			return new Point2D.Double(tx, ty);
 		}
 		return getCentre();

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureEllipseFigure.java
@@ -35,6 +35,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.AttributeKeys;
@@ -325,9 +326,12 @@ public class MeasureEllipseFigure
 			NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 			String ellipseArea = formatter.format(getArea());
 			ellipseArea = addUnits(ellipseArea);
-			double sz = ((Double) this.getAttribute(
-					MeasurementAttributes.FONT_SIZE));
-			g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
+			Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
 			Rectangle2D stringBoundsbounds = 
 				g.getFontMetrics().getStringBounds(ellipseArea, g);
 			measurementBounds =

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -124,6 +125,26 @@ public class MeasureLineConnectionFigure
 	/** The units of reference.*/
 	private String refUnits;
 	
+	/**
+	 * Formats the area.
+	 * 
+	 * @param value The value to format.
+	 * @return See above.
+	 */
+    private String formatValue(double value, boolean degree)
+    {
+        NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
+        if (units.isInMicrons()){ 
+            UnitsObject v = UIUtilities.transformSize(value);
+            StringBuffer buffer = new StringBuffer();
+            buffer.append(formatter.format(v.getValue()));
+            buffer.append(v.getUnits());
+            return buffer.toString();
+        }
+        if (degree) return addDegrees(formatter.format(value));
+        else return addUnits(formatter.format(value));
+    }
+
 	/** Creates instance of line connection figure.*/
 	public MeasureLineConnectionFigure()
 	{
@@ -183,13 +204,11 @@ public class MeasureLineConnectionFigure
 		    g.setColor(MeasurementAttributes.STROKE_COLOR.get(this));
 			if (getPointCount() == 2)
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				double angle = getAngle(0, 1);
 				if (angle > 90)
 					angle = Math.abs(angle-180);
 				angleArray.add(angle);
-				String lineAngle = formatter.format(angle);
-				lineAngle = addDegrees(lineAngle);
+				String lineAngle = formatValue(angle, true);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Point2D.Double lengthPoint = getLengthPosition(0, 1);
@@ -202,11 +221,9 @@ public class MeasureLineConnectionFigure
 			}
 			for (int x = 1 ; x < this.getPointCount()-1; x++)
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				double angle = getAngle(x-1, x, x+1);
 				angleArray.add(angle);
-				String lineAngle = formatter.format(angle);
-				lineAngle = addDegrees(lineAngle);
+				String lineAngle = formatValue(angle, true);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x, 
@@ -216,11 +233,9 @@ public class MeasureLineConnectionFigure
 			}
 			for (int x = 1 ; x < this.getPointCount(); x++)
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				double length = getLength(x-1, x);
 				lengthArray.add(length);
-				String lineLength = formatter.format(length);
-				lineLength = addUnits(lineLength);
+				String lineLength = formatValue(length, false);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineLength, g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x-15, 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
@@ -394,9 +394,9 @@ public class MeasureLineConnectionFigure
 			{
 				Point2D.Double pt = getPoint(i);
 				double tx = UIUtilities.transformSize(
-						pt.getX()*units.getMicronsPixelX()).getValue();
+						pt.getX()*units.getMicronsPixelX(), refUnits);
 				double ty = UIUtilities.transformSize(
-						pt.getY()*units.getMicronsPixelY()).getValue();
+						pt.getY()*units.getMicronsPixelY(), refUnits);
 				return new Point2D.Double(tx, ty);
 			}
 			return getPoint(i);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineConnectionFigure.java
@@ -36,6 +36,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -173,6 +174,12 @@ public class MeasureLineConnectionFigure
 		if (MeasurementAttributes.SHOWMEASUREMENT.get(this) || 
 				MeasurementAttributes.SHOWID.get(this))
 		{
+		    Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
 		    g.setColor(MeasurementAttributes.STROKE_COLOR.get(this));
 			if (getPointCount() == 2)
 			{
@@ -183,9 +190,6 @@ public class MeasureLineConnectionFigure
 				angleArray.add(angle);
 				String lineAngle = formatter.format(angle);
 				lineAngle = addDegrees(lineAngle);
-				double sz = ( Double) getAttribute(
-						MeasurementAttributes.FONT_SIZE);
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Point2D.Double lengthPoint = getLengthPosition(0, 1);
@@ -203,9 +207,6 @@ public class MeasureLineConnectionFigure
 				angleArray.add(angle);
 				String lineAngle = formatter.format(angle);
 				lineAngle = addDegrees(lineAngle);
-				double sz = (Double) getAttribute(
-						MeasurementAttributes.FONT_SIZE);
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int)sz));
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x, 
@@ -220,9 +221,6 @@ public class MeasureLineConnectionFigure
 				lengthArray.add(length);
 				String lineLength = formatter.format(length);
 				lineLength = addUnits(lineLength);
-				double sz = ((Double)
-						getAttribute(MeasurementAttributes.FONT_SIZE));
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineLength, g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x-15, 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -218,6 +219,12 @@ public class MeasureLineFigure
 		angleArray.clear();
 		if (MeasurementAttributes.SHOWMEASUREMENT.get(this))
 		{
+		    Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
 		    g.setColor(MeasurementAttributes.STROKE_COLOR.get(this));
 			if (getPointCount() == 2)
 			{
@@ -228,9 +235,6 @@ public class MeasureLineFigure
 				angleArray.add(angle);
 				String lineAngle = formatter.format(angle);
 				lineAngle = addDegrees(lineAngle);
-				double sz = ((Double) getAttribute(
-						MeasurementAttributes.FONT_SIZE));
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineAngle, g);
 				Point2D.Double lengthPoint = getLengthPosition(0, 1);
@@ -247,9 +251,6 @@ public class MeasureLineFigure
 				angleArray.add(angle);
 				String lineAngle = formatter.format(angle);
 				lineAngle = addDegrees(lineAngle);
-				double sz = (Double) getAttribute(
-						MeasurementAttributes.FONT_SIZE);
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x,
@@ -270,9 +271,6 @@ public class MeasureLineFigure
 				lengthArray.add(length);
 				String lineLength = formatter.format(length);
 				lineLength = addUnits(lineLength);
-				double sz = (Double) getAttribute(
-						MeasurementAttributes.FONT_SIZE);
-				g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
 				Point2D.Double lengthPoint = getLengthPosition(x-1, x);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineLength, g);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -141,9 +141,9 @@ public class MeasureLineFigure
 		{
 			Point2D.Double pt = getPoint(i);
 			double tx = UIUtilities.transformSize(
-					pt.getX()*units.getMicronsPixelX()).getValue();
+					pt.getX()*units.getMicronsPixelX(), refUnits);
 			double ty = UIUtilities.transformSize(
-					pt.getY()*units.getMicronsPixelY()).getValue();
+					pt.getY()*units.getMicronsPixelY(), refUnits);
 			return new Point2D.Double(tx, ty);
 		}
 		return getPoint(i);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -41,6 +41,10 @@ import java.util.List;
 import java.util.Map;
 
 
+
+
+
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -149,7 +153,27 @@ public class MeasureLineFigure
 		}
 		return getPoint(i);
 	}
-	
+
+	/**
+	 * Formats the area.
+	 * 
+	 * @param value The value to format.
+	 * @return See above.
+	 */
+	private String formatValue(double value, boolean degree)
+	{
+	    NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
+	    if (units.isInMicrons()){ 
+	        UnitsObject v = UIUtilities.transformSize(value);
+	        StringBuffer buffer = new StringBuffer();
+	        buffer.append(formatter.format(v.getValue()));
+	        buffer.append(v.getUnits());
+	        return buffer.toString();
+	    }
+	    if (degree) return addDegrees(formatter.format(value));
+	    else return addUnits(formatter.format(value));
+	}
+
 	/** Creates a new instance. */
 	public MeasureLineFigure()
 	{
@@ -228,13 +252,11 @@ public class MeasureLineFigure
 		    g.setColor(MeasurementAttributes.STROKE_COLOR.get(this));
 			if (getPointCount() == 2)
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				double angle = getAngle(0, 1);
 				if(angle>90)
 					angle = Math.abs(angle-180);
 				angleArray.add(angle);
-				String lineAngle = formatter.format(angle);
-				lineAngle = addDegrees(lineAngle);
+				String lineAngle = formatValue(angle, true);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineAngle, g);
 				Point2D.Double lengthPoint = getLengthPosition(0, 1);
@@ -246,11 +268,9 @@ public class MeasureLineFigure
 			}
 			for( int x = 1 ; x < this.getPointCount()-1; x++)
 			{
-				NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 				double angle = getAngle(x-1, x, x+1);
 				angleArray.add(angle);
-				String lineAngle = formatter.format(angle);
-				lineAngle = addDegrees(lineAngle);
+				String lineAngle = formatValue(angle, true);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(lineAngle,
 						g);
 				Rectangle2D bounds = new Rectangle2D.Double(getPoint(x).x,
@@ -269,8 +289,7 @@ public class MeasureLineFigure
 			{
 				double length = getLength(x-1, x);
 				lengthArray.add(length);
-				String lineLength = formatter.format(length);
-				lineLength = addUnits(lineLength);
+				String lineLength = formatValue(length, false);
 				Point2D.Double lengthPoint = getLengthPosition(x-1, x);
 				Rectangle2D rect = g.getFontMetrics().getStringBounds(
 						lineLength, g);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
@@ -190,7 +190,7 @@ public class MeasurePointFigure
     {
         if (units.isInMicrons()) {
             return UIUtilities.transformSize(
-                    getX()*units.getMicronsPixelX()).getValue();
+                    getX()*units.getMicronsPixelX(), refUnits);
         }
         return getX();
     }
@@ -204,9 +204,9 @@ public class MeasurePointFigure
     {
         if (units.isInMicrons()){
             double tx = UIUtilities.transformSize(
-                    getCentre().getX()*units.getMicronsPixelX()).getValue();
+                    getCentre().getX()*units.getMicronsPixelX(), refUnits);
             double ty = UIUtilities.transformSize(
-                    getCentre().getY()*units.getMicronsPixelY()).getValue();
+                    getCentre().getY()*units.getMicronsPixelY(), refUnits);
             return new Point2D.Double(tx, ty);
         }
         return getCentre();
@@ -221,7 +221,7 @@ public class MeasurePointFigure
     {
         if (units.isInMicrons()) {
             return UIUtilities.transformSize(
-                    getY()*units.getMicronsPixelY()).getValue();
+                    getY()*units.getMicronsPixelY(), refUnits);
         }
         return getY();
     }
@@ -235,7 +235,7 @@ public class MeasurePointFigure
     {
         if (units.isInMicrons()) {
             return UIUtilities.transformSize(
-                    getWidth()*units.getMicronsPixelX()).getValue();
+                    getWidth()*units.getMicronsPixelX(), refUnits);
         }
         return getWidth();
     }
@@ -249,7 +249,7 @@ public class MeasurePointFigure
     {
         if (units.isInMicrons()) {
             return UIUtilities.transformSize(
-                    getHeight()*units.getMicronsPixelY()).getValue();
+                    getHeight()*units.getMicronsPixelY(), refUnits);
         }
         return getHeight();
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -293,9 +294,12 @@ public class MeasurePointFigure
             String pointCentre = 
                     "("+formatter.format(getMeasurementCentre().getX())
                     + ","+formatter.format(getMeasurementCentre().getY())+")";
-            double sz = ((Double) this.getAttribute(
-                    MeasurementAttributes.FONT_SIZE));
-            g.setFont(new Font(FONT_FAMILY, FONT_STYLE, (int) sz));
+            Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
             bounds = g.getFontMetrics().getStringBounds(pointCentre, g);
             bounds = new Rectangle2D.Double(
                     this.getBounds().getCenterX()-bounds.getWidth()/2,

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
@@ -125,11 +125,10 @@ public class MeasureRectangleFigure
 	{
 	    NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
         if (units.isInMicrons()){ 
-            UnitsObject v = UIUtilities.transformSize(value);
+            UnitsObject v = UIUtilities.transformSquareSize(value);
             StringBuffer buffer = new StringBuffer();
             buffer.append(formatter.format(v.getValue()));
             buffer.append(v.getUnits());
-            buffer.append(UIUtilities.SQUARED_SYMBOL);
             return buffer.toString();
         }
         return addUnits(formatter.format(value));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
@@ -114,7 +114,27 @@ public class MeasureRectangleFigure
 	
 	/** Flag indicating if the user can move or resize the shape.*/
 	private boolean interactable;
-	
+
+	/**
+	 * Formats the area.
+	 * 
+	 * @param value The value to format.
+	 * @return See above.
+	 */
+	private String formatValue(double value)
+	{
+	    NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
+        if (units.isInMicrons()){ 
+            UnitsObject v = UIUtilities.transformSize(value);
+            StringBuffer buffer = new StringBuffer();
+            buffer.append(formatter.format(v.getValue()));
+            buffer.append(v.getUnits());
+            buffer.append(UIUtilities.SQUARED_SYMBOL);
+            return buffer.toString();
+        }
+        return addUnits(formatter.format(value));
+	}
+
     /** Creates a new instance. */
     public MeasureRectangleFigure() 
     {
@@ -329,9 +349,7 @@ public class MeasureRectangleFigure
 		if (MeasurementAttributes.SHOWMEASUREMENT.get(this) || 
 				MeasurementAttributes.SHOWID.get(this))
 		{
-			NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
-			String rectangleArea = formatter.format(getArea());
-			rectangleArea = addUnits(rectangleArea);
+			String rectangleArea = formatValue(getArea());
 			Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
             Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
             if (font != null) g.setFont(font.deriveFont(sz.floatValue()));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
@@ -241,7 +241,7 @@ public class MeasureRectangleFigure
     {
     	if (units.isInMicrons()) {
     		return UIUtilities.transformSize(
-					getX()*units.getMicronsPixelX()).getValue();
+					getX()*units.getMicronsPixelX(), refUnits);
     	}
     	return getX();
     }
@@ -255,7 +255,7 @@ public class MeasureRectangleFigure
     {
     	if (units.isInMicrons()) {
     		return UIUtilities.transformSize(
-					getY()*units.getMicronsPixelY()).getValue();
+					getY()*units.getMicronsPixelY(), refUnits);
     	}
     	return getY();
     }
@@ -270,7 +270,7 @@ public class MeasureRectangleFigure
     {
     	if (units.isInMicrons()) {
     		return UIUtilities.transformSize(
-					getWidth()*units.getMicronsPixelX()).getValue();
+					getWidth()*units.getMicronsPixelX(), refUnits);
     	}
     	return getWidth();
     }
@@ -284,7 +284,7 @@ public class MeasureRectangleFigure
     {
     	if (units.isInMicrons()) {
     		return UIUtilities.transformSize(
-					getHeight()*units.getMicronsPixelY()).getValue();
+					getHeight()*units.getMicronsPixelY(), refUnits);
     	}
     	return getHeight();
     }
@@ -485,9 +485,9 @@ public class MeasureRectangleFigure
 	{
      	if (units.isInMicrons()) {
      		double tx = UIUtilities.transformSize(
-     				rectangle.getCenterX()*units.getMicronsPixelX()).getValue();
+     				rectangle.getCenterX()*units.getMicronsPixelX(), refUnits);
      		double ty = UIUtilities.transformSize(
-     				rectangle.getCenterY()*units.getMicronsPixelY()).getValue();
+     				rectangle.getCenterY()*units.getMicronsPixelY(), refUnits);
      		return new Point2D.Double(tx, ty);
      	}
     	return new Point2D.Double(rectangle.getCenterX(), 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureRectangleFigure.java
@@ -36,6 +36,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractAttributedFigure;
 import org.jhotdraw.draw.FigureListener;
@@ -331,10 +332,12 @@ public class MeasureRectangleFigure
 			NumberFormat formatter = new DecimalFormat(FORMAT_PATTERN);
 			String rectangleArea = formatter.format(getArea());
 			rectangleArea = addUnits(rectangleArea);
-			//double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
-			Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
-			if (font != null) 
-				g.setFont(font);
+			Double sz = (Double) getAttribute(MeasurementAttributes.FONT_SIZE);
+            Font font = (Font) getAttribute(MeasurementAttributes.FONT_FACE);
+            if (font != null) g.setFont(font.deriveFont(sz.floatValue()));
+            else {
+                g.setFont(new Font(FONT_FAMILY, FONT_STYLE, sz.intValue()));
+            }
 			bounds = g.getFontMetrics().getStringBounds(rectangleArea, g);
 			bounds = new Rectangle2D.Double(
 						getBounds().getCenterX()-bounds.getWidth()/2,

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2526,7 +2526,42 @@ public class UIUtilities
 		}
 		return new UnitsObject(units, v);
 	}
-	
+
+    /**
+     * Transforms the size and returns the value and units.
+     * 
+     * @param value The value to transform.
+     * @param refUnits The units of reference.
+     * @return See above.
+     */
+    public static double transformSize(Double value, String refUnits)
+    {
+        double v = value.doubleValue();
+        String units = UnitsObject.MICRONS;
+        if (v > 0.0 && v < 0.01) {
+            units = UnitsObject.NANOMETER;
+            if (units.equals(refUnits)) v *= 1000;
+            if (v < 1) {
+                units = UnitsObject.ANGSTROM;
+                if (units.equals(refUnits)) v *= 10;
+            }
+            return v;
+        }
+        if (v > 1000) {
+            units = UnitsObject.MILLIMETER;
+            if (units.equals(refUnits)) v /= 1000;
+        }
+        if (v > 1000) {
+            units = UnitsObject.CENTIMETER;
+            if (units.equals(refUnits)) v /= 1000;
+        }
+        if (v > 1000) {
+            units = UnitsObject.METER;
+            if (units.equals(refUnits)) v /= 1000;
+        }
+        return v;
+    }
+    
 	/**
      * Formats the passed value in seconds.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2492,7 +2492,43 @@ public class UIUtilities
     	button.setIcon((Icon) a.getValue(Action.SMALL_ICON));
     	return button;
     }
-    
+
+    /**
+     * Transforms the size and returns the value and units.
+     * 
+     * @param value The value to transform.
+     * @return See above.
+     */
+    public static UnitsObject transformSquareSize(Double value)
+    {
+        double v = value.doubleValue();
+        double pow = Math.pow(10, 6);
+        String units = UnitsObject.MICRONS+UIUtilities.SQUARED_SYMBOL;
+        if (v > 0.0 && v < 0.0001) {
+            units = UnitsObject.NANOMETER;
+            v *= pow;
+            if (v < 100) {
+                units = UnitsObject.ANGSTROM;
+                v *= 100;
+            }
+            return new UnitsObject(units, v);
+        }
+        
+        if (v > pow) {
+            units = UnitsObject.MILLIMETER+UIUtilities.SQUARED_SYMBOL;
+            v /= pow;
+        }
+        if (v > pow) {
+            units = UnitsObject.CENTIMETER+UIUtilities.SQUARED_SYMBOL;
+            v /= pow;
+        }
+        if (v > pow) {
+            units = UnitsObject.METER+UIUtilities.SQUARED_SYMBOL;
+            v /= pow;
+        }
+        return new UnitsObject(units, v);
+    }
+
     /**
 	 * Transforms the size and returns the value and units.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/BezierTool.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/BezierTool.java
@@ -35,6 +35,7 @@ import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractTool;
 import org.jhotdraw.draw.AttributeKey;
@@ -47,6 +48,7 @@ import org.jhotdraw.geom.BezierPath;
 import org.jhotdraw.geom.Geom;
 import org.jhotdraw.util.ResourceBundleUtil;
 
+import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.drawingtools.figures.BezierTextFigure;
 
@@ -141,7 +143,10 @@ public class BezierTool
                     getView().getConstrainer().constrainPoint(
                     getView().viewToDrawing(anchor)
                     )));
+          //work around since the font size is reset when the figure is added.
+            Object s = createdFigure.getAttribute(MeasurementAttributes.FONT_SIZE);
             getDrawing().add(createdFigure);
+            createdFigure.setAttribute(MeasurementAttributes.FONT_SIZE, s);
             
             nodeCountBeforeDrag = createdFigure.getNodeCount();
         } else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingBezierTool.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingBezierTool.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 //Third-party libraries
 
+
+import org.jhotdraw.draw.AttributeKey;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.drawingtools.figures.BezierTextFigure;
 
@@ -70,8 +72,20 @@ public class DrawingBezierTool
 	public DrawingBezierTool(BezierTextFigure prototype, Map attributes)
 	{
 		super(prototype, attributes);
+		
 	}
-	
+
+	/**
+     * Sets the attributes.
+     *
+     * @param attributes The CreationTool applies these attributes to the
+     * prototype after having applied the default attributes from the DrawingEditor.
+     */
+    public void setAttributes(Map<AttributeKey, Object> attributes)
+    {
+        this.attributes = attributes;
+    }
+
 	/** 
 	 * Overridden to only fired event if the {@link #resetToSelect} is
 	 * <code>true</code>.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingObjectCreationTool.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingObjectCreationTool.java
@@ -202,6 +202,17 @@ public class DrawingObjectCreationTool
         }
         this.presentationName = name;
     }
+
+    /**
+     * Sets the attributes.
+     *
+     * @param attributes The CreationTool applies these attributes to the
+     * prototype after having applied the default attributes from the DrawingEditor.
+     */
+    public void setAttributes(Map<AttributeKey, Object> attributes)
+    {
+        prototypeAttributes = attributes;
+    }
     
     /**
      * Returns the prototype.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingObjectCreationTool.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/creationtools/DrawingObjectCreationTool.java
@@ -38,6 +38,7 @@ import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 
+
 //Third-party libraries
 import org.jhotdraw.draw.AbstractTool;
 import org.jhotdraw.draw.AttributeKey;
@@ -46,6 +47,7 @@ import org.jhotdraw.draw.Drawing;
 import org.jhotdraw.draw.DrawingEditor;
 import org.jhotdraw.draw.Figure;
 import org.jhotdraw.util.ResourceBundleUtil;
+import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
 
 //Application-internal dependencies
 
@@ -250,7 +252,10 @@ public class DrawingObjectCreationTool
         anchor.x = evt.getX();
         anchor.y = evt.getY();
         createdFigure.setBounds(p, p);
+        //work around since the font size is reset when the figure is added.
+        Object s = createdFigure.getAttribute(MeasurementAttributes.FONT_SIZE);
         getDrawing().add(createdFigure);
+        createdFigure.setAttribute(MeasurementAttributes.FONT_SIZE, s);
     }
     
     /**


### PR DESCRIPTION

This is the same as gh-3134 but rebased onto dev_5_0.

----

Fix some issues with ROI and big images
To test:
* Import a big image (>4kx4k plane) and some non big images.
* Open the measurement tool "results" tab is displayed
* Draw a rectangle (or any other shape)
* Check that the "results" tab is displayed and columns populated. (big images)
* Check that the formatting of the results tab. (cc @dominikl)
* Check that the area is now displayed when drawing a rectangle for example
* for big images, check that the font size changes according to the resolution level. (default was always 12)

                