### PR TITLE
Scripts/Downloads menu

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.EditorControl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -77,7 +77,6 @@ import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import org.openmicroscopy.shoola.env.data.events.ViewInPluginEvent;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.AnalysisParam;
-import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
 import org.openmicroscopy.shoola.env.data.model.FigureParam;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.Target;
@@ -215,9 +214,6 @@ class EditorControl
 	/** Action id indicating to remove other annotations. */
 	static final int REMOVE_OTHER_ANNOTATIONS = 25;
 
-	/** Action ID to download the metadata files. */
-	static final int DOWNLOAD_METADATA = 26;
-
 	/** Action ID to load the file path triggered by click on inplace import icon.*/
         static final int FILE_PATH_INPLACE_ICON = 27;
         
@@ -238,53 +234,6 @@ class EditorControl
 	
 	/** Reference to the figure dialog. */
 	private FigureDialog		figureDialog;
-
-	/** Download the original metadata.*/
-	private void downloadMetadata()
-	{
-		JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
-		FileChooser chooser = new FileChooser(f, FileChooser.SAVE, 
-				"Download Metadata", "Download the metadata file.", null, true);
-		chooser.setSelectedFileFull(FileAnnotationData.ORIGINAL_METADATA_NAME);
-		chooser.setCheckOverride(true);
-		FileAnnotationData data = view.getOriginalMetadata();
-		String name = "";
-		if (data != null) name = data.getFileName();
-		else {
-			ImageData img = view.getImage();
-			name = FilenameUtils.removeExtension(img.getName());
-		}
-		chooser.setSelectedFileFull(name);
-		chooser.setApproveButtonText("Download");
-		IconManager icons = IconManager.getInstance();
-		chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
-		chooser.addPropertyChangeListener(new PropertyChangeListener() {
-			
-			/** 
-			 * Handles the download of the original files
-			 */
-			public void propertyChange(PropertyChangeEvent evt) {
-				String name = evt.getPropertyName();
-				if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
-					File[] files = (File[]) evt.getNewValue();
-					File folder = files[0];
-					if (folder == null)
-						folder = UIUtilities.getDefaultFolder();
-					UserNotifier un =
-							MetadataViewerAgent.getRegistry().getUserNotifier();
-					ImageData img = view.getImage();
-					if (img == null) return;
-					IconManager icons = IconManager.getInstance();
-					DownloadActivityParam activity =
-							new DownloadActivityParam(img.getId(),
-						DownloadActivityParam.METADATA_FROM_IMAGE,
-								folder, icons.getIcon(IconManager.DOWNLOAD_22));
-					un.notifyActivity(model.getSecurityContext(), activity);
-				}
-			}
-		});
-		chooser.centerDialog();
-	}
 	
 	/** Launches RAPID. */
 	private void openFLIM()
@@ -907,9 +856,6 @@ class EditorControl
 				else {
 				    loadFileset(index);
 				}
-				break;
-			case DOWNLOAD_METADATA:
-				downloadMetadata();
 				break;
 			case SHOW_LOCATION:
 			    	view.displayLocation();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
@@ -80,7 +80,7 @@ class PublishingDialog
 	
 	/** The text associated to the export as OME-TIFF action. */
 	private static final String EXPORT_AS_OME_TIFF_TEXT = 
-		"Export As OME-TIFF...";
+		"Export as OME-TIFF...";
 	
 	/** The text associated to the SPLIT_VIEW_FIGURE action. */
 	private static final String SPLIT_VIEW_FIGURE_TEXT = "Split View Figure...";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -259,14 +259,7 @@ class ToolBar
         }
         exportAsOmeTiffItem.setEnabled(b);
         saveAsMenu.add(exportAsOmeTiffItem);
