### PR TITLE
Fix robot tests to work with 'Image' from ba0c476

### DIFF
--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -19,7 +19,7 @@ Test Script Run
     Select And Expand Project
     Select And Expand Dataset
     Select And Expand Image
-    Wait Until Page Contains Element            xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'image')]
+    Wait Until Page Contains Element            xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]
     ${imageId}=                                 Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
 
     # First Test 'custom' script forms

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -121,7 +121,7 @@ Test Rdef Copy Paste Save
 
     Select Experimenter
     Select And Expand Image
-    Wait Until Page Contains Element        xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'image')]
+    Wait Until Page Contains Element        xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]
     ${imageId}=                             Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
     Click Link                              Preview
     Wait Until Page Contains Element        id=viewport-img


### PR DESCRIPTION
This is a tiny fix in robot tests to match the last commit https://github.com/will-moore/openmicroscopy/commit/ba0c4766df802f668ef257726194f297407867fe from #3207.

Should fix failures such as

```
08:56:21 Element 'xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'image')]' did not appear in 5 seconds
```

--no-rebase
