### PR TITLE
Disable extra artifacts with package-extra=false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ before_install:
     - sudo pip install scc pytest
     - scc travis-merge
     - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8; fi
+    - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
-install:
-
-# retry the build due to:
+# retries the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507
+install:
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry ./components/tools/travis-build py-build; fi
+    - if [[ $BUILD == 'build-java' ]]; then travis_retry ./components/tools/travis-build java-build; fi
+
 script:
-    - "travis_retry ./components/tools/travis-build $BUILD"
+    - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-test; fi
+    - if [[ $BUILD == 'build-java' ]]; then ./components/tools/travis-build java-test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 
 install:
 
-# Running python tests as script, since there's no compile step.
+# Attempt the build twice, due to:
+# https://github.com/travis-ci/travis-ci/issues/2507
 script:
-    - ./components/tools/travis-build $BUILD
+    - ./components/tools/travis-build $BUILD || ([ $? -eq 247 ] && ./components/tools/travis-build $BUILD)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
 
-# Attempt the build twice, due to:
+# retry the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507
 script:
-    - ./components/tools/travis-build $BUILD || ([ $? -eq 247 ] && ./components/tools/travis-build $BUILD)
+    - "travis_retry ./components/tools/travis-build $BUILD"

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -62,7 +62,7 @@
         <ivy:retrieve settingsRef="ivy.${ant.project.name}"
             type="jar"
             pattern="${deps.lib.dir}/[artifact](-[classifier]).[ext]"
-            log="quiet" sync="false" symlink="true"/>
+            log="quiet" sync="false" symlink="true" haltonfailure="${package-extra}"/>
     </target>
 
     <target name="prepare" depends="retrieve">
@@ -383,6 +383,10 @@ omero.version=${omero.version}
     </target>
 
     <target name="package-extra">
+
+        <if><equals arg1="true" arg2="${package-extra}"/>
+            <then>
+
         <jar destfile="${target.dir}/${ivy.module}-sources.jar">
             <fileset dir="${src.dir}" includes="**/*.java"/>
             <fileset dir="${src.dest}" includes="**/*.java"/>
@@ -408,6 +412,8 @@ omero.version=${omero.version}
         <jar destfile="${target.dir}/${ivy.module}-javadoc.jar">
                 <fileset dir="${target.dir}/javadocs"/>
         </jar>
+
+        </then></if>
     </target>
 
     <target name="load-findbugs" depends="prepare">
@@ -473,7 +479,7 @@ omero.version=${omero.version}
             <mapping conf="*" scope="compile"/>
             <dependency group="ome" artifact="bio-formats" version="${omero.version}" optional="true"/>
         </ivy:makepom>
-        <publishArtifact/>
+        <publishArtifact haltonmissing="${package-extra}"/>
     </target>
 
     <!-- Previously dependend on integration, but that may need special controls.

--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -95,6 +95,10 @@
                 includes="**/*.class,omero.properties"/>
             <fileset dir="${target.dir}/generated-classes"/>
         </jar>
+
+        <if><equals arg1="true" arg2="${package-extra}"/>
+            <then>
+
         <jar destfile="${target.dir}/${ivy.module}-sources.jar">
             <!-- FIXME: Start off with some of the source classes -->
             <fileset dir="${blitz.comp}/src">
@@ -105,6 +109,8 @@
         </jar>
         <copy file="${blitz.comp}/target/blitz-javadoc.jar"
             tofile="${target.dir}/${ivy.module}-javadoc.jar"/>
+
+        </then></if>
     </target>
 
     <target name="tools-build" depends="tools-init,install"

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -14,22 +14,34 @@ clean()
     ant clean
 }
 
-build_java()
+java_build()
 {
     TEST="-p" ant build-default test-compile -Dpackage-extra=false
+}
+
+java_test()
+{
     ant -f components/tools/OmeroJava/build.xml test -Dtest.with.fail=true
     ant -f components/model/build.xml test -Dtest.with.fail=true
     ant -f components/common/build.xml test -Dtest.with.fail=true
 }
 
