### PR TITLE
General pane followup

### DIFF
--- a/components/blitz/src/pojos/AnnotationData.java
+++ b/components/blitz/src/pojos/AnnotationData.java
@@ -1,7 +1,7 @@
 /*
  * pojos.AnnotationData
  *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -105,6 +105,28 @@ public abstract class AnnotationData extends DataObject {
         return timeOfEvent(getDetails().getCreationEvent());
     }
 
+	/**
+	 * Retrieves the {@link Annotation#getDescription() description} of the
+	 * underlying {@link Annotation} instance.
+	 * 
+	 * @return See above
+	 */
+	public String getDescription() {
+		omero.RString desc = asAnnotation().getDescription();
+		return desc == null ? null : desc.getValue();
+	}
+
+	/**
+	 * Sets the description of the underlying {@link Annotation} instance.
+	 * 
+	 * @param description
+	 *            The description
+	 */
+	public void setDescription(String description) {
+		asAnnotation().setDescription(
+				description == null ? null : rstring(description));
+	}
+    
     /**
      * Sets the annotation value. If the improper content is given for the
      * current {@link Annotation}, then an

--- a/components/blitz/src/pojos/DataObject.java
+++ b/components/blitz/src/pojos/DataObject.java
@@ -1,7 +1,7 @@
 /*
  * pojos.DataObject
  *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -351,7 +351,7 @@ public abstract class DataObject {
 
     protected Timestamp timeOfEvent(Event event) {
         if (event == null || !event.isLoaded() || event.getTime() == null) {
-            throw new IllegalStateException("Event does not contain timestamp.");
+            return null;
         }
         return new Timestamp(event.getTime().getValue());
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchResultTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchResultTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -70,10 +70,6 @@ import pojos.ImageData;
  * @since 5.0
  */
 public class SearchResultTable extends JXTable {
-
-    /** Defines the format how the date is shown */
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat(
-            "yyyy-MM-dd HH:mm:ss"); //2013-04-20 18:13:43
     
     /** Reference to the DataBrowserModel */
     private AdvancedResultSearchModel model;
@@ -285,7 +281,7 @@ public class SearchResultTable extends JXTable {
                 JLabel l = new JLabel((Icon) value);
                 p.add(l);
             } else if (value instanceof Date) {
-                JLabel l = new JLabel(DATE_FORMAT.format((Date)value));
+                JLabel l = new JLabel(UIUtilities.formatDefaultDate(((Date)value)));
                 p.add(l);
             }
             else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.DocComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -34,6 +34,7 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -439,7 +440,6 @@ class DocComponent
 			return buf.toString();
 		}
 		
-		ExperimenterData exp = null;
 		if (name != null) {
 			buf.append("<b>");
 			buf.append("Name: ");
@@ -447,9 +447,37 @@ class DocComponent
 			buf.append(name);
 			buf.append("<br>");
 		}
