### PR TITLE
Properties cleanup

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -164,6 +164,16 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.name">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.description">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     
     <!-- End preference list -->
             </list>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -62,6 +62,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.upgrades.url">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.data.dir">
        <property name="mutable" value="true"/>
     </bean>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -158,7 +158,13 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-
+    <!--  CLIENT PROPERTIES -->
+    <bean class="ome.system.Preference" id="omero.client.scripts_to_ignore">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    
     <!-- End preference list -->
             </list>
         </property>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -174,7 +174,36 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.leaders">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.leaders.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.colleagues">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.colleagues.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.everyone">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.everyone.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/tools/OmeroPy/src/omero/gateway/utils.py
+++ b/components/tools/OmeroPy/src/omero/gateway/utils.py
@@ -177,13 +177,13 @@ def toBoolean(val):
 
         If the value is a boolean return the value.
         Otherwise check to see if the value is in
-        ["false", "f", "no", "n", "none", "0", "[]", "{}", "" ]
-        and returns True if value is not in the list
+        ["true", "yes", "y", "t", "1"]
+        and returns True if value is in the list
     """
 
     if val is True or val is False:
         return val
 
-    falseItems = ["false", "f", "no", "n", "none", "0", "[]", "{}", ""]
+    trueItems = ["true", "yes", "y", "t", "1"]
 
-    return not str(val).strip().lower() in falseItems
+    return str(val).strip().lower() in trueItems

--- a/components/tools/OmeroPy/src/omero/gateway/utils.py
+++ b/components/tools/OmeroPy/src/omero/gateway/utils.py
@@ -169,3 +169,21 @@ class ServiceOptsDict(dict):
              isinstance(item, float)):
             return True
         return False
+
+
+def toBoolean(val):
+    """
+    Get the boolean value of the provided input.
+
+        If the value is a boolean return the value.
+        Otherwise check to see if the value is in
+        ["false", "f", "no", "n", "none", "0", "[]", "{}", "" ]
+        and returns True if value is not in the list
+    """
+
+    if val is True or val is False:
+        return val
+
+    falseItems = ["false", "f", "no", "n", "none", "0", "[]", "{}", ""]
+
+    return not str(val).strip().lower() in falseItems

--- a/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
+++ b/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
@@ -232,6 +232,8 @@ class TestHelpers (object):
     def test_toBoolean_true(self, true_val):
         assert toBoolean(true_val)
 
-    @pytest.mark.parametrize('false_val', [False, "false", "f", "no", "n", "none", "0", "[]", "{}", "" ])
+    @pytest.mark.parametrize(
+        'false_val',
+        [False, "false", "f", "no", "n", "none", "0", "[]", "{}", ""])
     def test_toBoolean_false(self, false_val):
         assert not toBoolean(false_val)

--- a/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
+++ b/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
@@ -10,6 +10,7 @@
 """
 
 from omero.gateway.utils import ServiceOptsDict
+from omero.gateway.utils import toBoolean
 import pytest
 
 
@@ -223,3 +224,15 @@ class TestServiceOptsDict (object):
 
         d.setOmeroShare(share)
         assert d.get("omero.share") == d.getOmeroShare()
+
+
+class TestHelpers (object):
+
+    def test_toBoolean(self):
+        true_val = ["true", "yes", "y", "t", "1"]
+        false_val = ["false", "f", "no", "n", "none", "0", "[]", "{}", "" ]
+
+        for v in true_val:
+            assert toBoolean(v)
+        for v in false_val:
+            assert not toBoolean(v)

--- a/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
+++ b/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
@@ -228,11 +228,10 @@ class TestServiceOptsDict (object):
 
 class TestHelpers (object):
 
-    def test_toBoolean(self):
-        true_val = ["true", "yes", "y", "t", "1"]
-        false_val = ["false", "f", "no", "n", "none", "0", "[]", "{}", "" ]
+    @pytest.mark.parametrize('true_val', [True, "true", "yes", "y", "t", "1"])
+    def test_toBoolean_true(self, true_val):
+        assert toBoolean(true_val)
 
