### PR TITLE
Have disk usage give an error message when a bad class name is given

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
+++ b/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
@@ -464,7 +464,7 @@ public class CheckedPath {
             return true;
         if (!(object instanceof CheckedPath))
             return false;
-        return this.fsFile.equals(((CheckedPath) object).fsFile);
+        return this.file.equals(((CheckedPath) object).file);
     }
 
     /**
@@ -472,6 +472,6 @@ public class CheckedPath {
      */
     @Override
     public int hashCode() {
-        return this.fsFile.hashCode() * 98;
+        return this.file.hashCode() * 98;
     }
 }

--- a/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
+++ b/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
@@ -457,6 +457,7 @@ public class CheckedPath {
     /**
      * {@inheritDoc}
      * Instances are equal if their string representations match.
+     * On Windows systems the comparison is not case-sensitive.
      */
     @Override
     public boolean equals(Object object) {
@@ -469,6 +470,7 @@ public class CheckedPath {
 
     /**
      * {@inheritDoc}
+     * On Windows systems the calculation is not case-sensitive.
      */
     @Override
     public int hashCode() {

--- a/components/blitz/src/omero/cmd/Helper.java
+++ b/components/blitz/src/omero/cmd/Helper.java
@@ -281,7 +281,7 @@ public class Helper {
      * Like {@link #fail(ERR, String, String...)} throws a
      * {@link Cancel} exception.
      *
-     * A {@link Cancel} is thrown, even though one is also specificed as the
+     * A {@link Cancel} is thrown, even though one is also specified as the
      * return value. This permits:
      * <pre>
      * } catch (Throwable t) {

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -249,7 +249,7 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(DiskUsageI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        return new DiskUsageI(pixelsService, thumbnailService);
+                        return new DiskUsageI(pixelsService, thumbnailService, graphRequestFactory.getGraphPathBean());
                     }
                 });
         factories.put(SendEmailRequestI.ice_staticId(),

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -113,7 +113,8 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
         /* check that the user is a member of the destination group */
         final EventContext eventContext = helper.getEventContext();
         if (!(eventContext.isCurrentUserAdmin() || eventContext.getMemberOfGroupsList().contains(groupId))) {
-            throw helper.cancel(new ERR(), new IllegalArgumentException(), "not a member of the chgrp destination group");
+            final Exception e = new IllegalArgumentException("not a member of the chgrp destination group");
+            throw helper.cancel(new ERR(), e, "not-in-group");
         }
 
         final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
@@ -172,14 +173,15 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                 graphTraversal.processTargets();
                 return null;
             default:
-                throw helper.cancel(new ERR(), new IllegalArgumentException(), "model object graph operation has no step " + step);
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
             }
         } catch (GraphException ge) {
             final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
             graphERR.message = ge.message;
-            throw helper.cancel(graphERR, ge, "model object graph operation failed");
+            throw helper.cancel(graphERR, ge, "graph-fail");
         } catch (Throwable t) {
-            throw helper.cancel(new ERR(), t, "model object graph operation failed");
+            throw helper.cancel(new ERR(), t, "graph-fail");
         }
     }
 
@@ -198,7 +200,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                 try {
                     deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
                 } catch (Exception e) {
-                    helper.cancel(new ERR(), e, "file deletion error");
+                    helper.cancel(new ERR(), e, "file-delete-fail");
                 }
             }
             final Map<String, List<Long>> movedObjects = new HashMap<String, List<Long>>();

--- a/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
@@ -95,8 +95,9 @@ public class ChgrpFacadeI extends Chgrp implements IRequest {
         actualChgrp.groupId = grp;
         try {
             GraphUtil.translateOptions(graphRequestFactory, options, actualChgrp, helper.getEventContext().isCurrentUserAdmin());
-        } catch (GraphException e) {
-            throw helper.cancel(new ERR(), new IllegalArgumentException(), "could not accept request options");
+        } catch (GraphException ge) {
+            final Exception e = new IllegalArgumentException("could not accept request options");
+            throw helper.cancel(new ERR(), e, "bad-options");
         }
         /* check for root-anchored subgraph */
         final int lastSlash = type.lastIndexOf('/');

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -170,14 +170,15 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                 graphTraversal.processTargets();
                 return null;
             default:
-                throw helper.cancel(new ERR(), new IllegalArgumentException(), "model object graph operation has no step " + step);
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
             }
         } catch (GraphException ge) {
             final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
             graphERR.message = ge.message;
-            throw helper.cancel(graphERR, ge, "model object graph operation failed");
+            throw helper.cancel(graphERR, ge, "graph-fail");
         } catch (Throwable t) {
-            throw helper.cancel(new ERR(), t, "model object graph operation failed");
+            throw helper.cancel(new ERR(), t, "graph-fail");
         }
     }
 
