### PR TITLE
Add --protocol option to configure Web protocol in Robot config file (rebased onto dev_5_0)

### DIFF
--- a/components/tests/ui/plugins/robot.py
+++ b/components/tests/ui/plugins/robot.py
@@ -36,8 +36,13 @@ class RobotControl(BaseControl):
         config.add_argument(
             "--config-file", type=str,
             help="Path to an ICE configuration file. Default: ICE_CONFIG")
+        config.add_argument(
+            "--protocol", type=str, default="http",
+            help="Protocol to use for the OMERO.web robot tests."
+            " Default: http")
 
     def config(self, args):
+        """Generate a configuration file for the Robot framework tests"""
 
         if args.config_file:
             init_args = ["--Ice.Config=%s" % args.config_file]
@@ -52,8 +57,8 @@ class RobotControl(BaseControl):
             "HOST": p.getPropertyWithDefault("omero.host", "localhost"),
             "USER": p.getPropertyWithDefault("omero.user", "root"),
             "PASS": p.getPropertyWithDefault("omero.pass", "omero"),
-            "ENCODED_WEBPREFIX": 'test',
             "ROOTPASS": p.getPropertyWithDefault("omero.rootpass", "omero"),
+            "PROTOCOL": args.protocol,
         }
 
         # Add OMERO.web substitutions

--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -19,10 +19,10 @@ ${SERVER_ID}            1
 ${BROWSER}              Firefox
 ${DELAY}                0
 
-${LOGIN URL}            http://${WEB HOST}${WEB PREFIX}/webclient/login/
-${WELCOME URL}          http://${WEB HOST}${WEB PREFIX}/webclient/
+${LOGIN URL}            %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/login/
+${WELCOME URL}          %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/
 
-${WEBADMIN WELCOME URL}     http://${WEB HOST}${WEB PREFIX}/webadmin/
+${WEBADMIN WELCOME URL}     %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webadmin/
 ${WEBADMIN LOGIN URL}       ${LOGIN URL}?url=%(QWEBPREFIX)s%(QSEP)swebadmin%(QSEP)s
 ${WEBCLIENT LOGIN URL}      ${LOGIN URL}?url=%(QWEBPREFIX)s%(QSEP)swebclient%(QSEP)s
 


### PR DESCRIPTION

This is the same as gh-3491 but rebased onto dev_5_0.

----

For servers where HTTP is redirected to HTTPS, the OMERO.web robot framework tests will systematically fail. This commit allows to configure the transfer protocol when generating the configuration file, defaulting to HTTP.


                