### PR TITLE
Roi ellipse (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/EllipseTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/EllipseTextFigure.java
@@ -113,7 +113,7 @@ public class EllipseTextFigure
   		setText(t);
 		textBounds = null;
 		editable = true;
-		fromTransformUpdate = false;
+		fromTransformUpdate = true;
 	}	
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/RotateEllipseFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/RotateEllipseFigure.java
@@ -178,10 +178,8 @@ public class RotateEllipseFigure
 		newT.setToRotation(theta);
 		Point2D rotatedPoint = new Point2D.Double();
 		newT.transform(new Point2D.Double(x, y), rotatedPoint);
-		if(containsEllipseAlgorithm(rotatedPoint.getX(), rotatedPoint.getY(),
-				0,0, ellipse.getWidth(), ellipse.getHeight()))
-			return true;
-		return false;
+		return containsEllipseAlgorithm(rotatedPoint.getX(), rotatedPoint.getY(),
+				0,0, ellipse.getWidth(), ellipse.getHeight());
 	}
 	
 	private boolean containsEllipseAlgorithm(double x, double y, 
@@ -193,9 +191,7 @@ public class RotateEllipseFigure
 		double xx = x-cx;
 		double yy = y-cy;
 		double dist = (xx*xx)/(wr*wr)+(yy*yy)/(hr*hr);
-		if(dist<1)
-			return true;
-		return false;
+		return dist< 1;
 	}
 
 	


### PR DESCRIPTION

This is the same as gh-3300 but rebased onto dev_5_0.

----

Fix display of ROI

To test:
 * Open the Measurement tool
 * Draw an ellipse
 * Click Save. 
 * Check that the ellipse does not "jump" to the top-left corner.

                