### PR TITLE
Add CLI subcommand to generate graph report

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1402,13 +1402,7 @@ OMERO Diagnostics %s
 
         cfg = config.as_map()
         config.close()  # Early close. See #9800
-        for x in ("name", "user", "host", "port"):
-            # NOT passing password on command-line
-            k = "omero.db.%s" % x
-            if k in cfg:
-                v = cfg[k]
-                xargs.append("-D%s=%s" % (k, v))
-
+        self.set_db_arguments(cfg, xargs)
         if "omero.data.dir" in cfg:
             xargs.append("-Domero.data.dir=%s" % cfg["omero.data.dir"])
         for k, v in cfg.items():
@@ -1493,15 +1487,6 @@ OMERO Diagnostics %s
         debug = False
         if getattr(args, "jdwp"):
             debug = True
-
-        # Pass omero.db.pass using JAVA_OPTS environment variable
-        if "omero.db.pass" in cfg:
-            dbpassargs = "-Domero.db.pass=%s" % cfg["omero.db.pass"]
-            if "JAVA_OPTS" not in os.environ:
-                os.environ['JAVA_OPTS'] = dbpassargs
-            else:
-                os.environ['JAVA_OPTS'] = "%s %s" % (
-                    os.environ.get('JAVA_OPTS'), dbpassargs)
 
         self.ctx.dbg(
             "Launching Java: %s, debug=%s, xargs=%s" % (cmd, debug, xargs))

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1403,8 +1403,6 @@ OMERO Diagnostics %s
         cfg = config.as_map()
         config.close()  # Early close. See #9800
         self.set_db_arguments(cfg, xargs)
-        if "omero.data.dir" in cfg:
-            xargs.append("-Domero.data.dir=%s" % cfg["omero.data.dir"])
         for k, v in cfg.items():
             if k.startswith("omero.search"):
                 xargs.append("-D%s=%s" % (k, cfg[k]))

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -311,7 +311,9 @@ Bash examples:
                           default=[sys.stdin])
 
         graphreport = parser.add(
-            sub, self.graphreport, "Generate")
+            sub, self.graphreport,
+            help="Generate a full report of the object graph in"
+            " reStructuredText format")
         graphreport.add_argument(
             "--source", help="Configuration file to be used. Default:"
             " etc/grid/config.xml")
@@ -374,8 +376,10 @@ Bash examples:
         import os
         import omero.java
         server_dir = self.ctx.dir / "lib" / "server"
+        log_config_file = self.ctx.dir / "etc" / "logback-cli.xml"
+        logback = "-Dlogback.configurationFile=%s" % log_config_file
         classpath = [file.abspath() for file in server_dir.files("*.jar")]
-        xargs = ["-cp", os.pathsep.join(classpath)]
+        xargs = [logback, "-cp", os.pathsep.join(classpath)]
 
         cfg = config.as_map()
         config.close()  # Early close. See #9800

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -372,7 +372,7 @@ Bash examples:
 
     @with_config
     def graphreport(self, args, config):
-
+        """Generate a report of the object graph in reStructuredText format"""
         import os
         import omero.java
         server_dir = self.ctx.dir / "lib" / "server"

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -379,21 +379,7 @@ Bash examples:
 
         cfg = config.as_map()
         config.close()  # Early close. See #9800
-        for x in ("name", "user", "host", "port"):
-            # NOT passing password on command-line
-            k = "omero.db.%s" % x
-            if k in cfg:
-                v = cfg[k]
-                xargs.append("-D%s=%s" % (k, v))
-
-        # Pass omero.db.pass using JAVA_OPTS environment variable
-        if "omero.db.pass" in cfg:
-            dbpassargs = "-Domero.db.pass=%s" % cfg["omero.db.pass"]
-            if "JAVA_OPTS" not in os.environ:
-                os.environ['JAVA_OPTS'] = dbpassargs
-            else:
-                os.environ['JAVA_OPTS'] = "%s %s" % (
-                    os.environ.get('JAVA_OPTS'), dbpassargs)
+        self.set_db_arguments(cfg, xargs)
 
         cmd = ["ome.services.graphs.GraphPathReport", args.file]
 

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -77,14 +77,14 @@ def _make_open_and_close_config(func, allow_readonly):
 
 def with_config(func):
     """
-    opens a config and passes it as the second argument.
+    Opens a config and passes it as the second argument.
     """
     return wraps(func)(_make_open_and_close_config(func, True))
 
 
 def with_rw_config(func):
     """
-    opens a config and passes it as the second argument.
+    Opens a config and passes it as the second argument.
     Requires that the returned config be writeable
     """
     return wraps(func)(_make_open_and_close_config(func, False))
