### PR TITLE
Fix checked path equivalence checks

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
+++ b/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
@@ -454,4 +454,24 @@ public class CheckedPath {
         return ofile;
     }
 
+    /**
+     * {@inheritDoc}
+     * Instances are equal if their string representations match.
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (!(object instanceof CheckedPath))
+            return false;
+        return this.fsFile.equals(((CheckedPath) object).fsFile);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return this.fsFile.hashCode();
+    }
 }

--- a/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
+++ b/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
@@ -472,6 +472,6 @@ public class CheckedPath {
      */
     @Override
     public int hashCode() {
-        return this.fsFile.hashCode();
+        return this.fsFile.hashCode() * 98;
     }
 }

--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -535,13 +535,15 @@ public class RepositoryDaoImpl implements RepositoryDao {
                     sw.stop("omero.repo.save_fileset.register");
 
                     sw = new Slf4JStopWatch();
-                    try {
-                        for (int i = 0; i < size; i++) {
-                            CheckedPath checked = paths.get(i);
-                            ome.model.core.OriginalFile of = ofs.get(i);
-                            fs.getFilesetEntry(i).setOriginalFile(of);
-                        }
+                    for (int i = 0; i < size; i++) {
+                        CheckedPath checked = paths.get(i);
+                        ome.model.core.OriginalFile of = ofs.get(i);
+                        fs.getFilesetEntry(i).setOriginalFile(of);
+                    }
+                    sw.stop("omero.repo.save_fileset.update_fileset_entries");
 
+                    sw = new Slf4JStopWatch();
+                    try {
                         return sf.getUpdateService().saveAndReturnObject(fs);
                     } finally {
                         sw.stop("omero.repo.save_fileset.save");

--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -506,6 +506,7 @@ public class RepositoryDaoImpl implements RepositoryDao {
 
         final ome.model.fs.Fileset fs = (ome.model.fs.Fileset) mapper.reverse(_fs);
 
+        final StopWatch outer = new Slf4JStopWatch();
         try {
             return (Fileset) mapper.map((ome.model.fs.Fileset)
                     executor.execute(current.ctx, currentUser(current),
@@ -525,21 +526,32 @@ public class RepositoryDaoImpl implements RepositoryDao {
                         }
                     }
 
+                    StopWatch sw = new Slf4JStopWatch();
                     final int size = paths.size();
                     List<ome.model.core.OriginalFile> ofs =
                                 _internalRegister(repoUuid, paths, parents,
                                         checksumAlgorithm, null,
                                         sf, getSqlAction());
-                    for (int i = 0; i < size; i++) {
-                        CheckedPath checked = paths.get(i);
-                        ome.model.core.OriginalFile of = ofs.get(i);
-                        fs.getFilesetEntry(i).setOriginalFile(of);
+                    sw.stop("omero.repo.save_fileset.register");
+
+                    sw = new Slf4JStopWatch();
+                    try {
+                        for (int i = 0; i < size; i++) {
+                            CheckedPath checked = paths.get(i);
+                            ome.model.core.OriginalFile of = ofs.get(i);
+                            fs.getFilesetEntry(i).setOriginalFile(of);
+                        }
+
+                        return sf.getUpdateService().saveAndReturnObject(fs);
+                    } finally {
+                        sw.stop("omero.repo.save_fileset.save");
                     }
 
-                    return sf.getUpdateService().saveAndReturnObject(fs);
                 }}));
         } catch (Exception e) {
             throw (ServerError) mapper.handleException(e, executor.getContext());
+        } finally {
+            outer.stop("omero.repo.save_fileset");
         }
     }
 
@@ -779,10 +791,12 @@ public class RepositoryDaoImpl implements RepositoryDao {
                 basenames.add(path.getName());
             }
 
+            StopWatch sw = new Slf4JStopWatch();
             Map<String, Long> fileIds = sql.findRepoFiles(repoUuid,
                 level.get(0).getRelativePath(), /* all the same */
                 basenames, null /*mimetypes*/);
-            
+            sw.stop("omero.repo.internal_register.find_repo_files");
+
             List<Long> toLoad = new ArrayList<Long>();
             List<CheckedPath> toCreate = new ArrayList<CheckedPath>();
             for (int i = 0; i < level.size(); i++) {
@@ -803,12 +817,14 @@ public class RepositoryDaoImpl implements RepositoryDao {
                 toReturn.addAll(created);
             }
 
+            sw = new Slf4JStopWatch();
             if (toLoad.size() > 0) {
                 List<ome.model.core.OriginalFile> loaded = 
                     sf.getQueryService().findAllByQuery("select o from OriginalFile o " +
                         "where o.id in (:ids)", new Parameters().addIds(toLoad));
                 toReturn.addAll(loaded);
             }
+            sw.stop("omero.repo.internal_register.load");
         }
         return toReturn;
     }
