### PR TITLE
Itest improvements

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -98,34 +98,6 @@ class ITest(object):
         cls.update = cls.sf.getUpdateService()
         cls.query = cls.sf.getQueryService()
 
-    # def setup_method(self, method):
-    #
-    #     self.OmeroPy = self.omeropydir()
-    #
-    #     self.__clients = Clients()
-    #
-    #     p = Ice.createProperties(sys.argv)
-    #     rootpass = p.getProperty("omero.rootpass")
-    #
-    #     name = None
-    #     if rootpass:
-    #         self.root = omero.client()  # ok because adds self
-    #         self.__clients.add(self.root)
-    #         self.root.setAgent("OMERO.py.root_test")
-    #         self.root.createSession("root", rootpass)
-    #         newuser = self.new_user()
-    #         name = newuser.omeName.val
-    #     else:
-    #         self.root = None
-    #
-    #     self.client = omero.client()  # ok because adds self
-    #     self.__clients.add(self.client)
-    #     self.client.setAgent("OMERO.py.test")
-    #     self.sf = self.client.createSession(name, name)
-    #
-    #     self.update = self.sf.getUpdateService()
-    #     self.query = self.sf.getQueryService()
-
     @classmethod
     def omeropydir(self):
         count = 10
@@ -154,11 +126,12 @@ class ITest(object):
         return str(_uuid.uuid4())
 
     @classmethod
-    def login_args(self):
+    def login_args(self, key=None):
         p = self.client.ic.getProperties()
         host = p.getProperty("omero.host")
         port = p.getProperty("omero.port")
-        key = self.sf.ice_getIdentity().name
+        if not key:
+            key = self.sf.ice_getIdentity().name
         return ["-s", host, "-k", key, "-p", port]
 
     @classmethod

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -69,34 +69,64 @@ class ITest(object):
 
     log = logging.getLogger("ITest")
 
-    def setup_method(self, method):
+    @classmethod
+    def setup_class(cls):
 
-        self.OmeroPy = self.omeropydir()
+        cls.OmeroPy = cls.omeropydir()
 
-        self.__clients = Clients()
+        cls.__clients = Clients()
 
         p = Ice.createProperties(sys.argv)
         rootpass = p.getProperty("omero.rootpass")
 
         name = None
         if rootpass:
-            self.root = omero.client()  # ok because adds self
-            self.__clients.add(self.root)
-            self.root.setAgent("OMERO.py.root_test")
-            self.root.createSession("root", rootpass)
-            newuser = self.new_user()
+            cls.root = omero.client()  # ok because adds self
+            cls.__clients.add(cls.root)
+            cls.root.setAgent("OMERO.py.root_test")
+            cls.root.createSession("root", rootpass)
+            newuser = cls.new_user()
             name = newuser.omeName.val
         else:
-            self.root = None
+            cls.root = None
 
-        self.client = omero.client()  # ok because adds self
-        self.__clients.add(self.client)
-        self.client.setAgent("OMERO.py.test")
-        self.sf = self.client.createSession(name, name)
+        cls.client = omero.client()  # ok because adds self
+        cls.__clients.add(cls.client)
+        cls.client.setAgent("OMERO.py.test")
+        cls.sf = cls.client.createSession(name, name)
 
-        self.update = self.sf.getUpdateService()
-        self.query = self.sf.getQueryService()
+        cls.update = cls.sf.getUpdateService()
+        cls.query = cls.sf.getQueryService()
 
+    # def setup_method(self, method):
+    #
+    #     self.OmeroPy = self.omeropydir()
+    #
+    #     self.__clients = Clients()
+    #
+    #     p = Ice.createProperties(sys.argv)
+    #     rootpass = p.getProperty("omero.rootpass")
+    #
+    #     name = None
+    #     if rootpass:
+    #         self.root = omero.client()  # ok because adds self
+    #         self.__clients.add(self.root)
+    #         self.root.setAgent("OMERO.py.root_test")
+    #         self.root.createSession("root", rootpass)
+    #         newuser = self.new_user()
+    #         name = newuser.omeName.val
+    #     else:
+    #         self.root = None
+    #
+    #     self.client = omero.client()  # ok because adds self
+    #     self.__clients.add(self.client)
+    #     self.client.setAgent("OMERO.py.test")
+    #     self.sf = self.client.createSession(name, name)
+    #
+    #     self.update = self.sf.getUpdateService()
+    #     self.query = self.sf.getQueryService()
+
+    @classmethod
     def omeropydir(self):
         count = 10
         searched = []
@@ -118,10 +148,12 @@ class ITest(object):
         else:
             assert False, "Could not find OmeroPy/; searched %s" % searched
 