-build_python()
+py_flake8()
 {
     flake8 -v components/tools/OmeroPy/src
     flake8 -v components/tools/OmeroPy/test
     flake8 -v components/tools/OmeroWeb/omeroweb/webstart
     flake8 -v components/tools/OmeroWeb/omeroweb/webredirect
     flake8 -v components/tools/OmeroWeb/test
+}
+
+py_build()
+{
     ant build-default -Dpackage-extra=false
+}
+
+py_test()
+{
     ant -f components/tools/OmeroPy/build.xml test -Dtest.with.fail=true
     ant -f components/tools/OmeroWeb/build.xml test -Dtest.with.fail=true
     # make sure all OmeroWeb Python modules can be imported
@@ -55,9 +67,21 @@ do
         clean)
             clean ;;
         build-java)
-            build_java ;;
+            java_build && java_test ;;
         build-python)
-            build_python ;;
+            py_flake8 && py_build && py_test ;;
+        java-build)
+            java_build ;;
+        java-test)
+            java_test ;;
+        py-flake8)
+            py_flake8;;
+        py-build)
+            py_build ;;
+        py-test)
+            py_test ;;
+        all)
+            py_flake8 java_build java_test py_test ;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -8,6 +8,11 @@ if [ -z "$ICE_HOME" ]; then
   export ICE_HOME=/usr/share/Ice
 fi
 
+fold()
+{
+    printf "travis_fold:$1:$NAME.$2\n"
+}
+
 # Clean up
 clean()
 {
@@ -16,34 +21,69 @@ clean()
 
 java_build()
 {
-    TEST="-p" ant build-default test-compile -Dpackage-extra=false
+    NAME=java_build
+    fold start default
+        TEST="-p" ant build-default -Dpackage-extra=false
+    fold end default
+    fold start tests
+        TEST="-p" ant test-compile
+    fold end tests
 }
 
 java_test()
 {
-    ant -f components/tools/OmeroJava/build.xml test -Dtest.with.fail=true
-    ant -f components/model/build.xml test -Dtest.with.fail=true
-    ant -f components/common/build.xml test -Dtest.with.fail=true
+    NAME=java_test
+
+    fold start java
+        ant -f components/tools/OmeroJava/build.xml test -Dtest.with.fail=true
+    fold end java
+
+    fold start model
+        ant -f components/model/build.xml test -Dtest.with.fail=true
+    fold end model
+
+    fold start common
+        ant -f components/common/build.xml test -Dtest.with.fail=true
+    fold end common
 }
 
 py_flake8()
 {
-    flake8 -v components/tools/OmeroPy/src
-    flake8 -v components/tools/OmeroPy/test
-    flake8 -v components/tools/OmeroWeb/omeroweb/webstart
-    flake8 -v components/tools/OmeroWeb/omeroweb/webredirect
-    flake8 -v components/tools/OmeroWeb/test
+    NAME=py_flake8
+
+    fold start OmeroPy
+        flake8 -v components/tools/OmeroPy/src
+        flake8 -v components/tools/OmeroPy/test
+    fold end OmeroPy
+
+    fold start OmeroWeb
+        flake8 -v components/tools/OmeroWeb/omeroweb/webstart
+        flake8 -v components/tools/OmeroWeb/omeroweb/webredirect
+        flake8 -v components/tools/OmeroWeb/test
+    fold end OmeroWeb
 }
 
 py_build()
 {
-    ant build-default -Dpackage-extra=false
+    NAME=py_build
+    fold start default
+        ant build-default -Dpackage-extra=false
+    fold end default
 }
 
 py_test()
 {
-    ant -f components/tools/OmeroPy/build.xml test -Dtest.with.fail=true
-    ant -f components/tools/OmeroWeb/build.xml test -Dtest.with.fail=true
+    NAME=py_test
+
+    fold start OmeroPy
+        ant -f components/tools/OmeroPy/build.xml test -Dtest.with.fail=true
+    fold end OmeroPy
+
+    fold start OmeroWeb
+        ant -f components/tools/OmeroWeb/build.xml test -Dtest.with.fail=true
+    fold end OmeroWeb
+
+    fold start modules
     # make sure all OmeroWeb Python modules can be imported
     # (this will find invalid imports that flake8 does not check for)
     echo Checking OmeroWeb Python imports
@@ -59,6 +99,7 @@ py_test()
         grep -B2 ImportError
       )
     test $? = 0
+    fold end modules
 }
 
 for arg in "$@"

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -11,15 +11,15 @@ fi
 # Clean up
 clean()
 {
-    ./build.py clean
+    ant clean
 }
 
 build_java()
 {
-    TEST="-p" ./build.py build-default test-compile -Dpackage-extra=false
-    ./build.py -java test -Dtest.with.fail=true
-    ./build.py -f components/model/build.xml test -Dtest.with.fail=true
-    ./build.py -f components/common/build.xml test -Dtest.with.fail=true
+    TEST="-p" ant build-default test-compile -Dpackage-extra=false
+    ant -f components/tools/OmeroJava/build.xml test -Dtest.with.fail=true
+    ant -f components/model/build.xml test -Dtest.with.fail=true
+    ant -f components/common/build.xml test -Dtest.with.fail=true
 }
 
 build_python()
