### PR TITLE
Add permissions tests for CLI tag plugin

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -899,6 +899,18 @@ class ProjectionFixture(object):
         self.canEdit = canEdit
         self.canLink = canLink
 
+    def get_name(self):
+        name = self.perms
+        for e in [self.writer, self.reader]:
+            name += "-"
+            if "admin" in e:
+                name += "admin"
+            elif "owner" in e:
+                name += "owner"
+            else:
+                name += "member"
+        return name
+
 PF = ProjectionFixture
 PFS = (
     # Private group as root

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -875,3 +875,76 @@ class ITest(object):
             commands.append(Chgrp(t, id=i.id.val, grp=target))
 
         self.doAllSubmit(commands, client)
+
+
+class ProjectionFixture(object):
+    """
+    Used to test the return values from:
+        'select x.permissions from Object x'
+    """
+
+    def __init__(self, perms, writer, reader,
+                 canRead,
+                 canAnnotate=False, canDelete=False,
+                 canEdit=False, canLink=False):
+        self.perms = perms
+        self.writer = writer
+        self.reader = reader
+
+        self.canRead = canRead
+        self.canAnnotate = canAnnotate
+        self.canDelete = canDelete
+        self.canEdit = canEdit
+        self.canLink = canLink
+
+PF = ProjectionFixture
+PFS = (
+    # Private group as root
+    PF("rw----", "system-admin", "system-admin", 1, 0, 1, 1, 0),
+    PF("rw----", "system-admin", "group-owner", 1, 0, 1, 1, 0),
+    PF("rw----", "system-admin", "member2", 0),
+    # Private group as group-owner
+    PF("rw----", "group-owner", "system-admin", 1, 0, 1, 1, 0),
+    PF("rw----", "group-owner", "group-owner", 1, 0, 1, 1, 0),
+    PF("rw----", "group-owner", "member2", 0),
+    # Private group as member
+    PF("rw----", "member1", "system-admin", 1, 0, 1, 1, 0),
+    PF("rw----", "member1", "group-owner", 1, 0, 1, 1, 0),
+    PF("rw----", "member1", "member2", 0),
+    # Read-only group as root
+    PF("rwr---", "system-admin", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwr---", "system-admin", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwr---", "system-admin", "member2", 1, 0, 0, 0, 0),
+    # Read-only group as group-owner
+    PF("rwr---", "group-owner", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwr---", "group-owner", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwr---", "group-owner", "member2", 1, 0, 0, 0, 0),
+    # Read-only group as member
+    PF("rwr---", "member1", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwr---", "member1", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwr---", "member1", "member2", 1, 0, 0, 0, 0),
+    # Read-annotate group as root
+    PF("rwra--", "system-admin", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwra--", "system-admin", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwra--", "system-admin", "member2", 1, 1, 0, 0, 0),
+    # Read-annotate group as group-owner
+    PF("rwra--", "group-owner", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwra--", "group-owner", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwra--", "group-owner", "member2", 1, 1, 0, 0, 0),
+    # Read-annotate group as member
+    PF("rwra--", "member1", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwra--", "member1", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwra--", "member1", "member2", 1, 1, 0, 0, 0),
+    # Read-write group as root
+    PF("rwrw--", "system-admin", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwrw--", "system-admin", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwrw--", "system-admin", "member2", 1, 1, 1, 1, 1),
+    # Read-write group as group-owner
+    PF("rwrw--", "group-owner", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwrw--", "group-owner", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwrw--", "group-owner", "member2", 1, 1, 1, 1, 1),
+    # Read-write group as member
+    PF("rwrw--", "member1", "system-admin", 1, 1, 1, 1, 1),
+    PF("rwrw--", "member1", "group-owner", 1, 1, 1, 1, 1),
+    PF("rwrw--", "member1", "member2", 1, 1, 1, 1, 1),
+)

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -125,12 +125,14 @@ class ITest(object):
         return str(_uuid.uuid4())
 
     @classmethod
-    def login_args(self, key=None):
+    def login_args(self, client=None):
         p = self.client.ic.getProperties()
         host = p.getProperty("omero.host")
         port = p.getProperty("omero.port")
-        if not key:
+        if not client:
             key = self.sf.ice_getIdentity().name
+        else:
+            key = client.sf.ice_getIdentity().name
         return ["-s", host, "-k", key, "-p", port]
 
     @classmethod

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -473,7 +473,8 @@ JSON File Format:
         client = self.ctx.conn(args)
         session = client.getSession()
         update_service = session.getUpdateService()
-        update_service.saveArray([tag])
+        tag = update_service.saveAndReturnObject(tag)
+        self.ctx.out("TagAnnotation:%s" % tag.id.val)
 
     def createset(self, args):
         """
@@ -502,7 +503,8 @@ JSON File Format:
         session = client.getSession()
         update_service = session.getUpdateService()
         try:
-            update_service.saveArray(links)
+            links = update_service.saveAndReturnArray(links)
+            self.ctx.out("TagAnnotation:%s" % links[0].parent.id.val)
         except omero.ValidationException as e:
             self.ctx.err(e.message)
             self.ctx.err("Check that tag '%s' exists." % t)
@@ -544,7 +546,9 @@ JSON File Format:
         client = self.ctx.conn(args)
         session = client.getSession()
         update_service = session.getUpdateService()
-        update_service.saveArray(to_add)
+        to_add = update_service.saveAndReturnArray(to_add)
+        for link in to_add:
+            self.ctx.out("TagAnnotation:%s" % link[0].parent.id.val)
 
     def link(self, args):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -547,8 +547,12 @@ JSON File Format:
         session = client.getSession()
         update_service = session.getUpdateService()
         to_add = update_service.saveAndReturnArray(to_add)
-        for link in to_add:
-            self.ctx.out("TagAnnotation:%s" % link[0].parent.id.val)
+        for element in to_add:
+            if isinstance(element, TagAnnotationI):
+                self.ctx.out("TagAnnotation:%s" % element.id.val)
+            else:
+                self.ctx.out("AnnotationAnnotationLink:%s"
+                             % element.id.val)
 
     def link(self, args):
         """
@@ -595,7 +599,8 @@ JSON File Format:
                 "Object query returned nothing. Check your object type.")
             sys.exit(1)
         obj.linkAnnotation(annotation)
