### PR TITLE
CLI: review help command and add recursive argument

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -171,6 +171,15 @@ class HelpControl(BaseControl):
         self.ctx.out("\n" + command)
         self.ctx.out(sep * len(command) + "\n")
 
+    def print_command_help(self, control, args):
+        """Print help for a single command and optionally its subcommand"""
+        self.ctx.invoke([control, "-h"])
+        if args.recursive:
+            subcommands = self.ctx.controls[control].get_subcommands()
+            for subcommand in subcommands:
+                self.format_title(control + " " + subcommand, sep="^")
+                self.ctx.invoke([control, subcommand, "-h"])
+
     def __call__(self, args):
 
         self.ctx.waitForPlugins()
@@ -178,12 +187,7 @@ class HelpControl(BaseControl):
         if args.all:
             for control in sorted(self.ctx.controls):
                 self.format_title(control)
-                self.ctx.invoke([control, "-h"])
-                if args.recursive:
-                    subcommands = self.ctx.controls[control].get_subcommands()
-                    for subcommand in subcommands:
-                        self.format_title(control + " " + subcommand, sep="^")
-                        self.ctx.invoke([control, subcommand, "-h"])
+                self.print_command_help(control, args)
 
             for topic in sorted(self.ctx.topics):
                 self.format_title(topic)
@@ -201,7 +205,7 @@ class HelpControl(BaseControl):
             print HELP_USAGE % key_list
         else:
             if args.topic in self.ctx.controls:
-                self.ctx.invoke([args.topic, "-h"])
+                self.print_command_help(args.topic, args)
             elif args.topic in self.ctx.topics:
                 self.ctx.out(self.ctx.topics[args.topic])
             else:

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -157,7 +157,7 @@ class HelpControl(BaseControl):
             help="Print help for all commands and topics")
         group.add_argument(
             "--list", action="store_true",
-            help="Print list of all commands")
+            help="Print list of all commands and subcommands")
         group.add_argument(
             "topic", nargs="?", help="Command or topic for more information")
 

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -96,6 +96,22 @@ class ShellControl(BaseControl):
             ipshell = IPShellEmbed(args.arg)
             ipshell(local_ns=ns)
 
+HELP_USAGE = """usage: %(program_name)s <command> [options] args
+See 'help <command>' or '<command> -h' for more information on syntax
+Type 'quit' to exit
+
+Available commands:
+%(commands)s
+
+Other help topics:
+%(topics)s
+
+For additional information, see:
+http://www.openmicroscopy.org/site/support/omero5/users/\
+command-line-interface.html
+Report bugs to <ome-users@lists.openmicroscopy.org.uk>
+"""
+
 
 class HelpControl(BaseControl):
     """
@@ -144,33 +160,20 @@ class HelpControl(BaseControl):
             commands, topics = [
                 self.__parser__._format_list(x) for x in
                 [sorted(self.ctx.controls), sorted(self.ctx.topics)]]
-            key_list = {"program_name": sys.argv[0], "version": VERSION,
-                        "commands": commands, "topics": topics}
-            print """usage: %(program_name)s <command> [options] args
-See 'help <command>' or '<command> -h' for more information on syntax
-Type 'quit' to exit
-
-Available commands:
-%(commands)s
-
-Other help topics:
-%(topics)s
-
-For additional information, see:
-http://www.openmicroscopy.org/site/support/omero5/users/\
-command-line-interface.html
-Report bugs to <ome-users@lists.openmicroscopy.org.uk>
-""" % key_list
+            key_list = {
+                "program_name": sys.argv[0],
+                "version": VERSION,
+                "commands": commands,
+                "topics": topics}
+            print HELP_USAGE % key_list
 
         else:
-            try:
+            if args.topic in self.ctx.controls:
                 self.ctx.controls[args.topic]
-                self.ctx.invoke("%s -h" % args.topic)
-            except KeyError:
-                try:
-                    self.ctx.out(self.ctx.topics[args.topic])
-                except KeyError:
-                    self.ctx.err("Unknown help topic: %s" % args.topic)
+            elif args.topic in self.ctx.topics:
+                self.ctx.out(self.ctx.topics[args.topic])
+            else:
+                self.ctx.err("Unknown help topic or command: %s" % args.topic)
 
 controls = {
     "help": (HelpControl, "Syntax help for all commands"),

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -44,6 +44,26 @@ class VersionControl(BaseControl):
     def __call__(self, args):
         self.ctx.out(VERSION)
 
+LOAD_HELP = """Load file as if it were sent on standard in.
+
+This can be used as the #! header of a file to make standand-alone script.
+
+Examples:
+    #!/usr/bin/env omero load
+    login -C root@localhost
+    group add new_group
+    user add foo some user new_group
+
+ or
+
+    $ bin/omero login       # login can't take place in HERE-document
+    $ bin/omero load <<EOF
+    user list
+    group list
+    EOF
+
+"""
+
 
 class LoadControl(BaseControl):
 
@@ -196,26 +216,7 @@ controls = {
 All arguments not understood vi %(prog)s will be passed to the shell.
 Use "--" to end parsing, e.g. '%(prog)s -- --help' for IPython help"""),
     "version": (VersionControl, "Version number"),
