### PR TITLE
Filter map annotations by 'me' or 'others'

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -330,7 +330,7 @@ OME.filterAnnotationsAddedBy = function() {
         $this.css('width', '180px');
     }
 
-    $('.tag_annotation_wrapper, .file_ann_wrapper, .ann_comment_wrapper, #custom_annotations tr')
+    $('.tag_annotation_wrapper, .keyValueTable, .file_ann_wrapper, .ann_comment_wrapper, #custom_annotations tr')
             .each(function() {
         var $ann = $(this),
             addby = $ann.attr('data-added-by').split(",");

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
@@ -22,6 +22,7 @@
 
 
     <table {% if ma %}data-annId="{{ ma.id }}"{% endif %}
+            data-added-by="{% if ma %}{{ ma.getOwner.id }}{% else %}{{ ome.user.id }}{% endif %}"
             class="keyValueTable{% if canEdit %} editableKeyValueTable{% endif %}">
         <thead>
           <tr>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -92,7 +92,7 @@
                     k = rowData[0],
                     v = rowData[1];
                 // Don't add empty rows
-                if (k == "" && v =="") return;
+                if ((k == "" || k == "Add Key") && (v == "" || v == "Add Value")) return;
                 tableData.push(rowData);
             });
             // If we are editing a saved map annotation...

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -244,7 +244,7 @@
 
             // Nothing selected - actions will apply to user's own table
             if ($selRows.length == 0) {
-                var canEdit = $('.editableKeyValueTable').length > 0;
+                var canEdit = $('.editableKeyValueTable:visible').length > 0;
                 enabled["Insert rows"] = canEdit;
                 enabled["Copy rows"] = false;
                 enabled["Paste rows"] = (canPaste && canEdit);
@@ -373,6 +373,16 @@
 
         $( ".keyValueTable tbody" ).on( "blur", "input", function(event) {
             saveEdit();
+        });
+
+        // When we filter annotations by 'me'/'others', need to update toolbar
+        $("#annotationFilter").change(function(){
+            // wait for annotations to be shown/hidden
+            setTimeout(function(){
+                // de-select all rows first
+                $('.keyValueTable tr').removeClass("ui-selected");
+                enableToolbarButtons();
+            }, 50);
         });
     });
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -178,6 +178,7 @@
                 $nextRow = $selRows.next(":last");
 
             $selRows.remove();
+            saveMapAnnotation($tbody.parent());
 
             // Add back a placeholder if table is empty (after saving!)
             if ($tbody.find('tr').length == 0) {
@@ -190,7 +191,6 @@
                 $tbody.find('tr:last').addClass('ui-selected');
             }
             enableToolbarButtons();
-            saveMapAnnotation($tbody.parent());
         }
 
         var selectRows = function selectRows($clickedRow, event) {


### PR DESCRIPTION
Filter map annotations by 'me' or 'others'.

To test:
 - check that map annotations are now filtered correctly when "me" or "others" are chosen in the filter.

--no-rebase