### PR TITLE
MapAnnotation bugfixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
@@ -457,8 +457,6 @@ public class MapAnnotationsComponent extends JPanel implements
 		t.addFocusListener(new FocusListener() {
 			@Override
 			public void focusLost(FocusEvent e) {
-                if (t.getCellEditor() != null)
-                    t.getCellEditor().stopCellEditing();
 				MapTableModel m = (MapTableModel) t.getModel();
 				if (m.isDirty())
 					view.saveData(true);
@@ -486,6 +484,8 @@ public class MapAnnotationsComponent extends JPanel implements
 			boolean excludeEmpty) {
 		List<MapAnnotationData> result = new ArrayList<MapAnnotationData>();
 		for (MapTable t : mapTables) {
+            if (t.getCellEditor() != null)
+                t.getCellEditor().stopCellEditing();
 			if ((!onlyDirty || ((MapTableModel) t.getModel()).isDirty())
 					&& !(excludeEmpty && t.isEmpty()))
 				result.add(t.getData());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
@@ -609,6 +609,8 @@ public class MapAnnotationsComponent extends JPanel implements
 		MapTable t = getSelectedTable();
 		if (t == null)
 			t = getUserTable();
+		if (t == null) // no user table and nothing selected, don't know where to paste 
+		    return;
 		MapTableModel m = (MapTableModel) t.getModel();
 		int index = t.getSelectedRow() + 1;
 		m.addEntries(deepCopy(copiedValues), index);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/table/TableRowTransferHandler.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/table/TableRowTransferHandler.java
@@ -83,6 +83,8 @@ public class TableRowTransferHandler extends TransferHandler {
 
 	@Override
 	public boolean importData(TransferHandler.TransferSupport info) {
+	    if (!info.isDrop())
+	        return false;
 		JTable target = (JTable) info.getComponent();
 		JTable.DropLocation dl = (JTable.DropLocation) info.getDropLocation();
 		int index = dl.getRow();


### PR DESCRIPTION
Fixes several issues discovered during m4 testing:
- [Ticket 12747](https://trac.openmicroscopy.org.uk/ome/ticket/12747)
- [Ticket 12748](https://trac.openmicroscopy.org.uk/ome/ticket/12748)
- NPE when you tried to paste Key/Values when no MapAnnotation was selected and no own user table exists (e.g. admin annotating other user's DataObject in private group)
- Fixed bug which removed the text caret from cells (which had the effect, that you only could overwrite the cells content).