### PR TITLE
fix #12701: combine facade requests even for different target types

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -30,7 +30,6 @@ import org.apache.commons.collections.CollectionUtils;
 
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphOpts.Op;
-import omero.cmd.GraphModify;
 import omero.cmd.GraphModify2;
 import omero.cmd.Request;
 import omero.cmd.graphs.ChildOption;
@@ -240,8 +239,7 @@ public class GraphUtil {
      * @return if the target model object of the second request was successfully merged into those of the first request
      */
     private static boolean isCombined(ChgrpFacadeI chgrp1, ChgrpFacadeI chgrp2) {
-        if (chgrp1.type.equals(chgrp2.type) &&
-            isEqualMaps(chgrp1.options, chgrp2.options) &&
+        if (isEqualMaps(chgrp1.options, chgrp2.options) &&
             chgrp1.grp == chgrp2.grp) {
             chgrp1.addToTargets(chgrp2.type, chgrp2.id);
             return true;
@@ -257,8 +255,7 @@ public class GraphUtil {
      * @return if the target model object of the second request was successfully merged into those of the first request
      */
     private static boolean isCombined(ChownFacadeI chown1, ChownFacadeI chown2) {
-        if (chown1.type.equals(chown2.type) &&
-            isEqualMaps(chown1.options, chown2.options) &&
+        if (isEqualMaps(chown1.options, chown2.options) &&
             chown1.user == chown2.user) {
             chown1.addToTargets(chown2.type, chown2.id);
             return true;
@@ -276,7 +273,7 @@ public class GraphUtil {
     private static boolean isCombined(DeleteFacadeI delete1, DeleteFacadeI delete2) {
         /* in deleting original files, order is significant */
         if (!delete1.type.endsWith("/OriginalFile") &&
-            delete1.type.equals(delete2.type) &&
+            !delete2.type.endsWith("/OriginalFile") &&
             isEqualMaps(delete1.options, delete2.options)) {
             delete1.addToTargets(delete2.type, delete2.id);
             return true;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.OMEROGateway
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -8320,6 +8320,7 @@ class OMEROGateway
 			List<IObject> l;
 			Iterator<IObject> j;
 			List<Request> commands = new ArrayList<Request>();
+			List<Save> saves = new ArrayList<Save>();
 			Chgrp cmd;
 			long id;
 			Save save;
@@ -8339,7 +8340,7 @@ class OMEROGateway
 					while (j.hasNext()) {
 						save = new Save();
 						save.obj = j.next();
-						commands.add(save);
+						saves.add(save);
 					}
 				}
 			}
@@ -8368,7 +8369,7 @@ class OMEROGateway
 							while (j.hasNext()) {
 								save = new Save();
 								save.obj = j.next();
-								commands.add(save);
+								saves.add(save);
 							}
 						}
 					}
@@ -8390,11 +8391,12 @@ class OMEROGateway
 						while (j.hasNext()) {
 							save = new Save();
 							save.obj = j.next();
-							commands.add(save);
+							saves.add(save);
 						}
 					}
 				}
 			}
+			commands.addAll(saves);
 			return c.submit(commands, target);
 		} catch (Throwable e) {
 			handleException(e, "Cannot transfer the data.");


### PR DESCRIPTION
A weakness in the graphs reimplementation's API compatibility layer prevented Insight users from being able to move sets of images between groups where that set included both a MIF and an image script-generated from the MIF. For testing, projecting from `Beta Catenin.lif`, then moving the lot after selecting the individual images, should now work in both Insight and web, and other moves and deletes should continue to work.

Fixes http://trac.openmicroscopy.org/ome/ticket/12701.
--no-rebase