### PR TITLE
OMERO.web default listen IP

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
@@ -69,7 +69,7 @@ RewriteEngine on
     Require all granted
 </Directory>
 
-<Location fcgi://0.0.0.0:4080/>
+<Location fcgi://0.0.0.0:12345/>
     Require all granted
 </Location>
 
@@ -83,6 +83,6 @@ Alias /test-static /home/omero/OMERO.server/lib/python/omeroweb/static
 RewriteCond %{REQUEST_URI} !^(/test-static|/test.fcgi|/test/error)
 RewriteRule ^/test(/|$)(.*) /test.fcgi/$2 [PT]
 SetEnvIf Request_URI . proxy-fcgi-pathinfo=1
-ProxyPass /test.fcgi/ fcgi://0.0.0.0:4080/
+ProxyPass /test.fcgi/ fcgi://0.0.0.0:12345/
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
@@ -69,7 +69,7 @@ RewriteEngine on
     Require all granted
 </Directory>
 
-<Location fcgi://0.0.0.0:4080/>
+<Location fcgi://127.0.0.1:4080/>
     Require all granted
 </Location>
 
@@ -83,6 +83,6 @@ Alias /static /home/omero/OMERO.server/lib/python/omeroweb/static
 RewriteCond %{REQUEST_URI} !^(/static|/.fcgi|/error)
 RewriteRule ^(/|$)(.*) /.fcgi/$2 [PT]
 SetEnvIf Request_URI . proxy-fcgi-pathinfo=1
-ProxyPass /.fcgi/ fcgi://0.0.0.0:4080/
+ProxyPass /.fcgi/ fcgi://127.0.0.1:4080/
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
@@ -54,7 +54,7 @@
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:12345 -idle-timeout 60
 
 <Directory "/home/omero/OMERO.server/var">
     Options -Indexes FollowSymLinks

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
@@ -54,7 +54,7 @@
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:4080 -idle-timeout 60
+FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 127.0.0.1:4080 -idle-timeout 60
 
 <Directory "/home/omero/OMERO.server/var">
     Options -Indexes FollowSymLinks

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
@@ -46,7 +46,7 @@ http {
 
             error_page 502 @maintenance;
 
-            fastcgi_pass 0.0.0.0:4080;
+            fastcgi_pass 0.0.0.0:12345;
 
             fastcgi_split_path_info ^(/test)(.*)$;
             fastcgi_param PATH_INFO $fastcgi_path_info;

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
@@ -46,7 +46,7 @@ http {
 
             error_page 502 @maintenance;
 
-            fastcgi_pass 0.0.0.0:4080;
+            fastcgi_pass 127.0.0.1:4080;
 
             fastcgi_param PATH_INFO $fastcgi_script_name;
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
@@ -20,7 +20,7 @@
 
             error_page 502 @maintenance;
 
-            fastcgi_pass 0.0.0.0:4080;
+            fastcgi_pass 0.0.0.0:12345;
 
             fastcgi_split_path_info ^(/test)(.*)$;
             fastcgi_param PATH_INFO $fastcgi_path_info;

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
@@ -20,7 +20,7 @@
 
             error_page 502 @maintenance;
 
-            fastcgi_pass 0.0.0.0:4080;
+            fastcgi_pass 127.0.0.1:4080;
 
             fastcgi_param PATH_INFO $fastcgi_script_name;
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -344,7 +344,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "Available options \"fastcgi\" / \"fastcgi-tcp\"")],
     "omero.web.application_server.host":
         ["APPLICATION_SERVER_HOST",
-         "0.0.0.0",
+         "127.0.0.1",
          str,
          "Upstream application host"],
     "omero.web.application_server.port":


### PR DESCRIPTION
Change the OMERO.web fastcgi workers to listen on 127.0.0.1 by default instead of 0.0.0.0 (all interfaces including public ones).

https://trello.com/c/aRDoP7dC/355-omero-web-startup-review-default-ip

Testing: Regenerate nginx/apache-2.2/apache-2.4 web configs and check everything works.
Also check you can't connect to the app server (defaults to listening on port 4080) other than from localhost.

--norebase