### PR TITLE
adjust disk usage request API

### DIFF
--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -119,7 +119,8 @@ module omero {
         /**
          * Request to determine the disk usage of the given objects
          * and their contents. File-system paths used by multiple objects
-         * are de-duplicated in the total count.
+         * are de-duplicated in the total count. Specifying a class is
+         * equivalent to specifying all its instances as objects.
          *
          * Permissible classes include:
          *   ExperimenterGroup, Experimenter, Project, Dataset,
@@ -127,6 +128,7 @@ module omero {
          *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
          **/
         class DiskUsage extends Request {
+            omero::api::StringSet classes;
             omero::api::IdListMap objects;
         };
 

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -129,7 +129,7 @@ module omero {
          **/
         class DiskUsage extends Request {
             omero::api::StringSet classes;
-            omero::api::IdListMap objects;
+            omero::api::StringLongListMap objects;
         };
 
         /**

--- a/components/blitz/src/omero/cmd/IRequest.java
+++ b/components/blitz/src/omero/cmd/IRequest.java
@@ -81,7 +81,7 @@ public interface IRequest {
 
     /**
      * Post-transaction chance to map from the return value of
-     * {@link #step(int)} to a {@link omero.cmd.Respnse} object.
+     * {@link #step(int)} to a {@link omero.cmd.Response} object.
      * 
      * @param i
      * @param object

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -64,7 +64,7 @@ import omero.model.OriginalFile;
  */
 @SuppressWarnings("serial")
 public class DiskUsageI extends DiskUsage implements IRequest {
-    /* TODO: This class can be substantially refactored and simplified once the graph traversal reimplementation is merged. */
+    /* TODO: This class can be substantially refactored and simplified by using the graph traversal reimplementation. */
 
     /* FIELDS AND CONSTRUCTORS */
 

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -444,6 +444,16 @@ public class DiskUsageI extends DiskUsage implements IRequest {
 
         /* note the objects to process */
 
+        for (final String className : classes) {
+            final String hql = "SELECT id FROM " + className;
+            for (final Object[] resultRow : queryService.projection(hql, null)) {
+                if (resultRow != null) {
+                    final Long objectId = (Long) resultRow[0];
+                    objectsToProcess.put(className, objectId);
+                }
+            }
+        }
+
         for (final Map.Entry<String, long[]> objectList : objects.entrySet()) {
             objectsToProcess.putAll(objectList.getKey(), Arrays.asList(ArrayUtils.toObject(objectList.getValue())));
 

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,6 @@ package omero.cmd.graphs;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -454,8 +452,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
             }
         }
 
-        for (final Map.Entry<String, long[]> objectList : objects.entrySet()) {
-            objectsToProcess.putAll(objectList.getKey(), Arrays.asList(ArrayUtils.toObject(objectList.getValue())));
+        for (final Map.Entry<String, List<Long>> objectList : objects.entrySet()) {
+            objectsToProcess.putAll(objectList.getKey(), objectList.getValue());
 
             if (LOGGER.isDebugEnabled()) {
                 final List<Long> ids = Lists.newArrayList(objectsToProcess.get(objectList.getKey()));

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -20,6 +20,7 @@
 package integration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,18 +88,13 @@ public class DiskUsageTest extends AbstractServerTest {
     private Long thumbnailSize;
 
     /**
-     * Convert a Collection<Long> to a long[].
+     * Convert a {@code Collection<Long>} to a {@code List<Long>}.
      */
-    private static Function<Collection<Long>, long[]> LONG_COLLECTION_TO_ARRAY =
-            new Function<Collection<Long>, long[]>() {
+    private static Function<Collection<Long>, List<Long>> LONG_COLLECTION_TO_LIST =
+            new Function<Collection<Long>, List<Long>>() {
         @Override
-        public long[] apply(Collection<Long> ids) {
-            final long[] array = new long[ids.size()];
-            int index = 0;
-            for (final Long id : ids) {
-                array[index++] = id;
-            }
-            return array;
+        public List<Long> apply(Collection<Long> ids) {
+            return new ArrayList<Long>(ids);
         }
     };
 
@@ -110,7 +106,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     private DiskUsageResponse runDiskUsage(Map<java.lang.String, ? extends Collection<Long>> objects) throws Exception {
         final DiskUsage request = new DiskUsage();
-        request.objects = Maps.transformValues(objects, LONG_COLLECTION_TO_ARRAY);
+        request.objects = Maps.transformValues(objects, LONG_COLLECTION_TO_LIST);
         return (DiskUsageResponse) doChange(request);
     }
 


### PR DESCRIPTION
* adds `classes` member to indicate "all instances of given classes"
* adjusts `objects` member so that in Java the IDs come as a list, not an array (should be unchanged for Python)

--no-rebase