### PR TITLE
fix #12513: close import log earlier to set its size correctly

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -61,6 +61,7 @@ import omero.model.Image;
 import omero.model.IndexingJob;
 import omero.model.Job;
 import omero.model.MetadataImportJob;
+import omero.model.OriginalFile;
 import omero.model.PixelDataJob;
 import omero.model.Pixels;
 import omero.model.Plate;
@@ -358,12 +359,31 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         try {
             cleanupReader();
             cleanupStore();
+
+            log.info(ClassicConstants.FINALIZE_SESSION_MARKER, "Finalizing log file.");
+            /* hereafter back to normal log destination, not import log file*/
+            MDC.clear();
+            try {
+                /* requires usable session */
+                setLogFileSize();
+            } catch (ServerError se) {
+                log.error("failed to set import log file size", se);
+            }
+
             cleanupSession();
         } finally {
             autoClose();
         }
-        log.info(ClassicConstants.FINALIZE_SESSION_MARKER, "Finalizing log file.");
-        MDC.clear();
+    }
+
+    /**
+     * Set the import log file's size in the database to its current size on the filesystem.
+     * @throws ServerError if the import log's size could not be updated in the database
+     */
+    private void setLogFileSize() throws ServerError {
+        final OriginalFile logFile = (OriginalFile) sf.getQueryService().get(OriginalFile.class.getSimpleName(), logPath.getId());
+        logFile.setSize(omero.rtypes.rlong(logPath.size()));
+        sf.getUpdateService().saveObject(logFile);
     }
 
     public Object step(int step) {


### PR DESCRIPTION
Do some imports, look in the server's managed repository, and check that the import log file sizes on disk match those for the import logs in the database. Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12513.
```
bin/omero hql "SELECT path||name, size FROM OriginalFile WHERE mimetype = 'application/omero-log-file'"
```
We do thus close the import log very slightly earlier, but it is still after the interesting stuff has all happened, and after one has destroyed the session it is rather harder to update the database.

--no-rebase