### PR TITLE
Show in place imported images

### DIFF
--- a/components/tools/OmeroPy/src/omero/fs/__init__.py
+++ b/components/tools/OmeroPy/src/omero/fs/__init__.py
@@ -2,3 +2,17 @@
 # -*- coding: utf-8 -*-
 import IceImport
 IceImport.load("omero_FS_ice")
+
+#
+# Copied from:
+# blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
+#
+TRANSFERS = {
+    "ome.formats.importer.transfers.CopyFileTransfer": "cp",
+    "ome.formats.importer.transfers.CopyMoveFileTransfer": "cp_rm",
+    "ome.formats.importer.transfers.HardlinkFileTransfer": "ln",
+    "ome.formats.importer.transfers.MoveFileTransfer": "ln_rm",
+    "ome.formats.importer.transfers.SymlinkFileTransfer": "ln_s",
+    "ome.formats.importer.transfers.UploadRmFileTransfer": "upload_rm",
+    "ome.formats.importer.transfers.UploadFileTransfer": "",
+    }

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2819,15 +2819,25 @@ class _BlitzGateway (object):
 
         params = omero.sys.ParametersI()
         params.addIds(imageIds)
+
         query = "select distinct(fse) from FilesetEntry as fse "\
-                "left outer join fse.fileset as fs "\
+                "left outer join fetch fse.fileset as fs "\
+                "left outer join fetch fs.annotationLinks as link "\
+                "left outer join fetch link.child as a "\
                 "left outer join fetch fse.originalFile as f "\
                 "left outer join fs.images as image where image.id in (:ids)"
         queryService = self.getQueryService()
         fsinfo = queryService.findAllByQuery(query, params, self.SERVICE_OPTS)
         fsCount = len(fsinfo)
+        annNs = []
+        for fse in fsinfo:
+            for l in fse.fileset.copyAnnotationLinks():
+                annNs.append(l.child.ns.val)
         fsSize = sum([f.originalFile.getSize().val for f in fsinfo])
-        filesetFileInfo = {'count': fsCount, 'size': fsSize}
+        filesetFileInfo = {'fileset': True,
+                           'count': fsCount,
+                           'size': fsSize,
+                           'annNs': annNs}
         return filesetFileInfo
 
     def getArchivedFilesInfo(self, imageIds):
@@ -2849,7 +2859,9 @@ class _BlitzGateway (object):
         fsinfo = queryService.findAllByQuery(query, params, self.SERVICE_OPTS)
         fsCount = len(fsinfo)
         fsSize = sum([f.parent.getSize().val for f in fsinfo])
-        filesetFileInfo = {'count': fsCount, 'size': fsSize}
+        filesetFileInfo = {'fileset': False,
+                           'count': fsCount,
+                           'size': fsSize}
         return filesetFileInfo
 
     ############################
@@ -8619,12 +8631,11 @@ class _ImageWrapper (BlitzObjectWrapper):
         """
         Returns the number of Original 'archived' Files linked to primary
         pixels.
-        Used by :meth:`countImportedImageFiles` which also handles FS files.
         """
-        if self._archivedFileCount is None:
-            info = self._conn.getArchivedFilesInfo([self.getId()])
-            self._archivedFileCount = info['count']
-        return self._archivedFileCount
+        fsInfo = self.getImportedFilesInfo()
+        if not fsInfo['fileset']:
+            return fsInfo['count']
+        return 0
 
     def countFilesetFiles(self):
         """
@@ -8632,10 +8643,10 @@ class _ImageWrapper (BlitzObjectWrapper):
         this image
         """
 
-        if self._filesetFileCount is None:
-            info = self._conn.getFilesetFilesInfo([self.getId()])
-            self._filesetFileCount = info['count']
-        return self._filesetFileCount
+        fsInfo = self.getImportedFilesInfo()
+        if fsInfo['fileset']:
+            return fsInfo['count']
+        return 0
 
     def getImportedFilesInfo(self):
         """
@@ -8645,10 +8656,12 @@ class _ImageWrapper (BlitzObjectWrapper):
         :return:        A dict of 'count' and sum 'size' of the files.
         """
         if self._importedFilesInfo is None:
