### PR TITLE
Insight units followup

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -497,16 +497,18 @@ class ChannelAcquisitionComponent
 		while (j.hasNext()) {
 			info = (PlaneInfo) j.next();
 			details = EditorUtil.transformPlaneInfo(info);
-			notSet = (List<String>) details.get(EditorUtil.NOT_SET);
-			if (!notSet.contains(EditorUtil.EXPOSURE_TIME)) {
-			    values[0][i] = details.get(EditorUtil.DELTA_T)+
-			            EditorUtil.TIME_UNIT;
-				values[1][i] = details.get(EditorUtil.EXPOSURE_TIME)+
-				EditorUtil.TIME_UNIT;
-			} else {
-			    values[0][i] = "--";
-			    values[1][i] = "--";
-			}
+			notSet = (List<String>) details.get(EditorUtil.NOT_SET);	
+			if (!notSet.contains(EditorUtil.DELTA_T))
+				values[0][i] = details.get(EditorUtil.DELTA_T)
+						+ EditorUtil.TIME_UNIT;
+			else
+				values[0][i] = "--";
+
+			if (!notSet.contains(EditorUtil.EXPOSURE_TIME))
+				values[1][i] = details.get(EditorUtil.EXPOSURE_TIME)
+						+ EditorUtil.TIME_UNIT;
+			else
+				values[1][i] = "--";
 			names[i] = "t="+(i-1);
 			i++;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.ChannelAcquisitionComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -510,15 +510,21 @@ class ChannelAcquisitionComponent
 			names[i] = "t="+(i-1);
 			i++;
 		}
-		JTable table = new JTable(values, names);
-		table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-		table.setShowGrid(true);
-		table.setGridColor(Color.LIGHT_GRAY);
-		JScrollPane pane = new JScrollPane(table);
-		Dimension d = table.getPreferredSize();
-		Dimension de = exposureTask.getPreferredSize();
-		pane.setPreferredSize(new Dimension(de.width-10, 4*d.height));
-		exposureTask.add(pane);
+		if (i > 1) {
+			JTable table = new JTable(values, names);
+			table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+			table.setShowGrid(true);
+			table.setGridColor(Color.LIGHT_GRAY);
+			JScrollPane pane = new JScrollPane(table);
+			Dimension d = table.getPreferredSize();
+			Dimension de = exposureTask.getPreferredSize();
+			pane.setPreferredSize(new Dimension(de.width-10, 4*d.height));
+			exposureTask.add(pane);
+			exposureTask.setVisible(true);
+		}
+		else {
+			exposureTask.setVisible(false);
+		}
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.EditorUtil
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1206,7 +1206,7 @@ public class EditorUtil
             notSet.add(NAME);
         details.put(NAME, s);
 
-        Length wl = data.getEmissionWavelength(UnitsLength.NANOMETER);
+        Length wl = data.getEmissionWavelength(null);
         if (wl == null) {
         	notSet.add(EMISSION);
         } else {
@@ -1223,7 +1223,7 @@ public class EditorUtil
             }
         }
 
-        wl = data.getExcitationWavelength(UnitsLength.NANOMETER);
+        wl = data.getExcitationWavelength(null);
         if (wl == null) {
         	notSet.add(EXCITATION);
         } else {
@@ -1246,7 +1246,7 @@ public class EditorUtil
         else
         	details.put(ND_FILTER, f*100);
 
-        Length ph = data.getPinholeSize(UnitsLength.MICROMETER);
+        Length ph = data.getPinholeSize(null);
         if (ph == null) {
             notSet.add(PIN_HOLE_SIZE);
         }
@@ -1824,7 +1824,7 @@ public class EditorUtil
         else v = f;
         details.put(ATTENUATION, v*PERCENT_FRACTION);
 
-        Length wl = data.getLightSettingsWavelength(UnitsLength.NANOMETER);
+        Length wl = data.getLightSettingsWavelength(null);
         if (details.containsKey(WAVELENGTH)) {
             if (wl != null) { //override the value.
                 details.put(WAVELENGTH, wl.getValue()+NONBRSPACE+wl.getSymbol());
@@ -1930,7 +1930,7 @@ public class EditorUtil
                 notSet.add(MEDIUM);
             details.put(MEDIUM, s);
 
-            Length wl = data.getLaserWavelength(UnitsLength.NANOMETER);
+            Length wl = data.getLaserWavelength(null);
             double wave = 0;
             if (wl == null) {
                 notSet.add(WAVELENGTH);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1745,7 +1745,7 @@ public class EditorUtil
         if (StringUtils.isBlank(s))
             notSet.add(FILTER_WHEEL);
         details.put(FILTER_WHEEL, s);
-        Length wl = data.getCutIn(UnitsLength.NANOMETER);
+        Length wl = data.getCutIn(null);
         int i = 0;
         if (wl == null)
         	notSet.add(CUT_IN);
@@ -1754,7 +1754,7 @@ public class EditorUtil
         	 details.put(CUT_IN, i+NONBRSPACE+wl.getSymbol());
         }
 
-        wl = data.getCutOut(UnitsLength.NANOMETER);
+        wl = data.getCutOut(null);
         if (wl == null) {
             notSet.add(CUT_OUT);
         }
@@ -1763,7 +1763,7 @@ public class EditorUtil
         	details.put(CUT_OUT, i+NONBRSPACE+wl.getSymbol());
         }
 
-        wl = data.getCutInTolerance(UnitsLength.NANOMETER);
+        wl = data.getCutInTolerance(null);
         if (wl == null) {
             notSet.add(CUT_IN_TOLERANCE);
         }
@@ -1772,7 +1772,7 @@ public class EditorUtil
         	details.put(CUT_IN_TOLERANCE, i+NONBRSPACE+wl.getSymbol());
         }
 
-        wl = data.getCutOutTolerance(UnitsLength.NANOMETER);
+        wl = data.getCutOutTolerance(null);
         if (wl == null) {
             notSet.add(CUT_OUT_TOLERANCE);
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1461,7 +1461,7 @@ public class EditorUtil
         if (StringUtils.isBlank(s))
             notSet.add(CORRECTION);
         details.put(CORRECTION, s);
-        Length wd = data.getWorkingDistance(UnitsLength.MICROMETER);
+        Length wd = data.getWorkingDistance(null);
         if (wd==null) {
             notSet.add(WORKING_DISTANCE);
         }


### PR DESCRIPTION
Fixes the Insight issues mentioned on trello board [Units Client Follow-up](https://trello.com/c/PiLauXgp/47-units-client-follow-up). Also fixes ticket [12620](http://trac.openmicroscopy.org.uk/ome/ticket/12620) 

Test: 
1) Use file with non-default units: [alternate.ome](https://github.com/qidane/bioformats/blob/some-units-samples/components/specification/samples/develop/6x4y1z1t1c8b-swatch-instrument-units-alternate.ome);  check that the units and values are displayed correctly. 
2) Import a file with deltaT but not exposure time data (e. g. the file from [QA 10330](https://www.openmicroscopy.org/qa2/qa/feedback/10330/)), make sure deltaT values are displayed.
