### PR TITLE
fixing copy/past rendering settings in share

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -104,8 +104,8 @@ urlpatterns = patterns('django.views.generic.simple',
     url(r'^(?:(?P<share_id>[0-9]+)/)?render_col_plot/(?P<iid>[^/]+)/(?P<z>[^/]+)/(?P<t>[^/]+)/(?P<x>[^/]+)/(?:(?P<w>[^/]+)/)?$', webgateway.render_col_plot, name="web_render_col_plot"),
     url(r'^(?:(?P<share_id>[0-9]+)/)?render_split_channel/(?P<iid>[^/]+)/(?P<z>[^/]+)/(?P<t>[^/]+)/$', webgateway.render_split_channel, name="web_render_split_channel"),
     url(r'^saveImgRDef/(?P<iid>[^/]+)/$', webgateway.save_image_rdef_json, name="web_save_image_rdef_json"),
-    url(r'^getImgRDef/$', webgateway.get_image_rdef_json, name="web_get_image_rdef_json"),
-    url(r'^copyImgRDef/$', webgateway.copy_image_rdef_json, name="copy_image_rdef_json"),
+    url(r'^(?:(?P<share_id>[0-9]+)/)?getImgRDef/$', webgateway.get_image_rdef_json, name="web_get_image_rdef_json"),
+    url(r'^(?:(?P<share_id>[0-9]+)/)?copyImgRDef/$', webgateway.copy_image_rdef_json, name="copy_image_rdef_json"),
 
 
     # Fileset query (for delete or chgrp dialogs) obj-types and ids in REQUEST data


### PR DESCRIPTION
This should resolve HTTP 404 when coping and pasting rendering onto image in share.
To test:
 - choose user who has 2 images with the same number of channels (to make sure will be able to copy and past rendering settings) in private group.
 - share them with another user2 who normally cannot access these images.
 - login as user2 and try to copy and past rendering settings from one image to another in image viewer (not Preview tab)

Check Firebag console if there are no HTTP 404 responses

--no-rebase