### PR TITLE
Add omero.web.prefix as an alias for FORCE_SCRIPT_NAME

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -709,6 +709,17 @@ def report_settings(module):
                 "%s = %r (source:%s)", global_name,
                 cleanse_setting(global_name, global_value), source)
 
+    deprecated_settings = getattr(module, 'DEPRECATED_SETTINGS_MAPPINGS', {})
+    for key in sorted(deprecated_settings):
+        values = deprecated_settings[key]
+        global_name, default_value, mapping, description, using_default = \
+            values
+        global_value = getattr(module, global_name, None)
+        if global_name.isupper() and not using_default:
+            logger.warning(
+                "%s = %r (Deprecated: %s, %s)", global_name,
+                cleanse_setting(global_name, global_value), key, description)
+
 report_settings(sys.modules[__name__])
 
 SITE_ID = 1

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -301,11 +301,6 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["APPLICATION_SERVER_PORT", "4080", str, "Upstream application port"],
     "omero.web.application_server.max_requests":
         ["APPLICATION_SERVER_MAX_REQUESTS", 400, int, None],
-    "omero.web.force_script_name":
-        ["FORCE_SCRIPT_NAME",
-         None,
-         leave_none_unset,
-         ("DEPRECATED, use omero.web.prefix instead.")],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",
          None,
@@ -586,6 +581,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Configuration options for the viewer. -1: zoom in fully,"
           " 0: zoom out fully, unset: zoom to fit window")],
 
+}
+
+DEPRECATED_SETTINGS_MAPPINGS = {
+    # Deprecated settings, description should indicate the replacement.
+    "omero.web.force_script_name":
+        ["FORCE_SCRIPT_NAME",
+         None,
+         leave_none_unset,
+         ("Use omero.web.prefix instead.")],
 }
 
 del CUSTOM_HOST

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -716,8 +716,8 @@ def report_settings(module):
             values
         global_value = getattr(module, global_name, None)
         if global_name.isupper() and not using_default:
-            logger.warning(
-                "%s = %r (Deprecated: %s, %s)", global_name,
+            logger.debug(
+                "%s = %r (deprecated:%s, %s)", global_name,
                 cleanse_setting(global_name, global_value), key, description)
 
 report_settings(sys.modules[__name__])

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -305,6 +305,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["FORCE_SCRIPT_NAME",
          None,
          leave_none_unset,
+         ("DEPRECATED, use omero.web.prefix instead.")],
+    "omero.web.prefix":
+        ["FORCE_SCRIPT_NAME",
+         None,
+         leave_none_unset,
          ("Used as the value of the SCRIPT_NAME environment variable in any"
           " HTTP request.")],
     "omero.web.static_url":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -627,10 +627,6 @@ def map_deprecated_settings(settings):
 
 def process_custom_settings(
         module, settings='CUSTOM_SETTINGS_MAPPINGS', deprecated=None):
-    """
-    Handle deprecated settings. If both the old and new keys are set then
-    raise an exception, otherwise copy the deprecated property to the new one
-    """
     logging.info('Processing custom settings for module %s' % module.__name__)
 
     if deprecated:


### PR DESCRIPTION
See https://trello.com/c/C5yQwFGk/374-omero-web-use-omero-web-prefix-in-place-of-omero-web-force-script-name

At the moment both `omero.web.force_script_name` and `omero.web.prefix` have the same effect for backwards compatibility.