### PR TITLE
Automatically append / to omero.web.static_url

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -216,7 +216,7 @@ def identity(x):
 def str_slash(s):
     if s is not None:
         s = str(s)
-        if not s.endswith("/"):
+        if s and not s.endswith("/"):
             s += "/"
     return s
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -214,9 +214,10 @@ def identity(x):
 
 
 def str_slash(s):
-    s = str(s)
-    if not s.endswith("/"):
-        s += "/"
+    if s is not None:
+        s = str(s)
+        if not s.endswith("/"):
+            s += "/"
     return s
 
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -213,10 +213,10 @@ def identity(x):
     return x
 
 
-def remove_slash(s):
-    if s is not None and len(s) > 0:
-        if s.endswith("/"):
-            s = s[:-1]
+def str_slash(s):
+    s = str(s)
+    if not s.endswith("/"):
+        s += "/"
     return s
 
 
@@ -310,7 +310,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.static_url":
         ["STATIC_URL",
          "/static/",
-         str,
+         str_slash,
          ("URL to use when referring to static files. Example: ``'/static/'``"
           " or ``'http://static.example.com/'``. Used as the base path for"
           " asset  definitions (the Media class) and the staticfiles app. It"


### PR DESCRIPTION
Automatically append / to omero.web.static_url if necessary instead of failing with a warning that a trailing slash is required. Note this also removes the unused `omeroweb.settings.remove_slash` method.

Testing: Test `omero.static.url` with/without a trailing /, and unset.

--no-rebase