-    "load": (LoadControl, """Load file as if it were sent on standard in.
-
-This can be used as the #! header of a file to make standand-alone script.
-
-Examples:
-    #!/usr/bin/env omero load
-    login -C root@localhost
-    group add new_group
-    user add foo some user new_group
-
- or
-
-    $ bin/omero login       # login can't take place in HERE-document
-    $ bin/omero load <<EOF
-    user list
-    group list
-    EOF
-
-""")
-}
+    "load": (LoadControl, LOAD_HELP)}
 
 try:
     for k, v in controls.items():

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -164,10 +164,10 @@ class HelpControl(BaseControl):
         """
         return self.ctx.completenames(text, line, begidx, endidx)
 
-    def format_title(self, command):
-        self.ctx.out("*" * 80)
-        self.ctx.out(command)
-        self.ctx.out("*" * 80)
+    def format_title(self, command, sep="-"):
+        """Create heading for command or topic help"""
+        self.ctx.out("\n" + command)
+        self.ctx.out(sep * len(command) + "\n")
 
     def __call__(self, args):
 
@@ -177,18 +177,15 @@ class HelpControl(BaseControl):
             for control in sorted(self.ctx.controls):
                 self.format_title(control)
                 self.ctx.invoke([control, "-h"])
-                self.ctx.out("\n")
                 if args.recursive:
                     subcommands = self.ctx.controls[control].get_subcommands()
                     for subcommand in subcommands:
-                        self.format_title(control + " " + subcommand)
+                        self.format_title(control + " " + subcommand, sep="^")
                         self.ctx.invoke([control, subcommand, "-h"])
-                        self.ctx.out("\n")
 
             for topic in sorted(self.ctx.topics):
                 self.format_title(topic)
                 self.ctx.out(self.ctx.topics[topic])
-                self.ctx.out("\n")
 
         elif not args.topic:
             commands, topics = [

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -106,9 +106,10 @@ class HelpControl(BaseControl):
     def _configure(self, parser):
         self.__parser__ = parser  # For formatting later
         parser.set_defaults(func=self.__call__)
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--all", action="store_true", help="Print help for all topics")
-        parser.add_argument(
+        group.add_argument(
             "topic", nargs="?", help="Topic for more information")
 
     def _complete(self, text, line, begidx, endidx):
@@ -133,6 +134,9 @@ class HelpControl(BaseControl):
             for control in sorted(self.ctx.controls):
                 self.ctx.out("*" * 80)
                 self.ctx.out(control)
+                # print self.ctx.controls[control].HELP
+                #     print self.ctx.controls[control].get_subcommands()
+                #     c['db'].parser.description
                 self.ctx.out("*" * 80)
                 self.ctx.invoke([control, "-h"])
                 self.ctx.out("\n")
@@ -164,7 +168,6 @@ Report bugs to <ome-users@lists.openmicroscopy.org.uk>
 
         else:
             try:
-                print 1
                 self.ctx.controls[args.topic]
                 self.ctx.invoke("%s -h" % args.topic)
             except KeyError:

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -30,7 +30,7 @@ from omero.cli import VERSION
 class QuitControl(BaseControl):
 
     def _configure(self, parser):
-        return
+        parser.set_defaults(func=self.__call__)
 
     def __call__(self, args):
         self.ctx.exit("", newline=False)
@@ -39,7 +39,7 @@ class QuitControl(BaseControl):
 class VersionControl(BaseControl):
 
     def _configure(self, parser):
-        return
+        parser.set_defaults(func=self.__call__)
 
     def __call__(self, args):
         self.ctx.out(VERSION)

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -156,6 +156,9 @@ class HelpControl(BaseControl):
             "--all", action="store_true",
             help="Print help for all commands and topics")
         group.add_argument(
+            "--list", action="store_true",
+            help="Print list of all commands")
+        group.add_argument(
             "topic", nargs="?", help="Command or topic for more information")
 
     def _complete(self, text, line, begidx, endidx):
@@ -211,17 +214,31 @@ class HelpControl(BaseControl):
             self.format_title(topic)
             self.ctx.out(self.ctx.topics[topic])
 
+    def print_commands_list(self, args):
+        """Print a list of all commands"""
+
+        for control in sorted(self.ctx.controls):
+            subcommands = self.ctx.controls[control].get_subcommands()
+            if subcommands:
+                self.ctx.out("%s (%s)" % (control, len(subcommands)))
+                for subcommand in subcommands:
+                    self.ctx.out("\t%s" % subcommand)
+            else:
+                self.ctx.out("%s" % control)
+
     def __call__(self, args):
 
         self.ctx.waitForPlugins()
 
         # Fail-fast and print usage if no arg is passed
-        if not args.all and not args.topic:
+        if not args.all and not args.list and not args.topic:
             self.print_usage()
 
         if args.all:
             self.print_all_commands_and_topics(args)
-        else:
+        elif args.list:
+            self.print_commands_list(args)
+        elif args.topic:
             self.print_single_command_or_topic(args)
 
 controls = {

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -123,12 +123,6 @@ class HelpControl(BaseControl):
     def __call__(self, args):
 
         self.ctx.waitForPlugins()
-        # commands = "\n".join([" %s" % name for name in
-        # sorted(self.ctx.controls)])
-        # topics = "\n".join([" %s" % topic for topic in self.ctx.topics])
-        commands, topics = [
-            self.__parser__._format_list(x) for x in
-            [sorted(self.ctx.controls), sorted(self.ctx.topics)]]
 
         if args.all:
             for control in sorted(self.ctx.controls):
@@ -147,7 +141,9 @@ class HelpControl(BaseControl):
                 self.ctx.out(self.ctx.topics[topic])
                 self.ctx.out("\n")
         elif not args.topic:
-            # self.ctx.invoke("-h")
+            commands, topics = [
+                self.__parser__._format_list(x) for x in
+                [sorted(self.ctx.controls), sorted(self.ctx.topics)]]
             key_list = {"program_name": sys.argv[0], "version": VERSION,
                         "commands": commands, "topics": topics}
             print """usage: %(program_name)s <command> [options] args

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -29,11 +29,17 @@ from omero.cli import VERSION
 
 class QuitControl(BaseControl):
 
