### PR TITLE
Store last CLI session port

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -317,7 +317,7 @@ class SessionsControl(BaseControl):
         # If they've omitted some required value, we must ask for it.
         #
         if not server:
-            server, name, port = self._get_server(store, name)
+            server, name, port = self._get_server(store, name, port)
         if not name:
             name = self._get_username(previous[1])
 
@@ -638,11 +638,13 @@ class SessionsControl(BaseControl):
             name = default_name
         return server, name, port
 
-    def _get_server(self, store, name):
+    def _get_server(self, store, name, port):
         defserver = store.last_host()
-        rv = self.ctx.input("Server: [%s]" % defserver)
+        if not port:
+            port = str(omero.constants.GLACIER2PORT)
+        rv = self.ctx.input("Server: [%s:%s]" % (defserver, port))
         if not rv:
-            return defserver, name, None
+            return defserver, name, port
         else:
             return self._parse_conn(rv, name)
 

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -59,8 +59,8 @@ Options for logging in:
 
     # Provide all values interactively
     $ bin/omero sessions login
-    Server:
-    Username:
+    Server: [localhost:4064]
+    Username: [root]
     Password:
 
     # Pass values as the target
@@ -71,16 +71,16 @@ Options for logging in:
 
     # Pass some values via arguments
     $ bin/omero -s localhost sessions login
-    Username:
+    Username: [user]
     Password:
     $ bin/omero -p 24064 sessions login
-    Server:
-    Username:
+    Server: [localhost:24064]
+    Username: [user]
     Password:
 
     # Pass all non-password values via arguments
     $ bin/omero -s localhost -u john sessions login
-    Password
+    Password:
 
     # Use a session ID to login without a password
     $ bin/omero -s localhost -k 8afe443f-19fc-4cc4-bf4a-850ec94f4650 \

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -136,8 +136,8 @@ class SessionsStore(object):
             self.logger.debug("No uuid provided")
             return
         d = self.dir / host / name
-        f = self.dir / host / name / uuid
         if d.exists():
+            f = d / uuid
             if f.exists():
                 f.remove()
                 self.logger.debug("Removed %s" % f)
@@ -173,13 +173,15 @@ class SessionsStore(object):
             return []
         return [x.basename() for x in self.non_dot(d)]
 
-    def set_current(self, host, name=None, uuid=None):
+    def set_current(self, host, name=None, uuid=None, port=None):
         """
         Sets the current session, user, and host files
         These are used as defaults by other methods.
         """
         if host is not None:
             self.host_file().write_text(host)
+        if port is not None:
+            self.port_file().write_text(port)
         if name is not None:
             self.user_file(host).write_text(name)
         if uuid is not None:
@@ -201,7 +203,7 @@ class SessionsStore(object):
                 uuid = self.sess_file(host, name).text().strip()
             except IOError:
                 pass
-        return (host, name, uuid)
+        return (host, name, uuid, self.last_port())
 
     def last_host(self):
         """
@@ -215,6 +217,20 @@ class SessionsStore(object):
         if not text:
             return "localhost"
         return text
+
+    def last_port(self):
+        """
+        Prints either the last saved port (see get_current())
+        or "4064"
+        """
+        f = self.port_file()
+        if not f.exists():
+            import omero
+            return str(omero.constants.GLACIER2PORT)
+        port = f.text().strip()
+        if not port:
+            return str(omero.constants.GLACIER2PORT)
+        return port
 
     def find_name_by_key(self, server, uuid):
         """
@@ -334,7 +350,8 @@ class SessionsStore(object):
         if new:
             self.add(host, ec.userName, uuid, props, sudo=sudo)
         if set_current:
-            self.set_current(host, ec.userName, uuid)
+            self.set_current(host, ec.userName, uuid,
+                             props.get("omero.port", '4064'))
 
         return client, uuid, timeToIdle, timeToLive
 
@@ -367,6 +384,10 @@ class SessionsStore(object):
     def host_file(self):
         """ Returns the path-object which stores the last active host """
         return self.dir / "._LASTHOST_"
