### PR TITLE
Increase web zooming rate to 5% for non pyramid images

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -377,7 +377,7 @@ jQuery.fn.viewportImage = function(options) {
 
     this.doZoom = function (increment, justDirection, center) {
       if (justDirection) {
-        var t = Math.max(1,((imagewidth+3)*cur_zoom/imagewidth) - cur_zoom);
+        var t = Math.max(5,((imagewidth+3)*cur_zoom/imagewidth) - cur_zoom);
         increment = cur_zoom + (increment>0?t:-t);
       }
       this.setZoom(parseInt(increment, 10), null, null, center);


### PR DESCRIPTION
For us, the zooming rate of 1% for non pyramid images in the webclient is agonizing slow. It's much slower in scroll zooming of pyramided files (which for us increase by rate of 20% per zoom). 

This increases that rate to 5%.