@@ -29,9 +29,9 @@ build_python()
     flake8 -v components/tools/OmeroWeb/omeroweb/webstart
     flake8 -v components/tools/OmeroWeb/omeroweb/webredirect
     flake8 -v components/tools/OmeroWeb/test
-    ./build.py build-default -Dpackage-extra=false
-    ./build.py -py test -Dtest.with.fail=true
-    ./build.py -web test -Dtest.with.fail=true
+    ant build-default -Dpackage-extra=false
+    ant -f components/tools/OmeroPy/build.xml test -Dtest.with.fail=true
+    ant -f components/tools/OmeroWeb/build.xml test -Dtest.with.fail=true
     # make sure all OmeroWeb Python modules can be imported
     # (this will find invalid imports that flake8 does not check for)
     echo Checking OmeroWeb Python imports

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -16,7 +16,7 @@ clean()
 
 build_java()
 {
-    TEST="-p" ./build.py build-default test-compile
+    TEST="-p" ./build.py build-default test-compile -Dpackage-extra=false
     ./build.py -java test -Dtest.with.fail=true
     ./build.py -f components/model/build.xml test -Dtest.with.fail=true
     ./build.py -f components/common/build.xml test -Dtest.with.fail=true
@@ -29,7 +29,7 @@ build_python()
     flake8 -v components/tools/OmeroWeb/omeroweb/webstart
     flake8 -v components/tools/OmeroWeb/omeroweb/webredirect
     flake8 -v components/tools/OmeroWeb/test
-    ./build.py build-default
+    ./build.py build-default -Dpackage-extra=false
     ./build.py -py test -Dtest.with.fail=true
     ./build.py -web test -Dtest.with.fail=true
     # make sure all OmeroWeb Python modules can be imported

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -25,6 +25,7 @@ javac.debuglevel=lines,vars,source
 javac.maxmem=1050m
 javadoc.maxmem=1050m
 exe4j.home=/opt/exe4j
+package-extra=true
 
 artifactory.username=hudson
 artifactory.username=SECRET


### PR DESCRIPTION
The -javadoc and -sources packages are currently
built by default via the package targets dependency
on package-extra. By setting package-extra=false
either on the command-line or in etc/local.properties,
these sections can be disabled. On my system, that
takes a rebuild (without clean) from 5'45" to 3'30".

/cc @jburel @sbesson 

Testing
---------
The intent is that this change should improve the overall health of travis builds. If this build is green, then likely adding it to the regular 5.0 build is fine. If all the other builds remain green (incl. release!), then things are working well. Developers may want to set `package-extra=false` locally. Note: this may cause the daily merge to fail unexpectedly since nothing will have built javadocs until that point.