### PR TITLE
Compare full generated web configs

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
@@ -1,0 +1,78 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+RewriteEngine on
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+<Directory "../target/var">
+    Options -Indexes +FollowSymLinks
+    Require all granted
+</Directory>
+
+<Directory "../target/lib/python/omeroweb/static">
+    Options -Indexes +FollowSymLinks
+    Require all granted
+</Directory>
+
+<Location fcgi://0.0.0.0:4080/>
+    Require all granted
+</Location>
+
+Alias /test-static ../target/lib/python/omeroweb/static
+
+RewriteCond %{REQUEST_URI} !^(/test-static|/\.fcgi)
+RewriteRule ^/test(/|$)(.*) /test.fcgi/$2 [PT]
+SetEnvIf Request_URI . proxy-fcgi-pathinfo=1
+ProxyPass /test.fcgi/ fcgi://0.0.0.0:4080/
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
@@ -54,12 +54,12 @@ RewriteEngine on
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-<Directory "../target/var">
+<Directory "/home/omero/OMERO.server/var">
     Options -Indexes +FollowSymLinks
     Require all granted
 </Directory>
 
-<Directory "../target/lib/python/omeroweb/static">
+<Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes +FollowSymLinks
     Require all granted
 </Directory>
@@ -68,7 +68,7 @@ RewriteEngine on
     Require all granted
 </Location>
 
-Alias /test-static ../target/lib/python/omeroweb/static
+Alias /test-static /home/omero/OMERO.server/lib/python/omeroweb/static
 
 RewriteCond %{REQUEST_URI} !^(/test-static|/\.fcgi)
 RewriteRule ^/test(/|$)(.*) /test.fcgi/$2 [PT]

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
@@ -1,0 +1,78 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+RewriteEngine on
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+<Directory "../target/var">
+    Options -Indexes +FollowSymLinks
+    Require all granted
+</Directory>
+
+<Directory "../target/lib/python/omeroweb/static">
+    Options -Indexes +FollowSymLinks
+    Require all granted
+</Directory>
+
+<Location fcgi://0.0.0.0:4080/>
+    Require all granted
+</Location>
+
+Alias /static ../target/lib/python/omeroweb/static
+
+RewriteCond %{REQUEST_URI} !^(/static|/\.fcgi)
+RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]
+SetEnvIf Request_URI . proxy-fcgi-pathinfo=1
+ProxyPass /.fcgi/ fcgi://0.0.0.0:4080/
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
@@ -54,12 +54,12 @@ RewriteEngine on
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-<Directory "../target/var">
+<Directory "/home/omero/OMERO.server/var">
     Options -Indexes +FollowSymLinks
     Require all granted
 </Directory>
 
-<Directory "../target/lib/python/omeroweb/static">
+<Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes +FollowSymLinks
     Require all granted
 </Directory>
@@ -68,7 +68,7 @@ RewriteEngine on
     Require all granted
 </Location>
 
-Alias /static ../target/lib/python/omeroweb/static
+Alias /static /home/omero/OMERO.server/lib/python/omeroweb/static
 
 RewriteCond %{REQUEST_URI} !^(/static|/\.fcgi)
 RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
@@ -57,20 +57,20 @@ RewriteRule ^/?$ /test/ [R]
 ###
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
-FastCGIExternalServer "../target/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
 
-<Directory "../target/var">
+<Directory "/home/omero/OMERO.server/var">
     Options -Indexes FollowSymLinks
     Order allow,deny
     Allow from all
 </Directory>
 
-<Directory "../target/lib/python/omeroweb/static">
+<Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes FollowSymLinks
     Order allow,deny
     Allow from all
 </Directory>
 
-Alias /test-static ../target/lib/python/omeroweb/static
-Alias /test "../target/var/omero.fcgi/"
+Alias /test-static /home/omero/OMERO.server/lib/python/omeroweb/static
+Alias /test "/home/omero/OMERO.server/var/omero.fcgi/"
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
@@ -1,0 +1,76 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroWebClientRedirect - redirect / to /omero/webclient
+#  OmeroWebAdminRedirect  - redirect / to /omero/webadmin
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+RewriteEngine on
+RewriteRule ^/?$ /test/ [R]
+
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+FastCGIExternalServer "../target/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+
+<Directory "../target/var">
+    Options -Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+
+<Directory "../target/lib/python/omeroweb/static">
+    Options -Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+
+Alias /test-static ../target/lib/python/omeroweb/static
+Alias /test "../target/var/omero.fcgi/"
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
@@ -1,0 +1,74 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroWebClientRedirect - redirect / to /omero/webclient
+#  OmeroWebAdminRedirect  - redirect / to /omero/webadmin
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+FastCGIExternalServer "../target/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+
+<Directory "../target/var">
+    Options -Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+
+<Directory "../target/lib/python/omeroweb/static">
+    Options -Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+
+Alias /static ../target/lib/python/omeroweb/static
+Alias / "../target/var/omero.fcgi/"
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
@@ -55,20 +55,20 @@
 ###
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
-FastCGIExternalServer "../target/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
 
