### PR TITLE
assist #9610: adjust rules for moving link children

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -99,7 +99,8 @@
                                        p:changes="OF:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!DI].parent = [DI], L.child = C:!Job[E]/!d" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:[E]{o}/o" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:[E]{o}/d" p:changes="C:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ILink.parent = [I], L.child = C:[E]{o}/d" p:changes="C:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="$to_private, L:ILink[E].parent = [I], L.child = [E]{o}/!o" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:Job[E]{o}" p:changes="C:[I]"/>
         <bean parent="graphPolicyRule" p:matches="[I] == X:[E]{o}" p:changes="X:[I]"/>
         <bean parent="graphPolicyRule" p:matches="[I] == X:[D]" p:changes="X:[I]"/>
@@ -177,6 +178,11 @@
         <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [I], L.child = [E]{a}" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[E]{a}.parent = [I]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:BooleanAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:CommentAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:DoubleAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:LongAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:TimestampAnnotation[E]{o}" p:changes="C:[D]/n"/>
     </util:list>
 
     <util:list id="chownRules" value-type="ome.services.graphs.GraphPolicyRule">

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -96,7 +96,9 @@ public class AnnotationMoveTest extends AbstractServerTest {
         assertEquals(iQuery.findAllByQuery(sb.toString(), param).size(),
                 annotationIdsUser1.size());
         n = 0;
-        if (src.equals("rwrw--")) n = annotationIdsUser2.size();
+        if (src.equals("rwrw--") && !dest.equals("rw----")) {
+            n = annotationIdsUser2.size();
+        }
         param = new ParametersI();
         param.addIds(annotationIdsUser2);
         assertEquals("#9496? anns", iQuery.findAllByQuery(sb.toString(), param)

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -318,7 +318,6 @@ public class AnnotationMoveTest extends AbstractServerTest {
      * @throws Exception
      *             Thrown if an error occurred.
      */
-    @Test(groups = "broken")
     public void testMoveImageAnnotatedByUsersInDestinationGroupRWRWtoRW()
             throws Exception {
         moveImageWithNonSharedAnnotation("rwrw--", "rw----", true);
@@ -418,7 +417,6 @@ public class AnnotationMoveTest extends AbstractServerTest {
      * @throws Exception
      *             Thrown if an error occurred.
      */
-    @Test(groups = "broken")
     public void testMoveImageAnnotatedByUsersOneNotInDestinationGroupDestinationGroupRWRWtoRW()
             throws Exception {
         moveImageWithNonSharedAnnotation("rwrw--", "rw----", false);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -451,7 +451,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
      * @throws Exception
      *             Thrown if an error occurred.
      */
-    @Test(groups = "broken")
     public void testMoveDatasetImageGraphLinkDoneByImageOwnerRWRWtoRW()
             throws Exception {
         String perms = "rw----"; // destination


### PR DESCRIPTION
Marks three integration tests as no longer broken. Integration tests should still pass. Could look for regressions regarding moving images that have owner's and others' comments and tags between groups.