### PR TITLE
add a "current step" to status of async server jobs

### DIFF
--- a/components/blitz/resources/omero/cmd/API.ice
+++ b/components/blitz/resources/omero/cmd/API.ice
@@ -42,6 +42,9 @@ module omero {
             StateList flags;
             StringMap parameters;
 
+            /** the latest step to be commenced, from 0 to steps-1 */
+            int currentStep;
+            /** the total number of steps */
             int steps;
             long startTime;
             Ice::LongSeq stepStartTimes;

--- a/components/blitz/src/omero/cmd/HandleI.java
+++ b/components/blitz/src/omero/cmd/HandleI.java
@@ -433,6 +433,7 @@ public class HandleI implements _HandleOperations, IHandle,
                     if (!state.compareAndSet(State.READY, State.RUNNING)) {
                         throw helper.cancel(new ERR(), null, "not-ready");
                     }
+                    status.currentStep = j;
                     rv.add(req.step(j));
                 } catch (Cancel c) {
                     throw c;

--- a/components/blitz/src/omero/cmd/basic/DoAllI.java
+++ b/components/blitz/src/omero/cmd/basic/DoAllI.java
@@ -105,7 +105,9 @@ public class DoAllI extends DoAll implements IRequest {
          * value after being calculated via {@link #offset}
          */
         Object step(int step) {
-            return r.step(step - offset);
+            final int substep = step - offset;
+            h.getStatus().currentStep = substep;
+            return r.step(substep);
         }
 
         /**

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -147,6 +147,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
         if (step < graphRequestSkipStatus.steps) {
             try {
                 /* do a skip-head step */
+                graphRequestSkipStatus.currentStep = step;
                 graphRequestSkipObjects.add(((IRequest) graphRequestSkip).step(step));
             } catch (Cancel e) {
                 /* the step failed, so propagate the error response to this request */
@@ -191,6 +192,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
             if (substep < graphRequestPerformStatus.steps) {
                 try {
                     /* do a tail step */
+                    graphRequestPerformStatus.currentStep = substep;
                     graphRequestPerformObjects.add(((IRequest) graphRequestPerform).step(substep));
                 } catch (Cancel e) {
                     /* the step failed, so propagate the error response to this request */

--- a/components/blitz/test/omero/cmd/admin/ResetPasswordRequestTest.java
+++ b/components/blitz/test/omero/cmd/admin/ResetPasswordRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2014 University of Dundee. All rights reserved.
+ *   Copyright 2014-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -61,6 +61,7 @@ public class ResetPasswordRequestTest extends AbstractServantTest {
                 int j = 0;
                 while (j < status.steps) {
                     try {
+                        status.currentStep = j;
                         rv.add(req.step(j));
                     } catch (Cancel c) {
                         throw c;

--- a/components/blitz/test/omero/cmd/fs/OriginalMetadataRequestTest.java
+++ b/components/blitz/test/omero/cmd/fs/OriginalMetadataRequestTest.java
@@ -105,6 +105,7 @@ public class OriginalMetadataRequestTest extends AbstractServantTest {
 				int j = 0;
 				while (j < status.steps) {
 					try {
+						status.currentStep = j;
 						rv.add(req.step(j));
 					} catch (Cancel c) {
 						throw c;

--- a/components/blitz/test/omero/cmd/mail/SendEmailRequestTest.java
+++ b/components/blitz/test/omero/cmd/mail/SendEmailRequestTest.java
@@ -57,6 +57,7 @@ public class SendEmailRequestTest extends AbstractServantTest {
                 int j = 0;
                 while (j < status.steps) {
                     try {
+                        status.currentStep = j;
                         rv.add(req.step(j));
                     } catch (Cancel c) {
                         throw c;


### PR DESCRIPTION
Addresses some of the discussion on https://trac.openmicroscopy.org/ome/ticket/10474. Ensure that https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-python/lastCompletedBuild/testReport/test.integration.test_delete/TestDelete/ passes.

--no-rebase