### PR TITLE
IConfig Map methods

### DIFF
--- a/components/blitz/resources/omero/api/IConfig.ice
+++ b/components/blitz/resources/omero/api/IConfig.ice
@@ -24,6 +24,7 @@ module omero {
                 idempotent string getVersion() throws ServerError;
                 idempotent string getConfigValue(string key) throws ServerError;
                 idempotent omero::api::StringStringMap getConfigValues(string keyRegex) throws ServerError;
+                idempotent omero::api::StringStringMap getConfigDefaults() throws ServerError;
                 idempotent void setConfigValue(string key, string value) throws ServerError;
                 idempotent bool setConfigValueIfEquals(string key, string value, string test) throws ServerError;
                 idempotent string getDatabaseUuid() throws ServerError;

--- a/components/blitz/resources/omero/api/IConfig.ice
+++ b/components/blitz/resources/omero/api/IConfig.ice
@@ -23,6 +23,7 @@ module omero {
             {
                 idempotent string getVersion() throws ServerError;
                 idempotent string getConfigValue(string key) throws ServerError;
+                idempotent omero::api::StringStringMap getConfigValues(string keyRegex) throws ServerError;
                 idempotent void setConfigValue(string key, string value) throws ServerError;
                 idempotent bool setConfigValueIfEquals(string key, string value, string test) throws ServerError;
                 idempotent string getDatabaseUuid() throws ServerError;

--- a/components/blitz/src/ome/services/blitz/impl/ConfigI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ConfigI.java
@@ -12,6 +12,7 @@ import ome.api.IConfig;
 import ome.services.blitz.util.BlitzExecutor;
 import omero.ServerError;
 import omero.api.AMD_IConfig_getConfigValue;
+import omero.api.AMD_IConfig_getConfigValues;
 import omero.api.AMD_IConfig_getDatabaseTime;
 import omero.api.AMD_IConfig_getDatabaseUuid;
 import omero.api.AMD_IConfig_getServerTime;
@@ -40,6 +41,11 @@ public class ConfigI extends AbstractAmdServant implements _IConfigOperations {
     public void getConfigValue_async(AMD_IConfig_getConfigValue __cb,
             String key, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, key);
+    }
+
+    public void getConfigValues_async(AMD_IConfig_getConfigValues __cb,
+            String keyRegex, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, keyRegex);
     }
 
     public void getDatabaseTime_async(AMD_IConfig_getDatabaseTime __cb,

--- a/components/blitz/src/ome/services/blitz/impl/ConfigI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ConfigI.java
@@ -12,6 +12,7 @@ import ome.api.IConfig;
 import ome.services.blitz.util.BlitzExecutor;
 import omero.ServerError;
 import omero.api.AMD_IConfig_getConfigValue;
+import omero.api.AMD_IConfig_getConfigDefaults;
 import omero.api.AMD_IConfig_getConfigValues;
 import omero.api.AMD_IConfig_getDatabaseTime;
 import omero.api.AMD_IConfig_getDatabaseUuid;
@@ -46,6 +47,11 @@ public class ConfigI extends AbstractAmdServant implements _IConfigOperations {
     public void getConfigValues_async(AMD_IConfig_getConfigValues __cb,
             String keyRegex, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, keyRegex);
+    }
+
+    public void getConfigDefaults_async(AMD_IConfig_getConfigDefaults __cb,
+            Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current);
     }
 
     public void getDatabaseTime_async(AMD_IConfig_getDatabaseTime __cb,

--- a/components/common/src/ome/api/IConfig.java
+++ b/components/common/src/ome/api/IConfig.java
@@ -128,6 +128,16 @@ public interface IConfig extends ServiceInterface {
     String keyRegex);
 
     /**
+     * reads the etc/omero.properties file and returns all the key/value
+     * pairs that are found there. Since this file is not to be edited
+     * its assumed that these values are in the public domain and so
+     * there's no need to protect them.
+     *
+     * @return a {@link Map} from the found keys to the linked values.
+     */
+    Map<String, String> getConfigDefaults();
+
+    /**
      * set a configuration value in the backend store. Permissions applied to
      * the configuration value may cause a {@link SecurityViolation} to be
      * thrown. If the value is null or empty, then the configuration will be

--- a/components/common/src/ome/api/IConfig.java
+++ b/components/common/src/ome/api/IConfig.java
@@ -9,6 +9,7 @@ package ome.api;
 
 // Java imports
 import java.util.Date;
+import java.util.Map;
 
 import ome.annotations.NotNull;
 import ome.annotations.RevisionDate;
@@ -113,6 +114,18 @@ public interface IConfig extends ServiceInterface {
      */
     String getConfigValue(@NotNull
     String key) throws ApiUsageException, SecurityViolation;
+
+    /**
+     * retrieve configuration values from the backend store which match the
+     * given regex. Any configuration value which would throw an exception
+     * on being loaded is omitted.
+     *
+     * @param keyRegex
+     *            The non-null regex of the desired configuration values
+     * @return a {@link Map} from the found keys to the linked values.
+     */
+    Map<String, String> getConfigValues(@NotNull
+    String keyRegex);
 
     /**
      * set a configuration value in the backend store. Permissions applied to

--- a/components/common/src/ome/system/PreferenceContext.java
+++ b/components/common/src/ome/system/PreferenceContext.java
@@ -12,6 +12,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
@@ -144,6 +145,10 @@ public class PreferenceContext extends PropertyPlaceholderConfigurer {
         }
 
         return key;
+    }
+
+    public Set<String> getKeySet() {
+        return preferences.keySet();
     }
 
     public boolean checkDatabase(String key) {

--- a/components/server/src/ome/logic/ConfigImpl.java
+++ b/components/server/src/ome/logic/ConfigImpl.java
@@ -15,10 +15,13 @@
 package ome.logic;
 
 import java.io.File;
+import java.io.FileReader;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -242,6 +245,27 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
             }
         }
         return rv;
+    }
+
+    @PermitAll
+    public Map<String, String> getConfigDefaults() {
+        File etc = new File("etc");
+        File omero = new File(etc, "omero.properties");
+        Properties p = new Properties();
+        Map<String, String> rv = new HashMap<String, String>();
+        try {
+            FileReader r = new FileReader(omero);
+            p.load(r);
+            for (Entry<Object, Object> entry : p.entrySet()) {
+                    rv.put(entry.getKey().toString(),
+                            entry.getValue().toString());
+            }
+            return rv;
+        } catch (Exception e) {
+            InternalException ie = new InternalException(e.getMessage());
+            ie.initCause(e);
+            throw ie;
+        }
     }
 
     public String getInternalValue(String key) {

--- a/components/server/src/ome/logic/ConfigImpl.java
+++ b/components/server/src/ome/logic/ConfigImpl.java
@@ -14,7 +14,12 @@
 
 package ome.logic;
 
+import java.io.File;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
@@ -216,6 +221,27 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
         }
 
         return getInternalValue(key);
+    }
+
+    @PermitAll
+    public Map<String, String> getConfigValues(String keyRegex) {
+        if (keyRegex == null) {
+            return Collections.emptyMap();
+        }
+
+        Pattern p = Pattern.compile(keyRegex);
+        Map<String, String> rv = new HashMap<String, String>();
+        Set<String> keys = prefs.getKeySet();
+        // Not resolving aliases since these come straight-from the prefs
+        for (String key : keys) {
+            if (p.matcher(key).find()) {
+                if (prefs.canRead(
+                        currentDetails.getCurrentEventContext(), key)) {
+                    rv.put(key, getInternalValue(key));
+                }
+            }
+        }
+        return rv;
     }
 
     public String getInternalValue(String key) {

--- a/components/tools/OmeroPy/test/integration/test_iconfig.py
+++ b/components/tools/OmeroPy/test/integration/test_iconfig.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   Integration test focused on the omero.api.IConfig interface.
+
+"""
+
+import pytest
+import library as lib
+
+
+class TestConfig(lib.ITest):
+
+    EXPECTS = (
+        (".*", ("omero.router.insecure",)),
+        ("^omero.*", ("omero.router.insecure",)),
+        (".*router.*", ("omero.router.insecure",)),
+        ("omero.db", ("omero.db.authority",)),
+    )
+    @pytest.mark.parametrize("data", EXPECTS)
+    def testValuesRegex(self, data):
+        regex, contains = data
+        cfg = self.sf.getConfigService()
+        rv = cfg.getConfigValues(regex)
+        for c in contains:
+            assert c in rv

--- a/components/tools/OmeroPy/test/integration/test_iconfig.py
+++ b/components/tools/OmeroPy/test/integration/test_iconfig.py
@@ -36,6 +36,7 @@ class TestConfig(lib.ITest):
         (".*router.*", ("omero.router.insecure",)),
         ("omero.db", ("omero.db.authority",)),
     )
+
     @pytest.mark.parametrize("data", EXPECTS)
     def testValuesRegex(self, data):
         regex, contains = data
@@ -43,3 +44,12 @@ class TestConfig(lib.ITest):
         rv = cfg.getConfigValues(regex)
         for c in contains:
             assert c in rv
+
+    def testDefaults(self):
+        cfg = self.sf.getConfigService()
+        defs = cfg.getConfigDefaults()
+        for x in (
+            "omero.version",
+            "omero.db.name",
+        ):
+            assert x in defs


### PR DESCRIPTION
Two methods have been added to IConfig to allow loading maps of values:
 * getConfigValues(String regex)
 * getConfigDefaults()

The first applies security settings to each value as if `IConfig.getConfigValue()` had been called individually. The second simply returns the contents of `etc/omero.properties`. There is *some* potential that a user has encoded something sensitive in this file (though they shouldn't). Shall we make it admin only?

Initially added for gh-3373 (and another PR from Ola)
cc: @dominikl @aleksandra-tarkowska 
--no-rebase