@@ -196,7 +197,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                 try {
                     deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
                 } catch (Exception e) {
-                    helper.cancel(new ERR(), e, "file deletion error");
+                    helper.cancel(new ERR(), e, "file-delete-fail");
                 }
             }
             final Map<String, List<Long>> givenObjects = new HashMap<String, List<Long>>();

--- a/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
@@ -95,8 +95,9 @@ public class ChownFacadeI extends Chown implements IRequest {
         actualChown.userId = user;
         try {
             GraphUtil.translateOptions(graphRequestFactory, options, actualChown, helper.getEventContext().isCurrentUserAdmin());
-        } catch (GraphException e) {
-            throw helper.cancel(new ERR(), new IllegalArgumentException(), "could not accept request options");
+        } catch (GraphException ge) {
+            final Exception e = new IllegalArgumentException("could not accept request options");
+            throw helper.cancel(new ERR(), e, "bad-options");
         }
         /* check for root-anchored subgraph */
         final int lastSlash = type.lastIndexOf('/');

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -155,14 +155,15 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                 graphTraversal.processTargets();
                 return null;
             default:
-                throw helper.cancel(new ERR(), new IllegalArgumentException(), "model object graph operation has no step " + step);
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
             }
         } catch (GraphException ge) {
             final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
             graphERR.message = ge.message;
-            throw helper.cancel(graphERR, ge, "model object graph operation failed");
+            throw helper.cancel(graphERR, ge, "graph-fail");
         } catch (Throwable t) {
-            throw helper.cancel(new ERR(), t, "model object graph operation failed");
+            throw helper.cancel(new ERR(), t, "graph-fail");
         }
     }
 
@@ -183,7 +184,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                 try {
                     deletionInstance.deleteFiles(GraphUtil.trimPackageNames(resultDeleted));
                 } catch (Exception e) {
-                    helper.cancel(new ERR(), e, "file deletion error");
+                    helper.cancel(new ERR(), e, "file-delete-fail");
                 }
             }
             final Map<String, List<Long>> deletedObjects = new HashMap<String, List<Long>>();

