### PR TITLE
Don't set info popup modal

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -305,7 +305,7 @@ class DocComponent
 		}
 		
 		TinyDialog d = new TinyDialog(null, comp, TinyDialog.CLOSE_ONLY);
-		d.setModal(true);
+		d.setModal(false);
 		d.getContentPane().setBackground(UIUtilities.BACKGROUND_COLOUR_EVEN);
 		SwingUtilities.convertPointToScreen(p, invoker);
 		d.pack();


### PR DESCRIPTION
Tiny PR which fixes [Ticket 12734](http://trac.openmicroscopy.org.uk/ome/ticket/12734)

Problem: Despite being modal, it could sometimes loose focus, move into the background and block the whole UI. I think there's no need for the info popup to be modal. Now it's just closed if it looses focus.
Best being tested by @gusferguson , because the bug seems to need quite a specific environment to appear.

--no-rebase