### PR TITLE
Fix windows tables

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -237,8 +237,9 @@ class HdfStorage(object):
             return tables.openFile(str(self.__hdf_path), mode=mode,
                                    title="OMERO HDF Measurement Storage",
                                    rootUEP="/")
-        except (tables.HDF5ExtError, IOError):
-            msg = "HDFStorage initialized with bad path: %s" % self.__hdf_path
+        except (tables.HDF5ExtError, IOError) as e:
+            msg = "HDFStorage initialized with bad path: %s: %s" % (
+                self.__hdf_path, e)
             self.logger.error(msg)
             raise omero.ValidationException(None, None, msg)
 

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -111,12 +111,11 @@ class HdfList(object):
         self._lock = threading.RLock()
         self.__filenos = {}
         self.__paths = {}
-        self.__locks = {}
 
     @locked
     def addOrThrow(self, hdfpath, hdfstorage):
 
-        if hdfpath in self.__locks:
+        if hdfpath in self.__paths:
             raise omero.LockTimeout(
                 None, None, "Path already in HdfList: %s" % hdfpath)
 
@@ -125,24 +124,21 @@ class HdfList(object):
             raise omero.ApiUsageException(
                 None, None, "Parent directory does not exist: %s" % parent)
 
-        lock = None
+        hdffile = hdfstorage.openfile("a")
+        fileno = hdffile.fileno()
+
         try:
-            lock = open(hdfpath, "a+")
-            portalocker.lock(lock, portalocker.LOCK_NB | portalocker.LOCK_EX)
-            self.__locks[hdfpath] = lock
+            portalocker.lockno(
+                fileno, portalocker.LOCK_NB | portalocker.LOCK_EX)
         except portalocker.LockException:
-            if lock:
-                lock.close()
+            hdffile.close()
             raise omero.LockTimeout(
                 None, None,
                 "Cannot acquire exclusive lock on: %s" % hdfpath, 0)
         except:
-            if lock:
-                lock.close()
+            hdffile.close()
             raise
 
-        hdffile = hdfstorage.openfile("a")
-        fileno = hdffile.fileno()
         if fileno in self.__filenos.keys():
             hdffile.close()
             raise omero.LockTimeout(
@@ -164,16 +160,6 @@ class HdfList(object):
     def remove(self, hdfpath, hdffile):
         del self.__filenos[hdffile.fileno()]
         del self.__paths[hdfpath]
-        try:
-            if hdfpath in self.__locks:
-                try:
-                    lock = self.__locks[hdfpath]
-                    lock.close()
-                finally:
-                    del self.__locks[hdfpath]
-        except Exception:
-            self.logger.warn("Exception on remove(%s)" %
-                             hdfpath, exc_info=True)
 
 # Global object for maintaining files
 HDFLIST = HdfList()

--- a/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_hdfstorage.py
@@ -88,11 +88,9 @@ class TestHdfStorage(TestCase):
     def testLocking(self):
         tmp = str(self.hdfpath())
         hdf1 = omero.tables.HdfStorage(tmp, self.lock)
-        try:
+        with pytest.raises(omero.LockTimeout) as exc_info:
             omero.tables.HdfStorage(tmp, self.lock)
-            assert False, "should be locked"
-        except omero.LockTimeout:
-            pass
+        assert exc_info.value.message.startswith('Path already in HdfList: ')
         hdf1.cleanup()
         hdf3 = omero.tables.HdfStorage(tmp, self.lock)
         hdf3.cleanup()


### PR DESCRIPTION
Attempt to fix https://trac.openmicroscopy.org.uk/ome/ticket/12321
(i.e. Tables should now work on Windows).

Note this requires modifications to `omero_ext/portalocker.py`... what's the best way of doing this?

Requires manual testing (no Windows integration tests at the moment.... hopefully soon)

Definitely needs someone to carefully go over the change in locking (/cc @joshmoore)

--no-rebase