### PR TITLE
Dropbox platform check for Windows (dev_5_0)

### DIFF
--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -52,9 +52,12 @@ def monitorPackage():
     import os
     system = platform.system()
     try:
-        platformCheck = not (os.environ["OMERO_PLATFORM_CHECK"] == 'false')
-    except:
+        check = os.environ["OMERO_PLATFORM_CHECK"]
+        platformCheck = not (check == 'false')
+        log.info("OMERO_PLATFORM_CHECK=%s" % check)
+    except KeyError:
         platformCheck = True
+        log.info("OMERO_PLATFORM_CHECK not set")
 
     # Mac OS of some flavour.
     if system == 'Darwin':

--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -8,18 +8,23 @@
 
 """
 
+import logging
+
+
 def monitorPackage():
     """
         Helper function to determine correct package to load for platform. 
         
     """
     
+    log = logging.getLogger("fsclient." + __name__)
+
     # This sequence tries to check the platform and OS version. 
     #
     # At the moment a limited subset of platforms is checked for:
     #     * Mac OS 10.5 or higher
     #     * Linux kernel 2.6 then .13 or higher or kernel 3.x.y
-    #     * Windows: XP, 2003Server, 2008Server, 2008ServerR2, Vista, and 7
+    #     * Windows: versions in the list 'winTested'
     #
     # Some fine-tuning may need to be applied, some additional Windows platforms added.
     # If any platform-specific stuff in the imported library fails an exception will be
@@ -89,6 +94,9 @@ def monitorPackage():
                 errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
         else:
             current = 'WIN_any'
+            log.warn("Strict platform checking disabled!"
+                     "Untested Windows version %s detected"
+                     % platform.platform())
 
     # Unknown OS.
     else:

--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -35,7 +35,7 @@ def monitorPackage():
                   'MACOS_10_5+'            : 'fsMac-10-5-Monitor',
                   'LINUX_2_6_13+pyinotify' : 'fsPyinotifyMonitor',
                   'WIN_tested'             : 'fsWin-XP-Monitor',
-                  'WIN_any'                : 'fsWin-XP-Monitor'
+                  'WIN_other'              : 'fsWin-XP-Monitor'
                 }
     
     # Versions of Windows that have been tested.
@@ -86,17 +86,18 @@ def monitorPackage():
 
     # Windows of some flavour.
     elif system == 'Windows':
-        if platformCheck:
-            version = platform.platform().split('-')
-            if version[1] in winTested:
-                current = 'WIN_tested'
-            else:
-                errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
+        if not platformCheck:
+            log.warn("Strict platform checking disabled!")
+        version = platform.platform().split('-')
+        if version[1] in winTested:
+            current = 'WIN_tested'
         else:
-            current = 'WIN_any'
-            log.warn("Strict platform checking disabled!"
-                     "Untested Windows version %s detected"
-                     % platform.platform())
+            if platformCheck:
+                errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
+            else:
+                current = 'WIN_other'
+                log.warn("Untested Windows version %s detected"
+                         % platform.platform())
 
     # Unknown OS.
     else:

--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -29,15 +29,14 @@ def monitorPackage():
     supported = {
                   'MACOS_10_5+'            : 'fsMac-10-5-Monitor',
                   'LINUX_2_6_13+pyinotify' : 'fsPyinotifyMonitor',
-                  'WIN_XP'                 : 'fsWin-XP-Monitor',
-                  'WIN_2003Server'         : 'fsWin-XP-Monitor',
-                  'WIN_2008Server'         : 'fsWin-XP-Monitor',
-                  'WIN_2008ServerR2'       : 'fsWin-XP-Monitor',
-                  'WIN_Vista'              : 'fsWin-XP-Monitor',
-                  'WIN_7'                  : 'fsWin-XP-Monitor',
+                  'WIN_tested'             : 'fsWin-XP-Monitor',
                   'WIN_any'                : 'fsWin-XP-Monitor'
                 }
     
+    # Versions of Windows that have been tested.
+    winTested = ['XP', '2003Server', '2008Server', '2008ServerR2', 'Vista',
+                 '7']
+
     # Initial state
     current = 'UNKNOWN'
     errorString = 'Unknown error'
@@ -84,18 +83,8 @@ def monitorPackage():
     elif system == 'Windows':
         if platformCheck:
             version = platform.platform().split('-')
-            if version[1] == 'XP':
-                current = 'WIN_XP'
-            elif version[1] == '2003Server':
-                current = 'WIN_2003Server'
-            elif version[1] == '2008Server':
-                current = 'WIN_2008Server'
-            elif version[1] == '2008ServerR2':
-                current = 'WIN_2008ServerR2'
-            elif version[1] == 'Vista':
-                current = 'WIN_Vista'
-            elif version[1] == '7':
-                current = 'WIN_7'
+            if version[1] in winTested:
+                current = 'WIN_tested'
             else:
                 errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
         else:

--- a/components/tools/OmeroFS/fsUtil.py
+++ b/components/tools/OmeroFS/fsUtil.py
@@ -35,6 +35,7 @@ def monitorPackage():
                   'WIN_2008ServerR2'       : 'fsWin-XP-Monitor',
                   'WIN_Vista'              : 'fsWin-XP-Monitor',
                   'WIN_7'                  : 'fsWin-XP-Monitor',
+                  'WIN_any'                : 'fsWin-XP-Monitor'
                 }
     
     # Initial state
@@ -44,8 +45,13 @@ def monitorPackage():
     # Determine the OS, then the version of that OS, 
     # and if necessary the version of any required packages.
     import platform
+    import os
     system = platform.system()
-    
+    try:
+        platformCheck = not (os.environ["OMERO_PLATFORM_CHECK"] == 'false')
+    except:
+        platformCheck = True
+
     # Mac OS of some flavour.
     if system == 'Darwin':
         version = platform.mac_ver()[0].split('.')
@@ -76,21 +82,24 @@ def monitorPackage():
 
     # Windows of some flavour.
     elif system == 'Windows':
-        version = platform.platform().split('-')
-        if version[1] == 'XP':
-            current = 'WIN_XP'
-        elif version[1] == '2003Server':
-            current = 'WIN_2003Server'
-        elif version[1] == '2008Server':
-            current = 'WIN_2008Server'
-        elif version[1] == '2008ServerR2':
-            current = 'WIN_2008ServerR2'
-        elif version[1] == 'Vista':
-            current = 'WIN_Vista'
-        elif version[1] == '7':
-            current = 'WIN_7'
+        if platformCheck:
+            version = platform.platform().split('-')
+            if version[1] == 'XP':
+                current = 'WIN_XP'
+            elif version[1] == '2003Server':
+                current = 'WIN_2003Server'
+            elif version[1] == '2008Server':
+                current = 'WIN_2008Server'
+            elif version[1] == '2008ServerR2':
+                current = 'WIN_2008ServerR2'
+            elif version[1] == 'Vista':
+                current = 'WIN_Vista'
+            elif version[1] == '7':
+                current = 'WIN_7'
+            else:
+                errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
         else:
-            errorString = "Windows XP, Vista, 7 or Server 2003, 2008 or 2008R2 required. You have: %s" % platform.platform()
+            current = 'WIN_any'
 
     # Unknown OS.
     else:


### PR DESCRIPTION
This PR allows an untested version of Windows to be used for a DropBox server. If the environment variable `OMERO_PLATFORM_CHECK` is set to `false` then on a Windows system the check for the specific platform will be bypassed. This allows an as yet untested version of Windows to be tried at the user's own risk. There is no guarantee DropBox will start up if the version of Windows being used does not support file notifications in the same way as the tested versions.

The easiest way to test this PR would be to edit the list at https://github.com/ximenesuk/openmicroscopy/blob/fce53dfc0982d6089ca152f0751cd6e29db72b49/components/tools/OmeroFS/fsUtil.py#L42 to remove the entry corresponding to the Windows testing platform. By default DropBox should then fail to started. Setting the environment variable `OMERO_PLATFORM_CHECK` to `false` should then allow DropBox to start with a logged warning in DropBox.log.

There are five key test cases, two with the default build, three with `dist/lib/omero/fsUtil.py` edited (no rebuild necessary after this edit). In each case the output of DropBox.log needs to be checked.

1. start server on a tested Windows platform XXX. DropBox should start okay.
2. set `OMERO_PLATFORM_CHECK` to `false` restart server. DropBox should start okay but the log should show that strict checking is disabled.
3. Remove relevant entry for XXX from `winTested` in `dist/lib/omero/fsUtil.py`. Leave  `OMERO_PLATFORM_CHECK` set to `false`, restart server.  DropBox should start okay but the log should show that strict checking is disabled and that an untested version of Windows has been detected.
4. unset `OMERO_PLATFORM_CHECK`, restart server. DropBox should fail to start with an appropriate error message in the log.
5.  set `OMERO_PLATFORM_CHECK` to anything other than the exact string `false`, restart server. DropBox should fail to start with an appropriate error message in the log.

This PR should not affect the behaviour of DropBox on either Linux or Mac OS.

Note that this implementation differs from that in gh-3360 in such a way as to not break the existing API but still allow some mechanism for relaxing the platform checking.

Partly --rebased-from #3360