### PR TITLE
Don't change group on web logout

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -287,11 +287,6 @@ def logout(request, conn=None, **kwargs):
     """ Logout of the session and redirects to the homepage (will redirect to login first) """
 
     if request.method == "POST":
-        if request.session.get('active_group') is not None:
-            try:
-                conn.setDefaultGroup(request.session.get('active_group'))
-            except:
-                logger.error('Exception during logout.', exc_info=True)
         try:
             try:
                 conn.seppuku()


### PR DESCRIPTION
From: https://trello.com/c/GkdpN8wD/311-rfe-change-default-group-to-active-group-in-uis

To test:
 - Browse to different group data in web, then logout. See that when you log in again you back to your Default group and this isn't changed on logout.
 - Can also confirm this by changing default group in user settings.