### PR TITLE
Log file

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -344,8 +344,7 @@ public class FileImportComponent
 	            displayLogFile();
 	        }
 	    });
-	    item.setEnabled(statusLabel.getLogFileID() > 0 ||
-	            statusLabel.getFileset() != null);
+	    item.setEnabled(statusLabel.getLogFileID() > 0);
 	    menu.add(item);
 
 	    item = new JMenuItem(new AbstractAction(checksumText) {


### PR DESCRIPTION
Enable view log file only if a log file id is returned.

Test 1
- Import a faulty image e.g. squig/data_repo/test_images_bad/multi-image-pixels.ome.tif 
- check that the View log file button is active

Test 2
-  import squig/data_repo/test_images_broken/broken_images_scenario/fails_at_processing/wrong-light-source-mk3.ome
  - check that the View log file button is  not active
