### PR TITLE
CLI nginx template improvements

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -234,7 +234,8 @@ class WebControl(BaseControl):
             "ROOT": self.ctx.dir,
             "OMEROWEBROOT": self._get_python_dir() / "omeroweb",
             "STATIC_URL": settings.STATIC_URL.rstrip("/"),
-            "NOW": str(datetime.now())}
+            "NOW": str(datetime.now()),
+            "HTTPORT": port}
 
         try:
             d["FORCE_SCRIPT_NAME"] = settings.FORCE_SCRIPT_NAME.rstrip("/")
@@ -242,7 +243,6 @@ class WebControl(BaseControl):
             d["FORCE_SCRIPT_NAME"] = "/"
 
         if server in ("nginx", "nginx-development"):
-            d["HTTPPORT"] = port
             d = self._set_nginx_fastcgi(d, settings)
 
         if server == "apache":

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -79,10 +79,16 @@ class WebControl(BaseControl):
             "  apache-fcgi: Apache 2.4+ with mod_proxy_fcgi\n")
         config.add_argument("type", choices=(
             "nginx", "nginx-development", "apache", "apache-fcgi"))
-        config.add_argument(
+        nginx_group = config.add_argument_group(
+            'Nginx arguments', 'Optional arguments for nginx templates.')
+        nginx_group.add_argument(
             "--http", type=int,
-            help="HTTP port for web server (nginx only)")
-        config.add_argument(
+            help="HTTP port for web server")
+        nginx_group.add_argument(
+            "--max-body-size", type=int, default=0,
+            help="Maximum allowed size of the client request body."
+            "Default: 0 (disabled)")
+        nginx_group.add_argument(
             "--system", action="store_true", help=SUPPRESS)
 
         parser.add(
@@ -234,8 +240,11 @@ class WebControl(BaseControl):
             "ROOT": self.ctx.dir,
             "OMEROWEBROOT": self._get_python_dir() / "omeroweb",
             "STATIC_URL": settings.STATIC_URL.rstrip("/"),
-            "NOW": str(datetime.now()),
-            "HTTPORT": port}
+            "NOW": str(datetime.now())}
+
+        if server in ("nginx", "nginx-development"):
+            d["HTTPPORT"] = port
+            d["MAX_BODY_SIZE"] = args.max_body_size
 
         try:
             d["FORCE_SCRIPT_NAME"] = settings.FORCE_SCRIPT_NAME.rstrip("/")

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -217,9 +217,13 @@ class WebControl(BaseControl):
                 "WARNING: --system is no longer supported, see --help")
 
         server = args.type
-        port = 8080
         if args.http:
             port = args.http
+        elif server == 'nginx-development':
+            port = 8080
+        else:
+            port = 80
+
         if settings.APPLICATION_SERVER == settings.FASTCGITCP:
             if settings.APPLICATION_SERVER_PORT == port:
                 self.ctx.die(

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -173,7 +173,6 @@ class WebControl(BaseControl):
                 script_info % settings.FORCE_SCRIPT_NAME)
         except:
             d["FASTCGI_PATH_SCRIPT_INFO"] = script_info_fallback
-        return d
 
     def _set_apache_fastcgi(self, d, settings):
         if settings.APPLICATION_SERVER == settings.FASTCGITCP:
@@ -252,7 +251,7 @@ class WebControl(BaseControl):
             d["FORCE_SCRIPT_NAME"] = "/"
 
         if server in ("nginx", "nginx-development"):
-            d = self._set_nginx_fastcgi(d, settings)
+            self._set_nginx_fastcgi(d, settings)
 
         if server == "apache":
             self._set_apache_fastcgi(d, settings)

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -156,17 +156,17 @@ class WebControl(BaseControl):
                 % self.ctx.dir
         d["FASTCGI_PASS"] = fastcgi_pass
 
+        script_info = (
+            "fastcgi_split_path_info ^(%s)(.*)$;\n"
+            "            fastcgi_param PATH_INFO $fastcgi_path_info;\n"
+            "            fastcgi_param SCRIPT_INFO $fastcgi_script_name;\n")
+        script_info_fallback = (
+            "fastcgi_param PATH_INFO $fastcgi_script_name;\n")
         try:
-            d["FASTCGI_PATH_SCRIPT_INFO"] = \
-                "fastcgi_split_path_info ^(%s)(.*)$;\n" \
-                "            " \
-                "fastcgi_param PATH_INFO $fastcgi_path_info;\n" \
-                "            " \
-                "fastcgi_param SCRIPT_INFO $fastcgi_script_name;\n" \
-                % (settings.FORCE_SCRIPT_NAME)
+            d["FASTCGI_PATH_SCRIPT_INFO"] = (
+                script_info % settings.FORCE_SCRIPT_NAME)
         except:
