### PR TITLE
Split view figure, z/t plane

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/SaveRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/SaveRndSettingsAction.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.actions.SaveRndSettingsAction
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -61,7 +61,7 @@ public class SaveRndSettingsAction
     /** Sets the flag depending on the permissions of the group. */
     private void handleChange()
     {
-    	if (model.isOriginalSettings()) {
+    	if (model.isOriginalSettings(true)) {
     		setEnabled(false);
     	} else {
     		setEnabled(model.canAnnotate());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1,7 +1,7 @@
 /* * org.openmicroscopy.shoola.agents.iviewer.view.ImViewer
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -999,9 +999,11 @@ public interface ImViewer
 	 * Returns <code>true</code> if the rendering settings used to render 
 	 * the image are the original ones, <code>false</code> otherwise.
 	 * 
+	 * @param checkPlane Pass <code>true</code> to check the plane,
+	 * 					 <code>false</code> otherwise.
 	 * @return See above.
 	 */
-	public boolean isOriginalSettings();
+	public boolean isOriginalSettings(boolean checkPlane);
 
 	/**
 	 * Sets the rendering settings to paste.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -306,7 +306,7 @@ class ImViewerComponent
 		JPanel p = new JPanel();
 		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
 		JCheckBox rndBox = null;
-		if (!model.isOriginalSettings()) {
+		if (!model.isOriginalSettings(true)) {
 			rndBox = new JCheckBox(RND);
 			rndBox.setSelected(true);
 			p.add(rndBox);
@@ -616,7 +616,7 @@ class ImViewerComponent
 	boolean hasSettingsToSave()
 	{
 		if (failureToSave) return false;
-		return !isOriginalSettings();
+		return !isOriginalSettings(true);
 	}
 	
 	/**
@@ -2809,14 +2809,14 @@ class ImViewerComponent
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#isOriginalSettings()
 	 */
-	public boolean isOriginalSettings()
+	public boolean isOriginalSettings(boolean checkPlane)
 	{
 		switch (model.getState()) {
 			case DISCARDED:
 				throw new IllegalArgumentException("This method cannot be " +
 				"invoked in the DISCARDED state.");
 		}
-		return model.isOriginalSettings();
+		return model.isOriginalSettings(checkPlane);
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2241,15 +2241,17 @@ class ImViewerModel
 	 * Returns <code>true</code> if the rendering settings are original,
 	 * <code>false</code> otherwise.
 	 * 
+	 * @param checkPlane Pass <code>true</code> to check the plane,
+	 * 					 <code>false</code> otherwise.
 	 * @return See above.
 	 */
-	boolean isOriginalSettings()
+	boolean isOriginalSettings(boolean checkPlane)
 	{
 		if (originalDef == null) return true;
 		if (metadataViewer == null) return true;
 		Renderer rnd = metadataViewer.getRenderer();
 		if (rnd == null) return true;
-		return isSameSettings(originalDef, false);
+		return isSameSettings(originalDef, checkPlane);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -1849,7 +1849,7 @@ class ImViewerModel
 	{
             RndProxyDef rndDef = null;
             Renderer rnd = metadataViewer.getRenderer();
-            if (rnd != null && rnd.isModified()) {
+            if (rnd != null && rnd.isModified(false)) {
                 rndDef = rnd.getRndSettingsCopy();
             }
             

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.actions.ManageRndSettingsAction
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -306,7 +306,7 @@ public class ManageRndSettingsAction
     private void copyRndSettings() {
 
             CopyRndSettings evt;
-            if (model.isModified()) {
+            if (model.isModified(false)) {
                 // copy the current 'pending' rendering settings
                 evt = new CopyRndSettings(model.getRefImage(), model.getRndSettingsCopy());
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -807,9 +807,12 @@ public interface Renderer
      * Returns <code>true</code> if the rendering settings 
      * have been modified
      *
+     * @param checkPlane Pass <code>true</code> to check the plane,
+	 * <code>false</code> otherwise.
+	 * 
      * @return See above.
      */
-    boolean isModified();
+    boolean isModified(boolean checkPlane);
     
     /**
      * Enables/Disables the paste action

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1010,8 +1010,8 @@ class RendererComponent
         * Implemented as specified by the {@link Renderer} interface.
         * @see Renderer#isModified()
         */
-	public boolean isModified() {
-	    return model.isModified();
+	public boolean isModified(boolean checkPlane) {
+	    return model.isModified(checkPlane);
 	}
 	
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.RendererControl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -451,7 +451,7 @@ class RendererControl
             actionsMap.get(SAVE).setEnabled(false);
         } 
         else {
-            boolean settingsModified = model.isModified();
+            boolean settingsModified = model.isModified(true);
             actionsMap.get(SAVE).setEnabled(settingsModified && model.canAnnotate());
         }
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -1398,12 +1398,15 @@ class RendererModel
        /**
         * Returns <code>true</code> if the rendering settings 
         * have been modified
-        *
+        * 
+        * @param checkPlane Pass <code>true</code> to check the plane,
+	    * <code>false</code> otherwise.
+	    * 
         * @return See above.
         */
-	boolean isModified() {
+	boolean isModified(boolean checkPlane) {
 	    if(rndControl!=null) {
-	        return !rndControl.isSameSettings(rndDef, false);
+	        return !rndControl.isSameSettings(rndDef, checkPlane);
 	    }
 	    return false;
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
@@ -1991,6 +1991,7 @@ public class FigureDialog
 		if (renderer == null)
 			throw new IllegalArgumentException("No renderer.");
 		this.renderer = renderer;
+		this.renderer.resetSettings();
 		rndDef = renderer.getInitialRndSettings();
 		channelsPane.removeAll();
 		switch (dialogType) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.util.FigureDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -1991,7 +1991,7 @@ public class FigureDialog
 		if (renderer == null)
 			throw new IllegalArgumentException("No renderer.");
 		this.renderer = renderer;
-		rndDef = renderer.getRndSettingsCopy();
+		rndDef = renderer.getInitialRndSettings();
 		channelsPane.removeAll();
 		switch (dialogType) {
 			case SPLIT:


### PR DESCRIPTION
Fixes [Trac 12709](https://trac.openmicroscopy.org.uk/ome/ticket/12709)

Note: But this will introduce a slight inconsistency. Z/T is part of the rendering settings. With this PR you can now save changes to Z/T, but you cannot undo/redo them like the other rendering settings.

Test: 
Select a multi-Z/T image. Modify the Z and/or T plane (full viewer and/or preview pane). Make sure the save button is enabled, but don't save. Open the 'Split View Figure' dialog. Make sure that the preview shows the saved Z/T plane and not your current non-saved modification of the plane.
