### PR TITLE
Sort users on last name in the webclient group dropdown

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2754,10 +2754,10 @@ class _BlitzGateway (object):
                 leaders = [self.getUser()]
             else:
                 colleagues = [self.getUser()]
-                
+
         colleagues.sort(key=lambda x: x.getLastName().lower())
         leaders.sort(key=lambda x: x.getLastName().lower())
-        
+
         return {"leaders": leaders, "colleagues": colleagues}
 
     def listStaffs(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2754,6 +2754,10 @@ class _BlitzGateway (object):
                 leaders = [self.getUser()]
             else:
                 colleagues = [self.getUser()]
+                
+        colleagues.sort(key=lambda x: x.getLastName().lower())
+        leaders.sort(key=lambda x: x.getLastName().lower())
+        
         return {"leaders": leaders, "colleagues": colleagues}
 
     def listStaffs(self):


### PR DESCRIPTION
The Users/Groups dropdown in the webclient is not sorted on anything at the moment. This will sort the list on last name.
I'm not sure this is the preferable way to fix this, or whether you would like this configurable. 

How to test: check whether the dropdown is sorted on last name.