### PR TITLE
Dropbox platform check for Windows

### DIFF
--- a/components/blitz/resources/omero/FS.ice
+++ b/components/blitz/resources/omero/FS.ice
@@ -385,6 +385,7 @@ module omero {
          * @param blockSize, the number of events to pack into each notification (int).
          * @param ignoreSysFiles, ignore system files or not (bool).
          * @param ignoreDirEvents, ignore directory events (bool).
+         * @param platformCheck, if true strictly check platform (bool).
          * @return monitorId, a uuid1 (string).
          * @throws omero::OmeroFSError
          **/
@@ -398,6 +399,7 @@ module omero {
                                 int blockSize,
                                 bool ignoreSysFiles,
                                 bool ignoreDirEvents,
+                                bool platformCheck,
                                 MonitorClient* proxy)
             throws omero::OmeroFSError;
 

--- a/components/tools/OmeroFS/src/fsDropBox.py
+++ b/components/tools/OmeroFS/src/fsDropBox.py
@@ -65,7 +65,10 @@ class DropBox(Ice.Application):
         # if not there's no point starting the FSDropBox client
         import fsUtil
         try:
-            fsUtil.monitorPackage()
+            checkString = props.getPropertyWithDefault(
+                "omero.fs.platformCheck", "True")
+            platformCheck = not (checkString == "False")
+            fsUtil.monitorPackage(platformCheck)
         except:
             log.exception("System requirements not met: \n")
             log.error("Quitting")
@@ -196,6 +199,7 @@ class DropBox(Ice.Application):
                         monitorParameters[user]['blockSize'],
                         monitorParameters[user]['ignoreSysFiles'],
                         monitorParameters[user]['ignoreDirEvents'],
+                        platformCheck,
                         mClientProxy)
 
                     log.info(

--- a/components/tools/OmeroFS/src/fsMonitor.py
+++ b/components/tools/OmeroFS/src/fsMonitor.py
@@ -64,11 +64,7 @@ class AbstractMonitor(object):
 
         # Now try to import the correct MonitorServer package
         import fsUtil
-        try:
-            PlatformMonitor = __import__(
-                fsUtil.monitorPackage(platformCheck))
-        except:
-            raise
+        PlatformMonitor = __import__(fsUtil.monitorPackage(platformCheck))
 
         self.proxy = proxy
         self.monitorId = monitorId

--- a/components/tools/OmeroFS/src/fsMonitor.py
+++ b/components/tools/OmeroFS/src/fsMonitor.py
@@ -10,7 +10,7 @@
 import logging
 import threading
 
-import omero.all
+__import__("omero.all")
 import omero.grid.monitors as monitors
 
 

--- a/components/tools/OmeroFS/src/fsMonitor.py
+++ b/components/tools/OmeroFS/src/fsMonitor.py
@@ -10,37 +10,34 @@
 import logging
 import threading
 
-# Now try to import the correct MonitorServer package
-import fsUtil
-try:
-    PlatformMonitor = __import__(fsUtil.monitorPackage())
-except:
-    raise
-
+import omero.all
 import omero.grid.monitors as monitors
 
 
 class MonitorFactory(object):
 
     @staticmethod
-    def createMonitor(mType, eTypes, pMode, pathString,
-                      whitelist, blacklist, timeout, blockSize,
-                      ignoreSysFiles, ignoreDirEvents, proxy, monitorId):
+    def createMonitor(mType, eTypes, pMode, pathString, whitelist, blacklist,
+                      timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
+                      platformCheck, proxy, monitorId):
 
         if str(mType) == 'Persistent':
             return PersistentMonitor(
                 eTypes, pMode, pathString, whitelist, blacklist, timeout,
-                blockSize, ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+                blockSize, ignoreSysFiles, ignoreDirEvents, platformCheck,
+                proxy, monitorId)
 
         elif str(mType) == 'OneShot':
             return OneShotMonitor(
                 eTypes, pMode, pathString, whitelist, blacklist, timeout,
-                ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+                ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
+                monitorId)
 
         elif str(mType) == 'Inactivity':
             return InactivityMonitor(
                 eTypes, pMode, pathString, whitelist, blacklist, timeout,
-                ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+                ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
+                monitorId)
 
         else:
             raise Exception("Unknown monitor type: %s", str(mType))
@@ -57,12 +54,22 @@ class AbstractMonitor(object):
     """
 
     def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
-                 ignoreSysFiles, ignoreDirEvents, proxy, monitorId):
+                 ignoreSysFiles, ignoreDirEvents, platformCheck, proxy,
+                 monitorId):
         """
             Initialise Monitor.
 
         """
         self.log = logging.getLogger("fsclient." + __name__)
+
+        # Now try to import the correct MonitorServer package
+        import fsUtil
+        try:
+            PlatformMonitor = __import__(
+                fsUtil.monitorPackage(platformCheck))
+        except:
+            raise
+
         self.proxy = proxy
         self.monitorId = monitorId
         self.pMonitor = PlatformMonitor.PlatformMonitor(
@@ -122,15 +129,15 @@ class PersistentMonitor(AbstractMonitor):
     """
 
     def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
-                 timeout, blockSize, ignoreSysFiles, ignoreDirEvents, proxy,
-                 monitorId):
+                 timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
+                 platformCheck, proxy, monitorId):
         """
             Initialise Monitor.
 
         """
         AbstractMonitor.__init__(
             self, eventTypes, pathMode, pathString, whitelist, blacklist,
-            ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+            ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
 
         self.notifier = NotificationScheduler(
             self.proxy, self.monitorId, timeout, blockSize)
@@ -180,14 +187,15 @@ class InactivityMonitor(AbstractMonitor):
     """
 
     def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
-                 timeout, ignoreSysFiles, ignoreDirEvents, proxy, monitorId):
+                 timeout, ignoreSysFiles, ignoreDirEvents, platformCheck,
+                 proxy, monitorId):
         """
             Initialise Monitor.
 
         """
         AbstractMonitor.__init__(
             self, eventTypes, pathMode, pathString, whitelist, blacklist,
-            ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+            ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
         self.timer = threading.Timer(timeout, self.inactive)
         self.log.info('Inactivity monitor created. Timer: %s', str(self.timer))
 
@@ -253,14 +261,15 @@ class OneShotMonitor(AbstractMonitor):
     """
 
     def __init__(self, eventTypes, pathMode, pathString, whitelist, blacklist,
-                 timeout, ignoreSysFiles, ignoreDirEvents, proxy, monitorId):
+                 timeout, ignoreSysFiles, ignoreDirEvents, platformCheck,
+                 proxy, monitorId):
         """
             Initialise Monitor.
 
         """
         AbstractMonitor.__init__(
             self, eventTypes, pathMode, pathString, whitelist, blacklist,
-            ignoreSysFiles, ignoreDirEvents, proxy, monitorId)
+            ignoreSysFiles, ignoreDirEvents, platformCheck, proxy, monitorId)
         self.timer = threading.Timer(timeout, self.inactive)
         self.log.info('OneShot monitor created. Timer: %s', str(self.timer))
 

