### PR TITLE
LightSource Attenuation as percent

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -1883,7 +1883,7 @@ class MetadataLightSourceForm(forms.Form):
             self.fields['attenuation'] = forms.CharField(
                 max_length=100,
                 widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(lightSourceSettings.id)+', \'attenuation\', this.value);'}),
-                initial=lightSourceSettings.attenuation,
+                initial=lightSourceSettings.attenuation * 100,
                 label="Attenuation (%)",
                 required=False)
         else:

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -364,11 +364,15 @@ class MetadataChannelForm(forms.Form):
         
         # ndFilter
         try:
-            if logicalCh is not None:
+            if logicalCh is not None and logicalCh.ndFilter is not None:
+                ndValue = logicalCh.ndFilter * 100
+                if ndValue != 100:
+                    # doing division uses the precision set with getcontext() above
+                    ndValue = Decimal(ndValue)/1
                 self.fields['ndFilter'] = forms.CharField(
                     max_length=100,
                     widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(logicalCh.id)+', \'name\', this.value);'}),
-                    initial=Decimal(logicalCh.ndFilter * 100)/1,
+                    initial=ndValue,
                     label="ND filter (%)",
                     required=False)
             else:

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -40,8 +40,12 @@ from omeroweb.webadmin.custom_forms import ExperimenterModelChoiceField, \
                         ExperimenterModelMultipleChoiceField, \
                         GroupModelMultipleChoiceField, GroupModelChoiceField
 
+from decimal import Decimal, getcontext
 
 logger = logging.getLogger(__name__)
+
+# Set precision for decimal display
+getcontext().prec = 2
              
 ##################################################################
 # Static values
@@ -364,7 +368,7 @@ class MetadataChannelForm(forms.Form):
                 self.fields['ndFilter'] = forms.CharField(
                     max_length=100,
                     widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(logicalCh.id)+', \'name\', this.value);'}),
-                    initial=logicalCh.ndFilter,
+                    initial=Decimal(logicalCh.ndFilter * 100)/1,
                     label="ND filter (%)",
                     required=False)
             else:

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -1888,10 +1888,14 @@ class MetadataLightSourceForm(forms.Form):
         
         # Attenuation
         if lightSourceSettings is not None and lightSourceSettings.attenuation is not None:
+            lsAttn = lightSourceSettings.attenuation * 100
+            if lsAttn != 100:
+                # doing division uses the precision set with getcontext() above
+                lsAttn = Decimal(lsAttn)/1
             self.fields['attenuation'] = forms.CharField(
                 max_length=100,
                 widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(lightSourceSettings.id)+', \'attenuation\', this.value);'}),
-                initial=lightSourceSettings.attenuation * 100,
+                initial=lsAttn,
                 label="Attenuation (%)",
                 required=False)
         else:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -980,6 +980,10 @@ def load_metadata_acquisition(request, c_type, c_id, conn=None, share_id=None, *
     form_channels = list()
     form_lasers = list()
 
+    lasertypes = list(conn.getEnumerationEntries("LaserType"))
+    arctypes = list(conn.getEnumerationEntries("ArcType"))
+    filamenttypes = list(conn.getEnumerationEntries("FilamentType"))
+
     # various enums we need for the forms (don't load unless needed)
     mediums =  None
     immersions = None
@@ -1022,10 +1026,16 @@ def load_metadata_acquisition(request, c_type, c_id, conn=None, share_id=None, *
 
                     lightSourceSettings = logicalChannel.getLightSourceSettings()
                     if lightSourceSettings is not None and lightSourceSettings._obj is not None:
-                        if lightSourceSettings.getLightSource() is not None:
-                            channel['form_light_source'] = MetadataLightSourceForm(initial={'lightSource': lightSourceSettings.getLightSource(),
+                        lightSrc = lightSourceSettings.getLightSource()
+                        if lightSrc is not None:
+                            lstypes = lasertypes
+                            if lightSrc.OMERO_CLASS == "Arc":
+                                lstypes = arctypes
+                            elif lightSrc.OMERO_CLASS == "Filament":
+                                lstypes = filamenttypes
+                            channel['form_light_source'] = MetadataLightSourceForm(initial={'lightSource': lightSrc,
                                             'lightSourceSettings': lightSourceSettings,
-                                            'lstypes': list(conn.getEnumerationEntries("LaserType")),
+                                            'lstypes': lstypes,
                                             'mediums': list(conn.getEnumerationEntries("LaserMediumI")),
                                             'pulses': list(conn.getEnumerationEntries("PulseI"))})
                 # TODO: We don't display filter sets here yet since they are not populated on Import by BioFormats.
@@ -1105,8 +1115,13 @@ def load_metadata_acquisition(request, c_type, c_id, conn=None, share_id=None, *
                 lasers = list(instrument.getLightSources())
                 if len(lasers) > 0:
                     for l in lasers:
+                        lstypes = lasertypes
+                        if l.OMERO_CLASS == "Arc":
+                            lstypes = arctypes
+                        elif l.OMERO_CLASS == "Filament":
+                            lstypes = filamenttypes
                         form_laser = MetadataLightSourceForm(initial={'lightSource': l,
-                                        'lstypes':list(conn.getEnumerationEntries("LaserType")),
+                                        'lstypes': lstypes,
                                         'mediums': list(conn.getEnumerationEntries("LaserMediumI")),
                                         'pulses': list(conn.getEnumerationEntries("PulseI"))})
                         form_lasers.append(form_laser)


### PR DESCRIPTION
Follow up for metadata panel display, see: https://trello.com/c/PiLauXgp/47-units-client-follow-up

To test (using units.ome.tif to test mostly):
 - Web should now do the same as Insight and show Light Source attenuation of 0.8 as "Attenuation (%): 80".
 - LightSource type should be displayed for Arc and Filament objects.
 - ND filter (%) should also be converted from fraction to percent, and rounded to 2 significant figures. Used a different DV file to test this.


![screen shot 2015-01-05 at 16 55 35](https://cloud.githubusercontent.com/assets/900055/5616365/bd5173e8-94fb-11e4-8e7a-4bc0e96b3e10.png)

![screen shot 2015-01-05 at 16 13 38](https://cloud.githubusercontent.com/assets/900055/5615800/9dcde326-94f6-11e4-9644-a9e060bf59d9.png)

![screen shot 2015-01-05 at 15 26 57](https://cloud.githubusercontent.com/assets/900055/5615097/c9ca6604-94ef-11e4-896d-b8e444b2b98c.png)