### PR TITLE
Webadmin set default group

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
+++ b/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
@@ -111,10 +111,11 @@ Create Edit User
     Input Text              last_name       ${user_name}
     Input Text              institution     ${user_name}
     
-    Click Element           xpath=//ul[@class='chosen-choices']
-    Page Should Contain Element             xpath=//ul[@class='chosen-results']
-    Click Element           xpath=//ul[@class='chosen-results']/li[contains(text(),'test_group')]
-
+    
+    Click Element           xpath=//div[@id='id_other_groups_chosen']/ul[@class='chosen-choices']
+    Page Should Contain Element             xpath=//div[@id='id_other_groups_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']
+    Click Element           xpath=//div[@id='id_other_groups_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']/li[contains(text(),'test_group')]
+    
     Click Button            Save
     Location Should Be      ${USERS URL}
     Page Should Contain     ${user_name}

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -93,8 +93,6 @@ class ExperimenterForm(NonASCIIForm):
                 label="Groups")
 
         try:
-            if kwargs['initial']['default_group']:
-                pass
             self.fields['default_group'] = GroupModelChoiceField(
                 queryset=kwargs['initial']['groups'],
                 initial=kwargs['initial']['default_group'],
@@ -103,7 +101,6 @@ class ExperimenterForm(NonASCIIForm):
             self.fields['default_group'] = GroupModelChoiceField(
                 queryset=kwargs['initial']['groups'],
                 empty_label=u"---------", required=False)
-        self.fields['default_group'].widget.attrs['class'] = 'hidden'
 
         if ('with_password' in kwargs['initial'] and
                 kwargs['initial']['with_password']):

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -94,13 +94,17 @@ class ExperimenterForm(NonASCIIForm):
 
         try:
             self.fields['default_group'] = GroupModelChoiceField(
-                queryset=kwargs['initial']['groups'],
+                queryset=kwargs['initial']['my_groups'],
                 initial=kwargs['initial']['default_group'],
-                empty_label=u"---------", required=False)
+                empty_label=u"", required=False)
         except:
-            self.fields['default_group'] = GroupModelChoiceField(
-                queryset=kwargs['initial']['groups'],
-                empty_label=u"---------", required=False)
+            try:
+                self.fields['default_group'] = GroupModelChoiceField(
+                    queryset=kwargs['initial']['my_groups'],
+                    empty_label=u"", required=False)
+            except:
+                self.fields['default_group'] = GroupModelChoiceField(
+                    queryset=list(), empty_label=u"", required=False)
 
         if ('with_password' in kwargs['initial'] and
                 kwargs['initial']['with_password']):
@@ -177,6 +181,13 @@ class ExperimenterForm(NonASCIIForm):
         if self.email_check:
             raise forms.ValidationError('This email already exist.')
         return self.cleaned_data.get('email')
