### PR TITLE
Removing FAQ link for XML validator

### DIFF
--- a/components/validator/WebApp/validator/templates/master.kid
+++ b/components/validator/WebApp/validator/templates/master.kid
@@ -30,7 +30,7 @@
         <div id="problem" style=>
             <h2>Problem with validator</h2>
             <p>We are experiencing a problem with the online validator hanging while validating files. This appears to be a problem related to the combination of XML parser and web application toolkit we are using. Unfortunately we cannot get this to work reliably so will have to completely re-write the validator. If you need to validate files we recommend to do so using the Bio-Formats command line <code>bftools</code>.</p>
-            <p>For further information check the <a href="http://www.openmicroscopy.org/site/support/faq/ome-xml-and-ome-tiff/how-do-i-validate-a-file-on-the-command-line">OME FAQ</a>. </p>
+            <p>For further information check the <a href="https://www.openmicroscopy.org/site/support/ome-model/ome-tiff/tools.html#validating-ome-xml">OME Model and Formats Documentation</a>. </p>
             <p>We are sorry for the inconvenience this may cause. </p>
         </div>
 		<div id="footer"> Copyright &copy;2007-2012 University of Dundee &amp; Open Microscopy Environment.</div>

--- a/components/validator/WebApp/validator/templates/master.kid
+++ b/components/validator/WebApp/validator/templates/master.kid
@@ -30,7 +30,7 @@
         <div id="problem" style=>
             <h2>Problem with validator</h2>
             <p>We are experiencing a problem with the online validator hanging while validating files. This appears to be a problem related to the combination of XML parser and web application toolkit we are using. Unfortunately we cannot get this to work reliably so will have to completely re-write the validator. If you need to validate files we recommend to do so using the Bio-Formats command line <code>bftools</code>.</p>
-            <p>For further information check the <a href="https://www.openmicroscopy.org/site/support/ome-model/ome-tiff/tools.html#validating-ome-xml">OME Model and Formats Documentation</a>. </p>
+            <p>For further information check the <a href="http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/tools.html#validating-ome-xml">OME Model and Formats Documentation</a>. </p>
             <p>We are sorry for the inconvenience this may cause. </p>
         </div>
 		<div id="footer"> Copyright &copy;2007-2012 University of Dundee &amp; Open Microscopy Environment.</div>


### PR DESCRIPTION
For completeness sake - removing the last FAQ link from the OMERO code (see https://trello.com/c/3uqvWhlq/240-faq-issues-needing-moved-to-docs-plone)

This file doesn't seem to exist on develop so

--no-rebase