### PR TITLE
Show sensible error message if image export fails

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
@@ -571,7 +571,7 @@ public class ImgSaver
             	}
             }
 		} catch (Exception e) {
-			if (e.getCause() instanceof IOException)
+			if (e instanceof IOException || e.getCause() instanceof IOException)
 				un.notifyInfo(
 						"Save Image failure",
 						"Could not access file "

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.util.saver.ImgSaver
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -36,6 +36,7 @@ import java.beans.PropertyChangeListener;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -49,11 +50,11 @@ import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.util.ImagePaintingFactory;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
-import org.openmicroscopy.shoola.env.log.Logger;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.filter.file.TIFFFilter;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.image.io.Encoder;
+import org.openmicroscopy.shoola.util.image.io.EncoderException;
 import org.openmicroscopy.shoola.util.image.io.TIFFEncoder;
 import org.openmicroscopy.shoola.util.image.io.WriterImage;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
@@ -221,9 +222,11 @@ public class ImgSaver
      * @param image		The image to create.
      * @param constrain	The constrain indicating to add the scale bar.
      * @param name		The name of the image.
+     * @throws EncoderException 
+     * @throws IOException
      */
     private void writeSingleImage(BufferedImage image, boolean constrain, 
-    							String name)
+    							String name) throws EncoderException, IOException
     {
     	int width = image.getWidth();
         int h = image.getHeight();
@@ -304,29 +307,22 @@ public class ImgSaver
      * 
      * @param image The image to write to the file.
      * @param n     The name of the image.
+     * @throws EncoderException 
+     * @throws IOException
      */
-    private void writeImage(BufferedImage image, String n)
+    private void writeImage(BufferedImage image, String n) throws EncoderException, IOException
     {
         //n += "."+format;
         String extendedName = getExtendedName(n, format);
         File f = new File(extendedName);
-        try {
-            if (TIFFFilter.TIF.equals(format)) {
-                Encoder encoder = new TIFFEncoder(Factory.createImage(image), 
-                        new DataOutputStream(new FileOutputStream(f)));
-                WriterImage.saveImage(encoder);
-            } else WriterImage.saveImage(f, image, format);
-            
-            close();
-        } catch (Exception e) {
-        	Logger logger = ImViewerAgent.getRegistry().getLogger();
-        	UserNotifier un = ImViewerAgent.getRegistry().getUserNotifier();
-        	String message = e.getMessage();
-            if (!f.delete())
-            	message += "\nCannot delete the file.";
-            logger.error(this, message);
-            un.notifyError("Save image failure", "Unable to save the image", e);
-        }
+		if (TIFFFilter.TIF.equals(format)) {
+			Encoder encoder = new TIFFEncoder(Factory.createImage(image),
+					new DataOutputStream(new FileOutputStream(f)));
+			WriterImage.saveImage(encoder);
+		} else
+			WriterImage.saveImage(f, image, format);
+
+		close();
     }
     
     /** Sets the properties of the dialog. */
@@ -575,9 +571,16 @@ public class ImgSaver
             	}
             }
 		} catch (Exception e) {
-			 un.notifyInfo("Saving Image", "An error occurred while saving " +
-			 		"the image.");
-			 return;
+			if (e.getCause() instanceof IOException)
+				un.notifyInfo(
+						"Save Image failure",
+						"Could not access file "
+								+ uiDelegate.getSelectedFilePath()
+								+ "\nMake sure you have the necessary permissions to perform this action.");
+			else
+				un.notifyError("Save Image failure",
+						"An error occurred while saving the image.", e);
+			return;
 		}
         notifySave(getExtendedName(uiDelegate.getSelectedFilePath(), format));
         if (uiDelegate.isSetDefaultFolder())

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/image/io/WriterImage.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/image/io/WriterImage.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.image.io.ImageWriter
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -39,6 +39,7 @@ import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.util.Iterator;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
@@ -101,9 +102,12 @@ public class WriterImage
     				ImageIO.getImageWritersByFormatName(format);
     		ImageWriter writer = writers.next();
     		ios = ImageIO.createImageOutputStream(f);
+			if (ios == null) {
+				throw new IOException("Can't access file");
+			}
     		writer.setOutput(ios);
     		writer.write(img);
-    	} catch (Exception e) {
+    	} catch (IOException e) {
     		throw new EncoderException("Cannot encode the image.", e);
     	} finally {
 			if (ios != null) {


### PR DESCRIPTION
Show a sensible error message if one exports an image from the full image viewer to a file one cannot write to. (See [Trac 12627](http://trac.openmicroscopy.org.uk/ome/ticket/12627)); before: the usual crash dialog showing the stack trace popped up, followed by the incorrect message that the image was successfully exported.

Test: Open an image in full viewer, export to a read-only location (or try to overwrite a read-only file)
![screen shot 2015-01-06 at 15 53 04](https://cloud.githubusercontent.com/assets/6575139/5631271/2c47eba8-95bd-11e4-8008-f21d067566cc.png)