-        update_service.saveAndReturnObject(obj)
+        obj = update_service.saveAndReturnObject(obj)
+        self.ctx.out("%sAnnotationLink:%s" % (obj_type, obj.id.val))
 
     def list(self, args):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -597,6 +597,9 @@ JSON File Format:
         except omero.SecurityViolation, sv:
             self.ctx.die(510, "SecurityViolation: %s" % sv.message)
 
+        if not annotation:
+            self.ctx.die(400, "Could not find annotation")
+
         obj = query_service.findByQuery(
             "select o from %s as o "
             "left outer join fetch o.annotationLinks "

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -547,12 +547,16 @@ JSON File Format:
         session = client.getSession()
         update_service = session.getUpdateService()
         to_add = update_service.saveAndReturnArray(to_add)
+        ids = []
         for element in to_add:
             if isinstance(element, TagAnnotationI):
                 self.ctx.out("TagAnnotation:%s" % element.id.val)
+                ids.append(element.id.val)
             else:
-                self.ctx.out("AnnotationAnnotationLink:%s"
-                             % element.id.val)
+                tag_id = element.parent.id.val
+                if tag_id not in ids:
+                    self.ctx.out("TagAnnotation:%s" % tag_id)
+                    ids.append(tag_id)
 
     def link(self, args):
         """

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -254,6 +254,26 @@ class TestTag(AbstractTagTest):
         link = self.get_link(object_type, oid)
         assert link.child.id.val == tid
 
+    def testLinkInvalidObject(self):
+        # Create a tag and an image
+        tid = self.create_tags(1, "%s" % self.uuid())
+
+        # Call tag link subcommand
+        self.args += ["link", "Project:0", "%s" % tid]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+
+    def testLinkInvalidTag(self):
+        # Create a tag and an image
+        img = self.new_image()
+        img.name = rstring("%s" % self.uuid())
+        img = self.update.saveAndReturnObject(img)
+
+        # Call tag link subcommand
+        self.args += ["link", "Image:%s" % img.id.val, "-1"]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+
 
 class TestPermissions(AbstractTagTest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -290,8 +290,7 @@ class TestPermissions(AbstractTagTest):
         self.args += ["link"]
         self.args += self.login_args(reader)
         self.args += ["Image:%s" % img.id.val, "%s" % tag.id.val]
-        print self.args
-        if fixture.canRead and fixture.canLink:
+        if fixture.canAnnotate:
             self.cli.invoke(self.args, strict=True)
 
             # Check link

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -268,7 +268,7 @@ class TestPermissions(AbstractTagTest):
         super(TestPermissions, self).setup_method(method)
         self.args = ["tag"]
 
-    @pytest.mark.parametrize('fixture', PFS)
+    @pytest.mark.parametrize('fixture', PFS, ids=[x.get_name() for x in PFS])
     def testLink(self, fixture):
         # Create a tag and an image
         tag = self.new_tag()

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -887,7 +887,8 @@ class TestPermissionProjections(lib.ITest):
         assert expected_arr == found_arr
 
     @pytest.mark.broken(ticket="12474")
-    @pytest.mark.parametrize("fixture", lib.PFS)
+    @pytest.mark.parametrize("fixture", lib.PFS,
+                             ids=[x.get_name() for x in lib.PFS])
     def testProjectionPermissions(self, fixture):
         writer = self.writer(fixture)
         reader = self.reader(fixture)

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -905,7 +905,8 @@ class TestPermissionProjections(lib.ITest):
         else:
             self.assertPerms(perms, fixture)
 
-    @pytest.mark.parametrize("fixture", lib.PFS)
+    @pytest.mark.parametrize("fixture", lib.PFS,
+                             ids=[x.get_name() for x in lib.PFS])
     def testProjectionPermissionsWorkaround(self, fixture):
         writer = self.writer(fixture)
         reader = self.reader(fixture)

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -846,94 +846,6 @@ class TestPermissions(lib.ITest):
         })
 
 
-# canX accessor methods
-# ===================================================
-
-
-class ProjectionFixture(object):
-
-    """
-    Used to test the return values from:
-        'select x.permissions from Object x'
-    """
-
-    def __init__(self, perms, writer, reader,
-                 canRead,
-                 canAnnotate=False, canDelete=False,
-                 canEdit=False, canLink=False):
-        self.perms = perms
-        self.writer = writer
-        self.reader = reader
-
-        self.canRead = canRead
-        self.canAnnotate = canAnnotate
-        self.canDelete = canDelete
-        self.canEdit = canEdit
-        self.canLink = canLink
-
-    def __repr__(self):
-        v = ("PF(perms=%s,writer=%s,reader=%s,"
-             "canRead=%s,canAnnotate=%s,canDelete=%s,"
-             "canEdit=%s,canLink=%s")
-        return v % (
-            self.perms, self.writer, self.reader,
-            self.canRead, self.canAnnotate, self.canDelete,
-            self.canEdit, self.canLink
-        )
-
-PF = ProjectionFixture
-PFS = (
-    # Private group as root
-    PF("rw----", "system-admin", "system-admin", 1, 0, 1, 1, 0),
-    PF("rw----", "system-admin", "group-owner", 1, 0, 1, 1, 0),
-    PF("rw----", "system-admin", "member2", 0),
-    # Private group as group-owner
-    PF("rw----", "group-owner", "system-admin", 1, 0, 1, 1, 0),
-    PF("rw----", "group-owner", "group-owner", 1, 0, 1, 1, 0),
-    PF("rw----", "group-owner", "member2", 0),
-    # Private group as member
-    PF("rw----", "member1", "system-admin", 1, 0, 1, 1, 0),
-    PF("rw----", "member1", "group-owner", 1, 0, 1, 1, 0),
-    PF("rw----", "member1", "member2", 0),
-    # Read-only group as root
-    PF("rwr---", "system-admin", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwr---", "system-admin", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwr---", "system-admin", "member2", 1, 0, 0, 0, 0),
-    # Read-only group as group-owner
-    PF("rwr---", "group-owner", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwr---", "group-owner", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwr---", "group-owner", "member2", 1, 0, 0, 0, 0),
-    # Read-only group as member
-    PF("rwr---", "member1", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwr---", "member1", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwr---", "member1", "member2", 1, 0, 0, 0, 0),
-    # Read-annotate group as root
-    PF("rwra--", "system-admin", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwra--", "system-admin", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwra--", "system-admin", "member2", 1, 1, 0, 0, 0),
-    # Read-annotate group as group-owner
-    PF("rwra--", "group-owner", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwra--", "group-owner", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwra--", "group-owner", "member2", 1, 1, 0, 0, 0),
-    # Read-annotate group as member
-    PF("rwra--", "member1", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwra--", "member1", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwra--", "member1", "member2", 1, 1, 0, 0, 0),
-    # Read-write group as root
-    PF("rwrw--", "system-admin", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwrw--", "system-admin", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwrw--", "system-admin", "member2", 1, 1, 1, 1, 1),
-    # Read-write group as group-owner
-    PF("rwrw--", "group-owner", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwrw--", "group-owner", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwrw--", "group-owner", "member2", 1, 1, 1, 1, 1),
-    # Read-write group as member
-    PF("rwrw--", "member1", "system-admin", 1, 1, 1, 1, 1),
-    PF("rwrw--", "member1", "group-owner", 1, 1, 1, 1, 1),
-    PF("rwrw--", "member1", "member2", 1, 1, 1, 1, 1),
-)
-
-
 class TestPermissionProjections(lib.ITest):
 
     _group = None
@@ -975,7 +887,7 @@ class TestPermissionProjections(lib.ITest):
         assert expected_arr == found_arr
 
     @pytest.mark.broken(ticket="12474")
-    @pytest.mark.parametrize("fixture", PFS)
+    @pytest.mark.parametrize("fixture", lib.PFS)
     def testProjectionPermissions(self, fixture):
         writer = self.writer(fixture)
         reader = self.reader(fixture)
@@ -993,7 +905,7 @@ class TestPermissionProjections(lib.ITest):
         else:
             self.assertPerms(perms, fixture)
 
-    @pytest.mark.parametrize("fixture", PFS)
+    @pytest.mark.parametrize("fixture", lib.PFS)
     def testProjectionPermissionsWorkaround(self, fixture):
         writer = self.writer(fixture)
         reader = self.reader(fixture)


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11628

This PR;
- moves the permissions fixtures to the common library and adds a `get_name()` method to return a short name used in fixtures (instead of `fixturexxx`)
- modifies the CLI tag creation commands to return the created object under the form `TagAnnotation:xxx` in the standard output
- adds try/except statement in the CLI `tag link` subcommand to handle permission exceptions
- adds permissions test for the `tag link` subcommand using the PermissionsFixture