### PR TITLE
Don't use Decimal for percent_fraction formatting

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -3,7 +3,7 @@
 # 
 # 
 # 
-# Copyright (c) 2008-2011 University of Dundee.
+# Copyright (c) 2008-2015 University of Dundee.
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,7 @@ from custom_forms import MetadataModelChoiceField, \
 from omeroweb.webadmin.custom_forms import ExperimenterModelChoiceField, \
                         ExperimenterModelMultipleChoiceField, \
                         GroupModelMultipleChoiceField, GroupModelChoiceField
+from omeroweb.webclient.webclient_utils import formatPercentFraction
 
 logger = logging.getLogger(__name__)
 
@@ -361,16 +362,10 @@ class MetadataChannelForm(forms.Form):
         # ndFilter
         try:
             if logicalCh is not None and logicalCh.ndFilter is not None:
-                ndValue = logicalCh.ndFilter * 100
-                # Format E.g. 50, 10, 0.5
-                if ndValue < 1:
-                    ndValue = "%.1f" % round(ndValue, 1)
-                else:
-                    ndValue = "%2d" % round(ndValue)
                 self.fields['ndFilter'] = forms.CharField(
                     max_length=100,
                     widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(logicalCh.id)+', \'name\', this.value);'}),
-                    initial=ndValue,
+                    initial=formatPercentFraction(logicalCh.ndFilter),
                     label="ND filter (%)",
                     required=False)
             else:
@@ -1969,16 +1964,10 @@ class MetadataLightSourceForm(forms.Form):
         
         # Attenuation
         if lightSourceSettings is not None and lightSourceSettings.attenuation is not None:
-            lsAttn = lightSourceSettings.attenuation * 100
-            # Format E.g. 50, 10, 0.5
-            if lsAttn < 1:
-                lsAttn = "%.1f" % round(lsAttn, 1)
-            else:
-                lsAttn = "%2d" % round(lsAttn)
             self.fields['attenuation'] = forms.CharField(
                 max_length=100,
                 widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(lightSourceSettings.id)+', \'attenuation\', this.value);'}),
-                initial=lsAttn,
+                initial=formatPercentFraction(lightSourceSettings.attenuation),
                 label="Attenuation (%)",
                 required=False)
         else:

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -40,12 +40,8 @@ from omeroweb.webadmin.custom_forms import ExperimenterModelChoiceField, \
                         ExperimenterModelMultipleChoiceField, \
                         GroupModelMultipleChoiceField, GroupModelChoiceField
 
-from decimal import Decimal, getcontext
-
 logger = logging.getLogger(__name__)
 
-# Set precision for decimal display
-getcontext().prec = 2
              
 ##################################################################
 # Static values
@@ -366,9 +362,11 @@ class MetadataChannelForm(forms.Form):
         try:
             if logicalCh is not None and logicalCh.ndFilter is not None:
                 ndValue = logicalCh.ndFilter * 100
-                if ndValue != 100:
-                    # doing division uses the precision set with getcontext() above
-                    ndValue = Decimal(str(ndValue))/1       # str() required for floats in python 2.6
+                # Format E.g. 50, 10, 0.5
+                if ndValue < 1:
+                    ndValue = "%.1f" % round(ndValue, 1)
+                else:
+                    ndValue = "%2d" % round(ndValue)
                 self.fields['ndFilter'] = forms.CharField(
                     max_length=100,
                     widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(logicalCh.id)+', \'name\', this.value);'}),
@@ -1972,9 +1970,11 @@ class MetadataLightSourceForm(forms.Form):
         # Attenuation
         if lightSourceSettings is not None and lightSourceSettings.attenuation is not None:
             lsAttn = lightSourceSettings.attenuation * 100
-            if lsAttn != 100:
-                # doing division uses the precision set with getcontext() above
-                lsAttn = Decimal(str(lsAttn))/1      # str() required for floats in python 2.6
+            # Format E.g. 50, 10, 0.5
+            if lsAttn < 1:
+                lsAttn = "%.1f" % round(lsAttn, 1)
+            else:
+                lsAttn = "%2d" % round(lsAttn)
             self.fields['attenuation'] = forms.CharField(
                 max_length=100,
                 widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(lightSourceSettings.id)+', \'attenuation\', this.value);'}),

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -1220,7 +1220,8 @@ class MetadataFilterForm(forms.Form):
                 self.fields['transmittance'] = forms.CharField(
                     max_length=100,
                     widget=forms.TextInput(attrs={'size':25, 'onchange':'javascript:saveMetadata('+str(kwargs['initial']['filter'].id)+', \'transmittance\', this.value);'}),
-                    initial=kwargs['initial']['filter'].getTransmittanceRange().transmittance,
+                    initial=formatPercentFraction(kwargs['initial']['filter'].getTransmittanceRange().transmittance),
+                    label="Transmittance (%)",
                     required=False)
             else:
                 self.fields['transmittance'] = forms.CharField(

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -1977,8 +1977,8 @@ class MetadataLightSourceForm(forms.Form):
                 widget=forms.TextInput(attrs={'size':25}),
                 initial="N/A",
                 required=False)
-            self.fields['attenuation'].widget.attrs['disabled'] = True
-            self.fields['attenuation'].widget.attrs['class'] = 'disabled-metadata'
+        self.fields['attenuation'].widget.attrs['disabled'] = True
+        self.fields['attenuation'].widget.attrs['class'] = 'disabled-metadata'
 
         self.fields.keyOrder = ['manufacturer', 'model', 'serialNumber', 'lotNumber', 'power', 'lstype', 'pump', 'lmedium', 'wavelength', 'frequencyMultiplication', 'tuneable', 'pulse' , 'repetitionRate', 'pockelCell', 'attenuation']
     

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_utils.py
@@ -23,6 +23,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+def formatPercentFraction(value):
+    """ Formats a fraction as a percentage for display """
+    value = value * 100
+    if value < 1:
+        value = "%.1f" % round(value, 1)
+    else:
+        value = "%s" % int(round(value))
+    return value
+
 def _formatReport(callback):
     """
     Added as workaround to the changes made in #3006.

--- a/components/tools/OmeroWeb/test/unit/test_util.py
+++ b/components/tools/OmeroWeb/test/unit/test_util.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Simple unit tests for the "webclient_utils" module.
+"""
+
+from omeroweb.webclient.webclient_utils import formatPercentFraction
+
+
+class TestUtil(object):
+    """
+    Tests various util methods
+    """
+
+    def test_format_percent_fraction(self):
+
+        assert formatPercentFraction(1) == "100"
+        assert formatPercentFraction(0.805) == "81"
+        assert formatPercentFraction(0.2) == "20"
+        assert formatPercentFraction(0.01) == "1"
+        assert formatPercentFraction(0.005) == "0.5"
+        assert formatPercentFraction(0.005) == "0.5"
+        assert formatPercentFraction(0.0025) == "0.3"
+        assert formatPercentFraction(0.00) == "0.0"


### PR DESCRIPTION
This removes the use of Decimal for formatting of percent fraction values (from #3309) for ND filter and attenuation.

Formatting should be as follows:
```
100 -> "100"
80.5 -> "81"
20 -> "20"
1.0 -> "1"
0.5 -> "0.5"
0.25 -> "0.3"
0 -> "0.0"
```