### PR TITLE
Bugfix: Admin editing other user's Annotation

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -559,12 +559,9 @@ class OmeroMetadataServiceImpl
 		ModelMapper.unloadCollections(ho);
 		IObject link = null;
 		boolean exist = false;
-		
-		//Annotation an = (Annotation) gateway.findIObject(gateway.convertPojos(
-		//		annotation.getClass()), annotation.getId());
-		//ModelMapper.unloadCollections(an);
+
 		Annotation an = annotation.asAnnotation();
-		ExperimenterData exp = getUserDetails();
+		ExperimenterData exp = data.getOwner();
 		if (annotation instanceof TagAnnotationData) {
 			TagAnnotationData tag = (TagAnnotationData) annotation;
 			//tag a tag.


### PR DESCRIPTION
Fix for [Ticket 12738](http://trac.openmicroscopy.org.uk/ome/ticket/12738)

Testing: Log in as an user in the private group on trout and create a MapAnnotation on a dataset (or project, image, whatever). Change to an admin user. Try to edit the MapAnnotation you just created for the other user. Make sure no exception is thrown and the data has been saved.

--no-rebase
