### PR TITLE
Index map annotations (Fix #12318)

### DIFF
--- a/components/common/test/ome/util/search/LuceneQueryBuilderTest.java
+++ b/components/common/test/ome/util/search/LuceneQueryBuilderTest.java
@@ -88,6 +88,8 @@ public class LuceneQueryBuilderTest extends TestCase{
         raw = "test AND dv";  expected = "((test) AND (dv))";
         checkQuery(fields, raw, expected);
        
+        raw = "has_key:foo"; expected = "has_key foo";
+        checkQuery(fields, raw, expected);
         
         
         // single field

--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -17,11 +17,13 @@ import ome.model.ILink;
 import ome.model.IObject;
 import ome.model.annotations.Annotation;
 import ome.model.annotations.FileAnnotation;
+import ome.model.annotations.MapAnnotation;
 import ome.model.annotations.TagAnnotation;
 import ome.model.annotations.TextAnnotation;
 import ome.model.annotations.TermAnnotation;
 import ome.model.core.OriginalFile;
 import ome.model.internal.Details;
+import ome.model.internal.NamedValue;
 import ome.model.internal.Permissions;
 import ome.model.meta.Event;
 import ome.model.meta.Experimenter;
@@ -207,6 +209,10 @@ public class FullTextBridge extends BridgeHelper {
                     FileAnnotation fileAnnotation = (FileAnnotation) annotation;
                     handleFileAnnotation(document, opts,
                             fileAnnotation);
+                } else if (annotation instanceof MapAnnotation) {
+                    MapAnnotation fileAnnotation = (MapAnnotation) annotation;
+                    handleMapAnnotation(document, opts,
+                            fileAnnotation);
                 }
             }
         }
@@ -352,6 +358,30 @@ public class FullTextBridge extends BridgeHelper {
                 add(document, "file.mimetype", file.getMimetype(), opts);
             }
             addContents(document, "file.contents", file, files, parsers, opts);
+        }
+    }
+
+    /**
+     * Creates {@link Field} instances for {@link MapAnnotation} named-value
+     * pair.
+     *
+     * @param document
+     * @param store
+     * @param index
+     * @param boost
+     * @param mapAnnotation
+     */
+    private void handleMapAnnotation(final Document document,
+            final LuceneOptions opts, MapAnnotation mapAnnotation) {
+
+        List<NamedValue> nvs = mapAnnotation.getMapValue();
+        if (nvs != null && nvs.size() > 0) {
+            for (NamedValue nv : nvs) {
+                if (nv != null) {
+                    add(document, nv.getName(), nv.getValue(), opts);
+                    add(document, "map.key", nv.getName(), opts);
+                }
+            }
         }
     }
 

--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -43,7 +43,7 @@ import org.hibernate.search.bridge.builtin.DateBridge;
  * Primary definition of what will be indexed via Hibernate Search. This class
  * is delegated to by the {@link DetailsFieldBridge}, and further delegates to
  * classes as defined under "SearchBridges".
- * 
+ *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3
  * @DEV.TODO insert/update OR delete regular type OR annotated type OR
