### PR TITLE
Insight progress bar fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
@@ -680,7 +680,7 @@ class BrowserModel
 		//to do with updates
 	    ImageFinder finder = new ImageFinder();
 	    accept(finder, ImageDisplayVisitor.ALL_NODES);
-	    return finder.getVisibleImageNodes();
+	    return new ArrayList<ImageNode>(finder.getVisibleImageNodes());
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
@@ -68,7 +68,7 @@ public class ImageFinder
     private Set<DataObject>		images;
     
     /** Set of <code>ImageNode</code>s */
-    private List<ImageNode>		visibleImageNodes;
+    private Set<ImageNode>		visibleImageNodes;
     
     /** Set of corresponding visible <code>DataObject</code>s */
     private Set<DataObject>		visibleImages;
@@ -79,7 +79,7 @@ public class ImageFinder
     	 images = new HashSet<DataObject>();
          imageNodes = new HashSet<ImageDisplay>();
          visibleImages = new HashSet<DataObject>();
-         visibleImageNodes = new ArrayList<ImageNode>();
+         visibleImageNodes = new HashSet<ImageNode>();
     }
    
     /** 
@@ -101,7 +101,7 @@ public class ImageFinder
      * 
      * @return See above.
      */
-    public List<ImageNode> getVisibleImageNodes()
+    public Set<ImageNode> getVisibleImageNodes()
     { 
     	return visibleImageNodes; 
     }


### PR DESCRIPTION
Fixes a bug introduced with PR #3320 , see also [Ticket 12699](http://trac.openmicroscopy.org.uk/ome/ticket/12699)
Test: Open a Dataset with several Images (or a Plate with several Wells), check that the progress bar (status bar in central panel) progresses up to 100% and then disappears again. (Before: Progressbar stopped at 50%).
