### PR TITLE
Fix parsing of script path on Windows

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2712,7 +2712,7 @@ def list_scripts (request, conn=None, **kwargs):
         # Each <ul> is a {}, each <li> is either a script 'name': <id> or directory 'name': {ul}
 
         ul = scriptMenu
-        dirs = fullpath.split("/");
+        dirs = fullpath.split(os.path.sep);
         for l, d in enumerate(dirs):
             if len(d) == 0:
                 continue


### PR DESCRIPTION
Fixes script menu display on Windows. See https://trello.com/c/PVZVUd6g/316-display-of-scripts-list-in-omero-web-on-windows-server-is-messed-up

NB: not tested on a Windows server locally.