@@ -953,8 +969,12 @@ public class RepositoryDaoImpl implements RepositoryDao {
             ofile.setHasher(ca);
         }
 
+
+        StopWatch sw = new Slf4JStopWatch();
         IObject[] saved = sf.getUpdateService().saveAndReturnArray(rv.toArray(new IObject[rv.size()]));
+        sw.stop("omero.repo.create_original_file.save");
         final List<Long> ids = new ArrayList<Long>(saved.length);
+        sw = new Slf4JStopWatch();
         for (int i = 0; i < saved.length; i++) {
             final CheckedPath path = checked.get(i);
             final ome.model.core.OriginalFile ofile = (ome.model.core.OriginalFile) saved[i];
@@ -964,7 +984,11 @@ public class RepositoryDaoImpl implements RepositoryDao {
                 internalMkdir(path);
             }
         }
+        sw.stop("omero.repo.create_original_file.internal_mkdir");
+
+        sw = new Slf4JStopWatch();
         sql.setFileRepo(ids, repoUuid);
+        sw.stop("omero.repo.create_original_file.set_file_repo");
         return rv;
     }
 

--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -772,7 +772,7 @@ public class RepositoryDaoImpl implements RepositoryDao {
             levels.put(parents.get(i), checked.get(i));
         }
 
