### PR TITLE
remove unused and wrong import (rebased from dev_5_0)

### DIFF
--- a/components/insight/TEST/org/openmicroscopy/shoola/env/data/LuceneQueryBuilderTest.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/env/data/LuceneQueryBuilderTest.java
@@ -31,8 +31,6 @@ import org.openmicroscopy.shoola.util.ui.search.LuceneQueryBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-
 @Test(testName = "LuceneQueryBuilderTest", enabled=false)
 public class LuceneQueryBuilderTest {
 


### PR DESCRIPTION
Trivial fix to remove an emory import that wasn't used anyway.

--rebased-from #3389