### PR TITLE
Email cli

### DIFF
--- a/components/blitz/src/omero/cmd/mail/SendEmailRequestI.java
+++ b/components/blitz/src/omero/cmd/mail/SendEmailRequestI.java
@@ -183,21 +183,26 @@ public class SendEmailRequestI extends SendEmailRequest implements IRequest {
                     .getSecurityRoles().getUserGroupId());
         }
 
-        if (groupIds.size() > 0) {
-            sql.append(" and e.id in ");
-            sql.append(" (select m.child from GroupExperimenterMap m "
-                    + " where m.parent.id in (:gids) )");
-            p.addSet("gids", new HashSet<Long>(groupIds));
-        }
+        if (!everyone) {
 
-        if (userIds.size() > 0) {
-            if (groupIds.size() > 0)
-                sql.append(" or ");
-            else
-                sql.append(" and ");
+            if (groupIds.size() > 0) {
+                sql.append(" and e.id in ");
+                sql.append(" (select m.child from GroupExperimenterMap m "
+                        + " where m.parent.id in (:gids) )");
+                p.addSet("gids", new HashSet<Long>(groupIds));
+            }
 
-            sql.append(" e.id in (:eids)");
-            p.addSet("eids", new HashSet<Long>(userIds));
+            if (userIds.size() > 0) {
+                if (groupIds.size() > 0) {
+                    sql.append(" or ");
+                } else {
+                    sql.append(" and ");
+                }
+
+                sql.append(" e.id in (:eids)");
+                p.addSet("eids", new HashSet<Long>(userIds));
+            }
+
         }
 
         IQuery iquery = helper.getServiceFactory().getQueryService();

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -790,29 +790,6 @@ class BaseControl(object):
                 subcommands.append(format(choice))
         return subcommands
 
-    def add_user_and_group_arguments(self, parser, *args,
-                                     **kwargs):
-
-        group = parser
-        try:
-            if kwargs.pop("exclusive"):
-                group = parser.add_mutually_exclusive_group()
-        except:
-            pass
-
-        group.add_argument("--user-id",
-                           help="ID of the user.",
-                           *args, **kwargs)
-        group.add_argument("--user-name",
-                           help="Name of the user.",
-                           *args, **kwargs)
-        group.add_argument("--group-id",
-                           help="ID of the group.",
-                           *args, **kwargs)
-        group.add_argument("--group-name",
-                           help="Name of the group.",
-                           *args, **kwargs)
-
     ###############################################
     #
     # Methods likely to be implemented by subclasses
@@ -2092,6 +2069,29 @@ class UserGroupControl(BaseControl):
             "--name", help="Name of the %s" % objtype)
         return group
 
+    def add_user_and_group_arguments(self, parser, *args,
+                                     **kwargs):
+
+        group = parser
+        try:
+            if kwargs.pop("exclusive"):
+                group = parser.add_mutually_exclusive_group()
+        except:
+            pass
+
+        group.add_argument("--user-id",
+                           help="ID of the user.",
+                           *args, **kwargs)
+        group.add_argument("--user-name",
+                           help="Name of the user.",
+                           *args, **kwargs)
+        group.add_argument("--group-id",
+                           help="ID of the group.",
+                           *args, **kwargs)
+        group.add_argument("--group-name",
+                           help="Name of the group.",
+                           *args, **kwargs)
+
     def add_user_arguments(self, parser, action=""):
         group = parser.add_argument_group('User arguments')
         group.add_argument("user_id_or_name",  metavar="user", nargs="*",
@@ -2208,3 +2208,37 @@ class UserGroupControl(BaseControl):
                 g_list.append(g)
 
         return gid_list, g_list
+
+    def get_users_groups(self, args, iadmin):
+        users = []
+        groups = []
+
+        if args.user_name:
+            for user_name in args.user_name:
+                uid, u = self.find_user_by_name(
+                    iadmin, user_name, fatal=False)
+                if uid is not None:
+                    users.append(uid)
+
+        if args.user_id:
+            for user_id in args.user_id:
+                uid, u = self.find_user_by_id(
+                    iadmin, user_id, fatal=False)
+                if uid is not None:
+                    users.append(uid)
+
+        if args.group_name:
+            for group_name in args.group_name:
+                gid, g = self.find_group_by_name(
+                    iadmin, group_name, fatal=False)
+                if gid is not None:
+                    groups.append(gid)
+
+        if args.group_id:
+            for group_id in args.group_id:
+                gid, g = self.find_group_by_id(
+                    iadmin, group_id, fatal=False)
+                if gid is not None:
+                    groups.append(gid)
+
+        return users, groups

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -790,6 +790,29 @@ class BaseControl(object):
                 subcommands.append(format(choice))
         return subcommands
 
+    def add_user_and_group_arguments(self, parser, *args,
+                                     **kwargs):
+
+        group = parser
+        try:
+            if kwargs.pop("exclusive"):
+                group = parser.add_mutually_exclusive_group()
+        except:
+            pass
+
+        group.add_argument("--user-id",
+                           help="ID of the user.",
+                           *args, **kwargs)
+        group.add_argument("--user-name",
+                           help="Name of the user.",
+                           *args, **kwargs)
+        group.add_argument("--group-id",
+                           help="ID of the group.",
+                           *args, **kwargs)
+        group.add_argument("--group-name",
+                           help="Name of the group.",
+                           *args, **kwargs)
+
     ###############################################
     #
     # Methods likely to be implemented by subclasses

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1373,7 +1373,7 @@ OMERO Diagnostics %s
                 ))
             if rsp.invalidusers:
                 self.ctx.out(
-                    "%s users had no email addresses" % len(
+                    "%s users had no email address" % len(
                         rsp.invalidusers)
                 )
             if rsp.invalidemails:

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -29,12 +29,14 @@ from omero.cli import CLI
 from omero.cli import DirectoryType
 from omero.cli import NonZeroReturnCode
 from omero.cli import VERSION
+from omero.cli import UserGroupControl
 
 from omero.plugins.prefs import \
     WriteableConfigControl, with_config, with_rw_config
 
 from omero_ext import portalocker
 from omero_ext.which import whichall
+from omero_ext.argparse import FileType
 from omero_version import ice_compatibility
 
 try:
@@ -65,7 +67,7 @@ Configuration properties:
 """ + "\n" + "="*50 + "\n"
 
 
-class AdminControl(WriteableConfigControl):
+class AdminControl(WriteableConfigControl, UserGroupControl):
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -158,6 +160,49 @@ already be running. This may automatically restart some server components.""")
         diagnostics.add_argument(
             "--no-logs", action="store_true",
             help="Skip log parsing")
