### PR TITLE
Prefix application_server.port when calling `omero admin ports`

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -26,12 +26,12 @@ import omero
 import omero.config
 
 from omero.cli import CLI
-from omero.cli import BaseControl
 from omero.cli import DirectoryType
 from omero.cli import NonZeroReturnCode
 from omero.cli import VERSION
 
-from omero.plugins.prefs import with_config, with_rw_config
+from omero.plugins.prefs import \
+    WriteableConfigControl, with_config, with_rw_config
 
 from omero_ext import portalocker
 from omero_ext.which import whichall
@@ -64,7 +64,7 @@ Configuration properties:
 """ + "\n" + "="*50 + "\n"
 
 
-class AdminControl(BaseControl):
+class AdminControl(WriteableConfigControl):
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -77,7 +77,8 @@ class AdminControl(BaseControl):
             if i >= 0:
                 f = line[i+l:]
                 return self._complete_file(f)
-        return BaseControl._complete(self, text, line, begidx, endidx)
+        return WriteableConfigControl._complete(
+            self, text, line, begidx, endidx)
 
     def _configure(self, parser):
         sub = parser.sub()
@@ -1374,10 +1375,6 @@ OMERO Diagnostics %s
             self.ctx.die(111, "Could not acquire lock on %s" % cfg_xml)
 
         return config
-
-    def die_on_ro(self, config):
-        if not config.save_on_close:
-            self.ctx.die(333, "Cannot modify %s" % config.filename)
 
     @with_config
     def reindex(self, args, config):

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -60,6 +60,7 @@ Configuration properties:
  omero.windows.pass
  omero.windows.servicename
  omero.web.application_server.port
+ omero.web.server_list
 
 """ + "\n" + "="*50 + "\n"
 
@@ -1506,6 +1507,9 @@ OMERO Diagnostics %s
         from omero.install.change_ports import change_ports
         webserverkey = 'omero.web.application_server.port'
         webserver_default_port = 4080
+        weblistkey = 'omero.web.server_list'
+        weblist_default_port = 4064
+        weblist_template = '[["localhost", %s, "omero"]]'
 
         if not args.skipcheck:
             if 0 == self.status(args, node_only=True):
@@ -1525,14 +1529,23 @@ OMERO Diagnostics %s
         if args.revert:
             webserver_from = args.webserver
             webserver_to = str(webserver_default_port)
+            weblist_from = weblist_template % args.ssl
+            weblist_to = weblist_template % str(weblist_default_port)
         else:
             webserver_from = str(webserver_default_port)
             webserver_to = args.webserver
+            weblist_from = weblist_template % str(weblist_default_port)
+            weblist_to = weblist_template % args.ssl
         try:
             waport = config[webserverkey]
         except KeyError:
             waport = ''
             webserver_from = ''
