### PR TITLE
Duplicate projects in tree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -339,7 +339,7 @@ def marshal_screens(conn, experimenter_id=None):
                left join splink.child plate
                left join plate.plateAcquisitions pa
         %s
-        order by lower(screen.name), lower(plate.name), pa.id
+        order by lower(screen.name), screen.id, lower(plate.name), pa.id
         """ % (where_clause)
 
     # TODO Remove this when fixed. Workaround for bug:
@@ -449,7 +449,7 @@ def marshal_plates(conn, experimenter_id):
             select splink from ScreenPlateLink as splink
             where splink.child = plate.id
         ) %s
-        order by lower(plate.name), pa.id
+        order by lower(plate.name), plate.id, pa.id
         """ % (where_clause)
 
     # TODO Remove this when fixed. Workaround for bug:

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -196,7 +196,7 @@ def marshal_projects(conn, experimenter_id):
                left join project.datasetLinks as pdlink
                left join pdlink.child dataset
         %s
-        order by lower(project.name), lower(dataset.name)
+        order by lower(project.name), project.id, lower(dataset.name)
         """ % (where_clause)
 
     # TODO Remove this when fixed. Workaround for bug:

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -410,6 +410,18 @@ class TestTree(lib.ITest):
         marshaled = marshal_projects(self.conn, self.conn.getUserId())
         assert marshaled == expected
 
+    def test_marshal_projects_datasets_duplicates(self, projects_datasets):
+        """
+        Test that same-named Projects are not duplicated in marshaled data.
+        See https://trac.openmicroscopy.org/ome/ticket/12771
+        """
+        # Re-name projects with all the same name
+        for p in projects_datasets:
+            p.name = rstring("Test_Duplicates")
+        projects_datasets = self.update.saveAndReturnArray(projects_datasets)
+        marshaled = marshal_projects(self.conn, self.conn.getUserId())
+        assert len(marshaled) == len(projects_datasets)
+
     def test_marshal_projects_different_users_as_other_user(
             self, projects_different_users):
         project_a, project_b = projects_different_users


### PR DESCRIPTION
Fix for http://trac.openmicroscopy.org/ome/ticket/12771

When multiple Projects containing multiple Datasets are retrieved by projection in marshal_projects() they are initially P-D pairs,

```
p1 - d1
p1 - d2
p2 - d3
```
and are organised into hierarchies by sorting by Project name, then collapsing datasets if 2 adjacent Projects are the same. 
E.g.
```
p1 - d1
    - d2
p2 - d3
```

However, if we have many Projects with the same name, then the same Project will not be sorted beside each other and not fully collapsed.
E.g. 
```
p1 - d1
p2 - d3
p1 - d2
```
Fix is to simply sort by ID after sorting by Project name.

To test, check that multiple same-named Projects with multiple Datasets only appear a single time in the tree. See ticket above for links to existing data in trout.

Also applied the same fix to Screens and Plates, so need to test that they still load OK in tree.

Added a marshal test that fails without the bug-fix.
```
OmeroWeb wmoore$ ./setup.py test -t test/integration/test_tree.py -k test_marshal_projects_datasets_duplicates
...
>       assert len(marshaled) == len(projects_datasets)
E       assert 15 == 4
```
--no-rebase