+    def _configure(self, parser):
+        return
+
     def __call__(self, args):
         self.ctx.exit("", newline=False)
 
 
 class VersionControl(BaseControl):
+
+    def _configure(self, parser):
+        return
 
     def __call__(self, args):
         self.ctx.out(VERSION)
@@ -127,6 +133,8 @@ class HelpControl(BaseControl):
             "--all", action="store_true", help="Print help for all topics")
         group.add_argument(
             "topic", nargs="?", help="Command or topic for more information")
+        parser.add_argument(
+            "--recursive", action="store_true", help="Also list subcommands")
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -150,6 +158,12 @@ class HelpControl(BaseControl):
                 self.format_title(control)
                 self.ctx.invoke([control, "-h"])
                 self.ctx.out("\n")
+                if args.recursive:
+                    subcommands = self.ctx.controls[control].get_subcommands()
+                    for subcommand in subcommands:
+                        self.format_title(control + " " + subcommand)
+                        self.ctx.invoke([control, subcommand, "-h"])
+                        self.ctx.out("\n")
 
             for topic in sorted(self.ctx.topics):
                 self.format_title(topic)

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -126,7 +126,7 @@ class HelpControl(BaseControl):
         group.add_argument(
             "--all", action="store_true", help="Print help for all topics")
         group.add_argument(
-            "topic", nargs="?", help="Topic for more information")
+            "topic", nargs="?", help="Command or topic for more information")
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -136,26 +136,26 @@ class HelpControl(BaseControl):
         """
         return self.ctx.completenames(text, line, begidx, endidx)
 
+    def format_title(self, command):
+        self.ctx.out("*" * 80)
+        self.ctx.out(command)
+        self.ctx.out("*" * 80)
+
     def __call__(self, args):
 
         self.ctx.waitForPlugins()
 
         if args.all:
             for control in sorted(self.ctx.controls):
-                self.ctx.out("*" * 80)
-                self.ctx.out(control)
-                # print self.ctx.controls[control].HELP
-                #     print self.ctx.controls[control].get_subcommands()
-                #     c['db'].parser.description
-                self.ctx.out("*" * 80)
+                self.format_title(control)
                 self.ctx.invoke([control, "-h"])
                 self.ctx.out("\n")
+
             for topic in sorted(self.ctx.topics):
-                self.ctx.out("*" * 80)
-                self.ctx.out(topic)
-                self.ctx.out("*" * 80)
+                self.format_title(topic)
                 self.ctx.out(self.ctx.topics[topic])
                 self.ctx.out("\n")
+
         elif not args.topic:
             commands, topics = [
                 self.__parser__._format_list(x) for x in
@@ -166,10 +166,9 @@ class HelpControl(BaseControl):
                 "commands": commands,
                 "topics": topics}
             print HELP_USAGE % key_list
-
         else:
             if args.topic in self.ctx.controls:
-                self.ctx.controls[args.topic]
+                self.ctx.invoke([args.topic, "-h"])
             elif args.topic in self.ctx.topics:
                 self.ctx.out(self.ctx.topics[args.topic])
             else:

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -148,13 +148,15 @@ class HelpControl(BaseControl):
     def _configure(self, parser):
         self.__parser__ = parser  # For formatting later
         parser.set_defaults(func=self.__call__)
+        parser.add_argument(
+            "--recursive", action="store_true",
+            help="Also print help for all subcommands")
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "--all", action="store_true", help="Print help for all topics")
+            "--all", action="store_true",
+            help="Print help for all commands and topics")
         group.add_argument(
             "topic", nargs="?", help="Command or topic for more information")
-        parser.add_argument(
-            "--recursive", action="store_true", help="Also list subcommands")
 
     def _complete(self, text, line, begidx, endidx):
         """

