### PR TITLE
FileExclusion: new extension for the ImportLibrary

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportEvent.java
+++ b/components/blitz/src/ome/formats/importer/ImportEvent.java
@@ -215,6 +215,12 @@ public class ImportEvent {
         }
     }
 
+    public static class FILESET_EXCLUSION extends FILE_UPLOAD_EVENT {
+        public FILESET_EXCLUSION(String filename, int fileIndex, int fileTotal) {
+            super(filename, fileIndex, fileTotal, 0l, 0l, null);
+        }
+    }
+
     public static class FILESET_UPLOAD_PREPARATION extends FILE_UPLOAD_EVENT {
         public FILESET_UPLOAD_PREPARATION(String filename, int fileIndex,
                 int fileTotal, Long uploadedBytes, Long contentLength,

--- a/components/blitz/src/ome/formats/importer/exclusions/AbstractFileExclusion.java
+++ b/components/blitz/src/ome/formats/importer/exclusions/AbstractFileExclusion.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.formats.importer.exclusions;
+
+import ome.formats.importer.transfers.AbstractFileTransfer.Transfers;
+import ome.formats.importer.transfers.FileTransfer;
+import ome.services.blitz.util.ChecksumAlgorithmMapper;
+import ome.util.checksum.ChecksumProvider;
+import ome.util.checksum.ChecksumProviderFactory;
+import ome.util.checksum.ChecksumProviderFactoryImpl;
+import omero.model.ChecksumAlgorithm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base {@link FileExclusion} implementation primarily providing a factory
+ * for {@link FileExclusion} implementations via {@link #createExclusion(String)}.
+ *
+ * @since 5.1
+ */
+public abstract class AbstractFileExclusion implements FileExclusion {
+
+    /**
+     * Enum of well-known {@link FileExclusion} names.
+     */
+    public enum Exclusion {
+        filename(FilenameExclusion.class);
+        Class<?> kls;
+        Exclusion(Class<?> kls) {
+            this.kls = kls;
+        }
+    }
+
+    /**
+     * Factory method for instantiating {@link FileTransfer} objects from
+     * a string. Supported values can be found in the {@link Transfers} enum.
+     * Otherwise, a FQN for a class on the classpath should be passed in.
+     * @param arg non-null
+     */
+    public static FileExclusion createExclusion(String arg) {
+        Logger tmp = LoggerFactory.getLogger(AbstractFileExclusion.class);
+        tmp.debug("Loading file exclusion class {}", arg);
+        try {
+            try {
+                return (FileExclusion) Exclusion.valueOf(arg).kls.newInstance();
+            } catch (Exception e) {
+                // Assume not in the enum
+            }
+            Class<?> c = Class.forName(arg);
+            return (FileExclusion) c.newInstance();
+        } catch (Exception e) {
+            tmp.error("Failed to load file exclusion class " + arg);
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    protected String checksum(String filename, ChecksumAlgorithm checksumAlgorithm) {
+        final ChecksumProviderFactory checksumProviderFactory = new ChecksumProviderFactoryImpl();
+        final ChecksumProvider cp = checksumProviderFactory.getProvider(
+                ChecksumAlgorithmMapper.getChecksumType(checksumAlgorithm));
+        cp.putFile(filename);
+        return cp.checksumAsString();
+    }
+
+}

--- a/components/blitz/src/ome/formats/importer/exclusions/FileExclusion.java
+++ b/components/blitz/src/ome/formats/importer/exclusions/FileExclusion.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.formats.importer.exclusions;
+
+import ome.formats.importer.ImportContainer;
+import omero.ServerError;
+import omero.api.ServiceFactoryPrx;
+
+/**
+ * Voter given the opportunity by the {@link ome.formats.importer.ImportLibrary}
+ * to cancel the importing of a given file.
+ *
+ * @since 5.1
+ */
+public interface FileExclusion {
+
+   /**
+    * Given the current {@link ServiceFactoryPrx session} attempt to discover
+    * if the given {@link ImportContainer container} should be skipped, i.e.
+    * not imported.
+    * @return
+    *   null if no suggestion is being made. false if this implementation
+    *   suggests skipping the given container, otherwise true.
+    */
+    Boolean
+    suggestExclusion(ServiceFactoryPrx factory, ImportContainer container)
+            throws ServerError;
+
+}

--- a/components/blitz/src/ome/formats/importer/exclusions/FilenameExclusion.java
+++ b/components/blitz/src/ome/formats/importer/exclusions/FilenameExclusion.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.formats.importer.exclusions;
+
+import static omero.rtypes.rstring;
+
+import java.util.List;
+
+import ome.formats.importer.ImportContainer;
+import omero.ServerError;
+import omero.api.IQueryPrx;
+import omero.api.ServiceFactoryPrx;
+import omero.model.ChecksumAlgorithm;
+import omero.model.IObject;
+import omero.model.OriginalFile;
+import omero.sys.ParametersI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link FileExclusion Voter} which checks the filename (not full path) of a
+ * given {@link java.io.File} along with the checksum to detect duplicates. If
+ * either the checksum or the checksum algorithm are null, then no detection
+ * will be attempted, i.e. the voter will return a null to abstain.
+ *
+ * @since 5.1
+ */
+public class FilenameExclusion extends AbstractFileExclusion {
+
+    private final static Logger log = LoggerFactory.getLogger(FilenameExclusion.class);
+
+    public Boolean suggestExclusion(ServiceFactoryPrx factory,
+            ImportContainer container) throws ServerError {
+        IQueryPrx query = factory.getQueryService();
+        String fullpath = container.getFile().getAbsolutePath();
+        String filename = container.getFile().getName();
+        List<IObject> files = query.findAllByQuery(
+                "select o from OriginalFile o "
+                + "join fetch o.hasher "
+                + "where o.name = :name",
+                new ParametersI().add("name", rstring(filename)));
+       for (IObject obj : files) {
+           OriginalFile ofile = (OriginalFile) obj;
+           log.debug("Found original file: {}", ofile.getId().getValue());
+           ChecksumAlgorithm algo = ofile.getHasher();
+           String chksm = ofile.getHash() == null ? null : ofile.getHash().getValue();
+           if (algo == null) {
+               log.debug("No hasher: no vote");
+               return null;
+           } else if (chksm == null) {
+               log.debug("No hash: no vote");
+               return null;
+           } else {
+               String checksum = checksum(fullpath, algo);
+               if (checksum == null) {
+                   log.debug("Null checksum: no vote");
+               } else {
+                   if (checksum.equals(chksm)) {
+                       log.info("Checksum match for filename: {}", filename);
+                       return true;
+                   }
+               }
+           }
+       }
+       return false; // Everything fine as far as we're concerned.
+    }
+
+}

--- a/components/blitz/src/ome/formats/importer/exclusions/package-info.java
+++ b/components/blitz/src/ome/formats/importer/exclusions/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * {@FileExclude File exclusion} mechanism for determing
+ * which potential filesets should be excluded from import.
+ */
+package ome.formats.importer.exclusions;


### PR DESCRIPTION
Similar to the FileTransfer interface, well-known or third
party FileExclusion instances can be passed to the ImportLibrary
in order to influence the import process. Each exclusion is
given the chance to veto the import of a given ImportContainer
which has been chosen, e.g., by ImportCandidates. For example,
passing `--exclude=filename` searches for a file with the same
name on the server and then subsequently checks that the hash
matches. If it goes, the call to `importImage` exits early with
the log statement:

```
INFO   ....exclusions.FilenameExclusion - Checksum match for filename:
```

Testing:
 * `bin/omero import $SOMEFILE`
 * `bin/omero import $SOMEFILE # This should produce a duplicate`
 * `bin/omero import -- --exclude=filename $SOMEFILE # This should import nothing.`
 * `bin/omero import -- --exclude=filename $SOMEOTHERFILE # imports`
 * `bin/omero import -- --exclude=filename $SOMEOTHERFILE # does not import`

cc: @jwgwarren @ximenesuk @jburel @mtbc 

*API comments welcome as are ideas for new implementations to test that API*