### PR TITLE
Download spw original files dev50

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -255,6 +255,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.server_list": ["SERVER_LIST", '[["%s", 4064, "omero"]]' % CUSTOM_HOST, json.loads],
     # Configuration options for the viewer. -1: zoom in fully, 0: zoom out fully, unset: zoom to fit window
     "omero.web.viewer.initial_zoom_level": ["VIEWER_INITIAL_ZOOM_LEVEL", None, leave_none_unset_int],
+    "omero.web.plate_download.enabled": ["PLATE_DOWNLOAD_ENABLED", "false", parse_boolean],
     # the following parameters configure when to show/hide the 'Volume viewer' icon in the Image metadata panel
     "omero.web.open_astex_max_side": ["OPEN_ASTEX_MAX_SIDE", 400, int],
     "omero.web.open_astex_min_side": ["OPEN_ASTEX_MIN_SIDE", 20, int],

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -181,12 +181,21 @@ class BaseContainer(BaseController):
         elif self.acquisition:
             return self.acquisition._obj.plate.id.val
         
-    def isDownloadDisabled(self):
+    def isDownloadDisabled(self, objDict=None):
         """
-        Returns True only if we have an SPW object and
+        Returns True only if we have an SPW object(s) and
         settings.PLATE_DOWNLOAD_ENABLED is false
         """