--- a/components/tools/OmeroFS/src/fsMonitorServer.py
+++ b/components/tools/OmeroFS/src/fsMonitorServer.py
@@ -79,7 +79,7 @@ class MonitorServerI(monitors.MonitorServer):
                 timeout : float
                     A timeout used by some types of monitor.
 
-                blockSize : intt
+                blockSize : int
                     Number of events to pack into one notification.
 
                 ignoreSysFiles : boolean

--- a/components/tools/OmeroFS/src/fsMonitorServer.py
+++ b/components/tools/OmeroFS/src/fsMonitorServer.py
@@ -52,7 +52,7 @@ class MonitorServerI(monitors.MonitorServer):
 
     def createMonitor(self, mType, eTypes, pMode, pathString, whitelist,
                       blacklist, timeout, blockSize, ignoreSysFiles,
-                      ignoreDirEvents, proxy, current=None):
+                      ignoreDirEvents, platformCheck, proxy, current=None):
         """
             Create a the Monitor for a given path.
 
@@ -88,6 +88,9 @@ class MonitorServerI(monitors.MonitorServer):
                 ignoreDirEvents : boolean
                     Flag. If true directory events are ignored
 
+                platformCheck : boolean
+                    Flag. If true platform check is strict
+
                 proxy :
                     A proxy to be informed of events
 
@@ -107,8 +110,8 @@ class MonitorServerI(monitors.MonitorServer):
             # changed.
             self.monitors[monitorId] = MonitorFactory.createMonitor(
                 mType, eTypes, pMode, pathString, whitelist, blacklist,
-                timeout, blockSize, ignoreSysFiles, ignoreDirEvents, self,
-                monitorId)
+                timeout, blockSize, ignoreSysFiles, ignoreDirEvents,
+                platformCheck, self, monitorId)
 
         except Exception, e:
             self.log.exception('Failed to create monitor: ')

--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -31,14 +31,13 @@ def monitorPackage(platformCheck):
     supported = {
         'MACOS_10_5+': 'fsMac-10-5-Monitor',
         'LINUX_2_6_13+pyinotify': 'fsPyinotifyMonitor',
-        'WIN_XP': 'fsWin-XP-Monitor',
-        'WIN_2003Server': 'fsWin-XP-Monitor',
-        'WIN_2008Server': 'fsWin-XP-Monitor',
-        'WIN_2008ServerR2': 'fsWin-XP-Monitor',
-        'WIN_Vista': 'fsWin-XP-Monitor',
-        'WIN_7': 'fsWin-XP-Monitor',
-        'WIN_any': 'fsWin-XP-Monitor',
+        'WIN_tested': 'fsWin-XP-Monitor',
+        'WIN_any': 'fsWin-XP-Monitor'
     }
+
+    # Versions of Windows that have been tested.
+    winTested = ['XP', '2003Server', '2008Server', '2008ServerR2', 'Vista',
+                 '7']
 
     # Initial state
     current = 'UNKNOWN'
@@ -88,20 +87,10 @@ def monitorPackage(platformCheck):
     elif system == 'Windows':
         if platformCheck:
             version = platform.platform().split('-')
-            if version[1] == 'XP':
-                current = 'WIN_XP'
-            elif version[1] == '2003Server':
-                current = 'WIN_2003Server'
-            elif version[1] == '2008Server':
-                current = 'WIN_2008Server'
-            elif version[1] == '2008ServerR2':
-                current = 'WIN_2008ServerR2'
-            elif version[1] == 'Vista':
-                current = 'WIN_Vista'
-            elif version[1] == '7':
-                current = 'WIN_7'
+            if version[1] in winTested:
+                current = 'WIN_tested'
             else:
-                errorString = ("Windows XP, Vista, 7 or Server 2003, 2008 or "
+                errorString = ("Windows XP, Vista, 7, Server 2003, 2008 or "
                                "2008R2 required. "
                                "You have: %s" % platform.platform())
         else:

--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -57,7 +57,7 @@ def monitorPackage(platformCheck):
                 current = 'MACOS_10_5+'
             # Unsupported Mac OS version.
             else:
-                errorString = ("Mac Os 10.5 or above required. You have: %s"
+                errorString = ("Mac OS 10.5 or above required. You have: %s"
                                % platform.platform())
         except:
             # mac_ver() on python built with macports returns a version tuple
@@ -66,7 +66,7 @@ def monitorPackage(platformCheck):
             # Until a better solution is found MACOS-UNKNOWN_VERSION is used to
             # flag this.
             current = 'MACOS-UNKNOWN_VERSION'
-            errorString = ("Mac Os 10.5 or above required. "
+            errorString = ("Mac OS 10.5 or above required. "
                            "You have an unkown version")
 
     # Linux of some flavour.

--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -9,7 +9,7 @@
 """
 
 