--- a/components/tools/OmeroPy/test/unit/clitest/test_basics.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_basics.py
@@ -59,5 +59,8 @@ class TestBasics(object):
         self.args = ["help", "list"]
         cli.invoke(self.args, strict=True)
 
+    def testQuit(object):
+        cli.invoke(["quit"], strict=True)
+
     def testVersion(object):
         cli.invoke(["version"], strict=True)

--- a/components/tools/OmeroPy/test/unit/clitest/test_basics.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_basics.py
@@ -29,35 +29,35 @@ commands = cli.controls.keys()
 topics = cli.topics.keys()
 
 
-class TestHelp(object):
-
-    def setup_method(self, method):
-        self.args = ["help"]
+class TestBasics(object):
 
     def testHelp(self):
-        self.args += ["-h"]
+        self.args = ["help", "-h"]
         cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize('recursive', [None, "--recursive"])
-    def testAll(self, recursive):
-        self.args += ["--all"]
+    def testHelpAll(self, recursive):
+        self.args = ["help", "--all"]
         if recursive:
             self.args.append(recursive)
         cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize('recursive', [None, "--recursive"])
     @pytest.mark.parametrize('command', commands)
-    def testCommand(self, command, recursive):
-        self.args += [command]
+    def testHelpCommand(self, command, recursive):
+        self.args = ["help", command]
         if recursive:
             self.args.append(recursive)
         cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize('topic', topics)
