### PR TITLE
Initial sketch of the ome.security.policy package

### DIFF
--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -250,6 +250,12 @@ module omero {
        **/
       const int ANNOTATERESTRICTION = 3;
 
+      /**
+       * Extended restriction name which may be applied to images and other
+       * downloadable materials. This string can also be found in the
+       * ome.security.policy.DownloadPolicy class.
+       **/
+      const string DOWNLOAD = "RESTRICT-DOWNLOAD";
     };
 
     module projection {

--- a/components/blitz/resources/omero/api/RawFileStore.ice
+++ b/components/blitz/resources/omero/api/RawFileStore.ice
@@ -18,18 +18,36 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://hudson.openmicroscopy.org.uk/job/OMERO/javadoc/ome/api/RawFileStore.html">RawFileStore.html</a>
+         * Raw file gateway which provides access to the OMERO file repository.
+         *
+         * Note: methods on this service are protected by a "DOWNLOAD" restriction.
+         *
+         * See also <a href="http://hudson.openmicroscopy.org.uk/job/OMERO/javadoc/ome/api/RawFileStore.html">RawFileStore.html</a>
          **/
         ["ami", "amd"] interface RawFileStore extends StatefulServiceInterface
             {
-                idempotent omero::RLong getFileId() throws ServerError;
+
+                /**
+                 * This method manages the state of the service. This method
+                 * will throw a [omero::SecurityViolation] if for the current user
+                 * context either the file is not readable or a
+                 * [omero::constants::permissions:DOWNLOAD] restriction is in
+                 * place.
+                 */
                 void setFileId(long fileId) throws ServerError;
+
+                /**
+                 * Returns the current file id or null if none has been set.
+                 */
+                idempotent omero::RLong getFileId() throws ServerError;
+
                 idempotent Ice::ByteSeq read(long position, int length) throws ServerError;
                 idempotent long size() throws ServerError;
                 idempotent bool truncate(long length) throws ServerError;
                 idempotent void write(Ice::ByteSeq buf, long position, int length) throws ServerError;
                 idempotent bool exists() throws ServerError;
                 idempotent omero::model::OriginalFile save() throws ServerError;
+
             };
     };
 };

--- a/components/common/src/ome/api/RawFileStore.java
+++ b/components/common/src/ome/api/RawFileStore.java
@@ -27,7 +27,9 @@ public interface RawFileStore extends StatefulServiceInterface {
     public Long getFileId();
 
     /**
-     * This method manages the state of the service.
+     * This method manages the state of the service. If the given file
+     * is not considered DOWNLOADABLE, this method will throw a
+     * {@link SecurityViolation}.
      * 
      * @param fileId
      *            an {@link ome.model.core.OriginalFile} id.

--- a/components/server/resources/ome/services/sec-primitives.xml
+++ b/components/server/resources/ome/services/sec-primitives.xml
@@ -71,6 +71,12 @@
 
   <bean id="tokenHolder" class="ome.security.basic.TokenHolder"/>
 
+  <alias name="${omero.security.policy_bean}" alias="policyService"/>
+
+  <bean id="defaultPolicyService" class="ome.security.policy.DefaultPolicyService"/>
+
+  <bean id="RESTRICT-DOWNLOAD" class="ome.security.policy.DownloadPolicy"/>
+
   <bean id="aclVoter" class="ome.security.CompositeACLVoter">
     <constructor-arg ref="currentDetails"/>
     <constructor-arg ref="sharingACLVoter"/>

--- a/components/server/resources/ome/services/sec-system.xml
+++ b/components/server/resources/ome/services/sec-system.xml
@@ -45,6 +45,7 @@
     <constructor-arg ref="internalServiceFactory"/>
     <constructor-arg ref="tokenHolder"/>
     <constructor-arg ref="securityFilterHolder"/>
+    <constructor-arg ref="policyService"/>
   </bean>
 
   <bean id="securityWiring" class="ome.security.basic.BasicSecurityWiring"

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -21,6 +21,7 @@ import ome.model.internal.Details;
 import ome.model.internal.Permissions;
 import ome.model.internal.Token;
 import ome.model.meta.ExperimenterGroup;
+import ome.security.policy.Policy;
 import ome.system.EventContext;
 import ome.system.Principal;
 import ome.system.Roles;
@@ -162,6 +163,17 @@ public interface SecuritySystem {
      * by the {@link SecuritySystem}.
      */
     boolean hasPrivilegedToken(IObject obj);
+
+    /**
+     * Checks whether or not a {@link ome.sercurity.Policy} instance of matching
+     * type and name has been registered, considers itself active, <em>and</em>
+     * considers the passed context object(s) to be restricted.
+     * 
+     * @param policy An instance of the {@link Policy} to be checked.
+     * @throws a {@link SecurityViolation} if the given {@link Policy} is
+     *      considered to be restricted.
+     */
+    void checkRestriction(Policy policy) throws SecurityViolation;
 
     // ~ Subsystem disabling
     // =========================================================================

--- a/components/server/src/ome/security/SecuritySystemHolder.java
+++ b/components/server/src/ome/security/SecuritySystemHolder.java
@@ -13,6 +13,7 @@ import ome.model.IObject;
 import ome.model.internal.Details;
 import ome.model.meta.ExperimenterGroup;
 import ome.security.basic.BasicSecuritySystem;
+import ome.security.policy.Policy;
 import ome.security.sharing.SharingSecuritySystem;
 import ome.system.EventContext;
 import ome.system.Principal;
@@ -98,6 +99,10 @@ public class SecuritySystemHolder implements SecuritySystem {
 
     public boolean hasPrivilegedToken(IObject obj) {
         return choose().hasPrivilegedToken(obj);
+    }
+
+    public void checkRestriction(Policy policy) {
+        choose().checkRestriction(policy);
     }
 
     public boolean isDisabled(String id) {

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -52,6 +52,9 @@ import ome.security.SecurityFilter;
 import ome.security.SecurityFilterHolder;
 import ome.security.SecuritySystem;
 import ome.security.SystemTypes;
+import ome.security.policy.DefaultPolicyService;
+import ome.security.policy.Policy;
+import ome.security.policy.PolicyService;
 import ome.services.messages.EventLogMessage;
 import ome.services.messages.ShapeChangeMessage;
 import ome.services.sessions.SessionManager;
@@ -103,6 +106,8 @@ public class BasicSecuritySystem implements SecuritySystem,
 
     protected final SecurityFilter filter;
 
+    protected final PolicyService policyService;
+
     protected/* final */OmeroContext ctx;
 
     protected/* final */ShareStore store;
@@ -124,7 +129,7 @@ public class BasicSecuritySystem implements SecuritySystem,
                 cd, new OneGroupSecurityFilter(roles),
                 new AllGroupsSecurityFilter(null, roles));
         BasicSecuritySystem sec = new BasicSecuritySystem(oi, st, cd, sm,
-                roles, sf, new TokenHolder(), holder);
+                roles, sf, new TokenHolder(), holder, new DefaultPolicyService());
         return sec;
     }
 
