### PR TITLE
Add displayName and display options to Params (See #10474)

### DIFF
--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -432,6 +432,14 @@ module omero {
              *
              **/
             omero::api::StringSet namespaces;
+
+            /**
+             * Defines where this script is intended for presentation to
+             * clients. Some scripts may be more for internal consumption
+             * or use by backend tools in which case they need not appear
+             * in the UI.
+             **/
+             bool display;
         };
 
         /**

--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -281,6 +281,19 @@ module omero {
              * </p>
              **/
             omero::api::StringSet namespaces;
+
+            /**
+             * A label which can be applied to this parameter in addition
+             * to its more programmatic name in the [omero::grid::JobParams]
+             * object.
+             **/
+             string displayName;
+
+            /**
+             * Whether or not this parameter should be displayed to users
+             * for entry.
+             **/
+             bool display;
         };
 
         dictionary<string, Param> ParamMap;


### PR DESCRIPTION
These were initially suggested by Curtis during work
on imagej-omero in order to allow storing the same
info that's available in IJ2 plugins as params. No
GUI code is currently consuming the fields, but if
they are present for 5.1.0, then further PRs can.

cc: @ctrueden @jburel @gusferguson @will-moore @knabar 