### PR TITLE
Bugfixes: Change user's default group

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/GroupEditor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/GroupEditor.java
@@ -36,6 +36,7 @@ import org.openmicroscopy.shoola.env.data.ProcessReport;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
+import pojos.ExperimenterData;
 import pojos.GroupData;
 
 /** 
@@ -131,8 +132,10 @@ public class GroupEditor
 	        handle = adminView.updateGroup(ctx, group, this);
 	        break;
 	    case CHANGE:
-	        handle = adminView.changeGroup(ctx, group, viewer.getCurrentUser(),
-	                this);
+	    	ExperimenterData exp = viewer.getCurrentUser();
+	    	if(viewer.getRefObject()!=null && viewer.getRefObject() instanceof ExperimenterData)
+	    		exp = (ExperimenterData) viewer.getRefObject();
+	        handle = adminView.changeGroup(ctx, group, exp, this);
 	    }
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/GroupEditor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/GroupEditor.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.GroupEditor 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.UserProfile 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -32,6 +32,8 @@ import java.awt.Image;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -378,6 +380,12 @@ class UserProfile
         }
         groupsBox.setModel(m);
         if (selected != null) groupsBox.setSelectedItem(selected);
+        groupsBox.addItemListener(new ItemListener() {
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				hasDataToSave();
+			}
+		});
         permissionsPane = new PermissionsPane(defaultGroup.getPermissions(),
                 UIUtilities.BACKGROUND_COLOR);
         permissionsPane.disablePermissions();
@@ -947,6 +955,10 @@ class UserProfile
             saveButton.setEnabled(true);
             return true;
         }
+		if (original.getDefaultGroup().getId() != getSelectedGroup().getId()) {
+			saveButton.setEnabled(true);
+			return true;
+		}
         //if (selectedIndex != originalIndex) return true;
         if (details == null) return false;
         Entry<String, String> entry;


### PR DESCRIPTION
Fixes [Ticket 12378](http://trac.openmicroscopy.org.uk/ome/ticket/12378)
Also fixed: Save button did not become enabled if just the default group was changed.

Test: As an admin user try to change the default group of another user to a group the admin user is not a member of. This previously triggered the `DSOutOfServiceException: Can't modify the current group.` exception.