-        for (CheckedPath parent : levels.keys()) {
+        for (CheckedPath parent : levels.keySet()) {
             List<CheckedPath> level = levels.get(parent);
             List<String> basenames = new ArrayList<String>(checked.size());
             for (CheckedPath path: level) {


### PR DESCRIPTION
The underlying logic in `RepositoryDaoImpl` is expecting checked path equivalence checks to succeed either via `equals()` or `hashCode()`. This PR ensures that will be the case resulting in single level saves in `RepositoryDaoImpl._internalRegister()` which was the original intention of parts of gh-3399.  Performance and resource utilisation are dramatically increased where the file count is high (>1000) or
especially high (>10000).

Without these changes, `CheckedPath` is never equivalent as far as the `ListMultimap` in `_internalRegister()` is concerned. This results in a __single__ `createOriginalFile()` operation for every original file that needs to be registered. Where the file count is especially high (>10000) this can mean registration times in the __hours__ and very high resource utilisation throughout the entire bulk registration.

Every file format and every import will benefit from these changes but imports where the file count is especially high (>10000) are now feasible in a reasonable time frame.

Integration testing should be sufficient. If more manual testing is desired examining the command line import log for the transition between `FILESET_UPLOAD_PREPARATION` and `FILESET_UPLOAD_START` and/or the server log file for the time between `INSERT` operations for `ome.model.core.OriginalFile` after the invocation of `saveFileset()` can be useful. The latter is the most illustrative on smaller numbers of files. An example of both follow:

Before:

```
2015-02-18 05:37:49,620 3697       [      main] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_PREPARATION
2015-02-18 05:38:05,403 19480      [      main] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_START
```

After:

```
2015-02-18 05:27:07,034 2261       [      main] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_PREPARATION
2015-02-18 05:27:21,022 16249      [      main] INFO   ormats.importer.cli.LoggingImportMonitor - FILESET_UPLOAD_START
```

Before:

```
2015-02-18 05:37:50,709 INFO  [        ome.services.util.ServiceHandler] (l.Server-5)  Executor.doWork -- ome.services.blitz.repo.RepositoryDaoImpl.saveFileset[5bc9cc06-e326-49b0-b682-6da0f3f2a9f1, ome.model.fs.Fileset:Hash_604265482, (CheckedPath(root_0/2015-02/1
8/05-37-50.331/MFGTMP-PC_130509120002_B02f00d0.C01), CheckedPath(root_0/2015-02/18/05-37-50.331/MFGTMP-PC_130509120002_B02f00d1.C01), CheckedPath(root_0/2015-02/18/05-37-50.331/MFGTMP-PC_130509120002_B02f00d2.C01), ... 1059 more)]
2015-02-18 05:37:50,709 INFO  [        ome.services.util.ServiceHandler] (l.Server-5)  Args:    [null, InternalSF@2075832932]
2015-02-18 05:37:50,718 INFO  [         ome.security.basic.EventHandler] (l.Server-5)  Auth:    user=0,group=0,event=27221(User),sess=625432a9-27c7-4d87-afda-99033a49b07c
2015-02-18 05:37:50,733 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.fs.FilesetVersionInfo,501
2015-02-18 05:37:50,735 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.jobs.UploadJob,501
2015-02-18 05:37:50,736 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.jobs.JobOriginalFileLink,501
2015-02-18 05:37:50,767 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.fs.FilesetVersionInfo,502
2015-02-18 05:37:50,769 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.jobs.MetadataImportJob,502
2015-02-18 05:37:50,784 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.jobs.PixelDataJob,503
2015-02-18 05:37:50,801 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.jobs.IndexingJob,504
2015-02-18 05:37:50,819 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12053
2015-02-18 05:37:50,828 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12054
2015-02-18 05:37:50,838 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12055
2015-02-18 05:37:50,860 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12056
2015-02-18 05:37:50,875 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12057
2015-02-18 05:37:50,886 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12058
2015-02-18 05:37:50,896 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12059
2015-02-18 05:37:50,907 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12060
2015-02-18 05:37:50,917 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12061
2015-02-18 05:37:50,928 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12062
2015-02-18 05:37:50,940 INFO  [       ome.security.basic.CurrentDetails] (l.Server-5) Adding log:INSERT,class ome.model.core.OriginalFile,12063
...
```

After:

```
2015-02-18 05:27:07,368 INFO  [        ome.services.util.ServiceHandler] (.Server-17)  Executor.doWork -- ome.services.blitz.repo.RepositoryDaoImpl.saveFileset[5bc9cc06-e326-49b0-b682-6da0f3f2a9f1, ome.model.fs.Fileset:Hash_1873725506, (CheckedPath(root_0/2015-02/
18/05-27-07.256/MFGTMP-PC_130509120002_B02f00d0.C01), CheckedPath(root_0/2015-02/18/05-27-07.256/MFGTMP-PC_130509120002_B02f00d1.C01), CheckedPath(root_0/2015-02/18/05-27-07.256/MFGTMP-PC_130509120002_B02f00d2.C01), ... 1059 more)]
2015-02-18 05:27:07,368 INFO  [        ome.services.util.ServiceHandler] (.Server-17)  Args:    [null, InternalSF@873855119]
2015-02-18 05:27:07,373 INFO  [         ome.security.basic.EventHandler] (.Server-17)  Auth:    user=0,group=0,event=24681(User),sess=a846158c-dfc6-4b2e-a2b8-c00405b877e7
2015-02-18 05:27:07,378 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.fs.FilesetVersionInfo,453
2015-02-18 05:27:07,379 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.jobs.UploadJob,456
2015-02-18 05:27:07,380 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.jobs.JobOriginalFileLink,454
2015-02-18 05:27:07,394 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.fs.FilesetVersionInfo,454
2015-02-18 05:27:07,396 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.jobs.MetadataImportJob,457
2015-02-18 05:27:07,402 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.jobs.PixelDataJob,458
2015-02-18 05:27:07,407 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.jobs.IndexingJob,459
2015-02-18 05:27:07,493 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10968
2015-02-18 05:27:07,495 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10969
2015-02-18 05:27:07,495 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10970
2015-02-18 05:27:07,496 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10971
2015-02-18 05:27:07,496 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10972
2015-02-18 05:27:07,497 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10973
2015-02-18 05:27:07,497 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10974
2015-02-18 05:27:07,497 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10975
2015-02-18 05:27:07,497 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10976
2015-02-18 05:27:07,498 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10977
2015-02-18 05:27:07,498 INFO  [       ome.security.basic.CurrentDetails] (.Server-17) Adding log:INSERT,class ome.model.core.OriginalFile,10978
...
```

/cc @mtbc, @melissalinkert, @joshmoore 