### PR TITLE
Fix jvmcfg unittests

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -79,7 +79,7 @@ class TestModel51(lib.ITest):
         # once it has been dropped.
         UL = [getattr(UL, x) for x in sorted(UL._names)]
 
-    @pytest.mark.parametrize("ul", UL)
+    @pytest.mark.parametrize("ul", UL, ids = [str(x) for x in UL])
     def testAllLengths(self, ul):
         one = omero.model.LengthI()
         one.setValue(1.0)

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -79,7 +79,7 @@ class TestModel51(lib.ITest):
         # once it has been dropped.
         UL = [getattr(UL, x) for x in sorted(UL._names)]
 
-    @pytest.mark.parametrize("ul", UL, ids = [str(x) for x in UL])
+    @pytest.mark.parametrize("ul", UL, ids=[str(x) for x in UL])
     def testAllLengths(self, ul):
         one = omero.model.LengthI()
         one.setValue(1.0)

--- a/components/tools/OmeroPy/test/unit/test_jvmcfg.py
+++ b/components/tools/OmeroPy/test/unit/test_jvmcfg.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2014-2015 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify
@@ -215,7 +215,7 @@ def template_xml():
 
 class TestAdjustStrategy(object):
 
-    @pytest.mark.parametrize("fixture", AFS)
+    @pytest.mark.parametrize("fixture", AFS, ids=[x.name for x in AFS])
     def test_adjust(self, fixture):
         p = write_config(fixture.input)
         xml = template_xml()

--- a/components/tools/OmeroPy/test/unit/test_jvmcfg.py
+++ b/components/tools/OmeroPy/test/unit/test_jvmcfg.py
@@ -216,7 +216,9 @@ def template_xml():
 class TestAdjustStrategy(object):
 
     @pytest.mark.parametrize("fixture", AFS, ids=[x.name for x in AFS])
-    def test_adjust(self, fixture):
+    def test_adjust(self, fixture, monkeypatch):
+        monkeypatch.setattr(Strategy, '_system_memory_mb_java',
+                            lambda x: (2000, 4000))
         p = write_config(fixture.input)
         xml = template_xml()
         config = ConfigXml(filename=str(p), env_config="default")

--- a/components/tools/OmeroPy/test/unit/test_model.py
+++ b/components/tools/OmeroPy/test/unit/test_model.py
@@ -343,7 +343,7 @@ class TestModel(object):
         # once it has been dropped.
         UL = [getattr(UL, x) for x in sorted(UL._names)]
 
-    @pytest.mark.parametrize("ul", UL)
+    @pytest.mark.parametrize("ul", UL, ids=[str(x) for x in UL])
     def testEnumerators(self, ul):
         assert hasattr(omero.model.enums.UnitsLength, str(ul))
 

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -34,7 +34,7 @@ build_java()
 
 build_python()
 {
-    flake8 -v .
+    flake8 .
     ./build.py build-default
     ./build.py -py test -Dtest.with.fail=true -DMARK="not broken"
     ./build.py -fs test -Dtest.with.fail=true -DMARK="not broken"


### PR DESCRIPTION
As reported by @mtbc, the unit tests for the JVM configuration can vary depending on the level where they run, i.e. the following commands report different results

```
$ ./build.py -f components/tools/OmeroPy/build.xml test -DTEST=test/unit/test_jvmcfg.py
$ cd components/tools/OmeroPy && ./setup.py test -t test/unit/test_jvmcfg.py -v
```

This is due to one of the tests using the `server.jar` to calculate the system memory and not the other (because of a path issue). In all cases, some of the tests in the `testjvmcfg.json` have assumptions on the memory configuration of the system. This PR is monkeypatching `Strategy._system_memory_mb_java()` to return the default value. In a more advanced version of this PR, these settings could be made variable and also stored in the JSON.
Additionally, the fixtures are now properly named by settings the `ids` keyword.

To test this PR, check both top-level and OmeroPy level tests pass.