-    def testTopic(self, topic):
-        self.args += [topic, "-h"]
+    def testHelpTopic(self, topic):
+        self.args = ["help", topic, "-h"]
         cli.invoke(self.args, strict=True)
 
-    def testList(self):
-        self.args += ["list", "-h"]
+    def testHelpList(self):
+        self.args = ["help", "list"]
         cli.invoke(self.args, strict=True)
+
+    def testVersion(object):
+        cli.invoke(["version"], strict=True)

--- a/components/tools/OmeroPy/test/unit/clitest/test_help.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_help.py
@@ -57,3 +57,7 @@ class TestHelp(object):
     def testTopic(self, topic):
         self.args += [topic, "-h"]
         cli.invoke(self.args, strict=True)
+
+    def testList(self):
+        self.args += ["list", "-h"]
+        cli.invoke(self.args, strict=True)

--- a/components/tools/OmeroPy/test/unit/clitest/test_help.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_help.py
@@ -21,7 +21,7 @@
 
 
 import pytest
-from omero.cli import CLI, NonZeroReturnCode
+from omero.cli import CLI
 
 cli = CLI()
 cli.loadplugins()

--- a/components/tools/OmeroPy/test/unit/clitest/test_help.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_help.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import pytest
+from omero.cli import CLI, NonZeroReturnCode
+
+cli = CLI()
+cli.loadplugins()
+commands = cli.controls.keys()
+topics = cli.topics.keys()
+
+
+class TestHelp(object):
+
+    def setup_method(self, method):
+        self.args = ["help"]
+
+    def testHelp(self):
+        self.args += ["-h"]
+        cli.invoke(self.args, strict=True)
+
+    @pytest.mark.parametrize('recursive', [None, "--recursive"])
+    def testAll(self, recursive):
+        self.args += ["--all"]
+        if recursive:
+            self.args.append(recursive)
+        cli.invoke(self.args, strict=True)
+
+    @pytest.mark.parametrize('recursive', [None, "--recursive"])
+    @pytest.mark.parametrize('command', commands)
+    def testCommand(self, command, recursive):
+        self.args += [command]
+        if recursive:
+            self.args.append(recursive)
+        cli.invoke(self.args, strict=True)
+
+    @pytest.mark.parametrize('topic', topics)
+    def testTopic(self, topic):
+        self.args += [topic, "-h"]
+        cli.invoke(self.args, strict=True)


### PR DESCRIPTION
Following discussion https://github.com/openmicroscopy/openmicroscopy/pull/3507, this PR also aims to address https://trac.openmicroscopy.org/ome/ticket/10851.

Notable changes to the CLI `HelpControl` class are listed below:
- `--all/topic` are moved in a mutually exclusive group
- a `--recursive` argument is added to the parser allowing to display subcommands help
- a `--list` argument is added to the parser allowing to list all commands/subcommands
- the command title is formatted to distinguish commands and subcommands
- Sphinx compatible separators are used in case we want including this output of `bin/omero help --all --recursive` in the documentation
- unit tests are added and should be run by Travis

To test this PR, review the various versions of the command:

```
bin/omero help -h
bin/omero help --all
bin/omero help --all --recursive
bin/omero help --list
bin/omero help <command_or_topic>
bin/omero help <command_or_topic> --recursive
```

The subcommands list suggestion proposed in https://github.com/openmicroscopy/openmicroscopy/pull/3507#issuecomment-75281762 is hard to implement as it requires modifying the argparse formatter. An option would be to generate a simple list subcommands like `bin/omero config parse --keys`. Thoughts @ximenesuk ?

--no-rebase