-            self._importedFilesInfo = self._conn.getArchivedFilesInfo(
-                [self.getId()])
+            # Check for Filesets first...
+            self._importedFilesInfo = self._conn.getFilesetFilesInfo(
+                    [self.getId()])
             if (self._importedFilesInfo['count'] == 0):
-                self._importedFilesInfo = self._conn.getFilesetFilesInfo(
+                # If none, check Archived files
+                self._importedFilesInfo = self._conn.getArchivedFilesInfo(
                     [self.getId()])
         return self._importedFilesInfo
 
@@ -8659,10 +8672,7 @@ class _ImageWrapper (BlitzObjectWrapper):
         This will only be 0 if the image was imported pre-FS
         and original files NOT archived
         """
-        fCount = self.countFilesetFiles()
-        if fCount > 0:
-            return fCount
-        return self.countArchivedFiles()
+        return self.getImportedFilesInfo()['count']
 
     def getArchivedFiles(self):
         """
@@ -8701,8 +8711,20 @@ class _ImageWrapper (BlitzObjectWrapper):
         Returns the Fileset linked to this Image.
         Fileset images, usedFiles and originalFiles are loaded.
         """
-        if self.countFilesetFiles() > 0:
+        if self.fileset is not None:
             return self._conn.getObject("Fileset", self.fileset.id.val)
+
+    def isInplaceImport(self):
+        """
+        Returns True if the image was imported using file transfer.
+        Uses namespace of fileset annotations to detect this.
+
+        :rtype:     Boolean
+        :return:    True if imported via in-place import
+        """
+        ns = omero.constants.namespaces.NSFILETRANSFER
+        fsInfo = self.getImportedFilesInfo()
+        return 'annNs' in fsInfo and ns in fsInfo['annNs']
 
     def getROICount(self, shapeType=None, filterByCurrentUser=False):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8658,7 +8658,7 @@ class _ImageWrapper (BlitzObjectWrapper):
         if self._importedFilesInfo is None:
             # Check for Filesets first...
             self._importedFilesInfo = self._conn.getFilesetFilesInfo(
-                    [self.getId()])
+                [self.getId()])
             if (self._importedFilesInfo['count'] == 0):
                 # If none, check Archived files
                 self._importedFilesInfo = self._conn.getArchivedFilesInfo(

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -39,23 +39,10 @@ from omero.rtypes import rstring
 from omero.rtypes import unwrap
 from omero.sys import Principal
 from omero.util.temp_files import create_path
+from omero.fs import TRANSFERS
 
 
 HELP = """Filesystem utilities"""
-
-#
-# Copied from:
-# blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
-#
-TRANSFERS = {
-    "ome.formats.importer.transfers.CopyFileTransfer": "cp",
-    "ome.formats.importer.transfers.CopyMoveFileTransfer": "cp_rm",
-    "ome.formats.importer.transfers.HardlinkFileTransfer": "ln",
-    "ome.formats.importer.transfers.MoveFileTransfer": "ln_rm",
-    "ome.formats.importer.transfers.SymlinkFileTransfer": "ln_s",
-    "ome.formats.importer.transfers.UploadRmFileTransfer": "upload_rm",
-    "ome.formats.importer.transfers.UploadFileTransfer": "",
-    }
 
 Entry = namedtuple("Entry", ("level", "id", "path", "mimetype"))
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -521,21 +521,18 @@
 		
         
         
-            
-    #toolbar_info_panel textarea {
-    	width:99%;
-    	float:right;
-    	resize:none;
-    	border:none;
-    	padding:5px 0 0 0;
-    	margin:0px;
-    }
 
     #toolbar_info_panel .panel_div {
         border-top: solid #ddd 1px;
     }
     
+    #toolbar_info_panel p {
+        margin:5px
+    }
 
+    #toolbar_info_panel .show_more {
+        margin-left:10px
+    }
 
     
     

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -38,6 +38,11 @@
 {% endif %}
 
 <div style="position:relative">
+    {% if inPlace %}
+      <img title="This file in an in-place import. The data might not be located within the OMERO data directory."
+        style="position: absolute; top: 0; right: 3px"
+        src="{% static 'webclient/image/inPlace_16.png' %}"/>
+    {% endif %}
     <table style="width: 50%">
         {% if wellImageId %}
         <tr>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -122,11 +122,14 @@
                 });
 
                 // show original file path links for images
-                var original_file_paths_url;
+                var original_file_paths_url,
+                    importTransfer;
                 {% if manager.image %}
                 original_file_paths_url = "{% url 'original_file_paths' manager.image.id %}";
+                importTransfer = "{{ manager.image.getInplaceImportCmd }}";
                 {% elif manager.well.getWellSample.image %}
                 original_file_paths_url = "{% url 'original_file_paths' manager.well.getWellSample.image.id %}";
+                importTransfer = "{{ manager.well.getWellSample.image.getInplaceImportCmd }}";
                 {% endif %}
 
                 var $toolbar_info_panel = $("#toolbar_info_panel"),
@@ -149,9 +152,14 @@
                         $.getJSON(original_file_paths_url,
                             function(data) {
                                 var repo = data.repo,
-                                    client = data.client;
+                                    client = data.client,
+                                    importTitle = 'Imported from:';
                                 $panel_title.html(repo.length + " Image file" + (repo.length>1 ? "s:" : ":"));
-                                $panel_div.append('<p style="margin:5px">Imported from:</p>');
+
+                                if (importTransfer) {
+                                    importTitle = "Imported with <strong>--transfer="+ importTransfer + "</strong> from:";
+                                }
+                                $panel_div.append('<p style="margin:5px">' + importTitle + '</p>');
                                 $("<textarea readonly='true'></textarea>")
                                     .val(client.join("\n"))
                                     .attr("cols", 150)
@@ -566,7 +574,7 @@
             </div>
 
             <!-- Image Name, ID, owner -->
-            {% with obj=manager.image nameText=manager.image.name inPlace=manager.image.isInplaceImport %}
+            {% with obj=manager.image nameText=manager.image.name %}
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
                   

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -148,11 +148,21 @@
                     if (original_file_paths_url) {
                         $.getJSON(original_file_paths_url,
                             function(data) {
-                                $panel_title.html(data.length + " Image file" + (data.length>1 ? "s:" : ":"));
-                                $("<textarea readonly='true'></textarea")
-                                    .val(data.join("\n"))
+                                var repo = data.repo,
+                                    client = data.client;
+                                $panel_title.html(repo.length + " Image file" + (repo.length>1 ? "s:" : ":"));
+                                $panel_div.append('<p style="margin:5px">Imported from:</p>');
+                                $("<textarea readonly='true'></textarea>")
+                                    .val(client.join("\n"))
                                     .attr("cols", 150)
-                                    .attr("rows", Math.max(3, data.length))
+                                    .attr("rows", Math.max(3, client.length))
+                                    .appendTo($panel_div);
+                                $panel_div.append('<div style="clear:both">');
+                                $panel_div.append('<p style="margin:5px">Path' + (repo.length>1 ? "s" : "") + ' on server:</p>');
+                                $("<textarea readonly='true'></textarea>")
+                                    .val(repo.join("\n"))
+                                    .attr("cols", 150)
+                                    .attr("rows", Math.max(3, repo.length))
                                     .appendTo($panel_div);
                             });
                     }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -556,7 +556,7 @@
             </div>
 
             <!-- Image Name, ID, owner -->
-            {% with obj=manager.image nameText=manager.image.name %}
+            {% with obj=manager.image nameText=manager.image.name inPlace=manager.image.isInplaceImport %}
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
                   

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -137,6 +137,12 @@
                         $panel_title = $("#toolbar_info_panel .panel_title"),
                         $panel_div = $("#toolbar_info_panel .panel_div");
 
+
+                $( "#toolbar_info_panel" ).on( "click", ".show_more", function() {
+                    $(this).hide().next().show();
+                    return false;
+                });
+
                 $("#show_fs_files_btn").click(function(){
 
                     // If we're already showing Image file info, toggle hide
@@ -153,25 +159,32 @@
                             function(data) {
                                 var repo = data.repo,
                                     client = data.client,
-                                    importTitle = 'Imported from:';
+                                    html = "";
                                 $panel_title.html(repo.length + " Image file" + (repo.length>1 ? "s:" : ":"));
 
                                 if (importTransfer) {
-                                    importTitle = "Imported with <strong>--transfer="+ importTransfer + "</strong> from:";
+                                    html += "<p>Imported with <strong>--transfer="+ importTransfer;
+                                    html += "</strong></p><hr/>";
                                 }
-                                $panel_div.append('<p style="margin:5px">' + importTitle + '</p>');
-                                $("<textarea readonly='true'></textarea>")
-                                    .val(client.join("\n"))
-                                    .attr("cols", 150)
-                                    .attr("rows", Math.max(3, client.length))
-                                    .appendTo($panel_div);
-                                $panel_div.append('<div style="clear:both">');
-                                $panel_div.append('<p style="margin:5px">Path' + (repo.length>1 ? "s" : "") + ' on server:</p>');
-                                $("<textarea readonly='true'></textarea>")
-                                    .val(repo.join("\n"))
-                                    .attr("cols", 150)
-                                    .attr("rows", Math.max(3, repo.length))
-                                    .appendTo($panel_div);
+
+                                html += "<p>Imported from:</p>";
+                                html += "<p class='pathlist'>" + client.slice(0,2).join("<br>") + "<br>";
+                                if (client.length > 2) {
+                                    html += "<a class='show_more' href='#'> Show more...</a>";
+                                    html += "<span style='display:none'>" + client.slice(2).join("<br>");
+                                    html += "</span>";
+                                }
+                                html += "</p><hr/>";
+
+                                html += "<p>Paths on server:</p>";
+                                html += "<p class='pathlist'>" + repo.slice(0,2).join("<br>") + "<br>";
+                                if (repo.length > 2) {
+                                    html += "<a class='show_more' href='#'> Show more...</a>";
+                                    html += "<span style='display:none'>" + repo.slice(2).join("<br>");
+                                    html += "</span>";
+                                }
+                                html += "</p>";
+                                $panel_div.append(html);
                             });
                     }
                 });

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2334,6 +2334,17 @@ class ImageWrapper (OmeroWebObjectWrapper, omero.gateway.ImageWrapper):
             return fsImgs
         return []
 
+    def getInplaceImportCmd(self):
+        cmds = {'ome.formats.importer.transfers.MoveFileTransfer': 'ln_rm',
+                'ome.formats.importer.transfers.CopyFileTransfer': 'cp',
+                'ome.formats.importer.transfers.CopyMoveFileTransfer': 'cp_rm',
+                'ome.formats.importer.transfers.HardlinkFileTransfer': 'ln',
+                'ome.formats.importer.transfers.SymlinkFileTransfer': 'ln_s'}
+        inplace = self.getInplaceImport()
+        if inplace and inplace in cmds:
+            return cmds[inplace]
+        return ""
+
 
 omero.gateway.ImageWrapper = ImageWrapper
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -56,6 +56,8 @@ from omero.gateway import TagAnnotationWrapper, \
                 AnnotationWrapper, \
                 OmeroGatewaySafeCallWrapper, CommentAnnotationWrapper
 
+from omero.fs import TRANSFERS
+
 from omero.gateway import KNOWN_WRAPPERS
 
 from django.utils.encoding import smart_str
@@ -2335,14 +2337,13 @@ class ImageWrapper (OmeroWebObjectWrapper, omero.gateway.ImageWrapper):
         return []
 
     def getInplaceImportCmd(self):
-        cmds = {'ome.formats.importer.transfers.MoveFileTransfer': 'ln_rm',
-                'ome.formats.importer.transfers.CopyFileTransfer': 'cp',
-                'ome.formats.importer.transfers.CopyMoveFileTransfer': 'cp_rm',
-                'ome.formats.importer.transfers.HardlinkFileTransfer': 'ln',
-                'ome.formats.importer.transfers.SymlinkFileTransfer': 'ln_s'}
+        """
+        Returns the command used to do import transfer for this image,
+        E.g. 'ln', or empty string if not in-place imported.
+        """
         inplace = self.getInplaceImport()
-        if inplace and inplace in cmds:
-            return cmds[inplace]
+        if inplace and inplace in TRANSFERS:
+            return TRANSFERS[inplace]
         return ""
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -393,7 +393,11 @@ are assembled into a zip file on the fly, and this is downloaded.
 original_file_paths = url(r'^original_file_paths/(?P<iid>[0-9]+)/$',
                           'webgateway.views.original_file_paths',
                           name="original_file_paths")
-""" Get a json array of path/name strings for original files for the Image"""
+"""
+Get a json dict of original file paths.
+'repo' is a list of path/name strings for original files in managed repo
+'client' is a list of paths for original files on the client when imported
+"""
 
 urlpatterns = patterns(
     '',

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2133,21 +2133,36 @@ def original_file_paths(request, iid, conn=None, **kwargs):
     image
     """
 
-    image = conn.getObject("Image", iid)
-    if image is None:
-        logger.debug(
-            "Cannot get original file paths becuase Image does not exist.")
-        return HttpResponseServerError(
-            "Cannot get original file paths becuase Image does not exist"
-            " (id:%s)." % (iid))
+    qs = conn.getQueryService()
+    params = omero.sys.ParametersI()
+    params.addLong("iid", iid)
+    query = "select fse from FilesetEntry fse join fetch fse.fileset as fs "\
+            "left outer join fetch fs.usedFiles as usedFile " \
+            "join fetch usedFile.originalFile " \
+            "left outer join fs.images as image where image.id=:iid"
 
-    files = list(image.getImportedImageFiles())
+    result = qs.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
-    if len(files) == 0:
-        return HttpResponseServerError("This image has no Original Files.")
+    fileNames = []
+    clientPaths = []
+    if len(result) > 0:
+        fileset = result[0].fileset
+        for f in fileset.copyUsedFiles():
+            path = unwrap(f.originalFile.path)
+            name = unwrap(f.originalFile.name)
+            fileNames.append("%s%s" % (path, name))
 
-    fileNames = [f.getPath() + f.getName() for f in files]
-    return fileNames
+        for fse in result:
+            clientPaths.append(unwrap(fse.clientPath))
+
+    else:
+        # Images with No Fileset, check for any Archived Origina files
+        image = conn.getObject("Image", iid)
+        if image is not None:
+            files = list(image.getImportedImageFiles())
+            fileNames = [f.getPath() + f.getName() for f in files]
+
+    return {'repo': fileNames, 'client': clientPaths}
 
 
 @login_required()


### PR DESCRIPTION
This replicates Insight's indication of images that are imported with "in place" import.

To test:
 - import an image with transfer, E.g: ``` $ bin/omero import -- --transfer=ln_s my_file.dv ```
 - Check that this image shows the link icon to the right of Image ID in right panel, with tooltip.
 - Check other images or P/D etc don't show this.

![screen shot 2015-02-09 at 16 34 46](https://cloud.githubusercontent.com/assets/900055/6110466/c816c76c-b079-11e4-9c47-b8654794c598.png)

--no-rebase