### PR TITLE
5-0-8 history (rebased onto develop)

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,13 @@
 OMERO version history
 =====================
 
+5.0.8 (February 2015)
+---------------------
+
+This is a bug-fix release for one specific issue causing OMERO.insight to
+crash when trying to open the Projection tab for an image with multiple
+z-stacks.
+
 5.0.7 (February 2015)
 ---------------------
 


### PR DESCRIPTION


This is the same as gh-3457 but rebased onto develop.

----

Adding 5.0.8 version history for OMERO.

                    