### PR TITLE
Fix 'Save to All' in web preview panel

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1827,8 +1827,7 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
         if fromid is None:
             # if we have rdef, save to source image, then use that image as
             # 'fromId', then revert.
-            if request.session.get('rdef') is not None and len(toids) > 0:
-                rdef = request.session.get('rdef')
+            if rdef is not None and len(toids) > 0:
                 fromImage = conn.getObject("Image", rdef['imageId'])
                 if fromImage is not None:
                     # copy orig settings


### PR DESCRIPTION
See: https://trac.openmicroscopy.org/ome/ticket/12697

Fixes the "Save to all" button in web preview panel.
To test:

 - Choose an image with other similar ones in the same Dataset
 - Edit rendering settings in Preview Panel and click "Save to all".
 - Other compatible images in the Dataset should be updated (thumbnails) and
    the rdef thumbnail in the Preview panel should also update.