### PR TITLE
Add CLI info, listusers and listgroups subcommands

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -78,8 +78,6 @@ class ITest(object):
 
         p = Ice.createProperties(sys.argv)
         rootpass = p.getProperty("omero.rootpass")
-        if not rootpass:
-            raise Exception("No omero.rootpass found in ICE_CONFIG")
 
         try:
             cls.root = omero.client()  # ok because adds self

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -78,18 +78,19 @@ class ITest(object):
 
         p = Ice.createProperties(sys.argv)
         rootpass = p.getProperty("omero.rootpass")
+        if not rootpass:
+            raise Exception("No omero.rootpass found in ICE_CONFIG")
 
-        name = None
-        if rootpass:
+        try:
             cls.root = omero.client()  # ok because adds self
             cls.__clients.add(cls.root)
             cls.root.setAgent("OMERO.py.root_test")
             cls.root.createSession("root", rootpass)
-            newuser = cls.new_user()
-            name = newuser.omeName.val
-        else:
-            cls.root = None
+        except:
+            raise Exception("Could not initiate a root connection")
 
+        newuser = cls.new_user()
+        name = newuser.omeName.val
         cls.client = omero.client()  # ok because adds self
         cls.__clients.add(cls.client)
         cls.client.setAgent("OMERO.py.test")

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1955,16 +1955,19 @@ class UserGroupControl(BaseControl):
             tb.set_style(args.style)
 
         # Sort users
