### PR TITLE
Omero reader update : Open OMERO ROIs in ImageJ

### DIFF
--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -382,15 +382,17 @@ public class OmeroReader extends FormatReader {
 
             MetadataStore store = getMetadataStore();
             //Load ROIs to the img -->
-            RoiResult r = gateway.getRoiService().findByImage(iid, new RoiOptions());
-            if (r == null) return;
-            List<Roi> rois = r.rois;
+            RoiOptions options = new RoiOptions();
+            options.userId = omero.rtypes.rlong(serviceFactory.getAdminService().getEventContext().userId);
+            RoiResult r = serviceFactory.getRoiService().findByImage(img.getId().getValue(), new RoiOptions());
+            if (r != null){
+                List<Roi> rois = r.rois;
 
-            int n = rois.size();
-            if (n>0){
-                saveOmeroRoiToMetadataStore(rois,store);
+                int n = rois.size();
+                if (n != 0){
+                    saveOmeroRoiToMetadataStore(rois,store);
+                }
             }
-
             MetadataTools.populatePixels(store, this);
             store.setImageName(name, 0);
             store.setImageDescription(description, 0);

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -44,6 +44,7 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+import loci.plugins.util.ROIHandler;
 import ome.xml.model.primitives.Timestamp;
 import omero.RString;
 import omero.RTime;
@@ -51,6 +52,8 @@ import omero.ServerError;
 import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.RawPixelsStorePrx;
+import omero.api.RoiOptions;
+import omero.api.RoiResult;
 import omero.api.ServiceFactoryPrx;
 import omero.model.Channel;
 import omero.model.Experimenter;
@@ -61,6 +64,7 @@ import omero.model.Image;
 import omero.model.Length;
 import omero.model.LogicalChannel;
 import omero.model.Pixels;
+import omero.model.Roi;
 import omero.model.Time;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
@@ -372,6 +376,16 @@ public class OmeroReader extends FormatReader {
       RTime date = img.getAcquisitionDate();
 
       MetadataStore store = getMetadataStore();
+      //Load ROIs to the img -->
+      RoiResult r = gateway.getRoiService().findByImage(iid, new RoiOptions());
+      if (r == null) return;
+      List<Roi> rois = r.rois;
+
+      int n = rois.size();
+      if (n>0){
+        ROIHandler.saveOmeroRoiToMetadataStore(rois,store);
+      }
+
       MetadataTools.populatePixels(store, this);
       store.setImageName(name, 0);
       store.setImageDescription(description, 0);

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -47,6 +47,11 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+import ome.formats.model.UnitsFactory;
+import ome.model.units.Unit;
+import ome.units.UNITS;
+import ome.xml.model.enums.FontStyle;
+import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.Timestamp;
 import omero.RString;
 import omero.RTime;
@@ -66,6 +71,7 @@ import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Label;
 import omero.model.Length;
+import omero.model.LengthI;
 import omero.model.LineI;
 import omero.model.LogicalChannel;
 import omero.model.Pixels;
@@ -76,6 +82,7 @@ import omero.model.RectI;
 import omero.model.Roi;
 import omero.model.Shape;
 import omero.model.Time;
+import omero.model.enums.UnitsLength;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import Glacier2.CannotCreateSessionException;
@@ -437,6 +444,7 @@ public class OmeroReader extends FormatReader {
                 }
             }
 
+            //            store.setImageID("omero:iid=", (int) img.getId().getValue());
             //Load ROIs to the img -->
             RoiOptions options = new RoiOptions();
             options.userId = omero.rtypes.rlong(serviceFactory.getAdminService().getEventContext().userId);
@@ -508,7 +516,7 @@ public class OmeroReader extends FormatReader {
 
     public static void saveOmeroRoiToMetadataStore(List<omero.model.Roi> rois,
             MetadataStore store) {
-        
+
         int n = rois.size();
 
         for (int thisROI=0  ; thisROI<n ; thisROI++){
@@ -553,20 +561,37 @@ public class OmeroReader extends FormatReader {
 
     private static void storeOmeroLabel(Shape shape, MetadataStore store,
             int roiNum, int shapeNum) {
-        
+
         Label shape1 = (Label) shape;
 
         String polylineID = MetadataTools.createLSID("Shape", roiNum, shapeNum);
         store.setLabelID(polylineID, roiNum, shapeNum);
-        store.setLabelText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        if (shape1.getTextValue() != null){
+            store.setLabelText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        }
         store.setLabelX(shape1.getX().getValue(), roiNum, shapeNum);
         store.setLabelY(shape1.getY().getValue(), roiNum, shapeNum);
+
+        if (shape1.getStrokeWidth() != null) {
+            store.setLabelStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeColor() != null){
+            store.setLabelStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+        }
+        if (shape1.getFillColor() != null){
+            store.setLabelFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+        }
+
+        if (shape1.getFontSize() != null){
+            ome.units.quantity.Length labelSize = new ome.units.quantity.Length(shape1.getFontSize().getValue(), UNITS.PIXEL);
+            store.setLabelFontSize(labelSize , roiNum, shapeNum);
+        }
 
     }
 
     private static void storeOmeroRect(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
-        
+
         RectI shape1 = (RectI) shape;
 
         double x1 = shape1.getX().getValue();
@@ -580,12 +605,24 @@ public class OmeroReader extends FormatReader {
         store.setRectangleY(y1, roiNum, shapeNum);
         store.setRectangleWidth(width, roiNum, shapeNum);
         store.setRectangleHeight(height, roiNum, shapeNum);
+        if (shape1.getTextValue() != null){
+            store.setRectangleText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeWidth() != null) {
+            store.setRectangleStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeColor() != null){
+            store.setRectangleStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+        }
+        if (shape1.getFillColor() != null){
+            store.setRectangleFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+        }
 
     }
 
     private static void storeOmeroEllipse(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
-        
+
         EllipseI shape1 = (EllipseI) shape;
 
         double x1 = shape1.getCx().getValue();
@@ -600,11 +637,24 @@ public class OmeroReader extends FormatReader {
         store.setEllipseRadiusX(width, roiNum, shapeNum);
         store.setEllipseRadiusY(height, roiNum, shapeNum);
 
+        if (shape1.getTextValue() != null){
+            store.setEllipseText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeWidth() != null) {
+            store.setEllipseStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeColor() != null){
+            store.setEllipseStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+        }
+        if (shape1.getFillColor() != null){
+            store.setEllipseFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+        }
+
     }
 
     private static void storeOmeroPoint(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
-        
+
         PointI shape1 = (PointI) shape;
         double ox1 = shape1.getCx().getValue();
         double oy1 = shape1.getCy().getValue();
@@ -614,11 +664,24 @@ public class OmeroReader extends FormatReader {
         store.setPointX(ox1, roiNum, shapeNum);
         store.setPointY(oy1, roiNum, shapeNum);
 
+        if (shape1.getTextValue() != null){
+            store.setPointText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeWidth() != null) {
+            store.setPointStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeColor() != null){
+            store.setPointStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+        }
+        if (shape1.getFillColor() != null){
+            store.setPointFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+        }
+
     }
 
     private static void storeOmeroLine(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
-        
+
         LineI shape1 = (LineI) shape;
         double x1 = shape1.getX1().getValue();
         double y1 = shape1.getY1().getValue();
@@ -632,6 +695,21 @@ public class OmeroReader extends FormatReader {
         store.setLineX2(new Double(x2), roiNum, shapeNum);
         store.setLineY1(new Double(y1), roiNum, shapeNum);
         store.setLineY2(new Double(y2), roiNum, shapeNum);
+
+        if (shape1.getTextValue() != null){
+            store.setLineText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeWidth() != null) {
+            UnitsLength cc = UnitsFactory.Shape_StrokeWidth;
+            store.setLineStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+        }
+        if (shape1.getStrokeColor() != null){
+            store.setLineStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+        }
+        if (shape1.getFillColor() != null){
+            store.setLineFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+        }
+
 
     }
 
@@ -648,6 +726,18 @@ public class OmeroReader extends FormatReader {
 
             store.setPolygonID(polylineID, roiNum, shapeNum);
             store.setPolygonPoints(points2d, roiNum, shapeNum);
+            if (shape1.getTextValue() != null){
+                store.setPolygonText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+            }
+            if (shape1.getStrokeWidth() != null) {
+                store.setPolygonStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+            }
+            if (shape1.getStrokeColor() != null){
+                store.setPolygonStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+            }
+            if (shape1.getFillColor() != null){
+                store.setPolygonFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+            }
         }else{
             PolylineI shape1 = (PolylineI) shape;
             points = shape1.getPoints().getValue();
@@ -655,6 +745,19 @@ public class OmeroReader extends FormatReader {
 
             store.setPolylineID(polylineID, roiNum, shapeNum);
             store.setPolylinePoints(points2d, roiNum, shapeNum);
+
+            if (shape1.getTextValue() != null){
+                store.setPolylineText(shape1.getTextValue().getValue(), roiNum, shapeNum);
+            }
+            if (shape1.getStrokeWidth() != null) {
+                store.setPolylineStrokeWidth(new ome.units.quantity.Length(shape1.getStrokeWidth().getValue(), UNITS.PIXEL), roiNum, shapeNum);
+            }
+            if (shape1.getStrokeColor() != null){
+                store.setPolylineStrokeColor(new ome.xml.model.primitives.Color(shape1.getStrokeColor().getValue()), roiNum, shapeNum);
+            }
+            if (shape1.getFillColor() != null){
+                store.setPolylineFillColor(new ome.xml.model.primitives.Color(shape1.getFillColor().getValue()), roiNum, shapeNum);
+            }
         }
 
     }

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -292,32 +292,19 @@ public class OmeroReader extends FormatReader {
                         !new Long(defaultGroup.getId().getValue()).equals(groupID))
                 {
                     Experimenter exp = iAdmin.getExperimenter(eventContext.userId);
+                    List<Long> groupList = iAdmin.getMemberOfGroupIds(exp);
 
-                    ParametersI p = new ParametersI();
-                    p.addId(eventContext.userId);
-                    List<IObject> groupList = iQuery.findAllByQuery(
-                            "select distinct g from ExperimenterGroup as g " +
-                                    "join fetch g.groupExperimenterMap as map " +
-                                    "join fetch map.parent e " +
-                                    "left outer join fetch map.child u " +
-                                    "left outer join fetch u.groupExperimenterMap m2 " +
-                                    "left outer join fetch m2.parent p " +
-                                    "where g.id in " +
-                                    "  (select m.parent from GroupExperimenterMap m " +
-                                    "  where m.child.id = :id )", p);
+                    Iterator<Long> i = groupList.iterator();
 
-                    Iterator<IObject> i = groupList.iterator();
-
-                    ExperimenterGroup g = null;
+                    Long g = null;
 
                     boolean in = false;
                     while (i.hasNext()) {
-                        g = (ExperimenterGroup) i.next();
-                        if (g.getName().getValue().equals(group) ||
-                                new Long(g.getId().getValue()).equals(groupID))
+                        g = i.next();
+                        if (g.equals(groupID))
                         {
                             in = true;
-                            groupID = g.getId().getValue();
+                            groupID = g;
                             break;
                         }
                     }

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -502,7 +502,7 @@ public class OmeroReader extends FormatReader {
         }
         omeroReader.close();
     }
-
+    /** Converts omero.model.Roi to ome.xml.model.* and updates the MetadataStore */
     public static void saveOmeroRoiToMetadataStore(List<omero.model.Roi> rois,
             MetadataStore store) {
 
@@ -547,7 +547,7 @@ public class OmeroReader extends FormatReader {
 
     }
 
-
+    /** Converts omero.model.Shape (omero.model.Label in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroLabel(Shape shape, MetadataStore store,
             int roiNum, int shapeNum) {
 
@@ -577,7 +577,7 @@ public class OmeroReader extends FormatReader {
         }
 
     }
-
+    /** Converts omero.model.Shape (omero.model.RectI in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroRect(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
 
@@ -608,7 +608,7 @@ public class OmeroReader extends FormatReader {
         }
 
     }
-
+    /** Converts omero.model.Shape (omero.model.EllipseI in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroEllipse(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
 
@@ -640,7 +640,7 @@ public class OmeroReader extends FormatReader {
         }
 
     }
-
+    /** Converts omero.model.Shape (omero.model.PointI in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroPoint(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
 
@@ -667,7 +667,7 @@ public class OmeroReader extends FormatReader {
         }
 
     }
-
+    /** Converts omero.model.Shape (omero.model.LineI in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroLine(omero.model.Shape shape,
             MetadataStore store, int roiNum, int shapeNum) {
 
@@ -701,7 +701,7 @@ public class OmeroReader extends FormatReader {
 
 
     }
-
+    /** Converts omero.model.Shape (omero.model.PolygonI/omero.model.PolylineI in this case) to ome.xml.model.* and updates the MetadataStore */
     private static void storeOmeroPolygon(omero.model.Shape shape, MetadataStore store,
             int roiNum, int shapeNum){
 
@@ -750,7 +750,7 @@ public class OmeroReader extends FormatReader {
         }
 
     }
-
+    /** Parse Points String obtained from convertPoints and extract Coordinates as String*/
     protected static String parsePoints(String str)
     {
         String points = null;
@@ -783,7 +783,7 @@ public class OmeroReader extends FormatReader {
 
         return points.toString();
     }
-
+    /** Split Points coordinates and obtain information for the first plane alone */
     private static String convertPoints(String pts, String type)
     {
         if (pts.length() == 0) return "";

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -279,11 +279,13 @@ public class OmeroReader extends FormatReader {
                 client = client.createClient(false);
                 serviceFactory = client.getSession();
             }
-
+            
+            IAdminPrx iAdmin = serviceFactory.getAdminService();
+            IQueryPrx iQuery = serviceFactory.getQueryService();
+            EventContext eventContext = iAdmin.getEventContext();
+            
             if (group != null || groupID != null) {
-                IAdminPrx iAdmin = serviceFactory.getAdminService();
-                IQueryPrx iQuery = serviceFactory.getQueryService();
-                EventContext eventContext = iAdmin.getEventContext();
+
                 ExperimenterGroup defaultGroup =
                         iAdmin.getDefaultGroup(eventContext.userId);
                 if (!defaultGroup.getName().getValue().equals(group) &&
@@ -447,7 +449,7 @@ public class OmeroReader extends FormatReader {
             //            store.setImageID("omero:iid=", (int) img.getId().getValue());
             //Load ROIs to the img -->
             RoiOptions options = new RoiOptions();
-            options.userId = omero.rtypes.rlong(serviceFactory.getAdminService().getEventContext().userId);
+            options.userId = omero.rtypes.rlong(iAdmin.getEventContext().userId);
             RoiResult r = serviceFactory.getRoiService().findByImage(img.getId().getValue(), new RoiOptions());
             if (r != null){
                 List<Roi> rois = r.rois;


### PR DESCRIPTION
To Test:

1) Open Insight : Add roi's to an existing OMERO image and save (All kinds of ROI's).
2) Now close Insight, and download/setup the Insight-IJ plugin, open the same OMERO image on ImageJ using this plugin.
3) Please check the "Display ROIs","Display OME-XML metadata" and "Display Metadata" checkbox's in the Bio-Formats Import options and press OK.
4) This should now open the IMAGE from OMERO in ImageJ. And the ROI's should be loaded onto the ImageJ ROI Manager.


NOTE: The label text ROI's will be displayed in the metadata, but the support for displaying the same in the ImageJ ROIManager will be done via a separate PR.