### PR TITLE
Fixed ROI issue with floating point images

### DIFF
--- a/components/blitz/src/pojos/PixelsData.java
+++ b/components/blitz/src/pojos/PixelsData.java
@@ -72,9 +72,9 @@ public class PixelsData extends DataObject {
 
     /**
      * Identifies the type used to store pixel values. Maps onto the <i>OME</i>
-     * <code>double</code> string identifier.
+     * <code>float</code> string identifier.
      */
-    public static final String FLOAT_TYPE = "double";
+    public static final String FLOAT_TYPE = "float";
 
     /**
      * Identifies the type used to store pixel values. Maps onto the <i>OME</i>


### PR DESCRIPTION
Fixes ticket [Trac 12711](https://trac.openmicroscopy.org.uk/ome/ticket/12711)

To Test:
Open/Import floating point image; open ROI tool, draw/select ROI, make sure Graph, Intensity and Result tabs are working (without PR just a warning dialog popped up, saying there was an error performing the analysis)