-            d["FASTCGI_PATH_SCRIPT_INFO"] = "fastcgi_param PATH_INFO " \
-                                            "$fastcgi_script_name;\n"
+            d["FASTCGI_PATH_SCRIPT_INFO"] = script_info_fallback
         return d
 
     def _set_apache_fastcgi(self, d, settings):
@@ -179,9 +179,9 @@ class WebControl(BaseControl):
                 self.ctx.dir
         d["FASTCGI_EXTERNAL"] = fastcgi_external
         try:
-            d["REWRITERULE"] = \
-                "RewriteEngine on\nRewriteRule ^/?$ %s/ [R]\n"\
-                % settings.FORCE_SCRIPT_NAME.rstrip("/")
+            d["REWRITERULE"] = (
+                "RewriteEngine on\nRewriteRule ^/?$ %s/ [R]\n"
+                % settings.FORCE_SCRIPT_NAME.rstrip("/"))
         except:
             d["REWRITERULE"] = ""
 
@@ -191,8 +191,7 @@ class WebControl(BaseControl):
         # path component containing a dot.
 
         if settings.APPLICATION_SERVER != settings.FASTCGITCP:
-            self.ctx.die(
-                679, "Apache mod_proxy_fcgi requires fastcgi-tcp")
+            self.ctx.die(679, "Apache mod_proxy_fcgi requires fastcgi-tcp")
         fastcgi_external = '%s:%s' % (
             settings.APPLICATION_SERVER_HOST,
             settings.APPLICATION_SERVER_PORT)
@@ -207,7 +206,6 @@ class WebControl(BaseControl):
 
     def config(self, args):
         """Generate a configuration file from a template"""
