### PR TITLE
os version in upgrade check

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/upgrade_check.py
+++ b/components/tools/OmeroPy/src/omero/util/upgrade_check.py
@@ -94,7 +94,7 @@ class UpgradeCheck(object):
     def getOSVersion(self):
         try:
             if len(platform.mac_ver()[0]) > 0:
-                version = "%s-%s" % (platform.platform(),
+                version = "%s;%s" % (platform.platform(),
                                      platform.mac_ver()[0])
             else:
                 version = platform.platform()

--- a/components/tools/OmeroPy/src/omero/util/upgrade_check.py
+++ b/components/tools/OmeroPy/src/omero/util/upgrade_check.py
@@ -91,6 +91,17 @@ class UpgradeCheck(object):
         self.upgradeUrl = results
         self.exc = e
 
+    def getOSVersion(self):
+        try:
+            if len(platform.mac_ver()[0]) > 0:
+                version = "%s-%s" % (platform.platform(),
+                                     platform.mac_ver()[0])
+            else:
+                version = platform.platform()
+        except:
+            version = platform.platform()
+        return version
+
     def run(self):
         """
         If the {@link #url} has been set to null or the empty string, then no
@@ -110,7 +121,7 @@ class UpgradeCheck(object):
             params["version"] = self.version
             params["os.name"] = platform.system()
             params["os.arch"] = platform.machine()
-            params["os.version"] = platform.version()
+            params["os.version"] = self.getOSVersion()
             params["python.version"] = platform.python_version()
             params["python.compiler"] = platform.python_compiler()
             params["python.build"] = platform.python_build()


### PR DESCRIPTION
@rleigh-dundee asked to provide more information about OS in UpgradeCheck. This is because original implementation uses only ```platform.version()```. This change should give more details to registry.

Mac OS X:
```
>>> "%s-%s" % (platform.platform(),platform.mac_ver()[0])
'Darwin-12.5.0-x86_64-i386-64bit-10.8.5'
```

Linux:
```
>>> platform.platform()
'Linux-2.6.32-431.29.2.el6.x86_64-x86_64-with-centos-6.5-Final'
```

Windows:
```
>>> platform.platform()
'Windows-2008Server-6.0.6002-SP2'
```

Test library locally logging to web calling python directly:

```
from omero.util.upgrade_check import UpgradeCheck
check = UpgradeCheck("OMERO.test")
check.run()
```

```
2015-01-14 16:26:10,994 DEBUG [                 omero.util.UpgradeCheck] (proc.31949) run:136 Attempting to connect to http://upgrade.openmicroscopy.org.uk/?os.version=Darwin-12.5.0-x86_64-i386-64bit-10.8.5&os.arch=x86_64&version=5.1.0-m4-ice34-SNAPSHOT&python.compiler=GCC+4.2.1+Compatible+Apple+Clang+4.0+%28tags%2FApple%2Fclang-418.0.60%29&python.build=%28%27default%27%2C+%27Oct+11+2012+20%3A14%3A37%27%29&os.name=Darwin&python.version=2.7.2
```