### PR TITLE
Batch remove tags

### DIFF
--- a/components/tests/ui/testcases/web/tagging_test.txt
+++ b/components/tests/ui/testcases/web/tagging_test.txt
@@ -11,7 +11,7 @@ Suite Teardown      Close all browsers
 *** Test Cases ***
 
 Test Tag
-    [Documentation]     Test Batch Annotation of 2 Projects that we create
+    [Documentation]     Several tests of the Tag dialog for single or batch tagging.
 
     Go To                                       ${WELCOME URL}
     Select Experimenter

--- a/components/tests/ui/testcases/web/tagging_test.txt
+++ b/components/tests/ui/testcases/web/tagging_test.txt
@@ -1,0 +1,100 @@
+*** Settings ***
+Documentation     Tests submission of forms.
+
+Resource          ../../resources/config.txt
+Resource          ../../resources/web/login.txt
+Resource          ../../resources/web/tree.txt
+
+Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Teardown      Close all browsers
+
+*** Test Cases ***
+
+Test Tag
+    [Documentation]     Test Batch Annotation of 2 Projects that we create
+
+    Go To                                       ${WELCOME URL}
+    Select Experimenter
+    ${projectId}=                               Create Project      robot test tagging_1
+    ${pId}=                                     Create Project      robot test tagging_2
+    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+
+    # Tag a single Project
+    Click Element                               launch_tags_form
+    Wait Until Page Contains Element            id_tag
+    Sleep                                       5                   # allow tags to load
+    Input Text                                  id_tag     robotTagTest${pid}TagOne
+    Click Element                               id_add_new_tag
+    Click Element                               xpath=//button/span[contains(text(),'Save')]
+    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
+    # Refresh, check and add another Tag, remove first one
+    Go To                                       ${WELCOME URL}?show=project-${pId}
+    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
+    Click Element                               launch_tags_form
+    Wait Until Page Contains Element            id_tag
+    Sleep                                       5                   # allow tags to load
+    # Create a second Tag
+    Input Text                                  id_tag     robotTagTest${pid}TagTwo
+    Click Element                               id_add_new_tag
+    # Remove previously added Tag
+    Click Element                               xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Click Element                               id=id_tag_deselect_button
+    Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    # Save - check Tag added and Tag removed
+    Click Element                               xpath=//button/span[contains(text(),'Save')]
+    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]  10
+    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+
+
+    # Now select both Projects...
+    Go To                                       ${WELCOME URL}?show=project-${projectId}|project-${pId}
+    Wait Until Page Contains Element            id=batch_ann_title
+
+    Click Element                               launch_tags_form
+    Wait Until Page Contains Element            id_tag
+    Sleep                                       5                   # allow tags to load
+
+    # Tags created above should be available to add to second Project
+    Wait Until Page Contains Element            xpath=//div[@id='id_all_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Page Should Contain Element                 xpath=//div[@id='id_all_tags']/div[contains(text(),'robotTagTest${pid}TagTwo')]
+    # And shouldn't appear in right column
+    Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagTwo')]
+    # Add the first Tag to both Projects
+    Click Element                               xpath=//div[@id='id_all_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Click Element                               id=id_tag_select_button
+    # Just 1 tag should be moved to right
+    Page Should Contain Element                 xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagTwo')]
+    # Save - check Tag added and Tag removed
+    Click Element                               xpath=//button/span[contains(text(),'Save')]
+    # Right panel Tag tooltip should indicate one tag is on BOTH Projects 'Can remove Tag from <b>2 objects</b>'
+    Wait Until Page Contains Element            xpath=//span[@class='tooltip_html']/b[contains(text(),'2 objects')]
+    # Other tag is still on one Project
+    Page Should Contain Element                 xpath=//span[@class='tooltip_html']/b[contains(text(),'1 object')]
+    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+
+    # Open Tag dialog again...
+    Click Element                               launch_tags_form
+    Wait Until Page Contains Element            id_tag
+    Sleep                                       5                   # allow tags to load
+    # Same tag as before should be on right
+    Wait Until Page Contains Element            xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagTwo')]
+    # Remove this Tag form Both projects...
+    Click Element                               xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
+    Click Element                               id=id_tag_deselect_button
+    # Create a third Tag
+    Input Text                                  id_tag     robotTagTest${pid}TagThree
+    Click Element                               id_add_new_tag
+    Click Element                               xpath=//button/span[contains(text(),'Save')]
+    # After Save, Tags Two and Three should be added, Tag One removed
+    # Seems we need a proper refresh here to be sure that TagOne is removed.
+    Go To                                       ${WELCOME URL}?show=project-${projectId}|project-${pId}
+    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagThree')]  10
+    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+
+

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -988,7 +988,7 @@ class BaseContainer(BaseController):
                         up_pdl = p
                         self.conn.deleteObjectDirect(up_pdl._obj)
             elif destination[0] == 'orphaned':
-                return 'Cannot move dataset to %s.' % conn.getOrphanedContainerSettings()[1]
+                return 'Cannot move dataset to %s.' % self.conn.getOrphanedContainerSettings()[1]
             else:
                 return 'Destination not supported.'
         elif self.image is not None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1570,6 +1570,12 @@ def annotate_tags(request, conn=None, **kwargs):
     # Get appropriate manager, either to list available Tags to add to single object, or list ALL Tags (multiple objects)
     manager = None
     self_id = conn.getEventContext().userId