+    @classmethod
     def uuid(self):
         import omero_ext.uuid as _uuid  # see ticket:3774
         return str(_uuid.uuid4())
 
+    @classmethod
     def login_args(self):
         p = self.client.ic.getProperties()
         host = p.getProperty("omero.host")
@@ -129,6 +161,7 @@ class ITest(object):
         key = self.sf.ice_getIdentity().name
         return ["-s", host, "-k", key, "-p", port]
 
+    @classmethod
     def root_login_args(self):
         p = self.root.ic.getProperties()
         host = p.getProperty("omero.host")
@@ -139,6 +172,7 @@ class ITest(object):
     def tmpfile(self):
         return str(create_path())
 
+    @classmethod
     def new_group(self, experimenters=None, perms=None):
         admin = self.root.sf.getAdminService()
         gname = self.uuid()
@@ -152,6 +186,7 @@ class ITest(object):
         self.add_experimenters(group, experimenters)
         return group
 
+    @classmethod
     def add_experimenters(self, group, experimenters):
         admin = self.root.sf.getAdminService()
         if experimenters:
@@ -431,6 +466,7 @@ class ITest(object):
         assert passes == is_ok, str(rsp)
         return callback
 
+    @classmethod
     def new_user(self, group=None, perms=None,
                  owner=False, system=False):
         """
@@ -537,6 +573,7 @@ class ITest(object):
 
         return group, name
 
+    @classmethod
     def user_and_name(self, user):
         user = unwrap(user)
         admin = self.root.sf.getAdminService()
@@ -748,10 +785,11 @@ class ITest(object):
                             omero_group=omero_group)
         return rsp
 
-    def teardown_method(self, method):
-        self.root.killSession()
-        self.root = None
-        self.__clients.__del__()
+    @classmethod
+    def teardown_class(cls):
+        cls.root.killSession()
+        cls.root = None
+        cls.__clients.__del__()
 
     def make_project(self, name=None, client=None):
         """

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -552,6 +552,7 @@ class ITest(object):
         elapsed = stop - start
         return elapsed, rv
 
+    @classmethod
     def group_and_name(self, group):
         group = unwrap(group)
         admin = self.root.sf.getAdminService()

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -29,10 +29,11 @@ from omero_ext.mox import Mox
 
 class AbstractCLITest(ITest):
 
-    def setup_method(self, method):
-        super(AbstractCLITest, self).setup_method(method)
-        self.cli = CLI()
-        self.cli.register("sessions", SessionsControl, "TEST")
+    @classmethod
+    def setup_class(cls):
+        super(AbstractCLITest, cls).setup_class()
+        cls.cli = CLI()
+        cls.cli.register("sessions", SessionsControl, "TEST")
 
     def setup_mock(self):
         self.mox = Mox()
@@ -45,12 +46,10 @@ class AbstractCLITest(ITest):
 class CLITest(AbstractCLITest):
 
     def setup_method(self, method):
-        super(CLITest, self).setup_method(method)
         self.args = self.login_args()
 
 
 class RootCLITest(AbstractCLITest):
 
     def setup_method(self, method):
-        super(RootCLITest, self).setup_method(method)
         self.args = self.root_login_args()

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -38,7 +38,6 @@ class TestObj(CLITest):
 
     def teardown_method(self, method):
         self.teardown_mock()
-        super(TestObj, self).teardown_method(method)
 
     def go(self):
         self.cli.invoke(self.args, strict=True)

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -39,7 +39,6 @@ class TestTag(CLITest):
 
     def teardown_method(self, method):
         self.teardown_mock()
-        super(TestTag, self).teardown_method(method)
 
     def create_tags(self, ntags, name):
         tag_ids = []

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -29,10 +29,10 @@ import __builtin__
 NSINSIGHTTAGSET = omero.constants.metadata.NSINSIGHTTAGSET
 
 
-class TestTag(CLITest):
+class AbstractTagTest(CLITest):
 
     def setup_method(self, method):
-        super(TestTag, self).setup_method(method)
+        super(AbstractTagTest, self).setup_method(method)
         self.cli.register("tag", TagControl, "TEST")
         self.args += ["tag"]
         self.setup_mock()
@@ -40,6 +40,7 @@ class TestTag(CLITest):
     def teardown_method(self, method):
         self.teardown_mock()
 
+    @classmethod
     def create_tags(self, ntags, name):
         tag_ids = []
         for i in list(xrange(ntags)):
@@ -52,6 +53,7 @@ class TestTag(CLITest):
                 tag_ids = tag.id.val
         return tag_ids
 
+    @classmethod
     def create_tagset(self, tag_ids, name):
         tagset = omero.model.TagAnnotationI()
         tagset.textValue = omero.rtypes.rstring(name)