+
+        email = Action(
+            "email",
+            """Send administrative emails to users.
+
+Administrators can contact OMERO users and groups of
+users based on configured email settings.
+
+Examples:
+
+  # Send the contents of a file to everyone
+  bin/omero admin email --everyone Subject < some_file.text
+
+  # Contact a single group
+  bin/omero admin email --group-name system Subject short message
+
+  # Contact a list of users
+  bin/omero admin email --user-id 10 \\
+                        --user-name ralph \\
+                        Subject ...
+
+  # Include inactive users in the email
+  bin/omero admin email --inactive ...
+
+
+            """).parser
+        email.add_argument(
+            "subject",
+            help="Required subject for the mail")
+        email.add_argument(
+            "text", nargs="*",
+            help=("All further arguments are combined "
+                  "to form the body. stdin if none or '-' "
+                  "is given."))
+        email.add_argument(
+            "--everyone", action="store_true",
+            help="Contact everyone in the system.")
+        email.add_argument(
+            "--inactive", action="store_true",
+            help="Contact inactive users.")
+        self.add_user_and_group_arguments(email,
+                                          action="append",
+                                          exclusive=False)
 
         Action(
             "jvmcfg",
@@ -1251,6 +1296,93 @@ OMERO Diagnostics %s
             WebControl().status(args)
         except:
             self.ctx.out("OMERO.web not installed!")
+
+    def get_users_groups(self, args, iadmin):
+        users = []
+        groups = []
+
+        if args.user_name:
+            for user_name in args.user_name:
+                uid, u = self.find_user_by_name(
+                    iadmin, user_name, fatal=False)
+                if uid is not None:
+                    users.append(uid)
+
+        if args.user_id:
+            for user_id in args.user_id:
+                uid, u = self.find_user_by_id(
+                    iadmin, user_id, fatal=False)
+                if uid is not None:
+                    users.append(uid)
+
+        if args.group_name:
+            for group_name in args.group_name:
+                gid, g = self.find_group_by_name(
+                    iadmin, group_name, fatal=False)
+                if gid is not None:
+                    groups.append(gid)
+
+        if args.group_id:
+            for group_id in args.group_id:
+                gid, g = self.find_group_by_id(
+                    iadmin, group_id, fatal=False)
+                if gid is not None:
+                    groups.append(gid)
+
+        return users, groups
+
+    def email(self, args):
+        client = self.ctx.conn(args)
+        iadmin = client.sf.getAdminService()
+        users, groups = self.get_users_groups(args, iadmin)
+
+        if not args.text:
+            args.text = ("-")
+
+        text = " ".join(args.text)
+        if text == "-":
+            stdin = FileType("r")("-")
+            text = stdin.read()
+
+        req = omero.cmd.SendEmailRequest(
+            subject=args.subject,
+            body=text,
+            userIds=users,
+            groupIds=groups,
+            everyone=args.everyone,
+            inactive=args.inactive)
+
+        try:
+            cb = client.submit(
+                req, loops=10, ms=500,
+                failonerror=True, failontimeout=True)
+        except omero.CmdError, ce:
+            err = ce.err
+            if err.name == "no-body" and err.parameters:
+                sb = err.parameters.items()
+                sb = ["%s:%s" % (k, v) for k, v in sb]
+                sb = "\n".join(sb)
+                self.ctx.die(12, sb)
+            self.ctx.die(13, "Failed to send emails:\n%s" % err)
+
+        try:
+            rsp = cb.getResponse()
+            self.ctx.out(
+                "Successfully sent %s of %s emails" % (
+                    rsp.success, rsp.total
+                ))
+            if rsp.invalidusers:
+                self.ctx.out(
+                    "%s users had no email addresses" % len(
+                        rsp.invalidusers)
+                )
+            if rsp.invalidemails:
+                self.ctx.out(
+                    "%s email addresses were invalid" % len(
+                        rsp.invalidemails)
+                )
+        finally:
+            cb.close(True)
 
     def getdirsize(self, directory):
         total = 0

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1297,40 +1297,6 @@ OMERO Diagnostics %s
         except:
             self.ctx.out("OMERO.web not installed!")
 
-    def get_users_groups(self, args, iadmin):
-        users = []
-        groups = []
-
-        if args.user_name:
-            for user_name in args.user_name:
-                uid, u = self.find_user_by_name(
-                    iadmin, user_name, fatal=False)
-                if uid is not None:
-                    users.append(uid)
-
-        if args.user_id:
-            for user_id in args.user_id:
-                uid, u = self.find_user_by_id(
-                    iadmin, user_id, fatal=False)
-                if uid is not None:
-                    users.append(uid)
-
-        if args.group_name:
-            for group_name in args.group_name:
-                gid, g = self.find_group_by_name(
-                    iadmin, group_name, fatal=False)
-                if gid is not None:
-                    groups.append(gid)
-
-        if args.group_id:
-            for group_id in args.group_id:
-                gid, g = self.find_group_by_id(
-                    iadmin, group_id, fatal=False)
-                if gid is not None:
-                    groups.append(gid)
-
-        return users, groups
-
     def email(self, args):
         client = self.ctx.conn(args)
         iadmin = client.sf.getAdminService()

--- a/components/tools/OmeroPy/src/omero/plugins/ldap.py
+++ b/components/tools/OmeroPy/src/omero/plugins/ldap.py
@@ -92,13 +92,6 @@ to users.""")
         for x in (active, list, getdn, setdn, discover, create):
             x.add_login_arguments()
 
-    def add_user_and_group_arguments(self, parser):
-        group = parser.add_mutually_exclusive_group()
-        group.add_argument("--user-id", help="ID of the user.")
-        group.add_argument("--user-name", help="Name of the user.")
-        group.add_argument("--group-id", help="ID of the group.")
-        group.add_argument("--group-name", help="Name of the group.")
-
     @admin_only
     def active(self, args):
         c = self.ctx.conn(args)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -528,11 +528,12 @@ omero.mail.bean=defaultMailSender
 # Enable or disable mail sender (`true` or `false`).
 omero.mail.config=false
 # the email address used for the "from" field
-omero.mail.from=
+omero.mail.from=omero@${omero.mail.host}
 # the hostname of smtp server
-omero.mail.host=smtp.domain
-# the port of smtp server 
+omero.mail.host=localhost
+# the port of smtp server
 omero.mail.port=25
+
 # the user name to connect to the smtp server (if required; can be empty)
 omero.mail.username=
 # the password to connect to the smtp server (if required; can be empty)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -548,7 +548,7 @@ omero.mail.smtp.connectiontimeout=60000
 omero.mail.smtp.starttls.enable=false
 omero.mail.smtp.socketFactory.class=javax.net.SocketFactory
 omero.mail.smtp.socketFactory.fallback=false
-omero.mail.smtp.socketFactory.port=25
+omero.mail.smtp.socketFactory.port=${omero.mail.port}
 omero.mail.smtp.timeout=60000
 
 #############################################


### PR DESCRIPTION
Implements a simple `bin/omero admin email` command to make use of @aleksandra-tarkowska's `SendEmailRequest` command. This also slightly changes the behavior of the `everyone` flag, allowing it to be passed when groups & users are passed.

cc: @sbesson @ximenesuk @pwalczysko @kennethgillen @aleksandra-tarkowska 