### PR TITLE
Improvements to disk usage plugin

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2014-2015 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -822,21 +822,15 @@ Examples:
         """
         from omero.util.text import TableBuilder
 
-        sum_by = allCols = sortCols = ("user", "group", "component")
+        sum_by = ("user", "group", "component")
         if args.sum_by is not None:
-            sum_by = sortCols = args.sum_by
-        sortCols = list(sortCols)
-        sortCols.extend(["size", "files"])
+            sum_by = args.sum_by
+        showCols = list(sum_by)
+        showCols.extend(["size", "files"])
 
-        cols = []
-        align = ''
-        for col in allCols:
-            if col in sum_by:
-                cols.append(col)
-                align += 'l'
-        cols.extend(["size","files"])
+        align = 'l'*len(sum_by)
         align += 'rr'
-        tb = TableBuilder(*cols)
+        tb = TableBuilder(*showCols)
         tb.set_align(align)
         if args.style:
             tb.set_style(args.style)
@@ -886,7 +880,7 @@ Examples:
             keys = []
             for col in args.sort_by:
                 try:
-                    pos = sortCols.index(col)
+                    pos = showCols.index(col)
                     keys.append(pos)
                 except:
                     pass

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -286,7 +286,7 @@ class FsControl(CmdControl):
             "--units", choices="KMGTP",
             help="Units to use for disk usage")
         usage.add_argument(
-            "--pretty", action="store_true",
+            "--human_readable", action="store_true",
             help="Use most appropriate units")
         usage.add_argument(
             "--groups",  action="store_true",
@@ -787,7 +787,7 @@ Examples:
                 if args.units:
                     size = ("%d %siB"
                             % (self._to_units(size, args.units), args.units))
-                elif args.pretty:
+                elif args.human_readable:
                     size = filesizeformat(size)
                 self.ctx.out(
                     "Total disk usage: %s bytes in %d files"
@@ -813,7 +813,7 @@ Examples:
             if col in sum_by:
                 cols.append(col)
                 align += 'l'
-        if args.pretty:
+        if args.human_readable:
             cols.extend(["size", "files"])
         else:
             cols.extend(["size (bytes)", "files"])
@@ -859,7 +859,7 @@ Examples:
 
         for key in subtotals.keys():
             row = list(key)
-            if args.pretty:
+            if args.human_readable:
                 subtotals[key][0] = filesizeformat(subtotals[key][0])
             row.extend(subtotals[key])
             tb.row(*tuple(row))

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -39,6 +39,7 @@ from omero.rtypes import rstring
 from omero.rtypes import unwrap
 from omero.sys import Principal
 from omero.util.temp_files import create_path
+from omero.util.text import filesizeformat
 from omero.fs import TRANSFERS
 
 
@@ -285,6 +286,9 @@ class FsControl(CmdControl):
             "--units", choices="KMGTP",
             help="Units to use for disk usage")
         usage.add_argument(
+            "--pretty", action="store_true",
+            help="Use most appropriate units")
+        usage.add_argument(
             "--groups",  action="store_true",
             help="Print size for all current user's groups")
         usage.add_argument(
@@ -308,7 +312,6 @@ class FsControl(CmdControl):
     def _extended_info(self, client, row, values):
 
         from omero.cmd import ManageImageBinaries
-        from omero.util.text import filesizeformat
 
         rsp = None
         try:
@@ -354,7 +357,6 @@ Examples:
 
         from omero.rtypes import unwrap
         from omero.sys import ParametersI
-        from omero.util.text import filesizeformat
 
         select = (
             "select i.id, i.name, fs.id,"
@@ -810,7 +812,10 @@ Examples:
         for col in allCols:
             if col in sum_by:
                 cols.append(col)
-        cols.extend(["size (bytes)", "files"])
+        if args.pretty:
+            cols.extend(["size", "files"])
+        else:
+            cols.extend(["size (bytes)", "files"])
         tb = TableBuilder(*cols)
         if args.style:
             tb.set_style(args.style)
@@ -834,6 +839,8 @@ Examples:
 
         for key in subtotals.keys():
             row = list(key)
+            if args.pretty:
+                subtotals[key][0] = filesizeformat(subtotals[key][0])
             row.extend(subtotals[key])
             tb.row(*tuple(row))
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -294,7 +294,9 @@ class FsControl(CmdControl):
             help="Print size for all current user's groups")
         usage.add_argument(
             "obj", nargs="*",
-            help="Objects to be queried in the form '<Class>:<Id>[,<Id> ...]'")
+            help=("Objects to be queried in the form "
+                  "'<Class>:<Id>[,<Id> ...]', or '<Class>:*' "
+                  "to query all the objects of the given type "))
 
         for x in (images, sets):
             x.add_argument(
@@ -710,6 +712,10 @@ Examples:
     bin/omero fs usage --groups    # total usage for current user's groups
     # total usage for five images with minimal output
     bin/omero fs usage Image:1,2,3,4,5 --size_only
+    # total usage for all images with in a human readable format
+    bin/omero fs usage Image:* --human-readable
+    # total usage for all users broken down by user and group
+    bin/omero fs usage Experimenter:* --report --sum-by user group
     # total usage for two projects and one dataset Megabytes
     bin/omero fs usage Project:1,2 Dataset:5 --units M
     # in this last case if the dataset was within one of the projects

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -808,14 +808,18 @@ Examples:
             sum_by = args.sum_by
 
         cols = []
+        align = ''
         for col in allCols:
             if col in sum_by:
                 cols.append(col)
+                align += 'l'
         if args.pretty:
             cols.extend(["size", "files"])
         else:
             cols.extend(["size (bytes)", "files"])
+        align += 'rr'
         tb = TableBuilder(*cols)
+        tb.set_align(align)
         if args.style:
             tb.set_style(args.style)
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -785,7 +785,8 @@ Examples:
             else:
                 files = sum(rsp.totalFileCount.values())
                 if args.units:
-                    size = "%d %siB" % (self._to_units(size, args.units), args.units)
+                    size = ("%d %siB"
+                            % (self._to_units(size, args.units), args.units))
                 elif args.pretty:
                     size = filesizeformat(size)
                 self.ctx.out(
@@ -821,6 +822,7 @@ Examples:
         subtotals = {}
         for userGroup in rsp.bytesUsedByReferer.keys():
             for (element, size) in rsp.bytesUsedByReferer[userGroup].items():
+                files = rsp.fileCountByReferer[userGroup][element]
                 keyList = []
                 if "user" in sum_by:
                     keyList.append(userGroup.first)
@@ -828,12 +830,12 @@ Examples:
                     keyList.append(userGroup.second)
                 if "component" in sum_by:
                     keyList.append(element)
-                key=tuple(keyList)
+                key = tuple(keyList)
                 if key in subtotals.keys():
                     subtotals[key][0] += size
-                    subtotals[key][1] += rsp.fileCountByReferer[userGroup][element]
+                    subtotals[key][1] += files
                 else:
-                    subtotals[key] = [size, rsp.fileCountByReferer[userGroup][element]]
+                    subtotals[key] = [size, files]
 
         for key in subtotals.keys():
             row = list(key)

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -796,7 +796,7 @@ Examples:
         """
         err = self.get_error(rsp)
         if err:
-            self.ctx.err("Error: " + rsp.name)
+            self.ctx.err("Error: " + rsp.parameters['message'])
         else:
             size = sum(rsp.totalBytesUsed.values())
             if args.size_only:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -824,16 +824,31 @@ Examples:
             tb.set_style(args.style)
 
         subtotals = {}
-        for userGroup in rsp.bytesUsedByReferer.keys():
-            for (element, size) in rsp.bytesUsedByReferer[userGroup].items():
-                files = rsp.fileCountByReferer[userGroup][element]
+        if "component" in sum_by:
+            for userGroup in rsp.bytesUsedByReferer.keys():
+                for (element, size) in rsp.bytesUsedByReferer[userGroup].items():
+                    files = rsp.fileCountByReferer[userGroup][element]
+                    keyList = []
+                    if "user" in sum_by:
+                        keyList.append(userGroup.first)
+                    if "group" in sum_by:
+                        keyList.append(userGroup.second)
+                    keyList.append(element)
+                    key = tuple(keyList)
+                    if key in subtotals.keys():
+                        subtotals[key][0] += size
+                        subtotals[key][1] += files
+                    else:
+                        subtotals[key] = [size, files]
+        else:
+            for userGroup in rsp.totalBytesUsed.keys():
+                size = rsp.totalBytesUsed[userGroup]
+                files = rsp.totalFileCount[userGroup]
                 keyList = []
                 if "user" in sum_by:
                     keyList.append(userGroup.first)
                 if "group" in sum_by:
                     keyList.append(userGroup.second)
