### PR TITLE
Pyramid

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -596,6 +596,9 @@ public class PixelsService extends AbstractFileSystemService
      * @return
      */
     public boolean requiresPixelsPyramid(Pixels pixels) {
+        String type = pixels.getPixelsType().getValue();
+        if ("float".equals(type) || "double".equals(type))
+            return false;
         final long sizeX = pixels.getSizeX();
         final long sizeY = pixels.getSizeY();
         final boolean requirePyramid = (sizeX * sizeY) > (sizes.getMaxPlaneWidth()*sizes.getMaxPlaneHeight());

--- a/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
@@ -73,7 +73,7 @@ public class BfPixelBufferUnitTest {
     @Test
     public void testRomioPixelBufferCreation() {
         service = new PixelsService(root);
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
         assertTrue(pixelBuffer instanceof RomioPixelBuffer);
     }
 

--- a/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
@@ -6,7 +6,6 @@
  */
 package ome.io.nio.utests;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;

--- a/components/romio/test/ome/io/nio/utests/HugePixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/HugePixelBufferUnitTest.java
@@ -55,7 +55,7 @@ public class HugePixelBufferUnitTest {
         pixels.setPixelsType(type);
 
         PixelsService service = new PixelsService(ROOT);
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
     }
 
 

--- a/components/romio/test/ome/io/nio/utests/LargePixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/LargePixelBufferUnitTest.java
@@ -55,7 +55,7 @@ public class LargePixelBufferUnitTest {
         pixels.setPixelsType(type);
 
         PixelsService service = new PixelsService(ROOT);
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
     }
 
     @Test

--- a/components/romio/test/ome/io/nio/utests/NormalPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/NormalPixelBufferUnitTest.java
@@ -55,7 +55,7 @@ public class NormalPixelBufferUnitTest {
         pixels.setPixelsType(type);
 
         PixelsService service = new PixelsService(ROOT);
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
     }
 
     @Test

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -63,7 +63,7 @@ public class PixelDataBitTest
     	// 14
     	assertEquals(0.0, data.getPixelValue(14));
     	data.setPixelValue(14, 1.0);
-    	assertEquals(1.0, data.getPixelValue(14));    	
+    	assertEquals(1.0, data.getPixelValue(14));
     }
     
     public void testSize()

--- a/components/romio/test/ome/io/nio/utests/PlanarDataTest.java
+++ b/components/romio/test/ome/io/nio/utests/PlanarDataTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.*;
 import ome.io.nio.RomioPixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
-import ome.util.Utils;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumProviderFactoryImpl;
 import ome.util.checksum.ChecksumType;

--- a/components/romio/test/ome/io/nio/utests/PyramidPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PyramidPixelBufferUnitTest.java
@@ -49,7 +49,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
 
     @Test
     public void testTruePyramidCreation() {
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
     }
 
     @Test(dependsOnMethods={"testTruePyramidCreation"}, enabled=true)
@@ -58,7 +58,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
         assertEquals(tileCount, 768);
         pixelBuffer.close();
         // close now nulls the reader to free file descriptors
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=false)

--- a/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 
 import ome.conditions.LockTimeout;
 import ome.io.bioformats.BfPyramidPixelBuffer;
-import ome.io.nio.PixelBuffer;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
@@ -48,7 +48,7 @@ public class PyramidWriteLockUnitTest extends AbstractPyramidPixelBufferUnitTest
      */
     @Test(groups = "ticket:5083", expectedExceptions = LockTimeout.class)
     public void testPyramidWriteLock() throws Exception {
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service._getPixelBuffer(pixels, true);
         final CountDownLatch latch = new CountDownLatch(1);
         final Runnable run = new Runnable() {
             public void run() {
@@ -69,7 +69,7 @@ public class PyramidWriteLockUnitTest extends AbstractPyramidPixelBufferUnitTest
 
         BfPyramidPixelBuffer pixelBuffer2 = null;
         try {
-            pixelBuffer2 = (BfPyramidPixelBuffer) service.getPixelBuffer(pixels);
+            pixelBuffer2 = (BfPyramidPixelBuffer) service._getPixelBuffer(pixels, true);
         } finally {
             latch.countDown();
             t.join();


### PR DESCRIPTION
Turn off pyramid generation for float/double images
To test this PR:
 * Import an image stored on squig under team/jburel/ForMelissa/floatForPyramid or squig/team/will/float0-data.zip
 * Make sure that no pyramid is created. Either check under /OMERO or open the viewer that the image is not a tiled image.