### PR TITLE
Customizable batch image export filename

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.Editor 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -483,14 +483,19 @@ public interface Editor
 	void analysisResultsLoaded(AnalysisResultsItem analysis);
 
 	/**
-	 * Saves the selected images as <code>JPEG</code>, <code>PNG</code>
-	 * or <code>TIFF</code>.
+	 * Saves the selected images as <code>JPEG</code>, <code>PNG</code> or
+	 * <code>TIFF</code>.
 	 * 
-	 * @param folder The folder to save.
-	 * @param format The format to use.
+	 * @param folder
+	 *            The folder to save.
+	 * @param format
+	 *            The format to use.
+	 * @param filename
+	 *            The filename to use for the batch export file (without
+	 *            extension)
 	 * @see org.openmicroscopy.shoola.env.data.model.FigureParam
 	 */
-	public void saveAs(File folder, int format);
+	public void saveAs(File folder, int format, String filename);
 
 	/** 
 	 * Invokes when the user has switched group.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.EditorComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1166,10 +1166,10 @@ class EditorComponent
 	 * Implemented as specified by the {@link Editor} interface.
 	 * @see Editor#saveAs(File, int)
 	 */
-	public void saveAs(File folder, int format)
+	public void saveAs(File folder, int format, String fileName)
 	{
 		if (folder == null) folder = UIUtilities.getDefaultFolder();
-		model.saveAs(folder, format);
+		model.saveAs(folder, format, fileName);
 	}
 	
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -54,7 +54,7 @@ import javax.swing.filechooser.FileFilter;
 //Third-party libraries
 import org.jdesktop.swingx.JXTaskPane;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.ArrayUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
@@ -97,6 +97,8 @@ import org.openmicroscopy.shoola.util.filter.file.TEXTFilter;
 import org.openmicroscopy.shoola.util.filter.file.TIFFFilter;
 import org.openmicroscopy.shoola.util.filter.file.WordFilter;
 import org.openmicroscopy.shoola.util.filter.file.XMLFilter;
+import org.openmicroscopy.shoola.util.filter.file.ZipFilter;
+import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
 import org.openmicroscopy.shoola.util.ui.omeeditpane.OMEWikiComponent;
@@ -374,27 +376,19 @@ class EditorControl
 	void saveAs(final int format)
 	{
 		String v = FigureParam.FORMATS.get(format);
-		JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
+		final JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
 		List<FileFilter> filters = new ArrayList<FileFilter>();
-		switch (format) {
-			case FigureParam.JPEG:
-				filters.add(new JPEGFilter());
-				break;
-			case FigureParam.PNG:
-				filters.add(new PNGFilter());
-				break;
-			case FigureParam.TIFF:
-				filters.add(new TIFFFilter());
-		}
-		FileChooser chooser = new FileChooser(f, FileChooser.FOLDER_CHOOSER, 
+		filters.add(new ZipFilter());
+		FileChooser chooser = new FileChooser(f, FileChooser.SAVE, 
 				"Save As", "Select where to save locally the images as "+v,
 				filters);
 		try {
 			File file = UIUtilities.getDefaultFolder();
-			if (file != null) chooser.setCurrentDirectory(file);
+			if (file != null) 
+				chooser.setCurrentDirectory(file);
+			chooser.setSelectedFile(UIUtilities.generateFileName(file,
+					"Batch_Image_Export", "zip"));
 		} catch (Exception ex) {}
-		String s = UIUtilities.removeFileExtension(view.getRefObjectName());
-		if (s != null && s.trim().length() > 0) chooser.setSelectedFile(s);
 		chooser.setApproveButtonText("Save");
 		IconManager icons = IconManager.getInstance();
 		chooser.setTitleIcon(icons.getIcon(IconManager.SAVE_AS_48));
@@ -403,22 +397,35 @@ class EditorControl
 			public void propertyChange(PropertyChangeEvent evt) {
 				String name = evt.getPropertyName();
 				if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
-					String value = (String) evt.getNewValue();
-					File folder = null;
-					if (StringUtils.isEmpty(value))
-						folder = UIUtilities.getDefaultFolder();
-					else folder = new File(value);
+					File[] files = (File[]) evt.getNewValue();
+					if (ArrayUtils.isEmpty(files))
+						return;
+					File file = files[0];
+					if (file == null)
+						file = UIUtilities.generateFileName(
+								UIUtilities.getDefaultFolder(),
+								"Batch_Image_Export", "zip");
+					if (file.exists()) {
+						MessageBox msg = new MessageBox(f, "File Exists",
+								"Do you want to overwrite the file?");
+						int option = msg.centerMsgBox();
+						if (option == MessageBox.NO_OPTION) {
+							return;
+						}
+					}
 					Object src = evt.getSource();
 					if (src instanceof FileChooser) {
 						((FileChooser) src).setVisible(false);
 						((FileChooser) src).dispose();
 					}
-					model.saveAs(folder, format);
+					model.saveAs(file.getParentFile(), format,
+							UIUtilities.removeFileExtension(file.getName()));
 				}
 			}
 		});
 		chooser.centerDialog();
 	}
