### PR TITLE
Remove fastcgi -socket from web template generation

### DIFF
--- a/etc/templates/apache.conf.template
+++ b/etc/templates/apache.conf.template
@@ -54,7 +54,7 @@
 ### Stanza for OMERO.web created %(NOW)s
 ###
 
-FastCGIExternalServer "%(ROOT)s/var/omero.fcgi" %(FASTCGI_EXTERNAL)s -idle-timeout 60
+FastCGIExternalServer "%(ROOT)s/var/omero.fcgi" -host %(FASTCGI_EXTERNAL)s -idle-timeout 60
 
 <Directory "%(ROOT)s/var">
     Options -Indexes FollowSymLinks

--- a/etc/templates/nginx-development.conf.template
+++ b/etc/templates/nginx-development.conf.template
@@ -46,7 +46,7 @@ http {
 
             error_page 502 @maintenance;
 
-            fastcgi_pass %(FASTCGI_PASS)s;
+            fastcgi_pass %(FASTCGI_EXTERNAL)s;
 
             %(FASTCGI_PATH_SCRIPT_INFO)s
 

--- a/etc/templates/nginx.conf.template
+++ b/etc/templates/nginx.conf.template
@@ -20,7 +20,7 @@
 
             error_page 502 @maintenance;
 
-            fastcgi_pass %(FASTCGI_PASS)s;
+            fastcgi_pass %(FASTCGI_EXTERNAL)s;
 
             %(FASTCGI_PATH_SCRIPT_INFO)s
 


### PR DESCRIPTION
See https://trello.com/c/FHk2rdFe/433-remove-non-tcp-fastcgi-apache-config

We never use or test FastCGI with sockets so there should be no visible effect of this PR. Just check that the generated templates are unchanged.

Note: FastCGI sockets continue to be usable with OMERO.web, but you'll have to create the web-server configuration file yourself.