@@ -92,10 +92,8 @@ def with_rw_config(func):
 
 class ConfigControl(BaseControl):
     """
-    Base class for controls which need write access to the OMERO configuration
-    using the @with_rw_config decorator
-
-    Note BaseControl should be used for read-only access using @with_config
+    Base class for controls which need read-only access to the OMERO
+    configuration using the :func:`with_config` decorator
     """
 
     def open_config(self, args):
@@ -123,9 +121,10 @@ class ConfigControl(BaseControl):
 class WriteableConfigControl(ConfigControl):
     """
     Base class for controls which need write access to the OMERO configuration
-    using the @with_rw_config decorator
+    using the :func:`with_rw_config` decorator
 
-    Note BaseControl should be used for read-only access using @with_config
+    Note :class:`ConfigControl` should be used for read-only access using
+    :func:`with_config`
     """
 
     def die_on_ro(self, config):

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -13,6 +13,7 @@
 
 """
 
+import os
 import sys
 
 from path import path
@@ -116,6 +117,23 @@ class ConfigControl(BaseControl):
             self.ctx.die(112, "Could not acquire lock on %s" % cfg_xml)
         except Exception, e:
             self.ctx.die(113, str(e))
+
+    def set_db_arguments(self, cfg, xargs):
+
+        # NOT passing password on command-line
+        for x in ("name", "user", "host", "port"):
+            key = "omero.db.%s" % x
+            if key in cfg:
+                xargs.append("-D%s=%s" % (key, cfg[key]))
+
+        # Pass omero.db.pass using JAVA_OPTS environment variable
+        if "omero.db.pass" in cfg:
+            dbpassargs = "-Domero.db.pass=%s" % cfg["omero.db.pass"]
+            if "JAVA_OPTS" not in os.environ:
+                os.environ['JAVA_OPTS'] = dbpassargs
+            else:
+                os.environ['JAVA_OPTS'] = "%s %s" % (
+                    os.environ.get('JAVA_OPTS'), dbpassargs)
 
 
 class WriteableConfigControl(ConfigControl):

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -119,12 +119,17 @@ class ConfigControl(BaseControl):
             self.ctx.die(113, str(e))
 
     def set_db_arguments(self, cfg, xargs):
+        """Set DB/binary repository arguments to be passed to Java"""
 
         # NOT passing password on command-line
         for x in ("name", "user", "host", "port"):
             key = "omero.db.%s" % x
             if key in cfg:
                 xargs.append("-D%s=%s" % (key, cfg[key]))
+
+        # Pass binary repository directory if applicable
+        if "omero.data.dir" in cfg:
+            xargs.append("-Domero.data.dir=%s" % cfg["omero.data.dir"])
 
         # Pass omero.db.pass using JAVA_OPTS environment variable
         if "omero.db.pass" in cfg:

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -53,7 +53,8 @@ class TestObj(CLITest):
 
     def test_create_from_file(self):
         path = self.create_script()
-        self.args.append("--file=%s" % path)
+        self.args.append("load")
+        self.args.append("%s" % path)
         self.cli.invoke(self.args, strict=True)
         state = self.cli.get("tx.state")
         assert 8 == len(state)
@@ -75,7 +76,8 @@ class TestObj(CLITest):
             new Dataset name=bar
             new ProjectDatasetLink parent@=0 child@=1
             """)
-        self.args.append("--file=%s" % path)
+        self.args.append("load")
+        self.args.append("%s" % path)
         state = self.go()
         assert 3 == len(state)
         assert state.get_row(0).startswith("Project")
@@ -91,7 +93,8 @@ class TestObj(CLITest):
             bar = new Dataset name=bar
             new ProjectDatasetLink parent@=foo child@=bar
             """)
-        self.args.append("--file=%s" % path)
+        self.args.append("load")
+        self.args.append("%s" % path)
         state = self.go()
         assert 3 == len(state)
         assert state.get_row(0).startswith("Project")
@@ -118,7 +121,8 @@ class TestObj(CLITest):
             new CommentAnnotation ns=test textValue=foo
             new DatasetAnnotationLink parent@=0 child@=1
             """)
-        self.args.append("--file=%s" % path)
+        self.args.append("load")
+        self.args.append("%s" % path)
         state = self.go()
         assert 3 == len(state)
         assert state.get_row(0).startswith("Dataset")


### PR DESCRIPTION
Follow up of https://github.com/openmicroscopy/openmicroscopy/pull/3404, this PR:
- adds a `bin/omero obj graphreport` command to generate the Sphinx documentation
- refactors the `ObjControl` class to implement proper subcommands
- converts the hidden `--file` argument of `ObjControl` into a `load` subcommand
- creates an intermediate `ConfigControl` class which contains the interface required for accessing the configuration in read-only mode with `WriteableConfigControl` being a subclass of it


To test this PR,
- check the tests are passing and the `bin/omero obj new/update` commands are working as expected
- check the `bin/omero obj load` and `bin/omero obj graphreport` subcommand
- check the `bin/omero admin reindex` logic is unmodified

--no-rebase