### PR TITLE
Use 'Active Group' instead of 'Default Group' in myaccount form

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -295,6 +295,7 @@ class MyAccountForm(NonASCIIForm):
             if kwargs['initial']['default_group']:
                 pass
             self.fields['default_group'] = GroupModelChoiceField(
+                label="Active Group",
                 queryset=kwargs['initial']['groups'],
                 initial=kwargs['initial']['default_group'],
                 empty_label=None)

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/myaccount.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/myaccount.html
@@ -56,7 +56,7 @@
     
     $(document).ready(function () {
         
-        $("#id_default_group").chosen({disable_search_threshold:5, placeholder_text:'Change your default group'});
+        $("#id_default_group").chosen({disable_search_threshold:5, placeholder_text:'Change your active group'});
         
         $("#groupTable").tablesorter( {
             //sortList: [[1,0]]


### PR DESCRIPTION
Tiny fix for https://trello.com/c/GkdpN8wD/311-rfe-change-default-group-to-active-group-in-uis

In user's settings form, we use "Active Group" instead of "Default Group".
Anywhere in the UI where this needs changing?

![screen shot 2015-02-20 at 14 21 58](https://cloud.githubusercontent.com/assets/900055/6287749/e2602b64-b90b-11e4-967d-e75cab9f2c9a.png)
