### PR TITLE
Delete FileAnnotation after image export

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.EditorModel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -4163,6 +4163,7 @@ class EditorModel
 	        SaveAsParam p = new SaveAsParam(folder, objects);
 	        p.setIndex(format);
 	        p.setIcon(icons.getIcon(IconManager.SAVE_AS_22));
+	        p.setDeleteWhenFinished(true);
 	        UserNotifier un =
 	                MetadataViewerAgent.getRegistry().getUserNotifier();
 	        un.notifyActivity(getSecurityContext(), p);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadActivityParam.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.model.DownloadActivityParam 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -33,6 +33,8 @@ import omero.RString;
 import omero.model.OriginalFile;
 
 import org.openmicroscopy.shoola.env.ui.FileLoader;
+
+import pojos.FileAnnotationData;
 
 /** 
  * Parameters required to download a file.
@@ -88,6 +90,9 @@ public class DownloadActivityParam
 
     /** Indicates to register in UI.*/
     private boolean uiRegister;
+    
+    /** FileAnnotation to delete after downloading */
+    private FileAnnotationData toDelete;
     
     /** 
      * Checks if the index is valid.
@@ -275,4 +280,23 @@ public class DownloadActivityParam
 	 */
 	public JComponent getSource() { return source; }
 
+	/**
+	 * Get the {@link FileAnnotationData} which should get
+	 * deleted after download finished
+	 * @return
+	 */
+	public FileAnnotationData getToDelete() {
+		return toDelete;
+	}
+
+	/**
+	 * Set the {@link FileAnnotationData} which should get
+	 * deleted after download finished
+	 * @param toDelete The {@link FileAnnotationData} to delete
+	 */
+	public void setToDelete(FileAnnotationData toDelete) {
+		this.toDelete = toDelete;
+	}
+
+	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/SaveAsParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/SaveAsParam.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.model.SaveAsParam 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2011 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -66,6 +66,9 @@ public class SaveAsParam
 	
     /** The icon associated to the parameters. */
     private Icon icon;
+    
+    /** Flag to indicate to delete the file after downloading */
+    private boolean deleteWhenFinished = false;
     
 	/**
 	 * Creates a new instance.
@@ -140,5 +143,24 @@ public class SaveAsParam
 	 * @return See above.
 	 */
 	public List<pojos.DataObject> getObjects() { return objects; }
+
+	/**
+	 * Returns <code>true</code> if the the file should
+	 * be deleted after downloading
+	 * @return See above
+	 */
+	public boolean isDeleteWhenFinished() {
+		return deleteWhenFinished;
+	}
+
+	/**
+	 * Pass <code>true</code> to delete the file after
+	 * downloading
+	 * @param deleteWhenFinished See above
+	 */
+	public void setDeleteWhenFinished(boolean deleteWhenFinished) {
+		this.deleteWhenFinished = deleteWhenFinished;
+	}
+	
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.ActivityComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -563,8 +563,9 @@ public abstract class ActivityComponent
 	 * @param text   The text used if the object is not loaded.
 	 * @param object The object to handle.
 	 * @param folder Indicates where to download the file or <code>null</code>.
+	 * @param deleteWhenFinished If set file is deleted after download finished
 	 */
