### PR TITLE
Bugfix: Progressbar stuck when plate thumbnails reloaded 

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.view.WellsModel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 
 //Third-party libraries
+import org.apache.commons.collections.CollectionUtils;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.dataBrowser.DataBrowserAgent;
@@ -64,6 +65,7 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.WellGridElement;
 import org.openmicroscopy.shoola.util.ui.colourpicker.ColourObject;
 import pojos.DataObject;
+import pojos.ImageData;
 import pojos.PlateData;
 import pojos.WellData;
 import pojos.WellSampleData;
@@ -713,7 +715,9 @@ class WellsModel
 	protected  List<DataBrowserLoader> createDataLoader(boolean refresh, 
 			Collection ids)
 	{
-		if (!withThumbnails) return null;
+		if (!withThumbnails) 
+			return null;
+		
 		List<ImageDisplay> l = getNodes();
 		Iterator<ImageDisplay> i = l.iterator();
 		ImageSet node;
@@ -733,12 +737,16 @@ class WellsModel
 							Factory.createDefaultImageThumbnail(
 									wellDimension.width, wellDimension.height));
 				}
-				else 
-					images.add(data.getImage());
+				else {
+					ImageData img = data.getImage();
+					if(CollectionUtils.isEmpty(ids) || ids.contains(img.getId()))
+						images.add(data.getImage());
+				}
 			}
 		}
 
-		if (images.size() == 0) return null;
+		if (images.size() == 0) 
+			return null;
 		return createThumbnailsLoader(sorter.sort(images));
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerModel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -994,9 +994,12 @@ class MetadataViewerModel
 	{
 	    if (viewedBy == null) return;
 		ImageData image = null;
-		if (refObject instanceof ImageData) image = (ImageData) refObject;
+		if (refObject instanceof ImageData) 
+			image = (ImageData) refObject;
 		else if (refObject instanceof WellSampleData)
 			image = ((WellSampleData) refObject).getImage();
+		if (image == null)
+			return;
 		Set experimenters = viewedBy.keySet();
 		Set<Long> ids = new HashSet<Long>();
 		Iterator i = experimenters.iterator();


### PR DESCRIPTION
Fixes [Ticket 12729](https://trac.openmicroscopy.org.uk/ome/ticket/12729)

Test:
Select a plate; use a plate which contains a fair amount of images (e. g. a 96 well plate) and takes a few seconds to load (the error didn't occur with small plates). Choose a well and modify the rendering settings in the right hand side preview panel. Don't save the settings for the single well, but immediately apply the settings to all wells ("Save to All"). The settings should be saved and the thumbnails start to reload; watch the progressbar on the bottom of the central panel, it should run continuously to 100% and then disappear (before: it often got stuck at some random value). The error appeared rather randomly, so better test a couple of times.

--no-rebase