@@ -81,7 +81,7 @@ public class FullTextBridge extends BridgeHelper {
 
     /**
      * Main constructor.
-     * 
+     *
      * @param files
      *            {@link OriginalFileServce} for getting access to binary files.
      * @param parsers
@@ -134,7 +134,7 @@ public class FullTextBridge extends BridgeHelper {
      * file which is then passed to
      * {@link #add(Document, String, Reader, Float)} using the field name
      * "file".
-     * 
+     *
      * @param name
      * @param object
      * @param document
@@ -155,7 +155,7 @@ public class FullTextBridge extends BridgeHelper {
     /**
      * Walks the various {@link Annotation} instances attached to the object
      * argument and adds various levels to the index.
-     * 
+     *
      * @param name
      * @param object
      * @param document
@@ -229,7 +229,7 @@ public class FullTextBridge extends BridgeHelper {
     /**
      * Parses all ownership and time-based details to the index for the given
      * object.
-     * 
+     *
      * @param name
      * @param object
      * @param document
@@ -297,7 +297,7 @@ public class FullTextBridge extends BridgeHelper {
      * Loops over each {@link #classes field bridge class} and calls its
      * {@link FieldBridge#set(String, Object, Document, Store, org.apache.lucene.document.Field.Index, Float)}
      * method. Any exceptions are logged but do not cancel execution.
-     * 
+     *
      * @param name
      * @param object
      * @param document
@@ -332,7 +332,7 @@ public class FullTextBridge extends BridgeHelper {
 
     /**
      * Creates {@link Field} instances for {@link FileAnnotation} objects.
-     * 
+     *
      * @param document
      * @param store
      * @param index
@@ -373,12 +373,10 @@ public class FullTextBridge extends BridgeHelper {
      */
     private void handleMapAnnotation(final Document document,
             final LuceneOptions opts, MapAnnotation mapAnnotation) {
-logger().error("handling map annotation");
         List<NamedValue> nvs = mapAnnotation.getMapValue();
         if (nvs != null && nvs.size() > 0) {
             for (NamedValue nv : nvs) {
                 if (nv != null) {
-logger().error("{}={}", nv.getName(), nv.getValue());
                     add(document, nv.getName(), nv.getValue(), opts);
                     add(document, "map.key", nv.getName(), opts);
                 }
@@ -390,7 +388,7 @@ logger().error("{}={}", nv.getName(), nv.getValue());
      * Return the short type name of an {@link Annotation}. If the instance is
      * an {@link ome.model.annotations.TextAnnotation} the returned value will
      * be "TextAnnotation".
-     * 
+     *
      * @param annotation
      * @return
      */

--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -378,7 +378,7 @@ public class FullTextBridge extends BridgeHelper {
             for (NamedValue nv : nvs) {
                 if (nv != null) {
                     add(document, nv.getName(), nv.getValue(), opts);
-                    add(document, "map.key", nv.getName(), opts);
+                    add(document, "has_key", nv.getName(), opts);
                 }
             }
         }

--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -207,12 +207,10 @@ public class FullTextBridge extends BridgeHelper {
                     }
                 } else if (annotation instanceof FileAnnotation) {
                     FileAnnotation fileAnnotation = (FileAnnotation) annotation;
-                    handleFileAnnotation(document, opts,
-                            fileAnnotation);
+                    handleFileAnnotation(document, opts, fileAnnotation);
                 } else if (annotation instanceof MapAnnotation) {
-                    MapAnnotation fileAnnotation = (MapAnnotation) annotation;
-                    handleMapAnnotation(document, opts,
-                            fileAnnotation);
+                    MapAnnotation mapAnnotation = (MapAnnotation) annotation;
+                    handleMapAnnotation(document, opts, mapAnnotation);
                 }
             }
         }
@@ -222,7 +220,9 @@ public class FullTextBridge extends BridgeHelper {
         if (object instanceof FileAnnotation) {
             FileAnnotation fileAnnotation = (FileAnnotation) object;
             handleFileAnnotation(document, opts, fileAnnotation);
-
+        } else if (object instanceof MapAnnotation) {
+            MapAnnotation mapAnnotation = (MapAnnotation) object;
+            handleMapAnnotation(document, opts, mapAnnotation);
         }
     }
 
@@ -373,11 +373,12 @@ public class FullTextBridge extends BridgeHelper {
      */
     private void handleMapAnnotation(final Document document,
             final LuceneOptions opts, MapAnnotation mapAnnotation) {
-
+logger().error("handling map annotation");
         List<NamedValue> nvs = mapAnnotation.getMapValue();
         if (nvs != null && nvs.size() > 0) {
             for (NamedValue nv : nvs) {
                 if (nv != null) {
+logger().error("{}={}", nv.getName(), nv.getValue());
                     add(document, nv.getName(), nv.getValue(), opts);
                     add(document, "map.key", nv.getName(), opts);
                 }

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -417,8 +417,8 @@ class TestSearch(lib.ITest):
                     x.id.val for x in search.results()
                 ], txt
 
-            # The value should not be found with as the key
-            # Nor the inverse v/k pair.
+            # The value should not be found as the key
+            # Nor should the inverse v/k pair return a result.
             for txt in ("%s:%s" % (val, key),
                         "%s:%s" % ("has_key", val)):
 

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -416,5 +416,14 @@ class TestSearch(lib.ITest):
                 assert proj.id.val in [
                     x.id.val for x in search.results()
                 ], txt
+
+            # The value should not be found with as the key
+            # Nor the inverse v/k pair.
+            for txt in ("%s:%s" % (val, key),
+                        "%s:%s" % ("has_key", val)):
+
+                search.byFullText(txt)
+                assert not search.hasNext(), txt
+
         finally:
             search.close()

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -410,7 +410,7 @@ class TestSearch(lib.ITest):
         try:
             for txt in (key, val,
                         "%s:%s" % (key, val),
-                        "map.key:%s" % key):
+                        "has_key:%s" % key):
                 search.byFullText(txt)
                 assert search.hasNext(), txt
                 assert proj.id.val in [


### PR DESCRIPTION
In order for the name-value pairs attach to objects
to be searchable by Lucene, a handler for the map
annotations needed to be added.

To discuss/do:
 * [ ] Which other map columns to index?
 * [x] Whether or not "map.key" is useful?
 * [x] Add documentation to the developers/Modules/Search.html page (https://github.com/openmicroscopy/ome-documentation/pull/1113)

To test:
 * Add a map annotation to an object and search for either the key or the value.
 * Additionally, searching for "key:value" should also return the object.