### PR TITLE
Update z for lifetime

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -828,6 +828,10 @@ class ImViewerComponent
                 firePropertyChange(ImViewer.T_SELECTED_PROPERTY,
                         Integer.valueOf(defaultT), Integer.valueOf(t));
             }
+	        if (defaultZ != z) {
+                firePropertyChange(ImViewer.Z_SELECTED_PROPERTY,
+                        Integer.valueOf(defaultZ), Integer.valueOf(z));
+            }
 	    } else {
 	        if (defaultZ == z && defaultT == t) return;
 	        if (defaultZ != z) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -1360,7 +1360,10 @@ class ImViewerUI
 	            buffer.append(" (");
 	            buffer.append(UIUtilities.roundTwoDecimals(
 	                    info.getRealValue(bin)));
-	            buffer.append(info.getUnit()+")");
+	            if (StringUtils.isNotBlank(info.getUnit())) {
+	                buffer.append(info.getUnit());
+	            }
+	            buffer.append(")");
 		    }
 		}
 		setLeftStatus(buffer.toString());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
@@ -1055,7 +1055,7 @@ public class DomainPane
             		convertUIBitResolution(bitDepthSlider.getValue()));
         } else if (source.equals(tSlider) || source.equals(zSlider)) {
             if (lifetimeSlider != null && lifetimeSlider.isVisible()) {
-                controller.setSelectedXYPlane(model.getDefaultZ(),
+                controller.setSelectedXYPlane(zSlider.getValue(),
                         tSlider.getValue(), lifetimeSlider.getValue());
             } else controller.setSelectedXYPlane(zSlider.getValue(),
                     tSlider.getValue());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -625,8 +625,8 @@ class RendererComponent
 	public void setSelectedXYPlane(int z, int t, int bin)
 	{
 		try {
+		    int defaultZ = model.getDefaultZ();
 			if (bin < 0) {
-			    int defaultZ = model.getDefaultZ();
 		        int selectedT = model.getRealSelectedT();
 				if (defaultZ == z && selectedT == t) return;
 				model.setSelectedXYPlane(z, t);
@@ -645,6 +645,11 @@ class RendererComponent
 			    if (selectedT != t) {
                     firePropertyChange(T_SELECTED_PROPERTY,
                             Integer.valueOf(selectedT), Integer.valueOf(t));
+                }
+			    model.setSelectedZ(z);
+			    if (defaultZ != z) {
+                    firePropertyChange(Z_SELECTED_PROPERTY,
+                            Integer.valueOf(defaultZ), Integer.valueOf(z));
                 }
 			}
 			firePropertyChange(RENDER_PLANE_PROPERTY,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -1049,6 +1049,21 @@ class RendererModel
 	}
 
 	/**
+	 * Sets the selected z-section.
+	 *
+	 * @param z The z-section to set.
+	 * @throws RenderingServiceException If an error occurred while setting
+	 *                                  the value.
+	 * @throws DSOutOfServiceException If the connection is broken.
+	 */
+    void setSelectedZ(int z)
+        throws RenderingServiceException, DSOutOfServiceException
+    {
+        if (rndControl == null) return;
+        if (z >= 0 && z != getDefaultZ()) rndControl.setDefaultZ(z);
+    }
+
+	/**
 	 * Turns on or off the specified channel.
 	 * 
 	 * @param index The index of the channel.


### PR DESCRIPTION
Update z when viewing lifetime images.
See https://trac.openmicroscopy.org.uk/ome/ticket/12445

To test
 * Import the following image  ```skyking/li-flim/samples/sample-extended.fli```
 * Open the preview. Move the z-slider, make sure the image is updated
 * Open the image in the main viewer. Move the z-slider, make sure the image is updated
 * Also check that in the status bar, after small t there is not in bracket (55null)