### PR TITLE
32 bit and float (rebased onto dev_5_0)

### DIFF
--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -262,11 +262,11 @@ public class StatsFactory {
     		minmax[0] = 0;
     		minmax[1] = 65535;
     	} else if (PlaneFactory.INT32.equals(typeAsString)) {
-    		minmax[0] = -32768;
-			minmax[1] = 32767;
+    		minmax[0] = -Math.pow(2, 32)/2;
+			minmax[1] = Math.pow(2, 32)/2-1;
     	} else if (PlaneFactory.UINT32.equals(typeAsString)) {
     		minmax[0] = 0;
-			minmax[1] = 65535;
+			minmax[1] = Math.pow(2, 32)-1;
     	} else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
     			PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
     		//b/c we don't know if it is signed or not

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -270,8 +270,8 @@ public class StatsFactory {
     	} else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
     			PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
     		//b/c we don't know if it is signed or not
-    		minmax[0] = 0;
-			minmax[1] = 32767;
+    		minmax[0] = -Double.MAX_VALUE;
+			minmax[1] = Double.MAX_VALUE;
     	}
     	return minmax;
     }

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -268,11 +268,13 @@ public class StatsFactory {
     	} else if (PlaneFactory.UINT32.equals(typeAsString)) {
     		minmax[0] = 0;
 			minmax[1] = Math.pow(2, 32)-1;
-    	} else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
-    			PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
+    	} else if (PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
     		//b/c we don't know if it is signed or not
     		minmax[0] = -Double.MAX_VALUE;
 			minmax[1] = Double.MAX_VALUE;
+    	} else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString)) {
+    	    minmax[0] = -Float.MAX_VALUE;
+            minmax[1] = Float.MAX_VALUE;
     	}
     	return minmax;
     }

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -16,6 +16,7 @@ import java.awt.Dimension;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.TileLoopIteration;
 import ome.io.nio.Utils;