-<Directory "../target/var">
+<Directory "/home/omero/OMERO.server/var">
     Options -Indexes FollowSymLinks
     Order allow,deny
     Allow from all
 </Directory>
 
-<Directory "../target/lib/python/omeroweb/static">
+<Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes FollowSymLinks
     Order allow,deny
     Allow from all
 </Directory>
 
-Alias /static ../target/lib/python/omeroweb/static
-Alias / "../target/var/omero.fcgi/"
+Alias /static /home/omero/OMERO.server/lib/python/omeroweb/static
+Alias / "/home/omero/OMERO.server/var/omero.fcgi/"
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
@@ -1,0 +1,75 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid ../target/var/pid.nginx;
+error_log ../target/var/log/nginx_error.log;
+worker_processes  5;
+working_directory ../target/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    ../target/var/log/nginx_access.log;
+    include       ../target/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path ../target/var/nginx_tmp;
+
+    keepalive_timeout  65;
+
+    server {
+        listen       1234;
+        server_name  _;
+        fastcgi_temp_path ../target/var/nginx_tmp;
+        proxy_temp_path ../target/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 2m;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root ../target/etc/templates/error;
+            try_files $uri $uri/ /502.html =502;
+        }
+
+        # weblitz django apps serve static content from here
+        location /test-static {
+            alias ../target/lib/python/omeroweb/static;
+        }
+
+        location /test {
+
+            error_page 502 @maintenance;
+
+            fastcgi_pass 0.0.0.0:4080;
+
+            fastcgi_split_path_info ^(/test)(.*)$;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+            fastcgi_param SCRIPT_INFO $fastcgi_script_name;
+
+
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param QUERY_STRING $query_string;
+            fastcgi_param CONTENT_TYPE $content_type;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param SERVER_NAME $server_name;
+            fastcgi_param SERVER_PROTOCOL $server_protocol;
+            fastcgi_param SERVER_PORT $server_port;
+            fastcgi_pass_header Authorization;
+            fastcgi_intercept_errors on;
+            fastcgi_read_timeout 60;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
+        }
+
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
@@ -4,10 +4,10 @@
 # nginx -c etc/nginx.conf
 # for inclusion in a system-wide nginx configuration see omero web config nginx
 #
-pid ../target/var/pid.nginx;
-error_log ../target/var/log/nginx_error.log;
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
 worker_processes  5;