-        if args.sort_by_login:
-            users.sort(key=lambda x: x.omeName.val)
-        elif args.sort_by_first_name:
-            users.sort(key=lambda x: x.firstName.val)
-        elif args.sort_by_last_name:
-            users.sort(key=lambda x: x.lastName.val)
-        elif args.sort_by_email:
-            users.sort(key=lambda x: (x.email and x.email.val or ""))
-        elif args.sort_by_id:
-            users.sort(key=lambda x: x.id.val)
+        if isinstance(users, list):
+            if args.sort_by_login:
+                users.sort(key=lambda x: x.omeName.val)
+            elif args.sort_by_first_name:
+                users.sort(key=lambda x: x.firstName.val)
+            elif args.sort_by_last_name:
+                users.sort(key=lambda x: x.lastName.val)
+            elif args.sort_by_email:
+                users.sort(key=lambda x: (x.email and x.email.val or ""))
+            elif args.sort_by_id:
+                users.sort(key=lambda x: x.id.val)
+        else:
+            users = [users]
 
         for user in users:
             row = [user.id.val, user.omeName.val, user.firstName.val,
@@ -2041,3 +2044,128 @@ class UserGroupControl(BaseControl):
                 row.append(len(memberids))
             tb.row(*tuple(row))
         self.ctx.out(str(tb.build()))
+
+    def add_id_name_arguments(self, parser, objtype=""):
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--id", help="ID of the %s" % objtype)
+        group.add_argument(
+            "--name", help="Name of the %s" % objtype)
+        return group
+
+    def add_user_arguments(self, parser, action=""):
+        group = parser.add_argument_group('User arguments')
+        group.add_argument("user_id_or_name",  metavar="user", nargs="*",
+                           help="ID or name of the user(s)%s" % action)
+        group.add_argument("--user-id", metavar="user", nargs="+",
+                           help="ID of the user(s)%s" % action)
+        group.add_argument("--user-name", metavar="user", nargs="+",
+                           help="Name of the user(s)%s" % action)
+        return group
+
+    def list_users(self, a, args, use_context=False):
+        """
+        Retrieve users from the arguments defined in
+        :meth:`add_user_arguments`
+        """
+
+        # Check input arguments
+        has_user_arguments = (args.user_id_or_name or args.user_id
+                              or args.user_name)
+        if (not use_context and not has_user_arguments):
+            self.error_no_input_user(fatal=True)
+
+        # Retrieve groups by id or name
+        uid_list = []
+        u_list = []
+        if args.user_id_or_name:
+            for user in args.user_id_or_name:
+                [uid, u] = self.find_user(a, user, fatal=False)
+                if uid is not None:
+                    uid_list.append(uid)
+                    u_list.append(u)
+
+        if args.user_id:
+            for user_id in args.user_id:
+                [uid, u] = self.find_user_by_id(a, user_id, fatal=False)
+                if uid is not None:
+                    uid_list.append(uid)
+                    u_list.append(u)
+
+        if args.user_name:
+            for user_name in args.user_name:
+                [uid, u] = self.find_user_by_name(a, user_name, fatal=False)
+                if uid is not None:
+                    uid_list.append(uid)
+                    u_list.append(u)
+
+        if not uid_list:
+            if not use_context or has_user_arguments:
+                self.error_no_user_found(fatal=True)
+            else:
+                ec = self.ctx.get_event_context()
+                [uid, u] = self.find_user_by_id(a, ec.userId, fatal=False)
+                uid_list.append(uid)
+                u_list.append(u)
+
+        return uid_list, u_list
+
+    def add_group_arguments(self, parser, action=""):
+        group = parser.add_argument_group('Group arguments')
+        group.add_argument(
+            "group_id_or_name",  metavar="group", nargs="*",
+            help="ID or name of the group(s)%s" % action)
+        group.add_argument(
+            "--group-id", metavar="group", nargs="+",
+            help="ID  of the group(s)%s" % action)
+        group.add_argument(
+            "--group-name", metavar="group", nargs="+",
+            help="Name of the group(s)%s" % action)
+        return group
+
+    def list_groups(self, a, args, use_context=False):
+        """
+        Retrieve users from the arguments defined in
+        :meth:`add_user_arguments`
+        """
+
+        # Check input arguments
+        has_group_arguments = (args.group_id_or_name or args.group_id
+                               or args.group_name)
+        if (not use_context and not has_group_arguments):
+            self.error_no_input_group(fatal=True)
+
+        # Retrieve groups by id or name
+        gid_list = []
+        g_list = []
+        if args.group_id_or_name:
+            for group in args.group_id_or_name:
+                [gid, g] = self.find_group(a, group, fatal=False)
+                if g:
+                    gid_list.append(gid)
+                    g_list.append(g)
+
+        if args.group_id:
+            for group_id in args.group_id:
+                [gid, g] = self.find_group_by_id(a, group_id, fatal=False)
+                if g:
+                    gid_list.append(gid)
+                    g_list.append(g)
+
+        if args.group_name:
+            for group_name in args.group_name:
+                [gid, g] = self.find_group_by_name(a, group_name, fatal=False)
+                if g:
+                    gid_list.append(gid)
+                    g_list.append(g)
+
+        if not gid_list:
+            if not use_context and has_group_arguments:
+                self.error_no_group_found(fatal=True)
+            else:
+                ec = self.ctx.get_event_context()
+                [gid, g] = self.find_group_by_id(a, ec.groupId, fatal=False)
+                gid_list.append(gid)
+                g_list.append(g)
+
+        return gid_list, g_list

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -2160,7 +2160,7 @@ class UserGroupControl(BaseControl):
                     g_list.append(g)
 
         if not gid_list:
-            if not use_context and has_group_arguments:
+            if not use_context or has_group_arguments:
                 self.error_no_group_found(fatal=True)
             else:
                 ec = self.ctx.get_event_context()

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -72,12 +72,12 @@ server-permissions.html
             x.add_user_print_arguments()
             x.add_group_sorting_arguments()
 
-        members = parser.add(
-            sub, self.members, "List members of the current group")
-        self.add_group_arguments(members)
-        members.add_style_argument()
-        members.add_group_print_arguments()
-        members.add_user_sorting_arguments()
+        listusers = parser.add(
+            sub, self.listusers, "List users of the current group")
+        self.add_group_arguments(listusers)
+        listusers.add_style_argument()
+        listusers.add_group_print_arguments()
+        listusers.add_user_sorting_arguments()
 
         copyusers = parser.add(sub, self.copyusers, "Copy the users of one"
                                " group to another group")
@@ -206,11 +206,12 @@ server-permissions.html
         [gid, groups] = self.list_groups(a, args, use_context=True)
         self.output_groups_list(groups, args)
 
-    def members(self, args):
+    def listusers(self, args):
         c = self.ctx.conn(args)
         admin = c.sf.getAdminService()
         [gids, groups] = self.list_groups(admin, args, use_context=True)
-        print gids[0]
+        if len(gids) != 1:
+            self.ctx.die(516, 'No more than one user')
         users = admin.containedExperimenters(gids[0])
         self.output_users_list(admin, users, args)
 

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -61,6 +61,12 @@ server-permissions.html
         list = parser.add(sub, self.list, "List current groups")
         list.add_style_argument()
 
+        members = parser.add(
+            sub, self.members, "List members of the current group")
+        members.add_style_argument()
+        members.add_group_print_arguments()
+        members.add_user_sorting_arguments()
+
         printgroup = list.add_mutually_exclusive_group()
         printgroup.add_argument(
             "--count", action="store_true", default=True,
@@ -238,6 +244,14 @@ server-permissions.html
                 row.append(len(memberids))
             tb.row(*tuple(row))
         self.ctx.out(str(tb.build()))
+
+    def members(self, args):
+        c = self.ctx.conn(args)
+        admin = c.sf.getAdminService()
+        ec = self.ctx.get_event_context()
+        [gid, g] = self.find_group_by_id(admin, ec.groupId, fatal=True)
+        users = admin.containedExperimenters(gid)
+        self.output_users_list(admin, users, args)
 
     def parse_groupid(self, a, args):
         if args.id:

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -58,10 +58,19 @@ server-permissions.html
         self.add_id_name_arguments(perms, "group")
         self.add_permissions_arguments(perms)
 
-        list = parser.add(sub, self.list, "List current groups")
-        list.add_style_argument()
-        list.add_user_print_arguments()
-        list.add_group_sorting_arguments()
+        list = parser.add(
+            sub, self.list, help="List information about all groups")
+
+        info = parser.add(
+            sub, self.info,
+            "List information about the group(s). Default to the context"
+            " group")
+        self.add_group_arguments(info)
+
+        for x in (list, info):
+            x.add_style_argument()
+            x.add_user_print_arguments()
+            x.add_group_sorting_arguments()
 
         members = parser.add(
             sub, self.members, "List members of the current group")
@@ -189,6 +198,12 @@ server-permissions.html
     def list(self, args):
         c = self.ctx.conn(args)
         groups = c.sf.getAdminService().lookupGroups()
+        self.output_groups_list(groups, args)
+
+    def info(self, args):
+        c = self.ctx.conn(args)
+        a = c.sf.getAdminService()
+        [gid, groups] = self.list_groups(a, args, use_context=True)
         self.output_groups_list(groups, args)
 
     def members(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -211,7 +211,7 @@ server-permissions.html
         admin = c.sf.getAdminService()
         [gids, groups] = self.list_groups(admin, args, use_context=True)
         if len(gids) != 1:
-            self.ctx.die(516, 'No more than one user')
+            self.ctx.die(516, 'Too many group arguments')
         users = admin.containedExperimenters(gids[0])
         self.output_users_list(admin, users, args)
 

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -62,11 +62,13 @@ class UserControl(UserGroupControl):
             x.add_group_print_arguments()
             x.add_user_sorting_arguments()
 
-        groups = parser.add(
-            sub, self.groups, "List groups of the current user")
-        groups.add_style_argument()
-        groups.add_user_print_arguments()
-        groups.add_group_sorting_arguments()
+        listgroups = parser.add(
+            sub, self.listgroups,
+            "List the groups of the user. Default to the context user")
+        self.add_user_arguments(listgroups)
+        listgroups.add_style_argument()
+        listgroups.add_user_print_arguments()
+        listgroups.add_group_sorting_arguments()
 
         password = parser.add(
             sub, self.password, help="Set user's password")
@@ -203,11 +205,13 @@ class UserControl(UserGroupControl):
         [uids, users] = self.list_users(a, args, use_context=True)
         self.output_users_list(a, users, args)
 
-    def groups(self, args):
+    def listgroups(self, args):
         c = self.ctx.conn(args)
         admin = c.sf.getAdminService()
-        ec = self.ctx.get_event_context()
-        groups = admin.containedGroups(ec.userId)
+        [uids, groups] = self.list_users(admin, args, use_context=True)
+        if len(uids) != 1:
+            self.ctx.die(516, 'No more than one user')
+        groups = admin.containedGroups(uids[0])
         self.output_groups_list(groups, args)
 
     @admin_only

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -51,31 +51,8 @@ class UserControl(UserGroupControl):
 
         list = parser.add(sub, self.list, help="List current users")
         list.add_style_argument()
-
-        printgroup = list.add_mutually_exclusive_group()
-        printgroup.add_argument(
-            "--long", action="store_true", default=True,
-            help="Print comma-separated list of all groups (default)")
-        printgroup.add_argument(
-            "--count", action="store_true", default=False,
-            help="Print count of all groups")
-
-        sortgroup = list.add_mutually_exclusive_group()
-        sortgroup.add_argument(
-            "--sort-by-id", action="store_true", default=True,
-            help="Sort users by ID (default)")
-        sortgroup.add_argument(
-            "--sort-by-login", action="store_true", default=False,
-            help="Sort users by login")
-        sortgroup.add_argument(
-            "--sort-by-first-name", action="store_true", default=False,
-            help="Sort users by first name")
-        sortgroup.add_argument(
-            "--sort-by-last-name", action="store_true", default=False,
-            help="Sort users by last name")
-        sortgroup.add_argument(
-            "--sort-by-email", action="store_true", default=False,
-            help="Sort users by email")
+        list.add_group_print_arguments()
+        list.add_user_sorting_arguments()
 
         password = parser.add(
             sub, self.password, help="Set user's password")
@@ -222,77 +199,7 @@ class UserControl(UserGroupControl):
         c = self.ctx.conn(args)
         a = c.sf.getAdminService()
         users = a.lookupExperimenters()
-        roles = a.getSecurityRoles()
-        user_group = roles.userGroupId
-        sys_group = roles.systemGroupId
-
-        from omero.util.text import TableBuilder
-        if args.count:
-            tb = TableBuilder("id", "login", "first name", "last name",
-                              "email", "active", "ldap", "admin",
-                              "# group memberships", "# group ownerships")
-        else:
-            tb = TableBuilder("id", "login", "first name", "last name",
-                              "email", "active", "ldap", "admin", "member of",
-                              "owner of")
-        if args.style:
-            tb.set_style(args.style)
-
-        # Sort users
-        if args.sort_by_login:
-            users.sort(key=lambda x: x.omeName.val)
-        elif args.sort_by_first_name:
-            users.sort(key=lambda x: x.firstName.val)
-        elif args.sort_by_last_name:
-            users.sort(key=lambda x: x.lastName.val)
-        elif args.sort_by_email:
-            users.sort(key=lambda x: (x.email and x.email.val or ""))
-        elif args.sort_by_id:
-            users.sort(key=lambda x: x.id.val)
-
-        for user in users:
-            row = [user.id.val, user.omeName.val, user.firstName.val,
-                   user.lastName.val]
-            row.append(user.email and user.email.val or "")
-            active = ""
-            admin = ""
-            ldap = user.ldap.val
-            member_of = []
-            leader_of = []
-            for x in user.copyGroupExperimenterMap():
-                if not x:
-                    continue
-                gid = x.parent.id.val
-                if user_group == gid:
-                    active = "Yes"
-                elif sys_group == gid:
-                    admin = "Yes"
-                elif x.owner.val:
-                    leader_of.append(str(gid))
-                else:
-                    member_of.append(str(gid))
-
-            row.append(active)
-            row.append(ldap)
-            row.append(admin)
-
-            if member_of:
-                if args.count:
-                    row.append(len(member_of))
-                else:
-                    row.append(",".join(member_of))
-            else:
-                row.append("")
-            if leader_of:
-                if args.count:
-                    row.append(len(leader_of))
-                else:
-                    row.append(",".join(leader_of))
-            else:
-                row.append("")
-
-            tb.row(*tuple(row))
-        self.ctx.out(str(tb.build()))
+        self.output_users_list(a, users, args)
 
     @admin_only
     def add(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -54,6 +54,12 @@ class UserControl(UserGroupControl):
         list.add_group_print_arguments()
         list.add_user_sorting_arguments()
 
+        info = parser.add(
+            sub, self.members, "List groups of the current user")
+        info.add_style_argument()
+        info.add_user_print_arguments()
+        info.add_group_sorting_arguments()
+
         password = parser.add(
             sub, self.password, help="Set user's password")
         password.add_argument(
@@ -200,6 +206,13 @@ class UserControl(UserGroupControl):
         a = c.sf.getAdminService()
         users = a.lookupExperimenters()
         self.output_users_list(a, users, args)
+
+    def info(self, args):
+        c = self.ctx.conn(args)
+        admin = c.sf.getAdminService()
+        ec = self.ctx.get_event_context()
+        groups = admin.containedGroups(ec.userId)
+        self.output_groups_list(groups, args)
 
     @admin_only
     def add(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -54,8 +54,7 @@ class UserControl(UserGroupControl):
         list.add_group_print_arguments()
         list.add_user_sorting_arguments()
 
-        info = parser.add(
-            sub, self.members, "List groups of the current user")
+        info = parser.add(sub, self.info, "List groups of the current user")
         info.add_style_argument()
         info.add_user_print_arguments()
         info.add_group_sorting_arguments()

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -210,7 +210,7 @@ class UserControl(UserGroupControl):
         admin = c.sf.getAdminService()
         [uids, groups] = self.list_users(admin, args, use_context=True)
         if len(uids) != 1:
-            self.ctx.die(516, 'No more than one user')
+            self.ctx.die(516, 'Too many user arguments')
         groups = admin.containedGroups(uids[0])
         self.output_groups_list(groups, args)
 

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -49,23 +49,24 @@ class UserControl(UserGroupControl):
             "--no-password", action="store_true", default=False,
             help="Create user with empty password")
 
-        list = parser.add(sub, self.list, help="List current users")
-        list.add_style_argument()
-        list.add_group_print_arguments()
-        list.add_user_sorting_arguments()
+        list = parser.add(
+            sub, self.list, help="List information about all users")
+
+        info = parser.add(
+            sub, self.info,
+            "List information about the user(s). Default to the context user")
+        self.add_user_arguments(info)
+
+        for x in (list, info):
+            x.add_style_argument()
+            x.add_group_print_arguments()
+            x.add_user_sorting_arguments()
 
         groups = parser.add(
             sub, self.groups, "List groups of the current user")
         groups.add_style_argument()
         groups.add_user_print_arguments()
         groups.add_group_sorting_arguments()
-
-        info = parser.add(
-            sub, self.info, "List information about the current user")
-        info.add_style_argument()
-        info.add_user_sorting_arguments()
-        info.add_user_print_arguments()
-        self.add_user_arguments(info)
 
         password = parser.add(
             sub, self.password, help="Set user's password")

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -103,3 +103,44 @@ GroupFixtures = (
     ArgumentFixture('--group-id', 'id'),
     ArgumentFixture('--group-name', 'name'),
     )
+
+
+def get_user_ids(out, sort_key=None):
+    columns = {'login': 1, 'first-name': 2, 'last-name': 3, 'email': 4}
+    lines = out.split('\n')
+    ids = []
+    last_value = None
+    for line in lines[2:]:
+        elements = line.split('|')
+        if len(elements) < 8:
+            continue
+
+        ids.append(int(elements[0].strip()))
+        if sort_key:
+            if sort_key == 'id':
+                new_value = ids[-1]
+            else:
+                new_value = elements[columns[sort_key]].strip()
+            assert new_value >= last_value
+            last_value = new_value
+    return ids
+
+
+def get_group_ids(out, sort_key=None):
+    lines = out.split('\n')
+    ids = []
+    last_value = None
+    for line in lines[2:]:
+        elements = line.split('|')
+        if len(elements) < 4:
+            continue
+
+        ids.append(int(elements[0].strip()))
+        if sort_key:
+            if sort_key == 'id':
+                new_value = ids[-1]
+            else:
+                new_value = elements[1].strip()
+            assert new_value >= last_value
+            last_value = new_value
+    return ids

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -53,3 +53,53 @@ class RootCLITest(AbstractCLITest):
 
     def setup_method(self, method):
         self.args = self.root_login_args()
+
+
+class ArgumentFixture(object):
+
+    """
+    Used to test the user/group argument
+    """
+
+    def __init__(self, prefix, attr):
+        self.prefix = prefix
+        self.attr = attr
+
+    def get_arguments(self, obj):
+        args = []
+        if self.prefix:
+            args += [self.prefix]
+        if self.attr:
+            args += ["%s" % getattr(obj, self.attr).val]
+        return args
+
+    def __repr__(self):
+        if self.prefix:
+            return "%s" % self.prefix
+        else:
+            return "%s" % self.attr
+
+
+UserIdNameFixtures = (
+    ArgumentFixture('--id', 'id'),
+    ArgumentFixture('--name', 'omeName'),
+    )
+
+UserFixtures = (
+    ArgumentFixture(None, 'id'),
+    ArgumentFixture(None, 'omeName'),
+    ArgumentFixture('--user-id', 'id'),
+    ArgumentFixture('--user-name', 'omeName'),
+    )
+
+GroupIdNameFixtures = (
+    ArgumentFixture('--id', 'id'),
+    ArgumentFixture('--name', 'name'),
+    )
+
+GroupFixtures = (
+    ArgumentFixture(None, 'id'),
+    ArgumentFixture(None, 'name'),
+    ArgumentFixture('--group-id', 'id'),
+    ArgumentFixture('--group-name', 'name'),
+    )

--- a/components/tools/OmeroPy/test/integration/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_group.py
@@ -35,12 +35,16 @@ perms_pairs.extend([('--type', v) for v in defaultperms.keys()])
 
 class TestGroup(CLITest):
 
-    def setup_method(self, method):
-        super(TestGroup, self).setup_method(method)
+    @classmethod
+    def setup_class(self):
+        super(TestGroup, self).setup_class()
         self.cli.register("group", GroupControl, "TEST")
-        self.args += ["group"]
         self.groups = self.sf.getAdminService().lookupGroups()
         self.group2 = self.new_group()
+
+    def setup_method(self, method):
+        super(TestGroup, self).setup_method(method)
+        self.args += ["group"]
 
     def get_group_ids(self, out, sort_key=None):
         lines = out.split('\n')
@@ -138,6 +142,12 @@ class TestGroup(CLITest):
         out, err = capsys.readouterr()
         ids = self.get_group_ids(out)
         assert ids == [self.group2.id.val]
+
+    def testInfoInvalidGroup(self, capsys):
+        self.args += ["info"]
+        self.args += ["-1"]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
 
 
 class TestGroupRoot(RootCLITest):

--- a/components/tools/OmeroPy/test/integration/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_group.py
@@ -80,31 +80,6 @@ class TestGroup(CLITest):
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
 
-    def testMembers(self, capsys):
-
-        import omero.model
-        adminService = self.sf.getAdminService()
-        gid = adminService.getEventContext().groupId
-        group = omero.model.ExperimenterGroupI(gid, False)
-        member = self.new_user(group=group)
-        owner = self.new_user(group=group, owner=True)
-        admin = self.new_user(group=group, system=True)
-        group_users = [x.id.val for x in [member, owner, admin]]
-        group_users.append(adminService.getEventContext().userId)
-
-        self.args += ["members"]
-        self.cli.invoke(self.args, strict=True)
-        out, err = capsys.readouterr()
-
-        lines = out.split('\n')
-        ids = []
-        for line in lines[2:]:
-            elements = line.split('|')
-            if len(elements) < 8:
-                continue
-            ids.append(int(elements[0].strip()))
-        assert set(ids) == set(group_users)
-
     # Info subcommand
     # ========================================================================
     def testInfoNoArgument(self, capsys):

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -125,6 +125,12 @@ class TestUser(CLITest):
         ids = self.get_user_ids(out)
         assert ids == [self.user2.id.val]
 
+    def testInfoInvalidUser(self, capsys):
+        self.args += ["info"]
+        self.args += ["-1"]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+
     @pytest.mark.parametrize("style", [None, "sql", "csv", "plain"])
     def testListWithStyles(self, capsys, style):
         self.args += ["list"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -325,17 +325,24 @@ class TestUserRoot(RootCLITest):
         lastname = self.uuid()
 
         self.args += ["add", login, firstname, lastname]
+        kwargs = {
+            'omeName': login,
+            'firstName': firstname,
+            'lastName': lastname}
         self.args += ["%s" % group.id.val]
         if middlename_prefix:
             middlename = self.uuid()
             self.args += [middlename_prefix, middlename]
+            kwargs['middleName'] = middlename
         if email_prefix:
             email = "%s.%s@%s.org" % (firstname[:6], lastname[:6],
                                       self.uuid()[:6])
             self.args += [email_prefix, email]
+            kwargs['email'] = email
         if institution_prefix:
             institution = self.uuid()
             self.args += [institution_prefix, institution]
+            kwargs['institution'] = institution
         if admin_prefix:
             self.args += [admin_prefix]
         self.args += ['-P', login]
@@ -343,16 +350,10 @@ class TestUserRoot(RootCLITest):
 
         # Check user has been added to the list of member/owners
         user = self.sf.getAdminService().lookupExperimenter(login)
-        assert user.omeName.val == login
-        assert user.firstName.val == firstname
-        assert user.lastName.val == lastname
+        for key, value in kwargs.iteritems():
+            assert getattr(user, key).val == kwargs[key]
+
         assert user.id.val in self.getuserids(group.id.val)
-        if middlename_prefix:
-            assert user.middleName.val == middlename
-        if email_prefix:
-            assert user.email.val == email
-        if institution_prefix:
-            assert user.institution.val == institution
         if admin_prefix:
             roles = self.sf.getAdminService().getSecurityRoles()
             assert user.id.val in self.getuserids(roles.systemGroupId)

--- a/components/tools/OmeroPy/test/unit/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_group.py
@@ -24,7 +24,7 @@ from omero.plugins.group import GroupControl
 from omero.cli import CLI
 
 subcommands = ['add', 'perms', 'list', 'copyusers', 'adduser', 'removeuser',
-               'members']
+               'listusers']
 
 
 class TestGroup(object):

--- a/components/tools/OmeroPy/test/unit/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_group.py
@@ -23,7 +23,8 @@ import pytest
 from omero.plugins.group import GroupControl
 from omero.cli import CLI
 
-subcommands = ['add', 'perms', 'list', 'copyusers', 'adduser', 'removeuser']
+subcommands = ['add', 'perms', 'list', 'copyusers', 'adduser', 'removeuser',
+               'members']
 
 
 class TestGroup(object):

--- a/components/tools/OmeroPy/test/unit/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_user.py
@@ -23,7 +23,8 @@ from omero.plugins.user import UserControl
 from omero.cli import CLI
 import pytest
 
-subcommands = ['add', 'list', 'password', 'email', 'joingroup', 'leavegroup']
+subcommands = ['add', 'list', 'password', 'email', 'joingroup', 'leavegroup',
+               'info']
 
 
 class TestUser(object):

--- a/components/tools/OmeroPy/test/unit/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_user.py
@@ -24,7 +24,7 @@ from omero.cli import CLI
 import pytest
 
 subcommands = ['add', 'list', 'password', 'email', 'joingroup', 'leavegroup',
-               'info']
+               'info', 'listgroups']
 
 
 class TestUser(object):


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12589

This PR adds 
- a `info` subcommand to both `UserControl` and `GroupControl` plugins. These commands have the same behavior as the `list` subcommand for a subset of users/groups. The following commands should now be accepted

  ```
bin/omero user info   # Give info about the context user
bin/omero user info user-1
bin/omero user info user-1 --user-id 3 --user-name user-4
bin/omero group info   # Give info about the context user
bin/omero group info read-write1
bin/omero group info read-write1 --group-id 3 --group-name read-annotate-1
```

- a `bin/omero group listusers` and a `bin/omero user listgroups` subcommands. Both subcommands either take no argument (using the context) or a single argument. The following calls should work:

  ```
bin/omero group listusers   # Return the users of the context group
bin/omero group listusers read-write1
bin/omero user listgroups   # Return the groups of the context user
bin/omero user listgroups user-6
```

To test this PR:
- check the commands above are working in a multi-user/multi-group context
- check the integration tests are passing both for the new commands as well as the `user list` and `group list` subcommands which were refactored as part of this PR

--no-rebase