### PR TITLE
Enable selective ROIs visualization on web viewer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -264,6 +264,21 @@ $.fn.roi_display = function(options) {
             });
         }
 
+        /*
+        If filter is not 'undefined' use the given ROI and shape IDs to build the list of active
+        elements that will be shown by the web viewer.
+        Filter is an associative array like
+          {
+           12: [1,2,3],
+           13: []
+          }
+        where keys are the ID of the ROIs and values lists with IDs of the selected shapes for
+        the given ROIs. If the value of a key is an empty list, all shapes related to that ROI
+        will be considered as active.
+        If the filter is 'undefined' set all ROIs and shapes coming from the DB as active.
+        The active_rois object will be used to determinate which shapes will be displayed by the
+        user interface when a change on the viewport occurs (like changing the Z or the T value).
+         */
         filter_rois = function (filter) {
             if (filter != undefined) {
                 for (r=0; r<roi_json.length; r++) {
@@ -295,6 +310,11 @@ $.fn.roi_display = function(options) {
             }
         }
 
+        /*
+        Use active_rois to actually filter and retrieve ROIs and shapes that are going to be
+        visualized in the viewport from the list of ROIs retrieved from the server.
+        The list of ROIs coming from the server, referenced as 'roi_json', won't be modified.
+         */
         get_active_rois = function () {
             var act_rois = [];
             for (r=0; r<roi_json.length; r++) {
@@ -324,6 +344,7 @@ $.fn.roi_display = function(options) {
             return act_rois;
         }
 
+        // get the filter that describes currently active ROIs and shapes
         this.get_current_rois_filter = function() {
             if (typeof active_rois != "undefined") {
                 if (Object.keys(active_rois).length == 0) {
@@ -336,6 +357,7 @@ $.fn.roi_display = function(options) {
             }
         }
 
+        // activate ROI with ID 'roi_id' and its related shapes
         this.activate_roi = function (roi_id) {
             var roi_id = parseInt(roi_id);
             if (!active_rois.hasOwnProperty(roi_id)) {
@@ -343,6 +365,7 @@ $.fn.roi_display = function(options) {
             }
         }
 
+        // deactivate ROI with ID 'roi_id' and its related shapes
         this.deactivate_roi = function (roi_id) {
             var roi_id = parseInt(roi_id);
             if (active_rois.hasOwnProperty(roi_id)) {
@@ -350,6 +373,7 @@ $.fn.roi_display = function(options) {
             }
         }
 
+        // activate shape with ID 'shape_id' related to ROI with ID 'roi_id'
         this.activate_shape = function (roi_id, shape_id) {
             var roi_id = parseInt(roi_id);
             var shape_id = parseInt(shape_id);
@@ -362,6 +386,7 @@ $.fn.roi_display = function(options) {
             }
         }
 
+        // deactivate shape with ID 'shape_id' related to ROI with ID 'roi_id'
         this.deactivate_shape = function(roi_id, shape_id) {
             var roi_id = parseInt(roi_id);
             var shape_id = parseInt(shape_id);
@@ -381,7 +406,10 @@ $.fn.roi_display = function(options) {
             return roi_json;
         }
 
-        // clears paper and draws ROIs (if rois_displayed) for the given T and Z. NB: indexes are 1-based. 
+        /*
+        Clears paper and draws ROIs (if rois_displayed) for the given T and Z. NB: indexes are 1-based.
+        Only shapes in 'active_rois' are going to be displayed.
+        */
         this.refresh_rois = function(theZ, theT, rois_filter) {
 
             if (typeof theZ != 'undefined') this.theZ = theZ;
@@ -390,7 +418,9 @@ $.fn.roi_display = function(options) {
             paper.clear();
             shape_objects.length = 0;
             if (!rois_displayed) return;
+            // build the filter for active ROIs and shapes
             filter_rois(rois_filter);
+            // apply the filter and get the description of ROIs and shapes that will be displayed
             rois = get_active_rois();
             if (rois == null) return;
 
@@ -492,6 +522,7 @@ $.fn.roi_display = function(options) {
             display_selected();
         }
 
+        // refresh the viewport using 'active_rois' as filter
         this.refresh_active_rois = function (theZ, theT) {
             rois_displayed = true;
             refresh_rois(theZ, theT, active_rois);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -291,6 +291,18 @@ $.fn.roi_display = function(options) {
             return act_rois;
         }
 
+        this.activate_roi = function (roi_id) {
+            if (active_rois.indexOf(roi_id) == -1) {
+                active_rois.push(roi_id);
+            }
+        }
+
+        this.deactivate_roi = function (roi_id) {
+            if (active_rois.indexOf(roi_id) != -1) {
+                active_rois.splice(active_rois.indexOf(roi_id), 1);
+            }
+        }
+
         // returns the ROI data as json. May be null if not yet loaded! 
         this.get_roi_json = function() {
             return roi_json;
@@ -407,6 +419,9 @@ $.fn.roi_display = function(options) {
             display_selected();
         }
 
+        this.refresh_active_rois = function (theZ, theT) {
+            refresh_rois(theZ, theT, active_rois);
+        }
 
         // loads the ROIs if needed and displays them
         this.show_rois = function(theZ, theT, filter) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -35,6 +35,7 @@ $.fn.roi_display = function(options) {
         }
 
         var roi_json = null;          // load ROI data as json when needed
+        var active_rois = null;       // show only the active ROIs
         this.theZ = null;
         this.theT = null;
         var rois_displayed = false;   // flag to toggle visability.
@@ -257,27 +258,37 @@ $.fn.roi_display = function(options) {
                 // plot the rois
                 if (display_rois) {
                   rois_displayed = true;
-                  refresh_rois(filter=filter);
+                  refresh_rois(undefined, undefined, filter);
                 }
                 $viewportimg.trigger("rois_loaded");
             });
         }
 
         filter_rois = function (filter) {
+            active_rois = [];
             if (filter != undefined) {
-                console.log('Applying filter ' + filter);
-                roi_json_filtered = [];
                 for (r=0; r<roi_json.length; r++) {
-                    console.log('Checking ID ' + roi_json[r].id);
-                    if (filter.indexOf(roi_json[r].id) != -1) {
-                        roi_json_filtered.push(roi_json[r]);
+                    if (filter.indexOf(roi_json[r].id) != -1 && active_rois.indexOf(roi_json[r].id) == -1) {
+                        active_rois.push(roi_json[r].id);
                     }
                 }
-                console.log('Filtered JSON ' + roi_json_filtered);
-                return roi_json_filtered;
             } else {
-                return roi_json;
+                for (r=0; r<roi_json.length; r++) {
+                    if (active_rois.indexOf(roi_json[r].id) == -1) {
+                        active_rois.push(roi_json[r].id);
+                    }
+                }
             }
+        }
+
+        get_active_rois = function () {
+            act_rois = [];
+            for (r=0; r<roi_json.length; r++) {
+                if (active_rois.indexOf(roi_json[r].id) != -1) {
+                    act_rois.push(roi_json[r]);
+                }
+            }
+            return act_rois;
         }
 
         // returns the ROI data as json. May be null if not yet loaded! 
@@ -294,10 +305,10 @@ $.fn.roi_display = function(options) {
             paper.clear();
             shape_objects.length = 0;
             if (!rois_displayed) return;
-            rois = filter_rois(rois_filter);
+            filter_rois(rois_filter);
+            rois = get_active_rois();
             if (rois == null) return;
-            
-            console.log('ROI JSON ' + rois);
+
             for (var r=0; r<rois.length; r++) {
                 var roi = rois[r];
                 var shapes = roi['shapes'];
@@ -408,10 +419,10 @@ $.fn.roi_display = function(options) {
               this.refresh_rois(undefined, undefined, filter);
           }
         }
-        
 
         // hides the ROIs from display
         this.hide_rois = function() {
+            active_rois = [];
             rois_displayed = false;
             this.refresh_rois();
         }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -248,7 +248,7 @@ $.fn.roi_display = function(options) {
         }
 
         // load the ROIs from json call and display
-        load_rois = function(display_rois) {
+        load_rois = function(display_rois, filter) {
             if (json_url == undefined) return;
             
             $.getJSON(json_url+'?callback=?', function(data) {
@@ -257,10 +257,27 @@ $.fn.roi_display = function(options) {
                 // plot the rois
                 if (display_rois) {
                   rois_displayed = true;
-                  refresh_rois();
+                  refresh_rois(filter=filter);
                 }
                 $viewportimg.trigger("rois_loaded");
             });
+        }
+
+        filter_rois = function (filter) {
+            if (filter != undefined) {
+                console.log('Applying filter ' + filter);
+                roi_json_filtered = [];
+                for (r=0; r<roi_json.length; r++) {
+                    console.log('Checking ID ' + roi_json[r].id);
+                    if (filter.indexOf(roi_json[r].id) != -1) {
+                        roi_json_filtered.push(roi_json[r]);
+                    }
+                }
+                console.log('Filtered JSON ' + roi_json_filtered);
+                return roi_json_filtered;
+            } else {
+                return roi_json;
+            }
         }
 
         // returns the ROI data as json. May be null if not yet loaded! 
@@ -269,7 +286,7 @@ $.fn.roi_display = function(options) {
         }
 
         // clears paper and draws ROIs (if rois_displayed) for the given T and Z. NB: indexes are 1-based. 
-        this.refresh_rois = function(theZ, theT) {
+        this.refresh_rois = function(theZ, theT, rois_filter) {
 
             if (typeof theZ != 'undefined') this.theZ = theZ;
             if (typeof theT != 'undefined') this.theT = theT;
@@ -277,11 +294,12 @@ $.fn.roi_display = function(options) {
             paper.clear();
             shape_objects.length = 0;
             if (!rois_displayed) return;
-            if (roi_json == null) return;
+            rois = filter_rois(rois_filter);
+            if (rois == null) return;
             
-
-            for (var r=0; r<roi_json.length; r++) {
-                var roi = roi_json[r];
+            console.log('ROI JSON ' + rois);
+            for (var r=0; r<rois.length; r++) {
+                var roi = rois[r];
                 var shapes = roi['shapes'];
                 var shape = null;
                 for (var s=0; s<shapes.length; s++) {
@@ -380,14 +398,14 @@ $.fn.roi_display = function(options) {
 
 
         // loads the ROIs if needed and displays them
-        this.show_rois = function(theZ, theT) {
-            this.theZ = theZ
-            this.theT = theT
+        this.show_rois = function(theZ, theT, filter) {
+            this.theZ = theZ;
+            this.theT = theT;
           if (roi_json == null) {
-              load_rois(true);      // load and display
+              load_rois(true, filter);      // load and display
           } else {
               rois_displayed = true;
-              this.refresh_rois();
+              this.refresh_rois(undefined, undefined, filter);
           }
         }
         
@@ -398,9 +416,9 @@ $.fn.roi_display = function(options) {
             this.refresh_rois();
         }
         
-        this.show_labels = function(visible) {
+        this.show_labels = function(visible, filter) {
             roi_label_displayed = visible;
-            this.refresh_rois();
+            this.refresh_rois(undefined, undefined, filter);
         }
 
         // sets the Zoom of the ROI paper (canvas)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -301,9 +301,14 @@ $.fn.roi_display = function(options) {
                 if (active_rois.hasOwnProperty(roi_json[r].id)) {
                     var roi = {"id": roi_json[r].id};
                     var shapes = roi_json[r].shapes;
-                    if (active_rois[roi_json[r].id].length == 0)
+                    if (active_rois[roi_json[r].id].length == 0) {
                         // No filter for the shapes, append all of them
                         roi['shapes'] = shapes;
+                        // Update filter as well, this will make possible to selectively disable shapes
+                        for (s = 0; s < shapes.length; s++) {
+                            active_rois[roi_json[r].id].push(shapes[s].id);
+                        }
+                    }
                     else {
                         roi['shapes'] = [];
                         for (s=0; s<shapes.length; s++) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -420,6 +420,7 @@ $.fn.roi_display = function(options) {
         }
 
         this.refresh_active_rois = function (theZ, theT) {
+            rois_displayed = true;
             refresh_rois(theZ, theT, active_rois);
         }
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -35,7 +35,7 @@ $.fn.roi_display = function(options) {
         }
 
         var roi_json = null;          // load ROI data as json when needed
-        var active_rois = null;       // show only the active ROIs
+        var active_rois = [];       // show only the active ROIs
         this.theZ = null;
         this.theT = null;
         var rois_displayed = false;   // flag to toggle visability.
@@ -265,7 +265,6 @@ $.fn.roi_display = function(options) {
         }
 
         filter_rois = function (filter) {
-            active_rois = [];
             if (filter != undefined) {
                 for (r=0; r<roi_json.length; r++) {
                     if (filter.indexOf(roi_json[r].id) != -1 && active_rois.indexOf(roi_json[r].id) == -1) {
@@ -291,13 +290,27 @@ $.fn.roi_display = function(options) {
             return act_rois;
         }
 
+        this.get_current_rois_filter = function() {
+            if (typeof active_rois != "undefined") {
+                if (active_rois.length == 0) {
+                    return undefined;
+                } else {
+                    return active_rois;
+                }
+            } else {
+                return undefined;
+            }
+        }
+
         this.activate_roi = function (roi_id) {
+            var roi_id = parseInt(roi_id);
             if (active_rois.indexOf(roi_id) == -1) {
                 active_rois.push(roi_id);
             }
         }
 
         this.deactivate_roi = function (roi_id) {
+            var roi_id = parseInt(roi_id);
             if (active_rois.indexOf(roi_id) != -1) {
                 active_rois.splice(active_rois.indexOf(roi_id), 1);
             }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1197,6 +1197,40 @@
         }
     }
 
+    var check_visibility_column = function() {
+        var roi_checkboxes = $('.roi_visibility');
+        var shape_checkboxes = $('.shape_visibility');
+        for (x=0; x<roi_checkboxes.length; x++) {
+            if (roi_checkboxes[x].checked) {
+                $('#toggle_roi_visibility').prop('checked', true);
+                return;
+            }
+        }
+        for (x=0; x<shape_checkboxes.length; x++) {
+            if (shape_checkboxes[x].checked) {
+                $('#toggle_roi_visibility').prop('checked', true);
+                return;
+            }
+        }
+        $('#toggle_roi_visibility').prop('checked', false);
+    }
+
+    var check_roi_visibility_checkbox = function(roi_id) {
+        var roi_id = parseInt(roi_id);
+        var roi_checkbox_id = '#' + roi_id + '_visibility';
+        var shape_checkboxes_class = '.roi_' + roi_id + '_vis';
+        var shape_checkboxes = $(shape_checkboxes_class);
+        for (x=0; x<shape_checkboxes.length; x++) {
+            if (shape_checkboxes[x].checked) {
+                $(roi_checkbox_id).prop('checked', true);
+                $('#toggle_roi_visibility').prop('checked', true);
+                return
+            }
+        }
+        $(roi_checkbox_id).prop('checked', false);
+        check_visibility_column();
+    }
+
     $("#roi_small_table").click(function(event) {
         var $target = $(event.target);
         if ($target.attr('id') == "toggle_roi_thumbs") {
@@ -1221,6 +1255,35 @@
             }
             $('.roi_visibility').prop('checked', activate_rois);
             $('.shape_visibility').prop('checked', activate_rois);
+            return true;
+        } else if ($target.hasClass('roi_visibility')) {
+            var roi_id = $target.attr('roi_id');
+            var act_roi = $target.is(':checked');
+            if (act_roi) {
+                viewport.viewportimg.get(0).activate_roi(roi_id);
+            } else {
+                viewport.viewportimg.get(0).deactivate_roi(roi_id);
+            }
+            var theZ = viewport.getZPos();
+            var theT = viewport.getTPos();
+            viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
+            var check_group_id = '.roi_' + roi_id + '_vis';
+            $(check_group_id).prop('checked', act_roi);
+            check_visibility_column();
+            return true;
+        } else if ($target.hasClass('shape_visibility')) {
+            var roi_id = $target.attr('roi_id');
+            var shape_id = $target.attr('shape_id');
+            var act_shape = $target.is(':checked');
+            if (act_shape) {
+                viewport.viewportimg.get(0).activate_shape(roi_id, shape_id);
+            } else {
+                viewport.viewportimg.get(0).deactivate_shape(roi_id, shape_id);
+            }
+            var theZ = viewport.getZPos();
+            var theT = viewport.getTPos();
+            viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
+            check_roi_visibility_checkbox(roi_id);
             return true;
         } else if ($target.hasClass('shape_cell')) {
             // a shape td click selects the shape.
@@ -1260,23 +1323,6 @@
             else if (nodeName == 'thead') {
                 toggle_th($tableRow.parent());
             }
-        }
-        if ($target.hasClass('roi_visibility')) {
-            var roi_id = $target.attr('roi_id');
-            var act_roi = $target.is( ":checked" );
-            if (act_roi) {
-                viewport.viewportimg.get(0).activate_roi(roi_id);
-            } else {
-                viewport.viewportimg.get(0).deactivate_roi(roi_id);
-            }
-            var theZ = viewport.getZPos();
-            var theT = viewport.getTPos();
-            viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
-            var check_group_id = '.roi_' + roi_id + '_vis';
-            $(check_group_id).prop('checked', act_roi);
-            return true;
-        } else if ($target.hasClass('shape_visibility')) {
-            return true;
         }
         return false;
     });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -344,15 +344,18 @@
   *     ROI load & table methods
   */
 
-  var refresh_rois = function () {
+  var refresh_rois = function (theZ, theT, rois_filter) {
       // re-plots the ROIs (if currently shown) for new Z and T position
       if (viewport.viewportimg.get(0).refresh_rois) {
           var theT = viewport.getTPos();
           var theZ = viewport.getZPos();
-          viewport.viewportimg.get(0).refresh_rois(theZ, theT);
+          // avoid to clear filter when changing image (changing channels, Z or T)
+          rois_filter = (rois_filter ? rois_filter : viewport.viewportimg.get(0).get_current_rois_filter());
+          viewport.viewportimg.get(0).refresh_rois(theZ, theT, rois_filter);
       }
   }
-  var show_rois = function () {
+
+  var show_rois = function (theZ, theT, filter) {
       var theT = viewport.getTPos();
       var theZ = viewport.getZPos();
 
@@ -1207,6 +1210,18 @@
             var show_labels = ($("#toggle_shape_text").is( ":checked" ));
             viewport.viewportimg.get(0).show_labels(show_labels);
             return true;
+        } else if ($target.attr('id') == "toggle_roi_visibility") {
+            var activate_rois = ($("#toggle_roi_visibility").is(":checked"));
+            if (activate_rois) {
+                var theT = viewport.getTPos();
+                var theZ = viewport.getZPos();
+                viewport.viewportimg.get(0).show_rois(theZ, theT, undefined);
+            } else {
+                viewport.viewportimg.get(0).hide_rois();
+            }
+            $('.roi_visibility').prop('checked', activate_rois);
+            $('.shape_visibility').prop('checked', activate_rois);
+            return true;
         } else if ($target.hasClass('shape_cell')) {
             // a shape td click selects the shape.
             var $shapeRow = $target.parent();
@@ -1245,6 +1260,23 @@
             else if (nodeName == 'thead') {
                 toggle_th($tableRow.parent());
             }
+        }
+        if ($target.hasClass('roi_visibility')) {
+            var roi_id = $target.attr('roi_id');
+            var act_roi = $target.is( ":checked" );
+            if (act_roi) {
+                viewport.viewportimg.get(0).activate_roi(roi_id);
+            } else {
+                viewport.viewportimg.get(0).deactivate_roi(roi_id);
+            }
+            var theZ = viewport.getZPos();
+            var theT = viewport.getTPos();
+            viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
+            var check_group_id = '.roi_' + roi_id + '_vis';
+            $(check_group_id).prop('checked', act_roi);
+            return true;
+        } else if ($target.hasClass('shape_visibility')) {
+            return true;
         }
         return false;
     });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1198,37 +1198,24 @@
     }
 
     var check_visibility_column = function() {
-        var roi_checkboxes = $('.roi_visibility');
-        var shape_checkboxes = $('.shape_visibility');
-        for (x=0; x<roi_checkboxes.length; x++) {
-            if (roi_checkboxes[x].checked) {
-                $('#toggle_roi_visibility').prop('checked', true);
-                return;
-            }
+        if ( $('.roi_visibility').is(':checked') || $('.shape_visibility').is(':checked') ) {
+            $('#toggle_roi_visibility').prop('checked', true);
+        } else {
+            $('#toggle_roi_visibility').prop('checked', false);
         }
-        for (x=0; x<shape_checkboxes.length; x++) {
-            if (shape_checkboxes[x].checked) {
-                $('#toggle_roi_visibility').prop('checked', true);
-                return;
-            }
-        }
-        $('#toggle_roi_visibility').prop('checked', false);
     }
 
     var check_roi_visibility_checkbox = function(roi_id) {
         var roi_id = parseInt(roi_id);
         var roi_checkbox_id = '#' + roi_id + '_visibility';
         var shape_checkboxes_class = '.roi_' + roi_id + '_vis';
-        var shape_checkboxes = $(shape_checkboxes_class);
-        for (x=0; x<shape_checkboxes.length; x++) {
-            if (shape_checkboxes[x].checked) {
-                $(roi_checkbox_id).prop('checked', true);
-                $('#toggle_roi_visibility').prop('checked', true);
-                return
-            }
+        if ( $(shape_checkboxes_class).is(':checked') ) {
+            $(roi_checkbox_id).prop('checked', true);
+            $('#toggle_roi_visibility').prop('checked', true);
+        } else {
+            $(roi_checkbox_id).prop('checked', false);
+            check_visibility_column();
         }
-        $(roi_checkbox_id).prop('checked', false);
-        check_visibility_column();
     }
 
     $("#roi_small_table").click(function(event) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -354,10 +354,10 @@
   }
   var show_rois = function () {
       var theT = viewport.getTPos();
-        var theZ = viewport.getZPos();
+      var theZ = viewport.getZPos();
 
       {% if image %}
-        // if the ROI plugin has not been initialised (method not available...) init and load ROIs...
+      // if the ROI plugin has not been initialised (method not available...) init and load ROIs...
       if (!viewport.viewportimg.get(0).show_rois) {
           var options = {'width':{{ image.getSizeX }},
                      'height':{{ image.getSizeY }},
@@ -374,7 +374,7 @@
       $("#roi_table_postit").show();
 
       // loads ROIs (if needed) and shows.
-    viewport.viewportimg.get(0).show_rois(theZ, theT);
+      viewport.viewportimg.get(0).show_rois(theZ, theT, filter);
   }
 
 
@@ -402,6 +402,7 @@
       }
       var toggle_roi_thumbs = "<input type='checkbox' id='toggle_roi_thumbs' title='Show ROI Previews' />";
       var toggle_shape_text = "<input type='checkbox' id='toggle_shape_text' checked='true' title='Show/Hide ROI text labels' />";
+      var toggle_roi_visibility = "<input type='checkbox' id='toggle_roi_visibility' checked='true' title='Show/Hide ROIs and shapes' />";
 
       // thead for whole table:
       var roi_html = "<thead id='roi_table_head'><tr>";
@@ -412,6 +413,7 @@
       roi_html += "<th>T</th>"; // no T for ROI
       roi_html += "<th>" + toggle_shape_text + " Text</th>";
       roi_html += "<th title='Pick colour of ROI outlines'><div style='white-space:nowrap;'>" + toggle_roi_thumbs + "Preview</div>"+ color_picker + "</th>";
+      roi_html += "<th>" + toggle_roi_visibility + " Visibility</th>";
       roi_html += "</tr></thead>";
       $roi_table.append($(roi_html));
 
@@ -429,7 +431,7 @@
               return text_string
           return text_string.substring(0,truncate_length) + "...";
       }
-      // populate table. Cols are: ID, Z, T, Shape, text
+      // populate table. Cols are: ID, Z, T, Shape, text, visibility
       for (var r=0; r<json.length; r++) {
           var roi = json[r];
           var shapes = roi['shapes'];
@@ -437,6 +439,10 @@
           // thumbnail of roi - display small & popup full-size
           var line_color = 'f00';   // store current line color, used when we 'show' thumbs to get url.
           var roiThumbHtml = "<img src='' id='"+ roi['id'] +"_roi_thumb' color='"+ line_color +"' width=50 height=33 class='roi_thumb'>";
+
+          // visibility check for ROI, used to turn ON\OFF all connected shapes
+          var roiVisibilityHtml = "<input type='checkbox'  id='" + roi['id'] + "_visibility' checked='true' " +
+                  "class='roi_visibility' roi_id='"+ roi['id'] +"'/>";
 
           // process the shapes first - note first shape & text
           var roiIcon = null;
@@ -462,7 +468,7 @@
                   if (maxZ === null || maxZ < shape.theZ) maxZ = shape.theZ;
               }
               if (shape['textValue'] != null) {
-                  text = shape['textValue']
+                  text = shape['textValue'];
                   if (shapes.length == 1) roiText = text;
               } else text = "";
               var indent = " &nbsp&nbsp&nbsp&nbsp";    // hack to add "indent", but not if shape is only-child
@@ -470,6 +476,10 @@
                   indent = " &nbsp";
               }
               var shapeThumbHtml = "<img src='' id='"+ shape['id'] +"_shape_thumb' color='"+ line_color +"' width=50 height=33 class='roi_thumb shape_thumb'>";
+
+              var shape_id = roi['id'] + '_' + shape['id'] + '_shape_visibility';
+              var shapeVisibilityHtml = "<input type='checkbox' id='" + shape_id + "' checked='true' " +
+                      "roi_id=" + roi['id'] +"' shape_id='" + shape['id'] +"' class='shape_visibility roi_" + roi['id'] + "_vis'/>";
 
               shapesHtml += "<tr id='"+shape['id']+"_shape' class='shape_row'>";
               // clicking on any cell of a shape 'shape_cell' selects it
@@ -484,6 +494,7 @@
               shapesHtml += "<td class='shape_cell'>" + theT + "</td>";
               shapesHtml += "<td class='shape_cell shape_text' title=\""+ text +"\"><p>"+ truncate_text(text.escapeHTML()) + "</p></td>";
               shapesHtml += "<td class='shape_cell'>" + shapeThumbHtml + "</td>";
+              shapesHtml += "<td class='shape_cell'>" + shapeVisibilityHtml + "</td>";
               shapesHtml += "</tr>";
               if (roiIcon == null) roiIcon = shape['type'];
               else if (roiIcon != shape['type']) roiIcon = "";    // mixture of shapes - show no icon
@@ -502,6 +513,7 @@
           roi_html += "<th style='white-space: nowrap'> "+ zRange +" </th>"; // no T for ROI
           roi_html += "<th class='shape_text' title=\""+ roiText +"\"><p>"+ truncate_text(roiText) +"</p></th>";
           roi_html += "<th>"+ roiThumbHtml +"</th>";
+          roi_html += "<th>" + roiVisibilityHtml + "</th>";
           roi_html += "</tr></thead>";
 
           var tbody = $(shapesHtml);

--- a/examples/Web/embed_rois_selection.html
+++ b/examples/Web/embed_rois_selection.html
@@ -84,7 +84,9 @@
                 viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
             } else {
                 // viewport was not initialized yet, invoke the show_rois method with roi_id as filter
-                show_rois([roi_id]);
+                var rois_filter = {};
+                rois_filter[roi_id] = [];
+                show_rois(rois_filter);
             }
         }
 

--- a/examples/Web/embed_rois_selection.html
+++ b/examples/Web/embed_rois_selection.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <META HTTP-EQUIV="Content-Style-Type" CONTENT="text/css">
+
+        <title>
+            OMERO.web - embeded viewer
+        </title>
+
+        <style type="text/css">
+            .viewport {
+                height: 500px;
+                width: 700px;
+                padding: 10px;
+            }
+        </style>
+
+        <link rel="stylesheet" type="text/css" href="http://OMERO_WEB_HOST/static/omeroweb.viewer.min.css">
+
+        <script type="text/javascript" src="http://OMERO_WEB_HOST/static/omeroweb.viewer.min.js"></script>
+
+        <script type="text/javascript">
+
+        $(document).ready(function () {
+            $.ajaxSettings.cache = false;
+        });
+
+        var viewport;
+
+        var show_rois = function(filter) {
+            if (filter == undefined) {
+                // No filter, activate all checkboxes
+                $('#roi1').prop('checked', true);
+                $('#roi2').prop('checked', true);
+                $('#roi3').prop('checked', true);
+            }
+            var theT = viewport.getTPos();
+            var theZ = viewport.getZPos();
+
+            if (!viewport.viewportimg.get(0).show_rois) {
+                var options = {'width':viewport.loadedImg.size.width, 
+                               'height':viewport.loadedImg.size.height,
+                               'json_url':'http://OMERO_WEB_HOST/webgateway/get_rois_json/'+viewport.loadedImg.id};
+                if (viewport.loadedImg.tiles) {
+                    options['tiles'] = true;
+                }
+
+                viewport.viewportimg.roi_display(options);
+                viewport.viewportimg.get(0).setRoiZoom(viewport.viewportimg.get(0).getZoom());
+            }
+
+            // loads ROIs (if needed) and shows. 
+            viewport.viewportimg.get(0).show_rois(theZ, theT, filter);
+
+        }
+
+        var refresh_rois = function (theZ, theT, filter) {
+            // re-plots the ROIs (if currently shown) for new Z and T position and apply (optional) filter
+            if (viewport.viewportimg.get(0).refresh_rois) {
+                var theT = viewport.getTPos();
+                var theZ = viewport.getZPos();
+                viewport.viewportimg.get(0).refresh_rois(theZ, theT, filter);
+            }
+        }
+
+        var hide_rois = function() {
+            // unckeck all checkboxes
+            $('#roi1').prop('checked', false);
+            $('#roi2').prop('checked', false);
+            $('#roi3').prop('checked', false);
+            // hides the display of ROIs.
+            if (viewport.viewportimg.get(0).hide_rois) {
+                viewport.viewportimg.get(0).hide_rois();
+            }
+        }
+
+        var show_roi = function(roi_id) {
+            if (viewport.viewportimg.get(0).activate_roi) {
+                // add the ROI to the list of the active ones
+                viewport.viewportimg.get(0).activate_roi(roi_id);
+                var theT = viewport.getTPos();
+                var theZ = viewport.getZPos();
+                // refresh the viewport
+                viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
+            } else {
+                // viewport was not initialized yet, invoke the show_rois method with roi_id as filter
+                show_rois([roi_id]);
+            }
+        }
+
+        var hide_roi = function(roi_id) {
+            if (viewport.viewportimg.get(0).deactivate_roi) {
+                // remove the ROI for the list of the active ones
+                viewport.viewportimg.get(0).deactivate_roi(roi_id);
+                var theT = viewport.getTPos();
+                var theZ = viewport.getZPos();
+                // refresh the viewport
+                viewport.viewportimg.get(0).refresh_active_rois(theZ, theT);
+            }
+        }
+
+        var show_scalebar = function () {
+          if (!viewport.viewportimg.get(0).show_scalebar) {
+          // if the Scalebar plugin has not been initialised (method not available...) init and load Scalebar...
+              var options = {'pixSizeX': viewport.getPixelSizes().x,
+                             'imageWidth': viewport.getSizes().width};
+              if (viewport.loadedImg.tiles) {
+                  options['tiles'] = true;
+              }
+              viewport.viewportimg.scalebar_display(options);
+          }
+
+          viewport.viewportimg.get(0).setScalebarZoom(viewport.getZoom()/100 );
+          viewport.viewportimg.get(0).show_scalebar();
+
+        }
+
+        var hide_scalebar = function () {
+            viewport.viewportimg.get(0).hide_scalebar();
+        }
+
+        var _imageLoad = function (ev, viewport) {
+
+            /**
+             * This function is called when an image is initially loaded.
+             * This is the place to sync everything; rendering model, quality, channel buttons, etc.
+             */
+
+            /* load metadata */
+            $('#image-name').html(viewport.loadedImg.meta.imageName);
+
+            /* enable scalebar */
+            tmp = viewport.getPixelSizes();
+            if (tmp.x !== 0) {
+                $("#viewport-scalebar").prop("disabled", false);
+                $("#viewport-scalebar").prop("checked", true);
+                show_scalebar();
+            }
+
+            /**
+             * Attach functions to the click event on specific buttons
+             */
+            $("#viewport-show-rois").click(function () {
+                show_rois();
+            });
+            $("#viewport-hide-rois").click(function () {
+                hide_rois();
+            });
+
+            /**
+             * Attach functions to the click event on specific buttons
+             */
+
+            // 'Scalebar' checkbox to left of image
+            $("#viewport-scalebar").change(function() {
+                if(this.checked) {
+                    show_scalebar();
+                } else {
+                    hide_scalebar();
+                }
+            });
+
+            /**
+             * Attach functions to the click event on specific checkboxes
+             */
+            $('#roi1').click(function () {
+                if (this.checked == true) {
+                    show_roi(ROI_1_ID);
+                } else {
+                    hide_roi(ROI_1_ID);
+                }
+            });
+            $('#roi2').click(function () {
+                if (this.checked == true) {
+                    show_roi(ROI_2_ID);
+                } else {
+                    hide_roi(ROI_2_ID);
+                }
+            });
+            $('#roi3').click(function () {
+                if (this.checked == true) {
+                    show_roi(ROI_3_ID);
+                } else {
+                    hide_roi(ROI_3_ID);
+                }
+            });
+
+        }
+
+        var instant_zoom = function(e, percent) {
+            if (viewport.viewportimg.get(0).setRoiZoom) {
+                viewport.viewportimg.get(0).setRoiZoom(percent);
+            }
+            if (viewport.viewportimg.get(0).setScalebarZoom) {
+                viewport.viewportimg.get(0).setScalebarZoom(percent/100);
+            }
+        }
+
+        $(document).ready(function () {
+
+            /* Prepare the viewport */
+            viewport = $.WeblitzViewport($("#viewport"), "http://OMERO_WEB_HOST/webgateway/", {
+                'mediaroot': "http://OMERO_WEB_HOST/static/"
+            });
+
+            /* Async call needs loading */
+            viewport.bind('imageLoad', _imageLoad);
+            /* Bind zoomimg action to the ROIs */
+            viewport.bind('instant_zoom', instant_zoom);
+
+            /* Load the selected image into the viewport */
+            viewport.load(IMAGE_ID);
+
+        });
+        </script>
+
+    </head>
+<body>
+
+<h1>Title: <span id="image-name"></span></h1>
+
+    <label for="viewport-scalebar">Scalebar</label>
+    <input id="viewport-scalebar" type="checkbox" disabled/>
+
+    <input id="roi1" type="checkbox" name="roi1">Show ROI 1</input>
+    <input id="roi2" type="checkbox" name="roi2">Show ROI 2</input>
+    <input id="roi3" type="checkbox" name="roi3">Show ROI 3</input>
+
+    <button id="viewport-show-rois" title="Show ROIs">Show ROIs</button>
+    <button id="viewport-hide-rois" title="Hide ROIs">Hide ROIs</button>
+
+    <div id="viewport" class="viewport"></div>
+
+</body>
+</html>


### PR DESCRIPTION
OMERO's web viewer now integrates methods to selectively hide\show ROIs for an image.
This features can be used to display only a subset of the ROIs defined on an image or to enable controls to activate or deactivate ROIs at runtime.
The embed_rois_selection.html can be used as example to show how to add three checkboxes to an embedded viewer to switch ON\OFF ROIs.