### PR TITLE
Make LightSettings indexing work with Channel and MicrobeamManipulation

### DIFF
--- a/components/blitz/src/ome/formats/OMEXMLModelComparator.java
+++ b/components/blitz/src/ome/formats/OMEXMLModelComparator.java
@@ -110,7 +110,6 @@ public class OMEXMLModelComparator implements Comparator<LSID>
 
         if (klass.equals(ObjectiveSettings.class)
             || klass.equals(DetectorSettings.class)
-            || klass.equals(LightSettings.class)
             || klass.equals(LightPath.class))
         {
             return 3;

--- a/components/blitz/src/ome/formats/model/ReferenceProcessor.java
+++ b/components/blitz/src/ome/formats/model/ReferenceProcessor.java
@@ -100,8 +100,15 @@ public class ReferenceProcessor implements ModelProcessor
 				}
 				else if (targetClass.equals(LightSettings.class))
 				{
-					indexes.put(Index.IMAGE_INDEX, indexArray[0]);
-					indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
+					if (indexArray.length == 2) {
+						indexes.put(Index.IMAGE_INDEX, indexArray[0]);
+						indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
+					}
+					else if (indexArray.length == 3) {
+						indexes.put(Index.EXPERIMENT_INDEX, indexArray[0]);
+						indexes.put(Index.MICROBEAM_MANIPULATION_INDEX, indexArray[1]);
+						indexes.put(Index.LIGHT_SOURCE_SETTINGS_INDEX, indexArray[2]);
+					}
 				}
 				else if (targetClass.equals(ObjectiveSettings.class))
 				{


### PR DESCRIPTION
A LightSettings object can be attached to either a Channel (with 2
indexes) or a MicrobeamManipulation (with 3 indexes).  This removes the
hard-coded index counts and updates ReferenceProcessor to fill in the
index map appropriately for both cases.  This should prevent
OMEXMLModelComparator from incorrectly detecting the LSID equality when
there are many of both types of LightSettings linkages, which in turn ensures that each LightSettings' reference to a LightSource is properly resolved.

Fixes http://trac.openmicroscopy.org/ome/ticket/12603.

To test as in the ticket, run:

```mkfake test.fake -plates 4 -runs 4 -rows 4 -columns 4 -fields 4```

and then import ```test.fake```.  Without this PR, an exception should be thrown during metadata processing as in the ticket; with this PR, the import should succeed.

While this does seem to work (at least in my testing), it does worry me that both of the files in question have not been substantially changed in some years.  Especially careful code review would be appreciated in addition to an import test to verify that this is not a bad idea.