### PR TITLE
Fixed typo(?) in HistogramPlot

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/graphutils/HistogramPlot.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/graphutils/HistogramPlot.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.graphutils.HistogramPlot 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -119,9 +119,8 @@ public class HistogramPlot
 	{
 		super(title);
 		if (newLegends == null || newData == null || newColours == null || 
-			newLegends.size() != newData.size() && 
-			newLegends.size() != newColours.size())// || 
-			//newLegends.size() == 0 || bins < 1)
+			newLegends.size() != newData.size() || 
+			newLegends.size() != newColours.size())
 			throw new IllegalArgumentException("Mismatch between argument " +
 						"length");
 		initialize();


### PR DESCRIPTION
While investigating [Ticket 12657](https://trac.openmicroscopy.org.uk/ome/ticket/12657) I noticed an if statement, which doesn't make sense, maybe a typo. I think the purpose of the statement is, to make sure that all three lists are not null and have the same size, therefore the 'and' should be an 'or'.

Test: Just review the changed if statement; apart from that, make sure the histogram plot (ROI/Measurement tool) still works.
Note: This isn't a fix for the ticket, but I'll close the ticket, because I can't reproduce it.

--no-rebase
