### PR TITLE
Fix ice.config modification when using bin/omero admin ports --prefix

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -262,6 +262,7 @@ class TestAdminPorts(object):
         self.args += ['--skipcheck']
         self.cli.invoke(self.args, strict=True)
 
+        # Check configuration file ports have been prefixed
         self.check_ice_config(**kwargs)
         self.check_cfg(**kwargs)
         self.check_config_xml(**kwargs)
@@ -271,22 +272,7 @@ class TestAdminPorts(object):
         self.args += ['--revert']
         self.cli.invoke(self.args, strict=True)
 
-        self.check_ice_config()
-        self.check_cfg()
-        self.check_config_xml()
-        self.check_default_xml()
-
-    @pytest.mark.parametrize('default', [True, False])
-    def testInitRevert(self, default):
-
-        if not default:
-            self.create_new_ice_config()
-
-        self.args += ['--prefix', '%s' % 1]
-        self.args += ['--skipcheck']
-        self.args += ['--revert']
-        self.cli.invoke(self.args, strict=True)
-
+        # Check configuration file ports have been deprefixed
         self.check_ice_config()
         self.check_cfg()
         self.check_config_xml()
@@ -298,15 +284,23 @@ class TestAdminPorts(object):
         if not default:
             self.create_new_ice_config()
 
+        kwargs = {'prefix': 1}
         self.args += ['--skipcheck']
-        self.args += ['--prefix', '%s' % 1]
+        self.args += ['--prefix', '%s' % kwargs['prefix']]
         self.cli.invoke(self.args, strict=True)
 
+        # Check configuration file ports
+        self.check_ice_config(**kwargs)
+        self.check_cfg(**kwargs)
+        self.check_config_xml(**kwargs)
+        self.check_default_xml(**kwargs)
+
+        # Test revert with a mismatching prefix
         self.args[-1] = "2"
         self.args += ['--revert']
         self.cli.invoke(self.args, strict=True)
 
-        kwargs = {'prefix': 1}
+        # Check configuration file ports have not been modified
         self.check_ice_config(**kwargs)
         self.check_cfg(**kwargs)
         self.check_config_xml(**kwargs)

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import re
 import pytest
 
 from path import path
@@ -224,7 +225,9 @@ class TestAdminPorts(object):
 
     def check_ice_config(self, prefix='', webserver=4080, ssl=4064, **kwargs):
         config_text = self.cfg_files["ice.config"].text()
-        assert config_text.endswith("\nomero.port=%s%s\n" % (prefix, ssl))
+        pattern = re.compile('^omero.port=\d+$', re.MULTILINE)
+        matches = pattern.findall(config_text)
+        assert matches == ["omero.port=%s%s" % (prefix, ssl)]
 
     def check_default_xml(self, prefix='', tcp=4063, ssl=4064, **kwargs):
         routerport = (

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -245,7 +245,13 @@ class TestAdminPorts(object):
             assert client_endpoints in s
 
     @pytest.mark.parametrize('prefix', [None, 1, 2])
-    def testRevert(self, prefix):
+    @pytest.mark.parametrize('default', [True, False])
+    def testRevert(self, prefix, default):
+
+        if not default:
+            with open(self.cfg_files['ice.config'], 'w') as f:
+                f.write('omero.host=localhost')
+
         kwargs = {}
         if prefix:
             self.args += ['--prefix', '%s' % prefix]


### PR DESCRIPTION
Without this PR, calling `admin ports` appends `omero.port=PORT` to the `ice.config`. This results in the following calls:

```
bin/omero admin ports --prefix=1
bin/omero admin ports --prefix=1 --revert
```

will append the following tow lines

```
omero.port=14064
omero.port=4064
```

This PR fixes the `ice.config` modification logic in `bin/omero admin ports` by:
1- looking for an `omero.port=xxx` line in ICE_CONFIG and replacing it using the new port (as for the other configuration files)
2- if not present, looking for the `## omero.port=xxx` line which ships with the default `ice.config` and uncommenting it
3- if 2 is not applicable, appending `omero.port=xxx` as done previously

--no-rebase