### PR TITLE
Add option to hide passwords in bin/omero config get

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -276,7 +276,7 @@ class PrefsControl(WriteableConfigControl):
                 self.ctx.out(config[k])
             else:
                 if (hide_password and is_password(k)):
-                    self.ctx.out("%s=%s" % (k, '*' * len(config[k])))
+                    self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -99,18 +99,18 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys)
 
     def testGetHidePassword(self, capsys):
-        self.invoke("set omero.X.pass password1")
-        self.invoke("set omero.Y.password password2")
+        self.invoke("set omero.X.pass shortpass")
+        self.invoke("set omero.Y.password long_password")
         self.invoke("set omero.Z val")
         self.invoke("get")
         self.assertStdoutStderr(capsys, out=(
-            'omero.X.pass=password1\n'
-            'omero.Y.password=password2\n'
+            'omero.X.pass=shortpass\n'
+            'omero.Y.password=long_password\n'
             'omero.Z=val'))
         self.invoke("get --hide-password")
         self.assertStdoutStderr(capsys, out=(
-            'omero.X.pass=*********\n'
-            'omero.Y.password=*********\n'
+            'omero.X.pass=********\n'
+            'omero.Y.password=********\n'
             'omero.Z=val'))
 
     def testSetFails(self, capsys):

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -100,16 +100,19 @@ class TestPrefs(object):
 
     def testGetHidePassword(self, capsys):
         self.invoke("set omero.X.pass shortpass")
+        self.cli.invoke(self.args + ["set", "omero.Y.pass", ""], strict=True)
         self.invoke("set omero.Y.password long_password")
         self.invoke("set omero.Z val")
         self.invoke("get")
         self.assertStdoutStderr(capsys, out=(
             'omero.X.pass=shortpass\n'
+            'omero.Y.pass=\n'
             'omero.Y.password=long_password\n'
             'omero.Z=val'))
         self.invoke("get --hide-password")
         self.assertStdoutStderr(capsys, out=(
             'omero.X.pass=********\n'
+            'omero.Y.pass=\n'
             'omero.Y.password=********\n'
             'omero.Z=val'))
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -104,9 +104,9 @@ class TestPrefs(object):
         self.invoke("set omero.Z val")
         self.invoke("get")
         self.assertStdoutStderr(capsys, out=(
-                'omero.X.pass=password1\n'
-                'omero.Y.password=password2\n'
-                'omero.Z=val'))
+            'omero.X.pass=password1\n'
+            'omero.Y.password=password2\n'
+            'omero.Z=val'))
         self.invoke("get --hide-password")
         self.assertStdoutStderr(capsys, out=(
             'omero.X.pass=*********\n'

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -98,6 +98,21 @@ class TestPrefs(object):
         self.invoke("keys")
         self.assertStdoutStderr(capsys)
 
+    def testGetHidePassword(self, capsys):
+        self.invoke("set omero.X.pass password1")
+        self.invoke("set omero.Y.password password2")
+        self.invoke("set omero.Z val")
+        self.invoke("get")
+        self.assertStdoutStderr(capsys, out=(
+                'omero.X.pass=password1\n'
+                'omero.Y.password=password2\n'
+                'omero.Z=val'))
+        self.invoke("get --hide-password")
+        self.assertStdoutStderr(capsys, out=(
+            'omero.X.pass=*********\n'
+            'omero.Y.password=*********\n'
+            'omero.Z=val'))
+
     def testSetFails(self, capsys):
         self.invoke("set A=B")
         self.assertStdoutStderr(


### PR DESCRIPTION
With this PR, the following command

```
$ bin/omero config get --hide-password
```

should return the server configuration and hide the values of all keys ending with `.pass` or `.password` (replacing them with '*'). Also check the unit tests are passing.