### PR TITLE
Do not load graphs by default in getProjects/getDatasets

### DIFF
--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -13,6 +13,7 @@ function datasets = getDatasets(session, varargin)
 %   datasets = getDatasets(session, ids, loaded) returns all the datasets
 %   identified by the input ids in the context of the session group. If
 %   loaded is False, the images attached to the datasets are not loaded.
+%   Default: false.
 %
 %   datasets = getDatasets(session, 'owner', owner) returns all the
 %   datasets owned by the input owner in the context of the session group.
@@ -52,7 +53,7 @@ function datasets = getDatasets(session, varargin)
 % Check input
 ip = inputParser;
 ip.addOptional('ids', [], @(x) isempty(x) || (isvector(x) && isnumeric(x)));
-ip.addOptional('loaded', true, @islogical);
+ip.addOptional('loaded', false, @islogical);
 ip.KeepUnmatched = true;
 ip.parse(varargin{:});
 

--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -33,7 +33,7 @@ function datasets = getDatasets(session, varargin)
 % See also: GETOBJECTS, GETPROJECTS, GETIMAGES
 
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -12,7 +12,8 @@ function [projects, datasets] = getProjects(session, varargin)
 %
 %   projects = getProjects(session, ids, loaded) returns all the projects
 %   identified by the input ids in the context of the session group. If
-%   loaded is False, the images attached to the  datasets are not loaded.
+%   loaded is false, the images attached to the  datasets are not loaded.
+%   Default: false.
 %
 %   projects = getProjects(session, 'owner', ownerId) returns all the
 %   projects owned by the input owner in the context of the session group.
@@ -57,7 +58,7 @@ function [projects, datasets] = getProjects(session, varargin)
 % Input check
 ip = inputParser;
 ip.addOptional('ids', [], @(x) isempty(x) || (isvector(x) && isnumeric(x)));
-ip.addOptional('loaded', true, @islogical);
+ip.addOptional('loaded', false, @islogical);
 ip.KeepUnmatched = true;
 ip.parse(varargin{:});
 

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -38,7 +38,7 @@ function [projects, datasets] = getProjects(session, varargin)
 %
 % See also: GETOBJECTS, GETDATASETS, GETIMAGES
 
-% Copyright (C) 2013-2014 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -66,8 +66,8 @@ try
     
     % Retrieve a dataset specified by an input identifier
     % If the dataset contains images, the images will be loaded
-    disp('Listing images')
-    dataset = getDatasets(session, datasetId);
+    disp('Reading dataset with loaded images');
+    dataset = getDatasets(session, datasetId, true);
     assert(~isempty(dataset), 'OMERO:ReadData', 'Dataset Id not valid');
     images = toMatlabList(dataset.linkedImageList); % The images in the dataset.
     fprintf(1, 'Found %g images in dataset %g using getDatasets()\n',...


### PR DESCRIPTION
This PR should modify the default behavior of `getProjects()` and `getDatasets` to return unloaded graphs by default.


--no-rebase