### PR TITLE
Imagej mif

### DIFF
--- a/components/blitz/src/pojos/ImageData.java
+++ b/components/blitz/src/pojos/ImageData.java
@@ -1,16 +1,12 @@
 /*
  * pojos.ImageData
  *
- *   Copyright 2006-2013 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
 package pojos;
 
-
-
-
-//Java imports
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -18,10 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-//Third-party libraries
-
-//Application-internal dependencies
 import static omero.rtypes.rstring;
+import omero.RInt;
 import omero.RTime;
 import omero.model.Annotation;
 import omero.model.CommentAnnotation;
@@ -202,7 +196,20 @@ public class ImageData extends DataObject {
      * @return See above.
      */
     public int getIndex() { return index; }
-    
+
+    /**
+     * Returns the series.
+     *
+     * @return See above.
+     */
+    public int getSeries()
+    {
+        Image image = asImage();
+        RInt value = image.getSeries();
+        if (value == null) return 0;
+        return value.getValue();
+    }
+
     /**
      * Returns the format of the image.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1537,8 +1537,21 @@ public class ImportDialog extends ClosableTabbedPaneComponent
         if (CollectionUtils.isEmpty(list)) {
             boolean active = locationDialog.isActiveWindow();
             list = new ArrayList<FileObject>();
+            FileObject f, ff;
             if (active) {
-                list.add(new FileObject(WindowManager.getCurrentImage()));
+                f = new FileObject(WindowManager.getCurrentImage());
+                //check if there are associated files
+                int[] values = WindowManager.getIDList();
+                String path = f.getAbsolutePath();
+                if (path != null) {
+                    for (int i = 0; i < values.length; i++) {
+                        ff = new FileObject(WindowManager.getImage(values[i]));
+                        if (path.equals(f.getAbsolutePath())) {
+                            f.addAssociatedFile(ff);
+                        }
+                    }
+                }
+                list.add(f);
             } else {
                 int[] values = WindowManager.getIDList();
                 for (int i = 0; i < values.length; i++) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -841,7 +841,6 @@ class ImporterComponent
 		element.setImportResult(component, result);
 		handleCompletion(element, result, !component.hasParent());
 		Collection<PixelsData> pixels = (Collection<PixelsData>) result;
-		
 		if (CollectionUtils.isEmpty(pixels)) return;
 		List<DataObject> l = new ArrayList<DataObject>();
 		Iterator<PixelsData> i = pixels.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -23,7 +23,6 @@
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
 //Java imports
-import ij.IJ;
 import ij.ImagePlus;
 
 import java.util.Collection;
@@ -603,6 +602,7 @@ class ImporterModel
                 }
                 //check roi manager
                 if (CollectionUtils.isEmpty(rois)) {
+                    
                     rois = reader.readImageJROI(id);
                 }
                 if (CollectionUtils.isNotEmpty(rois)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -590,12 +590,10 @@ class ImporterModel
             ImageData data;
             long id;
             Iterator<ImageData> i = images.iterator();
-            IJ.debugMode = true;
             while (i.hasNext()) {
                 data = i.next();
                 id = data.getId();
                 index = data.getSeries();
-                IJ.log("index:"+index);
                 //First check overlay
                 if (indexes.containsKey(index)) {
                    rois = indexes.get(index);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -23,6 +23,7 @@
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
 //Java imports
+import ij.IJ;
 import ij.ImagePlus;
 
 import java.util.Collection;
@@ -589,11 +590,13 @@ class ImporterModel
             ImageData data;
             long id;
             Iterator<ImageData> i = images.iterator();
+            IJ.debugMode = true;
             while (i.hasNext()) {
                 data = i.next();
                 id = data.getId();
-                index = data.getIndex(); //to be modified when series is available.
-              //First check overlay
+                index = data.getSeries();
+                IJ.log("index:"+index);
+                //First check overlay
                 if (indexes.containsKey(index)) {
                    rois = indexes.get(index);
                    linkRoisToImage(id, rois);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
@@ -130,8 +130,8 @@ public class SaveResultsDialog
         ResultsObject result;
         if (toImport.size() > 0) { //ask if they want to import the image
             StringBuffer buf = new StringBuffer();
-            buf.append("Do you wish to import the selected image(s), not in "
-                    + "OMERO?");
+            buf.append("Do you wish to import any selected images not already "
+                    + "saved in OMERO to the OMERO server?");
             MessageBox box = new MessageBox(this, "Import images", buf.toString());
             if (box.centerMsgBox() == MessageBox.YES_OPTION) {
                  result = new ResultsObject(toImport);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -97,7 +97,7 @@ public class FileObject
     /**
      * Returns the associated files if any or <code>null</code>.
      * 
-     * @preturn See above.
+     * @return See above.
      */
     public List<FileObject> getAssociatedFiles()
     {


### PR DESCRIPTION
Add support for overlay and MIF

To test
 * open  a mif in imageJ using B-F importer e.g. ```test_images_good/leica-lif/Beta Catenin.lif```
 * Make sure you select all series. 5 windows should opened
 * Draw a roi on an image e.g. series004, add it as an overlay
 * Draw a roi on an another image e.g. image001, add it as an overlay
 * Import the image to OMERO
 * Check the rois are on the correct images.
 