+
+    def clean_default_group(self):
+        if (self.cleaned_data.get('default_group') is None or
+                len(self.cleaned_data.get('default_group')) <= 0):
+            raise forms.ValidationError('No default group selected.')
+        else:
+            return self.cleaned_data.get('default_group')
 
     def clean_other_groups(self):
         if (self.cleaned_data.get('other_groups') is None or

--- a/components/tools/OmeroWeb/omeroweb/webadmin/static/webadmin/css/chosen.css
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/static/webadmin/css/chosen.css
@@ -1,4 +1,4 @@
-.chzn-container-multi .chzn-choices .search-choice-current {
+.chosen-container-multi .chosen-choices li.search-choice-current {
   cursor: pointer;
   border: 1px solid hsl(210,30%,40%);
   color: hsl(210,80%,10%);
@@ -10,6 +10,18 @@
   background:linear-gradient(top, hsl(210,40%,70%) 0%,hsl(210,40%,60%) 100%); /* W3C */
     
 }
+
+
+.chosen-container-single {
+    width:320px;
+    min-width:320px;
+    max-width:320px;
+}
+
+.empty-choice {
+    color: #e3646f;
+}
+
 
 .standard_form .hidden {
     display: none;

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/email.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/email.html
@@ -59,8 +59,8 @@
         $("#id_everyone").change(function(e){
           var state =  $(e.target).is(':checked');
           // Disable/Enable Users/Groups
-          $('#id_experimenters').prop('disabled', state).trigger("liszt:updated");
-          $('#id_groups').prop('disabled', state).trigger("liszt:updated");
+          $('#id_experimenters').prop('disabled', state).trigger("chosen:updated");
+          $('#id_groups').prop('disabled', state).trigger("chosen:updated");
         });
       });
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -50,29 +50,6 @@
     <script type="text/javascript">
     $(document).ready(function() 
     {
-        var highlightDefault = function() {
-            dv = $('#id_default_group').val();
-            if (dv.length > 0){
-                selected = $.grep($('#id_other_groups').data('chosen').results_data, function(item){
-                    return item.value == dv;
-                });
-                $("#id_other_groups_chzn_c_"+selected[0].array_index).addClass('search-choice-default').find("a").first().attr('rel');
-                $('#id_default_group').val(selected[0].value);
-            } else {
-                $('#id_default_group').val("");
-            }
-        }
-
-        var selectDefaultGroup = function(evt) {
-            evt.stopPropagation();
-            var target = $(evt.target).hasClass("search-choice") ? $(evt.target) : $(evt.target).parents(".search-choice").first();
-            $(".chzn-choices li.search-choice").removeClass('search-choice-default');
-            choice_id = $(evt.currentTarget).addClass('search-choice-default').find("a").first().attr('rel');
-            selected = $.grep($('#id_other_groups').data('chosen').results_data, function(item){
-                return item.array_index == choice_id;
-            })[0];
-            $("#id_default_group").selectOptions(selected.value, true);
-        };
 
         // Since we want to disable removal of 'system' group (id=0) from chosen, this hides the 'X'
         var admin_groups = {{ admin_groups|jsonify|safe }};
@@ -83,24 +60,43 @@
                 $system_li.find('a').hide();
             }
         }
-        
+
+        // The groups available as a default_group should match the groups chosen in 'other_groups'
+        var syncDefaultGroupOptions = function syncDefaultGroupOptions() {
+
+            var $defaultGroup = $("#id_default_group"),
+                currentDefaultGroup = $defaultGroup.val(),
+                groupIds = $("#id_other_groups").val();
+            $defaultGroup.empty();
+            // if other_groups <option> value is in selected IDs...
+            $("#id_other_groups option").each(function(){
+                if (groupIds.indexOf(this.value) > -1) {
+                    // ...put that <option> into default_group <select>
+                    $defaultGroup.append($(this).clone());
+                }
+            });
+            // Reset the val. If removed, this will select first <option>
+            $defaultGroup.val(currentDefaultGroup);
+        }
+
+        // Setup chosen plugin on 'Groups' chooser
         $("#id_other_groups").chosen({placeholder_text:'Type group names to add...'}).change(function(evt, data) {
             if (data && data.deselected) {
                 if (data.deselected === "0") {
                     $("input[name='administrator']").prop('checked', false);
                 }
-                $df = $('#id_default_group')
+                var $df = $('#id_default_group');
                 if ($df.val() === data.deselected){
-                    $("#id_default_group").selectOptions("", true);
+                    $df.selectOptions("", true);
                 } 
             } else if (data && data.selected) {
                 if (data.selected === "0") {
                     $("input[name='administrator']").prop('checked', true);
                 }
-                $("li.search-choice").click(selectDefaultGroup);
-                // In case we've added the system group:
             }
+            // In case we've added the system group:
             hideSystemGroupX();
+            syncDefaultGroupOptions();
         });
         
         $("input[name='administrator']").click( function(evt) {
@@ -109,15 +105,14 @@
                 $('#id_other_groups option[value=0]').prop('selected', true);
             } else {
                 $('#id_other_groups option[value=0]').prop('selected', false);
-                // also remove 'system' from the hidden 'default group' chooser
-                $df = $('#id_default_group');
+                // also remove 'system' from the 'default group' chooser
+                var $df = $('#id_default_group');
                 if ($df.val() === "0"){
                     $("#id_default_group").selectOptions("", true);
                 }
             }
             $("#id_other_groups").trigger("liszt:updated");
-            $("li.search-choice").click(selectDefaultGroup);
-            highlightDefault();
+            // In case we've added the system group:
             hideSystemGroupX();
         });
 
@@ -125,7 +120,9 @@
             evt.stopPropagation();
             selectDefaultGroup(evt);
         });
-        highlightDefault();
+
+        // Initial setup:
+        syncDefaultGroupOptions();
         hideSystemGroupX();
         
         
@@ -244,11 +241,6 @@
         {% for field in form %}
             {% if field.errors %}<div style="clear:both">{{ field.errors }}</div>{% endif %}
 
-            {% ifequal field.label_tag form.default_group.label_tag %}
-                <!-- default group -->
-                {{ field }}
-            
-            {% else %}
                 {% ifequal field.label_tag form.other_groups.label_tag %}
                     <!-- other groups -->
                     <span class="required">{{ field.label_tag }}</span>
@@ -263,7 +255,6 @@
                     {% endif %}
                     {{ field }}
                 {% endifequal %}