+
+    jsonmode = request.GET.get('jsonmode')
+    tags = []
+
+    # Prepare list of 'selected_tags' either for creation of the Tag dialog, OR to
+    # use with form POST to know what has been added / removed from selected tags.
     if obj_count == 1:
         for t in selected:
             if len(selected[t]) > 0:
@@ -1590,17 +1596,27 @@ def annotate_tags(request, conn=None, **kwargs):
         elif o_type in ("share", "sharecomment"):
             manager = BaseShare(conn, o_id)
 
-        manager.annotationList()
-        tags = manager.tag_annotations
+        if jsonmode is None:
+            manager.annotationList()
+            tags = manager.tag_annotations
 
     else:
         manager = BaseContainer(conn)
-        tags = []
-        # Use the first object we find to set context (assume all objects are in same group!)
-        for obs in oids.values():
-            if len(obs) > 0:
-                conn.SERVICE_OPTS.setOmeroGroup(obs[0].getDetails().group.id.val)
-                break
+        if jsonmode is None:
+            batchAnns = manager.loadBatchAnnotations(oids)
+
+            tags = []
+
+            for t in batchAnns['Tag']:
+                mylinks = [l for l in t['links'] if l.isOwned()]
+                if len(mylinks) == obj_count:
+                    t['ann'].link = mylinks[0]  # make sure we pick a link that we own
+                    tags.append(t['ann'])
+            # Use the first object we find to set context (assume all objects are in same group!)
+            for obs in oids.values():
+                if len(obs) > 0:
+                    conn.SERVICE_OPTS.setOmeroGroup(obs[0].getDetails().group.id.val)
+                    break
 
     selected_tags = []
     for tag in tags:
@@ -1614,7 +1630,6 @@ def annotate_tags(request, conn=None, **kwargs):
     initial = {'selected':selected, 'images':oids['image'], 'datasets': oids['dataset'], 'projects':oids['project'],
             'screens':oids['screen'], 'plates':oids['plate'], 'acquisitions':oids['acquisition'], 'wells':oids['well']}
 
-    jsonmode = request.GET.get('jsonmode')
     if jsonmode:
         try:
             offset = int(request.GET.get('offset'))
@@ -1628,13 +1643,29 @@ def annotate_tags(request, conn=None, **kwargs):
             all_tags = manager.tags_recursive
             all_tags_owners = manager.tags_recursive_owners
 
+        if jsonmode == 'tagcount':
+            # send number of tags for better paging progress bar
+            return dict(tag_count=tag_count)
+
+        elif jsonmode == 'tags':
+            # send tag information without descriptions
+            return list((i, t, o, s) for i, d, t, o, s in all_tags)
+
+        elif jsonmode == 'desc':
+            # send descriptions for tags
+            return dict((i, d) for i, d, t, o, s in all_tags)
+
+        elif jsonmode == 'owners':
+            # send owner information
+            return all_tags_owners
+
     if request.method == 'POST':
         # handle form submission
         form_tags = TagsAnnotationForm(initial=initial, data=request.REQUEST.copy())
         newtags_formset = NewTagsAnnotationFormSet(prefix='newtags', data=request.REQUEST.copy())
         # Create new tags or Link existing tags...
         if form_tags.is_valid() and newtags_formset.is_valid():
-            # filter down previously selected tags to the ones owned by current user
+            # filter down previously selected tags to the ones linked by current user
             selected_tag_ids = [stag[0] for stag in selected_tags if stag[5]]
             added_tags = [stag[0] for stag in selected_tags if not stag[5]]
             tags = [tag for tag in form_tags.cleaned_data['tags'] if tag not in selected_tag_ids]
@@ -1678,22 +1709,6 @@ def annotate_tags(request, conn=None, **kwargs):
                 context['can_remove'] = True
         else:
             return HttpResponse(str(form_tags.errors))      # TODO: handle invalid form error
-
-    elif jsonmode == 'tagcount':
-        # send number of tags for better paging progress bar
-        return dict(tag_count=tag_count)
-
-    elif jsonmode == 'tags':
-        # send tag information without descriptions
-        return list((i, t, o, s) for i, d, t, o, s in all_tags)
-
-    elif jsonmode == 'desc':
-        # send descriptions for tags
-        return dict((i, d) for i, d, t, o, s in all_tags)
-
-    elif jsonmode == 'owners':
-        # send owner information
-        return all_tags_owners
 
     else:
         form_tags = TagsAnnotationForm(initial=initial)


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12665
To test:
 - Select 2 or more objects and add Tags dialog.
 - Any tags that are on all selected objects should be shown in right 'selected' column.
 - E.g. try adding a tag to all selected objects. When the dialog is opened again this Tag should be in the right column.
 - Removing a Tag from the right column should remove it from all selected objects.

Permissions test (fails in Insight: https://trello.com/c/43AhivR0/325-insight-tag-dialog-for-admins)
 - In the case where an Admin is removing tags using the Tag dialog, he/she should not be able to remove Tags that another user has added.
 - Tags should only show up in the right column if Admin themselves has added that Tag to all selected objects.
 - If Admin has added Tag to all selected objects and Tag shows up in right column, removing it should not remove that Tag from selected objects where linked by other users. Is that clear!?

--no-rebase
 