### PR TITLE
adjust createdb commands to specify Unicode databases

### DIFF
--- a/docs/QUICKSTART.bat
+++ b/docs/QUICKSTART.bat
@@ -61,7 +61,7 @@ createuser -S -D -R -U postgres omero
 if errorlevel 1 echo Already exists?
 
 echo Creating %OMERO_CONFIG% db
-createdb -O omero -U postgres %OMERO_CONFIG%
+createdb -E UTF8 -O omero -U postgres %OMERO_CONFIG%
 if errorlevel 1 goto ERROR
 
 echo Adding pgsql to db

--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -111,7 +111,7 @@ export ICE_CONFIG=$(bin/brew --prefix omero51)/etc/ice.config
 if [ -d "$PSQL_DIR" ]; then
     rm -rf $PSQL_DIR
 fi
-bin/initdb $PSQL_DIR
+bin/initdb -E UTF8 $PSQL_DIR
 bin/pg_ctl -D $PSQL_DIR -l $PSQL_DIR/server.log -w start
 
 # Create user and database

--- a/docs/hudson/OMERO-homebrew-install.sh
+++ b/docs/hudson/OMERO-homebrew-install.sh
@@ -116,7 +116,7 @@ bin/pg_ctl -D $PSQL_DIR -l $PSQL_DIR/server.log -w start
 
 # Create user and database
 bin/createuser -w -D -R -S db_user
-bin/createdb -O db_user omero_database
+bin/createdb -E UTF8 -O db_user omero_database
 bin/psql -h localhost -U db_user -l
 
 # Set database

--- a/docs/hudson/OMERO-start.sh
+++ b/docs/hudson/OMERO-start.sh
@@ -36,7 +36,7 @@ echo omero.prefix=$OMERO_PREFIX >> $ICE_CONFIG
 cd dist
 
 dropdb $OMERO_CONFIG || echo Already gone maybe
-createdb -h localhost -U postgres -O hudson $OMERO_CONFIG
+createdb -h localhost -U postgres -E UTF8 -O hudson $OMERO_CONFIG
 createlang -h localhost -U postgres plpgsql $OMERO_CONFIG || echo Already installed maybe
 
 python bin/omero db script "" "" ome -f omero.sql

--- a/docs/install/VM/setup_postgres.sh
+++ b/docs/install/VM/setup_postgres.sh
@@ -12,7 +12,7 @@ chmod 600 .pgpass
 chown omero:omero .pgpass
 
 echo "CREATE USER omero PASSWORD 'omero'" | sudo -u postgres psql
-sudo -u postgres createdb -O omero omero
+sudo -u postgres createdb -E UTF8 -O omero omero
 sudo -u postgres createlang plpgsql omero || echo Already installed
 
 echo `psql -h localhost -U omero -l`


### PR DESCRIPTION
https://trello.com/c/Fv1HZVfs/779-virt-microscope-pg-9-for-testing reveals the need for a UTF8-encoded database for OMERO since 5.1 patch 12.

PostgreSQL 8.4 references can be updated once version prerequisites suggested via http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-January/004982.html are approved, so for now they are left alone.

See https://github.com/openmicroscopy/ome-documentation/pull/1070#discussion_r22995970

--no-rebase