### PR TITLE
Fixing Download button

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -150,7 +150,7 @@ class OmeroRestrictionWrapper (object):
         :return:    True if user can download.
         """
         return not self.getDetails().getPermissions().isRestricted(
-            omero.constants.permissions.DOWNLOAD)
+            omero.constants.permissions.BINARYACCESS)
 
 
 class BlitzObjectWrapper (object):

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2499,10 +2499,6 @@ class WellWrapper(OmeroWebObjectWrapper, omero.gateway.WellWrapper):
         if 'link' in kwargs:
             self.link = 'link' in kwargs and kwargs['link'] or None
 
-    def canDownload(self):
-        return False
-
-
 omero.gateway.WellWrapper = WellWrapper
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2049,20 +2049,21 @@ def archived_files(request, iid=None, conn=None, **kwargs):
     Downloads the archived file(s) as a single file or as a zip (if more than
     one file)
     """
+
     imgIds = []
     wellIds = []
+    imgIds = request.REQUEST.getlist('image')
+    wellIds = request.REQUEST.getlist('well')
     if iid is None:
-        imgIds = request.REQUEST.getlist('image')
-        if len(imgIds) == 0:
-            wellIds = request.REQUEST.getlist('well')
-            if len(wellIds) == 0:
-                return HttpResponseServerError(
-                    "No images or wells specified in request."
-                    " Use ?image=123 or ?well=123")
+        if len(imgIds) == 0 and len(wellIds) == 0:
+            return HttpResponseServerError(
+                "No images or wells specified in request."
+                " Use ?image=123 or ?well=123")
     else:
         imgIds = [iid]
 
-    images = []
+    images = list()
+    wells = list()
     if imgIds:
         images = list(conn.getObjects("Image", imgIds))
     elif wellIds:
@@ -2070,7 +2071,8 @@ def archived_files(request, iid=None, conn=None, **kwargs):
             index = int(request.REQUEST.get("index", 0))
         except ValueError:
             index = 0
-        for w in conn.getObjects("Well", wellIds):
+        wells = conn.getObjects("Well", wellIds)
+        for w in wells:
             images.append(w.getWellSample(index).image())
     if len(images) == 0:
         logger.debug(
@@ -2078,6 +2080,19 @@ def archived_files(request, iid=None, conn=None, **kwargs):
         return HttpResponseServerError(
             "Cannot download archived file because Images not found (ids:"
             " %s)." % (imgIds))
+
+    # Test permissions on images and weels
+    for ob in (images + wells):
+        if isinstance(ob, omero.gateway.ImageWrapper):
+            # If plate download disabled, check for SPW data...
+            well = ob.getParent().getParent()
+            if isinstance(well, omero.gateway.WellWrapper):
+                if hasattr(well, 'canDownload'):
+                    if not well.canDownload():
+                        raise Http404
+        if hasattr(ob, 'canDownload'):
+            if not ob.canDownload():
+                raise Http404
 
     # make list of all files, removing duplicates
     fileMap = {}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2082,17 +2082,17 @@ def archived_files(request, iid=None, conn=None, **kwargs):
             " %s)." % (imgIds))
 
     # Test permissions on images and weels
-    for ob in (images + wells):
-        if isinstance(ob, omero.gateway.ImageWrapper):
-            # If plate download disabled, check for SPW data...
-            well = ob.getParent().getParent()
-            if isinstance(well, omero.gateway.WellWrapper):
-                if hasattr(well, 'canDownload'):
-                    if not well.canDownload():
-                        raise Http404
+    for ob in (wells):
         if hasattr(ob, 'canDownload'):
             if not ob.canDownload():
                 raise Http404
+
+    for ob in (images):
+        well = ob.getParent().getParent()
+        if isinstance(well, omero.gateway.WellWrapper):
+            if hasattr(well, 'canDownload'):
+                if not well.canDownload():
+                    raise Http404
 
     # make list of all files, removing duplicates
     fileMap = {}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2088,11 +2088,18 @@ def archived_files(request, iid=None, conn=None, **kwargs):
                 raise Http404
 
     for ob in (images):
-        well = ob.getParent().getParent()
-        if isinstance(well, omero.gateway.WellWrapper):
-            if hasattr(well, 'canDownload'):
-                if not well.canDownload():
+        well = None
+        try:
+            well = ob.getParent().getParent()
+        except:
+            if hasattr(ob, 'canDownload'):
+                if not ob.canDownload():
                     raise Http404
