### PR TITLE
Mapannotation search fixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/AdvancedResultSearchModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/AdvancedResultSearchModel.java
@@ -45,6 +45,7 @@ import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ImageData;
+import pojos.PlateAcquisitionData;
 import pojos.PlateData;
 import pojos.ProjectData;
 import pojos.ScreenData;
@@ -100,6 +101,9 @@ public class AdvancedResultSearchModel extends DataBrowserModel {
         displays.addAll(createDisplays(results.getDataObjects(-1,
                 PlateData.class)));
         
+        displays.addAll(createDisplays(results.getDataObjects(-1,
+                PlateAcquisitionData.class)));
+        
         List<DataObject> imgs = results.getDataObjects(-1, ImageData.class);
         List<ImageDisplay> imgNodes = createDisplays(imgs);
         displays.addAll(imgNodes);
@@ -133,7 +137,8 @@ public class AdvancedResultSearchModel extends DataBrowserModel {
             } else if (dataObj instanceof ProjectData
                     || dataObj instanceof DatasetData
                     || dataObj instanceof ScreenData
-                    || dataObj instanceof PlateData) {
+                    || dataObj instanceof PlateData
+                    || dataObj instanceof PlateAcquisitionData) {
                 d = new ImageSet("", dataObj);
             }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchComponent.java
@@ -283,7 +283,7 @@ public class SearchComponent
 	{
 		firePropertyChange(CANCEL_SEARCH_PROPERTY,
 				Boolean.valueOf(false), Boolean.valueOf(true));
-		setSearchEnabled(false);
+		setSearchEnabled(-1);
 	}
 	
 	/** Sets the default contexts. */
@@ -479,17 +479,19 @@ public class SearchComponent
 		return groupsContext; 
 	}
 	
-	/**
-	 * Sets the buttons enabled when performing  search.
-	 * 
-	 * @param b Pass <code>true</code> to enable the {@link #searchButton}, 
-	 * 			<code>false</code>otherwise, and modifies the cursor.
-	 */
-	public void setSearchEnabled(boolean b)
-	{
-		if (b) setSearchEnabled("Searching", b);
-		else setSearchEnabled("", b);
-	}
+    /**
+     * Sets the buttons enabled when performing search.
+     * 
+     * @param resultSize
+     *            Number of results found, pass <code>-1</code> if search still
+     *            in progress
+     */
+    public void setSearchEnabled(int resultSize) {
+        if (resultSize == -1)
+            setSearchEnabled("Searching...", false);
+        else
+            setSearchEnabled(resultSize + " results found", false);
+    }
 	
 	/**
 	 * Sets the buttons enabled when performing  search.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchPanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchPanel.java
@@ -705,7 +705,8 @@ public class SearchPanel extends JPanel {
         Iterator<String> i = terms.iterator();
         while (i.hasNext()) {
             text.append(i.next());
-            text.append(SearchUtil.SPACE_SEPARATOR);
+            if(i.hasNext())
+                text.append(SearchUtil.SPACE_SEPARATOR);
         }
 
         fullTextArea.setText(text.toString());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchResultTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchResultTableModel.java
@@ -38,6 +38,7 @@ import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.GroupData;
 import pojos.ImageData;
+import pojos.PlateAcquisitionData;
 import pojos.PlateData;
 import pojos.ProjectData;
 import pojos.ScreenData;
@@ -202,6 +203,10 @@ public class SearchResultTableModel extends DefaultTableModel {
         else if (obj instanceof PlateData) {
             return IconManager.getInstance().getIcon(IconManager.PLATE);
         }
+        
+        else if (obj instanceof PlateAcquisitionData) {
+            return IconManager.getInstance().getIcon(IconManager.PLATE_ACQUISITION);
+        }
 
         return IconManager.getInstance().getIcon(IconManager.TRANSPARENT);
     }
@@ -244,6 +249,8 @@ public class SearchResultTableModel extends DefaultTableModel {
             name = ((ScreenData) obj).getName();
         } else if (obj instanceof PlateData) {
             name = ((PlateData) obj).getName();
+        } else if (obj instanceof PlateAcquisitionData) {
+            name = ((PlateAcquisitionData) obj).getLabel();
         }
 
         FontMetrics fm = parent.getGraphics().getFontMetrics();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -32,8 +32,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
+
 
 //Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
@@ -53,6 +55,7 @@ import pojos.DoubleAnnotationData;
 import pojos.FileAnnotationData;
 import pojos.ImageData;
 import pojos.LongAnnotationData;
+import pojos.PlateAcquisitionData;
 import pojos.TagAnnotationData;
 import pojos.TermAnnotationData;
 import pojos.TextualAnnotationData;
@@ -254,7 +257,9 @@ class GeneralPaneUI
                 showBrowser = true;
             }
             
-            if((refObject instanceof DatasetData || refObject instanceof FileAnnotationData) && !multi) {
+            if ((refObject instanceof DatasetData
+                    || refObject instanceof FileAnnotationData || refObject instanceof PlateAcquisitionData)
+                    && !multi) {
                 showBrowser = true;
             }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/AdvancedFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/AdvancedFinder.java
@@ -313,7 +313,7 @@ public class AdvancedFinder
 		loader = new AdvancedFinderLoader(this, secCtx, searchContext);
 		loader.load();
 		state = Finder.SEARCH;
-		setSearchEnabled(true);
+		setSearchEnabled(-1);
 	}
 	
 	/**
@@ -472,7 +472,7 @@ public class AdvancedFinder
 	 */
 	public void dispose() 
 	{
-		setSearchEnabled(false);
+		setSearchEnabled(-1);
 		setVisible(false);
 		cancel();
 	}
