### PR TITLE
Add security fix for NamedValue lists (HHH-4897)

### DIFF
--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -220,7 +220,7 @@ public class OmeroInterceptor implements Interceptor {
 
             if (!(entry.getCurrentPersister().getElementType()
                     instanceof ComponentType)) {
-                // We assume that any the modification of any
+                // We assume that any modification of any
                 // CollectionOfElements like NamedValue-lists
                 // should be subject to the security of the
                 // parent. If this *isn't* such a collection,

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -10,7 +10,9 @@ package ome.security.basic;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +21,10 @@ import org.hibernate.EmptyInterceptor;
 import org.hibernate.EntityMode;
 import org.hibernate.Interceptor;
 import org.hibernate.Transaction;
+import org.hibernate.collection.PersistentList;
+import org.hibernate.engine.CollectionEntry;
+import org.hibernate.engine.PersistenceContext;
+import org.hibernate.type.ComponentType;
 import org.hibernate.type.Type;
 import org.springframework.util.Assert;
 
@@ -162,7 +168,7 @@ public class OmeroInterceptor implements Interceptor {
     }
 
     /**
-     * callsback to
+     * calls back to
      * {@link BasicSecuritySystem#checkManagedDetails(IObject, Details)} for
      * properly setting {@link IObject#getDetails() Details}.
      */
@@ -207,6 +213,49 @@ public class OmeroInterceptor implements Interceptor {
     public void onCollectionUpdate(Object collection, Serializable key)
             throws CallbackException {
         debug("Intercepted collection update.");
+        if (collection instanceof PersistentList) {
+            PersistentList list = (PersistentList) collection;
+            PersistenceContext context = list.getSession().getPersistenceContext();
+            CollectionEntry entry = context.getCollectionEntry(list);
+
+            if (!(entry.getCurrentPersister().getElementType()
+                    instanceof ComponentType)) {
+                // We assume that any the modification of any
+                // CollectionOfElements like NamedValue-lists
+                // should be subject to the security of the
+                // parent. If this *isn't* such a collection,
+                // then exit.
+                return;
+            }
+
+            List snapshot = (List) entry.getSnapshot();
+            Object owner = list.getOwner();
+
+            if (list.size() == 0 && snapshot.size() == 0) {
+                // Nothing here, so we don't care
+                return;
+            }
+
+            // https://hibernate.atlassian.net/browse/HHH-4897 workaround:
+            // ----------------------------------------------------------
+            // Assuming we get here, we bump the version number for the
+            // object which will hopefully cause the regular security
+            // checks to fail.
+            try {
+                IObject iobj = (IObject) owner;
+                Method getter = iobj.getClass().getMethod("getVersion");
+                Integer oldVersion = (Integer) getter.invoke(iobj);
+                Integer newVersion = oldVersion == null ? 1 : oldVersion + 1;
+                Method setter = iobj.getClass().getMethod("setVersion", Integer.class);
+                setter.invoke(iobj, newVersion);
+                log.info("Updating version for collections from {} to {}",
+                        oldVersion, newVersion);
+            } catch (Exception e) {
+                InternalException ie = new InternalException("Failed to set version");
+                ie.initCause(e);
+                throw ie;
+            }
+        }
     }
 
     // ~ Flush (currently unclear semantics)


### PR DESCRIPTION
Previously, modifications to the CollectionOfElements
containing NamedValue instances were not being detected.
Anyone was allowed to modify the lists. To workaround
HHH-4897, we artificially bump the version field of the
containing object (the "owner") which triggers the regular
security process.

see:
 * https://hibernate.atlassian.net/browse/HHH-4897
 * https://forum.hibernate.org/viewtopic.php?f=1&t=1002411
 * https://issues.openmrs.org/browse/SYNC-306

/cc @will-moore @mtbc 