### PR TITLE
Image viewer projection fixes

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -829,7 +829,7 @@
               <!-- multiselect hidden for big images in jquery-plugin-viewportImage.js -->
             <div class="multiselect selected">
               Normal
-              <input type="radio" value="normal" name="wblitz-proj" onclick="return setProjection(this);" />
+              <input type="radio" value="normal" name="wblitz-proj" checked onclick="return setProjection(this);" />
             </div>
             <div class="multiselect">
               Max Intensity

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -241,10 +241,7 @@
       // disable line-plot for max projection, split-view etc
       $('#wblitz-lp-enable').prop('disabled', p != 'normal');
       //$('#wblitz-channels-box button').prop('disabled', p == 'split');
-      var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
-      $('[name="wblitz-proj"][value=intmax]').prop('disabled', disable_intmax);
     }
-
     //nosync || syncRDCW(viewport);
   };
 
@@ -1032,6 +1029,11 @@
       if ($.inArray(viewport.loadedImg.meta.pixelsType, ["float", "double"]) > -1) {
         $("#rdef-fullrange-btn").attr("disabled", "disabled");
       }
+
+      // disable 'Max Intensity' projection for single-Z images
+      var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
+      $('[name="wblitz-proj"][value=intmax]').prop('disabled', disable_intmax);
+
     });
 
     // 'Color' checkbox to left of image


### PR DESCRIPTION
A couple of minor fixes, including http://trac.openmicroscopy.org.uk/ome/ticket/12758

To test:
 - Open the web image viewer. The "Normal" projection radio button should be checked.
 - For single Z-plane images, the "Max Intensity" projection should be disabled (also check it's not disabled in Z-stack images).