### PR TITLE
Shift click range selection for wells

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.browser.BrowserModel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -679,7 +679,7 @@ class BrowserModel
 		//Note: avoid caching b/c we don't know yet what we are going
 		//to do with updates
 	    ImageFinder finder = new ImageFinder();
-	    accept(finder, ImageDisplayVisitor.IMAGE_SET_ONLY);
+	    accept(finder, ImageDisplayVisitor.ALL_NODES);
 	    return finder.getVisibleImageNodes();
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageFinder 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -120,6 +120,7 @@ public class ImageFinder
     public void visit(ImageNode node)
     {
         imageNodes.add(node);
+        visibleImageNodes.add(node);
         Object ho = node.getHierarchyObject();
         if (ho instanceof WellSampleData) {
         	WellSampleData wsd = (WellSampleData) ho;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -316,11 +316,10 @@ class EditorUI
     {
         ImageData img = model.getImage();
         if (img == null) return;
-        tabPane.setEnabledAt(ACQUISITION_INDEX, img.getId() > 0);
         boolean multi = model.isMultiSelection();
         boolean preview = model.isPreviewAvailable();
         tabPane.setEnabledAt(RND_INDEX, preview && !multi);
-        tabPane.setEnabledAt(ACQUISITION_INDEX, !multi);
+        tabPane.setEnabledAt(ACQUISITION_INDEX, !multi && img.getId() > 0);
         if (!preview) {
             tabPane.setToolTipTextAt(RND_INDEX, 
                     "Only available for non big images.");

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.EditorUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -317,8 +317,10 @@ class EditorUI
         ImageData img = model.getImage();
         if (img == null) return;
         tabPane.setEnabledAt(ACQUISITION_INDEX, img.getId() > 0);
+        boolean multi = model.isMultiSelection();
         boolean preview = model.isPreviewAvailable();
-        tabPane.setEnabledAt(RND_INDEX, preview);
+        tabPane.setEnabledAt(RND_INDEX, preview && !multi);
+        tabPane.setEnabledAt(ACQUISITION_INDEX, !multi);
         if (!preview) {
             tabPane.setToolTipTextAt(RND_INDEX, 
                     "Only available for non big images.");


### PR DESCRIPTION
Enables shift+click range selection for wells and disables acquisition and preview tab if multiple images/wells are selected. (Follow-up to PR #3311)

