### PR TITLE
Set omero.pixeldata.dispose=true by default (See #11675)

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -248,7 +248,7 @@ omero.pixeldata.memoizer_wait=0
 # lead to memory exceptions. See ticket #11675
 # for more information. Note: the property is
 # set globally for the JVM.
-omero.pixeldata.dispose=false
+omero.pixeldata.dispose=true
 
 # Default sizes for tiles are provided by a
 # ome.io.nio.TileSizes implementation. By default


### PR DESCRIPTION
Regularly, the long_running Python tests cause my JVM to
segfault locally when out of memory conditions occur.
Setting dispose to true prevents this from happening.

This proposes setting `true` as the default. If issues
arise, sysadmins can manually set it back to false.

See:
 * http://trac.openmicroscopy.org.uk/ome/ticket/11675
 * https://github.com/openmicroscopy/openmicroscopy/pull/1865
 * https://github.com/openmicroscopy/openmicroscopy/pull/1884

Testing:
 * Tests especially the long_running ones should continue to pass and possibly speed up.

cc: @mtbc @ximenesuk @sbesson 