-            {% endifequal %}
             <br />
             
         {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -56,76 +56,67 @@
         var hideSystemGroupX = function() {
             for (i=0; i<admin_groups.length; i++) {
                 var optText = $("#id_other_groups").find("option[value=" + admin_groups[i] + "]").text(),
-                    $system_li = $("#id_other_groups_chzn").find("span:contains('"+optText+"')").parent();
+                    $system_li = $("#id_other_groups_chosen").find("span:contains('"+optText+"')").parent();
                 $system_li.find('a').hide();
             }
         }
 
-        // The groups available as a default_group should match the groups chosen in 'other_groups'
-        var syncDefaultGroupOptions = function syncDefaultGroupOptions() {
-
-            var $defaultGroup = $("#id_default_group"),
-                currentDefaultGroup = $defaultGroup.val(),
-                groupIds = $("#id_other_groups").val();
-            $defaultGroup.empty();
-            // if other_groups <option> value is in selected IDs...
-            $("#id_other_groups option").each(function(){
-                if (groupIds.indexOf(this.value) > -1) {
-                    // ...put that <option> into default_group <select>
-                    $defaultGroup.append($(this).clone());
-                }
-            });
-            // Reset the val. If removed, this will select first <option>
-            $defaultGroup.val(currentDefaultGroup);
+        var syncDefaultGroupOptions = function(id) {
+            var $df = $('#id_default_group'), currentDefaultGroup = $df.val()
+            if (id === currentDefaultGroup) {
+                $("#id_default_group option[value='"+id+"']").removeAttr("selected");
+            } else if (currentDefaultGroup=='') {
+                $("#id_default_group option[value='']").removeAttr("selected");
+            }
+            if ($("#id_default_group option[value='"+id+"']").length > 0) {
+                $("#id_default_group option[value='"+id+"']").remove();
+            } else {
+                $df.append($("#id_other_groups option[value='"+id+"']").clone().removeAttr("selected"));
+            }
+            // if only one group
+            if( $( "#id_other_groups" ).val() && $( "#id_other_groups" ).val().length === 1) {
+                $df.selectOptions($( "#id_other_groups" ).val()[0], true);
+            }
+            $df.trigger("chosen:updated");
+            //$df.selectOptions(currentDefaultGroup, true);
         }
+
+        $("#id_default_group").chosen({disable_search_threshold:5, placeholder_text:'Change default group'});
 
         // Setup chosen plugin on 'Groups' chooser
         $("#id_other_groups").chosen({placeholder_text:'Type group names to add...'}).change(function(evt, data) {
+
             if (data && data.deselected) {
                 if (data.deselected === "0") {
                     $("input[name='administrator']").prop('checked', false);
                 }
-                var $df = $('#id_default_group');
-                if ($df.val() === data.deselected){
-                    $df.selectOptions("", true);
-                } 
+                syncDefaultGroupOptions(data.deselected);
             } else if (data && data.selected) {
                 if (data.selected === "0") {
                     $("input[name='administrator']").prop('checked', true);
                 }
+                syncDefaultGroupOptions(data.selected);
             }
             // In case we've added the system group:
             hideSystemGroupX();
-            syncDefaultGroupOptions();
         });
         
         $("input[name='administrator']").click( function(evt) {
             evt.stopPropagation();
             if($("input[name='administrator']").is(':checked')) {
-                $('#id_other_groups option[value=0]').prop('selected', true);
+                $("#id_other_groups option[value='0']").attr('selected','selected');
             } else {
-                $('#id_other_groups option[value=0]').prop('selected', false);
+                $("#id_other_groups option[value='0']").removeAttr("selected");
                 // also remove 'system' from the 'default group' chooser
-                var $df = $('#id_default_group');
-                if ($df.val() === "0"){
-                    $("#id_default_group").selectOptions("", true);
-                }
             }
             $("#id_other_groups").trigger("chosen:updated");
+            syncDefaultGroupOptions(0);
             // In case we've added the system group:
             hideSystemGroupX();
-            syncDefaultGroupOptions();
-        });
-
-        $("li.search-choice").click(function(evt) {
-            evt.stopPropagation();
-            selectDefaultGroup(evt);
         });
 
         // Initial setup:
-        syncDefaultGroupOptions();
         hideSystemGroupX();
-        
         
         // code for Change Password dialog - NB this is duplicated in myaccount.html. 
         $( "#password_change_dialog" ).dialog({
@@ -242,11 +233,16 @@
         {% for field in form %}
             {% if field.errors %}<div style="clear:both">{{ field.errors }}</div>{% endif %}
 
+            {% ifequal field.label_tag form.default_group.label_tag %}
+                <!-- default group -->
+                <span class="required">{{ field.label_tag }}</span>
+                {{ field }}
+                <br />
+            {% else %}
                 {% ifequal field.label_tag form.other_groups.label_tag %}
                     <!-- other groups -->
                     <span class="required">{{ field.label_tag }}</span>
                     {{ field }}
-                    
                 {% else %}
                     <!-- all other fields -->
                     {% if field.field.required %}
@@ -256,6 +252,7 @@
                     {% endif %}
                     {{ field }}
                 {% endifequal %}
+            {% endifequal %}
             <br />
             
         {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -111,9 +111,10 @@
                     $("#id_default_group").selectOptions("", true);
                 }
             }
-            $("#id_other_groups").trigger("liszt:updated");
+            $("#id_other_groups").trigger("chosen:updated");
             // In case we've added the system group:
             hideSystemGroupX();
+            syncDefaultGroupOptions();
         });
 
         $("li.search-choice").click(function(evt) {

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -81,7 +81,7 @@
             //$df.selectOptions(currentDefaultGroup, true);
         }
 
-        $("#id_default_group").chosen({disable_search_threshold:5, placeholder_text:'Change default group'});
+        $("#id_default_group").chosen({disable_search_threshold:5, placeholder_text:'Choose default group'});
 
         // Setup chosen plugin on 'Groups' chooser
         $("#id_other_groups").chosen({placeholder_text:'Type group names to add...'}).change(function(evt, data) {

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -48,11 +48,10 @@
                 var highlightCurrent = function() {
                     var userId = {{ userId }};
                     var selected = $.grep($('#id_members').data('chosen').results_data, function(item){
-                        if (parseInt(item.value) === userId) {
-                            $("#id_owners_chzn_c_"+item.array_index).addClass('search-choice-current').find("a").first().unbind("click").remove();                            
-                            $("#id_members_chzn_c_"+item.array_index).addClass('search-choice-current').find("a").first().unbind("click").remove();                            
-                        }
+                        return item.value == userId;
                     });
+                    $("#id_owners_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
+                    $("#id_members_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
                 }
                 
                 // Since we want to disable removal of 'system' users from chosen, this hides the 'X'
@@ -71,7 +70,7 @@
                         var selected = $.grep($('#id_owners').data('chosen').results_data, function(item){
                             if(item.selected && item.value === data.deselected) {
                                 $('#id_owners option[value='+data.deselected+']').prop('selected', false);
-                                $("#id_owners").trigger("liszt:updated");
+                                $("#id_owners").trigger("chosen:updated");
                                 highlightCurrent();
                             }
                         });

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -56,7 +56,7 @@
                         $.grep($('#id_owners').data('chosen').results_data, function(item){
                             if(item.selected && item.value === data.deselected) {
                                 $('#id_owners option[value='+data.deselected+']').prop('selected', false);
-                                $("#id_owners").trigger("liszt:updated");
+                                $("#id_owners").trigger("chosen:updated");
                                 highlightCurrent();
                             }
                         });

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -409,8 +409,11 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
         else:
             name_check = conn.checkOmeName(request.REQUEST.get('omename'))
             email_check = conn.checkEmail(request.REQUEST.get('email'))
-
+            my_groups = getSelectedGroups(
+                conn,
+                request.POST.getlist('other_groups'))
             initial = {'with_password': True,
+                       'my_groups': my_groups,
                        'groups': otherGroupsInitialList(groups)}
             form = ExperimenterForm(
                 initial=initial, data=request.REQUEST.copy(),
@@ -473,6 +476,7 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
             'administrator': experimenter.isAdmin(),
             'active': experimenter.isActive(),
             'default_group': defaultGroupId,
+            'my_groups': otherGroups,
             'other_groups': [g.id for g in otherGroups],
             'groups': otherGroupsInitialList(groups)}
         system_users = [conn.getAdminService().getSecurityRoles().rootId,
@@ -504,7 +508,10 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                                            experimenter.omeName)
             email_check = conn.checkEmail(request.REQUEST.get('email'),
                                           experimenter.email)
-            initial = {'active': True,
+            my_groups = getSelectedGroups(
+                conn,
+                request.POST.getlist('other_groups'))
+            initial = {'my_groups': my_groups,
                        'groups': otherGroupsInitialList(groups)}
             form = ExperimenterForm(initial=initial, data=request.POST.copy(),
                                     name_check=name_check,


### PR DESCRIPTION
This PR reverts changes to webadmin experimenter forms to simply allow choosing default group and fix few bugs.

tests:
- check if robot tests passed

to test experimenter:
 - Click **New user** and fill data:
   - by adding user to a group it imminently should become default group, choosing more groups shouldn't update default group.
 - Edit the user and see if all data are correct and default group is set.
 - Make user an admin and check if system group is added to the list. Choose system group as default. Save
 - Edit user again and uncheck admin, see if system group was removed and but default group remain selected -> message should appear: ```"Choose default group"``` Click save button and check if validation fail with message above default group saying ```"No default group selected"``` and above group field: ```"User must be a member of at least one group."```

to test group:
 - Login as root and admin_user and edit system group. Check if you cannot remove yourself 

cc: @will-moore @gusferguson 

--no-rebase