### PR TITLE
Fix config table and do lazy loading in CLI web plugin

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -22,13 +22,13 @@ try:
     CONFIG_TABLE = CONFIG_TABLE_FMT % ("Key", "Default?", "Current value")
 
     for key in sorted(settings.CUSTOM_SETTINGS_MAPPINGS):
-        global_name, default_value, mapping, using_default = \
+        global_name, default_value, mapping, desc, using_default = \
             settings.CUSTOM_SETTINGS_MAPPINGS[key]
         global_value = getattr(settings, global_name, "(unset)")
         CONFIG_TABLE += CONFIG_TABLE_FMT % (key, using_default, global_value)
 except:
-    CONFIG_TABLE = "INVALID OR LOCKED CONFIGURATION! Cannot display default"\
-        " values"
+    CONFIG_TABLE = (
+        "INVALID OR LOCKED CONFIGURATION! Cannot display default values")
 
 HELP = """OMERO.web configuration/deployment tools
 


### PR DESCRIPTION
See https://trello.com/c/VXklk1so/405-omero-web-refactor-configuration-logic

To test this PR:
- set up a server with a deprecated Web configuration e.g. `bin/omero config set omero.web.force_script_name /prefix`
- check `bin/omero web -h` gives the help without warning about the configuration
- check `bin/omero web help` works, throws a warning about the deprecated configuration and output a fully populated configuration table
- check `bin/omero web config {nginx, nginx-development, apache, apache-fcgi}` work and throws a warning about the deprecated configuration
- check the other commands, `bin/omero web start/stop...` are unaffected by the lazy loading

--no-rebase