### PR TITLE
Delete - KEEP children

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -61,7 +61,8 @@ Create Project
     [Return]    ${pid}
 
 Create Dataset
-    ${did}=     Create Container    dataset
+    [Arguments]     ${newName}=testCreateContainerRobot
+    ${did}=     Create Container    dataset    ${newName}
     [Return]    ${did}
 
 Create Button Should Be Enabled

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -25,6 +25,30 @@ Test Delete Project
     Page Should Not Contain Element         id=project-${pid}
 
 
+Test Delete Project Dataset
+    [Documentation]     Create and Delete a Project containing a Dataset
+
+    # Clear any activities from earlier tests etc.
+    Click Element                           id=launch_activities
+    Click Element                           id=clear_activities
+    Select Experimenter
+    ${pid}=                                 Create project      robot test delete
+    ${did}=                                 Create Dataset      robot test deleteChildren
+    Click Element                           refreshButton
+    Wait Until Page Contains Element        id=project-${pid}
+    Click Element                           css=#project-${pid}>a
+    Click Element                           id=deleteButton
+    Wait Until Page Contains Element        id=delete-dialog-form
+    Click Element                           xpath=//button/span[contains(text(),'Yes')]
+    # Wait for activities to show job done, then refresh tree...
+    Wait Until Page Contains Element        xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
+    Click Element                           refreshButton
+    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
+    Page Should Not Contain Element         id=project-${pid}
+    # Dataset should be Deleted too
+    Page Should Not Contain Element         id=dataset-${did}
+
+
 Test Edit Project
     [Documentation]     Create a Project and edit its name and description
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1318,7 +1318,7 @@ class BaseContainer(BaseController):
         elif self.screen:
             handle = self.conn.deleteObjects("Screen", [self.screen.id], deleteChildren=child, deleteAnns=anns)
         elif self.plate:
-            handle = self.conn.deleteObjects("Plate", [self.plate.id], deleteAnns=anns)
+            handle = self.conn.deleteObjects("Plate", [self.plate.id], deleteChildren=True, deleteAnns=anns)
         elif self.comment:
             handle = self.conn.deleteObjects("Annotation", [self.comment.id], deleteAnns=anns)
         elif self.tag:

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -147,8 +147,8 @@
                 if (del_form.data("clicked_button") == "Yes") {
                     var delete_anns = $("#delete_anns").prop('checked');
                     var delete_content = true;      // $("#delete_content").prop('checked');
-                    if (delete_content) ajax_data[ajax_data.length] = 'child=on';
-                    if (delete_anns) ajax_data[ajax_data.length] = 'anns=on';
+                    if (delete_content) ajax_data[ajax_data.length] = 'child=true';
+                    if (delete_anns) ajax_data[ajax_data.length] = 'anns=true';
                     var url = '{% url 'manage_action_containers' "deletemany" %}'
                     datatree.deselect_all();
                     $.ajax({


### PR DESCRIPTION
See: https://trac.openmicroscopy.org.uk/ome/ticket/12719

This fixes deletion of child objects when the parents are deleted in the jsTree.
Also includes a new Robot framework test that tests deletion of Project and Dataset (which fails without the first commit).
To test:
 - Delete a Project containing a Dataset. Check the Dataset and Images are deleted too (not orphaned).
 - Delete a Screen/Plate and check that the images are deleted (not found as orphans).