@@ -250,17 +251,17 @@ public class StatsFactory {
     	if (type == null) return minmax;
     	String typeAsString = type.getValue();
     	if (PlaneFactory.INT8.equals(typeAsString)) {
-    		minmax[0] = -128;
-    		minmax[1] = 127;
+    		minmax[0] = -Math.pow(2, 8)/2;
+    		minmax[1] = Math.pow(2, 8)/2-1;
     	} else if (PlaneFactory.UINT8.equals(typeAsString)) {
     		minmax[0] = 0;
-    		minmax[1] = 255;
+    		minmax[1] = Math.pow(2, 8)-1;
     	} else if (PlaneFactory.INT16.equals(typeAsString)) {
-    		minmax[0] = -32768;
-    		minmax[1] = 32767;
+    		minmax[0] = -Math.pow(2, 16)/2;
+    		minmax[1] = Math.pow(2, 16)/2-1;
     	} else if (PlaneFactory.UINT16.equals(typeAsString)) {
     		minmax[0] = 0;
-    		minmax[1] = 65535;
+    		minmax[1] = Math.pow(2, 16)-1;
     	} else if (PlaneFactory.INT32.equals(typeAsString)) {
     		minmax[0] = -Math.pow(2, 32)/2;
 			minmax[1] = Math.pow(2, 32)/2-1;

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -23,13 +23,9 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 
@@ -41,10 +37,10 @@ import ome.model.enums.PixelsType;
  * the 5D-notion of OME image, we first compute the normalized parameters. We
  * determine a pseudo-decile (not decile in maths terms) interval and compute
  * the associated parameters to reduce the irrelevant values (noiseReduction).
- * 
- * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ *
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *          <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @since OME5.1
  */
 public class Quantization_32_bit extends QuantumStrategy {
@@ -72,7 +68,7 @@ public class Quantization_32_bit extends QuantumStrategy {
 
     /** The upper bound of the decile interval. */
     private double Q9;
-    
+
     /**
      * The mapping parameters from the sub-interval of [Q1, Q9] to the device
      * space.
@@ -87,7 +83,7 @@ public class Quantization_32_bit extends QuantumStrategy {
 
     /**
      * Initializes the coefficient of the normalize mapping operation.
-     * 
+     *
      * @param k
      *            The coefficient of the selected curve.
      */
@@ -102,7 +98,7 @@ public class Quantization_32_bit extends QuantumStrategy {
      * Initializes the parameter to map the pixels intensities to the device
      * space and returned the default initial depending on the value of the
      * noise reduction flag.
-     * 
+     *
      * @param dStart
      *            The input window start.
      * @param dEnd
@@ -113,22 +109,22 @@ public class Quantization_32_bit extends QuantumStrategy {
         cdStart = qDef.getCdStart().intValue();
         cdEnd = qDef.getCdEnd().intValue();
         double denum = dEnd - dStart, num = MAX;
-        
+
         double v = 0, b = dStart;
         int e = 0;
         double startMin = min;
         double startMax = max;
         Q1 = min;
         Q9 = max;
-        
+
         if (dStart <= startMin) {
-        	Q1 = dStart;
+            Q1 = dStart;
         }
         if (dEnd >= startMax) Q9 = dEnd;
         if (startMin == startMax) v = 1;
         double decile = (startMax - startMin) / DECILE;
         if (getNoiseReduction()) {
-        	Q1 += decile;
+            Q1 += decile;
             Q9 -= decile;
             denum = Q9 - Q1;
             v = DECILE;
@@ -153,7 +149,7 @@ public class Quantization_32_bit extends QuantumStrategy {
         }
         aDecile = num / denum;
         bDecile = aDecile * b - e;
-        
+
         return v;
     }
 
@@ -163,7 +159,7 @@ public class Quantization_32_bit extends QuantumStrategy {
 
     /**
      * Creates a new strategy.
-     * 
+     *
      * @param qd
      *            Quantum definition object, contained mapping data.
      * @param type
@@ -175,7 +171,7 @@ public class Quantization_32_bit extends QuantumStrategy {
 
     /**
      * Implemented as specified in {@link QuantumStrategy}.
-     * 
+     *
      * @see QuantumStrategy#quantize(double)
      */
     @Override
@@ -187,7 +183,7 @@ public class Quantization_32_bit extends QuantumStrategy {
         } else if (x > dEnd) {
             return (byte) cdEnd;
         }
-        
+
         double k = getCurveCoefficient();
         double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
                 / qDef.getBitResolution().doubleValue();
@@ -197,7 +193,7 @@ public class Quantization_32_bit extends QuantumStrategy {
         // Initializes the decile map.
         double v = initDecileMap(dStart, dEnd);
         QuantumMap normalize = new PolynomialMap();
-        
+
         if (x > Q1) {
             if (x <= Q9) {
                 v = aDecile * normalize.transform(x, 1) - bDecile;
@@ -207,7 +203,7 @@ public class Quantization_32_bit extends QuantumStrategy {
         } else {
             v = cdStart;
         }
-        
+
         v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
         v = Math.round(v);
         v = Math.round(a1 * v + cdStart);

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -26,9 +26,6 @@ package omeis.providers.re.quantum;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 
@@ -47,9 +44,6 @@ import ome.model.enums.PixelsType;
  * @since OME5.1
  */
 public class Quantization_32_bit extends QuantumStrategy {
-
-    /** The logger for this particular class */
-    private static Logger log = LoggerFactory.getLogger(Quantization_32_bit.class);
 
     /** The lowest pixel intensity value. */
     private int min;

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Range;
 
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
@@ -230,7 +229,7 @@ public class Quantization_32_bit extends QuantumStrategy {
     @Override
     public int quantize(double value) throws QuantizationException {
         try {
-            Range<Double> r = getRange(value);
+            Range r = getRange(value);
             double v = (r.upperEndpoint()+r.lowerEndpoint())/2;
             return values.get(v);
         } catch (ExecutionException e) {

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -23,8 +23,12 @@
 
 package omeis.providers.re.quantum;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Range;
 
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
@@ -79,7 +83,7 @@ public class Quantization_32_bit extends QuantumStrategy {
     private int cdStart, cdEnd;
 
     /** The mapped values.*/
-    private Map<Double, Integer> values;
+    private LoadingCache<Double, Integer> values;
 
     /**
      * Initializes the coefficient of the normalize mapping operation.
@@ -156,38 +160,21 @@ public class Quantization_32_bit extends QuantumStrategy {
     /** The input window size changed, re-map the values. */
     @Override
     protected void onWindowChange() {
-        values.clear();
+        values.invalidateAll();
     }
 
     /**
-     * Creates a new strategy.
+     * Maps the value.
      *
-     * @param qd
-     *            Quantum definition object, contained mapping data.
-     * @param type
-     *            The pixel type;
+     * @param value The value to handle.
+     * @return The mapped value.
+     * @throws QuantizationException Thrown if an error occurred during
+     *                               the mapping.
      */
-    public Quantization_32_bit(QuantumDef qd, PixelsType type) {
-        super(qd, type);
-        values = new HashMap<Double, Integer>();
-    }
-
-    /**
-     * Implemented as specified in {@link QuantumStrategy}.
-     *
-     * @see QuantumStrategy#quantize(double)
-     */
-    @Override
-    public int quantize(double value) throws QuantizationException {
-        if (values.containsKey(value)) {
-            return values.get(value).intValue();
-        }
+    private int _quantize(double value)
+                throws QuantizationException
+    {
         double dStart = getWindowStart(), dEnd = getWindowEnd();
-        if (value < dStart) {
-            return ((byte) cdStart) & 0xFF;
-        } else if (value > dEnd) {
-            return ((byte) cdEnd) & 0xFF;
-        }
         double k = getCurveCoefficient();
         double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
                 / qDef.getBitResolution().doubleValue();
@@ -211,9 +198,42 @@ public class Quantization_32_bit extends QuantumStrategy {
         v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
         v = Math.round(v);
         v = Math.round(a1 * v + cdStart);
-        int x = ((byte) v) & 0xFF;
-        values.put(value, x);
-        return x;
+        return ((byte) v) & 0xFF;
+    }
+
+    /**
+     * Creates a new strategy.
+     *
+     * @param qd
+     *            Quantum definition object, contained mapping data.
+     * @param type
+     *            The pixel type;
+     */
+    public Quantization_32_bit(QuantumDef qd, PixelsType type) {
+        super(qd, type);
+        values = CacheBuilder.newBuilder()
+                .maximumSize(MAX-MIN+1)
+                .build(new CacheLoader<Double, Integer>() {
+                    public Integer load(Double key) throws Exception {
+                        return _quantize(key);
+                    }
+                });
+    }
+
+    /**
+     * Implemented as specified in {@link QuantumStrategy}.
+     *
+     * @see QuantumStrategy#quantize(double)
+     */
+    @Override
+    public int quantize(double value) throws QuantizationException {
+        try {
+            Range<Double> r = getRange(value);
+            double v = (r.upperEndpoint()+r.lowerEndpoint())/2;
+            return values.get(v);
+        } catch (ExecutionException e) {
+            throw new QuantizationException(e);
+        }
     }
 
 }

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -1,0 +1,353 @@
+/*
+ * omeis.providers.re.quantum.Quantization_32_bit
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
+package omeis.providers.re.quantum;
+
+// Java imports
+
+// Third-party libraries
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Application-internal dependencies
+import ome.model.display.QuantumDef;
+import ome.model.enums.PixelsType;
+
+/**
+ * Quantization process. In charge of building a look-up table for each active
+ * wavelength. The mapping process is done in three mapping steps, for some
+ * computer reasons, we cannot compose (in the mathematical sense) the three
+ * maps directly. Each wavelength initializes a strategy, in order to preserve
+ * the 5D-notion of OME image, we first compute the normalized parameters. We
+ * determine a pseudo-decile (not decile in maths terms) interval and compute
+ * the associated parameters to reduce the irrelevant values (noiseReduction).
+ * 
+ * 
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since OME5.1
+ */
+public class Quantization_32_bit extends QuantumStrategy {
+
+    /** The logger for this particular class */
+    private static Logger log = LoggerFactory.getLogger(Quantization_32_bit.class);
+
+    /** The look-up table. */
+    private byte[] LUT;
+
+    /** The lowest pixel intensity value. */
+    private int min;
+
+    /** The uppest pixel intensity value. */
+    private int max;
+
+    /** The lower bound of the table. */
+    private int lutMin;
+    
+    /** The upper bound of the table. */
+    private int lutMax;
+    
+    /** The input start normalized value. */
+    private double ysNormalized;
+
+    /** The input end normalized value. */
+    private double yeNormalized;
+
+    /** The slope of the normalized map. */
+    private double aNormalized;
+
+    /** The lower bound of the decile interval. */
+    private double Q1;
+
+    /** The upper bound of the decile interval. */
+    private double Q9;
+    
+    /**
+     * The mapping parameters from the sub-interval of [Q1, Q9] to the device
+     * space.
+     */
+    private double aDecile, bDecile;
+
+    /**
+     * The device space sub-interval. The values aren't the ones stored in
+     * {@link QuantumDef} if the noise reduction flag is <code>true</code>.
+     */
+    private int cdStart, cdEnd;
+    
+    /**
+     * Initializes the LUT. Comparable getGlobalMin and getGlobalMax assumed to
+     * be Integer, QuantumStrategy enforces min &lt; max. QuantumFactory makes
+     * sure 0 &lt; max-min &lt; 2^N where N = 8 or N = 16. LUT size is at most
+     * 256 bytes if N = 8 or 2^16 bytes = 2^6Kb = 64Kb if N = 16.
+     * 
+     * @param s The lower bound.
+     * @param e The upper bound.
+     */
+    private void initLUT(int s, int e)
+    {
+        min = (int) getGlobalMin();
+        max = (int) getGlobalMax();
+        
+        lutMin = (int) getPixelsTypeMin();
+        lutMax = (int) getPixelsTypeMax();
+        if (lutMax == 0) { //couldn't initialize the value
+        	if (s < min) lutMin = s;
+        	else lutMin = min;
+        	if (e > max) lutMax = e;
+        	else lutMax = max;
+        }
+        int range = lutMax - lutMin;
+        if (range > MAX_SIZE_LUT) 
+        {
+        	// We want to avoid *huge* memory allocations below so if we
+        	// couldn't initialize the value above and our lutMax and lutMin
+        	// have been assigned out of range values we want to choke, not
+        	// cause the server to throw a java.lang.OutOfMemory exception.
+        	// *** Ticket #1353 -- Chris Allan <callan@blackcat.ca> ***
+        	throw new IllegalArgumentException(String.format(
+        			"Lookup table of size %d greater than supported size %d",
+        			range, MAX_SIZE_LUT));
+        }
+        LUT = new byte[lutMax-lutMin+1];
+    }
+
+    /**
+     * Resets the LUT. We rebuild the LUT if and only if the 
+     * pixels type range was not determined at init time.
+     * 
+     * @param s The lower bound.
+     * @param e The upper bound.
+     */
+    private void resetLUT(int s, int e)
+    {
+    	int pMax = (int) getPixelsTypeMax();
+    	if (pMax != 0) return;
+    	if (s < lutMin && e > lutMax) {
+    		lutMin = s;
+    		lutMax = e;
+    		LUT = new byte[lutMax-lutMin+1];
+    	} else if (s < lutMin && e <= lutMax) {
+    		lutMin = s;
+    		LUT = new byte[lutMax-lutMin+1];
+    	} else if (s >= lutMin && e > lutMax) {
+    		lutMax = e;
+    		LUT = new byte[lutMax-lutMin+1];
+    	} 
+    }
+    
+    /**
+     * Initializes the coefficient of the normalize mapping operation.
+     * 
+     * @param k
+     *            The coefficient of the selected curve.
+     */
+    private void initNormalizedMap(double k) {
+        ysNormalized = valueMapper.transform(MIN, k);
+        yeNormalized = valueMapper.transform(MAX, k);
+        aNormalized = qDef.getBitResolution().intValue()
+                / (yeNormalized - ysNormalized);
+    }
+
+    /**
+     * Initializes the parameter to map the pixels intensities to the device
+     * space and returned the default initial depending on the value of the
+     * noise reduction flag.
+     * 
+     * @param dStart
+     *            The input window start.
+     * @param dEnd
+     *            The input window end.
+     * @return See above.
+     */
+    private double initDecileMap(double dStart, double dEnd) {
+        cdStart = qDef.getCdStart().intValue();
+        cdEnd = qDef.getCdEnd().intValue();
+        double denum = dEnd - dStart, num = MAX;
+        
+        double v = 0, b = dStart;
+        int e = 0;
+        double startMin = min;
+        double startMax = max;
+        Q1 = min;
+        Q9 = max;
+        
+        if (dStart <= startMin) {
+        	Q1 = dStart;
+        }
+        if (dEnd >= startMax) Q9 = dEnd;
+        if (startMin == startMax) v = 1;
+        double decile = (startMax - startMin) / DECILE;
+        if (getNoiseReduction()) {
+        	Q1 += decile;
+            Q9 -= decile;
+            denum = Q9 - Q1;
+            v = DECILE;
+            e = DECILE;
+            num = MAX - 2 * DECILE;
+            b = Q1;
+            if (dStart >= Q1 && dEnd > Q9) {
+                denum = Q9 - dStart;
+                b = dStart;
+            } else if (dStart >= Q1 && dEnd <= Q9) {
+                denum = dEnd - dStart;
+                b = dStart;
+            } else if (dStart < Q1 && dEnd <= Q9) {
+                denum = dEnd - Q1;
+            }
+            if (cdStart < DECILE) {
+                cdStart = DECILE;
+            }
+            if (cdEnd > MAX - DECILE) {
+                cdEnd = MAX - DECILE;
+            }
+        }
+        aDecile = num / denum;
+        bDecile = aDecile * b - e;
+        
+        return v;
+    }
+
+    /**
+     * Maps the input interval onto the codomain [cdStart, cdEnd] sub-interval
+     * of [0, 255]. Since the user can select the bitResolution 2^n-1 where n =
+     * 1..8, 2 steps. The mapping is the composition of 2 transformations: The
+     * first one <code>f</code> is one of the map selected by the user
+     * f:[inputStart, inputEnd]-&lt;[0, 2^n-1]. The second one <code>g</code>
+     * is a linear map: y = a1*x+b1 where b1 = codomainStart and a1 =
+     * (qDef.cdEnd-qDef.cdStart)/((double) qDef.bitResolution); g: [0,
+     * 2^n-1]-&lt;[cdStart, cdEnd]. For some reasons, we cannot compute directly
+     * gof.
+     */
+    private void buildLUT() {
+    	double dStart = getWindowStart(), dEnd = getWindowEnd();
+        if (LUT == null) {
+            initLUT((int) dStart, (int) dEnd);
+        } else {
+        	resetLUT((int) dStart, (int) dEnd);
+        }
+        // Comparable assumed to be Integer
+        // domain
+        
+        double k = getCurveCoefficient();
+        double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
+                / qDef.getBitResolution().doubleValue();
+
+        // Initializes the normalized map.
+        initNormalizedMap(k);
+        // Initializes the decile map.
+        double v = initDecileMap(dStart, dEnd);
+        QuantumMap normalize = new PolynomialMap();
+        
+
+        // Build the LUT
+        
+        int x = lutMin;
+        for (; x < dStart; ++x) {
+            LUT[x - lutMin] = (byte) cdStart;
+        }
+
+        for (; x < dEnd; ++x) {
+        	if (x > Q1) {
+                if (x <= Q9) {
+                    v = aDecile * normalize.transform(x, 1) - bDecile;
+                } else {
+                    v = cdEnd;
+                }
+            } else {
+                v = cdStart;
+            }
+        	
+            v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
+            v = Math.round(v);
+            v = Math.round(a1 * v + cdStart);
+            LUT[x - lutMin] = (byte) v;
+        }
+
+        for (; x <= lutMax; ++x) {
+            LUT[x - lutMin] = (byte) cdEnd;
+        }
+    }
+
+    /** The input window size changed, rebuild the LUT. */
+    @Override
+    protected void onWindowChange() {
+        buildLUT();
+    }
+
+    /**
+     * Creates a new strategy.
+     * 
+     * @param qd
+     *            Quantum definition object, contained mapping data.
+     * @param type
+     *            The pixel type;
+     */
+    public Quantization_32_bit(QuantumDef qd, PixelsType type) {
+        super(qd, type);
+    }
+
+    /**
+     * Implemented as specified in {@link QuantumStrategy}.
+     * 
+     * @see QuantumStrategy#quantize(double)
+     */
+    @Override
+    public int quantize(double value) throws QuantizationException {
+        int x = (int) value;
+        /*
+        if (x < min || x > max) {
+            throw new QuantizationException("The value " + x
+                    + " is not in the interval [" + min + "," + max + "]");
+        }
+        int i = LUT[x - min];
+        return i & 0xFF; // assumed x in [min, max]
+        */
+        /*
+        if (x < lutMin || x > lutMax) {
+            throw new QuantizationException("The value " + x
+                   + " is not in the interval [" + lutMin + "," + lutMax + "]");
+        }
+        */
+        int diff;
+        if (x < lutMin) {
+        	double r = getOriginalGlobalMax()-getOriginalGlobalMin();
+        	if (r != 0) {
+        		double f = (lutMax-lutMin)/r;
+        		x = (int) (f*(x-lutMin));
+        		if (x < lutMin) x = lutMin;
+        	} else x = lutMin;
+ 
+        }
+        if (x > lutMax) {
+        	double r = getOriginalGlobalMax()-getOriginalGlobalMin();
+        	if (r != 0) {
+        		double f = (lutMax-lutMin)/r;
+        		x = (int) (f*(x-lutMin));
+        		if (x > lutMax) x = lutMax;
+        	} else x = lutMax;
+        }
+        int i = LUT[x - lutMin];
+        return i & 0xFF; // assumed x in [min, max]
+    }
+
+}

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -24,6 +24,7 @@
 package omeis.providers.re.quantum;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -213,6 +214,7 @@ public class Quantization_32_bit extends QuantumStrategy {
         super(qd, type);
         values = CacheBuilder.newBuilder()
                 .maximumSize(MAX-MIN+1)
+                .expireAfterWrite(10, TimeUnit.MINUTES)
                 .build(new CacheLoader<Double, Integer>() {
                     public Integer load(Double key) throws Exception {
                         return _quantize(key);

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -300,21 +300,21 @@ public class Quantization_8_16_bit extends QuantumStrategy {
     public int quantize(double value) throws QuantizationException {
         int x = (int) value;
         if (x < lutMin) {
-        	double r = getOriginalGlobalMax()-getOriginalGlobalMin();
-        	if (r != 0) {
-        		double f = (lutMax-lutMin)/r;
-        		x = (int) (f*(x-lutMin));
-        		if (x < lutMin) x = lutMin;
-        	} else x = lutMin;
- 
+            double r = getOriginalGlobalMax()-getOriginalGlobalMin();
+            if (r != 0) {
+                double f = (lutMax-lutMin)/r;
+                x = (int) (f*(x-lutMin));
+                if (x < lutMin) x = lutMin;
+            } else x = lutMin;
+
         }
         if (x > lutMax) {
-        	double r = getOriginalGlobalMax()-getOriginalGlobalMin();
-        	if (r != 0) {
-        		double f = (lutMax-lutMin)/r;
-        		x = (int) (f*(x-lutMin));
-        		if (x > lutMax) x = lutMax;
-        	} else x = lutMax;
+            double r = getOriginalGlobalMax()-getOriginalGlobalMin();
+            if (r != 0) {
+                double f = (lutMax-lutMin)/r;
+                x = (int) (f*(x-lutMin));
+                if (x > lutMax) x = lutMax;
+            } else x = lutMax;
         }
         int i = LUT[x - lutMin];
         return i & 0xFF;

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -52,10 +52,10 @@ public class Quantization_8_16_bit extends QuantumStrategy {
 
     /** The lower bound of the table. */
     private int lutMin;
-    
+
     /** The upper bound of the table. */
     private int lutMax;
-    
+
     /** The input start normalized value. */
     private double ysNormalized;
 
@@ -70,7 +70,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
 
     /** The upper bound of the decile interval. */
     private double Q9;
-    
+
     /**
      * The mapping parameters from the sub-interval of [Q1, Q9] to the device
      * space.
@@ -82,13 +82,13 @@ public class Quantization_8_16_bit extends QuantumStrategy {
      * {@link QuantumDef} if the noise reduction flag is <code>true</code>.
      */
     private int cdStart, cdEnd;
-    
+
     /**
      * Initializes the LUT. Comparable getGlobalMin and getGlobalMax assumed to
      * be Integer, QuantumStrategy enforces min &lt; max. QuantumFactory makes
      * sure 0 &lt; max-min &lt; 2^N where N = 8 or N = 16. LUT size is at most
      * 256 bytes if N = 8 or 2^16 bytes = 2^6Kb = 64Kb if N = 16.
-     * 
+     *
      * @param s The lower bound.
      * @param e The upper bound.
      */
@@ -96,26 +96,28 @@ public class Quantization_8_16_bit extends QuantumStrategy {
     {
         min = (int) getGlobalMin();
         max = (int) getGlobalMax();
-        
+
         lutMin = (int) getPixelsTypeMin();
         lutMax = (int) getPixelsTypeMax();
         if (lutMax == 0) { //couldn't initialize the value
-        	if (s < min) lutMin = s;
-        	else lutMin = min;
-        	if (e > max) lutMax = e;
-        	else lutMax = max;
+            if (s < min) lutMin = s;
+            else lutMin = min;
+            if (e > max) lutMax = e;
+            else lutMax = max;
         }
         int range = lutMax - lutMin;
         if (range > MAX_SIZE_LUT) 
         {
-        	// We want to avoid *huge* memory allocations below so if we
-        	// couldn't initialize the value above and our lutMax and lutMin
-        	// have been assigned out of range values we want to choke, not
-        	// cause the server to throw a java.lang.OutOfMemory exception.
-        	// *** Ticket #1353 -- Chris Allan <callan@blackcat.ca> ***
-        	throw new IllegalArgumentException(String.format(
-        			"Lookup table of size %d greater than supported size %d",
-        			range, MAX_SIZE_LUT));
+            // We want to avoid *huge* memory allocations below so if we
+            // couldn't initialize the value above and our lutMax and lutMin
+            // have been assigned out of range values we want to choke, not
+            // cause the server to throw a java.lang.OutOfMemory exception.
+            // *** Ticket #1353 -- Chris Allan <callan@blackcat.ca> ***
+            //This should not happen since we have now strategy for float
+            //and 32bit.
+            throw new IllegalArgumentException(String.format(
+                    "Lookup table of size %d greater than supported size %f",
+                    range, MAX_SIZE_LUT));
         }
         LUT = new byte[lutMax-lutMin+1];
     }
@@ -123,30 +125,30 @@ public class Quantization_8_16_bit extends QuantumStrategy {
     /**
      * Resets the LUT. We rebuild the LUT if and only if the 
      * pixels type range was not determined at init time.
-     * 
+     *
      * @param s The lower bound.
      * @param e The upper bound.
      */
     private void resetLUT(int s, int e)
     {
-    	int pMax = (int) getPixelsTypeMax();
-    	if (pMax != 0) return;
-    	if (s < lutMin && e > lutMax) {
-    		lutMin = s;
-    		lutMax = e;
-    		LUT = new byte[lutMax-lutMin+1];
-    	} else if (s < lutMin && e <= lutMax) {
-    		lutMin = s;
-    		LUT = new byte[lutMax-lutMin+1];
-    	} else if (s >= lutMin && e > lutMax) {
-    		lutMax = e;
-    		LUT = new byte[lutMax-lutMin+1];
-    	} 
+        int pMax = (int) getPixelsTypeMax();
+        if (pMax != 0) return;
+        if (s < lutMin && e > lutMax) {
+            lutMin = s;
+            lutMax = e;
+            LUT = new byte[lutMax-lutMin+1];
+        } else if (s < lutMin && e <= lutMax) {
+            lutMin = s;
+            LUT = new byte[lutMax-lutMin+1];
+        } else if (s >= lutMin && e > lutMax) {
+            lutMax = e;
+            LUT = new byte[lutMax-lutMin+1];
+        }
     }
-    
+
     /**
      * Initializes the coefficient of the normalize mapping operation.
-     * 
+     *
      * @param k
      *            The coefficient of the selected curve.
      */
@@ -161,7 +163,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
      * Initializes the parameter to map the pixels intensities to the device
      * space and returned the default initial depending on the value of the
      * noise reduction flag.
-     * 
+     *
      * @param dStart
      *            The input window start.
      * @param dEnd
@@ -172,22 +174,22 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         cdStart = qDef.getCdStart().intValue();
         cdEnd = qDef.getCdEnd().intValue();
         double denum = dEnd - dStart, num = MAX;
-        
+
         double v = 0, b = dStart;
         int e = 0;
         double startMin = min;
         double startMax = max;
         Q1 = min;
         Q9 = max;
-        
+
         if (dStart <= startMin) {
-        	Q1 = dStart;
+            Q1 = dStart;
         }
         if (dEnd >= startMax) Q9 = dEnd;
         if (startMin == startMax) v = 1;
         double decile = (startMax - startMin) / DECILE;
         if (getNoiseReduction()) {
-        	Q1 += decile;
+            Q1 += decile;
             Q9 -= decile;
             denum = Q9 - Q1;
             v = DECILE;
@@ -212,7 +214,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         }
         aDecile = num / denum;
         bDecile = aDecile * b - e;
-        
+
         return v;
     }
 
@@ -232,11 +234,11 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         if (LUT == null) {
             initLUT((int) dStart, (int) dEnd);
         } else {
-        	resetLUT((int) dStart, (int) dEnd);
+            resetLUT((int) dStart, (int) dEnd);
         }
         // Comparable assumed to be Integer
         // domain
-        
+
         double k = getCurveCoefficient();
         double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
                 / qDef.getBitResolution().doubleValue();
@@ -249,7 +251,6 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         
 
         // Build the LUT
-        
         int x = lutMin;
         for (; x < dStart; ++x) {
             LUT[x - lutMin] = (byte) cdStart;
@@ -303,21 +304,6 @@ public class Quantization_8_16_bit extends QuantumStrategy {
     @Override
     public int quantize(double value) throws QuantizationException {
         int x = (int) value;
-        /*
-        if (x < min || x > max) {
-            throw new QuantizationException("The value " + x
-                    + " is not in the interval [" + min + "," + max + "]");
-        }
-        int i = LUT[x - min];
-        return i & 0xFF; // assumed x in [min, max]
-        */
-        /*
-        if (x < lutMin || x > lutMax) {
-            throw new QuantizationException("The value " + x
-                   + " is not in the interval [" + lutMin + "," + lutMax + "]");
-        }
-        */
-        int diff;
         if (x < lutMin) {
         	double r = getOriginalGlobalMax()-getOriginalGlobalMin();
         	if (r != 0) {
@@ -336,7 +322,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         	} else x = lutMax;
         }
         int i = LUT[x - lutMin];
-        return i & 0xFF; // assumed x in [min, max]
+        return i & 0xFF;
     }
 
 }

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -10,8 +10,6 @@ package omeis.providers.re.quantum;
 // Java imports
 
 // Third-party libraries
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // Application-internal dependencies
 import ome.model.display.QuantumDef;
@@ -37,9 +35,6 @@ import ome.model.enums.PixelsType;
  * @since OME2.2
  */
 public class Quantization_8_16_bit extends QuantumStrategy {
-
-    /** The logger for this particular class */
-    private static Logger log = LoggerFactory.getLogger(Quantization_8_16_bit.class);
 
     /** The look-up table. */
     private byte[] LUT;

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -175,7 +175,7 @@ public class Quantization_float extends QuantumStrategy {
     public Quantization_float(QuantumDef qd, PixelsType type) {
         super(qd, type);
         values = CacheBuilder.newBuilder()
-                .maximumSize(MAX_SIZE)
+                .maximumSize(MAX-MIN+1)
                 .build(new CacheLoader<Double, Integer>() {
                     public Integer load(Double key) throws Exception {
                         return _quantize(key);

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -1,0 +1,215 @@
+/*
+ * omeis.providers.re.quantum.Quantization_32_bit
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
+package omeis.providers.re.quantum;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import ome.model.display.QuantumDef;
+import ome.model.enums.PixelsType;
+
+/**
+ * Quantization process. In charge of building a look-up table for each active
+ * wavelength. The mapping process is done in three mapping steps, for some
+ * computer reasons, we cannot compose (in the mathematical sense) the three
+ * maps directly. Each wavelength initializes a strategy, in order to preserve
+ * the 5D-notion of OME image, we first compute the normalized parameters. We
+ * determine a pseudo-decile (not decile in maths terms) interval and compute
+ * the associated parameters to reduce the irrelevant values (noiseReduction).
+ *
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *          <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since OME5.1
+ */
+public class Quantization_float extends QuantumStrategy {
+
+    /** The lowest pixel intensity value. */
+    private int min;
+
+    /** The uppest pixel intensity value. */
+    private int max;
+
+    /** The input start normalized value. */
+    private double ysNormalized;
+
+    /** The input end normalized value. */
+    private double yeNormalized;
+
+    /** The slope of the normalized map. */
+    private double aNormalized;
+
+    /** The lower bound of the decile interval. */
+    private double Q1;
+
+    /** The upper bound of the decile interval. */
+    private double Q9;
+
+    /**
+     * The mapping parameters from the sub-interval of [Q1, Q9] to the device
+     * space.
+     */
+    private double aDecile, bDecile;
+
+    /**
+     * The device space sub-interval. The values aren't the ones stored in
+     * {@link QuantumDef} if the noise reduction flag is <code>true</code>.
+     */
+    private int cdStart, cdEnd;
+
+    /** The mapped values.*/
+    private Map<Double, Integer> values;
+
+    /**
+     * Initializes the coefficient of the normalize mapping operation.
+     *
+     * @param k
+     *            The coefficient of the selected curve.
+     */
+    private void initNormalizedMap(double k) {
+        ysNormalized = valueMapper.transform(MIN, k);
+        yeNormalized = valueMapper.transform(MAX, k);
+        aNormalized = qDef.getBitResolution().intValue()
+                / (yeNormalized - ysNormalized);
+    }
+
+    /**
+     * Initializes the parameter to map the pixels intensities to the device
+     * space and returned the default initial depending on the value of the
+     * noise reduction flag.
+     *
+     * @param dStart
+     *            The input window start.
+     * @param dEnd
+     *            The input window end.
+     * @return See above.
+     */
+    private double initDecileMap(double dStart, double dEnd) {
+        cdStart = qDef.getCdStart().intValue();
+        cdEnd = qDef.getCdEnd().intValue();
+        double denum = dEnd - dStart, num = MAX;
+
+        double v = 0, b = dStart;
+        int e = 0;
+        double startMin = min;
+        double startMax = max;
+        Q1 = min;
+        Q9 = max;
+
+        if (dStart <= startMin) {
+            Q1 = dStart;
+        }
+        if (dEnd >= startMax) Q9 = dEnd;
+        if (startMin == startMax) v = 1;
+        double decile = (startMax - startMin) / DECILE;
+        if (getNoiseReduction()) {
+            Q1 += decile;
+            Q9 -= decile;
+            denum = Q9 - Q1;
+            v = DECILE;
+            e = DECILE;
+            num = MAX - 2 * DECILE;
+            b = Q1;
+            if (dStart >= Q1 && dEnd > Q9) {
+                denum = Q9 - dStart;
+                b = dStart;
+            } else if (dStart >= Q1 && dEnd <= Q9) {
+                denum = dEnd - dStart;
+                b = dStart;
+            } else if (dStart < Q1 && dEnd <= Q9) {
+                denum = dEnd - Q1;
+            }
+            if (cdStart < DECILE) {
+                cdStart = DECILE;
+            }
+            if (cdEnd > MAX - DECILE) {
+                cdEnd = MAX - DECILE;
+            }
+        }
+        aDecile = num / denum;
+        bDecile = aDecile * b - e;
+
+        return v;
+    }
+
+    /** The input window size changed, re-map the values. */
+    @Override
+    protected void onWindowChange() {
+        values.clear();
+    }
+
+    /**
+     * Creates a new strategy.
+     *
+     * @param qd
+     *            Quantum definition object, contained mapping data.
+     * @param type
+     *            The pixel type;
+     */
+    public Quantization_float(QuantumDef qd, PixelsType type) {
+        super(qd, type);
+        values = new HashMap<Double, Integer>();
+    }
+
+    /**
+     * Implemented as specified in {@link QuantumStrategy}.
+     *
+     * @see QuantumStrategy#quantize(double)
+     */
+    @Override
+    public int quantize(double value) throws QuantizationException {
+        double dStart = getWindowStart(), dEnd = getWindowEnd();
+        if (value < dStart) {
+            return ((byte) cdStart) & 0xFF;
+        } else if (value > dEnd) {
+            return ((byte) cdEnd) & 0xFF;
+        }
+        double k = getCurveCoefficient();
+        double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
+                / qDef.getBitResolution().doubleValue();
+
+        // Initializes the normalized map.
+        initNormalizedMap(k);
+        // Initializes the decile map.
+        double v = initDecileMap(dStart, dEnd);
+        QuantumMap normalize = new PolynomialMap();
+
+        if (value > Q1) {
+            if (value <= Q9) {
+                v = aDecile * normalize.transform(value, 1) - bDecile;
+            } else {
+                v = cdEnd;
+            }
+        } else {
+            v = cdStart;
+        }
+
+        v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
+        v = Math.round(v);
+        v = Math.round(a1 * v + cdStart);
+        int x = ((byte) v) & 0xFF;
+        return x;
+    }
+
+}

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -196,11 +196,6 @@ public class Quantization_float extends QuantumStrategy {
                 throws QuantizationException
     {
         double dStart = getWindowStart(), dEnd = getWindowEnd();
-        if (value < dStart) {
-            return ((byte) cdStart) & 0xFF;
-        } else if (value > dEnd) {
-            return ((byte) cdEnd) & 0xFF;
-        }
         double k = getCurveCoefficient();
         double a1 = (qDef.getCdEnd().intValue() - qDef.getCdStart().intValue())
                 / qDef.getBitResolution().doubleValue();

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -25,12 +25,14 @@ package omeis.providers.re.quantum;
 
 import java.util.concurrent.ExecutionException;
 
+
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Range;
 
 /**
  * Quantization process. In charge of building a look-up table for each active
@@ -48,9 +50,6 @@ import com.google.common.cache.LoadingCache;
  */
 public class Quantization_float extends QuantumStrategy {
 
-    /** The maximum size of the cache.*/
-    private static final long MAX_SIZE = 1000;
-    
     /** The lowest pixel intensity value. */
     private int min;
 
@@ -224,9 +223,9 @@ public class Quantization_float extends QuantumStrategy {
         v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
         v = Math.round(v);
         v = Math.round(a1 * v + cdStart);
-        int x = ((byte) v) & 0xFF;
-        return x;
+        return ((byte) v) & 0xFF;
     }
+
     /**
      * Implemented as specified in {@link QuantumStrategy}.
      *
@@ -235,7 +234,9 @@ public class Quantization_float extends QuantumStrategy {
     @Override
     public int quantize(double value) throws QuantizationException {
         try {
-            return values.get(value);
+            Range<Double> r = getRange(value);
+            double v = (r.upperEndpoint()+r.lowerEndpoint())/2;
+            return values.get(v);
         } catch (ExecutionException e) {
             throw new QuantizationException(e);
         }

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -32,7 +32,6 @@ import ome.model.enums.PixelsType;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Range;
 
 /**
  * Quantization process. In charge of building a look-up table for each active
@@ -230,7 +229,7 @@ public class Quantization_float extends QuantumStrategy {
     @Override
     public int quantize(double value) throws QuantizationException {
         try {
-            Range<Double> r = getRange(value);
+            Range r = getRange(value);
             double v = (r.upperEndpoint()+r.lowerEndpoint())/2;
             return values.get(v);
         } catch (ExecutionException e) {

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -24,7 +24,7 @@
 package omeis.providers.re.quantum;
 
 import java.util.concurrent.ExecutionException;
-
+import java.util.concurrent.TimeUnit;
 
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
@@ -176,6 +176,7 @@ public class Quantization_float extends QuantumStrategy {
         super(qd, type);
         values = CacheBuilder.newBuilder()
                 .maximumSize(MAX-MIN+1)
+                .expireAfterWrite(10, TimeUnit.MINUTES)
                 .build(new CacheLoader<Double, Integer>() {
                     public Integer load(Double key) throws Exception {
                         return _quantize(key);

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
@@ -12,10 +12,13 @@ import java.util.List;
 
 // Third-party libraries
 
+
+
 // Application-internal dependencies
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneFactory;
 
 /**
  * Factory to create objects to carry out quantization for a given context. This
@@ -184,6 +187,10 @@ public class QuantumFactory {
      *         type.
      */
     private QuantumStrategy getQuantization(QuantumDef qd, PixelsType type) {
+        String typeAsString = type.getValue();
+        if (PlaneFactory.INT32.equals(typeAsString) ||
+                PlaneFactory.UINT32.equals(typeAsString))
+            return new Quantization_32_bit(qd, type);
         return new Quantization_8_16_bit(qd, type);
     }
 

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
@@ -191,6 +191,9 @@ public class QuantumFactory {
         if (PlaneFactory.INT32.equals(typeAsString) ||
                 PlaneFactory.UINT32.equals(typeAsString))
             return new Quantization_32_bit(qd, type);
+        else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
+                PlaneFactory.DOUBLE_TYPE.equals(typeAsString))
+            return new Quantization_float(qd, type);
         return new Quantization_8_16_bit(qd, type);
     }
 

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -12,6 +12,8 @@ package omeis.providers.re.quantum;
 // Third-party libraries
 
 // Application-internal dependencies
+import com.google.common.collect.Range;
+
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
@@ -57,6 +59,9 @@ public abstract class QuantumStrategy {
 
     /** The maximum size for a lookup table. */
     static final double MAX_SIZE_LUT = 0x10000;
+    
+    /** The maximum size of the cache.*/
+    static final long MAX_SIZE = 1000;
     
     /** The minimum value for the pixels type. */
     private double pixelsTypeMin;
@@ -224,6 +229,30 @@ public abstract class QuantumStrategy {
         initPixelsRange(false);
     }
 
+    /**
+     * Returns the range the values belongs to.
+     *
+     * @param value The value to handle
+     * @return See above.
+     */
+    protected Range<Double> getRange(double value)
+    {
+        //no range so we need to create it
+        double min = getWindowStart();
+        double max = getWindowEnd();
+        double step = Math.abs(max-min)/(MAX-MIN+1);
+        double end = min+step;
+        if (value == min) {
+            return Range.closedOpen(min, end);
+        }
+        while (min+step < value) {
+            min += step;
+            end += step;
+        }
+        if (end == max) return Range.closed(min, end);
+        return Range.closedOpen(min, end);
+    }
+    
     /**
      * Sets the maximum range of the input window.
      * 

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -16,6 +16,7 @@ import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
 import omeis.providers.re.data.PlaneFactory;
+import omeis.providers.re.metadata.StatsFactory;
 
 /**
  * Subclasses Work on explicit pixel types. Taking into
@@ -195,42 +196,7 @@ public abstract class QuantumStrategy {
     {
         double range;
         String typeAsString = type.getValue();
-        if (PlaneFactory.INT8.equals(typeAsString)) {
-            pixelsTypeMin = -128;
-            pixelsTypeMax = 127;
-        } else if (PlaneFactory.UINT8.equals(typeAsString)) {
-            pixelsTypeMin = 0;
-            pixelsTypeMax = 255;
-        } else if (PlaneFactory.INT16.equals(typeAsString)) {
-            pixelsTypeMin = -32768;
-            pixelsTypeMax = 32767;
-        } else if (PlaneFactory.UINT16.equals(typeAsString)) {
-            pixelsTypeMin = 0;
-            pixelsTypeMax = 65535;
-        } else if (PlaneFactory.INT32.equals(typeAsString)) {
-            if (withRange) {
-                range = globalMax - globalMin;
-                if (range < 0x10000) { 
-                    pixelsTypeMin = -32768;
-                    pixelsTypeMax = 32767;
-                }
-            } else {
-                pixelsTypeMin = -32768;
-                pixelsTypeMax = 32767;
-            }
-        } else if (PlaneFactory.UINT32.equals(typeAsString)) {
-            if (withRange) {
-                range = globalMax - globalMin;
-                if (range < 0x10000) { 
-                    pixelsTypeMin = 0;
-                    pixelsTypeMax = 65535;
-                }
-            } else {
-                pixelsTypeMin = 0;
-                pixelsTypeMax = 65535;
-            }
-
-        } else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
+        if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
                 PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
             if (withRange) {
                 range = globalMax - globalMin;
@@ -247,6 +213,11 @@ public abstract class QuantumStrategy {
                 pixelsTypeMin = 0;
                 pixelsTypeMax = 32767;
             }
+        } else {
+            StatsFactory sf = new StatsFactory();
+            double[] values = sf.initPixelsRange(type);
+            pixelsTypeMin = values[0];
+            pixelsTypeMax = values[1];
         }
     }
 

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -12,8 +12,6 @@ package omeis.providers.re.quantum;
 // Third-party libraries
 
 // Application-internal dependencies
-import com.google.common.collect.Range;
-
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
@@ -235,7 +233,7 @@ public abstract class QuantumStrategy {
      * @param value The value to handle
      * @return See above.
      */
-    protected Range<Double> getRange(double value)
+    protected Range getRange(double value)
     {
         //no range so we need to create it
         double min = getWindowStart();
@@ -243,14 +241,14 @@ public abstract class QuantumStrategy {
         double step = Math.abs(max-min)/(MAX-MIN+1);
         double end = min+step;
         if (value == min) {
-            return Range.closedOpen(min, end);
+            return new Range(min, end);//Range.closedOpen(min, end);
         }
         while (min+step < value) {
             min += step;
             end += step;
         }
-        if (end == max) return Range.closed(min, end);
-        return Range.closedOpen(min, end);
+        if (end == max) new Range(min, end);//closed(min, end);
+        return new Range(min, end);//Range.closedOpen(min, end);
     }
     
     /**

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -194,31 +194,10 @@ public abstract class QuantumStrategy {
      */
     private void initPixelsRange(boolean withRange)
     {
-        double range;
-        String typeAsString = type.getValue();
-        if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
-                PlaneFactory.DOUBLE_TYPE.equals(typeAsString)) {
-            if (withRange) {
-                range = globalMax - globalMin;
-                if (range < 0x10000 && globalMin > -1) { 
-                    pixelsTypeMin = 0;
-                    pixelsTypeMax = 65535;
-                }
-                if (range < 0x10000 && globalMin < 0) { 
-                    pixelsTypeMin = -32768;
-                    pixelsTypeMax = 32767;
-                }
-            } else {
-                //b/c we don't know if it is signed or not
-                pixelsTypeMin = 0;
-                pixelsTypeMax = 32767;
-            }
-        } else {
-            StatsFactory sf = new StatsFactory();
-            double[] values = sf.initPixelsRange(type);
-            pixelsTypeMin = values[0];
-            pixelsTypeMax = values[1];
-        }
+        StatsFactory sf = new StatsFactory();
+        double[] values = sf.initPixelsRange(type);
+        pixelsTypeMin = values[0];
+        pixelsTypeMax = values[1];
     }
 
     /**

--- a/components/rendering/src/omeis/providers/re/quantum/Range.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Range.java
@@ -1,0 +1,53 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omeis.providers.re.quantum;
+
+//Java imports
+
+/**
+ * Utility class. Temporary class until we update guava.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.0
+ */
+class Range {
+
+    private double upperBound;
+
+    private double lowerBound;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param lowerBound The lower bound of the interval.
+     * @param upperBound The upper bound of the interval.
+     */
+    Range(double lowerBound, double upperBound)
+    {
+        this.upperBound = upperBound;
+        this.lowerBound = lowerBound;
+    }
+
+    double upperEndpoint() { return upperBound; }
+
+    double lowerEndpoint() { return lowerBound; }
+}

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -987,7 +987,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
         try {
             errorIfInvalidState();
             ChannelBinding[] cb = renderer.getChannelBindings();
-            return cb[w].getInputEnd().intValue();
+            return cb[w].getInputEnd().doubleValue();
         } finally {
             rwl.readLock().unlock();
         }
@@ -1005,7 +1005,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
         try {
             errorIfInvalidState();
             ChannelBinding[] cb = renderer.getChannelBindings();
-            return cb[w].getInputStart().intValue();
+            return cb[w].getInputStart().doubleValue();
         } finally {
             rwl.readLock().unlock();
         }

--- a/components/server/test/omeis/providers/re/utests/TestOnTheFly16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestOnTheFly16BitRenderer.java
@@ -19,7 +19,7 @@ public class TestOnTheFly16BitRenderer extends BaseRenderingTest
 	protected QuantumFactory createQuantumFactory()
 	{
 		TestQuantumFactory qf = new TestQuantumFactory();
-		qf.setStratgey(new OnTheFlyStrategy(settings.getQuantization(),
+		qf.setStrategy(new OnTheFlyStrategy(settings.getQuantization(),
 				                            pixels.getPixelsType()));
 		return qf;
 	}

--- a/components/server/test/omeis/providers/re/utests/TestQuantumFactory.java
+++ b/components/server/test/omeis/providers/re/utests/TestQuantumFactory.java
@@ -31,7 +31,12 @@ public class TestQuantumFactory extends QuantumFactory {
     {
     	this.strategy = strategy;
     }
-    
+
+    public void setStrategy(QuantumStrategy strategy)
+    {
+        this.strategy = strategy;
+    }
+
     public QuantumStrategy getStrategy(QuantumDef qd, PixelsType pixelsType)
     {
     	if (strategy == null)

--- a/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
@@ -41,12 +41,14 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
 	@Test
 	public void testPixelValues() throws Exception
 	{
+	    QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(0.0, data.getPixelValue(i));
         }
         for (int i = 0; i < n/2; i++) {
-            assertEquals(Math.pow(2, 16)-1, data.getPixelValue(i+n/2));
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
         }
 
         try

--- a/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
@@ -44,10 +44,10 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
 		assertEquals(0.0, data.getPixelValue(1));
 		assertEquals(0.0, data.getPixelValue(2));
 		assertEquals(0.0, data.getPixelValue(3));
-		assertEquals(65535.0, data.getPixelValue(4));
-		assertEquals(65535.0, data.getPixelValue(5));
-		assertEquals(65535.0, data.getPixelValue(6));
-		assertEquals(65535.0, data.getPixelValue(7));
+		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(4));
+		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(5));
+		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(6));
+		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(7));
 		try
 		{
 			assertEquals(0.0, data.getPixelValue(8));

--- a/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
@@ -7,6 +7,7 @@
 package omeis.providers.re.utests;
 
 import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.quantum.QuantumStrategy;
 
 import org.perf4j.LoggingStopWatch;
 import org.perf4j.StopWatch;
@@ -40,20 +41,20 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
 	@Test
 	public void testPixelValues() throws Exception
 	{
-		assertEquals(0.0, data.getPixelValue(0));
-		assertEquals(0.0, data.getPixelValue(1));
-		assertEquals(0.0, data.getPixelValue(2));
-		assertEquals(0.0, data.getPixelValue(3));
-		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(4));
-		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(5));
-		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(6));
-		assertEquals(Math.pow(2, 16)-1, data.getPixelValue(7));
-		try
-		{
-			assertEquals(0.0, data.getPixelValue(8));
-			fail("Should have thrown an IndexOutOfBoundsException.");
-		}
-		catch (IndexOutOfBoundsException e) { }
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(Math.pow(2, 16)-1, data.getPixelValue(i+n/2));
+        }
+
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
 	}
 	
 	@Test
@@ -68,4 +69,12 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
 			stopWatch.stop();
 		}
 	}
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        assertEquals(0.0, qs.getPixelsTypeMin());
+        assertEquals(Math.pow(2, 16)-1, qs.getPixelsTypeMax());
+    }
 }

--- a/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
@@ -7,7 +7,7 @@
 package omeis.providers.re.utests;
 
 import ome.model.enums.PixelsType;
-
+import omeis.providers.re.quantum.QuantumStrategy;
 import org.testng.annotations.Test;
 
 public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTest
@@ -55,19 +55,29 @@ public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTe
 	@Test
 	public void testPixelValues() throws Exception
 	{
-		assertEquals(0.0, data.getPixelValue(0));
-		assertEquals(0.0, data.getPixelValue(1));
-		assertEquals(0.0, data.getPixelValue(2));
-		assertEquals(0.0, data.getPixelValue(3));
-		assertEquals(65535.0, data.getPixelValue(4));
-		assertEquals(65535.0, data.getPixelValue(5));
-		assertEquals(65535.0, data.getPixelValue(6));
-		assertEquals(65535.0, data.getPixelValue(7));
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
+        }
 		try
 		{
-			assertEquals(0.0, data.getPixelValue(8));
+			assertEquals(0.0, data.getPixelValue(n));
 			fail("Should have thrown an IndexOutOfBoundsException.");
 		}
 		catch (IndexOutOfBoundsException e) { }
 	}
+
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        assertEquals(0.0, qs.getPixelsTypeMin());
+        assertEquals(Math.pow(2, 32)-1, qs.getPixelsTypeMax());
+    }
 }

--- a/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
@@ -7,7 +7,11 @@
 package omeis.providers.re.utests;
 
 import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.quantum.QuantumStrategy;
+
+import org.perf4j.LoggingStopWatch;
+import org.perf4j.StopWatch;
 import org.testng.annotations.Test;
 
 public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTest
@@ -79,5 +83,18 @@ public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTe
                 settings.getQuantization(), pixels.getPixelsType());
         assertEquals(0.0, qs.getPixelsTypeMin());
         assertEquals(Math.pow(2, 32)-1, qs.getPixelsTypeMax());
+    }
+
+    @Test(timeOut=30000)
+    public void testRenderAsPackedInt() throws Exception
+    {
+        PlaneDef def = new PlaneDef(PlaneDef.XY, 0);
+        for (int i = 0; i < RUN_COUNT; i++)
+        {
+            StopWatch stopWatch =
+                new LoggingStopWatch("testRendererAsPackedInt");
+            renderer.renderAsPackedInt(def, pixelBuffer);
+            stopWatch.stop();
+        }
     }
 }

--- a/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesShouldFail.java
@@ -16,49 +16,49 @@ import org.testng.annotations.Test;
 
 public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTest
 {
-	
-	@Override
-	protected int getSizeX()
-	{
-		return 2;
-	}
-	
-	@Override
-	protected int getSizeY()
-	{
-		return 2;
-	}
-	
-	@Override
-	protected byte[] getPlane()
-	{
-		return new byte[] {
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-				(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-				(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-				(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-				};
-	}
-	
-	@Override
-	protected int getBytesPerPixel()
-	{
-		return 4;
-	}
-	
-	@Override
-	protected PixelsType getPixelsType()
-	{
-		PixelsType pixelsType = new PixelsType();
-		pixelsType.setValue("uint32");
-		return pixelsType;
-	}
-	
-	@Test
-	public void testPixelValues() throws Exception
-	{
+
+    @Override
+    protected int getSizeX()
+    {
+        return 2;
+    }
+
+    @Override
+    protected int getSizeY()
+    {
+        return 2;
+    }
+
+    @Override
+    protected byte[] getPlane()
+    {
+        return new byte[] {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+        };
+    }
+
+    @Override
+    protected int getBytesPerPixel()
+    {
+        return 4;
+    }
+
+    @Override
+    protected PixelsType getPixelsType()
+    {
+        PixelsType pixelsType = new PixelsType();
+        pixelsType.setValue("uint32");
+        return pixelsType;
+    }
+
+    @Test
+    public void testPixelValues() throws Exception
+    {
         QuantumStrategy qs = quantumFactory.getStrategy(
                 settings.getQuantization(), pixels.getPixelsType());
         int n = data.size();
@@ -68,13 +68,13 @@ public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTe
         for (int i = 0; i < n/2; i++) {
             assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
         }
-		try
-		{
-			assertEquals(0.0, data.getPixelValue(n));
-			fail("Should have thrown an IndexOutOfBoundsException.");
-		}
-		catch (IndexOutOfBoundsException e) { }
-	}
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
+    }
 
     @Test
     public void testPixelValuesRange() throws Exception
@@ -92,7 +92,7 @@ public class TestStandard32BitRendererLUTSizesShouldFail extends BaseRenderingTe
         for (int i = 0; i < RUN_COUNT; i++)
         {
             StopWatch stopWatch =
-                new LoggingStopWatch("testRendererAsPackedInt");
+                    new LoggingStopWatch("testRendererAsPackedInt");
             renderer.renderAsPackedInt(def, pixelBuffer);
             stopWatch.stop();
         }

--- a/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
@@ -118,7 +118,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
         assertEquals(Double.MAX_VALUE, qs.getPixelsTypeMax());
     }
 
-    @Test
+    @Test(timeOut=30000)
     public void testRenderAsPackedInt() throws Exception
     {
         PlaneDef def = new PlaneDef(PlaneDef.XY, 0);

--- a/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
@@ -38,7 +38,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
     protected QuantumFactory createQuantumFactory()
     {
         TestQuantumFactory qf = new TestQuantumFactory();
-        qf.setStratgey(new Quantization_float(settings.getQuantization(),
+        qf.setStrategy(new Quantization_float(settings.getQuantization(),
                 pixels.getPixelsType()));
         return qf;
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
@@ -1,0 +1,133 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omeis.providers.re.utests;
+
+import java.nio.ByteBuffer;
+
+import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.quantum.Quantization_float;
+import omeis.providers.re.quantum.QuantumFactory;
+import omeis.providers.re.quantum.QuantumStrategy;
+
+import org.perf4j.LoggingStopWatch;
+import org.perf4j.StopWatch;
+import org.testng.annotations.Test;
+
+public class TestStandardDoubleRenderer extends BaseRenderingTest
+{
+    @Override
+    protected QuantumFactory createQuantumFactory()
+    {
+        TestQuantumFactory qf = new TestQuantumFactory();
+        qf.setStratgey(new Quantization_float(settings.getQuantization(),
+                pixels.getPixelsType()));
+        return qf;
+    }
+    
+    @Override
+    protected int getSizeX()
+    {
+        return 2;
+    }
+
+    @Override
+    protected int getSizeY()
+    {
+        return 4;
+    }
+
+    @Override
+    protected int getBytesPerPixel()
+    {
+        return 4;
+    }
+
+    @Override
+    protected byte[] getPlane()
+    {
+        int n = 16;
+        Double[] output = new Double[16];
+        for (int i = 0; i < n/2; i++) {
+            output[i+n/2] = Double.MAX_VALUE;
+        }
+        for (int i = 0; i < n/2; i++) {
+            output[i] = 0.0;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(8 * output.length);
+
+        for (double value : output){
+            buffer.putDouble(value);
+        }
+        return buffer.array();
+    }
+
+    @Override
+    protected PixelsType getPixelsType()
+    {
+        PixelsType pixelsType = new PixelsType();
+        pixelsType.setValue("double");
+        return pixelsType;
+    }
+
+    @Test
+    public void testPixelValues() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
+        }
+
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
+    }
+
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        assertEquals(-Double.MAX_VALUE, qs.getPixelsTypeMin());
+        assertEquals(Double.MAX_VALUE, qs.getPixelsTypeMax());
+    }
+
+    @Test
+    public void testRenderAsPackedInt() throws Exception
+    {
+        PlaneDef def = new PlaneDef(PlaneDef.XY, 0);
+        for (int i = 0; i < RUN_COUNT; i++)
+        {
+            StopWatch stopWatch =
+                new LoggingStopWatch("testRendererAsPackedInt");
+            renderer.renderAsPackedInt(def, pixelBuffer);
+            stopWatch.stop();
+        }
+    }
+}

--- a/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
@@ -118,7 +118,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
         assertTrue(Float.MAX_VALUE == qs.getPixelsTypeMax());
     }
 
-    @Test
+    @Test(timeOut=30000)
     public void testRenderAsPackedInt() throws Exception
     {
         PlaneDef def = new PlaneDef(PlaneDef.XY, 0);

--- a/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
@@ -1,0 +1,134 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omeis.providers.re.utests;
+
+import java.nio.ByteBuffer;
+
+import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.quantum.Quantization_float;
+import omeis.providers.re.quantum.QuantumFactory;
+import omeis.providers.re.quantum.QuantumStrategy;
+
+import org.perf4j.LoggingStopWatch;
+import org.perf4j.StopWatch;
+import org.testng.annotations.Test;
+
+public class TestStandardFloatRenderer extends BaseRenderingTest
+{
+    @Override
+    protected QuantumFactory createQuantumFactory()
+    {
+        TestQuantumFactory qf = new TestQuantumFactory();
+        qf.setStratgey(new Quantization_float(settings.getQuantization(),
+                pixels.getPixelsType()));
+        return qf;
+    }
+    
+    @Override
+    protected int getSizeX()
+    {
+        return 2;
+    }
+
+    @Override
+    protected int getSizeY()
+    {
+        return 4;
+    }
+
+    @Override
+    protected int getBytesPerPixel()
+    {
+        return 4;
+    }
+
+    @Override
+    protected byte[] getPlane()
+    {
+        int n = 16;
+        Float[] output = new Float[16];
+        for (int i = 0; i < n/2; i++) {
+            output[i+n/2] = Float.MAX_VALUE;
+        }
+        for (int i = 0; i < n/2; i++) {
+            output[i] = 0.0f;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(4 * output.length);
+
+        for (float value : output){
+            buffer.putFloat(value);
+        }
+        return buffer.array();
+    }
+
+    @Override
+    protected PixelsType getPixelsType()
+    {
+        PixelsType pixelsType = new PixelsType();
+        pixelsType.setValue("float");
+        return pixelsType;
+    }
+
+    @Test
+    public void testPixelValues() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
+        }
+
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
+    }
+
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        System.err.println(-Float.MAX_VALUE);
+        assertTrue(-Float.MAX_VALUE == qs.getPixelsTypeMin());
+        assertTrue(Float.MAX_VALUE == qs.getPixelsTypeMax());
+    }
+
+    @Test
+    public void testRenderAsPackedInt() throws Exception
+    {
+        PlaneDef def = new PlaneDef(PlaneDef.XY, 0);
+        for (int i = 0; i < RUN_COUNT; i++)
+        {
+            StopWatch stopWatch =
+                new LoggingStopWatch("testRendererAsPackedInt");
+            renderer.renderAsPackedInt(def, pixelBuffer);
+            stopWatch.stop();
+        }
+    }
+}

--- a/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
@@ -114,7 +114,6 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
                 settings.getQuantization(), pixels.getPixelsType());
-        System.err.println(-Float.MAX_VALUE);
         assertTrue(-Float.MAX_VALUE == qs.getPixelsTypeMin());
         assertTrue(Float.MAX_VALUE == qs.getPixelsTypeMax());
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
@@ -38,7 +38,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     protected QuantumFactory createQuantumFactory()
     {
         TestQuantumFactory qf = new TestQuantumFactory();
-        qf.setStratgey(new Quantization_float(settings.getQuantization(),
+        qf.setStrategy(new Quantization_float(settings.getQuantization(),
                 pixels.getPixelsType()));
         return qf;
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
@@ -91,7 +91,7 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
         assertEquals(Math.pow(2, 16)/2-1, qs.getPixelsTypeMax());
     }
 
-    @Test
+    @Test(timeOut=30000)
     public void testRenderAsPackedInt() throws Exception
     {
         PlaneDef def = new PlaneDef(PlaneDef.XY, 0);

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
@@ -46,7 +46,8 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
     protected byte[] getPlane()
     {
         return new byte[] {
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 128, 0x00, (byte) 128, 0x00, (byte) 128, 0x00,
+                (byte) 128, 0x00,
                 (byte) 127, (byte) 0xFF, (byte) 127, (byte) 0xFF,
                 (byte) 127, (byte) 0xFF, (byte) 127, (byte) 0xFF,
         };
@@ -63,12 +64,14 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
     @Test
     public void testPixelValues() throws Exception
     {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
-            assertEquals(0.0, data.getPixelValue(i));
+            assertEquals(qs.getPixelsTypeMin(), data.getPixelValue(i));
         }
         for (int i = 0; i < n/2; i++) {
-            assertEquals(Math.pow(2, 16)/2-1, data.getPixelValue(i+n/2));
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
         }
 
         try

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
@@ -1,0 +1,104 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omeis.providers.re.utests;
+
+import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.quantum.QuantumStrategy;
+
+import org.perf4j.LoggingStopWatch;
+import org.perf4j.StopWatch;
+import org.testng.annotations.Test;
+
+public class TestStandardSigned16BitRenderer extends BaseRenderingTest
+{
+    @Override
+    protected int getSizeX()
+    {
+        return 2;
+    }
+
+    @Override
+    protected int getSizeY()
+    {
+        return 2;
+    }
+
+    @Override
+    protected byte[] getPlane()
+    {
+        return new byte[] {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 127, (byte) 0xFF, (byte) 127, (byte) 0xFF,
+                (byte) 127, (byte) 0xFF, (byte) 127, (byte) 0xFF,
+        };
+    }
+
+    @Override
+    protected PixelsType getPixelsType()
+    {
+        PixelsType pixelsType = new PixelsType();
+        pixelsType.setValue("int16");
+        return pixelsType;
+    }
+
+    @Test
+    public void testPixelValues() throws Exception
+    {
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(Math.pow(2, 16)/2-1, data.getPixelValue(i+n/2));
+        }
+
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
+    }
+
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        assertEquals(-Math.pow(2, 16)/2, qs.getPixelsTypeMin());
+        assertEquals(Math.pow(2, 16)/2-1, qs.getPixelsTypeMax());
+    }
+
+    @Test
+    public void testRenderAsPackedInt() throws Exception
+    {
+        PlaneDef def = new PlaneDef(PlaneDef.XY, 0);
+        for (int i = 0; i < RUN_COUNT; i++)
+        {
+            StopWatch stopWatch =
+                    new LoggingStopWatch("testRendererAsPackedInt");
+            renderer.renderAsPackedInt(def, pixelBuffer);
+            stopWatch.stop();
+        }
+    }
+
+}

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -36,7 +36,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     protected QuantumFactory createQuantumFactory()
     {
         TestQuantumFactory qf = new TestQuantumFactory();
-        qf.setStratgey(new Quantization_32_bit(settings.getQuantization(),
+        qf.setStrategy(new Quantization_32_bit(settings.getQuantization(),
                 pixels.getPixelsType()));
         return qf;
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -110,7 +110,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
         assertEquals(Math.pow(2, 32)/2-1, qs.getPixelsTypeMax());
     }
 
-    @Test
+    @Test(timeOut=30000)
     public void testRenderAsPackedInt() throws Exception
     {
         PlaneDef def = new PlaneDef(PlaneDef.XY, 0);

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -67,6 +67,12 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     }
 
     @Override
+    protected int getBytesPerPixel()
+    {
+        return 4;
+    }
+
+    @Override
     protected PixelsType getPixelsType()
     {
         PixelsType pixelsType = new PixelsType();

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -57,8 +57,8 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     protected byte[] getPlane()
     {
         return new byte[] {
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 128, 0x00, 0x00, 0x00, (byte) 128, 0x00, 0x00, 0x00,
+                (byte) 128, 0x00, 0x00, 0x00, (byte) 128, 0x00, 0x00, 0x00,
                 (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
                 (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
                 (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
@@ -78,11 +78,13 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     public void testPixelValues() throws Exception
     {
         int n = data.size();
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
         for (int i = 0; i < n/2; i++) {
-            assertEquals(0.0, data.getPixelValue(i));
+            assertEquals(qs.getPixelsTypeMin(), data.getPixelValue(i));
         }
         for (int i = 0; i < n/2; i++) {
-            assertEquals(Math.pow(2, 32)/2-1, data.getPixelValue(i+n/2));
+            assertEquals(qs.getPixelsTypeMax(), data.getPixelValue(i+n/2));
         }
 
         try

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -1,0 +1,117 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omeis.providers.re.utests;
+
+import ome.model.enums.PixelsType;
+import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.quantum.Quantization_32_bit;
+import omeis.providers.re.quantum.QuantumFactory;
+import omeis.providers.re.quantum.QuantumStrategy;
+
+import org.perf4j.LoggingStopWatch;
+import org.perf4j.StopWatch;
+import org.testng.annotations.Test;
+
+public class TestStandardSigned32BitRenderer extends BaseRenderingTest
+{
+    @Override
+    protected QuantumFactory createQuantumFactory()
+    {
+        TestQuantumFactory qf = new TestQuantumFactory();
+        qf.setStratgey(new Quantization_32_bit(settings.getQuantization(),
+                pixels.getPixelsType()));
+        return qf;
+    }
+
+    @Override
+    protected int getSizeX()
+    {
+        return 2;
+    }
+
+    @Override
+    protected int getSizeY()
+    {
+        return 4;
+    }
+
+    @Override
+    protected byte[] getPlane()
+    {
+        return new byte[] {
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 127, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                };
+    }
+
+    @Override
+    protected PixelsType getPixelsType()
+    {
+        PixelsType pixelsType = new PixelsType();
+        pixelsType.setValue("int32");
+        return pixelsType;
+    }
+
+    @Test
+    public void testPixelValues() throws Exception
+    {
+        int n = data.size();
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(0.0, data.getPixelValue(i));
+        }
+        for (int i = 0; i < n/2; i++) {
+            assertEquals(Math.pow(2, 32)/2-1, data.getPixelValue(i+n/2));
+        }
+
+        try
+        {
+            assertEquals(0.0, data.getPixelValue(n));
+            fail("Should have thrown an IndexOutOfBoundsException.");
+        }
+        catch (IndexOutOfBoundsException e) { }
+    }
+
+    @Test
+    public void testPixelValuesRange() throws Exception
+    {
+        QuantumStrategy qs = quantumFactory.getStrategy(
+                settings.getQuantization(), pixels.getPixelsType());
+        assertEquals(-Math.pow(2, 32)/2, qs.getPixelsTypeMin());
+        assertEquals(Math.pow(2, 32)/2-1, qs.getPixelsTypeMax());
+    }
+
+    @Test
+    public void testRenderAsPackedInt() throws Exception
+    {
+        PlaneDef def = new PlaneDef(PlaneDef.XY, 0);
+        for (int i = 0; i < RUN_COUNT; i++)
+        {
+            StopWatch stopWatch =
+                    new LoggingStopWatch("testRendererAsPackedInt");
+            renderer.renderAsPackedInt(def, pixelBuffer);
+            stopWatch.stop();
+        }
+    }
+}

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -1794,7 +1794,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         RenderingEnginePrx re = factory.createRenderingEngine();
         re.lookupPixels(id);
         if (!(re.lookupRenderingDef(id))) {
-            re.resetDefaultSettings(true);
+            re.resetDefaults();
             re.lookupRenderingDef(id);
         }
         re.load();

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -1766,4 +1766,58 @@ public class RenderingEngineTest extends AbstractServerTest {
     public void testSaveCurrentSettingsByAdminRWRW() throws Exception {
         saveRenderingSettings("rwrw--", ADMIN);
     }
+
+    /**
+     * Tests the retrieval of the rendering settings data using the rendering
+     * engine.
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testRenderingEngineChannelWindowGetter() throws Exception {
+        File f = File.createTempFile("testRenderingEngineGetters", "."
+                + OME_FORMAT);
+        XMLMockObjects xml = new XMLMockObjects();
+        XMLWriter writer = new XMLWriter();
+        writer.writeFile(f, xml.createImage(), true);
+        List<Pixels> pixels = null;
+        try {
+            pixels = importFile(f, OME_FORMAT);
+        } catch (Throwable e) {
+            throw new Exception("cannot import image", e);
+        }
+        Pixels p = pixels.get(0);
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        // retrieve the rendering def
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        QuantumDef q1 = def.getQuantization();
+        assertNotNull(q1);
+        List<ChannelBinding> channels1 = def.copyWaveRendering();
+        assertNotNull(channels1);
+        Iterator<ChannelBinding> i = channels1.iterator();
+        ChannelBinding c1;
+        int index = 0;
+        double s = 0.11;
+        double e = 0.21;
+        while (i.hasNext()) {
+            c1 = i.next();
+            e = c1.getInputEnd().getValue()+0.21;
+            s = c1.getInputStart().getValue()+0.11;
+            re.setChannelWindow(index, s, e);
+            assertEquals(s, re.getChannelWindowStart(index));
+            assertEquals(e, re.getChannelWindowEnd(index));
+            index++;
+        }
+        re.close();
+    }
 }


### PR DESCRIPTION

This is the same as gh-2955 but rebased onto dev_5_0.

----

Add support for  32-bits images (pixels type)
 * Import the following images. 
    * test_image_good/ubm
    * from skyking/gatan/chip/
   * from skyking/gatan/qa-7642
 * Check that you can view the images.
 * Open the images in ImageJ or Fiji using BioFormats to validate.

Images imported w/o this PR can be found under 
trout/ port 14064 (latest), user-1 private-1 Project imported 18-08-14 to test 32 bit

Add support for floating point image
To test this PR

make sure that the unit tests under server/test/omeis.providers.re.utests are green
Import floating point images. a selection can be found under squig/team/will/float0-data.zip
View the image in OMERO, modify some values e.g. pixels window.
View the same image in ImageJ.
Note that the pyramid generation for floating point images (>4kx4k)will not work. This will not be addressed in this PR.
                
--rebased-from #2955 
--rebased-from #3033