### PR TITLE
Scripts grouping

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.util.ScriptComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptComponent.java
@@ -30,6 +30,7 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -43,11 +44,13 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 
+
 //Third-party libraries
 import info.clearthought.layout.TableLayout;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
@@ -257,6 +260,13 @@ class ScriptComponent
     }
 
     /**
+     * Sets the parameter name.
+     *
+     * @param name The value to set.
+     */
+    void setParameterName(String name) { this.name = name;}
+
+    /**
      * Returns the name of the parameter.
      * 
      * @return See above.
@@ -316,7 +326,7 @@ class ScriptComponent
     void buildUI()
     {
         int width = TAB*getTabulationLevel();
-        if (DEFAULT_TEXT.equals(name)) width = 0;
+        if (DEFAULT_TEXT.equals(name) || NumberUtils.isNumber(name)) width = 0;
         if (CollectionUtils.isEmpty(children)) {
             double[][] size = {{width, TableLayout.PREFERRED, 5,
                 TableLayout.FILL}, {TableLayout.PREFERRED}};
@@ -336,7 +346,12 @@ class ScriptComponent
             int index = 1;
             while (i.hasNext()) {
                 child = i.next();
+                String v = child.parentIndex;
+                if (name != null && name.equals(v)) {
+                    child.parentIndex = null;
+                }
                 child.buildUI();
+                child.parentIndex = v;
                 layout.insertRow(index, TableLayout.PREFERRED);
                 add(child, "0, "+index);
                 index++;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.util.ScriptingDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -574,7 +574,7 @@ public class ScriptingDialog
             l = childrenMap.get(grouping);
             childrenMap.remove(grouping);
             if (l != null)
-                key.setChildren(sorter.sort(l));
+               key.setChildren(sorter.sort(l));
         }
         if (childrenMap != null && childrenMap.size() > 0) {
             Iterator<String> j = childrenMap.keySet().iterator();
@@ -584,6 +584,9 @@ public class ScriptingDialog
                 sc = new ScriptComponent();
                 sc.setGrouping(parent);
                 sc.setNameLabel(parent);
+                if (StringUtils.isBlank(sc.getName())) {
+                    sc.setParameterName(parent);
+                }
                 sc.setChildren(sorter.sort(childrenMap.get(parent)));
                 results.add(sc);
             }


### PR DESCRIPTION
Fix https://trac.openmicroscopy.org.uk/ome/ticket/12263
Do not run script
To test
 * log as adm-user-6
 * Click on the available scripts.
 * Select Documents> ThumbnailFigure2.py (modified script for testing UI.)
 * Make sure that all the fields are listed
```
scripts.String(
            "Data_Type", optional=False, grouping="1",
            description="The data you want to work with.",
            values=dataTypes, default="Dataset"),

        scripts.List(
            "IDs", optional=False, grouping="2",
            description="List of Dataset IDs or Image"
            " IDs").ofType(rlong(0)),

        scripts.List(
            "Tag_IDs", grouping="3",
            description="Group thumbnails by these tags."),

        scripts.Bool(
            "Show_Untagged_Images", grouping="3.1", default=False,
            description="If true (and you're sorting by tagIds) also"
            " show images without the specified tags"),

        scripts.Long(
            "Parent_ID", grouping="4",
            description="Attach figure to this Project (if datasetIds"
            " above) or Dataset if imageIds. If not specifed, attach"
            " figure to first dataset or image."),
        # this will be ignored if only a single ID in list - attach to
        # that object instead.

        scripts.Int(
            "Thumbnail_Size", grouping="5.1", min=10, max=250, default=100,
            description="The dimension of each thumbnail. Default is 100"),

        scripts.Int(
            "Max_Columns", grouping="5.2", min=1, default=10,
            description="The max number of thumbnail columns. Default is 10"),

        scripts.String(
            "Format", grouping="6.1",
            description="Format to save image.", values=formats,
            default="JPEG"),

        scripts.String(
            "Figure_Name", grouping="6.2", default='Thumbnail_Figure',
            description="File name of figure to create"),

```