-                if "component" in sum_by:
-                    keyList.append(element)
                 key = tuple(keyList)
                 if key in subtotals.keys():
                     subtotals[key][0] += size

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -767,7 +767,7 @@ Examples:
         oneK = 1024.0
         powers = {'K': 1, 'M': 2, 'G': 3, 'T': 4, 'P': 5}
         if units in powers.keys():
-            return round(size/oneK**powers[units], 2)
+            return round(size/oneK**powers[units], 1)
         else:
             raise ValueError("Unrecognized units: ", units)
 
@@ -786,7 +786,7 @@ Examples:
             else:
                 files = sum(rsp.totalFileCount.values())
                 if args.units:
-                    size = ("%d %siB"
+                    size = ("%s %siB"
                             % (self._to_units(size, args.units), args.units))
                 elif args.human_readable:
                     size = filesizeformat(size)

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -812,8 +812,8 @@ Examples:
                     "Total disk usage: %s bytes in %d files"
                     % (size, files))
 
-        if args.report and not args.size_only:
-            self._detailed_usage_report(req, rsp, status, args)
+            if args.report and not args.size_only and size > 0:
+                self._detailed_usage_report(req, rsp, status, args)
 
     def _detailed_usage_report(self, req, rsp, status, args):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -273,13 +273,13 @@ class FsControl(CmdControl):
             help="Number of seconds to wait for the processing to complete "
             "(Indefinite < 0; No wait=0).", default=-1)
         usage.add_argument(
-            "--size_only", action="store_true",
+            "--size-only", action="store_true",
             help="Print total bytes used in bytes")
         usage.add_argument(
             "--report", action="store_true",
             help="Print detailed breakdown of disk usage")
         usage.add_argument(
-            "--sum_by", nargs="+", choices=("user", "group", "component"),
+            "--sum-by", nargs="+", choices=("user", "group", "component"),
             help=("Breakdown of disk usage by a combination of "
                   "user, group and component"))
         unit_group = usage.add_mutually_exclusive_group()