--- a/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
@@ -97,8 +97,9 @@ public class DeleteFacadeI extends Delete implements IRequest {
         targetObjects.clear();
         try {
             GraphUtil.translateOptions(graphRequestFactory, options, actualDelete, helper.getEventContext().isCurrentUserAdmin());
-        } catch (GraphException e) {
-            throw helper.cancel(new ERR(), new IllegalArgumentException(), "could not accept request options");
+        } catch (GraphException ge) {
+            final Exception e = new IllegalArgumentException("could not accept request options");
+            throw helper.cancel(new ERR(), e, "bad-options");
         }
         /* check for root-anchored subgraph */
         final int lastSlash = type.lastIndexOf('/');

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -79,13 +79,13 @@ public class DiskUsageI extends DiskUsage implements IRequest {
     private static final ImmutableSet<String> OWNED_OBJECTS;
     private static final ImmutableSet<String> ANNOTATABLE_OBJECTS;
 
+    private static final Map<String, String> classIdProperties = Collections.synchronizedMap(new HashMap<String, String>());
+
     private final PixelsService pixelsService;
     private final ThumbnailService thumbnailService;
     private final GraphPathBean graphPathBean;
 
     private Helper helper;
-
-    private final Map<String, String> classIdProperties = new HashMap<String, String>();
 
     /**
      * Construct a disk usage request.

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -45,7 +45,9 @@ import ome.api.IQuery;
 import ome.io.bioformats.BfPyramidPixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.io.nio.ThumbnailService;
+import ome.model.IObject;
 import ome.parameters.Parameters;
+import ome.services.graphs.GraphPathBean;
 import ome.system.Login;
 import omero.api.LongPair;
 import omero.cmd.DiskUsage;
@@ -79,17 +81,22 @@ public class DiskUsageI extends DiskUsage implements IRequest {
 
     private final PixelsService pixelsService;
     private final ThumbnailService thumbnailService;
+    private final GraphPathBean graphPathBean;
 
     private Helper helper;
+
+    private final Map<String, String> classIdProperties = new HashMap<String, String>();
 
     /**
      * Construct a disk usage request.
      * @param pixelsService the pixels service
      * @param thumbnailService the thumbnail service
+     * @param graphPathBean the graph path bean
      */
-    public DiskUsageI(PixelsService pixelsService, ThumbnailService thumbnailService) {
+    public DiskUsageI(PixelsService pixelsService, ThumbnailService thumbnailService, GraphPathBean graphPathBean) {
         this.pixelsService = pixelsService;
         this.thumbnailService = thumbnailService;
+        this.graphPathBean = graphPathBean;
     }
 
     /* NAVIGATION OF MODEL OBJECT GRAPH */
@@ -360,6 +367,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
         }
         try {
             return getDiskUsage();
+        } catch (Cancel c) {
+            throw c;
         } catch (Throwable t) {
             throw helper.cancel(new ERR(), t, "disk usage operation failed");
         }
@@ -423,6 +432,30 @@ public class DiskUsageI extends DiskUsage implements IRequest {
     }
 
     /**
+     * Look up the identifier property for the given class.
+     * @param className a class name
+     * @return the identifier property, never {@code null}
+     * @throws Cancel if an identifier property could not be found for the given class
+     */
+    private String getIdPropertyFor(String className) throws Cancel {
+        String idProperty = classIdProperties.get(className);
+        if (idProperty == null) {
+            final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
+            if (actualClass == null) {
+                throw helper.cancel(new ERR(), new IllegalArgumentException(),
+                        "class " + className + " is unknown");
+            }
+            idProperty = graphPathBean.getIdentifierProperty(actualClass.getName());
+            if (idProperty == null) {
+                throw helper.cancel(new ERR(), new IllegalArgumentException(),
+                        "no identifier property is known for class " + className);
+            }
+            classIdProperties.put(className, idProperty);
+        }
+        return idProperty;
+    }
+
+    /**
      * Calculate the disk usage of the model objects specified in the request.
      * @return the total usage, in bytes
      */
@@ -443,7 +476,7 @@ public class DiskUsageI extends DiskUsage implements IRequest {
         /* note the objects to process */
 
         for (final String className : classes) {
-            final String hql = "SELECT id FROM " + className;
+            final String hql = "SELECT " + getIdPropertyFor(className) + " FROM " + className;
             for (final Object[] resultRow : queryService.projection(hql, null)) {
                 if (resultRow != null) {
                     final Long objectId = (Long) resultRow[0];
@@ -460,6 +493,12 @@ public class DiskUsageI extends DiskUsage implements IRequest {
                 Collections.sort(ids);
                 LOGGER.debug("size calculator to process " + objectList.getKey() + " " + Joiner.on(", ").join(ids));
             }
+        }
+
+        /* check that the objects' class names are valid */
+
+        for (final String className : objectsToProcess.keySet()) {
+            getIdPropertyFor(className);
         }
 
         /* iteratively process objects, descending the model graph */
@@ -487,7 +526,7 @@ public class DiskUsageI extends DiskUsage implements IRequest {
 
             if ("Pixels".equals(className)) {
                 /* Pixels may have /OMERO/Pixels/<id> files */
-                final String hql = "SELECT id, details.owner.id, details.group.id FROM " + className + " WHERE id IN (:ids)";
+                final String hql = "SELECT id, details.owner.id, details.group.id FROM Pixels WHERE id IN (:ids)";
                 for (final Object[] resultRow : queryService.projection(hql, parameters)) {
                     if (resultRow != null) {
                         final Long pixelsId = (Long) resultRow[0];
@@ -502,7 +541,7 @@ public class DiskUsageI extends DiskUsage implements IRequest {
                 }
             } else if ("Thumbnail".equals(className)) {
                 /* Thumbnails may have /OMERO/Thumbnails/<id> files */
-                final String hql = "SELECT id, details.owner.id, details.group.id FROM " + className + " WHERE id IN (:ids)";
+                final String hql = "SELECT id, details.owner.id, details.group.id FROM Thumbnail WHERE id IN (:ids)";
                 for (final Object[] resultRow : queryService.projection(hql, parameters)) {
                     if (resultRow != null) {
                         final Long thumbnailId = (Long) resultRow[0];
@@ -527,7 +566,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
             } else if ("Experimenter".equals(className)) {
                 /* for an experimenter, use the list of owned objects */
                 for (final String resultClassName : OWNED_OBJECTS) {
-                    final String hql = "SELECT id FROM " + resultClassName + " WHERE details.owner.id IN (:ids)";
+                    final String hql = "SELECT " + getIdPropertyFor(resultClassName) + " FROM " + resultClassName +
+                            " WHERE details.owner.id IN (:ids)";
                     for (final Object[] resultRow : queryService.projection(hql, parameters)) {
                         objectsToProcess.put(resultClassName, (Long) resultRow[0]);
                     }
@@ -535,7 +575,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
             } else if ("ExperimenterGroup".equals(className)) {
                 /* for an experimenter group, use the list of owned objects */
                 for (final String resultClassName : OWNED_OBJECTS) {
-                    final String hql = "SELECT id FROM " + resultClassName + " WHERE details.group.id IN (:ids)";
+                    final String hql = "SELECT " + getIdPropertyFor(resultClassName) + " FROM " + resultClassName +
+                            " WHERE details.group.id IN (:ids)";
                     for (final Object[] resultRow : queryService.projection(hql, parameters)) {
                         objectsToProcess.put(resultClassName, (Long) resultRow[0]);
                     }

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -442,13 +442,13 @@ public class DiskUsageI extends DiskUsage implements IRequest {
         if (idProperty == null) {
             final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
             if (actualClass == null) {
-                throw helper.cancel(new ERR(), new IllegalArgumentException(),
-                        "class " + className + " is unknown");
+                final Exception e = new IllegalArgumentException("class " + className + " is unknown");
+                throw helper.cancel(new ERR(), e, "bad-class");
             }
             idProperty = graphPathBean.getIdentifierProperty(actualClass.getName());
             if (idProperty == null) {
-                throw helper.cancel(new ERR(), new IllegalArgumentException(),
-                        "no identifier property is known for class " + className);
+                final Exception e = new IllegalArgumentException("no identifier property is known for class " + className);
+                throw helper.cancel(new ERR(), e, "bad-class");
             }
             classIdProperties.put(className, idProperty);
         }

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -103,6 +103,13 @@ public class GraphRequestFactory {
             LOGGER.warn("substituting Chgrp, Delete requests with Chgrp2, Delete2 requests");
         }
         this.isGraphsWrap = isGraphsWrap;
+    }
+
+    /**
+     * @return the graph path bean used by this instance
+     */
+    public GraphPathBean getGraphPathBean() {
+        return graphPathBean;
     }
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -176,9 +176,10 @@ public class SkipHeadI extends SkipHead implements IRequest {
                         final Class<? extends IObject> targetedClass;
                         try {
                             targetedClass = Class.forName(targetedClassName).asSubclass(IObject.class);
-                        } catch (ClassNotFoundException e) {
-                            throw helper.cancel(new ERR(), new IllegalStateException(),
+                        } catch (ClassNotFoundException cnfe) {
+                            final Exception e = new IllegalStateException(
                                     "response from " + graphRequestSkip.getClass() + " refers to class " + targetedClassName);
+                            throw helper.cancel(new ERR(), e, "bad-class");
                         }
                         if (startFromClass.isAssignableFrom(targetedClass)) {
                             final List<Long> ids = targetedObjectsByClass.getValue();
@@ -198,7 +199,8 @@ public class SkipHeadI extends SkipHead implements IRequest {
                     throw e;
                 }
             } else {
-                throw helper.cancel(new ERR(), new IllegalArgumentException(), "model object graph operation has no step " + step);
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
             }
         }
         return null;

--- a/components/server/src/ome/services/graphs/GraphPathBean.java
+++ b/components/server/src/ome/services/graphs/GraphPathBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -119,6 +119,9 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
     /* which properties are accessible */
     private final Set<Entry<String, String>> accessibleProperties = new HashSet<Entry<String, String>>();
 
+    /* the identifier properties of classes */
+    private final Map<String, String> classIdProperties = new HashMap<String, String>();
+
     /**
      * The application context after refresh should contain a usable Hibernate session factory.
      * If not already done, process the Hibernate domain object model from that bean.
@@ -214,6 +217,9 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
         for (final Entry<String, ClassMetadata> classMetadata : classesMetadata.entrySet()) {
             final String className = classMetadata.getKey();
             final ClassMetadata metadata = classMetadata.getValue();
+            /* note name of identifier property */
+            classIdProperties.put(metadata.getEntityName(), metadata.getIdentifierPropertyName());
+            /* queue other properties */
             final String[] propertyNames = metadata.getPropertyNames();
             final Type[] propertyTypes = metadata.getPropertyTypes();
             final boolean[] propertyNullabilities = metadata.getPropertyNullability();
@@ -434,5 +440,14 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      */
     public boolean isPropertyAccessible(String className, String propertyName) {
         return accessibleProperties.contains(Maps.immutableEntry(className, propertyName));
+    }
+
+    /**
+     * Get the identifier property for the given class.
+     * @param className the name of a class
+     * @return the identifier property, or {@code null} if one is not known
+     */
+    public String getIdentifierProperty(String className) {
+        return classIdProperties.get(className);
     }
 }

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -609,4 +609,15 @@ public class DiskUsageTest extends AbstractServerTest {
         }
         assertMapsEqual(response.totalFileCount, expected);
     }
+
+    /**
+     * Test that a bad class name causes an error response.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testBadClassName() throws Exception {
+        final DiskUsage request = new DiskUsage();
+        request.objects = ImmutableMap.of("NoClass", Collections.singletonList(1L));
+        doChange(client, factory, request, false, null);
+    }
 }


### PR DESCRIPTION
For instance, try `bin/omero fs usage Blah:1`; also check that https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration/DiskUsageTest/ passes.

--no-rebase