### PR TITLE
adjust graphs API to provide Collections-based Java interface

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -201,6 +201,7 @@ module omero {
              * specific kinds of children.
              * Only the first applicable option takes effect.
              **/
+            ["java:type:java.util.ArrayList<omero.cmd.graphs.ChildOption>:java.util.List<omero.cmd.graphs.ChildOption>"]
             sequence<ChildOption> ChildOptions;
         };
 

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -214,7 +214,7 @@ module omero {
              * The model objects upon which to operate.
              * Related model objects may also be targeted.
              **/
-            omero::api::IdListMap targetObjects;
+            omero::api::StringLongListMap targetObjects;
 
             /**
              * If the request should operate on specific kinds of children.
@@ -255,12 +255,12 @@ module omero {
             /**
              * The model objects that were moved.
              **/
-            omero::api::IdListMap includedObjects;
+            omero::api::StringLongListMap includedObjects;
 
             /**
              * The model objects that were deleted.
              **/
-            omero::api::IdListMap deletedObjects;
+            omero::api::StringLongListMap deletedObjects;
         };
 
         /**
@@ -286,12 +286,12 @@ module omero {
             /**
              * The model objects that were given.
              **/
-            omero::api::IdListMap includedObjects;
+            omero::api::StringLongListMap includedObjects;
 
             /**
              * The model objects that were deleted.
              **/
-            omero::api::IdListMap deletedObjects;
+            omero::api::StringLongListMap deletedObjects;
         };
 
         /**
@@ -308,7 +308,7 @@ module omero {
             /**
              * The model objects that were deleted.
              **/
-            omero::api::IdListMap deletedObjects;
+            omero::api::StringLongListMap deletedObjects;
         };
 
         /**

--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -345,7 +345,8 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
                     // Now after we've recursed, do the actual delete.
                     RLong id = (RLong) val.getValue().get("id");
                     final Delete2 del = (Delete2) delFactory.create(null);
-                    del.targetObjects = ImmutableMap.<String, long[]>of("OriginalFile", new long[] {id.getValue()});
+                    del.targetObjects =
+                            ImmutableMap.<String, List<Long>>of("OriginalFile", Collections.singletonList(id.getValue()));
                     commands.add(del);
                 }
             }

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -116,7 +116,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
             throw helper.cancel(new ERR(), new IllegalArgumentException(), "not a member of the chgrp destination group");
         }
 
-        final ChildOptionI[] childOptions = ChildOptionI.castChildOptions(this.childOptions);
+        final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
 
         if (childOptions != null) {
             for (final ChildOptionI childOption : childOptions) {

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -154,7 +154,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
             case 0:
                 /* if targetObjects were an IObjectList then this would need IceMapper.reverse */
                 final SetMultimap<String, Long> targetMultimap = HashMultimap.create();
-                for (final Entry<String, long[]> oneClassToTarget : targetObjects.entrySet()) {
+                for (final Entry<String, List<Long>> oneClassToTarget : targetObjects.entrySet()) {
                     String className = oneClassToTarget.getKey();
                     if (className.lastIndexOf('.') < 0) {
                         className = graphPathBean.getClassForSimpleName(className).getName();
@@ -201,21 +201,19 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                     helper.cancel(new ERR(), e, "file deletion error");
                 }
             }
-            final Map<String, long[]> movedObjects = new HashMap<String, long[]>();
-            final Map<String, long[]> deletedObjects = new HashMap<String, long[]>();
+            final Map<String, List<Long>> movedObjects = new HashMap<String, List<Long>>();
+            final Map<String, List<Long>> deletedObjects = new HashMap<String, List<Long>>();
             for (final Entry<String, Collection<Long>> oneMovedClass : result.getKey().asMap().entrySet()) {
                 final String className = oneMovedClass.getKey();
                 final Collection<Long> ids = oneMovedClass.getValue();
-                final long[] idArray = GraphUtil.idsToArray(ids);
-                movedObjectCount += idArray.length;
-                movedObjects.put(className, idArray);
+                movedObjectCount += ids.size();
+                movedObjects.put(className, new ArrayList<Long>(ids));
             }
             for (final Entry<String, Collection<Long>> oneDeletedClass : result.getValue().asMap().entrySet()) {
                 final String className = oneDeletedClass.getKey();
                 final Collection<Long> ids = oneDeletedClass.getValue();
-                final long[] idArray = GraphUtil.idsToArray(ids);
-                deletedObjectCount += idArray.length;
-                deletedObjects.put(className, idArray);
+                deletedObjectCount += ids.size();
+                deletedObjects.put(className, new ArrayList<Long>(ids));
             }
             final Chgrp2Response response = new Chgrp2Response(movedObjects, deletedObjects);
             helper.setResponseIfNull(response);
@@ -250,7 +248,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
     }
 
     @Override
