### PR TITLE
Basket preview viewer fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
@@ -83,6 +83,10 @@
 
     <script>
         $(document).ready(function(){
+
+            // setup in-line labels on top search field
+            $("#top_search_field label").inFieldLabels();
+
             // initially hidden
             $("#user_dropdown ul").css('visibility', 'hidden');
             // show on click

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
@@ -33,6 +33,7 @@
     <script type="text/javascript" src="{% static "webclient/javascript/ome.webclient.actions.js" %}"></script>
 
     <!-- The following are required by the right-hand panel, E.g. annotations/metadata_general.html -->
+    <script src="{% static 'webclient/javascript/jquery.infieldlabel.js' %}" type="text/javascript"></script>
     <script type="text/javascript" src="{% static "3rdparty/jquery.quicksearch.js" %}"></script>
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.editinplace.js" %}"></script>
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.form.js" %}"></script>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/history/history.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/history/history.html
@@ -40,8 +40,6 @@
 {% block script %}
     {{ block.super }}
     
-    <script src="{% static 'webclient/javascript/jquery.infieldlabel.js' %}" type="text/javascript"></script>
-
     <script type="text/javascript">
         $(document).ready(function() 
             {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -37,7 +37,6 @@
 
 {% block script %}
     {{ block.super }}
-    <script src="{% static 'webclient/javascript/jquery.infieldlabel.js' %}" type="text/javascript"></script>
     <script type="text/javascript" src="{% static "3rdparty/jquery.tablesorter/jquery.tablesorter.js" %}"></script>
     <script type="text/javascript" src="{% static "3rdparty/jquery.quicksearch.js" %}"></script>
     


### PR DESCRIPTION
This fixes the preview panel viewer on the basket page, as reported https://github.com/openmicroscopy/openmicroscopy/pull/3531
but the bug was actually the missing infieldlabel.js javascript library on the basket page.
Also found that this lib was duplicated for search and history pages, being also present in their parent template.

To test:
 - Check that in-line labels work (the placeholder text is removed when you start to type) in right panel Comments field on basket page, search results page and history page.
 - Check that in-line labels work for top search field on basket page.
 - Check that image viewer works in Preview panel on basket page.