-        JMenu menu = new JMenu();
-        menu.setIcon(icons.getIcon(IconManager.SAVE_AS));
-        menu.setText("Save as...");
-        menu.setToolTipText("Save the images at full size as JPEG. PNG or" +
-                "TIFF.");
         ActionListener l = new ActionListener() {
-
-
             public void actionPerformed(ActionEvent e) {
                 int index = Integer.parseInt(e.getActionCommand());
                 controller.saveAs(index);
@@ -281,14 +274,14 @@ class ToolBar
                 ho instanceof WellSampleData || ho instanceof DatasetData);
         while (i.hasNext()) {
             e = i.next();
-            item = new JMenuItem();
-            item.setText(e.getValue());
+            item = new JMenuItem(icons.getIcon(
+                    IconManager.EXPORT_AS_OMETIFF));
+            item.setText("Export As "+e.getValue());
             item.addActionListener(l);
             item.setActionCommand(""+e.getKey());
             item.setEnabled(enabled);
-            menu.add(item);
+            saveAsMenu.add(item);
         }
-        saveAsMenu.add(menu);
         setRootObject();
     	return saveAsMenu;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.ToolBar 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -181,12 +181,6 @@ class ToolBar
 	private JPopupMenu linkMenu;
 	
 	/** 
-	 * Component used to download the original metadata associated to the
-	 * image.
-	 */
-	private JMenuItem downloadOriginalMetadataItem;
-	
-	/** 
 	 * Creates or recycles the link menu.
 	 * 
 	 * @return See above.
@@ -250,21 +244,6 @@ class ToolBar
         }
         downloadItem.setEnabled(b);
         saveAsMenu.add(downloadItem);
-
-        downloadOriginalMetadataItem = new JMenuItem(
-                icons.getIcon(IconManager.DOWNLOAD));
-        downloadOriginalMetadataItem.setToolTipText("Download the " +
-                "metadata read from the image files.");
-        downloadOriginalMetadataItem.setText(
-                "Download Original metadata...");
-        downloadOriginalMetadataItem.addActionListener(controller);
-        downloadOriginalMetadataItem.setActionCommand(
-                ""+EditorControl.DOWNLOAD_METADATA);
-        downloadOriginalMetadataItem.setBackground(
-                UIUtilities.BACKGROUND_COLOR);
-        downloadOriginalMetadataItem.setEnabled(
-                model.hasOriginalMetadata());
-        saveAsMenu.add(downloadOriginalMetadataItem);
 
         exportAsOmeTiffItem = new JMenuItem(icons.getIcon(
                 IconManager.EXPORT_AS_OMETIFF));
@@ -759,16 +738,11 @@ class ToolBar
     	if (pathButton != null) pathButton.setEnabled(false);
 		if (exportAsOmeTiffButton != null)
 			exportAsOmeTiffButton.setEnabled(false);
-    	if (downloadOriginalMetadataItem != null)
-    		downloadOriginalMetadataItem.setEnabled(false);
     	if (model.isSingleMode() && model.getImage() != null) {
     		if (exportAsOmeTiffItem != null)
 				exportAsOmeTiffButton.setEnabled(!model.isLargeImage());
 			viewButton.setEnabled(true);
 			if (pathButton != null) pathButton.setEnabled(true);
-			if (downloadOriginalMetadataItem != null)
-				downloadOriginalMetadataItem.setEnabled(
-					model.hasOriginalMetadata());
     	}
     	
 		publishingButton.setEnabled(true);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -276,7 +276,7 @@ class ToolBar
             e = i.next();
             item = new JMenuItem(icons.getIcon(
                     IconManager.EXPORT_AS_OMETIFF));
-            item.setText("Export as "+e.getValue());
+            item.setText("Export as "+e.getValue()+"...");
             item.addActionListener(l);
             item.setActionCommand(""+e.getKey());
             item.setEnabled(enabled);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -276,7 +276,7 @@ class ToolBar
             e = i.next();
             item = new JMenuItem(icons.getIcon(
                     IconManager.EXPORT_AS_OMETIFF));
-            item.setText("Export As "+e.getValue());
+            item.setText("Export as "+e.getValue());
             item.addActionListener(l);
             item.setActionCommand(""+e.getKey());
             item.setEnabled(enabled);


### PR DESCRIPTION
Implements the m3 changes for scripts/downloads menu, see [Trello card](https://trello.com/c/3n7Plb19/189-scripts-menus-download-options).
Check for:
- 'Download Original MetaData' removed from download menu
- Download menu is now a single-level menu like Web
- Term 'Export' is used instead of 'Save As'

Task 'Delete FileAnnotation after Download' will be tackled in another PR.

--no-rebase