### PR TITLE
Impose pep8 1.5.7 for Travis validation (rebased onto dev_5_0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - git config --global user.name 'Snoopy Crime Cop'
     - sudo pip install scc pytest
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8 pep8==1.5.7; fi
 
 install:
 


### PR DESCRIPTION

This is the same as gh-3462 but rebased onto dev_5_0.

----

A new release of PEP8 (1.6.0) is out which invalids our Python code base. This commit should ensure Travis does not fail systematically

                