+
+    def port_file(self):
+        """ Returns the path-object which stores the last active port """
+        return self.dir / "._LASTPORT_"
 
     def user_file(self, host):
         """ Returns the path-object which stores the last active user """

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -40,6 +40,7 @@ from path import path
 
 """
 
+import omero.constants
 from omero.util import get_user_dir, make_logname
 from path import path
 
@@ -173,14 +174,15 @@ class SessionsStore(object):
             return []
         return [x.basename() for x in self.non_dot(d)]
 
-    def set_current(self, host, name=None, uuid=None, port=None):
+    def set_current(self, host, name=None, uuid=None, props=None):
         """
         Sets the current session, user, and host files
         These are used as defaults by other methods.
         """
         if host is not None:
             self.host_file().write_text(host)
-        if port is not None:
+        if props is not None:
+            port = props.get('omero.port', str(omero.constants.GLACIER2PORT))
             self.port_file().write_text(port)
         if name is not None:
             self.user_file(host).write_text(name)
@@ -225,7 +227,6 @@ class SessionsStore(object):
         """
         f = self.port_file()
         if not f.exists():
-            import omero
             return str(omero.constants.GLACIER2PORT)
         port = f.text().strip()
         if not port:
@@ -350,8 +351,7 @@ class SessionsStore(object):
         if new:
             self.add(host, ec.userName, uuid, props, sudo=sudo)
         if set_current:
-            self.set_current(host, ec.userName, uuid,
-                             props.get("omero.port", '4064'))
+            self.set_current(host, ec.userName, uuid, props)
 
         return client, uuid, timeToIdle, timeToLive
 

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -184,8 +184,8 @@ class SessionsStore(object):
             self.port_file().write_text(port)
         if name is not None:
             self.user_file(host).write_text(name)
-        if uuid is not None:
-            self.sess_file(host, name).write_text(uuid)
+            if uuid is not None:
+                self.sess_file(host, name).write_text(uuid)
 
     def get_current(self):
         host = None

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -56,7 +56,7 @@ class MyStore(SessionsStore):
             self.add(*add_tuple)
 
         if set_current:
-            self.set_current(*add_tuple[0:3])
+            self.set_current(*add_tuple)
 
         return return_tuple
 
@@ -201,17 +201,17 @@ class TestStore(object):
     @pytest.mark.parametrize('port', [None, '4064', '14064'])
     def testSetCurrent(self, name, uuid, port, tmpdir):
         s = self.store(tmpdir)
-        s.set_current("srv", name=name, uuid=uuid, port=port)
+        props = {}
+        if port:
+            props["omero.port"] = port
+        s.set_current("srv", name=name, uuid=uuid, props=props)
         session_dir = tmpdir / "omero" / "sessions"
 
         # Using last_* methods
         assert (session_dir / "._LASTHOST_").exists()
         assert "srv" == s.last_host()
+        assert (session_dir / "._LASTPORT_").exists()
         assert (port or '4064') == s.last_port()
-        if port:
-            assert (session_dir / "._LASTPORT_").exists()
-        else:
-            assert not (session_dir / "._LASTPORT_").exists()
 
         # Using helpers
         assert "srv" == s.host_file().text().strip()

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -266,9 +266,11 @@ class TestStore(object):
         s = self.store()
         s.add("a", "b", "c", {"omero.group": "1"})
         conflicts = s.conflicts("a", "b", "c", {})
-        assert "" != conflicts
+        assert conflicts == 'omero.group:1!=None;'
+        conflicts = s.conflicts("a", "b", "c", {}, ignore_nulls=True)
+        assert conflicts == ''
         conflicts = s.conflicts("a", "b", "c", {"omero.group": "2"})
-        assert "" != conflicts
+        assert conflicts == 'omero.group:1!=2;'
 
 
 class TestSessions(object):


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12609

This PR mostly adds a session file storing the last port used while connecting with the CLI (without modifying the file storage logic). The `SessionStore.set_current()/SessionStore.get_current()` logic is modified to store/return this value and the corresponding unit tests are modified to document these new inputs.

To test this PR, try to connect to the same server on different ports, e.g.
```
$ bin/omero login user@localhost:14064
$ bin/omero logout
$ bin/omero login
```

The last call should output `Previously logged in to localhost:14064 as user-1` before prompting the user for connection information.