### PR TITLE
Float rendering web dev 5 0

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5813,7 +5813,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         :rtype:     int
         """
 
-        return int(self._re.getChannelWindowStart(self._idx, self._conn.SERVICE_OPTS))
+        return self._re.getChannelWindowStart(self._idx, self._conn.SERVICE_OPTS)
 
     def setWindowStart (self, val):
         self.setWindow(val, self.getWindowEnd())
@@ -5826,7 +5826,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         :rtype:     int
         """
 
-        return int(self._re.getChannelWindowEnd(self._idx, self._conn.SERVICE_OPTS))
+        return self._re.getChannelWindowEnd(self._idx, self._conn.SERVICE_OPTS)
 
     def setWindowEnd (self, val):
         self.setWindow(self.getWindowStart(), val)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -99,7 +99,9 @@ def imageMarshal (image, key=None):
                      'wellSampleId': wellsample and wellsample.id or '',
                      'wellId': well and well.id.val or '',
                      'imageTimestamp': time.mktime(image.getDate().timetuple()),
-                     'imageId': image.id,},
+                     'imageId': image.id,
+                     'pixelsType': image.getPixelsType(),
+                    },
             }
     try:
         reOK = image._prepareRenderingEngine()

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.rangewidget.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.rangewidget.js
@@ -21,8 +21,8 @@
   $.fn.rangewidget = function (cfg) {
     return this.each(function () {
       this.cfg = {
-	min: cfg && !isNaN(parseInt(cfg.min)) ? parseInt(cfg.min) : null,
-	max: cfg && !isNaN(parseInt(cfg.max)) ? parseInt(cfg.max) : null,
+	min: cfg && !isNaN(parseFloat(cfg.min)) ? parseFloat(cfg.min) : null,
+	max: cfg && !isNaN(parseFloat(cfg.max)) ? parseFloat(cfg.max) : null,
 	lblStart: cfg && cfg.lblStart != undefined ? cfg.lblStart : 'Start',
 	lblEnd: cfg && cfg.lblEnd != undefined ? cfg.lblEnd : 'End',
         template: cfg && cfg.template ? cfg.template : null
@@ -42,6 +42,17 @@
           this.cfg.lblEnd = this.cfg.max;
         }
       }
+      // try to format if values aren't integers
+      try {
+        if (this.cfg.lblStart != parseInt(this.cfg.lblStart)) {
+          this.cfg.lblStart = this.cfg.lblStart.toFixed(3);
+        }
+        if (this.cfg.lblEnd != parseInt(this.cfg.lblEnd)) {
+          this.cfg.lblEnd = this.cfg.lblEnd.toFixed(3);
+        }
+      }
+      catch(err) {}
+
       var self = $(this);
       self.addClass('rangewidget');
       if (this.cfg.template == null) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1023,7 +1023,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
           t = t[1].split('$');
           var window = t[0].split(':');
           if (window.length == 2) {
-            this.setChannelWindow(idx, parseInt(window[0], 10), parseInt(window[1], 10), true);
+            this.setChannelWindow(idx, parseFloat(window[0], 10), parseFloat(window[1], 10), true);
           }
         }
         if (t.length > 1) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -238,6 +238,51 @@
 
     }
 
+    var slide_start_cb = function() {
+        // Note starting values, so we can tell which handle/value changed
+        // This is for floating point data where ui.values may not be what we set
+        return function(event, ui) {
+            $(this).data('channel_start', ui.values[0])
+                .data('channel_end', ui.values[1]);
+        };
+    };
+    var slide_cb = function() {
+        return function(event, ui) {
+            // Only update the value that changed
+            var s = $(this).data('channel_start');
+            var e = $(this).data('channel_end');
+            if (ui.values[0] !== s) {
+                $('#wblitz-ch'+$(event.target).data('channel-idx')+'-cw-start').val(ui.values[0]).change();
+            } else if (ui.values[1] !== e) {
+                $('#wblitz-ch'+$(event.target).data('channel-idx')+'-cw-end').val(ui.values[1]).change();
+            }
+        };
+    };
+
+    var init_ch_slider = function(i, channels) {
+        var min = Math.min(channels[i].window.min, channels[i].window.start),  // range may extend outside min/max pixel
+            max = Math.max(channels[i].window.max, channels[i].window.end),
+            start = channels[i].window.start,
+            end = channels[i].window.end,
+            ptype = viewport.loadedImg.meta.pixelsType,
+            step = 1;
+        if (ptype == "float") {
+            var STEPS = 100;
+            step = (max - min) / STEPS;
+        }
+
+        $('#wblitz-ch'+i+'-cwslider').slider({
+            range: true,
+            step: step,
+            min: min,
+            max: max,
+            values: [ start, end ],
+            start: slide_start_cb(),
+            slide: slide_cb(),
+            }).data('channel-idx', i);
+    };
+
+
     // disable 'split' view for single channel images.
     if (channels.length < 2) {
       $("input[value='split']").attr('disabled', 'disabled');
@@ -330,16 +375,7 @@
         template: '<span class="min">min: $min</span> $start - $end <span class="max">max: $max</span>',
         lblStart: '',
         lblEnd: ''});
-      $('#wblitz-ch'+i+'-cwslider').slider({
-        range: true,
-        min: Math.min(channels[i].window.min, channels[i].window.start+1),  // range may extend outside min/max pixel
-        max: Math.max(channels[i].window.max, channels[i].window.end-1),
-        values: [ channels[i].window.start+1, channels[i].window.end-1 ],
-        slide: function(event, ui) {
-          $('#wblitz-ch'+$(event.target).data('channel-idx')+'-cw-start').val(ui.values[0]).change();
-          $('#wblitz-ch'+$(event.target).data('channel-idx')+'-cw-end').val(ui.values[1]).change();
-        }
-        }).data('channel-idx', i);
+      init_ch_slider(i, channels);
       cb = function (i) {
         return function (e) {
           var new_start = e.target.value,


### PR DESCRIPTION
This is PR #3039 rebased onto dev_5_0.

Some small changes to support floating point data ranges in the channel sliders in Preview tab and main image viewer.
To test:
- Open a float pixel-type image in Preview panel. Test various images with very small and large dynamic ranges.
 - Start positions of slider handles are Integers (see above) but sliding handles should give a reasonable number of floating point increments (100 currently for full range of slider).
 - Save will save floating point start/end to DB (although this can't be verified because of bug above).
 - Launch Image Viewer from preview panel should apply the current floating point slider values to the image viewer.

--rebased-from #3039