### PR TITLE
5.0 graphs implementation deprecation

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -40,8 +40,8 @@ module omero {
 
         };
 
-        ["deprecated:omero::cmd::GraphModify is deprecated"]
-        ["java:type:java.util.ArrayList<omero.cmd.GraphModify>:java.util.List<omero.cmd.GraphModify>"]
+        ["deprecated:omero::cmd::GraphModify is deprecated",
+         "java:type:java.util.ArrayList<omero.cmd.GraphModify>:java.util.List<omero.cmd.GraphModify>"]
         sequence<GraphModify> GraphModifyList;
 
         /**

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -16,6 +16,7 @@ module omero {
         /**
          *
          **/
+        ["deprecated:use omero::cmd::GraphModify2 instead"]
         class GraphModify extends Request {
             string type;
             long id;
@@ -27,6 +28,7 @@ module omero {
          * is thrown. The contents of that internal exception are passed in
          * this instance.
          **/
+        ["deprecated:use omero::cmd::ERR instead"]
         class GraphConstraintERR extends ERR {
 
             /**
@@ -38,23 +40,27 @@ module omero {
 
         };
 
-
+        ["deprecated:omero::cmd::GraphModify is deprecated"]
         ["java:type:java.util.ArrayList<omero.cmd.GraphModify>:java.util.List<omero.cmd.GraphModify>"]
         sequence<GraphModify> GraphModifyList;
 
         /**
          *
          **/
+        ["deprecated:GraphSpecs in general are deprecated"]
         class GraphSpecList extends Request {};
 
+        ["deprecated:GraphSpecs in general are deprecated"]
         class GraphSpecListRsp extends Response {
             GraphModifyList list;
         };
 
+        ["deprecated:use omero::cmd::Chgrp2 instead"]
         class Chgrp extends GraphModify {
             long grp;
         };
 
+        ["deprecated:use omero::cmd::Chgrp2Response instead"]
         class ChgrpRsp extends Response {
         };
 
@@ -81,10 +87,12 @@ module omero {
         class ChmodRsp extends Response {
         };
 
+        ["deprecated:use omero::cmd::Chown2 instead"]
         class Chown extends GraphModify {
             long user;
         };
 
+        ["deprecated:use omero::cmd::Chown2Response instead"]
         class ChownRsp extends Response {
         };
 
@@ -93,6 +101,7 @@ module omero {
          * unless an error has occurred in which case a standard
          * [omero::cmd::ERR] may be returned.
          **/
+        ["deprecated:use omero::cmd::Delete2 instead"]
         class Delete extends GraphModify {
         };
 
@@ -101,6 +110,7 @@ module omero {
          * because if there was an error than an ERR object will be
          * returned.
          **/
+        ["deprecated:use omero::cmd::Delete2Response instead"]
         class DeleteRsp extends OK {
 
             /**

--- a/components/blitz/src/omero/cmd/Helper.java
+++ b/components/blitz/src/omero/cmd/Helper.java
@@ -365,6 +365,7 @@ public class Helper {
         return ec;
     }
 
+    @Deprecated
     public Cancel graphException(GraphException ge, long step, long id) {
         ERR err = new ERR();
         if (ge instanceof GraphConstraintException) {

--- a/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
@@ -40,7 +40,10 @@ import omero.cmd.HandleI.Cancel;
  * Implements an approximation of {@link Chgrp}'s API using {@link omero.cmd.Chgrp2}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChgrpFacadeI extends Chgrp implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
@@ -44,6 +44,7 @@ import omero.cmd.HandleI.Cancel;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChgrpFacadeI extends Chgrp implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/ChgrpI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpI.java
@@ -44,6 +44,7 @@ import org.springframework.context.ApplicationContext;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChgrpI extends Chgrp implements IGraphModifyRequest {
 
     private static final long serialVersionUID = -3653081139095111039L;

--- a/components/blitz/src/omero/cmd/graphs/ChgrpI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpI.java
@@ -40,7 +40,10 @@ import org.springframework.context.ApplicationContext;
 /**
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChgrpI extends Chgrp implements IGraphModifyRequest {
 
     private static final long serialVersionUID = -3653081139095111039L;

--- a/components/blitz/src/omero/cmd/graphs/ChmodI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodI.java
@@ -64,6 +64,7 @@ public class ChmodI extends Chmod implements IGraphModifyRequest {
     //
 
     @Override
+    @Deprecated
     public IGraphModifyRequest copy() {
         ChmodI copy = (ChmodI) ic.findObjectFactory(ice_id()).create(ChmodI.ice_staticId());
         copy.type = type;
@@ -116,6 +117,7 @@ public class ChmodI extends Chmod implements IGraphModifyRequest {
     }
 
     @Override
+    @Deprecated
     public void finish() throws Cancel {
         // no-op
     }

--- a/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
@@ -40,7 +40,10 @@ import omero.cmd.HandleI.Cancel;
  * Implements an approximation of {@link Chown}'s API using {@link omero.cmd.Chown2}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChownFacadeI extends Chown implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
@@ -44,6 +44,7 @@ import omero.cmd.HandleI.Cancel;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChownFacadeI extends Chown implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/ChownI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownI.java
@@ -39,6 +39,7 @@ import org.springframework.context.ApplicationContext;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChownI extends Chown implements IGraphModifyRequest {
 
     private static final long serialVersionUID = -3653063048111039L;

--- a/components/blitz/src/omero/cmd/graphs/ChownI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownI.java
@@ -35,7 +35,10 @@ import org.springframework.context.ApplicationContext;
 /**
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChownI extends Chown implements IGraphModifyRequest {
 
     private static final long serialVersionUID = -3653063048111039L;

--- a/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
@@ -42,7 +42,10 @@ import omero.cmd.HandleI.Cancel;
  * Implements an approximation of {@link Delete}'s API using {@link omero.cmd.Delete2}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class DeleteFacadeI extends Delete implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
@@ -46,6 +46,7 @@ import omero.cmd.HandleI.Cancel;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class DeleteFacadeI extends Delete implements IRequest {
 
     private final GraphRequestFactory graphRequestFactory;

--- a/components/blitz/src/omero/cmd/graphs/DeleteI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteI.java
@@ -40,7 +40,10 @@ import omero.cmd.Response;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.4.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 @SuppressWarnings("deprecation")
 public class DeleteI extends Delete implements IGraphModifyRequest {
 

--- a/components/blitz/src/omero/cmd/graphs/GraphSpecListI.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphSpecListI.java
@@ -29,7 +29,10 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphSpecListI extends GraphSpecList implements IRequest {
 
     private static final long serialVersionUID = -363984593874598374L;

--- a/components/blitz/src/omero/cmd/graphs/GraphSpecListI.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphSpecListI.java
@@ -33,6 +33,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphSpecListI extends GraphSpecList implements IRequest {
 
     private static final long serialVersionUID = -363984593874598374L;

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -59,7 +59,9 @@ public class GraphUtil {
      * Count how many objects are listed in a {@code IdListMap}.
      * @param idListMap lists of object IDs indexed by type name
      * @return how many objects are listed in given {@code IdListMap}
+     * @deprecated because facade classes are deprecated
      */
+    @Deprecated
     static int getIdListMapSize(Map<?, long[]> idListMap) {
         int size = 0;
         for (final long[] ids : idListMap.values()) {
@@ -107,7 +109,9 @@ public class GraphUtil {
      * @param request the request whose options should be updated
      * @param isAdmin if the current user is a system administrator
      * @throws GraphException if a non-administrator attempted to use {@link Op#FORCE}
+     * @deprecated because facade classes are deprecated
      */
+    @Deprecated
     static void translateOptions(GraphRequestFactory graphRequestFactory, Map<String, String> options,
             GraphModify2 request, boolean isAdmin) throws GraphException {
         if (options == null) {
@@ -171,7 +175,9 @@ public class GraphUtil {
      * Find the first class-name in a {@code /}-separated string.
      * @param type a type path in the style of the original graph traversal code
      * @return the first type found in the path
+     * @deprecated because facade classes are deprecated
      */
+    @Deprecated
     static String getFirstClassName(String type) {
         while (type.charAt(0) == '/') {
             type = type.substring(1);
@@ -189,7 +195,9 @@ public class GraphUtil {
      * should they wish those objects to be processed together.
      * Call this method before calling {@link omero.cmd.IRequest#init(omero.cmd.Helper)} on the requests.
      * @param requests the list of requests to adjust
+     * @deprecated because facade classes are deprecated
      */
+    @Deprecated
     public static void combineFacadeRequests(List<Request> requests) {
         if (requests == null) {
             return;

--- a/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
+++ b/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
@@ -28,6 +28,7 @@ import omero.cmd.IRequest;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public interface IGraphModifyRequest extends IRequest {
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
+++ b/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
@@ -24,7 +24,10 @@ import omero.cmd.IRequest;
  * during pre-processing.
  * 
  * @since 5.0.0
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public interface IGraphModifyRequest extends IRequest {
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/Preprocessor.java
+++ b/components/blitz/src/omero/cmd/graphs/Preprocessor.java
@@ -59,6 +59,7 @@ import omero.cmd.Request;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class Preprocessor {
 
     private final static Logger log = LoggerFactory.getLogger(Preprocessor.class);

--- a/components/blitz/src/omero/cmd/graphs/Preprocessor.java
+++ b/components/blitz/src/omero/cmd/graphs/Preprocessor.java
@@ -55,7 +55,10 @@ import omero.cmd.Request;
  * @author Josh Moore, josh at glencoesoftware.com
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class Preprocessor {
 
     private final static Logger log = LoggerFactory.getLogger(Preprocessor.class);

--- a/components/blitz/test/ome/services/blitz/test/ChgrpITest.java
+++ b/components/blitz/test/ome/services/blitz/test/ChgrpITest.java
@@ -78,6 +78,7 @@ import org.testng.annotations.Test;
 /**
  */
 @Test(groups = { "integration", "chgrp" })
+@SuppressWarnings("deprecation")
 public class ChgrpITest extends AbstractGraphTest {
 
     long oldGroupId = -1L;

--- a/components/blitz/test/ome/services/blitz/test/ChownITest.java
+++ b/components/blitz/test/ome/services/blitz/test/ChownITest.java
@@ -63,6 +63,7 @@ import org.testng.annotations.Test;
 /**
  */
 @Test(groups = { "integration", "chown" })
+@SuppressWarnings("deprecation")
 public class ChownITest extends AbstractGraphTest {
 
     long newUserId = 0L;

--- a/components/blitz/test/ome/services/blitz/test/utests/PreprocessorTest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/PreprocessorTest.java
@@ -54,6 +54,7 @@ import omero.cmd.graphs.Preprocessor;
  * @since 5.0
  */
 @Test(groups = {"fs"})
+@SuppressWarnings("deprecation")
 public class PreprocessorTest extends Preprocessor {
 
     private final Ice.Communicator ic = Ice.Util.initialize();

--- a/components/server/src/ome/services/chgrp/ChgrpStep.java
+++ b/components/server/src/ome/services/chgrp/ChgrpStep.java
@@ -43,7 +43,10 @@ import ome.util.SqlAction;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChgrpStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ChgrpStep.class);

--- a/components/server/src/ome/services/chgrp/ChgrpStep.java
+++ b/components/server/src/ome/services/chgrp/ChgrpStep.java
@@ -47,6 +47,7 @@ import ome.util.SqlAction;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChgrpStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ChgrpStep.class);

--- a/components/server/src/ome/services/chgrp/ChgrpStepFactory.java
+++ b/components/server/src/ome/services/chgrp/ChgrpStepFactory.java
@@ -25,6 +25,7 @@ import ome.tools.hibernate.ExtendedMetadata;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChgrpStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/chgrp/ChgrpStepFactory.java
+++ b/components/server/src/ome/services/chgrp/ChgrpStepFactory.java
@@ -21,7 +21,10 @@ import ome.tools.hibernate.ExtendedMetadata;
 /**
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChgrpStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/chown/ChownStep.java
+++ b/components/server/src/ome/services/chown/ChownStep.java
@@ -41,7 +41,10 @@ import org.perf4j.slf4j.Slf4JStopWatch;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChownStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ChownStep.class);

--- a/components/server/src/ome/services/chown/ChownStep.java
+++ b/components/server/src/ome/services/chown/ChownStep.java
@@ -45,6 +45,7 @@ import org.perf4j.slf4j.Slf4JStopWatch;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChownStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ChownStep.class);

--- a/components/server/src/ome/services/chown/ChownStepFactory.java
+++ b/components/server/src/ome/services/chown/ChownStepFactory.java
@@ -25,6 +25,7 @@ import ome.tools.hibernate.ExtendedMetadata;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ChownStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/chown/ChownStepFactory.java
+++ b/components/server/src/ome/services/chown/ChownStepFactory.java
@@ -21,7 +21,10 @@ import ome.tools.hibernate.ExtendedMetadata;
 /**
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.2
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ChownStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/delete/DeleteStep.java
+++ b/components/server/src/ome/services/delete/DeleteStep.java
@@ -35,7 +35,10 @@ import org.perf4j.slf4j.Slf4JStopWatch;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class DeleteStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(DeleteStep.class);

--- a/components/server/src/ome/services/delete/DeleteStep.java
+++ b/components/server/src/ome/services/delete/DeleteStep.java
@@ -39,6 +39,7 @@ import org.perf4j.slf4j.Slf4JStopWatch;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class DeleteStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(DeleteStep.class);

--- a/components/server/src/ome/services/delete/DeleteStepFactory.java
+++ b/components/server/src/ome/services/delete/DeleteStepFactory.java
@@ -28,6 +28,7 @@ import ome.tools.hibernate.ExtendedMetadata;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class DeleteStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/delete/DeleteStepFactory.java
+++ b/components/server/src/ome/services/delete/DeleteStepFactory.java
@@ -24,7 +24,10 @@ import ome.tools.hibernate.ExtendedMetadata;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
  * @see IDelete
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class DeleteStepFactory extends AbstractStepFactory {
 
     private final OmeroContext ctx;

--- a/components/server/src/ome/services/delete/Deletion.java
+++ b/components/server/src/ome/services/delete/Deletion.java
@@ -67,7 +67,10 @@ import com.google.common.collect.SetMultimap;
  * @see ome.api.IDelete
  * @see ome.services.blitz.impl.DeleteHandleI
  * @see omero.cmd.graphs.DeleteI
+ * @deprecated all except setup and {@link #deleteFiles(SetMultimap)} will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class Deletion {
 
     /**

--- a/components/server/src/ome/services/export/ExporterIndex.java
+++ b/components/server/src/ome/services/export/ExporterIndex.java
@@ -36,6 +36,7 @@ import org.hibernate.Session;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ExporterIndex {
 
     final int indicesNeeded;

--- a/components/server/src/ome/services/export/ExporterIndex.java
+++ b/components/server/src/ome/services/export/ExporterIndex.java
@@ -32,7 +32,10 @@ import org.hibernate.Session;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ExporterIndex {
 
     final int indicesNeeded;

--- a/components/server/src/ome/services/export/ExporterStep.java
+++ b/components/server/src/ome/services/export/ExporterStep.java
@@ -28,7 +28,10 @@ import org.hibernate.Session;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ExporterStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ExporterStep.class);

--- a/components/server/src/ome/services/export/ExporterStep.java
+++ b/components/server/src/ome/services/export/ExporterStep.java
@@ -32,6 +32,7 @@ import org.hibernate.Session;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ExporterStep extends GraphStep {
 
     final private static Logger log = LoggerFactory.getLogger(ExporterStep.class);

--- a/components/server/src/ome/services/export/ExporterStepFactory.java
+++ b/components/server/src/ome/services/export/ExporterStepFactory.java
@@ -42,6 +42,7 @@ import org.hibernate.Session;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ExporterStepFactory implements GraphStepFactory {
 
     private final static String[] TOP_LEVEL = new String[] {

--- a/components/server/src/ome/services/export/ExporterStepFactory.java
+++ b/components/server/src/ome/services/export/ExporterStepFactory.java
@@ -38,7 +38,10 @@ import org.hibernate.Session;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class ExporterStepFactory implements GraphStepFactory {
 
     private final static String[] TOP_LEVEL = new String[] {

--- a/components/server/src/ome/services/graphs/AbstractHierarchyGraphSpec.java
+++ b/components/server/src/ome/services/graphs/AbstractHierarchyGraphSpec.java
@@ -44,7 +44,10 @@ import org.springframework.beans.FatalBeanException;
  * @since 4.4.4
  * @see IGraph
  * @see ticket:9435
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public abstract class AbstractHierarchyGraphSpec extends BaseGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/AbstractHierarchyGraphSpec.java
+++ b/components/server/src/ome/services/graphs/AbstractHierarchyGraphSpec.java
@@ -48,6 +48,7 @@ import org.springframework.beans.FatalBeanException;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public abstract class AbstractHierarchyGraphSpec extends BaseGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/AbstractStepFactory.java
+++ b/components/server/src/ome/services/graphs/AbstractStepFactory.java
@@ -25,7 +25,10 @@ import java.util.List;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 5.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public abstract class AbstractStepFactory implements GraphStepFactory {
 
     protected int originalSize;

--- a/components/server/src/ome/services/graphs/AbstractStepFactory.java
+++ b/components/server/src/ome/services/graphs/AbstractStepFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public abstract class AbstractStepFactory implements GraphStepFactory {
 
     protected int originalSize;

--- a/components/server/src/ome/services/graphs/AnnotationGraphSpec.java
+++ b/components/server/src/ome/services/graphs/AnnotationGraphSpec.java
@@ -36,6 +36,7 @@ import org.springframework.beans.FatalBeanException;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class AnnotationGraphSpec extends AbstractHierarchyGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/AnnotationGraphSpec.java
+++ b/components/server/src/ome/services/graphs/AnnotationGraphSpec.java
@@ -32,7 +32,10 @@ import org.springframework.beans.FatalBeanException;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @see IGraph
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class AnnotationGraphSpec extends AbstractHierarchyGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/BaseGraphSpec.java
+++ b/components/server/src/ome/services/graphs/BaseGraphSpec.java
@@ -42,7 +42,10 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @see IGraph
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class BaseGraphSpec implements GraphSpec, BeanNameAware {
 
     private final static Logger log = LoggerFactory.getLogger(BaseGraphSpec.class);

--- a/components/server/src/ome/services/graphs/BaseGraphSpec.java
+++ b/components/server/src/ome/services/graphs/BaseGraphSpec.java
@@ -46,6 +46,7 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class BaseGraphSpec implements GraphSpec, BeanNameAware {
 
     private final static Logger log = LoggerFactory.getLogger(BaseGraphSpec.class);

--- a/components/server/src/ome/services/graphs/GraphConstraintException.java
+++ b/components/server/src/ome/services/graphs/GraphConstraintException.java
@@ -40,6 +40,7 @@ import com.google.common.collect.HashMultimap;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphConstraintException extends GraphException {
 
     private static final long serialVersionUID = 1L;

--- a/components/server/src/ome/services/graphs/GraphConstraintException.java
+++ b/components/server/src/ome/services/graphs/GraphConstraintException.java
@@ -36,7 +36,10 @@ import com.google.common.collect.HashMultimap;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 5.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphConstraintException extends GraphException {
 
     private static final long serialVersionUID = 1L;

--- a/components/server/src/ome/services/graphs/GraphEntry.java
+++ b/components/server/src/ome/services/graphs/GraphEntry.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphEntry {
 
     private final static Logger log = LoggerFactory.getLogger(GraphEntry.class);

--- a/components/server/src/ome/services/graphs/GraphEntry.java
+++ b/components/server/src/ome/services/graphs/GraphEntry.java
@@ -29,7 +29,10 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @see IGraph
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphEntry {
 
     private final static Logger log = LoggerFactory.getLogger(GraphEntry.class);

--- a/components/server/src/ome/services/graphs/GraphOpts.java
+++ b/components/server/src/ome/services/graphs/GraphOpts.java
@@ -20,7 +20,10 @@ import ome.system.EventContext;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @see IGraph
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphOpts {
 
     public enum Op {

--- a/components/server/src/ome/services/graphs/GraphOpts.java
+++ b/components/server/src/ome/services/graphs/GraphOpts.java
@@ -24,6 +24,7 @@ import ome.system.EventContext;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphOpts {
 
     public enum Op {

--- a/components/server/src/ome/services/graphs/GraphSpec.java
+++ b/components/server/src/ome/services/graphs/GraphSpec.java
@@ -33,7 +33,10 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @see IGraph
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public interface GraphSpec {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphSpec.java
+++ b/components/server/src/ome/services/graphs/GraphSpec.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.ListableBeanFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public interface GraphSpec {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphSpecPostProcessor.java
+++ b/components/server/src/ome/services/graphs/GraphSpecPostProcessor.java
@@ -20,7 +20,10 @@ import org.springframework.context.ApplicationContextAware;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphSpecPostProcessor implements BeanPostProcessor,
         ApplicationContextAware {
 

--- a/components/server/src/ome/services/graphs/GraphSpecPostProcessor.java
+++ b/components/server/src/ome/services/graphs/GraphSpecPostProcessor.java
@@ -24,6 +24,7 @@ import org.springframework.context.ApplicationContextAware;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphSpecPostProcessor implements BeanPostProcessor,
         ApplicationContextAware {
 

--- a/components/server/src/ome/services/graphs/GraphState.java
+++ b/components/server/src/ome/services/graphs/GraphState.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphState implements GraphStep.Callback {
 
     private final static Logger log = LoggerFactory.getLogger(GraphState.class);

--- a/components/server/src/ome/services/graphs/GraphState.java
+++ b/components/server/src/ome/services/graphs/GraphState.java
@@ -51,7 +51,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphState implements GraphStep.Callback {
 
     private final static Logger log = LoggerFactory.getLogger(GraphState.class);

--- a/components/server/src/ome/services/graphs/GraphStep.java
+++ b/components/server/src/ome/services/graphs/GraphStep.java
@@ -36,7 +36,10 @@ import com.google.common.collect.HashMultimap;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public abstract class GraphStep {
 
     public interface Callback {

--- a/components/server/src/ome/services/graphs/GraphStep.java
+++ b/components/server/src/ome/services/graphs/GraphStep.java
@@ -40,6 +40,7 @@ import com.google.common.collect.HashMultimap;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public abstract class GraphStep {
 
     public interface Callback {

--- a/components/server/src/ome/services/graphs/GraphStepFactory.java
+++ b/components/server/src/ome/services/graphs/GraphStepFactory.java
@@ -18,6 +18,7 @@ import java.util.List;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public interface GraphStepFactory {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphStepFactory.java
+++ b/components/server/src/ome/services/graphs/GraphStepFactory.java
@@ -14,7 +14,10 @@ import java.util.List;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public interface GraphStepFactory {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphSteps.java
+++ b/components/server/src/ome/services/graphs/GraphSteps.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphSteps extends AbstractList<GraphStep> implements RandomAccess {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphSteps.java
+++ b/components/server/src/ome/services/graphs/GraphSteps.java
@@ -34,7 +34,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 5.0.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphSteps extends AbstractList<GraphStep> implements RandomAccess {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphTables.java
+++ b/components/server/src/ome/services/graphs/GraphTables.java
@@ -26,7 +26,10 @@ import org.hibernate.Session;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.3
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class GraphTables {
 
     /**

--- a/components/server/src/ome/services/graphs/GraphTables.java
+++ b/components/server/src/ome/services/graphs/GraphTables.java
@@ -30,6 +30,7 @@ import org.hibernate.Session;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class GraphTables {
 
     /**

--- a/components/server/src/ome/services/graphs/LightSourceGraphSpec.java
+++ b/components/server/src/ome/services/graphs/LightSourceGraphSpec.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class LightSourceGraphSpec extends AbstractHierarchyGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/LightSourceGraphSpec.java
+++ b/components/server/src/ome/services/graphs/LightSourceGraphSpec.java
@@ -39,7 +39,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.4.4
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class LightSourceGraphSpec extends AbstractHierarchyGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/RenderingDefGraphSpec.java
+++ b/components/server/src/ome/services/graphs/RenderingDefGraphSpec.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class RenderingDefGraphSpec extends BaseGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/src/ome/services/graphs/RenderingDefGraphSpec.java
+++ b/components/server/src/ome/services/graphs/RenderingDefGraphSpec.java
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.4.4
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
 public class RenderingDefGraphSpec extends BaseGraphSpec {
 
     private final static Logger log = LoggerFactory

--- a/components/server/test/ome/services/graphs/ExportIndexUnitTest.java
+++ b/components/server/test/ome/services/graphs/ExportIndexUnitTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
  * (among others).
  */
 @Test
+@SuppressWarnings("deprecation")
 public class ExportIndexUnitTest extends MockGraphTest {
 
     class Step extends GraphStep {

--- a/components/server/test/ome/services/graphs/GraphSpecUnitTest.java
+++ b/components/server/test/ome/services/graphs/GraphSpecUnitTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.FatalBeanException;
 import org.testng.annotations.Test;
 
 @Test
+@SuppressWarnings("deprecation")
 public class GraphSpecUnitTest extends MockGraphTest {
 
     private final static Op DEFAULT = Op.HARD;

--- a/components/server/test/ome/services/graphs/GraphStateUnitTest.java
+++ b/components/server/test/ome/services/graphs/GraphStateUnitTest.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
  * @see ticket:3628
  */
 @Test(groups = "broken")
+@SuppressWarnings("deprecation")
 public class GraphStateUnitTest extends MockGraphTest {
 
     private Mock sessionMock;

--- a/components/server/test/ome/services/graphs/GraphStepsUnitTest.java
+++ b/components/server/test/ome/services/graphs/GraphStepsUnitTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 
 /**
  */
+@SuppressWarnings("deprecation")
 public class GraphStepsUnitTest extends MockGraphTest {
 
     GraphSteps steps;

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -261,6 +261,8 @@ omero.pixeldata.max_plane_width=3192
 omero.pixeldata.max_plane_height=3192
 
 # Whether to use the new Chgrp, Chown, Delete implementations.
+# Available only for OMERO 5.1:
+# from OMERO 5.2 the new implementations must be used.
 omero.graphs.wrap=true
 
 #############################################


### PR DESCRIPTION
After #3228 the previous `spec.xml`-based graphs implementation is no longer being actively tested. Deprecation warnings are added accordingly: `omero.graphs.wrap` no longer available in 5.2, API-compatibility layer no longer available in 5.3 (to give people more time to update clients and scripts).

@hflynn: If merged, I must update `omero/developers/Server/ObjectGraphs.txt` accordingly.

--no-rebase