### PR TITLE
Add extra event to return logfile id early.

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportEvent.java
+++ b/components/blitz/src/ome/formats/importer/ImportEvent.java
@@ -410,6 +410,22 @@ public class ImportEvent {
     // These extra PROGRESS_EVENT classes are added to allow some meaningful
     // event reporting under FS rather than abusing the ones above
 
+    public static class IMPORT_STARTED extends POST_UPLOAD_EVENT {
+        public IMPORT_STARTED(int index, String filename, IObject target,
+                Long pixId, int series, ImportSize size,
+                Integer numDone, Integer total, Long fsId) {
+            super(index, filename, target, pixId, series, size, numDone, total, fsId);
+        }
+
+        @Override
+        public String toLog() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(getClass().getSimpleName());
+            sb.append(String.format(" Logfile: %d", logFileId));
+            return sb.toString();
+        }
+    }
+
     public static class METADATA_IMPORTED extends POST_UPLOAD_EVENT {
         public METADATA_IMPORTED(int index, String filename, IObject target,
                 Long pixId, int series, ImportSize size,

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -560,6 +560,9 @@ public class ImportLibrary implements IObservable
                 this.container = container;
                 this.logFileId = loadLogFile();
                 initializationDone();
+                notifyObservers(new ImportEvent.IMPORT_STARTED(
+                        0, this.container.getFile().getAbsolutePath(),
+                        null, null, 0, null, 0, 0, logFileId));
         }
 
         protected Long loadLogFile() throws ServerError {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -707,9 +707,6 @@ public class StatusLabel
                 processingBar.setString(STEPS.get(step));
             }
         } else if (event instanceof ImportEvent.METADATA_IMPORTED) {
-            ImportEvent.METADATA_IMPORTED e =
-                    (ImportEvent.METADATA_IMPORTED) event;
-            if (e.logFileId != null) logFileID = e.logFileId;
             step = 2;
             processingBar.setValue(step);
             processingBar.setString(STEPS.get(step));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -737,6 +737,12 @@ public class StatusLabel
             firePropertyChange(FILE_IMPORT_STARTED_PROPERTY, null, this);
         } else if (event instanceof ImportEvent.FILESET_UPLOAD_PREPARATION) {
             generalLabel.setText("Preparing upload...");
+        } else if (event instanceof ImportEvent.IMPORT_STARTED) {
+            ImportEvent.IMPORT_STARTED e =
+                    (ImportEvent.IMPORT_STARTED) event;
+            if (e.logFileId != null) {
+                logFileID = e.logFileId;
+            }
         }
     }
 


### PR DESCRIPTION
This is a PR for @jburel's evaluation. An extra `POST_UPLOAD` event, `IMPORT_STARTED` has been added and propagated to give the logfile ID to the client as early as possible. Previously the ID was sent after the metadata import step. For direct testing the cli importer should show something like the following on the console:
```
...
2015-01-23 09:15:05,016 11413      [      main] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_END
2015-01-23 09:15:05,614 12011      [      main] INFO   ormats.importer.cli.LoggingImportMonitor - IMPORT_STARTED Import started. Logfile: 152
2015-01-23 09:15:07,561 13958      [l.Client-0] INFO   ormats.importer.cli.LoggingImportMonitor - METADATA_IMPORTED Step: 1 of 5  Logfile: 152
...
```
For testing within Insight an image file that fails early on import would be useful. @pwalczysko may be able to provide details.

To test this PR, you can use the following image on squig
```
data_repo/test_images_broken/broken_images_scenario/fails_at_processing/wrong-detector-settings-mk1.ome
```