+        else:
+            if well and isinstance(well, omero.gateway.WellWrapper):
+                if hasattr(well, 'canDownload'):
+                    if not well.canDownload():
+                        raise Http404
 
     # make list of all files, removing duplicates
     fileMap = {}

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -73,6 +73,18 @@ class TestDownload(IWebTest):
         }
         _get_response(self.django_client, request_url, data, status_code=404)
 
+    def test_orphaned_image_direct_download(self):
+        """
+        Download of archived files for a non-SPW orphaned Image.
+        """
+
+        image = self.importSingleImage()
+
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files',
+                              args=[image.id.val])
+        _get_response(self.django_client, request_url, {}, status_code=200)
+
     def test_orphaned_image_download(self):
         """
         Download of archived files for a non-SPW orphaned Image.

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -134,3 +134,17 @@ class TestDownload(IWebTest):
             "well": well.id.val
         }
         _get_response(self.django_client, request_url, data, status_code=404)
+
+    def test_attachement_download(self):
+        """
+        Download of attachement.
+        """
+
+        image = self.importSingleImage()
+        fa = self.make_file_annotation()
+        self.link(image, fa)
+
+        # download archived files
+        request_url = reverse('download_annotation',
+                              args=[fa.id.val])
+        _get_response(self.django_client, request_url, {}, status_code=200)

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -57,7 +57,7 @@ class TestDownload(IWebTest):
         ws.well = well
         well.addWellSample(ws)
         ws = self.update.saveAndReturnObject(ws)
-        return ws.image
+        return plate, well, ws.image
 
     def test_spw_download(self, image_well_plate):
         """
@@ -65,16 +65,17 @@ class TestDownload(IWebTest):
         and return a 404 response.
         """
 
-        image = image_well_plate
+        plate, well, image = image_well_plate
         # download archived files
         request_url = reverse('webgateway.views.archived_files')
         data = {
-            "image": image.id.val}
+            "image": image.id.val
+        }
         _get_response(self.django_client, request_url, data, status_code=404)
 
-    def test_image_download(self):
+    def test_orphaned_image_download(self):
         """
-        Download of archived files for a non-SPW Image.
+        Download of archived files for a non-SPW orphaned Image.
         """
 
         image = self.importSingleImage()
@@ -82,5 +83,54 @@ class TestDownload(IWebTest):
         # download archived files
         request_url = reverse('webgateway.views.archived_files')
         data = {
-            "image": image.id.val}
+            "image": image.id.val
+        }
         _get_response(self.django_client, request_url, data, status_code=200)
+
+    def test_image_in_dataset_download(self):
+        """
+        Download of archived files for a non-SPW Image in Dataset.
+        """
+
+        image = self.importSingleImage()
+        ds = self.make_dataset()
+        self.link(ds, image)
+
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files')
+        data = {
+            "image": image.id.val
+        }
+        _get_response(self.django_client, request_url, data, status_code=200)
+
+    def test_image_in_dataset_in_project_download(self):
+        """
+        Download of archived files for a non-SPW Image in Dataset in Project.
+        """
+
+        image = self.importSingleImage()
+        ds = self.make_dataset()
+        pr = self.make_project()
+
+        self.link(pr, ds)
+        self.link(ds, image)
+
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files')
+        data = {
+            "image": image.id.val
+        }
+        _get_response(self.django_client, request_url, data, status_code=200)
+
+    def test_well_download(self, image_well_plate):
+        """
+        Download of archived files for a SPW Well.
+        """
+
+        plate, well, image = image_well_plate
+        # download archived files
+        request_url = reverse('webgateway.views.archived_files')
+        data = {
+            "well": well.id.val
+        }
+        _get_response(self.django_client, request_url, data, status_code=404)


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/3543 follow up.

As long as PR #3593 is in, this should validate default settings and enable download button for image and file annotations but not allow to download plate. For custom config this can be tested as stated in #3593

**To test** go to Read-Ann group, choose user, choose own image and download. Repeat the same test in read-only and private group, try also with big image. Then test plate. Arrow button was turned on but you should see only export as, no Download.

Check if test passed
https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-web/lastCompletedBuild/testReport/test.integration.test_download/TestDownload/test_spw_download/

--no-rebase