### PR TITLE
Robot fixes backported

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -121,4 +121,5 @@ Select Node By Id
     [Arguments]         ${nodeId}
     # Make sure node is visible (by clicking parent node)
     Execute Javascript  if(!$("#${nodeId}").is(":visible")){$("#${nodeId}").parent().parent().children("a").click()}
+    Sleep               1
     Click Element       css=#${nodeId}>a

--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -162,7 +162,7 @@ Test Annotate
 Test Batch Annotate
     [Documentation]     Test Batch Annotation of 2 Projects that we create
 
-    Set Selenium Speed                          1 seconds
+    Go To                                       ${WELCOME URL}
     Select Experimenter
     ${projectId}=                               Create Project      robot test batch annotate
     ${pId}=                                     Create Project      robot test batch annotate
@@ -195,13 +195,14 @@ Test Search
     [Documentation]     Test basic search submission from header field or search page
     [Documentation]     Searching E.g. for the Projects we just created above
 
-    Input Text              id_search_query     test
-    Submit Form             id=search
+    Go To                                   ${WELCOME URL}
+    Input Text                              id_search_query     test
+    Submit Form                             id=search
 
     # We don't care about results, just check we get *some* results in dataTable
     Location Should Be                      ${WELCOME URL}search/
-    Wait Until Page Contains Element        dataTable
+    Wait Until Page Contains Element        dataTable                   60
     # Repeat search
     Submit Form                             searching_form
     Wait Until Page Contains                Loading data...
-    Wait Until Page Contains Element        dataTable
+    Wait Until Page Contains Element        dataTable                   60

--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -19,7 +19,7 @@ Test Script Run
     Select And Expand Project
     Select And Expand Dataset
     Select And Expand Image
-    Wait Until Page Contains Element            css=button.btn_figscripts
+    Wait Until Page Contains Element            xpath=//h2[contains(@class, 'data_heading_id')][contains(text(), 'image')]
     ${imageId}=                                 Get Text            css=.data_heading_id strong
 
     # First Test 'custom' script forms

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -122,6 +122,7 @@ Test Rdef Copy Paste Save
     Select Experimenter
     Select And Expand Image
     Wait Until Page Contains Element        css=.data_heading_id strong
+    Wait Until Page Contains Element        xpath=//h2[contains(@class, 'data_heading_id')][contains(text(), 'image')]
     ${imageId}=                             Get Text                    css=.data_heading_id strong
     Click Link                              Preview
     Wait Until Page Contains Element        id=viewport-img
@@ -146,17 +147,19 @@ Test Rdef Copy Paste Save
     Go To                                   ${WELCOME URL}img_detail/${imageId}
     # Toggle the color, then paste settings and check it has reverted
     Wait Until Page Contains Element        id=wblitz-ch0
-    ${color1}=                              Get Element Attribute       id=wblitz-rmodel@checked
+    ${checked1}=                            Execute Javascript  return ($("#wblitz-rmodel:checked").length == 1)
     Click Element                           id=wblitz-rmodel
-    ${color2}=                              Get Element Attribute       id=wblitz-rmodel@checked
-    Should Not Be True                      "${color1}" == "${color2}"
+    ${checked2}=                            Execute Javascript  return ($("#wblitz-rmodel:checked").length == 1)
+    Should Not Be True                      "${checked1}" == "${checked2}"
+    Click Link                              Edit
     Click Element                           xpath=//button[contains(@class, "paste_rdef")]
-    ${selector}=                            Set Variable If    "${color1}" == "true"     [@checked='checked']    [not(@checked='checked')]
-    Wait Until Page Contains Element        //input[@id='wblitz-rmodel']${selector}
+    ${selector}=                            Set Variable If    ${checked1}    1    0
+    Wait For Condition                      return ($("#wblitz-rmodel:checked").length == ${selector})
+
 
     # Toggle the color again, Save, refresh page to check
+    Set Selenium Speed                      0.5
     Click Element                           id=wblitz-rmodel
-    Click Link                              Edit
     Wait Until Page Contains Element        id=rdef-setdef-btn
     Click Element                           id=rdef-setdef-btn
     # Wait for response
@@ -164,6 +167,6 @@ Test Rdef Copy Paste Save
     Wait For Condition                      return ($(".blockUI").length == 0)
     Reload Page
     Wait Until Page Contains Element        id=wblitz-ch0
-    ${color3}=                              Get Element Attribute       id=wblitz-rmodel@checked
-    Should Be True                          "${color2}" == "${color3}"
+    ${checked3}=                            Execute Javascript  return ($("#wblitz-rmodel:checked").length == 1)
+    Should Be True                          "${checked2}" == "${checked3}"
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -578,7 +578,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
     if (this.isGreyModel() && this.getProjection() != 'split') {
       /* Only allow activation of channels, and disable all other */
       if (act) {
-	for (var i in _this.loadedImg.channels) {
+	for (var i=0; i < _this.loadedImg.channels.length; i++) {
           act = i == idx;
           if (act != _this.loadedImg.channels[i].active) {
 	    _this.loadedImg.channels[i].active = act;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -441,7 +441,7 @@
       btns.removeClass('forcegrey');
     }
     $('#wblitz-rmodel').attr('checked', !viewport.isGreyModel());
-    //$('#rd-wblitz-rmodel').attr('checked', !viewport.isGreyModel());
+    $('#rd-wblitz-rmodel').attr('checked', !viewport.isGreyModel());
     //syncRDCW();
   };
 


### PR DESCRIPTION
Brought a few robot fixes from develop back into dev_5_0 and also found and fixed a couple of minor bugs in the dev_5_0 image viewer.

To test image viewer fixes:
 - Open image viewer. Click "color" checkbox. It should toggle greyscale (previously was broken on the first click).
 - Open the 'Edit' popup. Click on the same 'color' checkbox in the main window again. Check that the 'Render as color' checkbox in the Edit panel is kept in sync (and "Save" saves the current settings).