@@ -67,6 +69,9 @@ class TestTag(CLITest):
         self.update.saveArray(links)
 
         return tagset.id.val
+
+
+class TestTag(AbstractTagTest):
 
     def get_tag_by_name(self, tag_name, ns=None):
         # Query
@@ -194,27 +199,6 @@ class TestTag(CLITest):
         tags = self.get_tags_in_tagset(tagset.id.val)
         assert sorted([x.textValue.val for x in tags]) == sorted(tag_names)
 
-    # Tag list commands
-    # ========================================================================
-    @pytest.mark.parametrize('list_command', ['list', 'listsets'])
-    @pytest.mark.parametrize('page_arg', ['', '--nopage'])
-    def testList(self, capsys, list_command, page_arg):
-        tag_ids = self.create_tags(2, 'list_tag')
-        tagset_id = self.create_tagset(tag_ids, 'list_tagset')
-
-        self.args += [list_command]
-        if page_arg:
-            self.args += [page_arg]
-        self.cli.invoke(self.args, strict=True)
-
-        out, err = capsys.readouterr()
-        assert str(tagset_id) in out
-        for tag_id in tag_ids:
-            if list_command == 'list':
-                assert str(tag_id) in out
-            else:
-                assert str(tag_id) not in out
-
     # Tag linking commands
     # ========================================================================
     def get_link(self, classname, object_id):
@@ -247,3 +231,42 @@ class TestTag(CLITest):
         # Check link
         link = self.get_link(object_type, oid)
         assert link.child.id.val == tid
+
+
+class TestTagList(AbstractTagTest):
+
+    @classmethod
+    def setup_class(cls):
+        super(TestTagList, cls).setup_class()
+        cls.tag_ids = cls.create_tags(2, 'list_tag')
+        cls.tagset_id = cls.create_tagset(cls.tag_ids, 'list_tagset')
+
+    # Tag list commands
+    # ========================================================================
+    @pytest.mark.parametrize('page_arg', ['', '--nopage'])
+    def testList(self, capsys, page_arg):
+
+        self.args += ["list"]
+        if page_arg:
+            self.args += [page_arg]
+        self.cli.invoke(self.args, strict=True)
+
+        out, err = capsys.readouterr()
+        assert str(self.tagset_id) in out
+        for tag_id in self.tag_ids:
+            assert str(tag_id) in out
+
+    # Tag listsets commands
+    # ========================================================================
+    @pytest.mark.parametrize('page_arg', ['', '--nopage'])
+    def testListSets(self, capsys, page_arg):
+
+        self.args += ["listsets"]
+        if page_arg:
+            self.args += [page_arg]
+        self.cli.invoke(self.args, strict=True)
+
+        out, err = capsys.readouterr()
+        assert str(self.tagset_id) in out
+        for tag_id in self.tag_ids:
+            assert str(tag_id) not in out

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -40,9 +40,14 @@ password_prefixes = [None, '-P', '--userpassword']
 
 class TestUser(CLITest):
 
+    @classmethod
+    def setup_class(self):
+        super(TestUser, self).setup_class()
+        self.cli.register("user", UserControl, "TEST")
+        self.users = self.sf.getAdminService().lookupExperimenters()
+
     def setup_method(self, method):
         super(TestUser, self).setup_method(method)
-        self.cli.register("user", UserControl, "TEST")
         self.args += ["user"]
 
     # List subcommand
@@ -77,18 +82,17 @@ class TestUser(CLITest):
                 last_value = new_value
 
         # Check all users are listed
-        users = self.sf.getAdminService().lookupExperimenters()
         if sort_key == 'login':
-            users.sort(key=lambda x: x.omeName.val)
+            sorted_list = sorted(self.users, key=lambda x: x.omeName.val)
         elif sort_key == 'first-name':
-            users.sort(key=lambda x: x.firstName.val)
+            sorted_list = sorted(self.users, key=lambda x: x.firstName.val)
         elif sort_key == 'last-name':
-            users.sort(key=lambda x: x.lastName.val)
+            sorted_list = sorted(self.users, key=lambda x: x.lastName.val)
         elif sort_key == 'email':
-            users.sort(key=lambda x: (x.email and x.email.val or ""))
+            sorted_list = sorted(self.users, key=lambda x: (x.email and x.email.val or ""))
         else:
-            users.sort(key=lambda x: x.id.val)
-        assert ids == [user.id.val for user in users]
+            sorted_list = sorted(self.users, key=lambda x: x.id.val)
+        assert ids == [user.id.val for user in sorted_list]
 
     @pytest.mark.parametrize("style", [None, "sql", "csv", "plain"])
     def testListWithStyles(self, capsys, style):