-        for v in true_val:
-            assert toBoolean(v)
-        for v in false_val:
-            assert not toBoolean(v)
+    @pytest.mark.parametrize('false_val', [False, "false", "f", "no", "n", "none", "0", "[]", "{}", "" ])
+    def test_toBoolean_false(self, false_val):
+        assert not toBoolean(false_val)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -592,17 +592,6 @@ CUSTOM_SETTINGS_MAPPINGS = {
          leave_none_unset_int,
          ("Configuration options for the viewer. -1: zoom in fully,"
           " 0: zoom out fully, unset: zoom to fit window")],
-    "omero.web.scripts_to_ignore":
-        ["SCRIPTS_TO_IGNORE",
-         ('["/omero/figure_scripts/Movie_Figure.py", '
-          '"/omero/figure_scripts/Split_View_Figure.py", '
-          '"/omero/figure_scripts/Thumbnail_Figure.py", '
-          '"/omero/figure_scripts/ROI_Split_Figure.py", '
-          ' "/omero/export_scripts/Make_Movie.py",'
-          '"/omero/setup_scripts/FLIM_initialise.py", '
-          '"/omero/import_scripts/Populate_ROI.py"]'),
-         parse_paths,
-         None],
 
 }
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -606,14 +606,6 @@ DEVELOPMENT_SETTINGS_MAPPINGS = {
     # "DESCRIPTION":"This is a virtual container with orphaned images. These
     # images are not linked anywhere. Just drag them to the selected
     # container."}'
-    "omero.web.ui.tree.orphaned":
-        ["UI_TREE_ORPHANED",
-         ('{"NAME":"Orphaned images",'
-          ' "DESCRIPTION":"This is a virtual container with orphaned images.'
-          ' These images are not linked anywhere. Just drag them to the'
-          ' selected container."}'),
-         json.loads,
-         None],
     "omero.web.webstart_admins_only":
         ["WEBSTART_ADMINS_ONLY", "false", parse_boolean, None],
     "omero.web.webadmin.enable_email":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -240,8 +240,11 @@ CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 INTERNAL_SETTINGS_MAPPING = {
     "omero.qa.feedback":
         ["FEEDBACK_URL", "http://qa.openmicroscopy.org.uk", str, None],
-    "omero.upgrades.url":
-        ["UPGRADES_URL", "http://upgrade.openmicroscopy.org.uk/", str, None],
+    "omero.upgrade-check.enabled":
+        ["UPGRADE_CHECK",
+         "true",
+         parse_boolean,
+         "A boolean that turns on/off upgrade check performed by OMERO.web."],
 
     # Allowed hosts:
     # https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -240,11 +240,8 @@ CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 INTERNAL_SETTINGS_MAPPING = {
     "omero.qa.feedback":
         ["FEEDBACK_URL", "http://qa.openmicroscopy.org.uk", str, None],
-    "omero.web.upgrade-check.enabled":
-        ["UPGRADE_CHECK",
-         "true",
-         parse_boolean,
-         "A boolean that turns on/off upgrade check performed by OMERO.web."],
+    "omero.web.upgrade-check.url":
+        ["UPGRADES_URL", "http://upgrade.openmicroscopy.org.uk/", str, None],
 
     # Allowed hosts:
     # https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -554,12 +554,6 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "E.g. ``'[[\"Webtest\", \"webtest_index\"], [\"Homepage\","
           " \"http://...\", {\"title\": \"Homepage\", \"target\": \"new\"}"
           " ]]'``")],
