### PR TITLE
fix #12179: adjust Insight JNLP specification for webstart

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
@@ -1,6 +1,6 @@
 {% comment %}
 <!--
-  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2015 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify
@@ -23,20 +23,16 @@
     <vendor>{{vendor}}</vendor>
     <homepage href="{{homepage}}"/>
     <icon href="{% static icon %}"/>
-    <shortcut online="false">
-      <desktop/>
-    </shortcut>
     <offline-allowed/>
   </information>
   <security>
       <all-permissions/>
   </security>
   <resources>
-    <j2se version="1.5+" max-heap-size="{{heap}}"/>{% for jar in jarlist %}
+    <j2se version="1.6+" max-heap-size="{{heap}}"/>{% for jar in jarlist %}
     <jar href="{{jar}}"/>{% endfor %}
     <property name="jnlp.omero.host" value="{{host}}"/>
     <property name="jnlp.omero.port" value="{{port}}"/>
   </resources>
   <application-desc main-class="{{class}}"/>
 </jnlp>
-


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12179.

* Bumps Java requirement up to 1.6.
* Removes preference for creating a desktop icon.

--no-rebase