### PR TITLE
CLI key session

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -23,6 +23,12 @@
 Library for managing user sessions.
 """
 
+import omero.constants
+from omero.util import get_user_dir, make_logname
+from path import path
+
+import logging
+
 """
  * Track last used
  * provide single library (with lock) which does all of this
@@ -39,12 +45,6 @@ from omero.cli import Arguments, BaseControl, VERSION
 from path import path
 
 """
-
-import omero.constants
-from omero.util import get_user_dir, make_logname
-from path import path
-
-import logging
 
 
 class SessionsStore(object):

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -123,6 +123,9 @@ class SessionsStore(object):
             new = new_props.get(key, None)
             if ignore_nulls and new is None:
                 continue
+            elif (key == "omero.port" and old is None and
+                    new == str(omero.constants.GLACIER2PORT)):
+                continue
             elif old != new:
                 conflicts += (key + (":%s!=%s;" % (old, new)))
         return conflicts

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -465,11 +465,11 @@ class TestSessions(object):
 
         del cli
 
+    @pytest.mark.parametrize('port', [None, 4064])
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    def testCopiedSessionWorks(self, connection):
+    def testCopiedSessionWorks(self, connection, port):
         """
-        Found by Colin while using a session key from
-        a non-CLI-source.
+        Found by Colin while using a session key from a non-CLI-source.
         """
         cli = MyCLI()
 
@@ -482,7 +482,7 @@ class TestSessions(object):
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
         cli.set_client(None)  # Forcing new instance
         cli.creates_client(sess=MOCKKEY, new=False)
-        conn_args = self.get_conn_args(connection, port=None)
+        conn_args = self.get_conn_args(connection, port=port)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
 
     def assert5975(self, key, cli):

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -279,13 +279,23 @@ class TestSessions(object):
 
     def get_conn_args(self, conn_type, host="testhost", name="testuser",
                       port=None):
-        if conn_type == "string":
-            pattern = "%s@%s"
-        elif conn_type == "prefixed_string":
-            pattern = "-s %s@%s"
+
+        if name:
+            if conn_type == "string":
+                pattern = "%s@%s"
+            elif conn_type == "prefixed_string":
+                pattern = "-s %s@%s"
+            else:
+                pattern = "-u %s -s %s"
+            args = pattern % (name, host)
         else:
-            pattern = "-u %s -s %s"
-        args = pattern % (name, host)
+            if conn_type == "string":
+                pattern = "%s"
+            elif conn_type == "prefixed_string":
+                pattern = "-s %s"
+            else:
+                pattern = "-s %s"
+            args = pattern % host
 
         if port:
             if conn_type == "options":
@@ -326,7 +336,7 @@ class TestSessions(object):
         cli = MyCLI()
         cli.STORE.add("testhost", "testuser", "key", {})
         cli.creates_client(sess="key", new=False)
-        conn_args = self.get_conn_args(connection)
+        conn_args = self.get_conn_args(connection, name=None)
         cli.invoke(["s", "login", "-k", "key"] + conn_args)
         assert 0 == cli.rv
 
@@ -438,7 +448,8 @@ class TestSessions(object):
 
         # Now try with session when it's still available
         cli.creates_client(sess=MOCKKEY, new=False)
-        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
+        key_conn_args = self.get_conn_args(connection, name=None)
+        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
         cli.set_client(None)  # Forcing new instance
 
         # Don't do creates_client, so the session key
@@ -446,7 +457,7 @@ class TestSessions(object):
         cli.throw_on_create(
             Glacier2.PermissionDeniedException("MOCKKEY EXPIRED"))
         try:
-            cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
+            cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
             assert False, "This must throw 'Bad session key'"
         except NonZeroReturnCode:
             pass
@@ -466,9 +477,13 @@ class TestSessions(object):
 
         # Try with session when it's still available
         cli.creates_client(sess=MOCKKEY, new=True)
-        conn_args = self.get_conn_args(connection)
+
+        conn_args = self.get_conn_args(connection, name=None, port=None)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
         cli.set_client(None)  # Forcing new instance
+        cli.creates_client(sess=MOCKKEY, new=False)
+        conn_args = self.get_conn_args(connection, port=None)
+        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
 
     def assert5975(self, key, cli):
         host, name, uuid, port = cli.STORE.get_current()
@@ -483,7 +498,7 @@ class TestSessions(object):
         cli = MyCLI()
         key = str(uuid.uuid4())
         cli.creates_client(sess=key, new=True)
-        conn_args = self.get_conn_args(connection)
+        conn_args = self.get_conn_args(connection, name=None)
         cli.invoke(["s", "login", "-k", "%s" % key] + conn_args)
         self.assert5975(key, cli)
 


### PR DESCRIPTION
Minor bug reported by @manics. Under certain conditions a local session file can be with no `omero.port=xxx` line while using the default port. When this session is re-attached via:

```
bin/omero session -s host -k key -p 4064
```

it results in a conflict between the old port (`None`) and the new port (`4064`). This PR adds a special case in `store.conflicts` to handle this particular case and implements the corresponding unit tests (which should pass).

--no-rebase