### PR TITLE
Use 5.0 versions of OMERO and Homebrew formulas

### DIFF
--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -76,30 +76,30 @@ cd /usr/local
 ###################################################################
 
 # Install Bio-Formats
-bin/brew install bioformats
-VERBOSE=1 bin/brew test bioformats
+bin/brew install bioformats50
+VERBOSE=1 bin/brew test bioformats50
 
 ###################################################################
 # OMERO installation
 ###################################################################
 
 # Install PostgreSQL and OMERO
-OMERO_PYTHONPATH=$(bin/brew --prefix omero)/lib/python
+OMERO_PYTHONPATH=$(bin/brew --prefix omero50)/lib/python
 if [ "$ICE" == "3.3" ]; then
-    bin/brew install omero --with-ice33 --with-nginx
+    bin/brew install omero50 --with-ice33 --with-nginx
     ICE_HOME=$(bin/brew --prefix zeroc-ice33)
     export PYTHONPATH=$OMERO_PYTHONPATH:$ICE_HOME/python
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib
 elif [ "$ICE" == "3.4" ]; then
-    bin/brew install omero --with-ice34 --with-nginx
+    bin/brew install omero50 --with-ice34 --with-nginx
     ICE_HOME=$(bin/brew --prefix zeroc-ice34)
     export PYTHONPATH=$OMERO_PYTHONPATH:$ICE_HOME/python
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib
 else
-    bin/brew install omero --with-nginx
+    bin/brew install omero50 --with-nginx
     export PYTHONPATH=$OMERO_PYTHONPATH
 fi
-VERBOSE=1 bin/brew test omero
+VERBOSE=1 bin/brew test omero50
 
 # Install PostgreSQL
 bin/brew install postgres
@@ -108,7 +108,7 @@ bin/brew install postgres
 bash bin/omero_python_deps
 
 # Set additional environment variables
-export ICE_CONFIG=$(bin/brew --prefix omero)/etc/ice.config
+export ICE_CONFIG=$(bin/brew --prefix omero50)/etc/ice.config
 
 # Note: If postgres startup fails it's probably because there was an old
 # process still running.
@@ -150,8 +150,8 @@ bin/omero logout
 # Start OMERO.web
 bin/omero config set omero.web.application_server "fastcgi-tcp"
 bin/omero config set omero.web.debug True
-bin/omero web config nginx --http $HTTPPORT > $(bin/brew --prefix omero)/etc/nginx.conf
-nginx -c $(bin/brew --prefix omero)/etc/nginx.conf
+bin/omero web config nginx --http $HTTPPORT > $(bin/brew --prefix omero50)/etc/nginx.conf
+nginx -c $(bin/brew --prefix omero50)/etc/nginx.conf
 bin/omero web start
 
 # Test simple Web connection
@@ -164,7 +164,7 @@ echo "$resp"
 
 # Stop OMERO.web
 bin/omero web stop
-nginx -c $(bin/brew --prefix omero)/etc/nginx.conf -s stop
+nginx -c $(bin/brew --prefix omero50)/etc/nginx.conf -s stop
 
 # Stop the server
 bin/omero admin stop


### PR DESCRIPTION
See also https://github.com/sbesson/openmicroscopy/commit/4321538e4f0abb0db6ca26c54a3ca9911afac526. This PR modifies the `OMERO-homebrew-install.sh` installation script under `dev_5_0` to use the new formulas introduced by https://github.com/ome/homebrew-alt/pull/70.

--no-rebase