### PR TITLE
Fixed: Used wrong groupId for getting ROI count

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1599,7 +1599,7 @@ public class PropertiesUI
          */
         void loadROICount(ImageData image) {
             ExperimenterData exp = MetadataViewerAgent.getUserDetails();
-            ROICountLoader l = new ROICountLoader(new SecurityContext(exp.getGroupId()), this, image.getId(), exp.getId());
+            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId(), exp.getId());
             l.load();
         }
         


### PR DESCRIPTION
Fix for a problem @pwalczysko recently noticed: If images were moved to another group, the ROI count in the metadata panel was wrong.
Test: Add some ROIs to an image, make sure ROI count is correct (the value is not automatically updated, you'll have to refresh the metadata panel); move the image to another group and again make sure, that the ROI count is correct.

--no-rebase
