### PR TITLE
Mark broken tests as xfail until hibernate update.

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -886,7 +886,7 @@ class TestPermissionProjections(lib.ITest):
             expected_arr.append(expected)
         assert expected_arr == found_arr
 
-    @pytest.mark.broken(ticket="12474")
+    @pytest.mark.xfail(ticket="12474")
     @pytest.mark.parametrize("fixture", lib.PFS,
                              ids=[x.get_name() for x in lib.PFS])
     def testProjectionPermissions(self, fixture):


### PR DESCRIPTION
This is a trivial PR that shouldn't need review. Its aim is to tidy the results of https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-broken/ where the number of fails (and passes) of should drop, fewer tests run. The number of tests run in https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-python/ will increase but there should be no extra fails due to this PR.

--no-rebase