+	
 	
 	/** Brings up the folder chooser. */
 	private void export()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -4141,7 +4141,7 @@ class EditorModel
 	 * @param folder The folder where to save the images.
 	 * @param format The format to use.
 	 */
-	void saveAs(File folder, int format)
+	void saveAs(File folder, int format, String filename)
 	{
 	    Collection l = parent.getRelatedNodes();
 	    List<DataObject> objects = new ArrayList<DataObject>();
@@ -4163,6 +4163,7 @@ class EditorModel
 	        SaveAsParam p = new SaveAsParam(folder, objects);
 	        p.setIndex(format);
 	        p.setIcon(icons.getIcon(IconManager.SAVE_AS_22));
+	        p.setBatchExportFilename(filename);
 	        p.setDeleteWhenFinished(true);
 	        UserNotifier un =
 	                MetadataViewerAgent.getRegistry().getUserNotifier();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -6215,6 +6215,9 @@ class OMEROGateway
 		map.put("IDs", omero.rtypes.rlist(ids));
 		map.put("Data_Type", omero.rtypes.rstring(type));
 		map.put("Format", omero.rtypes.rstring(param.getIndexAsString()));
+		if (!StringUtils.isEmpty(param.getBatchExportFilename()))
+			map.put("Folder_Name",
+					omero.rtypes.rstring(param.getBatchExportFilename()));
 		return runScript(ctx, id, map);
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadActivityParam.java
@@ -94,6 +94,9 @@ public class DownloadActivityParam
     /** FileAnnotation to delete after downloading */
     private FileAnnotationData toDelete;
     
+    /** Overwrite local file, if it already exists */
+    private boolean overwrite = false;
+    
     /** 
      * Checks if the index is valid.
      * 
@@ -292,11 +295,32 @@ public class DownloadActivityParam
 	/**
 	 * Set the {@link FileAnnotationData} which should get
 	 * deleted after download finished
+	 * 
 	 * @param toDelete The {@link FileAnnotationData} to delete
 	 */
 	public void setToDelete(FileAnnotationData toDelete) {
 		this.toDelete = toDelete;
 	}
 
+	/**
+	 * Returns <code>true</code> if the local file should be overwritten, if it
+	 * already exists
+	 * 
+	 * @return See above.
+	 */
+	public boolean isOverwrite() {
+		return overwrite;
+	}
+
+	/**
+	 * Determines if the local file should be overwritten, if it already exists
+	 * 
+	 * @param overwrite
+	 *            Set to <code>true</code> if local file should be overwritten
+	 */
+	public void setOverwrite(boolean overwrite) {
+		this.overwrite = overwrite;
+	}
+	
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/SaveAsParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/SaveAsParam.java
@@ -70,6 +70,9 @@ public class SaveAsParam
     /** Flag to indicate to delete the file after downloading */
     private boolean deleteWhenFinished = false;
     
+    /** Filename for the batch export */
+    private String batchExportFilename;
+    
 	/**
 	 * Creates a new instance.
 	 * 
@@ -161,6 +164,24 @@ public class SaveAsParam
 	public void setDeleteWhenFinished(boolean deleteWhenFinished) {
 		this.deleteWhenFinished = deleteWhenFinished;
 	}
-	
+
+	/**
+	 * Get the filename to use for the batch export file
+	 * 
+	 * @return See above.
+	 */
+	public String getBatchExportFilename() {
+		return batchExportFilename;
+	}
+
+	/**
+	 * Set the filename to use for the batch export file
+	 * 
+	 * @param batchExportFilename
+	 *            The filename
+	 */
+	public void setBatchExportFilename(String batchExportFilename) {
+		this.batchExportFilename = batchExportFilename;
+	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -619,6 +619,7 @@ public abstract class ActivityComponent
 			activity.setUIRegister(true);
 			if (fa != null && deleteWhenFinished)
 				activity.setToDelete(fa);
+			activity.setOverwrite(true);
 			viewer.notifyActivity(ctx, activity);
 			return;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadActivity.java
@@ -84,6 +84,9 @@ public class DownloadActivity extends ActivityComponent {
 	/** The local name of the file. */
 	private String localFileName;
 
+	/** Overwrite if local file already exists */
+	private boolean overwrite = false;
+	
 	/** The supported file filters. */
 	private static final List<CustomizedFileFilter> FILTERS;
 
@@ -190,6 +193,8 @@ public class DownloadActivity extends ActivityComponent {
 		else
 			localFileName = folder.toString();
 		messageLabel.setText(localFileName);
+		
+		this.overwrite = parameters.isOverwrite();
 	}
 
 	/**
@@ -207,7 +212,7 @@ public class DownloadActivity extends ActivityComponent {
 		registry.getLogger().debug(this, file.getAbsolutePath());
 
 		boolean load = true;
-		if (file.exists())
+		if (file.exists() && !overwrite)
 			load = false;
 
 		switch (parameters.getIndex()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
@@ -123,8 +123,7 @@ public class SaveAsActivity
 				}
 				
 				if(fa!=null && fa.isLoaded()) {
-					String name = getFileName(fa.getFileName());
-					download("", fa, new File(parameters.getFolder(), name), parameters.isDeleteWhenFinished());
+					download("", fa, new File(parameters.getFolder(), fa.getFileName()), parameters.isDeleteWhenFinished());
 					// call super method to stop busy label
 					super.endActivity(null);
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/filter/file/ZipFilter.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/filter/file/ZipFilter.java
@@ -1,0 +1,111 @@
+/*
+ * org.openmicroscopy.shoola.util.filter.file.CSVFilter 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ * 	This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.util.filter.file;
+
+import java.io.File;
+
+import javax.swing.filechooser.FileFilter;
+
+/**
+ * 
+ * Filters the <code>ZIP</code> files.
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ZipFilter extends CustomizedFileFilter {
+
+	/** Possible file extension. */
+	public static final String ZIP = "zip";
+
+	/** The possible extensions. */
+	public static final String[] extensions;
+
+	/** The description of the filter. */
+	private static final String description;
+
+	static {
+		extensions = new String[1];
+		extensions[0] = ZIP;
+
+		StringBuffer s = new StringBuffer();
+		s.append("Zip Archive (");
+		for (int i = 0; i < extensions.length; i++) {
+			s.append("*." + extensions[i]);
+			if (i < extensions.length - 1)
+				s.append(", ");
+		}
+		s.append(")");
+		description = s.toString();
+	}
+
+	/**
+	 * Overridden to return the MIME type.
+	 * 
+	 * @see CustomizedFileFilter#getMIMEType()
+	 */
+	public String getMIMEType() {
+		return "application/zip";
+	}
+
+	/**
+	 * Overridden to return the extension of the filter.
+	 * 
+	 * @see CustomizedFileFilter#getExtension()
+	 */
+	public String getExtension() {
+		return ZIP;
+	}
+
+	/**
+	 * Overridden to return the description of the filter.
+	 * 
+	 * @see FileFilter#getDescription()
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * Overridden to accept file with the declared file extensions.
+	 * 
+	 * @see FileFilter#accept(File)
+	 */
+	public boolean accept(File f) {
+		if (f == null)
+			return false;
+		if (f.isDirectory())
+			return true;
+		return isSupported(f.getName(), extensions);
+	}
+
+	/**
+	 * Overridden to accept the file identified by its name.
+	 * 
+	 * @see CustomizedFileFilter#accept(String)
+	 */
+	public boolean accept(String fileName) {
+		return isSupported(fileName, extensions);
+	}
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.UIUtilities
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -2688,4 +2688,23 @@ public class UIUtilities
         }
         return name;
     }
+    
+    /**
+     * Generates an unique filename in form 'folder'/'name'(INCREMENT).'ext', whereas
+     * INCREMENT is chosen in such a way, that the file does not exist yet.
+     * 
+     * @param folder The folder where the file is intended to be stored
+     * @param name The base name of the file
+     * @param ext The extension of the file
+     * @return The generated unique filename
+     */
+    public static File generateFileName(File folder, String name, String ext) {
+		int i = 0;
+		File file = new File(folder, name+"."+ext);
+		while(file.exists()) {
+			i++;
+			file = new File(folder, name+"("+i+")."+ext);
+		}
+		return file;
+	}
 }


### PR DESCRIPTION
See [Ticket 11895](https://trac.openmicroscopy.org/ome/ticket/11895)

Test: Select some images and export them as JPG, PNG or TIFF. You can now choose a name for the generated batch export zip file. Default name is "Batch_Image_Export.zip". Make sure that if a file with that name already exists, the default name will be incremented to "Batch_Image_Export(1).zip" and so on. Also check if the file gets overwritten if you select a file which already exists (and that you have to confirm this).
