### PR TITLE
Enable eager fetching of maps

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -408,7 +408,7 @@ implements java.io.Serializable, IObject
         this.${prop.name} = map;
     }
 
-    @javax.persistence.ElementCollection
+    @javax.persistence.ElementCollection(fetch = javax.persistence.FetchType.EAGER)
     @javax.persistence.OrderColumn(name="index")
     @javax.persistence.CollectionTable(name="${type.tableName()}_${prop.name}",
         joinColumns = @javax.persistence.JoinColumn(name="${type.tableName()}_id"))


### PR DESCRIPTION
Since the MapField properties are of little use
if the map itself has not been loaded, they are
now actively loaded. Queries need not include a
"left outer join fetch" clause.

Testing:
 * integration tests should be green.
 * some of @dominikl's work should pass **without** gh-3325