### PR TITLE
Bugfix: JavaImageScalingService, images < 3px

### DIFF
--- a/components/server/src/ome/logic/JavaImageScalingService.java
+++ b/components/server/src/ome/logic/JavaImageScalingService.java
@@ -1,23 +1,23 @@
 /*
  * ome.logic.JavaImageScalingService
  *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
 package ome.logic;
 
 // Java imports
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 
+//Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.perf4j.StopWatch;
 import org.perf4j.slf4j.Slf4JStopWatch;
-
 import com.mortennobel.imagescaling.ResampleOp;
-
-// Third-party libraries
 
 // Application-internal dependencies
 import ome.api.IScale;
@@ -46,11 +46,23 @@ public class JavaImageScalingService implements IScale {
         int thumbWidth = (int) (image.getWidth() * xScale);
         log.info("Scaling to: " + thumbHeight + "x" + thumbWidth);
 
-        StopWatch s1 = new Slf4JStopWatch("java-image-scaling.resampleOp");
-        ResampleOp  resampleOp = new ResampleOp(thumbWidth, thumbHeight);
-        //resampleOp.setNumberOfThreads(4);
-        BufferedImage toReturn = resampleOp.filter(image, null);
-        s1.stop();
-        return toReturn;
+		StopWatch s1 = new Slf4JStopWatch("java-image-scaling.resampleOp");
+		BufferedImage toReturn;
+		if (thumbWidth >= 3 && thumbHeight >= 3) {
+			ResampleOp resampleOp = new ResampleOp(thumbWidth, thumbHeight);
+			// resampleOp.setNumberOfThreads(4);
+			toReturn = resampleOp.filter(image, null);
+		} else {
+			toReturn = new BufferedImage(thumbWidth, thumbHeight,
+					image.getType());
+			Graphics2D g = toReturn.createGraphics();
+			g.getRenderingHints().add(
+					new RenderingHints(RenderingHints.KEY_ANTIALIASING,
+							RenderingHints.VALUE_ANTIALIAS_OFF));
+			g.drawImage(image, 0, 0, thumbWidth, thumbHeight, 0, 0,
+					image.getWidth(), image.getHeight(), null);
+		}
+		s1.stop();
+		return toReturn;
     }
 }

--- a/components/server/src/ome/logic/JavaImageScalingService.java
+++ b/components/server/src/ome/logic/JavaImageScalingService.java
@@ -38,7 +38,7 @@ public class JavaImageScalingService implements IScale {
      * (non-Javadoc)
      * 
      * @see ome.api.IScale#scaleBufferedImage(java.awt.image.BufferedImage,
-     *      float, float)
+     * float, float)
      */
     public BufferedImage scaleBufferedImage(BufferedImage image, float xScale,
             float yScale) {
@@ -46,23 +46,23 @@ public class JavaImageScalingService implements IScale {
         int thumbWidth = (int) (image.getWidth() * xScale);
         log.info("Scaling to: " + thumbHeight + "x" + thumbWidth);
 
-		StopWatch s1 = new Slf4JStopWatch("java-image-scaling.resampleOp");
-		BufferedImage toReturn;
-		if (thumbWidth >= 3 && thumbHeight >= 3) {
-			ResampleOp resampleOp = new ResampleOp(thumbWidth, thumbHeight);
-			// resampleOp.setNumberOfThreads(4);
-			toReturn = resampleOp.filter(image, null);
-		} else {
-			toReturn = new BufferedImage(thumbWidth, thumbHeight,
-					image.getType());
-			Graphics2D g = toReturn.createGraphics();
-			g.getRenderingHints().add(
-					new RenderingHints(RenderingHints.KEY_ANTIALIASING,
-							RenderingHints.VALUE_ANTIALIAS_OFF));
-			g.drawImage(image, 0, 0, thumbWidth, thumbHeight, 0, 0,
-					image.getWidth(), image.getHeight(), null);
-		}
-		s1.stop();
-		return toReturn;
+        StopWatch s1 = new Slf4JStopWatch("java-image-scaling.resampleOp");
+        BufferedImage toReturn;
+        if (thumbWidth >= 3 && thumbHeight >= 3) {
+            ResampleOp resampleOp = new ResampleOp(thumbWidth, thumbHeight);
+            // resampleOp.setNumberOfThreads(4);
+            toReturn = resampleOp.filter(image, null);
+        } else {
+            toReturn = new BufferedImage(thumbWidth, thumbHeight,
+                    image.getType());
+            Graphics2D g = toReturn.createGraphics();
+            g.getRenderingHints().add(
+                    new RenderingHints(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_OFF));
+            g.drawImage(image, 0, 0, thumbWidth, thumbHeight, 0, 0,
+                    image.getWidth(), image.getHeight(), null);
+        }
+        s1.stop();
+        return toReturn;
     }
 }


### PR DESCRIPTION
This should fix the error noticed by @sbesson :
```
*: trout-merge master-err:
Exception in thread "Thread-2809" java.lang.ArrayIndexOutOfBoundsException: 2
    at com.mortennobel.imagescaling.ResampleOp.verticalFromWorkToDst(ResampleOp.java:334)
    at com.mortennobel.imagescaling.ResampleOp.access$200(ResampleOp.java:31)
    at com.mortennobel.imagescaling.ResampleOp$2.run(ResampleOp.java:164)
    at java.lang.Thread.run(Thread.java:744)
```

Unfortunately I don't know how to test this. One somehow has to request a thumbnail with a height/width less than 3 pixels. Is this done by some integration tests? If so, just check the trout-merge log again for above mentioned error.