+        try:
+            weblist = config[weblistkey]
+        except KeyError:
+            weblist = ''
+            weblist_from = ''
 
         if waport != webserver_from:
             self.ctx.out('No match found for %s=%s in %s' % (
@@ -1541,6 +1554,14 @@ OMERO Diagnostics %s
             config[webserverkey] = webserver_to
             self.ctx.out('Converted: %s => %s %s in %s' % (
                 webserver_from, webserver_to, webserverkey, config.filename))
+
+        if weblist != weblist_from:
+            self.ctx.out('No match found for %s=%s in %s' % (
+                weblistkey, weblist_from, config.filename))
+        else:
+            config[weblistkey] = weblist_to
+            self.ctx.out('Converted: %s => %s %s in %s' % (
+                weblist_from, weblist_to, weblistkey, config.filename))
 
     def cleanse(self, args):
         self.check_access()

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -17,7 +17,7 @@ from path import path
 import omero
 import omero.clients
 
-from omero.cli import NonZeroReturnCode
+from omero.cli import CLI, NonZeroReturnCode
 from omero.plugins.admin import AdminControl
 from omero.plugins.prefs import PrefsControl
 from omero.util.temp_files import create_path
@@ -56,7 +56,7 @@ class TestAdmin(object):
         # Other setup
         self.cli = MockCLI()
         self.cli.dir = tmp_dir
-        self.cli.register("a", AdminControl, "TEST")
+        self.cli.register("admin", AdminControl, "TEST")
         self.cli.register("config", PrefsControl, "TEST")
 
     def teardown_method(self, method):
@@ -88,7 +88,7 @@ class TestAdmin(object):
         self.cli.checksIceVersion()
         self.cli.checksStatus(1)  # I.e. not running
 
-        self.invoke("a startasync")
+        self.invoke("admin startasync")
         self.cli.assertCalled()
         self.cli.assertStderr(
             ['No descriptor given. Using etc/grid/default.xml'])
@@ -96,13 +96,13 @@ class TestAdmin(object):
     def testStopAsyncRunning(self):
         self.cli.checksStatus(0)  # I.e. running
         self.cli.addCall(0)
-        self.invoke("a stopasync")
+        self.invoke("admin stopasync")
         self.cli.assertStderr([])
         self.cli.assertStdout([])
 
     def testStopAsyncNotRunning(self):
         self.cli.checksStatus(1)  # I.e. not running
-        self.invoke("a stopasync", fails=True)
+        self.invoke("admin stopasync", fails=True)
         self.cli.assertStderr(["Server not running"])
         self.cli.assertStdout([])
 
@@ -110,7 +110,7 @@ class TestAdmin(object):
         self.cli.checksStatus(0)  # I.e. running
         self.cli.addCall(0)
         self.cli.checksStatus(1)  # I.e. not running
-        self.invoke("a stop")
+        self.invoke("admin stop")
         self.cli.assertStderr([])
         self.cli.assertStdout(['Waiting on shutdown. Use CTRL-C to exit'])
 
@@ -125,7 +125,7 @@ class TestAdmin(object):
         popen.wait().AndReturn(1)
 
         self.cli.mox.ReplayAll()
-        pytest.raises(NonZeroReturnCode, self.invoke, "a status")
+        pytest.raises(NonZeroReturnCode, self.invoke, "admin status")
 
     def testStatusSMFails(self):
 
@@ -134,7 +134,7 @@ class TestAdmin(object):
         popen.wait().AndReturn(0)
 
         # Setup the call to session manager
-        control = self.cli.controls["a"]
+        control = self.cli.controls["admin"]
         control._intcfg = lambda: ""
 
         def sm(*args):
@@ -142,7 +142,7 @@ class TestAdmin(object):
         control.session_manager = sm
 
         self.cli.mox.ReplayAll()
-        pytest.raises(NonZeroReturnCode, self.invoke, "a status")
+        pytest.raises(NonZeroReturnCode, self.invoke, "admin status")
 
     def testStatusPasses(self):
 
@@ -151,7 +151,7 @@ class TestAdmin(object):
         popen.wait().AndReturn(0)
 
         # Setup the call to session manager
-        control = self.cli.controls["a"]
+        control = self.cli.controls["admin"]
         control._intcfg = lambda: ""
 
         def sm(*args):
@@ -163,5 +163,80 @@ class TestAdmin(object):
         control.session_manager = sm
 
         self.cli.mox.ReplayAll()
-        self.invoke("a status")
+        self.invoke("admin status")
         assert 0 == self.cli.rv
+
+
+class TestAdminPorts(object):
+
+    def setup_method(self, method):
+        # # Non-temp directories
+        ctxdir = path() / ".." / ".." / ".." / "dist"
+        etc_dir = ctxdir / "etc"
+        self.ice_config = etc_dir / "ice.config"
+        self.internal_cfg = etc_dir / "internal.cfg"
+        self.master_cfg = etc_dir / "master.cfg"
+        self.config_xml = etc_dir / "grid" / "config.xml"
+
+        # Create temp files for backup
+        tmp_dir = create_path(folder=True)
+        self.tmp_ice_config = tmp_dir / "ice.config"
+        self.tmp_internal_cfg = tmp_dir / "internal.cfg"
+        self.tmp_master_cfg = tmp_dir / "master.cfg"
+        self.tmp_config_xml = tmp_dir / "config.xml"
+
+        # Create backups
+        self.ice_config.copy(self.tmp_ice_config)
+        self.internal_cfg.copy(self.tmp_internal_cfg)
+        self.master_cfg.copy(self.tmp_master_cfg)
+        self.config_xml.copy(self.tmp_config_xml)
+
+        # Other setup
+        self.cli = CLI()
+        self.cli.dir = ctxdir
+        self.cli.register("admin", AdminControl, "TEST")
+        self.args = ["admin", "ports"]
+
+    def teardown_method(self, tmpdir):
+        # Restore backups
+        self.tmp_ice_config.copy(self.ice_config)
+        self.tmp_internal_cfg.copy(self.internal_cfg)
+        self.tmp_master_cfg.copy(self.master_cfg)
+        self.tmp_config_xml.copy(self.config_xml)
+
+    def check_config_xml(self, prefix=None):
+        config_text = self.config_xml.text()
+        serverport_property = (
+            '<property name="omero.web.application_server.port"'
+            ' value="%s4080"') % prefix
+        serverlist_property = (
+            '<property name="omero.web.server_list"'
+            ' value="[[&quot;localhost&quot;, %s4064, &quot;omero&quot;]]"'
+            ) % prefix
+        if prefix:
+            assert serverport_property in config_text
+            assert serverlist_property in config_text
+        else:
+            assert serverport_property not in config_text
+            assert serverlist_property not in config_text
+
+    @pytest.mark.parametrize('prefix', [1, 2])
+    def testPorts(self, prefix):
+        self.args += ['--prefix', '%s' % prefix]
+        self.args += ['--skipcheck']
+        self.cli.invoke(self.args, strict=True)
+
+        assert self.ice_config.text().endswith("omero.port=%s4064\n" % prefix)
+        assert "-p %s4061" % prefix in self.master_cfg.text()
+        assert "-p %s4061" % prefix in self.internal_cfg.text()
+        self.check_config_xml(prefix)
+
+        # Check revert argument
+        self.args += ['--revert']
+        self.cli.invoke(self.args, strict=True)
+        assert not self.ice_config.text().endswith(
+            "omero.port=%s4064\n" % prefix)
+        assert "-p 4061" in self.master_cfg.text()
+        assert "-p 4061" in self.internal_cfg.text()
+        self.check_config_xml()
+

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -197,7 +197,7 @@ class TestAdminPorts(object):
         self.cli.register("admin", AdminControl, "TEST")
         self.args = ["admin", "ports"]
 
-    def teardown_method(self):
+    def teardown_method(self, method):
         # Restore backups
         for key in self.cfg_files.keys():
             if self.tmp_cfg_files[key] is not None:

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -197,7 +197,7 @@ class TestAdminPorts(object):
         self.cli.register("admin", AdminControl, "TEST")
         self.args = ["admin", "ports"]
 
-    def teardown_method(self, tmpdir):
+    def teardown_method(self):
         # Restore backups
         for key in self.cfg_files.keys():
             if self.tmp_cfg_files[key] is not None:

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -242,7 +242,7 @@ class TestAdminPorts(object):
             assert client_endpoints in s
 
     @pytest.mark.parametrize('prefix', [None, 1, 2])
-    def testPrefix(self, prefix):
+    def testRevert(self, prefix):
         kwargs = {}
         if prefix:
             self.args += ['--prefix', '%s' % prefix]
@@ -264,12 +264,16 @@ class TestAdminPorts(object):
         self.check_config_xml()
         self.check_default_xml()
 
+    @pytest.mark.parametrize('prefix', [None, 1])
     @pytest.mark.parametrize('registry', [None, 111])
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
     @pytest.mark.parametrize('webserver', [None, 444])
-    def testSSL(self, registry, ssl, tcp, webserver):
+    def testSSL(self, registry, ssl, tcp, webserver, prefix):
         kwargs = {}
+        if prefix:
+            self.args += ['--prefix', '%s' % prefix]
+            kwargs['prefix'] = prefix
         if registry:
             self.args += ['--registry', '%s' % registry]
             kwargs["registry"] = registry

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -174,6 +174,7 @@ class TestAdminPorts(object):
         ctxdir = path() / ".." / ".." / ".." / "dist"
         etc_dir = ctxdir / "etc"
 
+        # List configuration files to backup
         self.cfg_files = {}
         for f in ['internal.cfg', 'master.cfg', 'ice.config']:
             self.cfg_files[f] = etc_dir / f
@@ -184,11 +185,8 @@ class TestAdminPorts(object):
         tmp_dir = create_path(folder=True)
         self.tmp_cfg_files = {}
         for key in self.cfg_files.keys():
-            self.tmp_cfg_files[key] = tmp_dir / key
-
-        # Create backups
-        for key in self.cfg_files.keys():
             if self.cfg_files[key].exists():
+                self.tmp_cfg_files[key] = tmp_dir / key
                 self.cfg_files[key].copy(self.tmp_cfg_files[key])
             else:
                 self.tmp_cfg_files[key] = None

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -264,7 +264,8 @@ class TestAdminPorts(object):
     @pytest.mark.parametrize('registry', [None, 111])
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
-    def testSSL(self, registry, ssl, tcp):
+    @pytest.mark.parametrize('webserver', [None, 444])
+    def testSSL(self, registry, ssl, tcp, webserver):
         kwargs = {}
         if registry:
             self.args += ['--registry', '%s' % registry]
@@ -275,6 +276,9 @@ class TestAdminPorts(object):
         if ssl:
             self.args += ['--ssl', '%s' % ssl]
             kwargs["ssl"] = ssl
+        if webserver:
+            self.args += ['--webserver', '%s' % webserver]
+            kwargs["webserver"] = webserver
         self.args += ['--skipcheck']
         self.cli.invoke(self.args, strict=True)
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -177,7 +177,7 @@ class TestAdminPorts(object):
         self.cfg_files = {}
         for f in ['internal.cfg', 'master.cfg', 'ice.config']:
             self.cfg_files[f] = etc_dir / f
-        for f in ['windefault.xml', 'windefault.xml', 'config.xml']:
+        for f in ['windefault.xml', 'default.xml', 'config.xml']:
             self.cfg_files[f] = etc_dir / 'grid' / f
 
         # Create temp files for backup
@@ -223,6 +223,20 @@ class TestAdminPorts(object):
             assert serverport_property not in config_text
             assert serverlist_property not in config_text
 
+    def check_default_xml(self, prefix=''):
+        routerport = ('<variable name="ROUTERPORT"    value="%s4064"/>'
+                      % prefix)
+        insecure_routerport = (
+            '<variable name="INSECUREROUTER" value="OMERO.Glacier2'
+            '/router:tcp -p %s4063 -h @omero.host@"/>' % prefix)
+        client_endpoints = ('client-endpoints="ssl -p ${ROUTERPORT}:tcp'
+                            ' -p %s4063"' % prefix)
+        for key in ['default.xml', 'windefault.xml']:
+            s = self.cfg_files[key].text()
+            assert routerport in s
+            assert insecure_routerport in s
+            assert client_endpoints in s
+
     @pytest.mark.parametrize('prefix', [1, 2])
     def testPorts(self, prefix):
         self.args += ['--prefix', '%s' % prefix]
@@ -234,6 +248,7 @@ class TestAdminPorts(object):
         assert "-p %s4061" % prefix in self.cfg_files["master.cfg"].text()
         assert "-p %s4061" % prefix in self.cfg_files["internal.cfg"].text()
         self.check_config_xml(prefix)
+        self.check_default_xml(prefix)
 
         # Check revert argument
         self.args += ['--revert']
@@ -243,3 +258,4 @@ class TestAdminPorts(object):
         assert "-p 4061" in self.cfg_files["master.cfg"].text()
         assert "-p 4061" in self.cfg_files["internal.cfg"].text()
         self.check_config_xml()
+        self.check_default_xml()

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -225,13 +225,13 @@ class TestAdminPorts(object):
         assert serverlist_property in config_text
 
     def check_default_xml(self, prefix=''):
-        routerport = ('<variable name="ROUTERPORT"    value="%s4064"/>'
-                      % prefix)
+        routerport = (
+            '<variable name="ROUTERPORT"    value="%s4064"/>' % prefix)
         insecure_routerport = (
             '<variable name="INSECUREROUTER" value="OMERO.Glacier2'
             '/router:tcp -p %s4063 -h @omero.host@"/>' % prefix)
-        client_endpoints = ('client-endpoints="ssl -p ${ROUTERPORT}:tcp'
-                            ' -p %s4063"' % prefix)
+        client_endpoints = (
+            'client-endpoints="ssl -p ${ROUTERPORT}:tcp -p %s4063"' % prefix)
         for key in ['default.xml', 'windefault.xml']:
             s = self.cfg_files[key].text()
             assert routerport in s

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -189,7 +189,10 @@ class TestAdminPorts(object):
         self.ice_config.copy(self.tmp_ice_config)
         self.internal_cfg.copy(self.tmp_internal_cfg)
         self.master_cfg.copy(self.tmp_master_cfg)
-        self.config_xml.copy(self.tmp_config_xml)
+        if self.config_xml.exists():
+            self.config_xml.copy(self.tmp_config_xml)
+        else:
+            self.tmp_config_xml = None
 
         # Other setup
         self.cli = CLI()
@@ -202,7 +205,8 @@ class TestAdminPorts(object):
         self.tmp_ice_config.copy(self.ice_config)
         self.tmp_internal_cfg.copy(self.internal_cfg)
         self.tmp_master_cfg.copy(self.master_cfg)
-        self.tmp_config_xml.copy(self.config_xml)
+        if self.tmp_config_xml:
+            self.config_xml.remove()
 
     def check_config_xml(self, prefix=None):
         config_text = self.config_xml.text()

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -207,7 +207,12 @@ class TestAdminPorts(object):
             else:
                 self.cfg_files[key].remove()
 
-    def check_config_xml(self, prefix=None):
+    def check_cfg(self, prefix=''):
+        for key in ['master.cfg', 'internal.cfg']:
+            s = self.cfg_files[key].text()
+            assert 'tcp -h 127.0.0.1 -p %s4061' % prefix in s
+
+    def check_config_xml(self, prefix=''):
         config_text = self.cfg_files["config.xml"].text()
         serverport_property = (
             '<property name="omero.web.application_server.port"'
@@ -216,12 +221,8 @@ class TestAdminPorts(object):
             '<property name="omero.web.server_list"'
             ' value="[[&quot;localhost&quot;, %s4064, &quot;omero&quot;]]"'
             ) % prefix
-        if prefix:
-            assert serverport_property in config_text
-            assert serverlist_property in config_text
-        else:
-            assert serverport_property not in config_text
-            assert serverlist_property not in config_text
+        assert serverport_property in config_text
+        assert serverlist_property in config_text
 
     def check_default_xml(self, prefix=''):
         routerport = ('<variable name="ROUTERPORT"    value="%s4064"/>'
@@ -245,8 +246,7 @@ class TestAdminPorts(object):
 
         assert self.cfg_files["ice.config"].text().endswith(
             "omero.port=%s4064\n" % prefix)
-        assert "-p %s4061" % prefix in self.cfg_files["master.cfg"].text()
-        assert "-p %s4061" % prefix in self.cfg_files["internal.cfg"].text()
+        self.check_cfg(prefix)
         self.check_config_xml(prefix)
         self.check_default_xml(prefix)
 
@@ -255,7 +255,6 @@ class TestAdminPorts(object):
         self.cli.invoke(self.args, strict=True)
         assert not self.cfg_files["ice.config"].text().endswith(
             "omero.port=%s4064\n" % prefix)
-        assert "-p 4061" in self.cfg_files["master.cfg"].text()
-        assert "-p 4061" in self.cfg_files["internal.cfg"].text()
+        self.check_cfg()
         self.check_config_xml()
         self.check_default_xml()

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -241,16 +241,19 @@ class TestAdminPorts(object):
             assert insecure_routerport in s
             assert client_endpoints in s
 
-    @pytest.mark.parametrize('prefix', [1, 2])
+    @pytest.mark.parametrize('prefix', [None, 1, 2])
     def testPrefix(self, prefix):
-        self.args += ['--prefix', '%s' % prefix]
+        kwargs = {}
+        if prefix:
+            self.args += ['--prefix', '%s' % prefix]
+            kwargs['prefix'] = prefix
         self.args += ['--skipcheck']
         self.cli.invoke(self.args, strict=True)
 
-        self.check_ice_config(prefix)
-        self.check_cfg(prefix)
-        self.check_config_xml(prefix)
-        self.check_default_xml(prefix)
+        self.check_ice_config(**kwargs)
+        self.check_cfg(**kwargs)
+        self.check_config_xml(**kwargs)
+        self.check_default_xml(**kwargs)
 
         # Check revert argument
         self.args += ['--revert']

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -269,7 +269,7 @@ class TestAdminPorts(object):
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
     @pytest.mark.parametrize('webserver', [None, 444])
-    def testSSL(self, registry, ssl, tcp, webserver, prefix):
+    def testExplicitPorts(self, registry, ssl, tcp, webserver, prefix):
         kwargs = {}
         if prefix:
             self.args += ['--prefix', '%s' % prefix]

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -239,4 +239,3 @@ class TestAdminPorts(object):
         assert "-p 4061" in self.master_cfg.text()
         assert "-p 4061" in self.internal_cfg.text()
         self.check_config_xml()
-


### PR DESCRIPTION
https://trello.com/c/ROD6R0L7/180-omero-web-custom-prefix

`omero admin ports --prefix N` now prefixes `omero.web.application_server.port` (`N4080`) in addition to the standard server ports by modifying `config.xml`. It also sets the port in `omero.web.server_list`.

Note: Updated with unit tests from @sbesson 

--no-rebase