@@ -508,12 +508,12 @@ public class AdvancedFinder
                 }
                 UserNotifier un = FinderFactory.getRegistry().getUserNotifier();
                 un.notifyError("Search error", msg);
-                setSearchEnabled(false);
+                setSearchEnabled(-1);
                 return;
             }
     
             results = result;
-            setSearchEnabled(false);
+            setSearchEnabled(result.size());
             firePropertyChange(RESULTS_FOUND_PROPERTY, null, results);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5011,6 +5011,10 @@ class OMEROGateway
             
             int batchSize = context.getTypes().size()==1 ? 1000 : context.getTypes().size()*500;
             
+            // if search for Plates automatically include Plate Runs
+            if(context.getTypes().contains(PlateData.class))
+                context.getTypes().add(PlateAcquisitionData.class);
+            
             for (Class<? extends DataObject> type : context.getTypes()) {
                 try {
                     // set general parameters

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5060,8 +5060,13 @@ class OMEROGateway
                         String fields = resolveScopeIdsAsString(context.getScope());
                         String dFrom = from != null ? df.format(from) : null;
                         String dTo = to != null ? df.format(to) : null;
-                        service.byLuceneQueryBuilder(fields, dFrom, dTo, dateType,
-                                context.getQuery(), m);
+                        try {
+                            service.byLuceneQueryBuilder(fields, dFrom, dTo, dateType,
+                                    context.getQuery(), m);
+                        } catch (ApiUsageException e) {
+                            result.setError(AdvancedSearchResultCollection.GENERAL_ERROR);
+                            return result;
+                        }
                     } else {
                         // have to build lucene query client side for versions pre 5.0.3
                         String query = LuceneQueryBuilder.buildLuceneQuery(

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.OmeroDataServiceImpl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -707,7 +707,7 @@ class OmeroDataServiceImpl
 		        else {
 		            types = context.getTypes();
 		        }
-		        for(Class<? extends DataObject> type : context.getTypes()) {
+		        for(Class<? extends DataObject> type : types) {
 		            AdvancedSearchResult res = new AdvancedSearchResult();
 		            res.setObjectId(id);
 		            res.setType(type);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -840,12 +840,18 @@ class OmeroDataServiceImpl
 			else if (WellSampleData.class.equals(type) ||
 					WellData.class.equals(type))
 				parentClass = Plate.class;
+			else if (PlateAcquisitionData.class.equals(type))
+                parentClass = Plate.class;
 			if (parentClass == null) return new HashSet();
 			List links = gateway.findLinks(ctx, parentClass, id, userID);
 			if (ImageData.class.equals(type) && (links == null ||
 					links.size() == 0)) {
 				return gateway.findPlateFromImage(ctx, id, userID);
 			}
+			if (PlateAcquisitionData.class.equals(type) && (links == null ||
+                    links.size() == 0)) {
+                return gateway.findPlateFromRun(ctx, id, userID);
+            }
 			if (links == null) return new HashSet();
 			Iterator i = links.iterator();
 			Set<DataObject> nodes = new HashSet<DataObject>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.Map.Entry;
 
-
 //Third-party libraries
 
 
@@ -64,6 +63,8 @@ import omero.model.MapAnnotationI;
 import omero.model.Namespace;
 import omero.model.Pixels;
 import omero.model.Plate;
+import omero.model.PlateAcquisition;
+import omero.model.PlateAcquisitionI;
 import omero.model.PlateI;
 import omero.model.Project;
 import omero.model.ProjectI;
@@ -92,6 +93,7 @@ import pojos.ImageData;
 import pojos.LongAnnotationData;
 import pojos.MapAnnotationData;
 import pojos.PixelsData;
+import pojos.PlateAcquisitionData;
 import pojos.PlateData;
 import pojos.ProjectData;
 import pojos.ROIData;
@@ -192,6 +194,8 @@ public class PojoMapper
         	return new ScreenData((Screen) object);
         else if (object instanceof Plate)
         	return new PlateData((Plate) object);
+        else if (object instanceof PlateAcquisition)
+            return new PlateAcquisitionData((PlateAcquisition) object);
         else if (object instanceof Well)
         	return new WellData((Well) object);
         else if (object instanceof WellSample)
@@ -444,6 +448,9 @@ public class PojoMapper
             else if (nodeType.equals(Plate.class) ||
                     nodeType.equals(PlateData.class))
                 return PlateI.class.getName();
+            else if (nodeType.equals(PlateAcquisition.class) ||
+                    nodeType.equals(PlateAcquisitionData.class))
+                return PlateAcquisitionI.class.getName();
             throw new IllegalArgumentException("type not supported");
     }
 }

--- a/components/server/src/ome/services/fulltext/FullTextBridge.java
+++ b/components/server/src/ome/services/fulltext/FullTextBridge.java
@@ -382,6 +382,8 @@ public class FullTextBridge extends BridgeHelper {
                 if (nv != null) {
                     add(document, nv.getName(), nv.getValue(), opts);
                     add(document, "has_key", nv.getName(), opts);
+                    add(document, "annotation", nv.getValue(), opts);
+                    add(document, "annotation", nv.getName(), opts);
                 }
             }
         }

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -300,7 +300,8 @@ omero.search.max_partition_size=1000000
 # options but may need to be expanded for
 # custom search bridges.
 omero.search.include_types=ome.model.core.Image,ome.model.containers.Project,\
-ome.model.containers.Dataset,ome.model.screen.Plate,ome.model.screen.Screen
+ome.model.containers.Dataset,ome.model.screen.Plate,ome.model.screen.Screen,\
+ome.model.screen.PlateAcquisition
 
 # EventLog.action values which will be indexed.
 # Unless custom code is generating other action


### PR DESCRIPTION
Fixes the blockers discovered in todays testing session, see [GDoc](https://docs.google.com/spreadsheets/d/1nPQbPov8dwIlHswGey0K779JirYsjdEg2CKK5khtI9w/edit#gid=1171413927)

Test:
- Search for a MapAnnotation key or value, when the checkbox "Annotation" is ticked (before: no results)
- Enter an invalid expression, e. g. a term with two colons asdf:123:asdf. You should see a message dialog, saying that the search expression is invalid (before: default crash/error dialog popped up)
- Enter something in the search field in the main toolbar, hit enter. The search panel on the left should open and show the same what you've entered in the main toolbar without a trailing space.
- Annotate a plate run and then search for it (before: plate runs were ignored)
- Check that the number of search results found, is shown (beneath the search button, after search has finished)

/cc @pwalczysko 

--no-rebase
