### PR TITLE
Server dialog (rebased onto dev_5_0)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.login.ScreenLogin 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -352,15 +352,6 @@ public class ScreenLogin
 	{
 		ServerDialog d;
 		String s = serverText.getText().trim();
-		/*
-		if (!hostConfigurable) {
-			d = new ServerDialog(this, speedIndex);
-		} else {
-			if (connectionSpeed) 
-				d = new ServerDialog(this, editor, s, speedIndex);
-			else d = new ServerDialog(this, editor, s);
-		}
-		*/
 		if (connectionSpeed) 
 			d = new ServerDialog(this, editor, s, speedIndex);
 		else d = new ServerDialog(this, editor, s);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ServerDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ServerDialog.java
@@ -397,7 +397,7 @@ class ServerDialog
 		initComponents(true);
 		initListeners();
 		buildGUI(index);
-		setSize(WINDOW_DIM);
+		pack();
 	}
 	
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.util.ui.login.ServerEditor 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -26,6 +26,7 @@ package org.openmicroscopy.shoola.util.ui.login;
 
 //Java imports
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -307,7 +308,10 @@ public class ServerEditor
         JPanel p = new JPanel();
         p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
         p.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-        p.add(new JScrollPane(table));
+        JScrollPane pane = new JScrollPane(table);
+        Dimension d = pane.getPreferredSize();
+        pane.setPreferredSize(new Dimension(d.width, 150));
+        p.add(pane);
         p.add(buildControls());
        
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));


### PR DESCRIPTION

This is the same as gh-2906 but rebased onto dev_5_0.

----

Review the layout of the server dialog.
Problem noticed while running the client from the command line

To test:
 * Start insight using the version matching your OS. e.g. mac
 * Click on the wrench to display the server dialog. Check that the display is correct.
 * Download the Linux client package and use the scripts from the command line to start insight
 * Click on the wrench to display the server dialog. Check that the display is correct.

                