@@ -110,8 +114,7 @@ class TestUser(CLITest):
         out, err = capsys.readouterr()
 
         # Check all users are listed
-        users = self.sf.getAdminService().lookupExperimenters()
-        emails = [x.email.val for x in users if x.email and x.email.val]
+        emails = [x.email.val for x in self.users if x.email and x.email.val]
         if oneperline_arg:
             assert out.strip() == "\n".join(emails)
         else:
@@ -174,9 +177,14 @@ class TestUser(CLITest):
 
 class TestUserRoot(RootCLITest):
 
+    @classmethod
+    def setup_class(self):
+        super(TestUserRoot, self).setup_class()
+        self.cli.register("user", UserControl, "TEST")
+        self.users = self.sf.getAdminService().lookupExperimenters()
+
     def setup_method(self, method):
         super(TestUserRoot, self).setup_method(method)
-        self.cli.register("user", UserControl, "TEST")
         self.args += ["user"]
 
     def getuserids(self, gid):

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -90,7 +90,8 @@ class TestUser(CLITest):
         elif sort_key == 'last-name':
             sorted_list = sorted(self.users, key=lambda x: x.lastName.val)
         elif sort_key == 'email':
-            sorted_list = sorted(self.users, key=lambda x: (x.email and x.email.val or ""))
+            sorted_list = sorted(self.users, key=lambda x: (
+                x.email and x.email.val or ""))
         else:
             sorted_list = sorted(self.users, key=lambda x: x.id.val)
         assert ids == [user.id.val for user in sorted_list]

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -38,7 +38,6 @@ pytestmark = pytest.mark.fs_suite
 class TestRename(AbstractRepoTest):
 
     def setup_method(self, method):
-        super(TestRename, self).setup_method(method)
         self.pixels = self.client.sf.getPixelsService()
         self.query = self.client.sf.getQueryService()
         self.update = self.client.sf.getUpdateService()

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
@@ -37,7 +37,6 @@ class TestCoverage(lib.ITest):
         getScripts returns official scripts,
         several of which are shipped with OMERO.
         """
-        lib.ITest.setup_method(self, method)
         self.rs = self.root.sf.getScriptService()
         self.us = self.client.sf.getScriptService()
         assert len(self.rs.getScripts()) > 0

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
@@ -32,16 +32,18 @@ import omero
 
 class TestCoverage(lib.ITest):
 
-    def setup_method(self, method):
+    @classmethod
+    def setup_class(cls):
         """
         getScripts returns official scripts,
         several of which are shipped with OMERO.
         """
-        self.rs = self.root.sf.getScriptService()
-        self.us = self.client.sf.getScriptService()
-        assert len(self.rs.getScripts()) > 0
-        assert len(self.us.getScripts()) > 0
-        assert len(self.us.getUserScripts([])) == 0  # New user. No scripts
+        super(TestCoverage, cls).setup_class()
+        cls.rs = cls.root.sf.getScriptService()
+        cls.us = cls.client.sf.getScriptService()
+        assert len(cls.rs.getScripts()) > 0
+        assert len(cls.us.getScripts()) > 0
+        assert len(cls.us.getUserScripts([])) == 0  # New user. No scripts
 
     def testGetScriptWithDetails(self):
         scriptList = self.us.getScripts()

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_make_movie.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_make_movie.py
@@ -35,7 +35,6 @@ class TestMakeMovie(lib.ITest):
     """
 
     def setup_method(self, method):
-        lib.ITest.setup_method(self, method)
         self.svc = self.client.sf.getScriptService()
 
     def testNoParams(self):

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -37,7 +37,6 @@ from omero.rtypes import rstring
 class AnnotationPermissions(lib.ITest):
 
     def setup_method(self, method, perms):
-        lib.ITest.setup_method(self, method)
 
         # Tag names and namespaces
         uuid = self.uuid()
@@ -68,7 +67,6 @@ class AnnotationPermissions(lib.ITest):
             self.project[user] = self.createProjectAs(user)
 
     def teardown_method(self, method):
-        lib.ITest.teardown_method(self, method)
         for user in self.users:
             self.clients[user].closeSession()
 

--- a/components/tools/OmeroPy/test/integration/test_client_ctors.py
+++ b/components/tools/OmeroPy/test/integration/test_client_ctors.py
@@ -36,7 +36,6 @@ here = os.path.abspath(os.path.dirname(__file__))
 class TestClientConstructors(lib.ITest):
 
     def setup_method(self, method):
-        lib.ITest.setup_method(self, method)
         c = omero.client(pmap=['--Ice.Config='+(os.environ.get("ICE_CONFIG"))])
         try:
             self.host = c.ic.getProperties().getProperty('omero.host')