-def monitorPackage():
+def monitorPackage(platformCheck):
     """
         Helper function to determine correct package to load for platform.
 
@@ -37,6 +37,7 @@ def monitorPackage():
         'WIN_2008ServerR2': 'fsWin-XP-Monitor',
         'WIN_Vista': 'fsWin-XP-Monitor',
         'WIN_7': 'fsWin-XP-Monitor',
+        'WIN_any': 'fsWin-XP-Monitor',
     }
 
     # Initial state
@@ -85,27 +86,31 @@ def monitorPackage():
 
     # Windows of some flavour.
     elif system == 'Windows':
-        version = platform.platform().split('-')
-        if version[1] == 'XP':
-            current = 'WIN_XP'
-        elif version[1] == '2003Server':
-            current = 'WIN_2003Server'
-        elif version[1] == '2008Server':
-            current = 'WIN_2008Server'
-        elif version[1] == '2008ServerR2':
-            current = 'WIN_2008ServerR2'
-        elif version[1] == 'Vista':
-            current = 'WIN_Vista'
-        elif version[1] == '7':
-            current = 'WIN_7'
+        if platformCheck:
+            version = platform.platform().split('-')
+            if version[1] == 'XP':
+                current = 'WIN_XP'
+            elif version[1] == '2003Server':
+                current = 'WIN_2003Server'
+            elif version[1] == '2008Server':
+                current = 'WIN_2008Server'
+            elif version[1] == '2008ServerR2':
+                current = 'WIN_2008ServerR2'
+            elif version[1] == 'Vista':
+                current = 'WIN_Vista'
+            elif version[1] == '7':
+                current = 'WIN_7'
+            else:
+                errorString = ("Windows XP, Vista, 7 or Server 2003, 2008 or "
+                               "2008R2 required. "
+                               "You have: %s" % platform.platform())
         else:
-            errorString = ("Windows XP, Vista, 7 or Server 2003, 2008 or "
-                           "2008R2 required. "
-                           "You have: %s" % platform.platform())
+            current = 'WIN_any'
+            # log above error as warning
 
     # Unknown OS.
     else:
-        errorString = "Unsupported platform: %s" % system
+        errorString = "Unsupported system: %s" % system
 
     try:
         return supported[current]

--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -8,6 +8,8 @@
 
 """
 
