### PR TITLE
Auto save 1 second after Map Annotation Edit

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -28,7 +28,7 @@
         var $input,
             inputEdited = false,
             saveInProgress = false,
-            saveTimeout,
+            saveTimeout, waitingToSave,
             $lastRow = $("<tr class='placeholder'><td>Add Key</td><td>Add Value</td></tr>"),
             multiSelectKey = OME.multi_key() + "Key";
 
@@ -64,6 +64,15 @@
             var key = getCellText($tr.children('td:first')),
                 val = getCellText($tr.children('td:last'));
             return [key, val]
+        }
+
+        var saveInASec = function saveInASec($table) {
+            if (waitingToSave) {
+                clearTimeout(waitingToSave)
+            }
+            waitingToSave = setTimeout(function() {
+                saveMapAnnotation($table);
+            }, 1000);
         }
 
         // Save $table data to OMERO via $.post()
@@ -365,6 +374,8 @@
                     break;
                 default:
                     inputEdited = true;
+                    $table = $td.parent().parent().parent();
+                    saveInASec($table);
             }
 
             // Ignore Tab


### PR DESCRIPTION
Fix for https://trac.openmicroscopy.org/ome/ticket/12754

There is no nice way to catch the click on the Tree and save any current Map Annotation edits before clearing the right panel.
An alternative solution is to simply automatically save a second after the last edit.
We already save the whole Map Annotation to the server whenever you leave a Key/Value input field and the 1 second delay should limit the number of calls to reduce synchronous updates.

To test: 
 - simply try a number of rapid edits, moving between key/value fields, with short delays etc
 - try editing a field, then navigating away in the Tree while still editing the field. Change should still be saved (unless you are very quick)!

--no-rebase