### PR TITLE
New bug fixes feb2015

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -908,9 +908,13 @@
                     
                 })
                 .delegate("a", "dblclick", function(e) {
-                    var obj_rel = $(this).parent().attr('rel');
+                    var $this = $(this),
+                        obj_rel = $this.parent().attr('rel'),
+                        ob_id = $this.parent().attr('id'),
+                        iid;
                     if ((obj_rel=='image') || (obj_rel=='image-locked')) {
-                        OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/"+$(this).attr('id').split("-")[1]+"/" ));
+                        iid = ob_id.split("-")[1];
+                        OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/" + iid + "/"));
                     }
                 })
                 .bind("select_node.jstree deselect_node.jstree", function (e, data) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2585,7 +2585,9 @@ def activities(request, conn=None, **kwargs):
                                     #except:
                                     #    pass
                                 if v.isLoaded() and hasattr(v, "name"):  # E.g Image, OriginalFile etc
-                                    obj_data['name'] = v.name.val
+                                    name = unwrap(v.name)
+                                    if name is not None:                # E.g. FileAnnotation has null name
+                                        obj_data['name'] = name
                                 rMap[key] = obj_data
                             else:
                                 rMap[key] = v


### PR DESCRIPTION
Fixes a couple of bugs that were found today in latest.

To test:
 - Run the Thumbnail_Figure script. Check that when the script completes, the Activities panel displays the result without error. Fixes this error:
```
  File "/opt/hudson/workspace/OMERO-5.1-merge-deploy/src/dist/lib/python/omeroweb/webclient/views.py", line 2628, in activities
    obj_data['name'] = v.name.val
```
- Double-click an Image in the tree to open an Image Viewer (viewer was previously not opening).

--no-rebase