+import logging
+
 
 def monitorPackage(platformCheck):
     """
@@ -15,12 +17,14 @@ def monitorPackage(platformCheck):
 
     """
 
+    log = logging.getLogger("fsclient." + __name__)
+
     # This sequence tries to check the platform and OS version.
     #
     # At the moment a limited subset of platforms is checked for:
     #     * Mac OS 10.5 or higher
     #     * Linux kernel 2.6 then .13 or higher or kernel 3.x.y
-    #     * Windows: XP, 2003Server, 2008Server, 2008ServerR2, Vista, and 7
+    #     * Windows: versions in the list 'winTested'
     #
     # Some fine-tuning may need to be applied, some additional Windows
     # platforms added.
@@ -95,7 +99,9 @@ def monitorPackage(platformCheck):
                                "You have: %s" % platform.platform())
         else:
             current = 'WIN_any'
-            # log above error as warning
+            log.warn("Strict platform checking disabled!"
+                     "Untested Windows version %s detected"
+                     % platform.platform())
 
     # Unknown OS.
     else:

--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -36,7 +36,7 @@ def monitorPackage(platformCheck):
         'MACOS_10_5+': 'fsMac-10-5-Monitor',
         'LINUX_2_6_13+pyinotify': 'fsPyinotifyMonitor',
         'WIN_tested': 'fsWin-XP-Monitor',
-        'WIN_any': 'fsWin-XP-Monitor'
+        'WIN_other': 'fsWin-XP-Monitor'
     }
 
     # Versions of Windows that have been tested.
@@ -89,19 +89,20 @@ def monitorPackage(platformCheck):
 
     # Windows of some flavour.
     elif system == 'Windows':
-        if platformCheck:
-            version = platform.platform().split('-')
-            if version[1] in winTested:
-                current = 'WIN_tested'
-            else:
-                errorString = ("Windows XP, Vista, 7, Server 2003, 2008 or "
+        if not platformCheck:
+            log.warn("Strict platform checking disabled!")
+        version = platform.platform().split('-')
+        if version[1] in winTested:
+            current = 'WIN_tested'
+        else:
+            if platformCheck:
+                errorString = ("Windows XP, Vista, 7 or Server 2003, 2008 or "
                                "2008R2 required. "
                                "You have: %s" % platform.platform())
-        else:
-            current = 'WIN_any'
-            log.warn("Strict platform checking disabled!"
-                     "Untested Windows version %s detected"
-                     % platform.platform())
+            else:
+                current = 'WIN_other'
+                log.warn("Untested Windows version %s detected"
+                         % platform.platform())
 
     # Unknown OS.
     else:

--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -125,6 +125,7 @@
        <property name="omero.fs.maxRetries"  value="5"/>
        <property name="omero.fs.retryInterval"  value="3"/>
        <property name="omero.fs.defaultDropBoxDir"  value="DropBox"/>
+       <property name="omero.fs.platformCheck"  value="True"/>
        <!--
           The remaining items can take the form of a semicolon separated list,
           one item for each user in the first property. Properties that


### PR DESCRIPTION
This PR allows an untested version of Windows to be used for a DropBox server.  If `omero.fs.platformCheck` is set to `False` then on a Windows system the check for the specific platform will be bypassed. This allows an as yet untested version of Windows to be tried at the user's own risk. There is no guarantee DropBox will start up if the version of Windows being used does not support file notifications in the same way as the tested versions.

The easiest way to test this PR would be to edit the list at https://github.com/ximenesuk/openmicroscopy/blob/45e049f093462218625a4129806d8703e4e8ce61/components/tools/OmeroFS/src/fsUtil.py#L43 to remove the entry corresponding to the Windows testing platform. By default DropBox should then fail to started. Setting the config `omero.fs.platformCheck` to `False` should then allow DropBox to start with a logged warning in `DropBox.log`.

There are five key test cases, two with the default build, three with `dist/lib/omero/fsUtil.py` edited (no rebuild necessary after this edit). In each case the output of DropBox.log needs to be checked.

1. start server on a tested Windows platform XXX. DropBox should start okay.
2. the config `omero.fs.platformCheck` to `False` , restart server. DropBox should start okay but the log should show that strict checking is disabled.
3. remove relevant entry for XXX from `winTested` in `dist/lib/omero/fsUtil.py`. Leave  the config `omero.fs.platformCheck` set to `False` , restart server.  DropBox should start okay but the log should show that strict checking is disabled and that an untested version of Windows has been detected.
4. unset the config `omero.fs.platformCheck`, restart server. DropBox should fail to start with an appropriate error message in the log.
5.  set the config `omero.fs.platformCheck` to anything other than the exact string `False`, restart server. DropBox should fail to start with an appropriate error message in the log.

This PR should not affect the behaviour of DropBox on either Linux or Mac OS.

Partly
--rebased-to #3361