### PR TITLE
Fix gateway test helpers to point at downloads.openmicroscopy.org (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -14,7 +14,7 @@ from types import StringTypes
 from path import path
 
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
-TESTIMG_URL = 'http://users.openmicroscopy.org.uk/~cneves-x/'
+TESTIMG_URL = 'http://downloads.openmicroscopy.org/images/gateway_tests/'
 DEFAULT_GROUP_PERMS = 'rwr---'
 
 if not omero.gateway.BlitzGateway.ICE_CONFIG:

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
@@ -31,13 +31,20 @@ dbhelpers.DATASETS = {
 }
 
 dbhelpers.IMAGES = {
-    'testimg1' : dbhelpers.ImageEntry('weblitz_test_priv_image', 'imgs/CHOBI_d3d.dv', 'testds1'),
-    'testimg2' : dbhelpers.ImageEntry('weblitz_test_priv_image2', 'imgs/CHOBI_d3d.dv', 'testds1'),
-    'tinyimg' : dbhelpers.ImageEntry('weblitz_test_priv_image_tiny', 'imgs/tinyTest.d3d.dv', 'testds1'),
-    'badimg' : dbhelpers.ImageEntry('weblitz_test_priv_image_bad', False, 'testds1'),
-    'tinyimg2' : dbhelpers.ImageEntry('weblitz_test_priv_image_tiny2', 'imgs/tinyTest.d3d.dv', 'testds2'),
-    'tinyimg3' : dbhelpers.ImageEntry('weblitz_test_priv_image_tiny3', 'imgs/tinyTest.d3d.dv', 'testds3'),
-    'bigimg' : dbhelpers.ImageEntry('weblitz_test_priv_image_big', 'imgs/big.tiff', 'testds3'),
+    'testimg1': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image', 'CHOBI_d3d.dv', 'testds1'),
+    'testimg2': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image2', 'CHOBI_d3d.dv', 'testds1'),
+    'tinyimg': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_tiny', 'tinyTest.d3d.dv', 'testds1'),
+    'badimg': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_bad', False, 'testds1'),
+    'tinyimg2': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_tiny2', 'tinyTest.d3d.dv', 'testds2'),
+    'tinyimg3': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_tiny3', 'tinyTest.d3d.dv', 'testds3'),
+    'bigimg': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_big', 'big.tiff', 'testds3'),
 }
 
 


### PR DESCRIPTION

This is the same as gh-3533 but rebased onto dev_5_0.

----

This PR removes the need for a personal URL as the necessary files are made public.

To test it, check the gateway tests still pass.

                