### PR TITLE
Cancel all

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1073,7 +1073,29 @@ public class FileImportComponent
 		}
 		return false;
 	}
-	
+
+	/**
+	 * Returns <code>true</code> if the component has imports to cancel,
+	 * <code>false</code> otherwise.
+	 * 
+	 * @return See above.
+	 */
+    public boolean hasImportToCancel()
+    {
+        boolean b = statusLabel.isMarkedAsCancel();
+        if (b) return false;
+        if (getFile().isFile() && !hasImportStarted()) return true;
+        if (components == null) return false;
+        Iterator<FileImportComponent> i = components.values().iterator();
+        FileImportComponent fc;
+        while (i.hasNext()) {
+            fc = i.next();
+            if (!fc.isCancelled() && !fc.hasImportStarted())
+                return true;
+        }
+        return false;
+    }
+    
 	/**
 	 * Returns <code>true</code> if the file can be re-imported,
 	 * <code>false</code> otherwise.
@@ -1127,7 +1149,7 @@ public class FileImportComponent
 		}
 		return count == components.size();
 	}
-	
+
 	/**
 	 * Returns <code>true</code> the error can be submitted, <code>false</code>
 	 * otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -897,7 +897,7 @@ class ImporterUIElement
 	boolean hasImportToCancel()
 	{
 	    for (final FileImportComponent fic : components.values()) {
-	    	if (!(fic.hasImportStarted() || fic.isCancelled())) {
+	    	if (fic.hasImportToCancel()) {
 	            return true;
 	        }
 	    }


### PR DESCRIPTION
Fix ticket https://trac.openmicroscopy.org.uk/ome/ticket/12165

To test: 
test 1
 * Select a folder to import
 * When scanning is done, cancel elements. Make sure the "Cancel All" button is enabled until there are still some import to cancel.

test 2
 * Select few files to import
 * When scanning is done, cancel elements. Make sure the "Cancel All" button is enabled until there are still some import to cancel.
