### PR TITLE
adding "on" as a True value in toBoolean

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/utils.py
+++ b/components/tools/OmeroPy/src/omero/gateway/utils.py
@@ -184,6 +184,6 @@ def toBoolean(val):
     if val is True or val is False:
         return val
 
-    trueItems = ["true", "yes", "y", "t", "1"]
+    trueItems = ["true", "yes", "y", "t", "1", "on"]
 
     return str(val).strip().lower() in trueItems

--- a/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
+++ b/components/tools/OmeroPy/test/unit/gatewaytest/test_utils.py
@@ -228,12 +228,13 @@ class TestServiceOptsDict (object):
 
 class TestHelpers (object):
 
-    @pytest.mark.parametrize('true_val', [True, "true", "yes", "y", "t", "1"])
+    @pytest.mark.parametrize('true_val',
+                             [True, "true", "yes", "y", "t", "1", "on"])
     def test_toBoolean_true(self, true_val):
         assert toBoolean(true_val)
 
     @pytest.mark.parametrize(
         'false_val',
-        [False, "false", "f", "no", "n", "none", "0", "[]", "{}", ""])
+        [False, "false", "f", "no", "n", "none", "0", "[]", "{}", "", "off"])
     def test_toBoolean_false(self, false_val):
         assert not toBoolean(false_val)

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -155,9 +155,8 @@ class ExperimenterForm(NonASCIIForm):
         max_length=250,
         widget=forms.TextInput(attrs={'size': 30, 'autocomplete': 'off'}),
         required=False)
-    administrator = forms.CharField(
-        widget=forms.CheckboxInput(), required=False)
-    active = forms.CharField(widget=forms.CheckboxInput(), required=False)
+    administrator = forms.BooleanField(required=False)
+    active = forms.BooleanField(required=False)
 
     def clean_confirmation(self):
         if (self.cleaned_data.get('password') or

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -989,8 +989,8 @@ def email(request, conn=None, **kwargs):
             message = form.cleaned_data['message']
             experimenters = form.cleaned_data['experimenters']
             groups = form.cleaned_data['groups']
-            everyone = toBoolean(form.cleaned_data['everyone'])
-            inactive = toBoolean(form.cleaned_data['inactive'])
+            everyone = form.cleaned_data['everyone']
+            inactive = form.cleaned_data['inactive']
 
             req = omero.cmd.SendEmailRequest(subject=subject, body=message,
                                              groupIds=groups,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -424,8 +424,8 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                 lastName = form.cleaned_data['last_name']
                 email = form.cleaned_data['email']
                 institution = form.cleaned_data['institution']
-                admin = toBoolean(form.cleaned_data['administrator'])
-                active = toBoolean(form.cleaned_data['active'])
+                admin = form.cleaned_data['administrator']
+                active = form.cleaned_data['active']
                 defaultGroup = form.cleaned_data['default_group']
                 otherGroups = form.cleaned_data['other_groups']
                 password = form.cleaned_data['password']
@@ -519,8 +519,8 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                 lastName = form.cleaned_data['last_name']
                 email = form.cleaned_data['email']
                 institution = form.cleaned_data['institution']
-                admin = toBoolean(form.cleaned_data['administrator'])
-                active = toBoolean(form.cleaned_data['active'])
+                admin = form.cleaned_data['administrator']
+                active = form.cleaned_data['active']
                 if experimenter.getId() == conn.getUserId():
                     active = True   # don't allow user to disable themselves!
                 defaultGroup = form.cleaned_data['default_group']

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -49,8 +49,6 @@ from forms import ForgottonPasswordForm, ExperimenterForm, GroupForm
 from forms import GroupOwnerForm, MyAccountForm, ChangePassword
 from forms import UploadPhotoForm, EmailForm
 
-from omero.gateway.utils import toBoolean
-
 from omeroweb.http import HttpJPEGResponse
 from omeroweb.webclient.decorators import login_required, render_response
 from omeroweb.connector import Connector

--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -80,7 +80,7 @@ class ShareForm(NonASCIIForm):
     
     message = forms.CharField(widget=forms.Textarea(attrs={'rows': 7, 'cols': 39}), help_text=help_wiki_c) 
     expiration = forms.CharField(max_length=100, widget=forms.TextInput(attrs={'size':20}), label="Expire date", help_text=help_expire, required=False)
-    enable = forms.CharField(widget=forms.CheckboxInput(attrs={'size':1}), required=False, help_text=help_enable)
+    enable = ssl = forms.BooleanField(required=False, help_text=help_enable)
     #guests = MultiEmailField(required=False, widget=forms.TextInput(attrs={'size':75}))
 
     def clean_expiration(self):

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2310,7 +2310,7 @@ def basket_action (request, action=None, conn=None, **kwargs):
             expiration = form.cleaned_data['expiration']
             members = form.cleaned_data['members']
             #guests = request.REQUEST['guests']
-            enable = toBoolean(form.cleaned_data['enable'])
+            enable = form.cleaned_data['enable']
             host = "%s?server=%i" % (request.build_absolute_uri(reverse("load_template", args=["public"])), int(conn.server_id))
             share = BaseShare(conn)
             share.createDiscussion(host, message, members, enable, expiration)

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -120,7 +120,7 @@ def login(request):
         username = form.cleaned_data['username']
         password = form.cleaned_data['password']
         server_id = form.cleaned_data['server']
-        is_secure = toBoolean(form.cleaned_data['ssl'])
+        is_secure = form.cleaned_data['ssl']
 
         connector = Connector(server_id, is_secure)
 
@@ -1871,7 +1871,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None, conn=None,
                 expiration = form.cleaned_data['expiration']
                 members = form.cleaned_data['members']
                 #guests = request.REQUEST['guests']
-                enable = toBoolean(form.cleaned_data['enable'])
+                enable = form.cleaned_data['enable']
                 host = "%s?server=%i" % (request.build_absolute_uri(reverse("load_template", args=["public"])), int(conn.server_id))
                 manager.updateShareOrDiscussion(host, message, members, enable, expiration)
                 return HttpResponse("DONE")
@@ -2283,7 +2283,7 @@ def basket_action (request, action=None, conn=None, **kwargs):
             expiration = form.cleaned_data['expiration']
             members = form.cleaned_data['members']
             #guests = request.REQUEST['guests']
-            enable = toBoolean(form.cleaned_data['enable'])
+            enable = form.cleaned_data['enable']
             host = "%s?server=%i" % (request.build_absolute_uri(reverse("load_template", args=["public"])), int(conn.server_id))
             share = BaseShare(conn)
             sid = share.createShare(host, images, message, members, enable, expiration)


### PR DESCRIPTION
As pointed in https://github.com/openmicroscopy/openmicroscopy/pull/3433#issuecomment-73008462 toBoolean should handle "on" as well

To be tested:

- **active** and **admin** checkbooks on experimenter form, test both creation and editing
- **ssl** on Login panel
- **enable** checkbox on share form, test both creation and editing
- **import/Acquisition** date select box in search
- checkbox on confirmation when deleting single and multiple objects
- check if you see all 3 categories in dropdown menu
    - test locally. Disable ```omero.client.ui.menu.dropdown.colleagues.enabled``` and check if list of members disappeared.

cc: @chris-allan 

--no-rebase