### PR TITLE
Reload MapAnnotations with NamedValue list initialized (temporary PR)

### DIFF
--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -22,6 +22,7 @@ import ome.api.local.LocalQuery;
 import ome.conditions.ApiUsageException;
 import ome.conditions.ValidationException;
 import ome.model.IObject;
+import ome.model.annotations.MapAnnotation;
 import ome.parameters.Filter;
 import ome.parameters.Parameters;
 import ome.services.SearchBean;
@@ -194,7 +195,12 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                             throws HibernateException {
 
                         IObject o = (IObject) session.get(klass, id);
-                        Hibernate.initialize(o);
+						Hibernate.initialize(o);
+						// Workaround for MapAnnotation's NamedValue list not loaded
+						// TODO: Remove if switched to eager loading
+						if (o instanceof MapAnnotation) {
+							((MapAnnotation) o).getMapValue().size();
+						}
                         return o;
 
                     }


### PR DESCRIPTION
This is just a temporary fix for loading MapAnnotations (with the NamedValue list initialized).
--on-hold  (has to be done properly in an other PR)