-working_directory ../target/var;
+working_directory /home/omero/OMERO.server/var;
 
 events {
     worker_connections  1024;
@@ -15,31 +15,31 @@ events {
 
 
 http {
-    access_log    ../target/var/log/nginx_access.log;
-    include       ../target/etc/mime.types;
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
     default_type  application/octet-stream;
-    client_body_temp_path ../target/var/nginx_tmp;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
 
     keepalive_timeout  65;
 
     server {
         listen       1234;
         server_name  _;
-        fastcgi_temp_path ../target/var/nginx_tmp;
-        proxy_temp_path ../target/var/nginx_tmp;
+        fastcgi_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
 
         sendfile on;
         client_max_body_size 2m;
 
         # maintenance page serve from here
         location @maintenance {
-            root ../target/etc/templates/error;
+            root /home/omero/OMERO.server/etc/templates/error;
             try_files $uri $uri/ /502.html =502;
         }
 
         # weblitz django apps serve static content from here
         location /test-static {
-            alias ../target/lib/python/omeroweb/static;
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
         }
 
         location /test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
@@ -4,10 +4,10 @@
 # nginx -c etc/nginx.conf
 # for inclusion in a system-wide nginx configuration see omero web config nginx
 #
-pid ../target/var/pid.nginx;
-error_log ../target/var/log/nginx_error.log;
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
 worker_processes  5;
-working_directory ../target/var;
+working_directory /home/omero/OMERO.server/var;
 
 events {
     worker_connections  1024;
@@ -15,31 +15,31 @@ events {
 
 
 http {
-    access_log    ../target/var/log/nginx_access.log;
-    include       ../target/etc/mime.types;
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
     default_type  application/octet-stream;
-    client_body_temp_path ../target/var/nginx_tmp;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
 
     keepalive_timeout  65;
 
     server {
         listen       8080;
         server_name  _;
-        fastcgi_temp_path ../target/var/nginx_tmp;
-        proxy_temp_path ../target/var/nginx_tmp;
+        fastcgi_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
 
         sendfile on;
         client_max_body_size 0;
 
         # maintenance page serve from here
         location @maintenance {
-            root ../target/etc/templates/error;
+            root /home/omero/OMERO.server/etc/templates/error;
             try_files $uri $uri/ /502.html =502;
         }
 
         # weblitz django apps serve static content from here
         location /static {
-            alias ../target/lib/python/omeroweb/static;
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
         }
 
         location / {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
@@ -1,0 +1,73 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid ../target/var/pid.nginx;
+error_log ../target/var/log/nginx_error.log;
+worker_processes  5;
+working_directory ../target/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    ../target/var/log/nginx_access.log;
+    include       ../target/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path ../target/var/nginx_tmp;
+
+    keepalive_timeout  65;
+
+    server {
+        listen       8080;
+        server_name  _;
+        fastcgi_temp_path ../target/var/nginx_tmp;
+        proxy_temp_path ../target/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 0;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root ../target/etc/templates/error;
+            try_files $uri $uri/ /502.html =502;
+        }
+
+        # weblitz django apps serve static content from here
+        location /static {
+            alias ../target/lib/python/omeroweb/static;
+        }
+
+        location / {
+
+            error_page 502 @maintenance;
+
+            fastcgi_pass 0.0.0.0:4080;
+
+            fastcgi_param PATH_INFO $fastcgi_script_name;
+
+
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param QUERY_STRING $query_string;
+            fastcgi_param CONTENT_TYPE $content_type;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param SERVER_NAME $server_name;
+            fastcgi_param SERVER_PROTOCOL $server_protocol;
+            fastcgi_param SERVER_PORT $server_port;
+            fastcgi_pass_header Authorization;
+            fastcgi_intercept_errors on;
+            fastcgi_read_timeout 60;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
+        }
+
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
@@ -1,0 +1,47 @@
+    server {
+        listen       1234;
+        server_name  $hostname;
+
+        sendfile on;
+        client_max_body_size 2m;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root ../target/etc/templates/error;
+            try_files $uri $uri/ /502.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /test-static {
+            alias ../target/lib/python/omeroweb/static;
+        }
+
+        location /test {
+
+            error_page 502 @maintenance;
+
+            fastcgi_pass 0.0.0.0:4080;
+
+            fastcgi_split_path_info ^(/test)(.*)$;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+            fastcgi_param SCRIPT_INFO $fastcgi_script_name;
+
+
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param QUERY_STRING $query_string;
+            fastcgi_param CONTENT_TYPE $content_type;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param SERVER_NAME $server_name;
+            fastcgi_param SERVER_PROTOCOL $server_protocol;
+            fastcgi_param SERVER_PORT $server_port;
+            fastcgi_pass_header Authorization;
+            fastcgi_intercept_errors on;
+            fastcgi_read_timeout 60;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
+        }
+
+    }
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
@@ -7,13 +7,13 @@
 
         # maintenance page serve from here
         location @maintenance {
-            root ../target/etc/templates/error;
+            root /home/omero/OMERO.server/etc/templates/error;
             try_files $uri $uri/ /502.html =502;
         }
 
         # weblitz django apps serve media from here
         location /test-static {
-            alias ../target/lib/python/omeroweb/static;
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
         }
 
         location /test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
@@ -7,13 +7,13 @@
 
         # maintenance page serve from here
         location @maintenance {
-            root ../target/etc/templates/error;
+            root /home/omero/OMERO.server/etc/templates/error;
             try_files $uri $uri/ /502.html =502;
         }
 
         # weblitz django apps serve media from here
         location /static {
-            alias ../target/lib/python/omeroweb/static;
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
         }
 
         location / {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
@@ -1,0 +1,45 @@
+    server {
+        listen       80;
+        server_name  $hostname;
+
+        sendfile on;
+        client_max_body_size 0;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root ../target/etc/templates/error;
+            try_files $uri $uri/ /502.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /static {
+            alias ../target/lib/python/omeroweb/static;
+        }
+
+        location / {
+
+            error_page 502 @maintenance;
+
+            fastcgi_pass 0.0.0.0:4080;
+
+            fastcgi_param PATH_INFO $fastcgi_script_name;
+
+
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param QUERY_STRING $query_string;
+            fastcgi_param CONTENT_TYPE $content_type;
+            fastcgi_param CONTENT_LENGTH $content_length;
+            fastcgi_param SERVER_NAME $server_name;
+            fastcgi_param SERVER_PROTOCOL $server_protocol;
+            fastcgi_param SERVER_PORT $server_port;
+            fastcgi_pass_header Authorization;
+            fastcgi_intercept_errors on;
+            fastcgi_read_timeout 60;
+            # Uncomment if nginx SSL module is enabled or you are using nginx 1.1.11 or later
+            # -- See: #10273, http://nginx.org/en/CHANGES
+            # fastcgi_param HTTPS $https;
+        }
+
+    }
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -185,7 +185,7 @@ class TestWeb(object):
             missing = self.required_lines_in([
                 ('Alias %s' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
-                'RewriteCond %{REQUEST_URI} !^(%s|/\\.fcgi)' %
+                'RewriteCond %%{REQUEST_URI} !^(%s|/\\.fcgi)' %
                 static_prefix[:-1],
                 'RewriteRule ^%s(/|$)(.*) %s.fcgi/$2 [PT]' % (prefix, prefix),
                 'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1',
@@ -194,7 +194,7 @@ class TestWeb(object):
         else:
             missing = self.required_lines_in([
                 ('Alias /static ', 'lib/python/omeroweb/static'),
-                'RewriteCond %{REQUEST_URI} !^(/static|/\\.fcgi)',
+                'RewriteCond %%{REQUEST_URI} !^(/static|/\\.fcgi)',
                 'RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]',
                 'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1',
                 'ProxyPass /.fcgi/ fcgi://0.0.0.0:4080/',

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -64,6 +64,20 @@ class TestWeb(object):
         lines = [line for line in lines if line and not line.startswith('#')]
         return lines
 
+    def required_lines_in(self, required, lines):
+        def compare(req, line):
+            if isinstance(req, tuple):
+                return line.startswith(req[0]) and line.endswith(req[1])
+            return req == line
+
+        n = 0
+        for req in required:
+            if not compare(req, lines[n]):
+                n += 1
+                if n == len(lines):
+                    return req
+        return None
+
     def normalise_generated(self, s):
         serverdir = self.cli.dir
         s = re.sub('\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}',
@@ -109,19 +123,22 @@ class TestWeb(object):
         lines = self.clean_generated_file(o)
 
         if server_type.split()[0] == "nginx":
-            assert lines[0] == "server {"
-            assert lines[1] == "listen       %s;" % (http or 80)
-            assert lines[4] == "client_max_body_size %s;" % (
-                max_body_size or '0')
-            assert lines[9] == "location %s {" % static_prefix[:-1]
-            assert lines[12] == "location %s {" % (prefix or "/")
+            missing = self.required_lines_in([
+                "server {",
+                "listen       %s;" % (http or 80),
+                "client_max_body_size %s;" % (max_body_size or '0'),
+                "location %s {" % static_prefix[:-1],
+                "location %s {" % (prefix or "/"),
+                ], lines)
         else:
-            assert lines[13] == "server {"
-            assert lines[14] == "listen       %s;" % (http or 8080)
-            assert lines[19] == "client_max_body_size %s;" % (
-                max_body_size or '0')
-            assert lines[24] == "location %s {" % static_prefix[:-1]
-            assert lines[27] == "location %s {" % (prefix or "/")
+            missing = self.required_lines_in([
+                "server {",
+                "listen       %s;" % (http or 8080),
+                "client_max_body_size %s;" % (max_body_size or '0'),
+                "location %s {" % static_prefix[:-1],
+                "location %s {" % (prefix or "/"),
+                ], lines)
+        assert not missing, 'Line not found: ' + missing
 
     @pytest.mark.parametrize('prefix', [None, '/test'])
     def testApacheConfig(self, prefix, capsys, monkeypatch):
@@ -135,23 +152,23 @@ class TestWeb(object):
         lines = self.clean_generated_file(o)
 
         if prefix:
-            assert lines[0] == 'RewriteEngine on'
-            assert lines[1] == 'RewriteRule ^/?$ %s/ [R]' % prefix
-            assert lines[2].startswith('FastCGIExternalServer ')
-            assert lines[2].endswith(
-                'var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60')
-            assert lines[-2].startswith('Alias %s ' % static_prefix[:-1])
-            assert lines[-2].endswith('lib/python/omeroweb/static')
-            assert lines[-1].startswith('Alias %s "' % prefix)
-            assert lines[-1].endswith('var/omero.fcgi/"')
+            missing = self.required_lines_in([
+                'RewriteEngine on',
+                'RewriteRule ^/?$ %s/ [R]' % prefix,
+                ('FastCGIExternalServer ',
+                 'var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60'),
+                ('Alias %s ' % static_prefix[:-1],
+                 'lib/python/omeroweb/static'),
+                ('Alias %s "' % prefix, 'var/omero.fcgi/"'),
+                ], lines)
         else:
-            assert lines[0].startswith('FastCGIExternalServer ')
-            assert lines[0].endswith(
-                'var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60')
-            assert lines[-2].startswith('Alias /static ')
-            assert lines[-2].endswith('lib/python/omeroweb/static')
-            assert lines[-1].startswith('Alias / "')
-            assert lines[-1].endswith('var/omero.fcgi/"')
+            missing = self.required_lines_in([
+                ('FastCGIExternalServer ',
+                 'var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60'),
+                ('Alias /static ', 'lib/python/omeroweb/static'),
+                ('Alias / "', 'var/omero.fcgi/"'),
+                ], lines)
+        assert not missing, 'Line not found: ' + missing
 
     @pytest.mark.parametrize('prefix', [None, '/test'])
     def testApacheFcgiConfig(self, prefix, capsys, monkeypatch):
@@ -165,23 +182,24 @@ class TestWeb(object):
         lines = self.clean_generated_file(o)
 
         if prefix:
-            assert lines[-5].startswith('Alias %s' % static_prefix[:-1])
-            assert lines[-5].endswith('lib/python/omeroweb/static')
-            assert lines[-4] == 'RewriteCond %{REQUEST_URI} ' + \
-                '!^(%s|/\\.fcgi)' % static_prefix[:-1]
-            assert lines[-3] == \
-                'RewriteRule ^%s(/|$)(.*) %s.fcgi/$2 [PT]' % (prefix, prefix)
-            assert lines[-2] == 'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1'
-            assert lines[-1] == 'ProxyPass %s.fcgi/ fcgi://0.0.0.0:4080/' \
-                % prefix
+            missing = self.required_lines_in([
+                ('Alias %s' % static_prefix[:-1],
+                 'lib/python/omeroweb/static'),
+                'RewriteCond %{REQUEST_URI} !^(%s|/\\.fcgi)' %
+                static_prefix[:-1],
+                'RewriteRule ^%s(/|$)(.*) %s.fcgi/$2 [PT]' % (prefix, prefix),
+                'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1',
+                'ProxyPass %s.fcgi/ fcgi://0.0.0.0:4080/' % prefix,
+                ], lines)
         else:
-            assert lines[-5].startswith('Alias /static ')
-            assert lines[-5].endswith('lib/python/omeroweb/static')
-            assert lines[-4] == \
-                'RewriteCond %{REQUEST_URI} !^(/static|/\\.fcgi)'
-            assert lines[-3] == 'RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]'
-            assert lines[-2] == 'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1'
-            assert lines[-1] == 'ProxyPass /.fcgi/ fcgi://0.0.0.0:4080/'
+            missing = self.required_lines_in([
+                ('Alias /static ', 'lib/python/omeroweb/static'),
+                'RewriteCond %{REQUEST_URI} !^(/static|/\\.fcgi)',
+                'RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]',
+                'SetEnvIf Request_URI . proxy-fcgi-pathinfo=1',
+                'ProxyPass /.fcgi/ fcgi://0.0.0.0:4080/',
+                ], lines)
+        assert not missing, 'Line not found: ' + missing
 
     @pytest.mark.parametrize('server_type', [
         "nginx", "nginx-development", "apache", "apache-fcgi"])

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -65,6 +65,8 @@ class TestWeb(object):
         return lines
 
     def required_lines_in(self, required, lines):
+        # Checks that all lines in required are present in the same order,
+        # but not necessarily consecutively
         def compare(req, line):
             if isinstance(req, tuple):
                 return line.startswith(req[0]) and line.endswith(req[1])

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -65,8 +65,7 @@ class TestWeb(object):
         return lines
 
     def normalise_generated(self, s):
-        serverdir = path(
-            omero.cli.__file__).dirname().dirname().dirname().dirname()
+        serverdir = self.cli.dir
         s = re.sub('\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}',
                    '0000-00-00 00:00:00.000000', s)
         s = s.replace(serverdir, '/home/omero/OMERO.server')


### PR DESCRIPTION
This should make it easier to review the effects of any future config changes.

Reference configs exist for each web-server with defaults, and each web-server with all options together. Combinations of options continue to be tested by the existing tests.