### PR TITLE
Impose pep8 1.5.7 for Travis validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     - git config --global user.name 'Snoopy Crime Cop'
     - sudo pip install scc pytest
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8 pep8==1.5.7; fi
 
 install:
 


### PR DESCRIPTION
A new release of PEP8 (1.6.0) is out which invalids our Python code base. This commit should ensure Travis does not fail systematically