-		if (annotation.getId() > 0)
+		
+		ExperimenterData exp = null;
+		
+		if(annotation.getId()>0) {
 			exp = model.getOwner(annotation);
-		if (exp != null) {
+			buf.append("<b>");
+			buf.append("ID: ");
+			buf.append("</b>");
+			buf.append(annotation.getId());
+			buf.append("<br>");
+		}
+		
+		String ns = annotation.getNameSpace();
+		if(!StringUtils.isEmpty(ns) && !isInternalNS(ns)) {
+			buf.append("<b>");
+			buf.append("Namespace: ");
+			buf.append("</b>");
+			buf.append(ns);
+			buf.append("<br>");
+		}
+		
+		String desc = annotation.getDescription();
+		if(!StringUtils.isEmpty(desc)) {
+			buf.append("<b>");
+			buf.append("Description: ");
+			buf.append("</b>");
+			buf.append(desc);
+			buf.append("<br>");
+		}
+		
+		if(exp!=null) {
 			buf.append("<b>");
 			buf.append("Owner: ");
 			buf.append("</b>");
@@ -457,14 +485,16 @@ class DocComponent
 			buf.append("<br>");
 		}
 		
+		Timestamp created = annotation.getCreated();
+		if(created !=null) {
+			buf.append("<b>");
+			buf.append("Date: ");
+			buf.append("</b>");
+			buf.append(UIUtilities.formatShortDateTime(created));
+			buf.append("<br>");
+		}
+		
 		if (data instanceof FileAnnotationData) {
-			String ns = ((FileAnnotationData) data).getNameSpace();
-			if (annotation.getId() > 0) {
-				buf.append("<b>");
-				buf.append("Annotation ID: ");
-				buf.append("</b>");
-				buf.append(annotation.getId());
-				buf.append("<br>");
 				buf.append("<b>");
 				buf.append("File ID: ");
 				buf.append("</b>");
@@ -472,14 +502,6 @@ class DocComponent
 				buf.append(fa.getFileID());
 				buf.append("<br>");
 				buf.append("<b>");
-				buf.append("Date Added: ");
-				buf.append("</b>");
-				buf.append(UIUtilities.formatWDMYDate(
-						annotation.getLastModified()));
-				buf.append("<br>");
-				buf.append("<b>");
-			}
-			
 			buf.append("Size: ");
 			buf.append("</b>");
 			//size not kb
@@ -487,13 +509,6 @@ class DocComponent
 			buf.append(UIUtilities.formatFileSize(size));
 			buf.append("<br>");
 			checkAnnotators(buf, annotation);
-			if (!StringUtils.isBlank(ns)) {
-			    buf.append("<b>");
-			    buf.append("Namespace: ");
-			    buf.append("</b>");
-			    buf.append(ns);
-			    buf.append("<br>");
-			}
 		} else if (data instanceof TagAnnotationData || data instanceof
 				XMLAnnotationData || data instanceof TermAnnotationData ||
 				data instanceof LongAnnotationData ||
@@ -505,6 +520,17 @@ class DocComponent
 		return buf.toString();
 	}
 
+	/**
+	 * Checks if the given namespace is an internal one.
+	 * 
+	 * @param ns
+	 *            The namespace to check
+	 * @return See above
+	 */
+	private boolean isInternalNS(String ns) {
+		return ns.startsWith("openmicroscopy.org") || ns.startsWith("omero.");
+	}
+	
 	/** Initializes the various buttons. */
 	private void initButtons()
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/FilterGroupComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/FilterGroupComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.FilterGroupComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
-import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -72,13 +71,6 @@ class FilterGroupComponent
 	extends JPanel
 	implements PropertyChangeListener
 {
-	
-	/** The title displayed if the data object is a filter set. */
-	private static final String FILTER_SET= "Filter Set";
-	
-	/** The title displayed if the data object is a light path. */
-	private static final String LIGHT_PATH = "Light Path";
-	
 	/** Reference to the parent of this component. */
 	private AcquisitionDataUI	parent;
 	
@@ -257,16 +249,13 @@ class FilterGroupComponent
 	/** Builds and lays out the UI. */
     private void buildGUI()
     {
-    	String title = FILTER_SET;
-    	if (object instanceof LightPathData) title = LIGHT_PATH;
-    	setBorder(BorderFactory.createTitledBorder(title));
 		setBackground(UIUtilities.BACKGROUND_COLOR);
 		setLayout(new GridBagLayout());
     	setBackground(UIUtilities.BACKGROUND_COLOR);
 		GridBagConstraints constraints = new GridBagConstraints();
 		constraints.fill = GridBagConstraints.BOTH;
 		constraints.anchor = GridBagConstraints.WEST;
-		constraints.insets = new Insets(0, 2, 2, 0);
+		constraints.insets = new Insets(0, 0, 0, 0);
 		constraints.weightx = 1.0;
 		constraints.gridy = 0;
 		if (object instanceof FilterSetData) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -768,16 +768,21 @@ public class PropertiesUI
     	JLabel l = new JLabel();
     	Font font = l.getFont();
     	int size = font.getSize()-2;
-    	JLabel label = UIUtilities.setTextFont(EditorUtil.ACQUISITION_DATE+":",
-    			Font.BOLD, size);
-    	JLabel value = UIUtilities.createComponent(null);
+    	JLabel label;
+    	JLabel value;
     	String v = model.formatDate(image);
-    	value.setText(v);
-    	content.add(label, c);
-    	c.gridx++;
-    	content.add(value, c);
-    	c.gridy++;
-    	c.gridx = 0;
+    	if(!StringUtils.isEmpty(v)) {
+	    	label = UIUtilities.setTextFont(EditorUtil.ACQUISITION_DATE+":",
+	    			Font.BOLD, size);
+	    	value = UIUtilities.createComponent(null);
+	    	value.setText(v);
+	    	content.add(label, c);
+	    	c.gridx++;
+	    	content.add(value, c);
+	    	c.gridy++;
+	    	c.gridx = 0;
+    	}
+    	
     	try { //just to be on the save side
     		label = UIUtilities.setTextFont(EditorUtil.IMPORTED_DATE+":",
         			Font.BOLD, size);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -62,6 +62,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
@@ -199,7 +200,7 @@ public class PropertiesUI
     private JPanel				descriptionPanel;
     
     /** The component hosting the id of the <code>DataObject</code>. */
-    private JLabel				idLabel;
+    private JTextField				idLabel;
     
     /** The component hosting the icon for inplace imported images */
     private JLabel 				inplaceIcon;
@@ -328,8 +329,10 @@ public class PropertiesUI
        	wellLabel.setFont(newFont);
        	wellLabel.setBackground(UIUtilities.BACKGROUND_COLOR);
        	
-       	idLabel = UIUtilities.setTextFont("");
-       	idLabel.setName("ID label");
+       	idLabel = new JTextField();
+       	idLabel.setFont(idLabel.getFont().deriveFont(Font.BOLD));
+       	idLabel.setEditable(false);
+       	idLabel.setBorder(BorderFactory.createEmptyBorder());
        	inplaceIcon = new JLabel(IconManager.getInstance().getIcon(IconManager.INPLACE_IMPORT));
        	ClickableTooltip inplaceIconTooltip = new ClickableTooltip(INPLACE_IMPORT_TOOLTIP_TEXT, createInplaceIconAction());
         inplaceIconTooltip.attach(inplaceIcon);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -44,6 +44,7 @@ import java.awt.event.KeyListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.sql.Timestamp;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.Iterator;
@@ -51,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -73,6 +75,7 @@ import javax.swing.event.DocumentListener;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.jdesktop.swingx.JXTaskPane;
+
 import com.google.common.base.CharMatcher;
 
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
@@ -687,7 +690,7 @@ public class PropertiesUI
     	Length z = (Length) details.get(EditorUtil.PIXEL_SIZE_Z);
     	Double dx = null, dy = null, dz = null;
     	boolean number = true;
-    	NumberFormat nf = NumberFormat.getInstance();
+    	NumberFormat nf = new DecimalFormat("0.##");
     	String units = null;
     	try {
     		x = UIUtilities.transformSize(x);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -690,7 +690,7 @@ public class PropertiesUI
     	Length z = (Length) details.get(EditorUtil.PIXEL_SIZE_Z);
     	Double dx = null, dy = null, dz = null;
     	boolean number = true;
-    	NumberFormat nf = new DecimalFormat("0.##");
+    	NumberFormat nf = new DecimalFormat("0.00");
     	String units = null;
     	try {
     		x = UIUtilities.transformSize(x);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -25,7 +25,6 @@ package org.openmicroscopy.shoola.agents.metadata.editor;
 
 
 //Java imports
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -52,7 +51,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -74,7 +72,6 @@ import javax.swing.event.DocumentListener;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.jdesktop.swingx.JXTaskPane;
-
 import com.google.common.base.CharMatcher;
 
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
@@ -375,7 +372,7 @@ public class PropertiesUI
     	descriptionWiki.setAllowOneClick(true);
     	descriptionWiki.addFocusListener(this);
     	descriptionWiki.addPropertyChangeListener(this);
-       	
+    	
     	defaultBorder = namePane.getBorder();
     	namePane.setFont(f.deriveFont(Font.BOLD));
     	typePane.setFont(f.deriveFont(Font.BOLD));
@@ -1261,7 +1258,6 @@ public class PropertiesUI
         descriptionWiki.setBackground(UIUtilities.BACKGROUND_COLOR);
         descriptionWiki.setForeground(UIUtilities.DEFAULT_FONT_COLOR);
 
-        
         editNames();
         if (b) {
             namePane.getDocument().addDocumentListener(this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.editor.PropertiesUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1080,13 +1080,13 @@ public class PropertiesUI
 			createDateLabel.setFont((new JLabel()).getFont().deriveFont(
 					Font.BOLD));
 
-			try {
-				Timestamp t = dob.getCreated();
-				createDateLabel.setText(CREATIONDATE_TEXT+UIUtilities.formatShortDateTime(t));
-			} catch (Exception e) {
-				e.printStackTrace();
-				createDateLabel.setText(CREATIONDATE_TEXT+"N/A");
-			}
+			Timestamp t = dob.getCreated();
+			if (t != null)
+				createDateLabel.setText(CREATIONDATE_TEXT
+						+ UIUtilities.formatShortDateTime(t));
+			else
+				createDateLabel.setText(CREATIONDATE_TEXT + "N/A");
+			
 			JPanel p = UIUtilities.buildComponentPanel(createDateLabel, 0, 0);
 			p.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
 			p.setBackground(UIUtilities.BACKGROUND_COLOR);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1079,23 +1079,22 @@ public class PropertiesUI
 				|| refObject instanceof ProjectData
 				|| refObject instanceof PlateData
 				|| refObject instanceof ScreenData) {
-
 			DataObject dob = (DataObject) refObject;
-			JLabel createDateLabel = new JLabel();
-			createDateLabel.setFont((new JLabel()).getFont().deriveFont(
-					Font.BOLD));
-
-			Timestamp t = dob.getCreated();
-			if (t != null)
-				createDateLabel.setText(CREATIONDATE_TEXT
-						+ UIUtilities.formatDefaultDate(t));
-			else
-				createDateLabel.setText(CREATIONDATE_TEXT + "N/A");
 			
-			JPanel p = UIUtilities.buildComponentPanel(createDateLabel, 0, 0);
-			p.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-			p.setBackground(UIUtilities.BACKGROUND_COLOR);
-			add(p);
+			Timestamp crDate = dob.getCreated();
+			if (crDate != null) {
+				JLabel createDateLabel = new JLabel();
+				createDateLabel.setFont((new JLabel()).getFont().deriveFont(
+						Font.BOLD));
+				createDateLabel.setText(CREATIONDATE_TEXT
+						+ UIUtilities.formatDefaultDate(crDate));
+
+				JPanel p = UIUtilities.buildComponentPanel(createDateLabel, 0,
+						0);
+				p.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+				p.setBackground(UIUtilities.BACKGROUND_COLOR);
+				add(p);
+			}
 		}
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -787,7 +787,7 @@ public class PropertiesUI
     		label = UIUtilities.setTextFont(EditorUtil.IMPORTED_DATE+":",
         			Font.BOLD, size);
         	value = UIUtilities.createComponent(null);
-        	v =  UIUtilities.formatShortDateTime(image.getInserted());
+        	v =  UIUtilities.formatDefaultDate(image.getInserted());
         	value.setText(v);
         	content.add(label, c);
         	c.gridx++;
@@ -1088,7 +1088,7 @@ public class PropertiesUI
 			Timestamp t = dob.getCreated();
 			if (t != null)
 				createDateLabel.setText(CREATIONDATE_TEXT
-						+ UIUtilities.formatShortDateTime(t));
+						+ UIUtilities.formatDefaultDate(t));
 			else
 				createDateLabel.setText(CREATIONDATE_TEXT + "N/A");
 			

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -709,8 +709,7 @@ public class EditorUtil
 			details.put(PIXEL_SIZE_Y,  l == null ? nullLength : l);
 			l = data.getPixelSizeZ(UnitsLength.MICROMETER);
 			details.put(PIXEL_SIZE_Z,  l == null ? nullLength : l);
-			details.put(PIXEL_TYPE,
-					PIXELS_TYPE_DESCRIPTION.get("" + data.getPixelType()));
+			details.put(PIXEL_TYPE, data.getPixelType());
         }
         details.put(EMISSION+" "+WAVELENGTH+"s", "");
         return details;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2340,7 +2340,7 @@ public class EditorUtil
         else if (object instanceof ImageData)
             time = getAcquisitionTime((ImageData) object);
         else time = object.getCreated();
-        if (time != null) date = UIUtilities.formatShortDateTime(time);
+        if (time != null) date = UIUtilities.formatDefaultDate(time);
         return date;
     }
 
@@ -2403,7 +2403,7 @@ public class EditorUtil
         l.add(v);
         try {
             v = "<b>"+IMPORTED_DATE+": </b>"+
-                    UIUtilities.formatShortDateTime(img.getInserted());
+                    UIUtilities.formatDefaultDate(img.getInserted());
             l.add(v);
         } catch (Exception e) {}
         PixelsData data = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewedByItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewedByItem.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.ViewedByItem 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -112,7 +112,7 @@ public class ViewedByItem extends JLabel {
         l.add("Viewed by: " + getText());
         Timestamp time = rndDef.getLastModified();
         if (time != null)
-            l.add("Last modified: " + UIUtilities.formatShortDateTime(time));
+            l.add("Last modified: " + UIUtilities.formatDefaultDate(time));
         setToolTipText(UIUtilities.formatToolTipText(l));
         
         addMouseListener(new MouseAdapter() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -350,7 +350,7 @@ public abstract class ActivityComponent
 		Font f = l.getFont();
 		l.setForeground(UIUtilities.LIGHT_GREY.darker());
 		l.setFont(f.deriveFont(f.getStyle(), f.getSize()-2));
-		String s = UIUtilities.formatShortDateTime(null);
+		String s = UIUtilities.formatDefaultDate(null);
 		String[] values = s.split(" ");
 		if (values.length > 1) {
 			String v = values[1];

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.UIUtilities
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -43,6 +43,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -108,7 +109,10 @@ import omero.model.enums.UnitsLength;
  */
 public class UIUtilities
 {
-	
+	/** Defines the format how the date is shown */
+    private static final DateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat(
+            "yyyy-MM-dd HH:mm:ss"); //2013-04-20 18:13:43
+    
 	/** Bound property indicating that the font changes.*/
 	public static final String HINTS_PROPERTY = "awt.font.desktophints";
 	
@@ -1460,6 +1464,32 @@ public class UIUtilities
     	return DateFormat.getDateTimeInstance(
     			DateFormat.SHORT, DateFormat.SHORT,
     			Locale.getDefault()).format(time);
+    }
+    
+    /**
+     * Formats as a <code>String</code> the specified time,
+     * using the default date format: yyyy-MM-dd HH:mm:ss
+     * @param time The timestamp to format.
+     * @return Returns the stringified version of the passed timestamp.
+     */
+    public static String formatDefaultDate(Timestamp time) 
+    {
+    	if (time == null)  
+    		time = getDefaultTimestamp();
+    	return DEFAULT_DATE_FORMAT.format(time);
+    }
+    
+    /**
+     * Formats as a <code>String</code> the specified time,
+     * using the default date format: yyyy-MM-dd HH:mm:ss
+     * @param time The timestamp to format.
+     * @return Returns the stringified version of the passed timestamp.
+     */
+    public static String formatDefaultDate(Date date) 
+    {
+    	if (date == null)  
+    		return formatDefaultDate((Timestamp)null);
+    	return DEFAULT_DATE_FORMAT.format(date);
     }
     
     /**

--- a/components/server/src/ome/services/query/PojosLoadHierarchyQueryDefinition.java
+++ b/components/server/src/ome/services/query/PojosLoadHierarchyQueryDefinition.java
@@ -39,6 +39,7 @@ public class PojosLoadHierarchyQueryDefinition extends Query {
         StringBuilder sb = new StringBuilder();
         if (Project.class.isAssignableFrom(klass)) {
             sb.append("select this from Project this ");
+            sb.append("left outer join fetch this.details.creationEvent ");
             sb.append("left outer join fetch this.datasetLinks pdl ");
             sb.append("left outer join fetch pdl.child ds ");
             if (params.isLeaves()) {
@@ -49,6 +50,7 @@ public class PojosLoadHierarchyQueryDefinition extends Query {
                     + "this.annotationLinksCountPerOwner this_a_c ");
         } else if (Dataset.class.isAssignableFrom(klass)) {
             sb.append("select this from Dataset this ");
+            sb.append("left outer join fetch this.details.creationEvent ");
             if (params.isLeaves()) {
                 sb.append("left outer join fetch this.imageLinks dil ");
                 sb.append("left outer join fetch dil.child img ");
@@ -59,6 +61,7 @@ public class PojosLoadHierarchyQueryDefinition extends Query {
                     + "this.imageLinksCountPerOwner this_i_c ");
         } else if (Screen.class.isAssignableFrom(klass)) {
         	sb.append("select this from Screen this ");
+        	sb.append("left outer join fetch this.details.creationEvent ");
             sb.append("left outer join fetch this.plateLinks pdl ");
             sb.append("left outer join fetch pdl.child ds ");
             sb.append("left outer join fetch ds.details.creationEvent ");
@@ -69,6 +72,7 @@ public class PojosLoadHierarchyQueryDefinition extends Query {
             sb.append("left outer join fetch sa.annotationLinksCountPerOwner sa_a_c ");
         } else if (Plate.class.isAssignableFrom(klass)) {
         	sb.append("select this from Plate this ");
+        	sb.append("left outer join fetch this.details.creationEvent ");
         	sb.append("left outer join fetch this.plateAcquisitions sa ");
             sb.append("left outer join fetch "
                     + "this.annotationLinksCountPerOwner this_a_c ");

--- a/components/tools/OmeroJava/test/integration/PojosServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/PojosServiceTest.java
@@ -2054,4 +2054,53 @@ public class PojosServiceTest extends AbstractServerTest {
             }
         }
     }
+    
+	/**
+	 * Checks if the creation date is loaded for all container {@link IObject}s
+	 * 
+	 * @throws Exception
+	 *             Thrown if an error occurred.
+	 */
+	@Test
+	public void testContainerCreationDateLoaded() throws Exception {
+		Project p = (Project) iUpdate.saveAndReturnObject(mmFactory
+				.simpleProjectData().asIObject());
+		List<Long> ids = new ArrayList<Long>();
+		ids.add(p.getId().getValue());
+		p = (Project) iContainer
+				.loadContainerHierarchy(Project.class.getName(), ids, null)
+				.iterator().next();
+
+		assertTrue(p.getDetails().getCreationEvent().isLoaded());
+
+		Dataset d = (Dataset) iUpdate.saveAndReturnObject(mmFactory
+				.simpleDatasetData().asIObject());
+		ids = new ArrayList<Long>();
+		ids.add(d.getId().getValue());
+		d = (Dataset) iContainer
+				.loadContainerHierarchy(Dataset.class.getName(), ids, null)
+				.iterator().next();
+
+		assertTrue(d.getDetails().getCreationEvent().isLoaded());
+
+		Screen s = (Screen) iUpdate.saveAndReturnObject(mmFactory
+				.simpleScreenData().asIObject());
+		ids = new ArrayList<Long>();
+		ids.add(s.getId().getValue());
+		s = (Screen) iContainer
+				.loadContainerHierarchy(Screen.class.getName(), ids, null)
+				.iterator().next();
+
+		assertTrue(s.getDetails().getCreationEvent().isLoaded());
+
+		Plate pl = (Plate) iUpdate.saveAndReturnObject(mmFactory
+				.simplePlateData().asIObject());
+		ids = new ArrayList<Long>();
+		ids.add(pl.getId().getValue());
+		pl = (Plate) iContainer
+				.loadContainerHierarchy(Plate.class.getName(), ids, null)
+				.iterator().next();
+
+		assertTrue(pl.getDetails().getCreationEvent().isLoaded());
+	}
 }


### PR DESCRIPTION
Follow-up PR to the General Pane alignment, see [Trello](https://trello.com/c/OBUND1Za/82-general-pane-client-alignment)
- Show creation date for Datasets, Projects, etc.
- Show Annotation tooltips like Web does (display namespace, description, etc.)
- Filters aren't wrapped into 'Light Path' titled border anymore

Also implements [Trac 12681](https://trac.openmicroscopy.org.uk/ome/ticket/12681) : The image ID can be selected and copied with CTRL+C