-
         from omeroweb import settings
         if not args.type:
             self.ctx.die(

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -85,7 +85,7 @@ class WebControl(BaseControl):
             "--http", type=int,
             help="HTTP port for web server")
         nginx_group.add_argument(
-            "--max-body-size", type=int, default=0,
+            "--max-body-size", type=str, default='0',
             help="Maximum allowed size of the client request body."
             "Default: 0 (disabled)")
         nginx_group.add_argument(

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -94,17 +94,17 @@ class TestWeb(object):
         if server_type.split()[0] == "nginx":
             assert lines[0] == "server {"
             assert lines[1] == "listen       %s;" % (http or 80)
-            assert lines[3] == "client_max_body_size %s;" % (
+            assert lines[5] == "client_max_body_size %s;" % (
                 max_body_size or '0')
-            assert lines[8] == "location %s {" % static_prefix[:-1]
-            assert lines[11] == "location %s {" % (prefix or "/")
+            assert lines[10] == "location %s {" % static_prefix[:-1]
+            assert lines[13] == "location %s {" % (prefix or "/")
         else:
-            assert lines[16] == "server {"
-            assert lines[17] == "listen       %s;" % (http or 8080)
-            assert lines[21] == "client_max_body_size %s;" % (
+            assert lines[13] == "server {"
+            assert lines[14] == "listen       %s;" % (http or 8080)
+            assert lines[20] == "client_max_body_size %s;" % (
                 max_body_size or '0')
-            assert lines[26] == "location %s {" % static_prefix[:-1]
-            assert lines[29] == "location %s {" % (prefix or "/")
+            assert lines[25] == "location %s {" % static_prefix[:-1]
+            assert lines[28] == "location %s {" % (prefix or "/")
 
     @pytest.mark.parametrize('prefix', [None, '/test'])
     def testApacheConfig(self, prefix, capsys, monkeypatch):

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -42,14 +42,18 @@ class TestWeb(object):
                             lambda x: dist_dir / "etc" / "templates")
 
     def add_prefix(self, prefix, monkeypatch):
+
+        def _get_default_value(x):
+            return settings.CUSTOM_SETTINGS_MAPPINGS[x][1]
         if prefix:
-            monkeypatch.setattr(settings, 'FORCE_SCRIPT_NAME', prefix,
-                                raising=False)
             static_prefix = prefix + '-static/'
-            monkeypatch.setattr(settings, 'STATIC_URL', static_prefix,
-                                raising=False)
         else:
-            static_prefix = settings.STATIC_URL
+            prefix = _get_default_value('omero.web.prefix')
+            static_prefix = _get_default_value('omero.web.static_url')
+        monkeypatch.setattr(settings, 'STATIC_URL', static_prefix,
+                            raising=False)
+        monkeypatch.setattr(settings, 'FORCE_SCRIPT_NAME', prefix,
+                            raising=False)
         return static_prefix
 
     def clean_generated_file(self, txt):

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -92,13 +92,15 @@ class TestWeb(object):
         if system:
             assert lines[0] == "server {"
             assert lines[1] == "listen       %s;" % (http or 80)
-            assert lines[7] == "location %s {" % static_prefix[:-1]
-            assert lines[10] == "location %s {" % (prefix or "/")
+            assert lines[3] == "client_max_body_size 0;"
+            assert lines[8] == "location %s {" % static_prefix[:-1]
+            assert lines[11] == "location %s {" % (prefix or "/")
         else:
             assert lines[16] == "server {"
             assert lines[17] == "listen       %s;" % (http or 8080)
-            assert lines[25] == "location %s {" % static_prefix[:-1]
-            assert lines[28] == "location %s {" % (prefix or "/")
+            assert lines[21] == "client_max_body_size 0;"
+            assert lines[26] == "location %s {" % static_prefix[:-1]
+            assert lines[29] == "location %s {" % (prefix or "/")
 
     @pytest.mark.parametrize('prefix', [None, '/test'])
     def testApacheConfig(self, prefix, capsys, monkeypatch):

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -91,7 +91,7 @@ class TestWeb(object):
 
         if system:
             assert lines[0] == "server {"
-            assert lines[1] == "listen       %s;" % (http or 8080)
+            assert lines[1] == "listen       %s;" % (http or 80)
             assert lines[7] == "location %s {" % static_prefix[:-1]
             assert lines[10] == "location %s {" % (prefix or "/")
         else:

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -94,17 +94,17 @@ class TestWeb(object):
         if server_type.split()[0] == "nginx":
             assert lines[0] == "server {"
             assert lines[1] == "listen       %s;" % (http or 80)
-            assert lines[5] == "client_max_body_size %s;" % (
+            assert lines[4] == "client_max_body_size %s;" % (
                 max_body_size or '0')
-            assert lines[10] == "location %s {" % static_prefix[:-1]
-            assert lines[13] == "location %s {" % (prefix or "/")
+            assert lines[9] == "location %s {" % static_prefix[:-1]
+            assert lines[12] == "location %s {" % (prefix or "/")
         else:
             assert lines[13] == "server {"
             assert lines[14] == "listen       %s;" % (http or 8080)
-            assert lines[20] == "client_max_body_size %s;" % (
+            assert lines[19] == "client_max_body_size %s;" % (
                 max_body_size or '0')
-            assert lines[25] == "location %s {" % static_prefix[:-1]
-            assert lines[28] == "location %s {" % (prefix or "/")
+            assert lines[24] == "location %s {" % static_prefix[:-1]
+            assert lines[27] == "location %s {" % (prefix or "/")
 
     @pytest.mark.parametrize('prefix', [None, '/test'])
     def testApacheConfig(self, prefix, capsys, monkeypatch):

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -71,38 +71,38 @@ class TestWeb(object):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('size', [None, '0', '1m'])
-    @pytest.mark.parametrize('system', [True, False])
+    @pytest.mark.parametrize('max_body_size', [None, '0', '1m'])
+    @pytest.mark.parametrize('server_type', [
+        "nginx", "nginx-development", "nginx --system"])
     @pytest.mark.parametrize('http', [False, 8081])
     @pytest.mark.parametrize('prefix', [None, '/test'])
-    def testNginxConfig(self, system, http, prefix, capsys, monkeypatch,
-                        size):
+    def testNginxConfig(self, server_type, http, prefix, capsys, monkeypatch,
+                        max_body_size):
 
         static_prefix = self.add_prefix(prefix, monkeypatch)
         self.args += ["config"]
-        if system:
-            self.args += ["nginx"]
-        else:
-            self.args += ["nginx-development"]
+        self.args += server_type.split()
         if http:
             self.args += ["--http", str(http)]
-        if size:
-            self.args += ["--max-body-size", size]
+        if max_body_size:
+            self.args += ["--max-body-size", max_body_size]
         self.set_templates_dir(monkeypatch)
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
         lines = self.clean_generated_file(o)
 
-        if system:
+        if server_type.split()[0] == "nginx":
             assert lines[0] == "server {"
             assert lines[1] == "listen       %s;" % (http or 80)
-            assert lines[3] == "client_max_body_size %s;" % (size or '0')
+            assert lines[3] == "client_max_body_size %s;" % (
+                max_body_size or '0')
             assert lines[8] == "location %s {" % static_prefix[:-1]
             assert lines[11] == "location %s {" % (prefix or "/")
         else:
             assert lines[16] == "server {"
             assert lines[17] == "listen       %s;" % (http or 8080)
-            assert lines[21] == "client_max_body_size %s;" % (size or '0')
+            assert lines[21] == "client_max_body_size %s;" % (
+                max_body_size or '0')
             assert lines[26] == "location %s {" % static_prefix[:-1]
             assert lines[29] == "location %s {" % (prefix or "/")
 

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -32,7 +32,7 @@ http {
         fastcgi_temp_path %(ROOT)s/var/nginx_tmp;
         proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
-        client_max_body_size %(MAX_BODY_SIZE)d;
+        client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here
         location @maintenance {

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -32,6 +32,8 @@ http {
         fastcgi_temp_path %(ROOT)s/var/nginx_tmp;
         proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
+        client_max_body_size 0;
+
         # maintenance page serve from here
         location @maintenance {
             root %(ROOT)s/etc/templates/error;

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -32,7 +32,7 @@ http {
         fastcgi_temp_path %(ROOT)s/var/nginx_tmp;
         proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
-        client_max_body_size 0;
+        client_max_body_size %(MAX_BODY_SIZE)d;
 
         # maintenance page serve from here
         location @maintenance {

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -29,7 +29,6 @@ http {
         proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
         sendfile on;
-        send_timeout 60s;
         client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -19,10 +19,6 @@ http {
     include       %(ROOT)s/etc/mime.types;
     default_type  application/octet-stream;
     client_body_temp_path %(ROOT)s/var/nginx_tmp;
-    
-    sendfile on;
-    send_timeout 60s;
-    client_max_body_size 0;
 
     keepalive_timeout  65;
 
@@ -32,6 +28,8 @@ http {
         fastcgi_temp_path %(ROOT)s/var/nginx_tmp;
         proxy_temp_path %(ROOT)s/var/nginx_tmp;
 
+        sendfile on;
+        send_timeout 60s;
         client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -2,7 +2,7 @@
         listen       %(HTTPPORT)d;
         server_name  $hostname;
 
-        client_max_body_size %(MAX_BODY_SIZE)d;
+        client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here
         location @maintenance {

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -2,6 +2,7 @@
         listen       %(HTTPPORT)d;
         server_name  $hostname;
 
+        client_max_body_size 0;
 
         # maintenance page serve from here
         location @maintenance {

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -2,6 +2,8 @@
         listen       %(HTTPPORT)d;
         server_name  $hostname;
 
+        sendfile on;
+        send_timeout 60s;
         client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -2,7 +2,7 @@
         listen       %(HTTPPORT)d;
         server_name  $hostname;
 
-        client_max_body_size 0;
+        client_max_body_size %(MAX_BODY_SIZE)d;
 
         # maintenance page serve from here
         location @maintenance {

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -3,7 +3,6 @@
         server_name  $hostname;
 
         sendfile on;
-        send_timeout 60s;
         client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here


### PR DESCRIPTION
See https://trello.com/c/llYcBf5H/408-omero-web-nginx-client-max-body-size and https://trello.com/c/lm5ZOYF0/412-omero-web-nginx-default-port-change-to-80-instead-of-8080.

The CLI web plugin and nginx templates has been modified to:
- reduce the complexity of the `config()` method
- group all nginx arguments into an argument group
- use `8080` as the default for the development nginx and `80` as the default for the system nginx
- set `max_client_body_size` and allow it to be control via CLI (defaulting to 0, i.e. no size check)

Unit tests have been updated to reflect these changes, test all combinations but also test the backwards compatible `bin/omero web config nginx --system`.
The improvements in this PR can be manually checked by running the following commands.

```
bin/omero web config -h  # should group all nginx arguments

bin/omero web config nginx   # should give listen 80;
bin/omero web config nginx --http 8081  # should give listen 8081;
bin/omero web config nginx-development   # should give listen 8080;
bin/omero web config nginx-development --http 8081  # should give listen 8081;

bin/omero web config nginx-development   # should give client_max_body_size 0;
bin/omero web config nginx-development --max-body-size 0   # should give client_max_body_size 0;
bin/omero web config nginx-development --max-body-size 1m   # should give client_max_body_size 1m;

# same commands as the last block with nginx instead of nginx-development
```


/cc @manics
--no-rebase