### PR TITLE
Column can be a group or user (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.html
@@ -40,7 +40,7 @@
 
             <table id="drivespaceTable" class="tablesorter" style="display: none;">
                 <thead>
-                    <tr><th>User</th><th>Usage</th></tr>
+                    <tr><th>Group/User</th><th>Usage</th></tr>
                 </thead>
                 <tbody>
                 </tbody>


### PR DESCRIPTION

This is the same as gh-3398 but rebased onto develop.

----

In OMERO.webadmin the drive space statistics table can either be by group or by user. This PR includes a very simple visual change to the column header from `User` to `Group/User`. As the content is loaded by AJAX, changing the header itself based on the type of data being displayed is much more involved.

To test, open up OMERO.webadmin and examine the drive space statistics page (`.../webadmin/stats/`). The header for the leftmost column should be `Group/User`:

![screenshot 1](https://cloud.githubusercontent.com/assets/487082/5921844/bee201ec-a63e-11e4-9304-819b043b668d.png)


                