### PR TITLE
Backported UI support for float images

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/player/MoviePlayerControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.util.player.MoviePlayerControl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -303,21 +303,21 @@ class MoviePlayerControl
         int e = -1;
         if (TwoKnobsSlider.LEFT_MOVED_PROPERTY.equals(name)) {
         	if (source.equals(view.zSlider)) {
-        		s = view.zSlider.getStartValue();
+        		s = view.zSlider.getStartValueAsInt();
         		model.setStartZ(s);
         		view.setStartZ(s);
         	} else if (source.equals(view.tSlider)) {
-        		s = view.tSlider.getStartValue();
+        		s = view.tSlider.getStartValueAsInt();
         		model.setStartT(s);
         		view.setStartT(s);
         	}
         } else if (TwoKnobsSlider.RIGHT_MOVED_PROPERTY.equals(name)) {
             if (source.equals(view.zSlider)) {
-                e = view.zSlider.getEndValue();
+                e = view.zSlider.getEndValueAsInt();
                 model.setEndZ(e);
                 view.setEndZ(e);
             } else if (source.equals(view.tSlider)) {
-                e = view.tSlider.getEndValue();
+                e = view.tSlider.getEndValueAsInt();
                 model.setEndT(e);
                 view.setEndT(e);
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.view.ControlPane
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1597,14 +1597,14 @@ class ControlPane
      *
      * @return See above.
      */
-    int getProjectionStartZ() { return projectionRange.getStartValue()-1; }
+    int getProjectionStartZ() { return projectionRange.getStartValueAsInt()-1; }
 
     /**
      * Returns the lower bound of the z-section to project.
      *
      * @return See above.
      */
-    int getProjectionEndZ() { return projectionRange.getEndValue()-1; }
+    int getProjectionEndZ() { return projectionRange.getEndValueAsInt()-1; }
 
     /**
      * Updates UI components when a zooming factor for the grid

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.actions.ManageRndSettingsAction
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -141,7 +141,7 @@ public class ManageRndSettingsAction
 			case ABSOLUTE_MIN_MAX:
 				putValue(Action.NAME, NAME_ABSOLUTE_MIN_MAX);
 				setEnabled(model.getPixelsDimensionsC() < 
-						Renderer.MAX_CHANNELS);
+						Renderer.MAX_CHANNELS && model.isIntegerPixelData());
 				putValue(Action.SHORT_DESCRIPTION, 
 						UIUtilities.formatToolTipText(
 								DESCRIPTION_ABSOLUTE_MIN_MAX));

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/ChannelSlider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/ChannelSlider.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.ChannelSlider 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -92,32 +92,61 @@ class ChannelSlider
 	/** Initializes the component composing the display. */
 	private void initComponents()
 	{
-		int index = channel.getIndex();
-		int f = model.getRoundFactor(index);
-    	int s = (int) (model.getWindowStart(index)*f);
-        int e = (int) (model.getWindowEnd(index)*f);
-        int min = (int) (channel.getGlobalMin()*f);
-        int max = (int) (channel.getGlobalMax()*f);
-        slider = new TextualTwoKnobsSlider();
-        slider.layoutComponents(
-        		TextualTwoKnobsSlider.LAYOUT_SLIDER_FIELDS_X_AXIS);
-        slider.setBackground(UIUtilities.BACKGROUND_COLOR);
+		final int index = channel.getIndex();
+		double s = model.getWindowStart(index);
+		double e = model.getWindowEnd(index);
+		double min = channel.getGlobalMin();
+		double max = channel.getGlobalMax();
+        
+		boolean intMode = model.isIntegerPixelData();
+		
+		if (intMode) {
+		        int absMin = (int) (model.getLowestValue(index));
+		        int absMax = (int) (model.getHighestValue(index));
+		        if (!channel.hasStats()) {
+		                min = absMin;
+		                max = absMax;
+		        }
+		        int lowestBound = absMin;
+		        int highestBound = absMax;
 
-        int absMin = (int) (model.getLowestValue(index)*f);
-        int absMax = (int) (model.getHighestValue(index)*f);
-        if (!channel.hasStats()) {
-        	min = absMin;
-        	max = absMax;
-        }
-        double range = (max-min)*GraphicsPane.RATIO;
-        int lowestBound = (int) (min-range);
-        //if (lowestBound < absMin) lowestBound = absMin;
-        lowestBound = absMin;
-        int highestBound = (int) (max+range);
-        //if (highestBound > absMax) highestBound = absMax;
-        highestBound = absMax;
-        slider.setValues(max, min, highestBound, lowestBound,
-        		max, min, s, e, f);
+		        slider = new TextualTwoKnobsSlider(0, 100);
+		        
+		        slider.layoutComponents(
+                                TextualTwoKnobsSlider.LAYOUT_SLIDER_FIELDS_X_AXIS);
+                        slider.setBackground(UIUtilities.BACKGROUND_COLOR);
+                        
+                        slider.setValues((int)max, (int)min, (int)highestBound, (int)lowestBound,
+                                (int)max, (int)min, (int)s, (int)e);
+                        
+                        slider.layoutComponents(
+                                TextualTwoKnobsSlider.LAYOUT_SLIDER_FIELDS_X_AXIS);
+                        slider.setBackground(UIUtilities.BACKGROUND_COLOR);
+		}
+		else {
+		    double absMin = model.getLowestValue(index);
+		    double absMax = model.getHighestValue(index);
+                    if (!channel.hasStats()) {
+                            min = absMin;
+                            max = absMax;
+                    }
+                    
+                    double lowestBound = absMin;
+                    double highestBound = absMax;
+
+                    slider = new TextualTwoKnobsSlider(lowestBound, highestBound);
+                    
+                    slider.layoutComponents(
+                            TextualTwoKnobsSlider.LAYOUT_SLIDER_FIELDS_X_AXIS);
+                    slider.setBackground(UIUtilities.BACKGROUND_COLOR);
+                    
+                    slider.setValues(max, min, highestBound, lowestBound,
+                            max, min, s, e);
+                    
+                    slider.layoutComponents(
+                            TextualTwoKnobsSlider.LAYOUT_SLIDER_FIELDS_X_AXIS);
+                    slider.setBackground(UIUtilities.BACKGROUND_COLOR);
+		}
         
         slider.getSlider().setPaintLabels(false);
         slider.getSlider().setPaintEndLabels(false);
@@ -221,7 +250,7 @@ class ChannelSlider
 	 * @param s The lowest bound of the interval.
 	 * @param e The upper bound of the interval.
 	 */
-	void setInterval(int s, int e)
+	void setInterval(double s, double e)
 	{
 		slider.setInterval(s, e);
 	}
@@ -235,14 +264,14 @@ class ChannelSlider
 	void setInputRange(boolean absolute)
 	{
 		int index = channel.getIndex();
-		int f = model.getRoundFactor(index);
-    	int s = (int) (model.getWindowStart(index)*f);
-        int e = (int) (model.getWindowEnd(index)*f);
-        int min = (int) (channel.getGlobalMin()*f);
-        int max = (int) (channel.getGlobalMax()*f);
+		double s = model.getWindowStart(index);
+    	double e = model.getWindowEnd(index);
+    	double min = channel.getGlobalMin();
+    	double max = channel.getGlobalMax();
        
-        int absMin = (int) (model.getLowestValue(index)*f);
-        int absMax = (int) (model.getHighestValue(index)*f);
+    	double absMin = model.getLowestValue(index);
+    	double absMax = model.getHighestValue(index);
+    	
         if (absolute)
         	slider.getSlider().setValues(absMax, absMin, absMax, absMin, s, e);
         else 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPaneUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.GraphicsPaneUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -129,11 +129,10 @@ class GraphicsPaneUI
 		double codomainMax = model.getCodomainEnd();
 		//double domainGlobalMin = model.getGlobalMin();
 		//double domainGlobalMax = model.getGlobalMax();
-		int f = model.getRoundFactor();
 		double domainGlobalMin = view.getPartialMinimum();
 		double domainGlobalMax = view.getPartialMaximum();
-		double domainMin = model.getWindowStart()*f;
-		double domainMax = model.getWindowEnd()*f;
+		double domainMin = model.getWindowStart();
+		double domainMax = model.getWindowEnd();
 		//Added jmarie 03/10/07
 		if (domainMin < domainGlobalMin) domainMin = domainGlobalMin;
 		if (domainMax > domainGlobalMax) domainMax = domainGlobalMax;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.Renderer 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -586,6 +586,12 @@ public interface Renderer
      */
     boolean isMappedImageRGB(List channels);
 
+    /**
+	 * Checks if the image pixel type is integer
+	 * @return See above
+	 */
+    boolean isIntegerPixelData();
+    
     /**
      * Creates an image with only the passed channel turned on.
      * All active channels will turn off then back on when the has been created.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.RendererComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1018,6 +1018,14 @@ class RendererComponent
 		return model.isMappedImageRGB(channels);
 	}
 
+	/** 
+     * Implemented as specified by the {@link Renderer} interface.
+     * @see Renderer#isIntegerPixelData()
+     */
+	public boolean isIntegerPixelData() {
+		return model.isIntegerPixelData();
+	}
+	
 	/** 
      * Implemented as specified by the {@link Renderer} interface.
      * @see Renderer#createSingleChannelImage(int, Color, PlaneDef)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.RendererModel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -35,8 +35,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+
 //Third-party libraries
 import com.sun.opengl.util.texture.TextureData;
+
 
 //Application-internal dependencies
 import omero.romio.PlaneDef;
@@ -47,6 +49,7 @@ import org.openmicroscopy.shoola.agents.metadata.RenderingControlShutDown;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.util.ViewerSorter;
 import org.openmicroscopy.shoola.env.data.DSOutOfServiceException;
+import org.openmicroscopy.shoola.env.data.OmeroImageService;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
@@ -56,7 +59,7 @@ import org.openmicroscopy.shoola.env.rnd.data.ResolutionLevel;
 import org.openmicroscopy.shoola.util.file.modulo.ModuloInfo;
 import org.openmicroscopy.shoola.util.file.modulo.ModuloParser;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
-import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import pojos.ChannelData;
 import pojos.ImageData;
 import pojos.PixelsData;
@@ -657,32 +660,6 @@ class RendererModel
 			return globalMinChannels.doubleValue();
 		}
 		return getGlobalMin(selectedChannelIndex);
-	}
-
-	/**
-	 * Returns the rounding factor used for the input value.
-	 *
-	 * @return See above.
-	 */
-	int getRoundFactor()
-	{
-		return getRoundFactor(selectedChannelIndex);
-	}
-	
-	/**
-	 * Returns the rounding factor used for the input value.
-	 *
-	 * @param channel The channel to handle.
-	 * @return See above.
-	 */
-	int getRoundFactor(int channel)
-	{
-		double min = getGlobalMin(channel);
-		double max = getGlobalMax(channel);
-		double rmin = UIUtilities.roundTwoDecimals(min);
-		double rmax = UIUtilities.roundTwoDecimals(max);
-		if (rmin == min && rmax == max) return 1;
-		return 100;
 	}
 
 	/**
@@ -1661,4 +1638,18 @@ class RendererModel
             }
         }
     }
+	
+	/**
+	 * Checks if the image pixel type is integer
+	 * @return See above
+	 */
+	boolean isIntegerPixelData() {
+        String t = image.getDefaultPixels().getPixelType();
+        return t.equals(OmeroImageService.INT_8)
+                || t.equals(OmeroImageService.UINT_8)
+                || t.equals(OmeroImageService.INT_16)
+                || t.equals(OmeroImageService.UINT_16)
+                || t.equals(OmeroImageService.INT_32)
+                || t.equals(OmeroImageService.UINT_32);
+	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/flim/FLIMResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/flim/FLIMResultsDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.FLIMResultsDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -936,8 +936,8 @@ public class FLIMResultsDialog
 		}else if(TwoKnobsSlider.KNOB_RELEASED_PROPERTY.equals(name) && evt.getSource().equals(thresholdSlider))
 		{
 
-			double startValue = calculateValue(thresholdSlider.getStartValue(),true);
-			double endValue = calculateValue(thresholdSlider.getEndValue(),false);
+			double startValue = calculateValue(thresholdSlider.getStartValueAsInt(),true);
+			double endValue = calculateValue(thresholdSlider.getEndValueAsInt(),false);
 	    	chartObject.setThreshold(startValue, endValue);
 	    	thresholdSliderMinValue.setText(UIUtilities.formatToDecimal(startValue));
 	    	thresholdSliderMaxValue.setText(UIUtilities.formatToDecimal(endValue));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/NumericalTextField.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/NumericalTextField.java
@@ -60,6 +60,12 @@ public class NumericalTextField
     /** Bounds property indicating that the text has been updated. */
     public static final String TEXT_UPDATED_PROPERTY = "textUpdated";
 
+    /** Block typing out-of-range values */
+    public static final int VALIDATION_MODE_BLOCK = 0;
+    
+    /** Correct out-of-range values to minimum or maximum */
+    public static final int VALIDATION_MODE_CORRECT = 1;
+    
     /** Accepted value if integer. */
     private static final String NUMERIC = "0123456789";
 
@@ -87,6 +93,10 @@ public class NumericalTextField
     /** The accepted characters. */
     private String accepted;
 
+    /** Flag indicating if a warning should be shown if the 
+     *  valid value range is exceeded */
+    private boolean showWarning = false;
+    
     /**
      * Checks if the value is correct.
      *
@@ -95,44 +105,68 @@ public class NumericalTextField
     private String checkValue()
     {
         String str = getText();
+        String result = str;
         try {
             if (Integer.class.equals(numberType)) {
-                int m = (int) getMinimum();
+                int min = (int) getMinimum();
+                int max = (int) getMaximum();
                 if (StringUtils.isBlank(str)) {
-                    return ""+m;
+                    result = "" + min;
                 }
                 int val = Integer.parseInt(str);
-                if (val < m) return ""+m;
+                if (val < min)
+                    result = "" + min;
+                if (val > max)
+                    result = "" + max;
             } else if (Double.class.equals(numberType)) {
                 Double min = getMinimum();
+                Double max = getMaximum();
                 if (StringUtils.isBlank(str)) {
                     return ""+min;
                 }
                 double val = Double.parseDouble(str);
-                if (val < min && !min.equals(Double.MIN_VALUE)) {
-                    return ""+min;
-                }
+                if (val < min) 
+                    result = "" + min;
+                if (val > max)
+                    result = "" + max;
+                
             } else if (Long.class.equals(numberType)) {
                 Long min = new Long((long) getMinimum());
+                Long max = new Long((long) getMaximum());
                 if (StringUtils.isBlank(str)) {
-                    return ""+min;
+                    result = ""+min;
                 }
                 long val = Long.parseLong(str);
-                if (val < min && !min.equals(Long.MIN_VALUE)) {
-                    return ""+min;
-                }
+                if (val < min)
+                    result = "" + min;
+                if (val > max)
+                    result = "" + max;
+                
             } else if (Float.class.equals(numberType)) {
                 Float min = new Float(getMinimum());
+                Float max = new Float(getMaximum());
                 if (StringUtils.isBlank(str)) {
-                    return ""+min;
+                    result = ""+min;
                 }
                 float val = Float.parseFloat(str);
-                if (val < min && !min.equals(Float.MIN_VALUE)) {
-                    return ""+min;
-                }
+                if (val < min)
+                    result = "" + min;
+                if (val > max)
+                    result = "" + max;
             }
-        } catch(NumberFormatException nfe) {}
-        return str;
+        } catch(NumberFormatException nfe) {
+            String msg = "The value you entered is not a valid number";
+            PopupHint hint = new PopupHint(this, msg, 8000);
+            hint.show();
+            return "";
+        }
+        
+        if(!result.equals(str) && showWarning) {
+            String msg = "<html>The value you entered is outside of the allowed range,<br>therefore it is reset to the minimal/maximal allowed value.</hmtl>";
+            PopupHint hint = new PopupHint(this, msg, 8000);
+            hint.show();
+        }
+        return result;
     }
 
     /**
@@ -184,7 +218,21 @@ public class NumericalTextField
      */
     public NumericalTextField(double min, double max, Class<?> type)
     {
-        document = new NumericalPlainDocument(min, max);
+        this(min, max, type, VALIDATION_MODE_CORRECT);
+    }
+    
+    /**
+     * Creates a new instance.
+     *
+     * @param min The minimum value of the text field.
+     * @param max The maximum value of the text field.
+     * @param type The number type.
+     * @param validationMode See {@link #VALIDATION_MODE_BLOCK},  {@link #VALIDATION_MODE_CORRECT}
+     */
+    public NumericalTextField(double min, double max, Class<?> type, int validationMode)
+    {
+        boolean blockInput = validationMode == VALIDATION_MODE_BLOCK;
+        document = new NumericalPlainDocument(min, max, blockInput);
         setHorizontalAlignment(JTextField.RIGHT);
         setDocument(document);
         originalText = null;
@@ -209,7 +257,12 @@ public class NumericalTextField
             }
         });
         numberType = type;
-        accepted = NUMERIC;
+        
+        if (Integer.class.equals(type) || Long.class.equals(type))
+            accepted = NUMERIC;
+        else
+            accepted = FLOAT;
+        
         setNegativeAccepted(min < 0);
     }
 
@@ -340,6 +393,15 @@ public class NumericalTextField
     }
 
     /**
+     * If set to <code>true</code> a warning hint will be shown
+     * in the case a value outside the given min/max range is entered
+     * @param showWarning See above
+     */
+    public void setShowWarning(boolean showWarning) {
+        this.showWarning = showWarning;
+    }
+
+    /**
      * Updates the <code>foreground</code> color depending on the text entered.
      * @see DocumentListener#insertUpdate(DocumentEvent)
      */
@@ -396,6 +458,9 @@ public class NumericalTextField
         /** The maximum value of the text field. */
         private double max;
 
+        /** Flag to indicate if out-of-range input is prohibited */
+        private boolean blockOutOfRangeInput;
+        
         /**
          * Returns <code>true</code> if the passed string is in the
          * [min, max] range if a range is specified, <code>false</code> 
@@ -410,17 +475,19 @@ public class NumericalTextField
                 if (Integer.class.equals(numberType)) {
                     int val = Integer.parseInt(str);
                     int mx = (int) max;
-                    return (val <= mx);
+                    int mi = (int) min;
+                    return (val >= mi && val <= mx);
                 } else if (Double.class.equals(numberType)) {
                     double val = Double.parseDouble(str);
-                    return (val <= max);
+                    return (val >= min && val <= max);
                 } else if (Long.class.equals(numberType)) {
                     long val = Long.parseLong(str);
                     long mx = (long) max;
-                    return (val <= mx);
+                    long mi = (long) min;
+                    return (val >= mi && val <= mx);
                 } else if (Float.class.equals(numberType)) {
                     float val = Float.parseFloat(str);
-                    return (val <= max);
+                    return (val >= min && val <= max);
                 }
             } catch(NumberFormatException nfe) {}
             return false;
@@ -428,14 +495,19 @@ public class NumericalTextField
 
         /**
          * Creates a new instance.
-         *
-         * @param min The minimum value.
-         * @param max The maximum value.
+         * 
+         * @param min
+         *            The minimum value.
+         * @param max
+         *            The maximum value.
+         * @param blockOutOfRangeInput
+         *            If set the user won't be able to type out-of-range values
          */
-        NumericalPlainDocument(double min, double max)
+        NumericalPlainDocument(double min, double max, boolean blockOutOfRangeInput)
         {
             this.min = min;
             this.max = max;
+            this.blockOutOfRangeInput = blockOutOfRangeInput;
         }
 
         /**
@@ -498,7 +570,7 @@ public class NumericalTextField
                 } else {
                     String s = this.getText(0, this.getLength());
                     s += str;
-                    if (isInRange(s))
+                    if (!blockOutOfRangeInput || isInRange(s))
                         super.insertString(offset, str, a);
                 }
             } catch (Exception e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/PopupHint.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/PopupHint.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.shoola.util.ui;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPopupMenu;
+import javax.swing.Timer;
+import javax.swing.UIManager;
+import javax.swing.plaf.FontUIResource;
+
+/**
+ * A popup hint in the style of a tooltip, e. g. for displaying a 'lightweight'
+ * warning message
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class PopupHint {
+
+    /** Delay until the tooltip vanishes again */
+    private static final int DEFAULT_SHOW_TIME = 3000;
+
+    /** The width of the empty border around the tooltip */
+    private static final int INSETS = 3;
+
+    /** The component the hint is attached to */
+    private JComponent component;
+
+    /** The hint, which is actually a popup menu */
+    private JPopupMenu popup;
+
+    /** The timer providing the hide delay */
+    private Timer hideTimer;
+
+    /** The message which is shown */
+    private JLabel text;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param component
+     *            The component the hint is attached to
+     * @param message
+     *            The message to show
+     */
+    public PopupHint(final JComponent component, String message) {
+        this(component, message, DEFAULT_SHOW_TIME);
+    }
+
+    /**
+     * Creates a new instance
+     * 
+     * @param component
+     *            The component the hint is attached to
+     * @param message
+     *            The message to show
+     * @param showTime
+     *            The duration for showing the hint
+     */
+    public PopupHint(final JComponent component, String message, int showTime) {
+        this.component = component;
+
+        Color c = UIUtilities.TOOLTIP_COLOR;
+        Font f = (FontUIResource) UIManager.get("ToolTip.font");
+
+        popup = new JPopupMenu();
+        popup.setLayout(new BoxLayout(popup, BoxLayout.PAGE_AXIS));
+        popup.setBorder(BorderFactory.createEmptyBorder(INSETS, INSETS, INSETS,
+                INSETS));
+        popup.setBackground(c);
+        popup.setFont(f);
+
+        text = new JLabel(message);
+        text.setBackground(c);
+        text.setFont(f);
+        popup.add(text);
+
+        hideTimer = new Timer(showTime, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent arg0) {
+                popup.setVisible(false);
+                hideTimer.stop();
+            }
+        });
+
+    }
+
+    /**
+     * Shows the hint
+     */
+    public void show() {
+        if (!popup.isVisible()) {
+            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            Dimension textDim = text.getPreferredSize();
+
+            // make sure the hint is not shown outside the screen area
+            int xOffset = 0;
+            int xScreen = component.getLocationOnScreen().x + textDim.width;
+            if (xScreen > (screenSize.width - 5)) {
+                xOffset = xScreen - screenSize.width + 5;
+            }
+
+            int x = component.getLocation().x - xOffset;
+            int y = component.getLocation().y - textDim.height - 5;
+            popup.show(component, x, y);
+            hideTimer.start();
+        } else {
+            hideTimer.restart();
+        }
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TextualTwoKnobsSlider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TextualTwoKnobsSlider.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.slider.TextualTwoKnobsSlider 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -24,8 +24,6 @@ package org.openmicroscopy.shoola.util.ui.slider;
 
 
 //Java imports
-import info.clearthought.layout.TableLayout;
-
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -41,7 +39,8 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -104,6 +103,18 @@ public class TextualTwoKnobsSlider
 	/** The name of the property used to identify the text field. */
 	private static final String NAME_DOC = "name";
 	
+	/** The precision used for formatting floating point numbers */
+        private static final int DECIMAL_PRECISION = 3;
+    
+        /** Format used for printing floating point numbers */
+        private static final NumberFormat NUMBER_FORMAT;
+        static {
+            String s = "0.";
+            for (int i = 0; i < DECIMAL_PRECISION; i++)
+                s += "0";
+            NUMBER_FORMAT = new DecimalFormat(s);
+        }
+	
 	/** The slider. */
 	private TwoKnobsSlider 		slider;
 	
@@ -113,6 +124,13 @@ public class TextualTwoKnobsSlider
 	/** The field hosting the end value. */
 	private NumericalTextField 	endField;
 	
+	/** Factor by which to reduce the calculated text field length;
+         *  apparently the calculated text field length is just too large */
+        private final static double TEXTFIELD_LENGTH_CORRECTION = 1;
+        
+        /** Limit the textfield length (columns) to the given size */
+        private static final int MAX_TEXTFIELD_LENGTH = 6;
+        
 	/** The label displayed in front of the {@link #startField}. */
 	private JLabel				startLabel;
 	
@@ -128,11 +146,8 @@ public class TextualTwoKnobsSlider
 	/** The end value. */
 	private double				end;
 	
-	/** 
-	 * The factor by which the values have to be multiplied or
-	 * divided by. 
-	 */
-	private int					roundingFactor;
+	/** Flag to indicate if numbers shall be treated as integers */
+	private boolean intMode = false;
 	
 	/** 
 	 * Formats the passed value.
@@ -140,12 +155,18 @@ public class TextualTwoKnobsSlider
 	 * @param value The value to handle.
 	 * @return See above.
 	 */
-	private String formatValue(int value)
+	private String formatValue(double value)
 	{
-		if (roundingFactor == 1) return ""+value;
-		double v = ((double) value)/roundingFactor;
-		return ""+v;
+	    String s;
+	    if (intMode) {
+	        s = ""+((int) value);
+	    }
+	    else {
+	        s = NUMBER_FORMAT.format(value);
+	    }
+	    return s;
 	}
+	  
 	
 	/** Attaches the listeners to the components. */
 	private void attachListeners()
@@ -213,97 +234,107 @@ public class TextualTwoKnobsSlider
 	 * @param max    The maximum value.
 	 * @param start  The start value.
 	 * @param end    The end value.
-	 * @param roundingFactor The factor by which the values are multiplied by
-	 * 						 or divided by.
 	 */
-	private void initComponents(int absMin, int absMax, int min, int max, 
-			int start, int end, int roundingFactor)
+	private void initComponents(double absMin, double absMax, double min, double max, 
+	        double start, double end)
 	{
-		if (roundingFactor < 1) roundingFactor = 1;
-		this.roundingFactor = roundingFactor;
 		sliderLabel = new JLabel();
 		startLabel = new JLabel("Start");
 		endLabel = new JLabel("End");
 		slider = new TwoKnobsSlider(absMin, absMax, min, max, start, end);
 		setSliderPaintingDefault(false);
-		String minus = "";
-		int maxValue = Math.max(Math.abs(min), Math.abs(max));
-		if (min < 0 || max < 0) minus = "-";
-		int length = (minus+((double) maxValue/roundingFactor)).length(); 
-		length = length/2;
-		double minR = ((double) absMin)/roundingFactor;
-		double maxR = ((double) absMax)/roundingFactor;
 		
-		Class type = Integer.class;
+		Class type = intMode ? Integer.class : Double.class;
 		
-		if (roundingFactor > 1) type = Double.class;
+                int textFieldLength = calculateRequiredTextfieldLength(absMin, absMax);
+                
+		startField = new NumericalTextField(absMin, absMax, type, NumericalTextField.VALIDATION_MODE_CORRECT);
+		startField.setColumns(textFieldLength);
+		startField.setShowWarning(true);
 		
-		startField = new NumericalTextField(minR, maxR, type);
-		startField.setColumns(length);
+		endField = new NumericalTextField(absMin, absMax, type, NumericalTextField.VALIDATION_MODE_CORRECT);
+		endField.setColumns(textFieldLength);
+		endField.setShowWarning(true);
 		
-		endField = new NumericalTextField(minR, maxR, type);
-		endField.setColumns(length);
 		endField.setText(formatValue(end));
 		startField.setText(formatValue(start));
+		
 		//No need to check values b/c already done by the slider.
 		this.start = start;
 		this.end = end;
 	}
+        
+        /**
+         * Determines the length (columns) needed for the text fields
+         * 
+         * @param min
+         *            The minimum value which can be entered
+         * @param max
+         *            The maximum value which can be entered
+         * @return The required length for the text fields
+         */
+        private int calculateRequiredTextfieldLength(double min, double max) {
+            double maxValue = Math.max(Math.abs(min), Math.abs(max));
+            if (min < 0)
+                maxValue *= -1;
+            int result = formatValue(maxValue).length();
+            if (result > MAX_TEXTFIELD_LENGTH)
+                result = MAX_TEXTFIELD_LENGTH;
+            result = (int)(result * TEXTFIELD_LENGTH_CORRECTION);
+            return result;
+        }
 	
-	/** Sets the start value. */
-	private void setStartValue()
-	{
-		boolean valid = false;
-		double val = 0;
-		try {
-            val = Double.parseDouble(startField.getText());
-            val = val*roundingFactor;
-            //if (slider.getPartialMinimum() <= val && val < end) valid = true;
-            if (startField.getMinimum()*roundingFactor <= val && val <= end) 
-            	valid = true;
-        } catch(NumberFormatException nfe) {}
-        if (!valid) {
-            startField.selectAll();
-            return;
+        /** Sets the start value. */
+        private void setStartValue() {
+            boolean valid = false;
+            double val = 0;
+            try {
+                val = Double.parseDouble(startField.getText());
+                // if (slider.getPartialMinimum() <= val && val < end) valid = true;
+                if (startField.getMinimum() <= val && val <= end)
+                    valid = true;
+            } catch (NumberFormatException nfe) {
+            }
+            if (!valid) {
+                startField.selectAll();
+                return;
+            }
+            start = val;
+            // endField.setMinimum(start);
+            if (start < slider.getPartialMinimum()) {
+                val = slider.getPartialMinimum();
+            }
+            removeSliderListeners();
+            slider.setStartValue(val);
+            firePropertyChange(TwoKnobsSlider.KNOB_RELEASED_PROPERTY, null, val);
+            attachSliderListeners();
         }
-        start = val;
-        //endField.setMinimum(start);
-        if (start < slider.getPartialMinimum()*roundingFactor) {
-        	val = slider.getPartialMinimum()*roundingFactor;
-        }
-        removeSliderListeners();
-        int old = slider.getStartValue();
-        slider.setStartValue((int) val);
-        firePropertyChange(TwoKnobsSlider.KNOB_RELEASED_PROPERTY, old, val);
-        attachSliderListeners();
-	}
 	
-	/** Sets the end value. */
-	private void setEndValue()
-	{
-		boolean valid = false;
-		double val = 0;
-		try {
-            val = Double.parseDouble(endField.getText());
-            val = val*roundingFactor;
-            //if (start < val && val <= slider.getPartialMaximum()) valid = true;
-            if (start <= val && val <= endField.getMaximum()*roundingFactor) 
-            	valid = true;
-        } catch(NumberFormatException nfe) {}
-        if (!valid) {
-            endField.selectAll();
-            return;
+        /** Sets the end value. */
+        private void setEndValue() {
+            boolean valid = false;
+            double val = 0;
+            try {
+                val = Double.parseDouble(endField.getText());
+                // if (start < val && val <= slider.getPartialMaximum()) valid =
+                // true;
+                if (start <= val && val <= endField.getMaximum())
+                    valid = true;
+            } catch (NumberFormatException nfe) {
+            }
+            if (!valid) {
+                endField.selectAll();
+                return;
+            }
+            end = val;
+            if (end > slider.getPartialMaximum()) {
+                val = slider.getPartialMaximum();
+            }
+            removeSliderListeners();
+            slider.setEndValue(val);
+            firePropertyChange(TwoKnobsSlider.KNOB_RELEASED_PROPERTY, null, val);
+            attachSliderListeners();
         }
-        end = val;
-        if (end > slider.getPartialMaximum()*roundingFactor) {
-        	val = slider.getPartialMaximum()*roundingFactor;
-        }
-        removeSliderListeners();
-        int old = slider.getEndValue();
-        slider.setEndValue((int) val);
-        firePropertyChange(TwoKnobsSlider.KNOB_RELEASED_PROPERTY, old, val);
-        attachSliderListeners();
-	}
 	
 	/**
 	 * Synchronizes the slider and the {@link #startField} when the 
@@ -311,7 +342,7 @@ public class TextualTwoKnobsSlider
 	 * 
 	 * @param value The value to set.
 	 */
-	private void synchStartValue(int value)
+	private void synchStartValue(double value)
 	{
 		start = value;
 		uninstallFieldListeners(startField);
@@ -326,43 +357,13 @@ public class TextualTwoKnobsSlider
 	 * 
 	 * @param value The value to set.
 	 */
-	private void synchEndValue(int value)
+	private void synchEndValue(double value)
 	{
 		end = value;
 		uninstallFieldListeners(endField);
 		endField.setText(formatValue(value));
 		//startField.setMaximum(end);
 		installFieldListeners(endField, END);
-	}
-	
-	/**
-	 * Updates the field linked to the passed document.
-	 * 
-	 * @param doc The document to handle.
-	 */
-	private void updateTextValue(Document doc)
-	{
-		if (slider == null || endField == null || startField == null) return;
-		String value = (String) doc.getProperty(NAME_DOC);
-		int index = Integer.parseInt(value);
-		Number v;
-		Number ref;
-		switch (index) {
-			case START:
-				//setStartValue();
-				//v = (Number) startField.getValueAsNumber();
-				//ref = (Number) endField.getValueAsNumber();
-				//if (ref == null || v == null) return;
-				//if (ref > v) startField.setMaximum(slider.getPartialMaximum());
-				break;
-			case END:
-				//v = (Number) endField.getValueAsNumber();
-				//ref = (Number) startField.getValueAsNumber();
-				//if (ref == null || v == null) return;
-				//if (ref > v) endField.setMinimum(slider.getPartialMinimum());
-				//setEndValue();
-				break;
-		}
 	}
 	
 	/** 
@@ -431,20 +432,44 @@ public class TextualTwoKnobsSlider
 	}
 	
 	/**
-	 * Creates a new instance.
-	 * 
-	 * @param min   The minimum value.
-	 * @param max   The maximum value.
-	 * @param start The start value.
-	 * @param end   The end value.
-	 */
-	public TextualTwoKnobsSlider(int min, int max, int start, int end)
-	{
-		this(min, max, min, max, start, end, 1);
-	}
-	
+         * Creates a new instance.
+         * 
+         * @param min   The minimum value.
+         * @param max   The maximum value.
+         */
+        public TextualTwoKnobsSlider(double min, double max)
+        {
+                this(min, max, min, max);
+        }
+        
+        /**
+         * Creates a new instance.
+         * 
+         * @param min   The minimum value.
+         * @param max   The maximum value.
+         * @param start The start value.
+         * @param end   The end value.
+         */
+        public TextualTwoKnobsSlider(int min, int max, int start, int end)
+        {
+                this(min, max, min, max, start, end);
+        }
+        
+        /**
+         * Creates a new instance.
+         * 
+         * @param min   The minimum value.
+         * @param max   The maximum value.
+         * @param start The start value.
+         * @param end   The end value.
+         */
+        public TextualTwoKnobsSlider(double min, double max, double start, double end)
+        {
+                this(min, max, min, max, start, end);
+        }
+        
 	/**
-	 * Creates a new instance.
+	 * Creates a new instance. (integer mode)
 	 * 
 	 * @param absMin The absolute minimum value of the slider.
 	 * @param absMax The absolute maximum value of the slider.
@@ -452,16 +477,33 @@ public class TextualTwoKnobsSlider
 	 * @param max    The maximum value.
 	 * @param start  The start value.
 	 * @param end    The end value.
-	 * @param roundingFactor The factor by which the values are multiplied by
-	 * 						 or divided by.
 	 */
 	public TextualTwoKnobsSlider(int absMin, int absMax, int min, int max, 
-			int start, int end, int roundingFactor)
+			int start, int end)
 	{
-		initComponents(absMin, absMax, min, max, start, end, roundingFactor);
+	        intMode = true;
+		initComponents(absMin, absMax, min, max, start, end);
 		attachListeners();
 	}
 	
+	/**
+         * Creates a new instance. (floating point mode)
+         * 
+         * @param absMin The absolute minimum value of the slider.
+         * @param absMax The absolute maximum value of the slider.
+         * @param min    The minimum value.
+         * @param max    The maximum value.
+         * @param start  The start value.
+         * @param end    The end value.
+         */
+        public TextualTwoKnobsSlider(double absMin, double absMax, double min, double max, 
+                double start, double end)
+        {
+                intMode = false;
+                initComponents(absMin, absMax, min, max, start, end);
+                attachListeners();
+        }
+        
 	/**
 	 * Sets the text of the {@link #startLabel}.
 	 * 
@@ -493,25 +535,18 @@ public class TextualTwoKnobsSlider
 	}
 	
 	/**
-	 * Returns the rounding factor.
-	 * 
-	 * @return See above.
-	 */
-	public int getRoundingFactor() { return roundingFactor; }
-	
-	/**
 	 * Returns the start value. 
 	 * 
 	 * @return See above.
 	 */
-	public double getStartValue() { return ((double) start)/roundingFactor; }
+	public double getStartValue() { return start; }
 	
 	/**
 	 * Returns the end value. 
 	 * 
 	 * @return See above.
 	 */
-	public double getEndValue() { return ((double) end)/roundingFactor; }
+	public double getEndValue() { return end; }
 	
 	/** Lays out the components. */
 	public void layoutComponents() { layoutComponents(LAYOUT_ALL); }
@@ -531,24 +566,42 @@ public class TextualTwoKnobsSlider
 				add(slider);
 				break;
 			case LAYOUT_SLIDER_FIELDS_X_AXIS:
-				//setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-				double tableSize[][] =
-		          {{0.18, 0.64, 0.18},
-		           {TableLayout.PREFERRED, TableLayout.PREFERRED,
-		        	  TableLayout.PREFERRED}};
-				setLayout(new TableLayout(tableSize));
-				add(startField,"0, 0, 0, 1");
-				add(slider,"1, 0, 1, 1");
-				add(endField,"2 , 0, 2, 1");
-				break;
+			    setLayout(new GridBagLayout());
+
+                            // have to set minimum size to preferred size, otherwise
+                            // textfields will collapse in GridBayLayout;
+                            // see: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4247013
+                            startField.setMinimumSize(startField.getPreferredSize());
+                            endField.setMinimumSize(endField.getPreferredSize());
+
+                            GridBagConstraints c = new GridBagConstraints();
+                            c.gridx = 0;
+                            c.gridy = 0;
+                            c.weightx = 0;
+                            c.weighty = 0;
+                            c.anchor = GridBagConstraints.WEST;
+                            c.fill = GridBagConstraints.NONE;
+
+                            add(startField, c);
+                            c.gridx++;
+
+                            c.weightx = 1;
+                            c.fill = GridBagConstraints.HORIZONTAL;
+                            add(slider, c);
+                            c.gridx++;
+
+                            c.weightx = 0;
+                            c.fill = GridBagConstraints.NONE;
+                            add(endField, c);
+                            break;
 			case LAYOUT_SLIDER_FIELDS_LABELS_X_AXIS:
-				setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-				add(sliderLabel);
-				add(startField);
-				add(slider);
-				add(endField);
-				add(endLabel);
-				break;
+			    setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
+                            add(sliderLabel);
+                            add(startField);
+                            add(slider);
+                            add(endField);
+                            add(endLabel);
+                            break;
 			case LAYOUT_SLIDER_AND_LABEL:
 				JPanel content = new JPanel();
 				content.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
@@ -600,15 +653,15 @@ public class TextualTwoKnobsSlider
 	 * @param start     	The value of the start knob.
 	 * @param end       	The value of the end knob.
 	 */
-	public void setValues(int absoluteMax, int absoluteMin, 
+	public void G(int absoluteMax, int absoluteMin, 
 			int max, int min, int start, int end)
 	{
 		setValues(absoluteMax, absoluteMin, absoluteMax, absoluteMin, max, min,
-				start, end, roundingFactor);
+				start, end);
 	}
 	
 	/**
-	 * Resets the default value of the slider.
+	 * Resets the default value of the slider, using integer mode;
 	 * 
 	 * @param absoluteMaxSlider	The absolute maximum value of the slider.
 	 * @param absoluteMinSlider The absolute minimum value of the slider.
@@ -621,32 +674,27 @@ public class TextualTwoKnobsSlider
 	 */
 	public void setValues(int absoluteMaxSlider, int absoluteMinSlider, 
 			int absoluteMaxText, int absoluteMinText, 
-			int max, int min, int start, int end, int roundingFactor)
+			int max, int min, int start, int end)
 	{
-		if (roundingFactor < 1) roundingFactor = 1;
-		this.roundingFactor = roundingFactor;
 		slider.setValues(absoluteMaxSlider, absoluteMinSlider, max, min, start, 
 				end);
 		removeListeners();
-		String minus = "";
-		int maxValue = Math.max(Math.abs(min), Math.abs(max));
-		if (min < 0 || max < 0) minus = "-";
-		int length = (minus+((double) maxValue/roundingFactor)).length(); 
-		length = length/2+6;
-		if (roundingFactor > 1) {
-			startField.setNumberType(Double.class);
-			endField.setNumberType(Double.class);
-		}
-		startField.setColumns(length);
-		endField.setColumns(length);
+		
+		intMode = true;
+		
+                int textFieldLength = calculateRequiredTextfieldLength(absoluteMinText, absoluteMaxText);
+                
+		startField.setNumberType(Integer.class);
+		endField.setNumberType(Integer.class);
+		
+		startField.setColumns(textFieldLength);
+		endField.setColumns(textFieldLength);
 		endField.setMaximum(absoluteMaxText);
 		endField.setMinimum(absoluteMinText);
 		startField.setMaximum(absoluteMaxText);
 		startField.setMinimum(absoluteMinText);
 		endField.setText(formatValue(end));
 		startField.setText(formatValue(start));
-		//endField.setMinimum(absoluteMinText);
-		//startField.setMaximum(absoluteMaxText);
 		StringBuffer buffer = new StringBuffer();
 		buffer.append("<html><body>");
 		buffer.append("<b>Min:</b> "+min);
@@ -665,6 +713,61 @@ public class TextualTwoKnobsSlider
 		attachListeners();
 	}
 	
+	/**
+         * Resets the default value of the slider, using floating point number mode;
+         * 
+         * @param absoluteMaxSlider     The absolute maximum value of the slider.
+         * @param absoluteMinSlider The absolute minimum value of the slider.
+         * @param absoluteMaxText       The absolute maximum value of the slider.
+         * @param absoluteMinText       The absolute minimum value of the slider.
+         * @param max                   The maximum value.
+         * @param min                   The minimum value.
+         * @param start                 The value of the start knob.
+         * @param end                   The value of the end knob.
+         */
+        public void setValues(double absoluteMaxSlider, double absoluteMinSlider, 
+                double absoluteMaxText, double absoluteMinText, 
+                double max, double min, double start, double end)
+        {
+                slider.setValues(absoluteMaxSlider, absoluteMinSlider, max, min, start, 
+                                end);
+                removeListeners();
+                
+                intMode = false;
+                
+                int textFieldLength = calculateRequiredTextfieldLength(absoluteMinText, absoluteMinText);
+                
+                startField.setNumberType(Double.class);
+                startField.setNegativeAccepted(true);
+                endField.setNumberType(Double.class);
+                endField.setNegativeAccepted(true);
+                
+                startField.setColumns(textFieldLength);
+                endField.setColumns(textFieldLength);
+                endField.setMaximum(absoluteMaxText);
+                endField.setMinimum(absoluteMinText);
+                startField.setMaximum(absoluteMaxText);
+                startField.setMinimum(absoluteMinText);
+                endField.setText(formatValue(end));
+                startField.setText(formatValue(start));
+                StringBuffer buffer = new StringBuffer();
+                buffer.append("<html><body>");
+                buffer.append("<b>Min:</b> "+min);
+                buffer.append("<br><b>Pixels Type Min: </b>"+absoluteMinText);
+                buffer.append("</body></html>");
+                startField.setToolTipText(buffer.toString());
+                buffer = new StringBuffer();
+                buffer.append("<html><body>");
+                buffer.append("<b>Max:</b> "+max);
+                buffer.append("<br><b>Pixels Type Max: </b>"+absoluteMaxText);
+                buffer.append("</body></html>");
+                endField.setToolTipText(buffer.toString());
+                
+                this.start = start;
+                this.end = end;
+                attachListeners();
+        }
+        
 	/**
 	 * Returns the number of the columns.
 	 * 
@@ -705,15 +808,13 @@ public class TextualTwoKnobsSlider
 	 * @param s The start value to set.
 	 * @param e The end value to set.
 	 */
-	public void setInterval(int s, int e)
+	public void setInterval(double s, double e)
 	{
 		removeListeners();
 		endField.setText(formatValue(e));
 		startField.setText(formatValue(s));
 		slider.setStartValue(s);
 		slider.setEndValue(e);
-		//endField.setMinimum(s);
-		//startField.setMaximum(e);
 		start = s;
 		end = e;
 		attachListeners();
@@ -784,10 +885,10 @@ public class TextualTwoKnobsSlider
 	{
 		String name = evt.getPropertyName();
 		if (TwoKnobsSlider.LEFT_MOVED_PROPERTY.equals(name)) {
-			Integer value = (Integer) evt.getNewValue();
+			Double value = (Double) evt.getNewValue();
 			synchStartValue(value);
 		} else if (TwoKnobsSlider.RIGHT_MOVED_PROPERTY.equals(name)) {
-			Integer value = (Integer) evt.getNewValue();
+		    Double value = (Double) evt.getNewValue();
 			synchEndValue(value);
 		}
 		firePropertyChange(name, evt.getOldValue(), evt.getNewValue());
@@ -828,12 +929,10 @@ public class TextualTwoKnobsSlider
 	}
 
 	/**
-	 * Updates the field whose text is modified.
 	 * @see DocumentListener#removeUpdate(DocumentEvent)
 	 */
 	public void removeUpdate(DocumentEvent e)
 	{
-		updateTextValue(e.getDocument());
 	}
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.slider.TwoKnobsSlider
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -117,11 +117,11 @@ public class TwoKnobsSlider
 
 	/** The preferred dimension of a vertical slider. */
 	protected static final Dimension    PREFERRED_VERTICAL = new Dimension(21, 
-			200);
+			80);
 
 	/** The preferred dimension of a horizontal slider. */
 	protected static final Dimension    PREFERRED_HORIZONTAL =
-		new Dimension(200, 21);
+		new Dimension(80, 21);
 
 	/** The insets. */
 	protected Insets            insetCache = null;
@@ -219,8 +219,8 @@ public class TwoKnobsSlider
 	private void handleMouseEvent(MouseEvent me)
 	{
 		if (!model.isEnabled()) return;
-		int oldStart = getStartValue();
-		int oldEnd = getEndValue();
+		double oldStart = getStartValue();
+		double oldEnd = getEndValue();
 		if (model.getOrientation() == TwoKnobsSlider.HORIZONTAL) {
 			handleMouseEventForHorizSlider((int) me.getPoint().getX());
 			switch (knobControl) {
@@ -396,7 +396,7 @@ public class TwoKnobsSlider
 	 * @param start The start value.
 	 * @param end   The end value.
 	 */
-	public TwoKnobsSlider(int min, int max, int start, int end)
+	public TwoKnobsSlider(double min, double max, double start, double end)
 	{
 		this(min, max, min, max, start, end);
 	}
@@ -412,8 +412,8 @@ public class TwoKnobsSlider
 	 * @param start 		The start value.
 	 * @param end   		The end value.
 	 */
-	public TwoKnobsSlider(int absoluteMin, int absoluteMax, 
-			int min, int max, int start, int end)
+	public TwoKnobsSlider(double absoluteMin, double absoluteMax, 
+	        double min, double max, double start, double end)
 	{
 		model = new TwoKnobsSliderModel(absoluteMax, absoluteMin, max, min, 
 				start, end);
@@ -453,7 +453,17 @@ public class TwoKnobsSlider
 	 * 
 	 * @return See above.
 	 */
-	public int getStartValue() { return model.getStartValue(); }
+	public double getStartValue() { return model.getStartValue(); }
+	
+	/**
+	 * Rounds and returns the start value as int
+	 * (e. g. 2.49 will be rounded to 2, whereas 2.51 will
+	 *  be rounded to 3)
+	 * @return See above.
+	 */
+	public int getStartValueAsInt() {
+	    return (int)(model.getStartValue()+0.5);
+	}
 
 	/**
 	 * Returns the value of the end knob i.e. value between
@@ -461,20 +471,30 @@ public class TwoKnobsSlider
 	 * 
 	 * @return See above.
 	 */
-	public int getEndValue() { return model.getEndValue(); }
+	public double getEndValue() { return model.getEndValue(); }
 
+	/**
+         * Rounds and returns the end value as int
+         * (e. g. 2.49 will be rounded to 2, whereas 2.51 will
+         *  be rounded to 3)
+         * @return See above.
+         */
+	public int getEndValueAsInt() {
+            return (int)(model.getEndValue()+0.5);
+        }
+	
 	/**
 	 * Sets the start value. The value must be greater than the minimum and
 	 * lower than the end value.
 	 * 
 	 * @param v The value to set.
 	 */
-	public void setStartValue(int v)
+	public void setStartValue(double v)
 	{
-		int old = model.getStartValue();
+	    double old = model.getStartValue();
 		model.setStartValue(v);
-		firePropertyChange(START_VALUE_PROPERTY, Integer.valueOf(old), 
-				Integer.valueOf(v));
+		firePropertyChange(START_VALUE_PROPERTY, Double.valueOf(old), 
+		        Double.valueOf(v));
 		repaint();
 	}
 	
@@ -484,12 +504,12 @@ public class TwoKnobsSlider
 	 * 
 	 * @param v The value to set.
 	 */
-	public void setEndValue(int v)
+	public void setEndValue(double v)
 	{
-		int old = model.getStartValue();
+	    double old = model.getStartValue();
 		model.setEndValue(v);
-		firePropertyChange(END_VALUE_PROPERTY, Integer.valueOf(old), 
-				Integer.valueOf(v));
+		firePropertyChange(END_VALUE_PROPERTY, Double.valueOf(old), 
+		        Double.valueOf(v));
 		repaint();
 		/*
 		int max = model.getAbsoluteMaximum();
@@ -512,8 +532,8 @@ public class TwoKnobsSlider
 	 * @param start     	The value of the start knob.
 	 * @param end       	The value of the end knob.
 	 */
-	public void setValues(int absoluteMax, int absoluteMin, 
-			int max, int min, int start, int end)
+	public void setValues(double absoluteMax, double absoluteMin, 
+	        double max, double min, double start, double end)
 	{
 		model.checkValues(absoluteMax, absoluteMin, max, min, start, end);
 		firePropertyChange(SET_VALUES_PROPERTY, Boolean.valueOf(false), 
@@ -527,18 +547,18 @@ public class TwoKnobsSlider
 	 * @param start	The value of the start knob.
 	 * @param end	The value of the end knob.
 	 */
-	public void setInterval(int start, int end)
+	public void setInterval(double start, double end)
 	{
 		if (start > end) return;
-		int max = model.getAbsoluteMaximum();
+		double max = model.getAbsoluteMaximum();
 		if (end > max) return;
-		int oldEnd = model.getEndValue();
-		int oldStart = model.getStartValue();
+		double oldEnd = model.getEndValue();
+		double oldStart = model.getStartValue();
 		model.setInterval(start, end);
-		firePropertyChange(START_VALUE_PROPERTY, Integer.valueOf(oldStart), 
-				Integer.valueOf(start));
-		firePropertyChange(END_VALUE_PROPERTY, Integer.valueOf(oldEnd), 
-				Integer.valueOf(end));
+		firePropertyChange(START_VALUE_PROPERTY, Double.valueOf(oldStart), 
+		        Double.valueOf(start));
+		firePropertyChange(END_VALUE_PROPERTY, Double.valueOf(oldEnd), 
+		        Double.valueOf(end));
 		repaint();
 	}
 	
@@ -636,7 +656,7 @@ public class TwoKnobsSlider
 	public void setPaintMinorTicks(boolean b)
 	{
 		if (b) {
-			int m = model.getMinorTickSpacing();
+			double m = model.getMinorTickSpacing();
 			if (m == 0) m = 1;
 			model.setMinorTickSpacing(m);
 		} model.setMinorTickSpacing(0);
@@ -659,7 +679,7 @@ public class TwoKnobsSlider
 	 * 
 	 * @return See above.
 	 */
-	public int getPartialMinimum()
+	public double getPartialMinimum()
 	{
 		return model.getPartialMinimum();
 	}
@@ -670,7 +690,7 @@ public class TwoKnobsSlider
 	 * 
 	 * @return See above.
 	 */
-	public int getPartialMaximum()
+	public double getPartialMaximum()
 	{
 		return model.getPartialMaximum();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.slider.TwoKnobSliderModel
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -50,22 +50,22 @@ class TwoKnobsSliderModel
 {
 
 	/** The absolute minimum. */
-	private int							absoluteMin;
+	private double							absoluteMin;
 
 	/** The absolute maximum. */
-	private int							absoluteMax;
+	private double							absoluteMax;
 
 	/** The maximum value. */
-	private int         				maximum;
+	private double         				maximum;
 
 	/** The minimum value. */
-	private int         				minimum;
+	private double         				minimum;
 
 	/** The value of the start knob, the default value is {@link #minimum}. */
-	private int         				startValue;
+	private double         				startValue;
 
 	/** The value of the end knob, the default value is {@link #maximum}. */
-	private int         				endValue;
+	private double         				endValue;
 
 	/** Flag indicating if we can move the knobs. */
 	private boolean     				enabled;
@@ -83,16 +83,16 @@ class TwoKnobsSliderModel
 	private boolean     				paintEndLabels;
 
 	/** The space between the major ticks. */
-	private int         				majorTickSpacing;
+	private double         				majorTickSpacing;
 
 	/** The space between the minor ticks. */
-	private int         				minorTickSpacing;
+	private double         				minorTickSpacing;
 
 	/** The ticks increment value. */
-	private int         				increment;
+	private double         				increment;
 
 	/** The collection storing the labels. */
-	private Map<Integer, String>		labels;
+	private Map<Double, String>		labels;
 
 	/**
 	 * Identifies the orientation of the slider either 
@@ -101,10 +101,10 @@ class TwoKnobsSliderModel
 	private int         				orientation;
 
 	/** The partial min is for example the minimum value minus the increment. */
-	private int							partialMin;
+	private double							partialMin;
 
 	/** The partial max is for example the maximum value plus the increment. */
-	private int							partialMax;
+	private double							partialMax;
 
 	/** Indicates that overlap is allowed.*/
 	private boolean						overlap;
@@ -112,15 +112,15 @@ class TwoKnobsSliderModel
 	/** Creates labels for the minimum and maximum values. */
 	private void createEndLabels()
 	{
-		labels.put(Integer.valueOf(minimum), render(minimum));
-		labels.put(Integer.valueOf(maximum), render(maximum));
+		labels.put(Double.valueOf(minimum), render(minimum));
+		labels.put(Double.valueOf(maximum), render(maximum));
 	}
 
 	/** Creates the labels. */
 	private void createLabels()
 	{
-		for (int i = minimum; i <= maximum; i += increment)
-			labels.put(Integer.valueOf(i), render(i));
+		for (double i = minimum; i <= maximum; i += increment)
+			labels.put(Double.valueOf(i), render(i));
 	}
 
 	/** Initializes the controls with the default values. */
@@ -131,7 +131,7 @@ class TwoKnobsSliderModel
 		increment = (maximum-minimum)/10;
 		minorTickSpacing = 1;
 		majorTickSpacing = 10;
-		labels = new HashMap<Integer, String>();
+		labels = new HashMap<Double, String>();
 		setPaintLabels(false);
 		setPaintEndLabels(true);
 		setOrientation(TwoKnobsSlider.HORIZONTAL);
@@ -147,14 +147,15 @@ class TwoKnobsSliderModel
 	 * @param startValue    The value of the start knob.
 	 * @param endValue      The value of the end knob.
 	 */
-	TwoKnobsSliderModel(int absoluteMax, int absoluteMin, int maximum, 
-			int minimum, int startValue, int endValue)
+	TwoKnobsSliderModel(double absoluteMax, double absoluteMin, double maximum, 
+	        double minimum, double startValue, double endValue)
 	{
 		checkValues(absoluteMax, absoluteMin, maximum, minimum, startValue, 
 				endValue);
 		installDefaults();
 	}
 
+        
 	/**
 	 * Checks if the specified values are valid.
 	 * 
@@ -165,8 +166,8 @@ class TwoKnobsSliderModel
 	 * @param startValue    The value of the start knob.
 	 * @param endValue      The value of the end knob.
 	 */
-	void checkValues(int absoluteMax, int absoluteMin, int maximum, int minimum,
-			int startValue, int endValue)
+	void checkValues(double absoluteMax, double absoluteMin, double maximum, double minimum,
+	        double startValue, double endValue)
 	{
 		if (maximum >= minimum && startValue <= endValue &&
 				absoluteMax >= absoluteMin && maximum <= absoluteMax &&
@@ -206,56 +207,56 @@ class TwoKnobsSliderModel
 	 * 
 	 * @return See above.
 	 */
-	int getEndValue() { return endValue; }
+	double getEndValue() { return endValue; }
 
 	/**
 	 * Returns the value of the start knob.
 	 * 
 	 * @return See above.
 	 */
-	int getStartValue() { return startValue; }
+	double getStartValue() { return startValue; }
 
 	/**
 	 * Returns the maximum value of the slider.
 	 * 
 	 * @return See above.
 	 */
-	int getMaximum() { return maximum; }
+	double getMaximum() { return maximum; }
 
 	/**
 	 * Returns the minimum value of the slider.
 	 * 
 	 * @return See above.
 	 */
-	int getMinimum() { return minimum; }
+	double getMinimum() { return minimum; }
 
 	/**
 	 * Returns the maximum value of the slider.
 	 * 
 	 * @return See above.
 	 */
-	int getAbsoluteMaximum() { return absoluteMax; }
+	double getAbsoluteMaximum() { return absoluteMax; }
 
 	/**
 	 * Returns the minimum value of the slider.
 	 * 
 	 * @return See above.
 	 */
-	int getAbsoluteMinimum() { return absoluteMin; }
+	double getAbsoluteMinimum() { return absoluteMin; }
 
 	/**
 	 * Returns the partial minimum.
 	 * 
 	 * @return See above.
 	 */
-	int getPartialMinimum() { return absoluteMin; }
+	double getPartialMinimum() { return absoluteMin; }
 
 	/**
 	 * Returns the partial maximum.
 	 * 
 	 * @return See above.
 	 */
-	int getPartialMaximum() { return absoluteMax; }
+	double getPartialMaximum() { return absoluteMax; }
 
 	/**
 	 * Sets the value of the start knob, value in the range
@@ -263,7 +264,7 @@ class TwoKnobsSliderModel
 	 * 
 	 * @param startValue The value to set.
 	 */
-	void setStartValue(int startValue)
+	void setStartValue(double startValue)
 	{ 
 		if (overlap) {
 			if (startValue > endValue) return;
@@ -283,7 +284,7 @@ class TwoKnobsSliderModel
 	 * 
 	 * @param endValue The value to set.
 	 */
-	void setEndValue(int endValue)
+	void setEndValue(double endValue)
 	{ 
 		if (overlap) {
 			if (endValue < startValue) return;
@@ -302,7 +303,7 @@ class TwoKnobsSliderModel
 	 * @param start	The value to set.
 	 * @param end	The value to set.
 	 */
-	void setInterval(int start, int end)
+	void setInterval(double start, double end)
 	{
 		if (end > absoluteMax) end = absoluteMax;
 		if (end >= partialMax) partialMax = end;
@@ -389,7 +390,7 @@ class TwoKnobsSliderModel
 	 * 
 	 * @return See above. 
 	 */
-	int getMajorTickSpacing() { return majorTickSpacing; }
+	double getMajorTickSpacing() { return majorTickSpacing; }
 
 	/**
 	 * Sets the majorTickSpacing value.  
@@ -403,28 +404,28 @@ class TwoKnobsSliderModel
 	 * 
 	 * @return See above. 
 	 */
-	int getMinorTickSpacing() { return minorTickSpacing; }
+	double getMinorTickSpacing() { return minorTickSpacing; }
 
 	/**
 	 * Sets the minorTickSpacing value.  
 	 * 
 	 * @param v The value to set.
 	 */
-	void setMinorTickSpacing(int v) { minorTickSpacing = v; }
+	void setMinorTickSpacing(double v) { minorTickSpacing = v; }
 
 	/**
 	 * Returns the increment value.
 	 * 
 	 * @return See above.
 	 */
-	int getIncrement() { return increment; }
+	double getIncrement() { return increment; }
 
 	/**
 	 * Returns the map with the labels.
 	 * 
 	 * @return See above. 
 	 */
-	Map<Integer, String> getLabels() { return labels; }
+	Map<Double, String> getLabels() { return labels; }
 
 	/**
 	 * Formats the specified value.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.slider.TwoKnobsSliderUI
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -159,12 +159,12 @@ class TwoKnobsSliderUI
 	{
 		g.setColor(shadowColor);
 		g.translate(0, tickRect.y);
-		int value = model.getMinimum();
+		double value = model.getMinimum();
 		int xPos = 0;
-		int minor = model.getMinorTickSpacing();
-		int major = model.getMajorTickSpacing();
-		int max = model.getMaximum();
-		int min = model.getMinimum();
+		double minor = model.getMinorTickSpacing();
+		double major = model.getMajorTickSpacing();
+		double max = model.getMaximum();
+		double min = model.getMinimum();
 		if (model.getOrientation() == TwoKnobsSlider.HORIZONTAL) {
 			if (minor > 0) {
 				while (value <= max) {
@@ -512,8 +512,8 @@ class TwoKnobsSliderUI
 			if (model.isPaintEndLabels())
 				trackRect.setBounds(x, EXTRA, size.width-2*x, h);
 			else
-				trackRect.setBounds(w/2, EXTRA, size.width-2*w, h);
-				//trackRect.setBounds(w/2, EXTRA, size.width-w, h);
+				//trackRect.setBounds(w/2, EXTRA, size.width-2*w, h);
+				trackRect.setBounds(w/2, EXTRA, size.width-w, h);
 
 			if (model.isPaintCurrentValues()) {
 				int v = fontMetrics.stringWidth(model.render(
@@ -618,17 +618,17 @@ class TwoKnobsSliderUI
 	 * @param value The value to map.
 	 * @return See above.
 	 */
-	int xPositionForValue(int value)
+	int xPositionForValue(double value)
 	{
-		int min = model.getPartialMinimum();
-		int max = model.getPartialMaximum();
+	        double min = model.getPartialMinimum();
+	        double max = model.getPartialMaximum();
 		int trackLength = trackRect.width;
 		double valueRange = (double) max-(double) min;
-		double pixelsPerValue = trackLength/valueRange;
+		double pixelsPerValue = (double)trackLength/valueRange;
 		int trackLeft = trackRect.x;
 		int trackRight = trackRect.x+trackRect.width-1;
 		int xPosition = trackLeft;
-		xPosition += Math.round(pixelsPerValue*((double) value-min));
+		xPosition += Math.round(pixelsPerValue*(value-min));
 		xPosition = Math.max(trackLeft, xPosition);
 		xPosition = Math.min(trackRight, xPosition);
 		return xPosition;
@@ -641,13 +641,13 @@ class TwoKnobsSliderUI
 	 * @param value The value to map.
 	 * @return See above.
 	 */
-	int yPositionForValue(int value)
+	int yPositionForValue(double value)
 	{
-		int min = model.getPartialMinimum();
-		int max = model.getPartialMaximum();
+	        double min = model.getPartialMinimum();
+	        double max = model.getPartialMaximum();
 		int trackLength = trackRect.height; 
 		double valueRange = (double) max-(double) min;
-		double pixelsPerValue = trackLength/valueRange;
+		double pixelsPerValue = (double)trackLength/valueRange;
 		int trackTop = trackRect.y;
 		int trackBottom = trackRect.y+trackRect.height-1;
 		int yPosition= trackTop;
@@ -665,24 +665,28 @@ class TwoKnobsSliderUI
 	 *              <code>false</code> to start from the end.
 	 * @return See above.
 	 */
-	int xValueForPosition(int xPosition, boolean start)
+	double xValueForPosition(int xPosition, boolean start)
 	{
-		int value;
-		int minValue = model.getPartialMinimum();
-		int maxValue = model.getPartialMaximum();
+	        double value;
+	        double minValue = model.getPartialMinimum();
+	        double maxValue = model.getPartialMaximum();
 		int trackLength = trackRect.width;
 		int trackLeft = trackRect.x; 
 		int trackRight = trackRect.x+trackRect.width-1;
 
-		if (xPosition <= trackLeft)  value = minValue;
-		else if (xPosition >= trackRight) value = maxValue;
+		double valueRange = -1;
+		double valuePerPixel = - 1;
+		if (xPosition <= trackLeft)  
+			value = minValue;
+		else if (xPosition >= trackRight) 
+			value = maxValue;
 		else {
-			int distanceFromTrackLeft = trackRight-xPosition;
-			if (start) distanceFromTrackLeft = xPosition-trackLeft;
-			double valueRange = (double) maxValue-(double) minValue;
-			double valuePerPixel = Math.ceil(valueRange/trackLength*1000)/1000;
-			int valueFromTrackLeft = 
-			  (int) Math.ceil(distanceFromTrackLeft*valuePerPixel);
+			double distanceFromTrackLeft = trackRight-xPosition;
+			if (start) 
+				distanceFromTrackLeft = xPosition-trackLeft;
+			valueRange = (double) maxValue-(double) minValue;
+			valuePerPixel = valueRange/(double)trackLength;
+			double valueFromTrackLeft = distanceFromTrackLeft*valuePerPixel;
 			if (start) value = minValue+valueFromTrackLeft;
 			else value = maxValue-valueFromTrackLeft;
 		}
@@ -697,11 +701,11 @@ class TwoKnobsSliderUI
 	 *              <code>false</code> to start from the end.
 	 * @return See above.
 	 */
-	int yValueForPosition(int yPosition, boolean start)
+	double yValueForPosition(int yPosition, boolean start)
 	{
-		int value;
-		int minValue = model.getPartialMinimum();
-		int maxValue = model.getPartialMaximum();
+	        double value;
+	        double minValue = model.getPartialMinimum();
+	        double maxValue = model.getPartialMaximum();
 		int trackLength = trackRect.height;
 		int trackTop = trackRect.y;
 		int trackBottom = trackRect.y+trackRect.height-1;
@@ -713,8 +717,8 @@ class TwoKnobsSliderUI
 			if (start) distanceFromTrackTop = yPosition-trackTop;
 			double valueRange = (double) maxValue-(double) minValue;
 			double valuePerPixel = Math.ceil(valueRange/trackLength*1000)/1000;
-			int valueFromTrackTop = 
-				(int) Math.ceil(distanceFromTrackTop*valuePerPixel);
+			double valueFromTrackTop = 
+				Math.ceil(distanceFromTrackTop*valuePerPixel*1000)/1000;
 			//value = maxValue-valueFromTrackTop;
 			if (!start) value = minValue+valueFromTrackTop;
 			else value = maxValue-valueFromTrackTop;


### PR DESCRIPTION
Gathered all UI changes for float images from develop branch together and rebased them to dev_5_0; this mainly affects the TwoKnobSlider.
Review: Check that the channel sliders work with int and float images. But also check other places where the TwoKnobSlider is used, e. g. the movie dialog.

To be able test this PR, #3366 should be included in the build.
/cc @jburel 