-    "omero.web.ui.menu.dropdown":
-        ["UI_MENU_DROPDOWN",
-         ('{"LEADERS": "Owners", "COLLEAGUES": "Members", '
-          '"ALL": "All members"}'),
-         json.loads,
-         "Shows/hides users in dropdown menu."],
     "omero.web.ui.right_plugins":
         ["RIGHT_PLUGINS",
          ('[["Acquisition",'

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -240,8 +240,8 @@ CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 INTERNAL_SETTINGS_MAPPING = {
     "omero.qa.feedback":
         ["FEEDBACK_URL", "http://qa.openmicroscopy.org.uk", str, None],
-    "omero.web.upgrade-check.url":
-        ["UPGRADES_URL", "http://upgrade.openmicroscopy.org.uk/", str, None],
+    "omero.web.upgrades.url":
+        ["UPGRADES_URL", None, leave_none_unset, None],
 
     # Allowed hosts:
     # https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -240,7 +240,7 @@ CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 INTERNAL_SETTINGS_MAPPING = {
     "omero.qa.feedback":
         ["FEEDBACK_URL", "http://qa.openmicroscopy.org.uk", str, None],
-    "omero.upgrade-check.enabled":
+    "omero.web.upgrade-check.enabled":
         ["UPGRADE_CHECK",
          "true",
          parse_boolean,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -49,7 +49,7 @@ from forms import ForgottonPasswordForm, ExperimenterForm, GroupForm
 from forms import GroupOwnerForm, MyAccountForm, ChangePassword
 from forms import UploadPhotoForm, EmailForm
 
-from omeroweb.webadmin.webadmin_utils import toBoolean
+from omero.gateway.utils import toBoolean
 
 from omeroweb.http import HttpJPEGResponse
 from omeroweb.webclient.decorators import login_required, render_response

--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -37,24 +37,6 @@ def upgradeCheck():
         logger.info("Upgrade check was manually disabled.\n")
 
 
-def toBoolean(val):
-    """
-    Get the boolean value of the provided input.
-
-        If the value is a boolean return the value.
-        Otherwise check to see if the value is in
-        ["false", "f", "no", "n", "none", "0", "[]", "{}", "" ]
-        and returns True if value is not in the list
-    """
-
-    if val is True or val is False:
-        return val
-
-    falseItems = ["false", "f", "no", "n", "none", "0", "[]", "{}", ""]
-
-    return not str(val).strip().lower() in falseItems
-
-
 def removeUnaddressable(experimenters):
     """
     Remove experimenters that do not have email addresses or do not pass

--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -21,20 +21,17 @@ def upgradeCheck():
     # For more information, see
     # http://trac.openmicroscopy.org.uk/ome/wiki/UpgradeCheck
     #
-    if settings.UPGRADE_CHECK:
-        try:
-            check = UpgradeCheck("web")
-            check.run()
-            if check.isUpgradeNeeded():
-                logger.error(
-                    "Upgrade is available. Please visit"
-                    " http://downloads.openmicroscopy.org/latest/omero/.\n")
-            else:
-                logger.debug("Up to date.\n")
-        except Exception, x:
-            logger.error("Upgrade check error: %s" % x)
-    else:
-        logger.info("Upgrade check was manually disabled.\n")
+    try:
+        check = UpgradeCheck("web", url=settings.UPGRADES_URL)
+        check.run()
+        if check.isUpgradeNeeded():
+            logger.error(
+                "Upgrade is available. Please visit"
+                " http://downloads.openmicroscopy.org/latest/omero/.\n")
+        else:
+            logger.debug("Up to date.\n")
+    except Exception, x:
+        logger.error("Upgrade check error: %s" % x)
 
 
 def removeUnaddressable(experimenters):

--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -3,6 +3,9 @@
 import logging
 
 from django.core.validators import validate_email
+from django.conf import settings
+
+from omero.util.upgrade_check import UpgradeCheck
 
 logger = logging.getLogger(__name__)
 
@@ -18,19 +21,20 @@ def upgradeCheck():
     # For more information, see
     # http://trac.openmicroscopy.org.uk/ome/wiki/UpgradeCheck
     #
-    try:
-        from omero.util.upgrade_check import UpgradeCheck
-        from django.conf import settings
-        check = UpgradeCheck("web", url=settings.UPGRADES_URL)
-        check.run()
-        if check.isUpgradeNeeded():
-            logger.error(
-                "Upgrade is available. Please visit"
-                " http://downloads.openmicroscopy.org/latest/omero/.\n")
-        else:
-            logger.debug("Up to date.\n")
-    except Exception, x:
-        logger.error("Upgrade check error: %s" % x)
+    if settings.UPGRADE_CHECK:
+        try:
+            check = UpgradeCheck("web")
+            check.run()
+            if check.isUpgradeNeeded():
+                logger.error(
+                    "Upgrade is available. Please visit"
+                    " http://downloads.openmicroscopy.org/latest/omero/.\n")
+            else:
+                logger.debug("Up to date.\n")
+        except Exception, x:
+            logger.error("Upgrade check error: %s" % x)
+    else:
+        logger.info("Upgrade check was manually disabled.\n")
 
 
 def toBoolean(val):

--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -3,9 +3,6 @@
 import logging
 
 from django.core.validators import validate_email
-from django.conf import settings
-
-from omero.util.upgrade_check import UpgradeCheck
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +19,8 @@ def upgradeCheck():
     # http://trac.openmicroscopy.org.uk/ome/wiki/UpgradeCheck
     #
     try:
+        from omero.util.upgrade_check import UpgradeCheck
+        from django.conf import settings
         check = UpgradeCheck("web", url=settings.UPGRADES_URL)
         check.run()
         if check.isUpgradeNeeded():

--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -7,7 +7,7 @@ from django.core.validators import validate_email
 logger = logging.getLogger(__name__)
 
 
-def upgradeCheck():
+def upgradeCheck(url):
     # upgrade check:
     # -------------
     # On each startup OMERO.web checks for possible server upgrades
@@ -20,15 +20,15 @@ def upgradeCheck():
     #
     try:
         from omero.util.upgrade_check import UpgradeCheck
-        from django.conf import settings
-        check = UpgradeCheck("web", url=settings.UPGRADES_URL)
-        check.run()
-        if check.isUpgradeNeeded():
-            logger.error(
-                "Upgrade is available. Please visit"
-                " http://downloads.openmicroscopy.org/latest/omero/.\n")
-        else:
-            logger.debug("Up to date.\n")
+        if url:
+            check = UpgradeCheck("web", url=url)
+            check.run()
+            if check.isUpgradeNeeded():
+                logger.error(
+                    "Upgrade is available. Please visit"
+                    " http://downloads.openmicroscopy.org/latest/omero/.\n")
+            else:
+                logger.debug("Up to date.\n")
     except Exception, x:
         logger.error("Upgrade check error: %s" % x)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -958,7 +958,7 @@ class BaseContainer(BaseController):
                         up_pdl = p
                         self.conn.deleteObjectDirect(up_pdl._obj)
             elif destination[0] == 'orphaned':
-                return 'Cannot move dataset to %s.' % settings.UI_TREE_ORPHANED.NAME
+                return 'Cannot move dataset to %s.' % conn.getOrphandContainerSettings()[1]
             else:
                 return 'Destination not supported.'
         elif self.image is not None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -958,7 +958,7 @@ class BaseContainer(BaseController):
                         up_pdl = p
                         self.conn.deleteObjectDirect(up_pdl._obj)
             elif destination[0] == 'orphaned':
-                return 'Cannot move dataset to %s.' % conn.getOrphandContainerSettings()[1]
+                return 'Cannot move dataset to %s.' % conn.getOrphanedContainerSettings()[1]
             else:
                 return 'Destination not supported.'
         elif self.image is not None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -115,7 +115,7 @@ class render_response(omeroweb.decorators.render_response):
         context['global_search_form'] = GlobalSearchForm()
         # UI server preferences
         context.setdefault('ui', {})   # don't overwrite existing ui
-        context['ui']['orphans_name'], context['ui']['orphans_desc'] = conn.getOrphandContainerSettings()
+        context['ui']['orphans_name'], context['ui']['orphans_desc'] = conn.getOrphanedContainerSettings()
         context['ui']['dropdown_menu'] = conn.getDropdownMenuSettings()
         
         if settings.WEBSTART and (not settings.WEBSTART_ADMINS_ONLY \

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -116,6 +116,7 @@ class render_response(omeroweb.decorators.render_response):
         # UI server preferences
         context.setdefault('ui', {})   # don't overwrite existing ui
         context['ui']['orphans_name'], context['ui']['orphans_desc'] = conn.getOrphandContainerSettings()
+        context['ui']['dropdown_menu'] = conn.getDropdownMenuSettings()
         
         if settings.WEBSTART and (not settings.WEBSTART_ADMINS_ONLY \
             or (conn.isAdmin() or (settings.WEBSTART_ADMINS_ONLY and len(list(conn.listOwnedGroups())) > 0))):

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -113,6 +113,9 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['group_id'] = request.session.get('group_id', None)
         context['ome']['active_group'] = request.session.get('active_group', conn.getEventContext().groupId)
         context['global_search_form'] = GlobalSearchForm()
+        # UI server preferences
+        context.setdefault('ui', {})   # don't overwrite existing ui
+        context['ui']['orphans_name'], context['ui']['orphans_desc'] = conn.getOrphandContainerSettings()
         
         if settings.WEBSTART and (not settings.WEBSTART_ADMINS_ONLY \
             or (conn.isAdmin() or (settings.WEBSTART_ADMINS_ONLY and len(list(conn.listOwnedGroups())) > 0))):

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
@@ -80,13 +80,13 @@
                         {% else %}
                         <a href="{% url 'change_active_group' %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1">
                         {% endifequal %}
-                            {% setting UI_MENU_DROPDOWN.ALL %}
+                        {{ ui.dropdown_menu.everyone }}
                         </a>
                     </li>
                 {% endif %}
                 
                 {% if grp.leaders %}
-                    <li class="non_selectable"><strong>{% setting UI_MENU_DROPDOWN.LEADERS %}</strong></li>
+                    <li class="non_selectable"><strong>{{ ui.dropdown_menu.leaders }}</strong></li>
                     {% for user in grp.leaders %}
                         <li {% ifequal user.id experimenter %}class="current_user"{% endifequal %}>
                             <!-- if this user is in current group, we just switch user -->
@@ -96,14 +96,14 @@
                             {% else %}
                             <a href="{% url 'change_active_group' %}?active_group={{grp.id}}&url={{ current_url }}?experimenter={{user.id}}">
                             {% endifequal %}
-                                {{ user.getFullName }}
+                            {{ user.getFullName }}
                             </a>
                         </li>
                     {% endfor %}
                 {% endif %}
                 
                 {% if grp.colleagues %}
-                    <li class="non_selectable"><strong>{% setting UI_MENU_DROPDOWN.COLLEAGUES %}</strong></li>
+                    <li class="non_selectable"><strong>{{ ui.dropdown_menu.colleagues }}</strong></li>
                     {% for user in grp.colleagues %}
                         <li {% ifequal user.id experimenter %}class="current_user"{% endifequal %}>
                             {% ifequal grp.id active_group.id %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_tree.html
@@ -23,7 +23,7 @@
 {% endcomment %}
 
 <ul>
-    <li id="experimenter-0" rel="experimenter"><a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{% setting UI_MENU_DROPDOWN.ALL %}{% endif %}</a>
+    <li id="experimenter-0" rel="experimenter"><a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{{ ui.dropdown_menu_all }}{% endif %}</a>
         {% if manager.t_size %}
         <ul>
             {% for t in manager.tags %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -26,7 +26,7 @@
 
 <ul>
     <li id="experimenter-0" rel="experimenter{% ifnotequal manager.experimenter.id ome.eventContext.userId %}-locked{% endifnotequal %}">
-        <a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{% setting UI_MENU_DROPDOWN.ALL %}{% endif %}</a>
+        <a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{{ ui.dropdown_menu.everyone }}{% endif %}</a>
         <ul>
             {% for c in projects %}
             <li id='project-{{ c.id }}' rel="project{% if not c.isOwned %}-locked{% endif %}" class="{{ c.permsCss }}">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -110,7 +110,7 @@
             {% endfor %}
             
             {% if not share %}
-            <li id='orphaned-0' rel="orphaned" {% if orphans %}class="jstree-closed"{% endif %}><a href="#">{% setting UI_TREE_ORPHANED.NAME %}</a></li>
+            <li id='orphaned-0' rel="orphaned" {% if orphans %}class="jstree-closed"{% endif %}><a href="#">{{ ui.orphans_name }}</a></li>
             {% endif %}
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -93,7 +93,7 @@ $(function () {
             if ($metadata_general.is(":visible") && $metadata_general.is(":empty")) {
                 // orphaned
                 if (oid.indexOf("orphaned")>=0) {
-                    $metadata_general.html('<div class="right_tab_inner"><p class="description">{% setting UI_TREE_ORPHANED.DESCRIPTION %}</p></div>');
+                    $metadata_general.html('<div class="right_tab_inner"><p class="description">{{ ui.orphans_desc }}</p></div>');
                     //return;
                 // experimenter
                 } else if (oid.indexOf("experimenter")>=0) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -139,8 +139,13 @@ def login(request):
                 userGroupId = conn.getAdminService().getSecurityRoles().userGroupId
                 if userGroupId in conn.getEventContext().memberOfGroups:
                     request.session['connector'] = connector
-                    upgradeCheck()
-
+                    # UpgradeCheck URL should be loaded from the server or loaded
+                    # omero.web.upgrades.url allows to customize web only
+                    try:
+                        upgrades_url = settings.UPGRADES_URL
+                    except:
+                        upgrades_url = conn.getUpgradesUrl()
+                    upgradeCheck(url=upgrades_url)
                     # if 'active_group' remains in session from previous login, check it's valid for this user
                     if request.session.get('active_group'):
                         if request.session.get('active_group') not in conn.getEventContext().memberOfGroups:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -39,6 +39,8 @@ from omero_version import omero_version
 import omero, omero.scripts
 from omero.rtypes import wrap, unwrap
 
+from omero.gateway.utils import toBoolean
+
 from django.conf import settings
 from django.template import loader as template_loader
 from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseServerError
@@ -69,7 +71,7 @@ from controller.search import BaseSearch
 from controller.share import BaseShare
 
 from omeroweb.webadmin.forms import LoginForm
-from omeroweb.webadmin.webadmin_utils import toBoolean, upgradeCheck
+from omeroweb.webadmin.webadmin_utils import upgradeCheck
 
 from omeroweb.webgateway import views as webgateway_views
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2517,12 +2517,15 @@ def list_scripts (request, conn=None, **kwargs):
 
     # group scripts into 'folders' (path), named by parent folder name
     scriptMenu = {}
+    scripts_to_ignore = conn.getConfigService() \
+                        .getConfigValue("omero.client.scripts_to_ignore") \
+                        .split(",")
     for s in scripts:
         scriptId = s.id.val
         path = s.path.val
         name = s.name.val
         fullpath = os.path.join(path, name)
-        if fullpath in settings.SCRIPTS_TO_IGNORE:
+        if fullpath in scripts_to_ignore:
             logger.info('Ignoring script %r' % fullpath)
             continue
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -62,7 +62,7 @@ from django.utils.encoding import smart_str
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 
-from omeroweb.webadmin.webadmin_utils import toBoolean
+from omero.gateway.utils import toBoolean
 
 try:
     import hashlib

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -168,6 +168,11 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
             logger.error(traceback.format_exc())
             return False
     
+    def getOrphandContainerSettings(self):
+        name = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.name") or "Orphaned image"
+        description = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.description") or "This is a virtual container with orphaned images."
+        return name, description
+
     ##############################################
     ##   IAdmin                                 ##
     

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -170,7 +170,7 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
             logger.error(traceback.format_exc())
             return False
     
-    def getOrphandContainerSettings(self):
+    def getOrphanedContainerSettings(self):
         name = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.name") or "Orphaned image"
         description = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.description") or "This is a virtual container with orphaned images."
         return name, description

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -290,6 +290,17 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
         conf = self.getConfigService()
         return conf.getConfigValue("omero.version")
 
+    def getUpgradesUrl(self):
+        """
+        Retrieves a configuration value "omero.upgrades.url" from
+        the backend store.
+        
+        @return:        String
+        """
+        
+        conf = self.getConfigService()
+        return conf.getConfigValue("omero.upgrades.url")
+
 
     #########################################################
     ##  From Bram b(dot)gerritsen(at)nki(dot)nl            ##

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -62,6 +62,8 @@ from django.utils.encoding import smart_str
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 
+from omeroweb.webadmin.webadmin_utils import toBoolean
+
 try:
     import hashlib
     hash_sha1 = hashlib.sha1
@@ -172,6 +174,19 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
         name = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.name") or "Orphaned image"
         description = self.getConfigService().getConfigValue("omero.client.ui.tree.orphans.description") or "This is a virtual container with orphaned images."
         return name, description
+
+    def getDropdownMenuSettings(self):
+        dropdown_menu = dict()
+        if toBoolean(self.getConfigService().getConfigValue("omero.client.ui.menu.dropdown.leaders.enabled")):
+            dropdown_menu["leaders"] = self.getConfigService() \
+                .getConfigValue("omero.client.ui.menu.dropdown.leaders")
+        if toBoolean(self.getConfigService().getConfigValue("omero.client.ui.menu.dropdown.colleagues.enabled")):
+            dropdown_menu["colleagues"] = self.getConfigService() \
+                 .getConfigValue("omero.client.ui.menu.dropdown.colleagues")
+        if toBoolean(self.getConfigService().getConfigValue("omero.client.ui.menu.dropdown.everyone.enabled")):
+            dropdown_menu["everyone"] = self.getConfigService() \
+                .getConfigValue("omero.client.ui.menu.dropdown.everyone")
+        return dropdown_menu
 
     ##############################################
     ##   IAdmin                                 ##
@@ -2103,16 +2118,16 @@ class ExperimenterGroupWrapper (OmeroWebObjectWrapper, omero.gateway.Experimente
         @return:    {'leaders': list L{ExperimenterWrapper}, 'colleagues': list L{ExperimenterWrapper}}
         @rtype:     dict
         """
-        
+        dropdown_menu = self._conn.getDropdownMenuSettings()
         summary = self._conn.groupSummary(self.getId())
-        if settings.UI_MENU_DROPDOWN.get("LEADERS", None):
+        if "leaders" in dropdown_menu.keys():
             self.leaders = summary["leaders"]
             self.leaders.sort(key=lambda x: x.getLastName().lower())
-        if settings.UI_MENU_DROPDOWN.get("COLLEAGUES", None):
+        if "colleagues" in dropdown_menu.keys():
             self.colleagues = summary["colleagues"]
             self.colleagues.sort(key=lambda x: x.getLastName().lower())
         # Only show 'All Members' option if configured, and we're not in a private group
-        if settings.UI_MENU_DROPDOWN.get("ALL", None):
+        if "everyone" in dropdown_menu:
             if self.details.permissions.isGroupRead() or self._conn.isAdmin() or self.isOwner():
                 self.all = True
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -641,32 +641,32 @@ omero.ldap.new_user_group=default
 ## OMERO client properties:
 #############################################
 
-## Serverside scripts used in IScript service Clients shouldn't display.
+# Serverside scripts used in IScript service Clients shouldn't display.
 omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/Split_View_Figure.py,\
 /omero/figure_scripts/Thumbnail_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
-## Name of the "Orphand images" container located in client tree data manager.
+# Name of the "Orphand images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned images
 
-## Description of the "Orphand images" container.
+# Description of the "Orphand images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
-## Client dropdown menu leader label.
+# Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners
 ## Flag to show/hides leader.
 omero.client.ui.menu.dropdown.leaders.enabled=true
 
-## Client dropdown menu colleagues label.
+# Client dropdown menu colleagues label.
 omero.client.ui.menu.dropdown.colleagues=Members
-## Flag to show/hides colleagues
+# Flag to show/hides colleagues
 omero.client.ui.menu.dropdown.colleagues.enabled=true
 
-## Client dropdown menu all users label.
+# Client dropdown menu all users label.
 omero.client.ui.menu.dropdown.everyone=All Members
-## Flag to show/hides all users.
+# Flag to show/hides all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -641,14 +641,14 @@ omero.ldap.new_user_group=default
 ## OMERO client properties:
 #############################################
 
-# Serverside scripts used in IScript service Clients shouldn't display.
+# Server-side scripts used in IScript service Clients shouldn't display.
 omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/Split_View_Figure.py,\
 /omero/figure_scripts/Thumbnail_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
-# Name of the "Orphand images" container located in client tree data manager.
+# Name of the "Orphaned images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned images
 
 # Description of the "Orphand images" container.
@@ -656,17 +656,17 @@ omero.client.ui.tree.orphans.description=This is a virtual container with orphan
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners
-## Flag to show/hides leader.
+## Flag to show/hide leader.
 omero.client.ui.menu.dropdown.leaders.enabled=true
 
 # Client dropdown menu colleagues label.
 omero.client.ui.menu.dropdown.colleagues=Members
-# Flag to show/hides colleagues
+# Flag to show/hide colleagues
 omero.client.ui.menu.dropdown.colleagues.enabled=true
 
 # Client dropdown menu all users label.
 omero.client.ui.menu.dropdown.everyone=All Members
-# Flag to show/hides all users.
+# Flag to show/hide all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -638,6 +638,17 @@ omero.ldap.new_user_group=default
 ## omero.ldap.new_user_group=:bean:myNewUserGroupMapperBean
 
 #############################################
+## OMERO client properties:
+#############################################
+
+## Serverside scripts used in IScript service Clients shouldn't display.
+omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
+/omero/figure_scripts/Split_View_Figure.py,\
+/omero/figure_scripts/Thumbnail_Figure.py,\
+/omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
+/omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
+
+#############################################
 ## Ice overrides
 ##
 ## Though not used directly by OMERO, a number

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -654,6 +654,21 @@ omero.client.ui.tree.orphans.name=Orphaned images
 ## Description of the "Orphand images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
+## Client dropdown menu leader label.
+omero.client.ui.menu.dropdown.leaders=Owners
+## Flag to show/hides leader.
+omero.client.ui.menu.dropdown.leaders.enabled=true
+
+## Client dropdown menu colleagues label.
+omero.client.ui.menu.dropdown.colleagues=Members
+## Flag to show/hides colleagues
+omero.client.ui.menu.dropdown.colleagues.enabled=true
+
+## Client dropdown menu all users label.
+omero.client.ui.menu.dropdown.everyone=All Members
+## Flag to show/hides all users.
+omero.client.ui.menu.dropdown.everyone.enabled=true
+
 #############################################
 ## Ice overrides
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -651,7 +651,7 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 # Name of the "Orphaned images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned images
 
-# Description of the "Orphand images" container.
+# Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
 # Client dropdown menu leader label.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -648,6 +648,12 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
+## Name of the "Orphand images" container located in client tree data manager.
+omero.client.ui.tree.orphans.name=Orphaned images
+
+## Description of the "Orphand images" container.
+omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
+
 #############################################
 ## Ice overrides
 ##


### PR DESCRIPTION
This PR centralize common client properties.

 - ```omero.web.scripts_to_ignore``` list of scripts shouldn't be displayed in the client. It became:
    - omero.client.scripts_to_ignore
 - ```omero.web.ui.tree.orphaned``` allows to customize name and description of the Orphaned Images container. It became:
    - omero.client.ui.tree.orphans.name
    - omero.client.ui.tree.orphans.description
 - ```omero.web.ui.menu.dropdown``` allows to control which part of the User/Group menu should be displayed. It became:
    - omero.client.ui.menu.dropdown.leaders
    - omero.client.ui.menu.dropdown.leaders.enabled
    - omero.client.ui.menu.dropdown.colleagues
    - omero.client.ui.menu.dropdown.colleagues.enabled
    - omero.client.ui.menu.dropdown.everyone
    - omero.client.ui.menu.dropdown.everyone.enabled

To test use ```bin/omero config set ...``` to alter UI.

cc: @dominikl @jburel could you apply them in Insight in corresponding PR?
If you need any help please let me know

--no-rebase