@@ -287,7 +287,7 @@ class FsControl(CmdControl):
             "--units", choices="KMGTP",
             help="Units to use for disk usage")
         unit_group.add_argument(
-            "--human_readable", action="store_true",
+            "--human-readable", action="store_true",
             help="Use most appropriate units")
         usage.add_argument(
             "--groups",  action="store_true",

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -726,7 +726,7 @@ Examples:
     bin/omero fs usage Experimenter:* --report --sum-by user group
     # total usage for two projects and one dataset Megabytes
     bin/omero fs usage Project:1,2 Dataset:5 --units M
-    # in this last case if the dataset was within one of the projects
+    # in this last case if the dataset was within project 1 or 2
     # then the size returned would be identical to:
     bin/omero fs usage Project:1,2 --units M
         """

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -796,7 +796,7 @@ Examples:
         """
         err = self.get_error(rsp)
         if err:
-            self.ctx.err(err)
+            self.ctx.err("Error: " + rsp.parameters['message'])
         else:
             size = sum(rsp.totalBytesUsed.values())
             if args.size_only:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -826,7 +826,8 @@ Examples:
         subtotals = {}
         if "component" in sum_by:
             for userGroup in rsp.bytesUsedByReferer.keys():
-                for (element, size) in rsp.bytesUsedByReferer[userGroup].items():
+                for (element, size) in rsp.bytesUsedByReferer[
+                        userGroup].items():
                     files = rsp.fileCountByReferer[userGroup][element]
                     keyList = []
                     if "user" in sum_by:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -834,13 +834,7 @@ Examples:
             if col in sum_by:
                 cols.append(col)
                 align += 'l'
-        if args.units:
-            cols.append("size (%siB)" % args.units)
-        elif args.human_readable:
-            cols.append("size")
-        else:
-            cols.append("size (bytes)")
-        cols.append("files")
+        cols.extend(["size","files"])
         align += 'rr'
         tb = TableBuilder(*cols)
         tb.set_align(align)
@@ -883,11 +877,6 @@ Examples:
 
         for key in subtotals.keys():
             row = list(key)
-            if args.units:
-                subtotals[key][0] = self._to_units(
-                    subtotals[key][0], args.units)
-            elif args.human_readable:
-                subtotals[key][0] = filesizeformat(subtotals[key][0])
             row.extend(subtotals[key])
             tb.row(*tuple(row))
 
@@ -903,8 +892,21 @@ Examples:
                     pass
         else:
             keys = [0]
-
         tb.sort(cols=keys, reverse=args.reverse)
+
+        # Format the size column after sorting.
+        if args.units:
+            col = tb.get_col("size")
+            col = [self._to_units(val, args.units) for val in col]
+            tb.replace_col("size", col)
+            tb.replace_header("size", "size (%siB)" % args.units)
+        elif args.human_readable:
+            col = tb.get_col("size")
+            col = [filesizeformat(val) for val in col]
+            tb.replace_col("size", col)
+        else:
+            tb.replace_header("size", "size (bytes)")
+
         self.ctx.out(str(tb.build()))
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -282,10 +282,11 @@ class FsControl(CmdControl):
             "--sum_by", nargs="+", choices=("user", "group", "component"),
             help=("Breakdown of disk usage by a combination of "
                   "user, group and component"))
