### PR TITLE
Modify setup.py usage in Python testing

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -109,7 +109,7 @@ build_year = "${python_build_year}"
                 <arg value="test"/>
                 <optionalArgs/>
                 <arg value="-v"/>
-                <arg value="-s"/>
+                <arg value="-t"/>
                 <arg file="@{target}"/>
                 <arg value="--junitxml=${testreports.dir}/junit-results.xml"/>
             </setup_py>

--- a/components/tools/test_setup.py
+++ b/components/tools/test_setup.py
@@ -22,20 +22,20 @@ sys.path.insert(0, LIB)
 
 class PyTest(TestCommand):
 
-    user_options = TestCommand.user_options + \
-        [('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-         ('test-ice-config=', 'i',
-          "use specified 'ice config' file instead of default"),
-         ('test-string=', 'k', "only run tests including 'string'"),
-         ('test-marker=', 'm', "only run tests including 'marker'"),
-         ('test-path=', 's', "base dir for test collection"),
-         ('test-failfast', 'x', "Exit on first error"),
-         ('test-verbose', 'v', "more verbose output"),
-         ('test-quiet', 'q', "less verbose output"),
-         ('junitxml=', None, "create junit-xml style report file at 'path'"),
-         ('pdb', None, "fallback to pdb on error"),
-         ('markers', None, "list available markers'"),
-         ]
+    user_options = [
+        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        ('test-ice-config=', 'i',
+         "use specified 'ice config' file instead of default"),
+        ('test-string=', 'k', "only run tests including 'string'"),
+        ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-path=', 's', "base dir for test collection"),
+        ('test-failfast', 'x', "Exit on first error"),
+        ('test-verbose', 'v', "more verbose output"),
+        ('test-quiet', 'q', "less verbose output"),
+        ('junitxml=', None, "create junit-xml style report file at 'path'"),
+        ('pdb', None, "fallback to pdb on error"),
+        ('markers', None, "list available markers'"),
+        ]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)

--- a/components/tools/test_setup.py
+++ b/components/tools/test_setup.py
@@ -29,6 +29,7 @@ class PyTest(TestCommand):
          "use specified 'ice config' file instead of default"),
         ('test-string=', 'k', "only run tests including 'string'"),
         ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-no-capture', 's', "don't suppress test output"),
         ('test-failfast', 'x', "Exit on first error"),
         ('test-verbose', 'v', "more verbose output"),
         ('test-quiet', 'q', "less verbose output"),
@@ -44,6 +45,7 @@ class PyTest(TestCommand):
         self.test_string = None
         self.test_marker = None
         self.test_path = None
+        self.test_no_capture = False
         self.test_failfast = False
         self.test_quiet = False
         self.test_verbose = False
@@ -60,6 +62,8 @@ class PyTest(TestCommand):
             self.test_args.extend(['-k', self.test_string])
         if self.test_marker is not None:
             self.test_args.extend(['-m', self.test_marker])
+        if self.test_no_capture:
+            self.test_args.extend(['-s'])
         if self.test_failfast:
             self.test_args.extend(['-x'])
         if self.test_verbose:

--- a/components/tools/test_setup.py
+++ b/components/tools/test_setup.py
@@ -23,12 +23,12 @@ sys.path.insert(0, LIB)
 class PyTest(TestCommand):
 
     user_options = [
+        ('test-path=', 't', "base dir for test collection"),
         ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
         ('test-ice-config=', 'i',
          "use specified 'ice config' file instead of default"),
         ('test-string=', 'k', "only run tests including 'string'"),
         ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-path=', 's', "base dir for test collection"),
         ('test-failfast', 'x', "Exit on first error"),
         ('test-verbose', 'v', "more verbose output"),
         ('test-quiet', 'q', "less verbose output"),


### PR DESCRIPTION
This PR tries to fix a long-standing bugbear for some of us on the Python side, it allows the `-s` option to be passed through from 'setup.py`. It implements a `-t` option (not used anywhere else in `py.test`) for the test path. It also removes the inherited options (only used for `unittest`) which led to a confusing help listing.

To test:
 + firstly the CI tests should run okay
 + `./setup.py test --help` should no longer display the old `-m`, `-s` and `-r` options at the top of the `PyTest` option list
 + `./setup.py test -t <path to tests>` should run a folder of tests
 + `./setup.py test -t <path to tests> -s` should run a folder of tests and output any stdout with the tests to the console.

This sill
--no-rebase