### PR TITLE
robot edit new group / user by name, instead of sort by id

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
+++ b/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
@@ -86,10 +86,8 @@ Create Edit Group
 
     Location Should Be      ${GROUPS URL}
     Page Should Contain     ${group_name}
-    # To edit the same group again, sort by ID (reverse) and edit first row
-    Click Element           xpath=//th[contains(text(), "ID")]
-    Click Element           xpath=//th[contains(text(), "ID")]
-    Click Element           xpath=//table[@id="groupTable"]/tbody/tr[1]//a[contains(@class, "btn_edit")]
+    # find row which contains group name, and click 'btn_edit' of that row
+    Click Element           xpath=//table[@id="groupTable"]/tbody/tr[descendant::td[contains(text(), '${group_name}')]]//a[contains(@class, "btn_edit")]
     Page Should Contain Element   xpath=//input[@id='id_name'][@value='${group_name}']
     Input Text              name    ${group_name}-Edited
     Click Button            Save
@@ -118,10 +116,9 @@ Create Edit User
     Click Button            Save
     Location Should Be      ${USERS URL}
     Page Should Contain     ${user_name}
-    # To edit the same user again, sort by ID (reverse) and edit first row
-    Click Element           xpath=//th[contains(text(), "ID")]
-    Click Element           xpath=//th[contains(text(), "ID")]
-    Click Element           xpath=//table[@id="experimenterTable"]/tbody/tr[1]//a[contains(@class, "btn_edit")]
+    # find row which contains user name, and click 'btn_edit' of that row
+    Click Element           xpath=//table[@id="experimenterTable"]/tbody/tr[descendant::td[contains(text(), '${user_name}')]]//a[contains(@class, "btn_edit")]
+
     Page Should Contain Element   xpath=//input[@id='id_first_name'][@value='${user_name}']
 
     # Edit Password


### PR DESCRIPTION
This aims to fix occasional robot failures such as:

```
06:14:06 Create Edit Group :: Tests group creation                             | FAIL |
06:14:06 Page should have contained element 'xpath=//input[@id='id_name'][@value='test_group_1418364571']' but did not
```

E.g. https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-robotframework/104/console

Latest group / user is selected from the table by name (instead of sorting by ID and selecting first) which should be a bit more robust.

To test, check latest
https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-robotframework/lastCompletedBuild/console