-	void download(String text, Object object, File folder)
+	void download(String text, Object object, File folder, final boolean deleteWhenFinished)
 	{
 		if (!(object instanceof FileAnnotationData || 
 				object instanceof OriginalFile)) return;
@@ -574,15 +575,16 @@ public abstract class ActivityComponent
 		String description = "";
 		long dataID = -1;
 		OriginalFile of = null;
+		FileAnnotationData fa = null;
 		if (object instanceof FileAnnotationData) {
-			FileAnnotationData data = (FileAnnotationData) object;
-			if (data.isLoaded()) {
-				name = data.getFileName();
-				description = data.getDescription();
-				of = (OriginalFile) data.getContent();
+			fa = (FileAnnotationData) object;
+			if (fa.isLoaded()) {
+				name = fa.getFileName();
+				description = fa.getDescription();
+				of = (OriginalFile) fa.getContent();
 			} else {
 				of = null;
-				dataID = data.getId();
+				dataID = fa.getId();
 				index = DownloadActivityParam.FILE_ANNOTATION;
 				if (text.length() == 0) text = "Annotation";
 				name = text+"_"+dataID;
@@ -614,7 +616,9 @@ public abstract class ActivityComponent
 						folder, icons.getIcon(IconManager.DOWNLOAD_22));
 			}
 			activity.setLegend(desc);
-			activity.setUIRegister(false);
+			activity.setUIRegister(true);
+			if (fa != null && deleteWhenFinished)
+				activity.setToDelete(fa);
 			viewer.notifyActivity(ctx, activity);
 			return;
 		}
@@ -626,6 +630,7 @@ public abstract class ActivityComponent
 		chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
 		chooser.setSelectedFileFull(name);
 		chooser.setApproveButtonText("Download");
+		final FileAnnotationData anno = fa;
 		chooser.addPropertyChangeListener(new PropertyChangeListener() {
 		
 			public void propertyChange(PropertyChangeEvent evt) {
@@ -645,6 +650,8 @@ public abstract class ActivityComponent
 								folder, icons.getIcon(IconManager.DOWNLOAD_22));
 					}
 					activity.setLegend(desc);
+					if (anno != null && deleteWhenFinished)
+						activity.setToDelete(anno);
 					viewer.notifyActivity(ctx, activity);
 				}
 			}