-        usage.add_argument(
+        unit_group = usage.add_mutually_exclusive_group()
+        unit_group.add_argument(
             "--units", choices="KMGTP",
             help="Units to use for disk usage")
-        usage.add_argument(
+        unit_group.add_argument(
             "--human_readable", action="store_true",
             help="Use most appropriate units")
         usage.add_argument(

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -813,10 +813,13 @@ Examples:
             if col in sum_by:
                 cols.append(col)
                 align += 'l'
-        if args.human_readable:
-            cols.extend(["size", "files"])
+        if args.units:
+            cols.append("size (%siB)" % args.units)
+        elif args.human_readable:
+            cols.append("size")
         else:
-            cols.extend(["size (bytes)", "files"])
+            cols.append("size (bytes)")
+        cols.append("files")
         align += 'rr'
         tb = TableBuilder(*cols)
         tb.set_align(align)
@@ -859,7 +862,10 @@ Examples:
 
         for key in subtotals.keys():
             row = list(key)
-            if args.human_readable:
+            if args.units:
+                subtotals[key][0] = self._to_units(
+                    subtotals[key][0], args.units)
+            elif args.human_readable:
                 subtotals[key][0] = filesizeformat(subtotals[key][0])
             row.extend(subtotals[key])
             tb.row(*tuple(row))

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -796,7 +796,7 @@ Examples:
         """
         err = self.get_error(rsp)
         if err:
-            self.ctx.err("Error: " + rsp.parameters['message'])
+            self.ctx.err("Error: " + rsp.name)
         else:
             size = sum(rsp.totalBytesUsed.values())
             if args.size_only:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -779,20 +779,18 @@ Examples:
         if err:
             self.ctx.err(err)
         else:
+            size = sum(rsp.totalBytesUsed.values())
             if args.size_only:
-                self.ctx.out(sum(rsp.totalBytesUsed.values()))
-            elif args.units:
-                size = self._to_units(
-                    sum(rsp.totalBytesUsed.values()), args.units)
-                files = sum(rsp.totalFileCount.values())
-                self.ctx.out(
-                    "Total disk usage: %d %siB in %d files"
-                    % (size, args.units, files))
+                self.ctx.out(size)
             else:
+                files = sum(rsp.totalFileCount.values())
+                if args.units:
+                    size = "%d %siB" % (self._to_units(size, args.units), args.units)
+                elif args.pretty:
+                    size = filesizeformat(size)
                 self.ctx.out(
-                    "Total disk usage: %d bytes in %d files"
-                    % (sum(rsp.totalBytesUsed.values()),
-                       sum(rsp.totalFileCount.values())))
+                    "Total disk usage: %s bytes in %d files"
+                    % (size, files))
 
         if args.report and not args.size_only:
             self._detailed_usage_report(req, rsp, status, args)

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -881,6 +881,7 @@ Examples:
             row.extend(subtotals[key])
             tb.row(*tuple(row))
 
+        tb.sort(col=0)
         self.ctx.out(str(tb.build()))
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -732,7 +732,7 @@ Examples:
                 args.obj.append(
                     "ExperimenterGroup:%s" % ",".join(map(str, gids)))
 
-        req.objects = self._usage_obj(args.obj)
+        req.objects, req.classes = self._usage_obj(args.obj)
         cb = None
         try:
             rsp, status, cb = self.response(client, req, wait=args.wait)
@@ -744,21 +744,25 @@ Examples:
     def _usage_obj(self, obj):
         """
         Take the positional arguments and marshal them into
-        a dictionary for the command argument.
+        a dictionary and a list for the command argument.
         """
         objects = {}
+        classes = set()
         for o in obj:
             try:
                 parts = o.split(":", 1)
                 assert len(parts) == 2
-                type = parts[0]
-                ids = parts[1].split(",")
-                ids = map(long, ids)
-                objects[type] = ids
+                klass = parts[0]
+                if '*' in parts[1]:
+                    classes.add(klass)
+                else:
+                    ids = parts[1].split(",")
+                    ids = map(long, ids)
+                    objects[klass] = ids
             except:
                 raise ValueError("Bad object: ", o)
 
-        return objects
+        return (objects, list(classes))
 
     def _to_units(self, size, units):
         """

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -135,12 +135,24 @@ class TableBuilder(object):
         self.headers = list(headers)
         self.results = [[] for x in self.headers]
         self.page_info = None
+        self.align = None
 
     def page(self, offset, limit, total):
         self.page_info = (offset, limit, total)
 
     def set_style(self, style):
         self.style = find_style(style)
+
+    def set_align(self, align):
+        """
+        Set column alignments using alignments string, one char for each
+        column. 'r' for right-aligned columns, the default, anything else,
+        is left-aligned. If the argument list in too short it will be padded
+        with the default.
+        """
+        self.align = list(align)
+        if len(self.align) < len(self.headers):
+            self.align.extend(['l'] * (len(self.headers) - len(self.align)))
 
     def col(self, name):
         """
@@ -183,7 +195,11 @@ class TableBuilder(object):
     def build(self):
         columns = []
         for i, x in enumerate(self.headers):
-            columns.append(Column(x, self.results[i], style=self.style))
+            align = ALIGN.LEFT
+            if self.align and self.align[i] == 'r':
+                align = ALIGN.RIGHT
+            columns.append(
+                Column(x, self.results[i], align=align, style=self.style))
         table = Table(*columns)
         if self.page_info:
             table.page(*self.page_info)

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -192,18 +192,19 @@ class TableBuilder(object):
                 if self.results[idx][-1] is None:
                     self.results[idx][-1] = ""
 
-    def sort(self, col=0):
+    def sort(self, cols=[0], reverse=False):
         """
         Sort the results on a given column by transposing,
         sorting and then transposing.
         """
-        if col+1 > len(self.headers):
-            raise ValueError("Column mismatch: %s of %s" %
-                             (col, len(self.headers)))
+        for col in cols:
+            if col+1 > len(self.headers):
+                raise ValueError("Column mismatch: %s of %s" %
+                                 (col, len(self.headers)))
 
         from operator import itemgetter
         tr = zip(*self.results)
-        tr.sort(key=itemgetter(col))
+        tr.sort(key=itemgetter(*cols), reverse=reverse)
         self.results = zip(*tr)
 
     def build(self):

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -3,7 +3,7 @@
 #
 # OMERO Text handling utilities
 #
-# Copyright 2010 Glencoe Software, Inc.  All Rights Reserved.
+# Copyright 2010-2015 Glencoe Software, Inc.  All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -169,6 +169,36 @@ class TableBuilder(object):
             if name not in self.headers:
                 self.col(name)
 
+    def get_col(self, name):
+        """
+        Return a column by header name.
+        """
+        if name not in self.headers:
+            raise KeyError("%s not in %s" % (name, self.headers))
+        idx = self.headers.index(name)
+        return self.results[idx]
+
+    def replace_col(self, name, col):
+        """
+        Replace a column by header name, it must be the same length.
+        """
+        if name not in self.headers:
+            raise KeyError("%s not in %s" % (name, self.headers))
+        idx = self.headers.index(name)
+        if len(self.results[idx]) != len(col):
+            raise ValueError("Size mismatch: %s != %s" %
+                             (self.results[idx], len(col)))
+        self.results[idx] = col
+
+    def replace_header(self, name, new_name):
+        """
+        Replace a header name with a new name.
+        """
+        if name not in self.headers:
+            raise KeyError("%s not in %s" % (name, self.headers))
+        idx = self.headers.index(name)
+        self.headers[idx] = new_name
+
     def row(self, *items, **by_name):
 
         if len(items) > len(self.headers):

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -192,6 +192,20 @@ class TableBuilder(object):
                 if self.results[idx][-1] is None:
                     self.results[idx][-1] = ""
 
+    def sort(self, col=0):
+        """
+        Sort the results on a given column by transposing,
+        sorting and then transposing.
+        """
+        if col+1 > len(self.headers):
+            raise ValueError("Column mismatch: %s of %s" %
+                             (col, len(self.headers)))
+
+        from operator import itemgetter
+        tr = zip(*self.results)
+        tr.sort(key=itemgetter(col))
+        self.results = zip(*tr)
+
     def build(self):
         columns = []
         for i, x in enumerate(self.headers):


### PR DESCRIPTION
This PR is intended to improve the output options for the disk usage plug-in now that size and file counts are available at a per-user, per-group, per-component level. Firstly it allows totals to be summed by any of the three parts above:
```
--sum_by {user,group,component} [{user,group,component} ...]`
```
which will sum the totals by one, two or all three options. Summing by all three options is the same as not using this flag at all, ie the default. This only has an effect when the `--report`` option is used.

The second addition is:
```
--pretty
```
This pretty-prints the sizes by making the human-readable. This works for both the single value and for the table when `--report` is used. It is, however, overridden by any `--units` setting for the single value. The other minor point is `--units` produces KiB, MiB, etc., while `--pretty` produces KB, MB, etc.

This PR is very much for comments.
 + I'm not wedded to the option names, I don't really like `--sum_by` even though it describes what it does.
 + Same goes with `--pretty`, I originally had `--human-readable`. Maybe adding single letter options would help?
 + Should `--units` apply to the table to, ie either forced units or human-readable across the board? The downside with this is that the smaller table entries may show as 0 for large units
 + KiB vs KB!? The method producing the pretty printing is used exclusively by the `fs` command as far as I can see so we could switch. Or add an `iec=False` argument, though that seems like overkill for what this does

TODO: Since these numbers pass through dictionaries the original ordering from the response object is lost. An order was never guaranteed but it tended to be ordered to the eye. So adding an ordering by columns option, probably pushed to TableBuilder, makes sense.

Testing instructions
--------------------------
See https://github.com/openmicroscopy/openmicroscopy/pull/3009 for basic instructions.
```
bin/omero fs usage -h
```
should provide more help. The two added options are `--pretty` and `--sum_by`. 

For `--pretty` try it with and without the `--units` option. The latter option should have precedence. Also try it with `--report`, the bytes column in the table should have more human readable numbers.

For  `--sum_by`, which only works in combination with `--report`, try it with all combinations of `user`, `group` and `component`. Using all three options should be the same as not using `--sum_by` at all. The final two columns should be right-justified for any use of `--report`.

Finally, check some other commands that produce tables, `bin/omero user list`, etc. The tables should be correctly formatted and all columns should be left justified.