--- a/components/tools/OmeroPy/test/integration/test_imetadata.py
+++ b/components/tools/OmeroPy/test/integration/test_imetadata.py
@@ -39,7 +39,6 @@ NAMES = ("TagAnnotation",
 class TestIMetadata(lib.ITest):
 
     def setup_method(self, method):
-        lib.ITest.setup_method(self, method)
         self.md = self.client.sf.getMetadataService()
 
     def testLoadAnnotations3671(self):

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -392,6 +392,7 @@ class TestIShare(lib.ITest):
             tb.setPixelsId(rdefs[0].pixels.id.val)
         except omero.SecurityViolation:
             assert False, "Pixels was not in share"
+        share.deactivate()
 
     def test1201(self):
         admin = self.client.sf.getAdminService()
@@ -441,7 +442,9 @@ class TestIShare(lib.ITest):
         return client_user1, sid, expiration
 
     def test1201b(self):
-        share = self.client.sf.getShareService()
+        new_group = self.new_group()
+        new_client, new_user = self.new_client_and_user(new_group)
+        share = new_client.sf.getShareService()
         # create share
         description = "my description"
         timeout = None
@@ -698,9 +701,11 @@ class TestIShare(lib.ITest):
         Accessing deleted image in share seems to have changed.
         This tests what happens using the raw API.
         """
-        share = self.client.sf.getShareService()
-        query = self.client.sf.getQueryService()
-        update = self.client.sf.getUpdateService()
+        new_group = self.new_group()
+        new_client, new_user = self.new_client_and_user(new_group)
+        share = new_client.sf.getShareService()
+        query = new_client.sf.getQueryService()
+        update = new_client.sf.getUpdateService()
 
         image = self.new_image()
         image = update.saveAndReturnObject(image)
@@ -708,12 +713,12 @@ class TestIShare(lib.ITest):
 
         share_id = share.createShare("", None, objects, [], [], True)
         new_context = omero.model.ShareI(share_id, False)
-        old_context = self.client.sf.setSecurityContext(new_context)
+        old_context = new_client.sf.setSecurityContext(new_context)
         query.get("Image", image.id.val)
 
-        self.client.sf.setSecurityContext(old_context)
+        new_client.sf.setSecurityContext(old_context)
         update.deleteObject(image)
-        self.client.sf.setSecurityContext(new_context)
+        new_client.sf.setSecurityContext(new_context)
 
         with pytest.raises(omero.ValidationException):
             query.get("Image", image.id.val)
@@ -723,9 +728,11 @@ class TestIShare(lib.ITest):
         Accessing deleted image in share seems to have changed.
         This tests what happens using BlitzGateway wrappers.
         """
-        share = self.client.sf.getShareService()
-        query = self.client.sf.getQueryService()
-        update = self.client.sf.getUpdateService()
+        new_group = self.new_group()
+        new_client, new_user = self.new_client_and_user(new_group)
+        share = new_client.sf.getShareService()
+        query = new_client.sf.getQueryService()
+        update = new_client.sf.getUpdateService()
 
         image = self.new_image()
         image = update.saveAndReturnObject(image)
@@ -733,17 +740,17 @@ class TestIShare(lib.ITest):
 
         share_id = share.createShare("", None, objects, [], [], True)
         new_context = omero.model.ShareI(share_id, False)
-        old_context = self.client.sf.setSecurityContext(new_context)
+        old_context = new_client.sf.setSecurityContext(new_context)
         image = query.get("Image", image.id.val)
 
         from omero.gateway import ImageWrapper, BlitzGateway
 
-        conn = BlitzGateway(client_obj=self.client)
+        conn = BlitzGateway(client_obj=new_client)
         wrapper = ImageWrapper(conn=conn, obj=image)
 
-        self.client.sf.setSecurityContext(old_context)
+        new_client.sf.setSecurityContext(old_context)
         update.deleteObject(image)
-        self.client.sf.setSecurityContext(new_context)
+        new_client.sf.setSecurityContext(new_context)
 
         with pytest.raises(IndexError):
             wrapper.__loadedHotSwap__()

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -157,7 +157,7 @@ class TestPermissions(lib.ITest):
     def testCreatAndUpdatePrivateGroup(self):
         # this is the test of creating private group and updating it
         # including changes in #1434
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1
@@ -188,7 +188,7 @@ class TestPermissions(lib.ITest):
     def testCreatAndUpdatePublicGroupReadOnly(self):
         # this is the test of creating public group read-only and updating it
         # including changes in #1434
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1
@@ -218,7 +218,7 @@ class TestPermissions(lib.ITest):
 
     def testCreatAndUpdatePublicGroupReadAnnotate(self):
         # this is the test of creating public group and updating it
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1
@@ -249,7 +249,7 @@ class TestPermissions(lib.ITest):
     def testCreatAndUpdatePublicGroup(self):
         # this is the test of creating public group and updating it
         # including changes in #1434
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1
@@ -279,7 +279,7 @@ class TestPermissions(lib.ITest):
     def testCreatGroupAndchangePermissions(self):
         # this is the test of updating group permissions
         # including changes in #1434
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1
@@ -345,7 +345,7 @@ class TestPermissions(lib.ITest):
     def testGroupOwners(self):
         # this is the test of creating private group and updating it
         # including changes in #1434
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         admin = self.root.sf.getAdminService()
 
         # create group1

--- a/components/tools/OmeroPy/test/integration/test_pixelsService.py
+++ b/components/tools/OmeroPy/test/integration/test_pixelsService.py
@@ -31,7 +31,7 @@ import library as lib
 
 class TestPixelsService(lib.ITest):
 
-    def testCreateImage(self):
+    def createImage(self):
         """
         Create a new image
         """
@@ -47,16 +47,17 @@ class TestPixelsService(lib.ITest):
         sizeZ = 1
         sizeT = 1
         channelList = range(1, 4)
-        pixelsService.createImage(
+        id = pixelsService.createImage(
             sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
-            "testCreateImage", description=None)
+            self.uuid(), description=None)
+        return id
 
     def test9655(self):
         # Create an image without statsinfo objects and attempt
         # to retrieve it from the Rendering service.
 
         # Get the pixels
-        image_id = self.testCreateImage()
+        image_id = self.createImage()
         gateway = omero.gateway.BlitzGateway(client_obj=self.client)
         image = gateway.getObject("Image", image_id)
         pixels_id = image.getPrimaryPixels().id

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -43,7 +43,6 @@ from omero.util.temp_files import create_path
 class TestReimportArchivedFiles(lib.ITest):
 
     def setup_method(self, method):
-        super(TestReimportArchivedFiles, self).setup_method(method)
         self.pixels = self.client.sf.getPixelsService()
         self.query = self.client.sf.getQueryService()
         self.update = self.client.sf.getUpdateService()

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -29,7 +29,6 @@ from omero_version import omero_version
 class AbstractRepoTest(lib.ITest):
 
     def setup_method(self, method):
-        super(AbstractRepoTest, self).setup_method(method)
         self.unique_dir = self.test_dir()
 
     def test_dir(self, client=None):

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -128,7 +128,8 @@ class TestScripts(lib.ITest):
             impl.cleanup()
 
     def testUploadOfficialScript(self):
-        scriptService = self.root.sf.getScriptService()
+        root_client = self.new_client(system=True)
+        scriptService = root_client.sf.getScriptService()
         uuid = self.uuid()
 
         scriptLines = [
@@ -145,7 +146,7 @@ class TestScripts(lib.ITest):
 
         id = scriptService.uploadOfficialScript(
             "/testUploadOfficialScript%s.py" % uuid, script)
-        impl = omero.processor.usermode_processor(self.root)
+        impl = omero.processor.usermode_processor(root_client)
         try:
             # force the server to parse the file enough to get params (checks
             # syntax etc)
@@ -165,9 +166,9 @@ class TestScripts(lib.ITest):
     def testRunScript(self):
         # Trying to run script as described:
         # http://trac.openmicroscopy.org.uk/ome/browser/trunk/components/blitz/resources/omero/api/IScript.ice#L40
-        scriptService = self.root.sf.getScriptService()
+        root_client = self.new_client(system=True)
+        scriptService = root_client.sf.getScriptService()
         uuid = self.uuid()
-        client = self.root
 
         scriptLines = [
             "import omero",
@@ -189,11 +190,11 @@ class TestScripts(lib.ITest):
             "offical/test/script%s.py" % uuid, script)
         assert scriptService.canRunScript(officialScriptId)  # ticket:2341
 
-        impl = omero.processor.usermode_processor(self.root)
+        impl = omero.processor.usermode_processor(root_client)
         try:
             proc = scriptService.runScript(officialScriptId, map, None)
             try:
-                cb = omero.scripts.ProcessCallbackI(client, proc)
+                cb = omero.scripts.ProcessCallbackI(root_client, proc)
                 while not cb.block(1000):  # ms.
                     pass
                 cb.close()
@@ -221,7 +222,7 @@ class TestScripts(lib.ITest):
         try:
             proc = scriptService.runScript(userScriptId, map, None)
             try:
-                cb = omero.scripts.ProcessCallbackI(client, proc)
+                cb = omero.scripts.ProcessCallbackI(root_client, proc)
                 while not cb.block(1000):  # ms.
                     pass
                 cb.close()
@@ -235,14 +236,15 @@ class TestScripts(lib.ITest):
         assert "returnMessage" not in results, \
             "Script should not have run. No user processor!"
 
-        impl = omero.processor.usermode_processor(self.root)
+        impl = omero.processor.usermode_processor(root_client)
         try:
             assert scriptService.canRunScript(userScriptId)  # ticket:2341
         finally:
             impl.cleanup()
 
     def testEditScript(self):
-        scriptService = self.root.sf.getScriptService()
+        root_client = self.new_client(system=True)
+        scriptService = root_client.sf.getScriptService()
         uuid = self.uuid()
 
         scriptLines = [
@@ -294,7 +296,8 @@ client.closeSession()
             assert x in paramsAfter.outputs
 
     def testScriptValidation(self):
-        scriptService = self.root.sf.getScriptService()
+        root_client = self.new_client(system=True)
+        scriptService = root_client.sf.getScriptService()
         uuid = self.uuid()
 
         invalidScript = "This text is not valid as a script"

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -129,7 +129,7 @@ class TestScripts(lib.ITest):
 
     def testUploadOfficialScript(self):
         scriptService = self.root.sf.getScriptService()
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
 
         scriptLines = [
             "import omero",
@@ -166,7 +166,7 @@ class TestScripts(lib.ITest):
         # Trying to run script as described:
         # http://trac.openmicroscopy.org.uk/ome/browser/trunk/components/blitz/resources/omero/api/IScript.ice#L40
         scriptService = self.root.sf.getScriptService()
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
         client = self.root
 
         scriptLines = [
@@ -243,7 +243,7 @@ class TestScripts(lib.ITest):
 
     def testEditScript(self):
         scriptService = self.root.sf.getScriptService()
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
 
         scriptLines = [
             "import omero",
@@ -295,10 +295,7 @@ client.closeSession()
 
     def testScriptValidation(self):
         scriptService = self.root.sf.getScriptService()
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
-
-        scriptService = self.root.sf.getScriptService()
-        uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
+        uuid = self.uuid()
 
         invalidScript = "This text is not valid as a script"
 

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -387,7 +387,8 @@ client.closeSession()
 
     @pytest.mark.broken(ticket="11539")
     def testParamLoadingPerformanceTicket2285(self):
-        svc = self.root.sf.getScriptService()
+        root_client = self.new_client(system=True)
+        svc = root_client.sf.getScriptService()
         SCRIPT = """if True:
         import omero.model as OM
         import omero.rtypes as OR
@@ -399,7 +400,7 @@ client.closeSession()
         """
         upload_time, scriptID = self.timeit(
             svc.uploadOfficialScript, "/test/perf%s.py" % self.uuid(), SCRIPT)
-        impl = omero.processor.usermode_processor(self.root)
+        impl = omero.processor.usermode_processor(root_client)
         try:
             params_time, params = self.timeit(svc.getParams, scriptID)
             assert params_time < (upload_time / 10), \
@@ -411,7 +412,7 @@ client.closeSession()
                 svc.runScript, scriptID, wrap({"a": long(5)}).val, None)
 
             def wait():
-                cb = omero.scripts.ProcessCallbackI(self.root, process)
+                cb = omero.scripts.ProcessCallbackI(root_client, process)
                 while cb.block(500) is None:
                     # process.poll() # This seems to make things much faster
                     pass

--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -101,8 +101,8 @@ class TestTickets3000(lib.ITest):
         p1.theFilter = f1
 
         # Nor was this
-        with pytest.raises(
-            (Ice.UnknownUserException, Ice.UnknownLocalException)):
+        with pytest.raises((Ice.UnknownUserException,
+                            Ice.UnknownLocalException)):
             q.findAllByQuery(sql, p1)
 
         # Only IQuery.projection can return non-IObject types

--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -91,7 +91,8 @@ class TestTickets3000(lib.ITest):
 
         # This was never supported
         with pytest.raises(
-                (Ice.UnmarshalOutOfBoundsException, Ice.UnknownUserException)):
+                (Ice.UnmarshalOutOfBoundsException, Ice.UnknownUserException,
+                 Ice.UnknownLocalException)):
             q.findAllByQuery(sql, None)
 
         p1 = omero.sys.Parameters()
@@ -100,7 +101,8 @@ class TestTickets3000(lib.ITest):
         p1.theFilter = f1
 
         # Nor was this
-        with pytest.raises(Ice.UnknownUserException):
+        with pytest.raises(
+            (Ice.UnknownUserException, Ice.UnknownLocalException)):
             q.findAllByQuery(sql, p1)
 
         # Only IQuery.projection can return non-IObject types

--- a/components/tools/OmeroPy/test/integration/test_tickets4000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets4000.py
@@ -35,7 +35,8 @@ class TestTickets4000(lib.ITest):
         self.loginAttempt(name, 3.0)
 
     def testChangeActiveGroup(self):
-        admin = self.client.sf.getAdminService()
+        client = self.new_client()
+        admin = client.sf.getAdminService()
 
         assert 2 == len(admin.getEventContext().memberOfGroups)
 
@@ -49,9 +50,9 @@ class TestTickets4000(lib.ITest):
 
         proxies = dict()
         # creating stateful services
-        proxies['search'] = self.client.sf.createSearchService()
-        proxies['thumbnail'] = self.client.sf.createThumbnailStore()
-        proxies['admin'] = self.client.sf.getAdminService()
+        proxies['search'] = client.sf.createSearchService()
+        proxies['thumbnail'] = client.sf.createThumbnailStore()
+        proxies['admin'] = client.sf.getAdminService()
 
         # changing group
         for k in proxies.keys():
@@ -60,18 +61,19 @@ class TestTickets4000(lib.ITest):
             except AttributeError:
                 pass
 
-        self.client.sf.setSecurityContext(
+        client.sf.setSecurityContext(
             omero.model.ExperimenterGroupI(grp.id.val, False))
         admin.setDefaultGroup(admin.getExperimenter(
             admin.getEventContext().userId),
             omero.model.ExperimenterGroupI(grp.id.val, False))
         assert grp.id.val == \
-            self.client.sf.getAdminService().getEventContext().groupId
+            client.sf.getAdminService().getEventContext().groupId
 
-    def testChageActiveGroupWhenConnectionLost(self):
+    def testChangeActiveGroupWhenConnectionLost(self):
         import os
-        admin = self.client.sf.getAdminService()
-        uuid = self.client.sf.getAdminService().getEventContext().sessionUuid
+        client = self.new_client()
+        admin = client.sf.getAdminService()
+        uuid = client.sf.getAdminService().getEventContext().sessionUuid
         assert 2 == len(admin.getEventContext().memberOfGroups)
 
         # AS ROOT: adding user to extra group
@@ -84,9 +86,9 @@ class TestTickets4000(lib.ITest):
 
         proxies = dict()
         # creating stateful services
-        proxies['search'] = self.client.sf.createSearchService()  # 1A
-        proxies['thumbnail'] = self.client.sf.createThumbnailStore()  # 1B
-        proxies['admin'] = self.client.sf.getAdminService()
+        proxies['search'] = client.sf.createSearchService()  # 1A
+        proxies['thumbnail'] = client.sf.createThumbnailStore()  # 1B
+        proxies['admin'] = client.sf.getAdminService()
         copy = dict(proxies)
 
         # loosing the connection

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -53,10 +53,10 @@ def itest(request):
     finalizer so that pytest will clean it up.
     """
     o = lib.ITest()
-    o.setup_method(None)
+    o.setup_class()
 
     def finalizer():
-        o.teardown_method(None)
+        o.teardown_class()
     request.addfinalizer(finalizer)
     return o
 

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -40,10 +40,10 @@ def itest(request):
     finalizer so that pytest will clean it up.
     """
     o = lib.ITest()
-    o.setup_method(None)
+    o.setup_class()
 
     def finalizer():
-        o.teardown_method(None)
+        o.teardown_class()
     request.addfinalizer(finalizer)
     return o
 

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -48,10 +48,10 @@ def itest(request):
     attached finalizer so that pytest will clean it up.
     """
     o = lib.ITest()
-    o.setup_method(None)
+    o.setup_class()
 
     def finalizer():
-        o.teardown_method(None)
+        o.teardown_class()
     request.addfinalizer(finalizer)
     return o
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -54,10 +54,10 @@ def itest(request):
     attached finalizer so that pytest will clean it up.
     """
     o = lib.ITest()
-    o.setup_method(None)
+    o.setup_class()
 
     def finalizer():
-        o.teardown_method(None)
+        o.teardown_class()
     request.addfinalizer(finalizer)
     return o
 


### PR DESCRIPTION
This PR refactors the `ITest` class in the Python library to perform the setup at the class level instead of the method level. This should not affect the validity of the tests but mostly result in a performance improvements while running the integration tests due to the reduction of the setup overhead.

Specific test cases which were relying on the previous per-method setup should be corrected e.g. by using `self.new_clients()`.

To test this PR, check the Python/Web integration  tests are green and that the full time required to complete the Python integration tests is significantly reduced.

/cc @ximenesuk 