-    public Map<String, long[]> getStartFrom(Response response) {
+    public Map<String, List<Long>> getStartFrom(Response response) {
         return ((Chgrp2Response) response).includedObjects;
     }
 

--- a/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,11 @@
 
 package omero.cmd.graphs;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.HashMultimap;
@@ -85,9 +87,9 @@ public class ChgrpFacadeI extends Chgrp implements IRequest {
         final Chgrp2I actualChgrp = (Chgrp2I) chgrpRequest;
         /* set target object and group then review options */
         addToTargets(type, id);
-        actualChgrp.targetObjects = new HashMap<String, long[]>();
+        actualChgrp.targetObjects = new HashMap<String, List<Long>>();
         for (final Map.Entry<String, Collection<Long>> oneClassToTarget : targetObjects.asMap().entrySet()) {
-            actualChgrp.targetObjects.put(oneClassToTarget.getKey(), GraphUtil.idsToArray(oneClassToTarget.getValue()));
+            actualChgrp.targetObjects.put(oneClassToTarget.getKey(), new ArrayList<Long>(oneClassToTarget.getValue()));
         }
         targetObjects.clear();
         actualChgrp.groupId = grp;

--- a/components/blitz/src/omero/cmd/graphs/ChildOptionI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChildOptionI.java
@@ -20,6 +20,8 @@
 package omero.cmd.graphs;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 
@@ -193,14 +195,15 @@ public class ChildOptionI extends ChildOption {
      * @param childOptions an array of {@code ChildOption} which may all be casted to {@code ChildOptionI}, may be {@code null}
      * @return an array of {@code ChildOptionI}, may be {@code null}
      */
-    public static ChildOptionI[] castChildOptions(ChildOption[] childOptions) {
+    public static List<ChildOptionI> castChildOptions(Collection<ChildOption> childOptions) {
         if (childOptions == null) {
             return null;
         } else {
-            final ChildOptionI[] childOptionsI = new ChildOptionI[childOptions.length];
-            for (int index = 0; index < childOptions.length; index++) {
-                childOptionsI[index] = (ChildOptionI) childOptions[index];
+            final List<ChildOptionI> childOptionsI = new ArrayList<ChildOptionI>(childOptions.size());
+            for (final ChildOption childOption : childOptions) {
+                childOptionsI.add((ChildOptionI) childOption);
             }
+
             return childOptionsI;
         }
     }

--- a/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
@@ -19,11 +19,13 @@
 
 package omero.cmd.graphs;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,9 +53,9 @@ public class ChildOptionsPolicy {
      * @return the adjusted graph policy
      */
     public static GraphPolicy getChildOptionsPolicy(final GraphPolicy graphPolicyToAdjust, final GraphPathBean graphPathBean,
-            final ChildOptionI[] childOptions, final Set<GraphPolicy.Ability> requiredPermissions) {
+            final Collection<ChildOptionI> childOptions, final Set<GraphPolicy.Ability> requiredPermissions) {
 
-        if (childOptions == null || childOptions.length == 0) {
+        if (CollectionUtils.isEmpty(childOptions)) {
             /* there are no adjustments to make to the policy */
             return graphPolicyToAdjust;
         }

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -152,7 +152,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             case 0:
                 /* if targetObjects were an IObjectList then this would need IceMapper.reverse */
                 final SetMultimap<String, Long> targetMultimap = HashMultimap.create();
-                for (final Entry<String, long[]> oneClassToTarget : targetObjects.entrySet()) {
+                for (final Entry<String, List<Long>> oneClassToTarget : targetObjects.entrySet()) {
                     String className = oneClassToTarget.getKey();
                     if (className.lastIndexOf('.') < 0) {
                         className = graphPathBean.getClassForSimpleName(className).getName();
@@ -199,21 +199,19 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                     helper.cancel(new ERR(), e, "file deletion error");
                 }
             }
-            final Map<String, long[]> givenObjects = new HashMap<String, long[]>();
-            final Map<String, long[]> deletedObjects = new HashMap<String, long[]>();
+            final Map<String, List<Long>> givenObjects = new HashMap<String, List<Long>>();
+            final Map<String, List<Long>> deletedObjects = new HashMap<String, List<Long>>();
             for (final Entry<String, Collection<Long>> oneGivenClass : result.getKey().asMap().entrySet()) {
                 final String className = oneGivenClass.getKey();
                 final Collection<Long> ids = oneGivenClass.getValue();
-                final long[] idArray = GraphUtil.idsToArray(ids);
-                givenObjectCount += idArray.length;
-                givenObjects.put(className, idArray);
+                givenObjectCount += ids.size();
+                givenObjects.put(className, new ArrayList<Long>(ids));
             }
             for (final Entry<String, Collection<Long>> oneDeletedClass : result.getValue().asMap().entrySet()) {
                 final String className = oneDeletedClass.getKey();
                 final Collection<Long> ids = oneDeletedClass.getValue();
-                final long[] idArray = GraphUtil.idsToArray(ids);
-                deletedObjectCount += idArray.length;
-                deletedObjects.put(className, idArray);
+                deletedObjectCount += ids.size();
+                deletedObjects.put(className, new ArrayList<Long>(ids));
             }
             final Chown2Response response = new Chown2Response(givenObjects, deletedObjects);
             helper.setResponseIfNull(response);
@@ -248,7 +246,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
     }
 
     @Override
-    public Map<String, long[]> getStartFrom(Response response) {
+    public Map<String, List<Long>> getStartFrom(Response response) {
         return ((Chown2Response) response).includedObjects;
     }
 

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -122,7 +122,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             acceptableGroups = ImmutableSet.copyOf(iAdmin.getMemberOfGroupIds(new Experimenter(userId, false)));
         }
 
-        final ChildOptionI[] childOptions = ChildOptionI.castChildOptions(this.childOptions);
+        final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
 
         if (childOptions != null) {
             for (final ChildOptionI childOption : childOptions) {

--- a/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,11 @@
 
 package omero.cmd.graphs;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.HashMultimap;
@@ -85,9 +87,9 @@ public class ChownFacadeI extends Chown implements IRequest {
         final Chown2I actualChown = (Chown2I) chownRequest;
         /* set target object and group then review options */
         addToTargets(type, id);
-        actualChown.targetObjects = new HashMap<String, long[]>();
+        actualChown.targetObjects = new HashMap<String, List<Long>>();
         for (final Map.Entry<String, Collection<Long>> oneClassToTarget : targetObjects.asMap().entrySet()) {
-            actualChown.targetObjects.put(oneClassToTarget.getKey(), GraphUtil.idsToArray(oneClassToTarget.getValue()));
+            actualChown.targetObjects.put(oneClassToTarget.getKey(), new ArrayList<Long>(oneClassToTarget.getValue()));
         }
         targetObjects.clear();
         actualChown.userId = user;

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -137,7 +137,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
             case 0:
                 /* if targetObjects were an IObjectList then this would need IceMapper.reverse */
                 final SetMultimap<String, Long> targetMultimap = HashMultimap.create();
-                for (final Entry<String, long[]> oneClassToTarget : targetObjects.entrySet()) {
+                for (final Entry<String, List<Long>> oneClassToTarget : targetObjects.entrySet()) {
                     String className = oneClassToTarget.getKey();
                     if (className.lastIndexOf('.') < 0) {
                         className = graphPathBean.getClassForSimpleName(className).getName();
@@ -186,12 +186,11 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                     helper.cancel(new ERR(), e, "file deletion error");
                 }
             }
-            final Map<String, long[]> deletedObjects = new HashMap<String, long[]>();
+            final Map<String, List<Long>> deletedObjects = new HashMap<String, List<Long>>();
             for (final String className : Sets.union(resultProcessed.keySet(), resultDeleted.keySet())) {
                 final Set<Long> ids = Sets.union(resultProcessed.get(className), resultDeleted.get(className));
-                final long[] idArray = GraphUtil.idsToArray(ids);
-                deletedObjectCount += idArray.length;
-                deletedObjects.put(className, idArray);
+                deletedObjectCount += ids.size();
+                deletedObjects.put(className, new ArrayList<Long>(ids));
             }
             final Delete2Response response = new Delete2Response(deletedObjects);
             helper.setResponseIfNull(response);
@@ -225,7 +224,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
     }
 
     @Override
-    public Map<String, long[]> getStartFrom(Response response) {
+    public Map<String, List<Long>> getStartFrom(Response response) {
         return ((Delete2Response) response).deletedObjects;
     }
 

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -107,7 +107,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
 
         final EventContext eventContext = helper.getEventContext();
 
-        final ChildOptionI[] childOptions = ChildOptionI.castChildOptions(this.childOptions);
+        final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
 
         if (childOptions != null) {
             for (final ChildOptionI childOption : childOptions) {

--- a/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,9 +19,11 @@
 
 package omero.cmd.graphs;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.HashMultimap;
@@ -88,9 +90,9 @@ public class DeleteFacadeI extends Delete implements IRequest {
         final Delete2I actualDelete = (Delete2I) deleteRequest;
         /* set target object then review options */
         addToTargets(type, id);
-        actualDelete.targetObjects = new HashMap<String, long[]>();
+        actualDelete.targetObjects = new HashMap<String, List<Long>>();
         for (final Map.Entry<String, Collection<Long>> oneClassToTarget : targetObjects.asMap().entrySet()) {
-            actualDelete.targetObjects.put(oneClassToTarget.getKey(), GraphUtil.idsToArray(oneClassToTarget.getValue()));
+            actualDelete.targetObjects.put(oneClassToTarget.getKey(), new ArrayList<Long>(oneClassToTarget.getValue()));
         }
         targetObjects.clear();
         try {
@@ -145,11 +147,11 @@ public class DeleteFacadeI extends Delete implements IRequest {
         facadeResponse.undeletedFiles = new HashMap<String, long[]>();
 
         if (actualResponse == null) {
-            facadeResponse.scheduledDeletes = GraphUtil.getIdListMapSize(((GraphModify2) deleteRequest).targetObjects);
+            facadeResponse.scheduledDeletes = ((GraphModify2) deleteRequest).targetObjects.size();
             facadeResponse.actualDeletes = 0;
         } else {
             facadeResponse.scheduledDeletes = 0;
-            facadeResponse.actualDeletes = GraphUtil.getIdListMapSize(actualResponse.deletedObjects);
+            facadeResponse.actualDeletes = actualResponse.deletedObjects.size();
         }
 
         return facadeResponse;

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -55,41 +55,21 @@ public class GraphUtil {
     }
 
     /**
-     * Count how many objects are listed in a {@code IdListMap}.
-     * @param idListMap lists of object IDs indexed by type name
-     * @return how many objects are listed in given {@code IdListMap}
-     * @deprecated because facade classes are deprecated
-     */
-    @Deprecated
-    static int getIdListMapSize(Map<?, long[]> idListMap) {
-        int size = 0;
-        for (final long[] ids : idListMap.values()) {
-            size += ids.length;
-        }
-        return size;
-    }
-
-    /**
-     * Copy the given collection of IDs to an array of native {@code long}s.
-     * @param ids a collection of IDs, none of which may be {@code null}
-     * @return the same IDs in a new array
-     */
-    static long[] idsToArray(Collection<Long> ids) {
-        final long[] idArray = new long[ids.size()];
-        int index = 0;
-        for (final long id : ids) {
-            idArray[index++] = id;
-        }
-        return idArray;
-    }
-
-    /**
      * Copy the {@link GraphModify2} fields of one request to another.
      * @param requestFrom the source of the field copy
      * @param requestTo the target of the field copy
      */
     static void copyFields(GraphModify2 requestFrom, GraphModify2 requestTo) {
-        requestTo.targetObjects = requestFrom.targetObjects == null ? null : new HashMap<String, long[]>(requestFrom.targetObjects);
+        if (requestFrom.targetObjects == null) {
+            requestTo.targetObjects = null;
+        } else {
+            requestTo.targetObjects = new HashMap<String, List<Long>>();
+            for (final Map.Entry<String, List<Long>> targetObjectsOneClass : requestFrom.targetObjects.entrySet()) {
+                final String targetClass = targetObjectsOneClass.getKey();
+                final List<Long> targetIds = targetObjectsOneClass.getValue();
+                requestTo.targetObjects.put(targetClass, new ArrayList<Long>(targetIds));
+            }
+        }
         if (requestFrom.childOptions == null) {
             requestTo.childOptions = null;
         } else {

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -73,10 +73,7 @@ public class GraphUtil {
         if (requestFrom.childOptions == null) {
             requestTo.childOptions = null;
         } else {
-            requestTo.childOptions = new ChildOption[requestFrom.childOptions.length];
-            for (int index = 0; index < requestFrom.childOptions.length; index++) {
-                requestTo.childOptions[index] = new ChildOptionI((ChildOptionI) requestFrom.childOptions[index]);
-            }
+            requestTo.childOptions = new ArrayList<ChildOption>(requestFrom.childOptions);
         }
         requestTo.dryRun = requestFrom.dryRun;
     }
@@ -131,7 +128,7 @@ public class GraphUtil {
                 childOptions.add(childOption);
             }
         }
-        request.childOptions = childOptions.isEmpty() ? null : childOptions.toArray(new ChildOption[childOptions.size()]);
+        request.childOptions = childOptions.isEmpty() ? null : childOptions;
     }
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -162,8 +162,8 @@ public class SkipHeadI extends SkipHead implements IRequest {
                     ((IRequest) graphRequestSkip).buildResponse(i, graphRequestSkipObjects.get(i));
                 }
                 final Response response = ((IRequest) graphRequestSkip).getResponse();
-                final Map<String, long[]> allTargetedObjects = ((WrappableRequest<?>) graphRequestSkip).getStartFrom(response);
-                graphRequestPerform.targetObjects = new HashMap<String, long[]>();
+                final Map<String, List<Long>> allTargetedObjects = ((WrappableRequest<?>) graphRequestSkip).getStartFrom(response);
+                graphRequestPerform.targetObjects = new HashMap<String, List<Long>>();
                 /* pick out the model objects matching the startFrom classes */
                 for (String startFromClassName : startFrom) {
                     final int lastDot = startFromClassName.lastIndexOf('.');
@@ -171,7 +171,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
                         startFromClassName = startFromClassName.substring(lastDot + 1);
                     }
                     final Class<? extends IObject> startFromClass = graphPathBean.getClassForSimpleName(startFromClassName);
-                    for (final Map.Entry<String, long[]> targetedObjectsByClass : allTargetedObjects.entrySet()) {
+                    for (final Map.Entry<String, List<Long>> targetedObjectsByClass : allTargetedObjects.entrySet()) {
                         final String targetedClassName = targetedObjectsByClass.getKey();
                         final Class<? extends IObject> targetedClass;
                         try {
@@ -181,7 +181,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
                                     "response from " + graphRequestSkip.getClass() + " refers to class " + targetedClassName);
                         }
                         if (startFromClass.isAssignableFrom(targetedClass)) {
-                            final long[] ids = targetedObjectsByClass.getValue();
+                            final List<Long> ids = targetedObjectsByClass.getValue();
                             graphRequestPerform.targetObjects.put(targetedClassName, ids);
                         }
                     }

--- a/components/blitz/src/omero/cmd/graphs/WrappableRequest.java
+++ b/components/blitz/src/omero/cmd/graphs/WrappableRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,6 +19,7 @@
 
 package omero.cmd.graphs;
 
+import java.util.List;
 import java.util.Map;
 
 import ome.services.graphs.GraphPolicy;
@@ -56,5 +57,5 @@ public interface WrappableRequest<X> extends IRequest {
      * @param response the head-skipping request's response
      * @return the model objects to target
      */
-    Map<String, long[]> getStartFrom(Response response);
+    Map<String, List<Long>> getStartFrom(Response response);
 }

--- a/components/blitz/test/omero/cmd/graphs/GraphUtilTest.java
+++ b/components/blitz/test/omero/cmd/graphs/GraphUtilTest.java
@@ -19,7 +19,6 @@
 
 package omero.cmd.graphs;
 
-import java.util.Collections;
 import java.util.Map.Entry;
 
 import ome.services.graphs.GraphTraversal;
@@ -29,8 +28,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 
@@ -41,60 +38,6 @@ import com.google.common.collect.SetMultimap;
  */
 @Test
 public class GraphUtilTest {
-
-    /**
-     * Test that {@link GraphUtil#getIdListMapSize(java.util.Map)} counts an empty map as having no IDs.
-     */
-    public void testGetIdListMapSizeUnpopulated() {
-        final int expected = 0;
-        final int actual = GraphUtil.getIdListMapSize(Collections.<Object, long[]>emptyMap());
-        Assert.assertEquals(actual, expected,
-                "an empty ID list map must have no IDs");
-    }
-
-    /**
-     * Test that {@link GraphUtil#getIdListMapSize(java.util.Map)} counts IDs correctly.
-     */
-    public void testGetIdListMapSizePopulated() {
-        final ImmutableMap.Builder<Integer, long[]> builder = ImmutableMap.builder();
-        int expected = 0;
-        for (int i = 0; i < 20; i++) {
-            builder.put(i, new long[i]);
-            expected += i;
-        }
-        final int actual = GraphUtil.getIdListMapSize(builder.build());
-        Assert.assertEquals(actual, expected,
-                "ID list map size is incorrect");
-    }
-
-    /**
-     * Test that {@link GraphUtil#idsToArray(java.util.Collection)} converts an empty list to an empty array.
-     */
-    public void testIdsToArrayUnpopulatedList() {
-        final int expected = 0;
-        final int actual = GraphUtil.idsToArray(Collections.<Long>emptyList()).length;
-        Assert.assertEquals(actual, expected,
-                "an empty list should become an empty array");
-    }
-
-    /**
-     * Test that {@link GraphUtil#idsToArray(java.util.Collection)} converts a set of IDs to an array correctly.
-     */
-    public void testIdsToArrayPopulatedSet() {
-        final ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
-        final long[] expected = new long[20];
-        for (int i = 0; i < expected.length; i++) {
-            builder.add(Long.valueOf(i));
-            expected[i] = i;
-        }
-        final long[] actual = GraphUtil.idsToArray(builder.build());
-        Assert.assertEquals(actual.length, expected.length,
-                "after conversion to an array there should be the same number of elements");
-        for (int i = 0; i < expected.length; i++) {
-            Assert.assertEquals(actual[i], expected[i],
-                    "conversion to an array ought not mutate elements");
-        }
-    }
 
     /**
      * Test that {@link GraphUtil#trimPackageNames(SetMultimap)} correctly trim package names from map keys.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
@@ -1,0 +1,1281 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.shoola.env.data;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import omero.cmd.Chgrp2;
+import omero.cmd.Chown2;
+import omero.cmd.Delete2;
+import omero.cmd.GraphModify2;
+import omero.cmd.SkipHead;
+import omero.cmd.graphs.ChildOption;
+
+/**
+ * A utility class of factory methods with various signatures for clients to use in generating requests for graph operations.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.0
+ */
+public class Requests {
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, childOptions, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, boolean dryRun, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, childOptions, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, boolean dryRun, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
+            long groupId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, long groupId) {
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, long groupId) {
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long groupId) {
+        return new Chgrp2(targetObjects, childOptions, false, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, boolean dryRun, long groupId) {
+        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long groupId) {
+        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chgrp2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param groupId the destination group ID
+     * @return the new request
+     */
+    public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
+            long groupId) {
+          return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, childOptions, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, boolean dryRun, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chown2(targetObjects, childOptions, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, childOptions, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, boolean dryRun, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
+            long userId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chown2(targetObjects, childOptions, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, long userId) {
+        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, long userId) {
+        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long userId) {
+        return new Chown2(targetObjects, childOptions, false, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, boolean dryRun, long userId) {
+        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long userId) {
+        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Chown2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param userId the destination user ID
+     * @return the new request
+     */
+    public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
+            long userId) {
+          return new Chown2(targetObjects, childOptions, dryRun, userId);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, childOptions, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Delete2(targetObjects, childOptions, dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, childOptions, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Delete2(targetObjects, childOptions, dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects) {
+        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption) {
+        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions) {
+        return new Delete2(targetObjects, childOptions, false);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects, boolean dryRun) {
+        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun) {
+        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+    }
+
+    /**
+     * Create a new {@link Delete2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @return the new request
+     */
+    public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun) {
+          return new Delete2(targetObjects, childOptions, dryRun);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
+            String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, List<String> startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, List<String> startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, List<String> startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, String startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
+            String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
+            String startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, List<String> startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions,
+            List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, List<String> startFrom,
+            GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, String startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, String startFrom,
+            GraphModify2 request) {
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String startFrom,
+            GraphModify2 request) {
+        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, String startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
+            String startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
+                request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the class from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
+            String startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<String> startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, List<String> startFrom,
+            GraphModify2 request) {
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, List<String> startFrom,
+            GraphModify2 request) {
+        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, List<String> startFrom,
+            GraphModify2 request) {
+        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+    }
+
+    /**
+     * Create a new {@link SkipHead} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param startFrom the classes from which to start the actual processing
+     * @param request the processor to use
+     * @return the new request
+     */
+    public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
+            List<String> startFrom, GraphModify2 request) {
+        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
@@ -39,6 +39,86 @@ import omero.cmd.graphs.ChildOption;
 public class Requests {
 
     /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child type to include in the request's operation
+     * @param excludeType the child type to exclude from the request's operation
+     * @return the new instance
+     */
+    public static ChildOption option(String includeType, String excludeType) {
+        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
+        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
+        return new ChildOption(includeTypeList, excludeTypeList, null, null);
+    }
+
+    /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child types to include in the request's operation
+     * @param excludeType the child types to exclude from the request's operation
+     * @return the new instance
+     */
+    public static ChildOption option(List<String> includeType, List<String> excludeType) {
+        return new ChildOption(includeType, excludeType, null, null);
+    }
+
+    /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child type to include in the request's operation
+     * @param excludeType the child type to exclude from the request's operation
+     * @param includeNs the annotation namespace to which this option applies
+     * @param excludeNs the annotation namespace to which this option does not apply
+     * @return the new instance
+     */
+    public static ChildOption option(String includeType, String excludeType, String includeNs, String excludeNs) {
+        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
+        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
+        final List<String> includeNsList = includeNs == null ? null : Collections.singletonList(includeNs);
+        final List<String> excludeNsList = excludeNs == null ? null : Collections.singletonList(excludeNs);
+        return new ChildOption(includeTypeList, excludeTypeList, includeNsList, excludeNsList);
+    }
+
+    /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child type to include in the request's operation
+     * @param excludeType the child type to exclude from the request's operation
+     * @param includeNs the annotation namespaces to which this option applies
+     * @param excludeNs the annotation namespaces to which this option does not apply
+     * @return the new instance
+     */
+    public static ChildOption option(String includeType, String excludeType, List<String> includeNs,
+            List<String> excludeNs) {
+        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
+        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
+        return new ChildOption(includeTypeList, excludeTypeList, includeNs, excludeNs);
+    }
+
+    /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child types to include in the request's operation
+     * @param excludeType the child types to exclude from the request's operation
+     * @param includeNs the annotation namespace to which this option applies
+     * @param excludeNs the annotation namespace to which this option does not apply
+     * @return the new instance
+     */
+    public static ChildOption option(List<String> includeType, List<String> excludeType, String includeNs, String excludeNs) {
+        final List<String> includeNsList = includeNs == null ? null : Collections.singletonList(includeNs);
+        final List<String> excludeNsList = excludeNs == null ? null : Collections.singletonList(excludeNs);
+        return new ChildOption(includeType, excludeType, includeNsList, excludeNsList);
+    }
+
+    /**
+     * Create a new {@link ChildOption} instance.
+     * @param includeType the child types to include in the request's operation
+     * @param excludeType the child types to exclude from the request's operation
+     * @param includeNs the annotation namespaces to which this option applies
+     * @param excludeNs the annotation namespaces to which this option does not apply
+     * @return the new instance
+     */
+    public static ChildOption option(List<String> includeType, List<String> excludeType, List<String> includeNs,
+            List<String> excludeNs) {
+        return new ChildOption(includeType, excludeType, includeNs, excludeNs);
+    }
+
+    /**
      * Create a new {@link Chgrp2} request.
      * @param targetClass the target object class
      * @param targetId the target object ID

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -300,7 +300,7 @@ public class DiskUsageTest extends AbstractServerTest {
 
             final ChildOption option = new ChildOption();
             option.excludeType = Collections.singletonList("Image");
-            request.childOptions = new ChildOption[] {option};
+            request.childOptions = Collections.singletonList(option);
 
             doChange(request);
         }


### PR DESCRIPTION
OMERO should still work, including moves and deletes, and tests should still pass: there should be no change in behavior.

*Update:* Now provides Insight with a utility class for constructing graphs requests.

--no-rebase