### PR TITLE
Prevent property with trailing equal sign in config set

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -285,10 +285,14 @@ class PrefsControl(WriteableConfigControl):
 
     @with_rw_config
     def set(self, args, config):
-        if "=" in args.KEY and args.VALUE is None:
+        if "=" in args.KEY:
             k, v = args.KEY.split("=", 1)
-            self.ctx.err(""" "=" in key name. Did you mean "...set %s %s"?"""
-                         % (k, v))
+            msg = """ "=" in key name. Did you mean "...set %s %s"?"""
+            if args.VALUE is None:
+                k, v = args.KEY.split("=", 1)
+                self.ctx.err(msg % (k, v))
+            elif args.KEY.endswith("="):
+                self.ctx.err(msg % (k, args.VALUE))
         elif args.file:
             if args.file == "-":
                 # Read from standard input

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -112,8 +112,9 @@ class TestPrefs(object):
             'omero.Y.password=********\n'
             'omero.Z=val'))
 
-    def testSetFails(self, capsys):
-        self.invoke("set A=B")
+    @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
+    def testSetFails(self, capsys, argument):
+        self.invoke("set %s" % argument)
         self.assertStdoutStderr(
             capsys, err="\"=\" in key name. Did you mean \"...set A B\"?")
 


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7752#p15430

This PR should prevent an operation like
```
bin/omero config set omero.property= value
```

Apart from checking the unit tests are green in Travis, testing this PR should include running this command and testing `config.xml` remains unmodified.

--no-rebase