@@ -660,7 +667,7 @@ public abstract class ActivityComponent
 	 */
 	void download(String text, Object object)
 	{
-		download(text, object, null);
+		download(text, object, null, false);
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataObjectRemover.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataObjectRemover.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DataObjectRemover
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -97,7 +97,8 @@ public class DataObjectRemover
      */
     protected void onException(String message, Throwable ex)
     { 
-    	activity.notifyError("Unable to delete the object", message, ex);
+    	if (activity != null)
+    		activity.notifyError("Unable to delete the object", message, ex);
     }
     
     /**
@@ -170,7 +171,8 @@ public class DataObjectRemover
     			if (callback != null)
     				callback.cancel();
 			}
-    		activity.onActivityCancelled();
+    		if (activity != null)
+    			activity.onActivityCancelled();
 		} catch (Exception e) {
 			handleException(e);
 		}
@@ -194,7 +196,7 @@ public class DataObjectRemover
             	callBack.setAdapter(this);
             	callBacks.add(callBack);
             	number++;
-            	if (number == objects.size())
+            	if (number == objects.size() && activity != null)
             		activity.onCallBackSet();
         	}
         }
@@ -209,11 +211,13 @@ public class DataObjectRemover
      */
     public void handleResult(Object result)
     {
-    	if (result instanceof Boolean) {
-    		boolean b = ((Boolean) result).booleanValue();
-    		if (b) activity.endActivity(DeleteActivity.DELETE_COMPLETE);
-    		else onException(MESSAGE_RESULT, null);
-    	} else activity.endActivity(result);
+    	if (activity != null) {
+	    	if (result instanceof Boolean) {
+	    		boolean b = ((Boolean) result).booleanValue();
+	    		if (b) activity.endActivity(DeleteActivity.DELETE_COMPLETE);
+	    		else onException(MESSAGE_RESULT, null);
+	    	} else activity.endActivity(result);
+    	}
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DownloadActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -33,6 +33,7 @@ import java.util.List;
 import omero.model.OriginalFile;
 
 import org.openmicroscopy.shoola.env.config.Registry;
+import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.util.filter.file.CustomizedFileFilter;
@@ -265,6 +266,14 @@ public class DownloadActivity extends ActivityComponent {
 			else
 				url = FILE + "/" + localFileName;
 			registry.getTaskBar().openURL(url);
+		}
+		
+		if (parameters.getToDelete() != null) {
+			List<DeletableObject> tmp = new ArrayList<DeletableObject>();
+			tmp.add(new DeletableObject(parameters.getToDelete()));
+			DataObjectRemover eraser = new DataObjectRemover(viewer, registry,
+					tmp, null);
+			eraser.load();
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
@@ -126,7 +126,8 @@ public class SaveAsActivity
 				}
 				
 				if(fa!=null && fa.isLoaded()) {
-					download("", fa, new File(parameters.getFolder(), fa.getFileName()), parameters.isDeleteWhenFinished());
+					String name = getFileName(fa.getFileName());
+					download("", fa, new File(parameters.getFolder(), name), parameters.isDeleteWhenFinished());
 					// call super method to stop busy label
 					super.endActivity(null);
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.SaveAsActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,6 +25,7 @@ package org.openmicroscopy.shoola.env.ui;
 
 //Java imports
 import java.io.File;
+import java.util.Map;
 
 //Third-party libraries
 import org.apache.commons.io.FilenameUtils;
@@ -110,23 +111,56 @@ public class SaveAsActivity
 		return loader;
 	}
 
+	
+	@Override
+	public void endActivity(Object result) {
+		if(parameters.isDeleteWhenFinished()) {
+			if (result instanceof Map) {
+				FileAnnotationData fa = null;
+				Map<String, Object> m = (Map<String, Object>) result;
+				for(Object obj : m.values()) {
+					if(obj instanceof FileAnnotationData) {
+						fa = (FileAnnotationData) obj;
+						break;
+					}
+				}
+				
+				if(fa!=null && fa.isLoaded()) {
+					download("", fa, new File(parameters.getFolder(), fa.getFileName()), parameters.isDeleteWhenFinished());
+					// call super method to stop busy label
+					super.endActivity(null);
+				}
+				else
+					super.endActivity(result);
+			}
+		}
+		else
+			super.endActivity(result);
+	}
+
 	/**
 	 * Modifies the text of the component.
 	 * @see ActivityComponent#notifyActivityEnd()
 	 */
 	protected void notifyActivityEnd()
 	{
-		//Download the file.
-		if (result instanceof FileAnnotationData) {
-			FileAnnotationData data = (FileAnnotationData) result;
-			String name = "";
-			if (data.isLoaded()) name = data.getFileName();
-			else name = "Annotation_"+data.getId();
-			name = getFileName(name);
-			download("", result, new File(parameters.getFolder(), name));
+		if (!parameters.isDeleteWhenFinished()) {
+			// Download the file.
+			if (result instanceof FileAnnotationData) {
+				FileAnnotationData data = (FileAnnotationData) result;
+				String name = "";
+				if (data.isLoaded())
+					name = data.getFileName();
+				else
+					name = "Annotation_" + data.getId();
+				name = getFileName(name);
+				download("", result, new File(parameters.getFolder(), name),
+						false);
+			}
+
+			type.setText(DESCRIPTION_CREATED + " "
+					+ parameters.getFolder().getName());
 		}
-		
-		type.setText(DESCRIPTION_CREATED+" "+parameters.getFolder().getName());
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
@@ -96,9 +96,6 @@ public class SaveAsActivity
 		this.parameters = parameters;
 		initialize(DESCRIPTION_CREATION+parameters.getIndexAsString(),
 				parameters.getIcon());
-		File folder = parameters.getFolder();
-		messageLabel.setText("in "+folder.getName());
-		messageLabel.setToolTipText(folder.getAbsolutePath());
 	}
 
 	/**


### PR DESCRIPTION
If an image is exported as JPEG, PNG or TIFF the images are zipped into a Batch_Image_Export.zip file (attached to the image), which is then downloaded. Previously this file was kept and stayed attached to the image. Now it is removed after the download has finished.
Test: Make sure the export as JPEG/PNG/TIFF functionality still works and that the FileAnnotation with the zip file is deleted after it was downloaded.

--no-rebase
