### PR TITLE
Fixed ConcurrentModificationException

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/Connector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/Connector.java
@@ -657,7 +657,8 @@ class Connector
         shutdownStateful();
         shutdownImports();
         if (!rendering) return;
-        for (Long pixelsId : reServices.keySet()) {
+        Set<Long> tmp = new HashSet<Long>(reServices.keySet());
+        for (Long pixelsId : tmp) {
             shutDownRenderingEngine(pixelsId);
         }
     }


### PR DESCRIPTION
Fixes [Ticket 12397](http://trac.openmicroscopy.org.uk/ome/ticket/12397)

Test: Open multiple images in fullviewer; don't close the image viewer windows (thus multiple rendering services are left open) and directly close Insight. This previously triggered the ConcurrentModificationException.