### PR TITLE
Show GraphException message

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/ProcessReport.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/ProcessReport.java
@@ -29,8 +29,10 @@ import java.util.Map;
 
 //Third-party libraries
 
+
 //Application-internal dependencies
 import omero.cmd.ERR;
+import omero.cmd.GraphException;
 
 /** 
  * Error that occurred when moving data, deleting etc.
@@ -75,6 +77,18 @@ public class ProcessReport {
 	 * 
 	 * @return See above.
 	 */
-	public Map<String, String> getDetails() { return error.parameters; }
+	public Map<String, String> getDetails() { return error.parameters;}
+	
+	/** 
+	 * Returns the {@link GraphException} if this ProcessReport represents
+	 * a GraphException (<code>null</code> if it doesn't)
+	 * 
+	 * @return See above.
+	 */
+	public GraphException getGraphException() {
+		if(error instanceof GraphException)
+			return (GraphException) error;
+		return null;
+	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -63,7 +63,6 @@ import org.openmicroscopy.shoola.env.Environment;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.ProcessException;
-import org.openmicroscopy.shoola.env.data.ProcessReport;
 import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
 import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
@@ -963,21 +962,6 @@ public abstract class ActivityComponent
 		if (removeButton != null) removeButton.setBackground(color);
 		if (cancelButton != null) cancelButton.setBackground(color);
 		if (exceptionButton != null) exceptionButton.setBackground(color);
-	}
-	
-	/**
-	 * Extracts the GraphException message from a ProcessReport, if there is
-	 * one.
-	 * 
-	 * @param rep
-	 *            The ProcessReport
-	 * @return The GraphException message (if there is one)
-	 */
-	protected String getGraphExceptionMessage(ProcessReport rep) {
-		String st = rep.getDetails().get("stacktrace");
-		String msg = StringUtils.substringBetween(st,
-				"GraphException(message=", ")");
-		return msg;
 	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -63,6 +63,7 @@ import org.openmicroscopy.shoola.env.Environment;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.ProcessException;
+import org.openmicroscopy.shoola.env.data.ProcessReport;
 import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
 import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
@@ -962,6 +963,21 @@ public abstract class ActivityComponent
 		if (removeButton != null) removeButton.setBackground(color);
 		if (cancelButton != null) cancelButton.setBackground(color);
 		if (exceptionButton != null) exceptionButton.setBackground(color);
+	}
+	
+	/**
+	 * Extracts the GraphException message from a ProcessReport, if there is
+	 * one.
+	 * 
+	 * @param rep
+	 *            The ProcessReport
+	 * @return The GraphException message (if there is one)
+	 */
+	protected String getGraphExceptionMessage(ProcessReport rep) {
+		String st = rep.getDetails().get("stacktrace");
+		String msg = StringUtils.substringBetween(st,
+				"GraphException(message=", ")");
+		return msg;
 	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
@@ -26,8 +26,10 @@ package org.openmicroscopy.shoola.env.ui;
 //Java imports
 import javax.swing.Icon;
 
+
+import omero.cmd.GraphException;
+
 //Third-party libraries
-import org.apache.commons.lang.StringUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -109,9 +111,9 @@ public class DataTransferActivity
 	{
 		if (result instanceof ProcessReport) {
 			type.setText(DESCRIPTION_ERROR);
-			String graphExMsg = getGraphExceptionMessage((ProcessReport) result);
-			if(!StringUtils.isEmpty(graphExMsg)) 
-				messageLabel.setText(messageLabel.getText()+" [Details: "+graphExMsg+"]");
+			GraphException ex = ((ProcessReport) result).getGraphException();
+			if (ex != null) 
+				messageLabel.setText(messageLabel.getText()+" [Details: "+ex.message+"]");
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
@@ -113,7 +113,7 @@ public class DataTransferActivity
 			type.setText(DESCRIPTION_ERROR);
 			GraphException ex = ((ProcessReport) result).getGraphException();
 			if (ex != null) 
-				messageLabel.setText(messageLabel.getText()+" [Details: "+ex.message+"]");
+				messageLabel.setText(messageLabel.getText()+" - "+ex.message);
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DataTransferActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DataTransferActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2012 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -24,10 +24,10 @@
 package org.openmicroscopy.shoola.env.ui;
 
 //Java imports
-import java.util.Collection;
 import javax.swing.Icon;
 
 //Third-party libraries
+import org.apache.commons.lang.StringUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -109,6 +109,9 @@ public class DataTransferActivity
 	{
 		if (result instanceof ProcessReport) {
 			type.setText(DESCRIPTION_ERROR);
+			String graphExMsg = getGraphExceptionMessage((ProcessReport) result);
+			if(!StringUtils.isEmpty(graphExMsg)) 
+				messageLabel.setText(messageLabel.getText()+" [Details: "+graphExMsg+"]");
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
@@ -175,7 +175,7 @@ public class DeleteActivity
 			type.setText(DESCRIPTION_ERROR);
 			GraphException ex = ((ProcessReport) result).getGraphException();
 			if (ex != null) 
-				messageLabel.setText(messageLabel.getText()+" [Details: "+ex.message+"]");
+				messageLabel.setText(messageLabel.getText()+" - "+ex.message);
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
@@ -26,10 +26,13 @@ package org.openmicroscopy.shoola.env.ui;
 //Java imports
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.Icon;
 
+
+import omero.cmd.GraphException;
+
 //Third-party libraries
-import org.apache.commons.lang.StringUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -170,9 +173,9 @@ public class DeleteActivity
 	{
 		if (result instanceof ProcessReport) {
 			type.setText(DESCRIPTION_ERROR);
-			String graphExMsg = getGraphExceptionMessage((ProcessReport) result);
-			if(!StringUtils.isEmpty(graphExMsg)) 
-				messageLabel.setText(messageLabel.getText()+" [Details: "+graphExMsg+"]");
+			GraphException ex = ((ProcessReport) result).getGraphException();
+			if (ex != null) 
+				messageLabel.setText(messageLabel.getText()+" [Details: "+ex.message+"]");
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DeleteActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DeleteActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import java.util.List;
 import javax.swing.Icon;
 
 //Third-party libraries
+import org.apache.commons.lang.StringUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -169,6 +170,9 @@ public class DeleteActivity
 	{
 		if (result instanceof ProcessReport) {
 			type.setText(DESCRIPTION_ERROR);
+			String graphExMsg = getGraphExceptionMessage((ProcessReport) result);
+			if(!StringUtils.isEmpty(graphExMsg)) 
+				messageLabel.setText(messageLabel.getText()+" [Details: "+graphExMsg+"]");
 			notifyActivityError();
 		} else {
 			type.setText(DESCRIPTION_END);


### PR DESCRIPTION
Show the GraphException message, if a move or delete action in fails (see [Ticket 12722](https://trac.openmicroscopy.org/ome/ticket/12722) ).

Test: Provoke a failed move and/or delete action; check that the GraphException message providing more details about the cause is shown in the activity status.

/cc @mtbc 
--no-rebase
