### PR TITLE
Save "pending" MapAnnotations changes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
@@ -456,6 +456,8 @@ public class MapAnnotationsComponent extends JPanel implements
 		t.addFocusListener(new FocusListener() {
 			@Override
 			public void focusLost(FocusEvent e) {
+                if (t.getCellEditor() != null)
+                    t.getCellEditor().stopCellEditing();
 				MapTableModel m = (MapTableModel) t.getModel();
 				if (m.isDirty())
 					view.saveData(true);


### PR DESCRIPTION
Fixes [Ticket 12736](http://trac.openmicroscopy.org.uk/ome/ticket/12736)

If text was entered/modified within a MapAnnotation and the save button was hit, the latest changes weren't saved, unless the enter/tab button was pressed before to "confirm" the changes.

Test: Modify some keys/values of a MapAnnotation, don't hit enter/tab after the last change,but directly press save button (or switch do another DataObject in the browser - should automatically save the changes). Make sure also the last modification has been saved.

Note: The save button still doesn't become enabled on typing only; but as changes are saved automatically, I think we should remove the save button anyway in another PR (also to make it conform to Web).

--no-rebase
