### PR TITLE
Float big image

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -655,11 +655,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         int maxPlaneSize = sizes.getMaxPlaneWidth() * sizes.getMaxPlaneHeight();
         if (((long) reader.getSizeX()
              * (long) reader.getSizeY()) > maxPlaneSize) {
-            int pixelType = reader.getPixelType();
-            if (pixelType != FormatTools.FLOAT &&
-                    pixelType != FormatTools.DOUBLE) {
-                    return null;
-            }
+            return null;
         }
         int bytesPerPixel = getBytesPerPixel(reader.getPixelType());
         MessageDigest md;

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -656,14 +656,9 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         if (((long) reader.getSizeX()
              * (long) reader.getSizeY()) > maxPlaneSize) {
             int pixelType = reader.getPixelType();
-            long[] minMax = FormatTools.defaultMinMax(pixelType);
-            for (int c = 0; c < reader.getSizeC(); c++) {
-                store.setChannelGlobalMinMax(
-                        c, minMax[0], minMax[1], series);
-            }
             if (pixelType != FormatTools.FLOAT &&
-                pixelType != FormatTools.DOUBLE) {
-                return null;
+                    pixelType != FormatTools.DOUBLE) {
+                    return null;
             }
         }
         int bytesPerPixel = getBytesPerPixel(reader.getPixelType());
@@ -692,7 +687,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
 
 
     /**
-     * Read a plane to cause min/max valus to be calculated.
+     * Read a plane to cause min/max values to be calculated.
      *
      * @param size Sizes of the Pixels set.
      * @param z The Z-section offset to write to.

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -661,7 +661,10 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
                 store.setChannelGlobalMinMax(
                         c, minMax[0], minMax[1], series);
             }
-            return null;
+            if (pixelType != FormatTools.FLOAT &&
+                pixelType != FormatTools.DOUBLE) {
+                return null;
+            }
         }
         int bytesPerPixel = getBytesPerPixel(reader.getPixelType());
         MessageDigest md;


### PR DESCRIPTION
Do not set the min max values to full range for big images of type float or double
We do not generate pyramid for big images of that pixels type
to test the PR:
 * Import ```team/will/float-data/mrc/AMI-public-data/GroEL/...ef.mrc``` team/will/float-data.zip
 * Check that the min max does not correspond is resp. ```181.491``` and ```627.354``` (was ```-2147483648``` and ```2147483647```)
 * Open the image in imageJ and check it matches the omero image. 