-        if (self.screen is None and self.acquisition is None and
+        # As used in batch_annotate panel
+        if objDict is not None:
+            spwData = False
+            for spw in ('screen', 'plate', 'well', 'acquisition'):
+                if spw in objDict and len(objDict[spw]) > 0:
+                    spwData = True
+            if not spwData:
+                return False
+        # As used in metadata_general panel
+        elif (self.screen is None and self.acquisition is None and
                 self.plate is None and self.well is None):
             return False
         if hasattr(settings, 'PLATE_DOWNLOAD_ENABLED'):

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -181,6 +181,16 @@ class BaseContainer(BaseController):
         elif self.acquisition:
             return self.acquisition._obj.plate.id.val
         
+    def isDownloadDisabled(self):
+        """
+        Returns True only if we have an SPW object and
+        settings.PLATE_DOWNLOAD_ENABLED is false
+        """
+        if (self.screen is None and self.acquisition is None and
+                self.plate is None and self.well is None):
+            return False
+        if hasattr(settings, 'PLATE_DOWNLOAD_ENABLED'):
+            return (not settings.PLATE_DOWNLOAD_ENABLED)
 
     def listFigureScripts(self, objDict=None):
         """

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -90,7 +90,7 @@
                 Download...</a>
             </li>
             {% endif %}
-            {% if image %}
+            {% if image and not omeTiffDisabled %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -81,7 +81,7 @@
                     href="{% url 'archived_files' %}?{{ obj_string }}"
                   {% else %}
                     href="#"
-                    onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&fileCount={{ filesetInfo.count }}');"
+                    onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&fileCount={{ filesetInfo.count }}&index={{ index }}');"
                   {% endifequal %}
                 {% endifequal %}
                 title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s as zip'}} ({{ filesetInfo.size|filesizeformat }})"
@@ -122,17 +122,17 @@
               {% if filesetInfo %}
               <li>
                 <a href="#"
-                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=jpeg');"
+                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=jpeg&index={{ index }}');"
                   title="Download as JPEGs (zip)">Save As JPEG</a>
               </li>
               <li>
                 <a href="#"
-                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=png');"
+                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=png&index={{ index }}');"
                   title="Download as PNGs (zip)">Save As PNG</a>
               </li>
               <li>
                 <a href="#"
-                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=tif');"
+                  onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&format=tif&index={{ index }}');"
                   title="Download as TIFFs (zip)">Save As TIFF</a>
               </li>
               {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -45,7 +45,7 @@
     <!-- This is used for 'batch annotate' panel with 'filesetCount'... -->
     <!-- ... and for single images -->
 
-    {% if manager.image or filesetInfo %}
+    {% if image or filesetInfo %}
     <!-- download options -->
     <div class="toolbar_dropdown">
         <button class="btn silver btn_download" title="Download Image as...">
@@ -53,17 +53,17 @@
         </button>
         <ul class="dropdown">
             <!-- Here we handle a single image (in metadata general) - see below for multiple images (batch annotate) -->
-            {% if manager.image.getImportedFilesInfo.count %}
-              {% with filesetInfo=manager.image.getImportedFilesInfo %}
+            {% if image.getImportedFilesInfo.count %}
+              {% with filesetInfo=image.getImportedFilesInfo %}
             <li>
                 <!-- if we have a single orig file, download directly. Otherwise popup a 
                   'preparing zip' download placeholder -->
                 <a id="download-origfile" 
                   {% ifequal filesetInfo.count 1 %}
-                    href="{% url 'archived_files' manager.image.id %}"
+                    href="{% url 'archived_files' image.id %}"
                   {% else %}
                     href="#"
-                    onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids=image-{{ manager.image.id }}&fileCount={{ fileCount }}&name={{ manager.image.name }}');"
+                    onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids=image-{{ image.id }}&fileCount={{ fileCount }}&name={{ image.name }}');"
                   {% endifequal %}
                 title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s as zip'}} ({{ filesetInfo.size|filesizeformat }})"
                 >
@@ -89,9 +89,9 @@
                 Download...</a>
             </li>
             {% endif %}
-            {% if manager.image %}
+            {% if image %}
             <li>
-                <a id="create-ometiff" href="{% url 'ome_tiff_script' manager.image.id %}" 
+                <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>
             </li>
             {% else %}
@@ -102,19 +102,19 @@
             <li>{{ manager.}}
             {% endif %}
 
-            {% if manager.image %}
+            {% if image %}
               <li>
-                <a href="{% url 'web_render_image_download' manager.image.id %}" title="Download as JPEG">
+                <a href="{% url 'web_render_image_download' image.id %}" title="Download as JPEG">
                   Save As JPEG
                 </a>
               </li>
               <li>
-                <a href="{% url 'web_render_image_download' manager.image.id %}?format=png" title="Download as PNG">
+                <a href="{% url 'web_render_image_download' image.id %}?format=png" title="Download as PNG">
                   Save As PNG
                 </a>
               </li>
               <li>
-                <a href="{% url 'web_render_image_download' manager.image.id %}?format=tif" title="Download as TIFF">
+                <a href="{% url 'web_render_image_download' image.id %}?format=tif" title="Download as TIFF">
                   Save As TIFF
                 </a>
               </li>
@@ -140,7 +140,7 @@
         </ul>
     </div>
 
-    {% if manager.image.showOriginalFilePaths %}
+    {% if image.showOriginalFilePaths %}
       <!-- show original file paths -->
       <button id="show_fs_files_btn" class="btn silver btn_fspath" title="Show file paths on server">
         <span></span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -47,6 +47,7 @@
 
     {% if image or filesetInfo %}
     <!-- download options -->
+    {% if not disableDownload %}
     <div class="toolbar_dropdown">
         <button class="btn silver btn_download" title="Download Image as...">
             <span></span>
@@ -139,6 +140,7 @@
             {% endif %}
         </ul>
     </div>
+    {% endif %}
 
     {% if image.showOriginalFilePaths %}
       <!-- show original file paths -->

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -138,21 +138,27 @@
                 });
 
                 // show original file path links for images
+                var original_file_paths_url;
                 {% if manager.image %}
+                original_file_paths_url = "{% url 'original_file_paths' manager.image.id %}";
+                {% elif manager.well.getWellSample.image %}
+                original_file_paths_url = "{% url 'original_file_paths' manager.well.getWellSample.image.id %}";
+                {% endif %}
                 $("#show_fs_files_btn").click(function(){
                     $("#fs_paths_popup").show();
                     var fs_input = $("#fs_paths_popup textarea");
-                    $.getJSON("{% url 'original_file_paths' manager.image.id %}",
-                        function(data) {
-                            fs_input.val(data.join("\n"));
-                            fs_input.attr("cols", 150);
-                            fs_input.attr("rows", Math.max(3, data.length));
-                        });
+                    if (original_file_paths_url) {
+                        $.getJSON(original_file_paths_url,
+                            function(data) {
+                                fs_input.val(data.join("\n"));
+                                fs_input.attr("cols", 150);
+                                fs_input.attr("rows", Math.max(3, data.length));
+                            });
+                    }
                 });
                 $("#fs_paths_popup img").click(function(){
                     $("#fs_paths_popup").hide();
                 });
-                {% endif %}
 
                 // handle submit of Add Comment form
                 $("#add_comment_form").ajaxForm({
@@ -456,7 +462,9 @@
            
             {% if manager.image %}            
 
-            {% include "webclient/annotations/includes/toolbar.html" %}
+            {% with image=manager.image %}
+                {% include "webclient/annotations/includes/toolbar.html" %}
+            {% endwith %}
 
             <!-- Image Name -->
             {% with obj=manager.image nameText=manager.image.name %}
@@ -608,7 +616,9 @@
             
             {% if manager.well %}            
 
-            {% include "webclient/annotations/includes/toolbar.html" %}
+            {% with image=manager.well.getWellSample.image %}
+                {% include "webclient/annotations/includes/toolbar.html" %}
+            {% endwith %}
 
                         <!-- Image (in WellSample) Description -->
             {% with obj=manager.well.getWellSample.image nameText=manager.well.getWellSample.image.name %}
@@ -630,6 +640,17 @@
             </button>
             
             <div style="clear:both"></div>
+
+            {% if manager.well.getWellSample.image.showOriginalFilePaths %}
+            <!-- duplicated under 'image' above -->
+            <div style="clear:both"></div>
+            <div id="fs_paths_popup" style="display:none; background: #fff; border: solid 1px #ddd; margin-bottom:5px">
+                <img title="Close" src="{% static 'webgateway/img/close.gif' %}" style="float:right; margin:3px"/>
+                <div style="margin: 4px">{{ manager.well.getWellSample.image.getImportedFilesInfo.count }} Image file{{ manager.well.getWellSample.image.getImportedFilesInfo.count|pluralize:'s'}}:</div>
+                <textarea readonly="true" style="width:99%; float:right; resize:none; border:none; padding:5px 0 0 0; margin:0px"></textarea>
+                <div style="clear:both"></div>
+            </div>
+            {% endif %}
 
             <hr/>
             

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -616,7 +616,7 @@
             
             {% if manager.well %}            
 
-            {% with image=manager.well.getWellSample.image %}
+            {% with image=manager.well.getWellSample.image disableDownload=manager.isDownloadDisabled %}
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -616,7 +616,7 @@
             
             {% if manager.well %}            
 
-            {% with image=manager.well.getWellSample.image disableDownload=manager.isDownloadDisabled %}
+            {% with image=manager.well.getWellSample.image disableDownload=manager.isDownloadDisabled omeTiffDisabled=True %}
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1145,6 +1145,7 @@ def batch_annotate(request, conn=None, **kwargs):
             'figScripts':figScripts, 'filesetInfo': filesetInfo, 'annotationBlocked': annotationBlocked}
     if len(groupIds) > 1:
         context['annotationBlocked'] = "Can't add annotations because objects are in different groups"
+    context['disableDownload'] = manager.isDownloadDisabled(objs)
     context['template'] = "webclient/annotations/batch_annotate.html"
     context['webclient_path'] = request.build_absolute_uri(reverse('webindex'))
     return context

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1115,8 +1115,12 @@ def batch_annotate(request, conn=None, **kwargs):
     batchAnns = manager.loadBatchAnnotations(objs)
     figScripts = manager.listFigureScripts(objs)
     filesetInfo = None
+    iids = []
+    if 'well' in objs and len(objs['well']) > 0:
+        iids = [w.getWellSample(index).image().getId() for w in objs['well']]
     if 'image' in objs and len(objs['image']) > 0:
         iids = [i.getId() for i in objs['image']]
+    if len(iids) > 0:
         filesetInfo = conn.getFilesetFilesInfo(iids)
         archivedInfo = conn.getArchivedFilesInfo(iids)
         filesetInfo['count'] += archivedInfo['count']
@@ -1928,6 +1932,8 @@ def download_placeholder(request):
     download_url = download_url + "?" + query
     if format is not None:
         download_url = download_url + "&format=%s" % format
+    if request.REQUEST.get('index'):
+        download_url = download_url + "&index=%s" % request.REQUEST.get('index')
 
     context = {
             'template': "webclient/annotations/download_placeholder.html",

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1723,14 +1723,29 @@ def download_as(request, iid=None, conn=None, **kwargs):
     format = request.REQUEST.get('format', 'png')
     if format not in ('jpeg', 'png', 'tif'):
         format = 'png'
+
+    imgIds = []
+    wellIds = []
     if iid is None:
         imgIds = request.REQUEST.getlist('image')
         if len(imgIds) == 0:
-            return HttpResponseServerError("No images specified in request. Use ?image=123")
+            wellIds = request.REQUEST.getlist('well')
+            if len(wellIds) == 0:
+                return HttpResponseServerError("No images or wells specified in request. Use ?image=123 or ?well=123")
     else:
         imgIds = [iid]
 
-    images = list(conn.getObjects("Image", imgIds))
+    images = []
+    if imgIds:
+        images = list(conn.getObjects("Image", imgIds))
+    elif wellIds:
+        try:
+            index = int(request.REQUEST.get("index", 0))
+        except ValueError:
+            index = 0
+        for w in conn.getObjects("Well", wellIds):
+            images.append(w.getWellSample(index).image())
+
     if len(images) == 0:
         msg = "Cannot download as %s. Images (ids: %s) not found." % (format, imgIds)
         logger.debug(msg)
@@ -1805,14 +1820,27 @@ def archived_files(request, iid=None, conn=None, **kwargs):
     """
     Downloads the archived file(s) as a single file or as a zip (if more than one file)
     """
+    imgIds = []
+    wellIds = []
     if iid is None:
         imgIds = request.REQUEST.getlist('image')
         if len(imgIds) == 0:
-            return HttpResponseServerError("No images specified in request. Use ?image=123")
+            wellIds = request.REQUEST.getlist('well')
+            if len(wellIds) == 0:
+                return HttpResponseServerError("No images or wells specified in request. Use ?image=123 or ?well=123")
     else:
         imgIds = [iid]
 
-    images = list(conn.getObjects("Image", imgIds))
+    images = []
+    if imgIds:
+        images = list(conn.getObjects("Image", imgIds))
+    elif wellIds:
+        try:
+            index = int(request.REQUEST.get("index", 0))
+        except ValueError:
+            index = 0
+        for w in conn.getObjects("Well", wellIds):
+            images.append(w.getWellSample(index).image())
     if len(images) == 0:
         logger.debug("Cannot download archived file becuase Images not found.")
         return HttpResponseServerError("Cannot download archived file becuase Images not found (ids: %s)." % (imgIds))

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1830,6 +1830,19 @@ def archived_files(request, iid=None, conn=None, **kwargs):
     else:
         imgIds = [iid]
 
+    # If plate download disabled, check for SPW data...
+    if hasattr(settings, 'PLATE_DOWNLOAD_ENABLED') and not settings.PLATE_DOWNLOAD_ENABLED:
+        if imgIds:
+            # if any WellSamples exist with image ids?
+            params = omero.sys.ParametersI()
+            params.addIds(imgIds)
+            query = ("select count(*) from WellSample as w where w.image.id in (:ids)")
+            ws = conn.getQueryService().projection(query, params, conn.SERVICE_OPTS)
+            if ws[0][0].val > 0:
+                raise Http404
+        elif wellIds:
+            raise Http404
+
     images = []
     if imgIds:
         images = list(conn.getObjects("Image", imgIds))

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -17,7 +17,9 @@ for tools in glob.glob("../../../lib/repository/setuptools*.egg"):
     if tools.find(".".join(map(str, sys.version_info[0:2]))) > 0:
         sys.path.insert(0, os.path.abspath(tools))
 
-os.environ.setdefault('OMERO_HOME', os.path.join("..", "..","..","dist"))
+os.environ.setdefault('OMERO_HOME', os.path.abspath(
+    os.path.join("..", "..", "..", "dist")))
+
 
 LIB = os.path.join("..", "target", "lib", "python")
 sys.path.insert(0, LIB)

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -140,15 +140,14 @@ class TestDownload(object):
         Download of archived files for a non-SPW Image.
         """
 
-        iid1 = itest.createTestImage(sizeC=2,
-                                     session=client.getSession()).id.val
+        image = itest.importSingleImage(client=client)
+
         # download archived files
         request_url = reverse('webgateway.views.archived_files')
         data = {
-            "image": iid1
+            "image": image.id.val
         }
-        # Currently get a 500 error since test image has no archived files.
-        _get_reponse(django_client, request_url, data, status_code=500)
+        _get_reponse(django_client, request_url, data, status_code=200)
 
 
 # Helpers

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -120,8 +120,9 @@ class TestDownload(object):
     Tests to check download is disabled where specified.
     """
 
-    def test_spw_download(self, itest, client, django_client, image_well_plate):
-        """ 
+    def test_spw_download(self, itest, client, django_client,
+                          image_well_plate):
+        """
         Download of an Image that is part of a plate should be disabled,
         and return a 404 response.
         """

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test download of data.
+"""
+
+# import omero
+# import omero.clients
+from omero.model import PlateI, WellI, WellSampleI
+from omero.rtypes import rstring
+
+import pytest
+import test.integration.library as lib
+
+from urllib import urlencode
+from django.test import Client
+from django.core.urlresolvers import reverse
+
+
+@pytest.fixture(scope='function')
+def itest(request):
+    """
+    Returns a new L{test.integration.library.ITest} instance. With attached
+    finalizer so that pytest will clean it up.
+    """
+    o = lib.ITest()
+    o.setup_method(None)
+
+    def finalizer():
+        o.teardown_method(None)
+    request.addfinalizer(finalizer)
+    return o
+
+
+@pytest.fixture(scope='function')
+def client(request, itest):
+    """Returns a new user client in a read-only group."""
+    # Use group read-only permissions (not private) by default
+    return itest.new_client(perms='rwr---')
+
+
+@pytest.fixture(scope='function')
+def django_client(request, client):
+    """Returns a logged in Django test client."""
+    django_client = Client(enforce_csrf_checks=True)
+    login_url = reverse('weblogin')
+
+    response = django_client.get(login_url)
+    assert response.status_code == 200
+    csrf_token = django_client.cookies['csrftoken'].value
+
+    data = {
+        'server': 1,
+        'username': client.getProperty('omero.user'),
+        'password': client.getProperty('omero.pass'),
+        'csrfmiddlewaretoken': csrf_token
+    }
+    response = django_client.post(login_url, data)
+    assert response.status_code == 302
+
+    def finalizer():
+        logout_url = reverse('weblogout')
+        data = {'csrfmiddlewaretoken': csrf_token}
+        response = django_client.post(logout_url, data=data)
+        assert response.status_code == 302
+    request.addfinalizer(finalizer)
+    return django_client
+
+
+@pytest.fixture(scope='function')
+def update_service(request, client):
+    """Returns a new OMERO update service."""
+    return client.getSession().getUpdateService()
+
+
+@pytest.fixture(scope='function')
+def image_well_plate(request, itest, update_service):
+    """
+    Returns a new OMERO Project, linked Dataset and linked Image populated
+    by an L{test.integration.library.ITest} instance with required fields
+    set.
+    """
+    plate = PlateI()
+    plate.name = rstring(itest.uuid())
+    plate = update_service.saveAndReturnObject(plate)
+
+    well = WellI()
+    well.plate = plate
+    well = update_service.saveAndReturnObject(well)
+
+    image = itest.new_image(name=itest.uuid())
+
+    ws = WellSampleI()
+    ws.image = image
+    ws.well = well
+    well.addWellSample(ws)
+    ws = update_service.saveAndReturnObject(ws)
+    return ws.image
+
+
+class TestDownload(object):
+    """
+    Tests to check download is disabled where specified.
+    """
+
+    def test_spw_download(self, itest, client, django_client, image_well_plate):
+        """ 
+        Download of an Image that is part of a plate should be disabled,
+        and return a 404 response.
+        """
+
+        image = image_well_plate
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files')
+        data = {
+            "image": image.id.val
+        }
+        _get_reponse(django_client, request_url, data, status_code=404)
+
+
+# Helpers
+def _get_reponse(django_client, request_url, query_string, status_code=405):
+    query_string = urlencode(query_string.items())
+    response = django_client.get('%s?%s' % (request_url, query_string))
+    assert response.status_code == status_code
+    return response

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -135,6 +135,21 @@ class TestDownload(object):
         }
         _get_reponse(django_client, request_url, data, status_code=404)
 
+    def test_image_download(self, itest, client, django_client):
+        """
+        Download of archived files for a non-SPW Image.
+        """
+
+        iid1 = itest.createTestImage(sizeC=2,
+                                     session=client.getSession()).id.val
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files')
+        data = {
+            "image": iid1
+        }
+        # Currently get a 500 error since test image has no archived files.
+        _get_reponse(django_client, request_url, data, status_code=500)
+
 
 # Helpers
 def _get_reponse(django_client, request_url, query_string, status_code=405):


### PR DESCRIPTION
This is https://github.com/openmicroscopy/openmicroscopy/pull/2953 rebased back to dev_5_0 (discussed last Tuesday meeting).

This adds the "Download" menu (and fileset paths) to SPW images when wells are selected.

To test:

Import a Plate.
Also create a plate from a Dataset with Dataset_To_Plate.py script (simpler if images are not MIFs).
Select ONE well from each plate:
Test the "Show paths" button
Download the Original files for the well. This will be a single image for the created plate and the whole plate for the imported plate.
Export as png/jpeg/tiff. Check that you get the correct image for the current Plate 'index'.
Select MULTIPLE wells from each plate:
Test paths, download original and export png/jpeg/tiff as described above.


![screen shot 2015-01-15 at 13 46 26](https://cloud.githubusercontent.com/assets/900055/5758412/5ee8f62c-9cbd-11e4-9772-4582601bfe47.png)