@@ -134,8 +139,10 @@ public class BasicSecuritySystem implements SecuritySystem,
     public BasicSecuritySystem(OmeroInterceptor interceptor,
             SystemTypes sysTypes, CurrentDetails cd,
             SessionManager sessionManager, Roles roles, ServiceFactory sf,
-            TokenHolder tokenHolder, SecurityFilter filter) {
+            TokenHolder tokenHolder, SecurityFilter filter,
+            PolicyService policyService) {
         this.sessionManager = sessionManager;
+        this.policyService = policyService;
         this.tokenHolder = tokenHolder;
         this.interceptor = interceptor;
         this.sysTypes = sysTypes;
@@ -639,6 +646,10 @@ public class BasicSecuritySystem implements SecuritySystem,
      */
     public boolean hasPrivilegedToken(IObject obj) {
         return tokenHolder.hasPrivilegedToken(obj);
+    }
+
+    public void checkRestriction(Policy policy) {
+        
     }
 
     // ~ Configured Elements

--- a/components/server/src/ome/security/policy/BasePolicy.java
+++ b/components/server/src/ome/security/policy/BasePolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Extensible service and security policies which can influence
+ * whether a user, group, or other agent can perform a certain
+ * action.
+ */
+package ome.security.policy;
+
+import ome.conditions.SecurityViolation;
+
+public abstract class BasePolicy implements Policy {
+
+    public abstract String getName();
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void check() {
+        throw new SecurityViolation(getName()+ ":: disallowed.");
+    }
+
+}

--- a/components/server/src/ome/security/policy/DefaultPolicyService.java
+++ b/components/server/src/ome/security/policy/DefaultPolicyService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Extensible service and security policies which can influence
+ * whether a user, group, or other agent can perform a certain
+ * action.
+ */
+package ome.security.policy;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import ome.tools.spring.OnContextRefreshedEventListener;
+
+import org.springframework.context.event.ContextRefreshedEvent;
+
+public class DefaultPolicyService
+    extends OnContextRefreshedEventListener
+    implements PolicyService {
+
+    private final Map<String, Policy> policies = new HashMap<String, Policy>();
+
+    /**
+     * Loads all {@link Policy} instances from the context,
+     * and uses them to initialize this {@link PolicyService}.
+     */
+    @Override
+    public void handleContextRefreshedEvent(ContextRefreshedEvent event) {
+        policies.putAll(
+                event.getApplicationContext()
+                    .getBeansOfType(Policy.class));
+    }
+
+    //
+    // INTERFACE METHODS
+    //
+
+    @Override
+    public boolean isRestricted(String policyName) {
+        if (!policies.containsKey(policyName)) {
+            return false;
+        }
+        return policies.get(policyName).isActive();
+    }
+
+    @Override
+    public void checkRestriction(String policyName) {
+        if (policies.containsKey(policyName)) {
+            policies.get(policyName).check();
+        }
+    }
+
+    @Override
+    public Set<String> listAllRestrictions() {
+        return policies.keySet();
+    }
+
+    @Override
+    public Set<String> listActiveRestrictions() {
+        Set<String> active = new HashSet<String>();
+        for (Map.Entry<String, Policy> entry : policies.entrySet()) {
+            if (entry.getValue().isActive()) {
+                active.add(entry.getKey());
+            }
+        }
+        return active;
+    }
+}

--- a/components/server/src/ome/security/policy/DownloadPolicy.java
+++ b/components/server/src/ome/security/policy/DownloadPolicy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.security.policy;
+
+import ome.model.core.OriginalFile;
+
+
+/**
+ * 
+ *
+ */
+public class DownloadPolicy extends BasePolicy {
+
+    /**
+     * This string can also be found in the Constants.ice file in the
+     * blitz package.
+     */
+    public final static String NAME = "RESTRICT-DOWNLOAD";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    /**
+     * Default constructor which is used to create the context-free
+     * {@link Policy} which performs the actual checks.
+     */
+    public DownloadPolicy() {
+        
+    }
+
+    /**
+     * {@link DownloadPolicy} with a particular file as the context.
+     * @param file
+     */
+    public DownloadPolicy(OriginalFile file) {
+
+    }
+
+}

--- a/components/server/src/ome/security/policy/Policy.java
+++ b/components/server/src/ome/security/policy/Policy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Extensible service and security policies which can influence
+ * whether a user, group, or other agent can perform a certain
+ * action.
+ */
+package ome.security.policy;
+
+public interface Policy {
+
+    String getName();
+
+    boolean isActive();
+
+    void check();
+
+}

--- a/components/server/src/ome/security/policy/PolicyService.java
+++ b/components/server/src/ome/security/policy/PolicyService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Extensible service and security policies which can influence
+ * whether a user, group, or other agent can perform a certain
+ * action.
+ */
+package ome.security.policy;
+
+import java.util.Set;
+
+public interface PolicyService {
+
+    boolean isRestricted(String policyName);
+
+    void checkRestriction(String policyName);
+
+    Set<String> listAllRestrictions();
+
+    Set<String> listActiveRestrictions();
+
+}

--- a/components/server/src/ome/security/policy/package-info.java
+++ b/components/server/src/ome/security/policy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Extensible service and security policies which can influence
+ * whether a user, group, or other agent can perform a certain
+ * action.
+ */
+package ome.security.policy;

--- a/components/server/src/ome/security/sharing/SharingSecuritySystem.java
+++ b/components/server/src/ome/security/sharing/SharingSecuritySystem.java
@@ -26,6 +26,7 @@ import ome.security.AdminAction;
 import ome.security.SecureAction;
 import ome.security.SecuritySystem;
 import ome.security.basic.BasicSecuritySystem;
+import ome.security.policy.Policy;
 import ome.system.EventContext;
 import ome.system.Principal;
 import ome.system.Roles;
@@ -98,6 +99,10 @@ public class SharingSecuritySystem implements SecuritySystem {
     public boolean hasPrivilegedToken(IObject obj) {
         // TODO Auto-generated method stub
         return false;
+    }
+
+    public void checkRestriction(Policy policy) {
+        // TODO Auto-generated method stub
     }
 
     public boolean isDisabled(String id) {

--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.NonWritableChannelException;
-import java.security.MessageDigest;
 import java.sql.SQLException;
 
 import ome.annotations.RolesAllowed;
@@ -41,12 +40,11 @@ import ome.conditions.SecurityViolation;
 import ome.io.nio.FileBuffer;
 import ome.io.nio.OriginalFilesService;
 import ome.model.core.OriginalFile;
+import ome.security.policy.DownloadPolicy;
 import ome.util.ShallowCopy;
-import ome.util.checksum.ChecksumProvider;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumType;
 
-import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.hibernate.HibernateException;
@@ -345,6 +343,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
 
             modified = false;
             file = iQuery.get(OriginalFile.class, fileId);
+            sec.checkRestriction(new DownloadPolicy(file));
 
             String mode = "r";
             try {

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -48,11 +48,16 @@ omero.db.profile=psql
 # for DB usage (by Hibernate, etc)
 omero.db.statistics=true
 
+#########################################################
+## Security settings
+#########################################################
+
 omero.security.chmod_strategy=groupChmodStrategy
 omero.security.filter.bitand=(int8and(permissions,%s) = %s)
 omero.security.login_failure_throttle_count=1
 omero.security.login_failure_throttle_time=3000
 omero.security.password_provider=chainedPasswordProvider
+omero.security.policy_bean=defaultPolicyService
 
 # Controls whether the server will allow creation of user accounts
 # with an empty password. If set to true (default, strict mode),


### PR DESCRIPTION
In order to support the new Permissions.extendedRestriction
client-side checks, this commit adds a server-side interface,
ome.security.policy.PolicyService, which is configured with
instances of ome.security.policy.Policy. Similar to the JVM's
SecurityManager and Permission objects, calling code can either
check if a call *would* fail, or simply let the service raise
a SecurityViolation.

Currently, the only prototypical restriction policy in place
is the DownloadPolicy.


--exclude
NOTE: This is intended for API comments only. The branch will likely be force-pushed.
cc: @mtbc @aleksandra-tarkowska 