### PR TITLE
Thumbnail by section

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8373,6 +8373,20 @@ class _ImageWrapper (BlitzObjectWrapper):
         """
         return self._re.getDefaultT()
 
+    @assert_re()
+    def setDefaultZ(self, z):
+        """
+        Sets the default Z index to the rendering engine
+        """
+        return self._re.setDefaultZ(z)
+
+    @assert_re()
+    def setDefaultT(self, t):
+        """
+        Sets the default T index to the rendering engine
+        """
+        return self._re.setDefaultT(t)
+
     @assert_pixels
     def getPixelsType(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7221,7 +7221,11 @@ class _ImageWrapper (BlitzObjectWrapper):
                 return None
             if isinstance(size, IntType):
                 size = (size,)
-            if z is not None and t is not None:
+            if z is not None or t is not None:
+                if z is None:
+                    z = self.getDefaultZ()
+                if t is None:
+                    t = self.getDefaultT()
                 pos = z, t
             else:
                 pos = None

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -81,20 +81,13 @@ from omeroweb.webclient.decorators import render_response
 from omeroweb.webclient.show import Show, IncorrectMenuError
 from omeroweb.connector import Connector
 from omeroweb.decorators import ConnCleaningHttpResponse, parse_url, get_client_ip
+from omeroweb.webgateway.util import getIntOrDefault
 
 import tree
 
 logger = logging.getLogger(__name__)
 
 logger.info("INIT '%s'" % os.getpid())
-
-# helper method
-def getIntOrDefault(request, name, default):
-    try:
-        index = int(request.REQUEST.get(name, default))
-    except ValueError:
-        index = 0
-    return index
 
 
 ################################################################################

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -99,7 +99,6 @@ render_thumbnail = url(r'^render_thumbnail/(?P<iid>[^/]+)/(?:(?P<w>[^/]+)/)?(?:(
 Returns a thumbnail jpeg of the OMERO Image, optionally scaled to max-width and max-height.
 See L{views.render_thumbnail}. Uses current rendering settings.
 Query string can be used to specify Z or T section. E.g. ?z=10.
-NB: this will update the default Z or T section for this image.
 Params in render_thumbnail/<iid>/<w>/<h> are:
     - iid:  Image ID
     - w:    Optional max width

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -97,7 +97,9 @@ Params in render_col_plot/<iid>/<z>/<t>/<x>/<w> are:
 render_thumbnail = url(r'^render_thumbnail/(?P<iid>[^/]+)/(?:(?P<w>[^/]+)/)?(?:(?P<h>[^/]+)/)?$', 'webgateway.views.render_thumbnail')
 """
 Returns a thumbnail jpeg of the OMERO Image, optionally scaled to max-width and max-height.
-See L{views.render_thumbnail}. Uses current rendering settings. 
+See L{views.render_thumbnail}. Uses current rendering settings.
+Query string can be used to specify Z or T section. E.g. ?z=10.
+NB: this will update the default Z or T section for this image.
 Params in render_thumbnail/<iid>/<w>/<h> are:
     - iid:  Image ID
     - w:    Optional max width

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -26,6 +26,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# helper method
+def getIntOrDefault(request, name, default):
+    try:
+        index = request.REQUEST.get(name, default)
+        if index is not None:
+            index = int(index)
+    except ValueError:
+        index = 0
+    return index
+
 def zip_archived_files(images, temp, zipName):
     """
     Util function to download original files from a list of images

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -56,7 +56,7 @@ import logging, os, traceback, time, zipfile, shutil
 
 from omeroweb.decorators import login_required, ConnCleaningHttpResponse
 from omeroweb.connector import Connector
-from omeroweb.webgateway.util import zip_archived_files
+from omeroweb.webgateway.util import zip_archived_files, getIntOrDefault
 
 logger = logging.getLogger(__name__)
 
@@ -284,9 +284,9 @@ def render_thumbnail (request, iid, w=None, h=None, conn=None, _defcb=None, **kw
     if size == (96,):
         direct = False
     user_id = conn.getUserId()
-    rdefId = request.REQUEST.get('rdefId', None)
-    if rdefId is not None:
-        rdefId = int(rdefId)
+    z = getIntOrDefault(request, 'z', None)
+    t = getIntOrDefault(request, 't', None)
+    rdefId = getIntOrDefault(request, 'rdefId', None)
     # TODO - cache handles rdefId
     jpeg_data = webgateway_cache.getThumb(request, server_id, user_id, iid, size)
     if jpeg_data is None:
@@ -300,7 +300,7 @@ def render_thumbnail (request, iid, w=None, h=None, conn=None, _defcb=None, **kw
             else:
                 raise Http404
         else:
-            jpeg_data = img.getThumbnail(size=size, direct=direct, rdefId=rdefId)
+            jpeg_data = img.getThumbnail(size=size, direct=direct, rdefId=rdefId, z=z, t=t)
             if jpeg_data is None:
                 logger.debug("(c)Image %s not found..." % (str(iid)))
                 if _defcb:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -668,8 +668,8 @@ def _get_prepared_image (request, iid, server_id=None, conn=None, saveDefs=False
     img.setInvertedAxis(bool(r.get('ia', "0") == "1"))
     compress_quality = r.get('q', None)
     if saveDefs:
-        r.has_key('z') and img._re.setDefaultZ(long(r['z'])-1)
-        r.has_key('t') and img._re.setDefaultT(long(r['t'])-1)
+        r.has_key('z') and img.setDefaultZ(long(r['z'])-1)
+        r.has_key('t') and img.setDefaultT(long(r['t'])-1)
         img.saveDefaults()
     return (img, compress_quality)
 


### PR DESCRIPTION
This adds support for Z & T to the webgateway/render_thumbnail url, as an alternative to #3278.

E.g. webgateway/render_thumbnail/3455/?z=10

To test, try various z/t combinations.

Also test that you can set the default Z/T by POSTing like:
```
$.ajax({type:"POST", url: "http://localhost:4080/webgateway/saveImgRDef/3455/?z=22"})
```
Refreshing the thumbnail (without specifying z or t) should update to the default z or t set by this POST.

--no-rebase