### PR TITLE
Add no StatsInfo option to importer

### DIFF
--- a/components/blitz/resources/omero/Repositories.ice
+++ b/components/blitz/resources/omero/Repositories.ice
@@ -286,6 +286,11 @@ module omero {
              omero::RBool doThumbnails;
 
              /**
+              * Whether we are to disable StatsInfo population.
+              **/
+             omero::RBool noStatsInfo;
+
+             /**
               * User choice of checksum algorithm for verifying upload.
               **/
              omero::model::ChecksumAlgorithm checksumAlgorithm;

--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -484,33 +484,6 @@ public class ImportCandidates extends DirectoryWalker
     }
 
     /**
-     * Creates a Pixels object populated with the dimensions for each image
-     * that Bio-Formats has detected.
-     * @return A list of Pixels objects, in the order of <i>series</i>
-     * populated with dimensions X, Y, Z, C and T.
-     */
-    private List<Pixels> getPixelsWithDimensions()
-    {
-        List<Pixels> toReturn = new ArrayList<Pixels>();
-        for (int i = 0; i < reader.getSeriesCount(); i++)
-        {
-            reader.setSeries(i);
-            Pixels pixels = new PixelsI();
-            PixelsType pixelsType = new PixelsTypeI();
-            pixelsType.setValue(rstring(
-                    FormatTools.getPixelTypeString(reader.getPixelType())));
-            pixels.setSizeX(rint(reader.getSizeX()));
-            pixels.setSizeY(rint(reader.getSizeY()));
-            pixels.setSizeZ(rint(reader.getSizeZ()));
-            pixels.setSizeC(rint(reader.getSizeC()));
-            pixels.setSizeT(rint(reader.getSizeT()));
-            pixels.setPixelsType(pixelsType);
-            toReturn.add(pixels);
-        }
-        return toReturn;
-    }
-
-    /**
      * This method uses the {@link FileInfo#usedToInitialize} flag to re-order
      * used files. All files which can be used to initialize a fileset are
      * returned first.

--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -422,6 +422,7 @@ public class ImportCandidates extends DirectoryWalker
                         file, null, null,
                         readerClassName, usedFiles, isSPW);
                 ic.setDoThumbnails(config.doThumbnails.get());
+                ic.setNoStatsInfo(config.noStatsInfo.get());
                 String configImageName = config.userSpecifiedName.get();
                 if (configImageName == null)
                 {

--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -107,6 +107,7 @@ public class ImportConfig {
     public final StrValue sessionKey;
     public final LongValue group;
     public final BoolValue doThumbnails;
+    public final BoolValue noStatsInfo;
     public final StrValue email;
     public final StrValue userSpecifiedName;
     public final StrValue userSpecifiedDescription;
@@ -244,6 +245,7 @@ public class ImportConfig {
         sessionKey   = new StrValue("session", this);
         group		 = new LongValue("group", this, null);
         doThumbnails = new BoolValue("doThumbnails", this, true);
+        noStatsInfo  = new BoolValue("noStatsInfo", this, false);
         email        = new StrValue("email", this);
         qaBaseURL    = new StrValue("qaBaseURL", this, DEFAULT_QABASEURL);
         userSpecifiedName = new StrValue("userSpecifiedName", this);

--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -59,6 +59,7 @@ public class ImportContainer
     private String userSpecifiedName;
     private String userSpecifiedDescription;
     private boolean doThumbnails = true;
+    private boolean noStatsInfo = false;
     private List<Annotation> customAnnotationList;
     private IObject target;
     private String checksumAlgorithm;
@@ -86,7 +87,7 @@ public class ImportContainer
     /**
      * Retrieves whether or not we are performing thumbnail creation upon
      * import completion.
-     * return <code>true</code> if we are to perform thumbnail creation and
+     * @return <code>true</code> if we are to perform thumbnail creation and
      * <code>false</code> otherwise.
      * @since OMERO Beta 4.3.0.
      */
@@ -105,6 +106,28 @@ public class ImportContainer
     public void setDoThumbnails(boolean v)
     {
         doThumbnails = v;
+    }
+
+    /**
+     * Retrieves whether or not we disabling <codeStatsInfo</code> population.
+     * @returns <code>true</code> if we are to disable <code>StatsInfo</code>
+     * population. <code>false</code> otherwise.
+     * @since OMERO 5.1.
+     */
+    public boolean getNoStatsInfo()
+    {
+        return noStatsInfo;
+    }
+
+    /**
+     * Sets whether or not we disabling <codeStatsInfo</code> population.
+     * @param v <code>true</code> if we are to disable <code>StatsInfo</code>
+     * population. <code>false</code> otherwise.
+     * @since OMERO 5.1.
+     */
+    public void setNoStatsInfo(boolean v)
+    {
+        noStatsInfo = v;
     }
 
     /**
@@ -298,6 +321,7 @@ public class ImportContainer
         // TODO: These should possible be a separate option like
         // ImportUserSettings rather than misusing ImportContainer.
         settings.doThumbnails = rbool(getDoThumbnails());
+        settings.noStatsInfo = rbool(getNoStatsInfo());
         settings.userSpecifiedTarget = getTarget();
         settings.userSpecifiedName = getUserSpecifiedName() == null ? null
                 : rstring(getUserSpecifiedName());

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -515,11 +515,14 @@ public class CommandLineImporter {
         LongOpt qaBaseURL = new LongOpt(
                 "qa_baseurl", LongOpt.REQUIRED_ARGUMENT, null, 21);
 
+        LongOpt noStatsInfo =
+                new LongOpt("no_stats_info", LongOpt.NO_ARGUMENT, null, 22);
+
         // DEPRECATED OPTIONS
         LongOpt plateName = new LongOpt(
-                "plate_name", LongOpt.REQUIRED_ARGUMENT, null, 22);
+                "plate_name", LongOpt.REQUIRED_ARGUMENT, null, 90);
         LongOpt plateDescription = new LongOpt(
-                "plate_description", LongOpt.REQUIRED_ARGUMENT, null, 23);
+                "plate_description", LongOpt.REQUIRED_ARGUMENT, null, 91);
 
         Getopt g = new Getopt(APP_NAME, args, "cfl:s:u:w:d:r:k:x:n:p:h",
                 new LongOpt[] { debug, report, upload, logs, email,
@@ -528,7 +531,7 @@ public class CommandLineImporter {
                                 annotationLink, transferOpt, advancedHelp,
                                 checksumAlgorithm, minutesWait,
                                 closeCompleted, waitCompleted, autoClose,
-                                exclude,
+                                exclude, noStatsInfo,
                                 qaBaseURL, plateName, plateDescription});
         int a;
 
@@ -653,9 +656,13 @@ public class CommandLineImporter {
                 config.qaBaseURL.set(g.getOptarg());
                 break;
             }
+            case 22: {
+                config.noStatsInfo.set(true);
+                break;
+            }
             // ADVANCED END ---------------------------------------------------
             // DEPRECATED OPTIONS
-            case 22: {
+            case 90: {
                 if (userSpecifiedNameAlreadySet) {
                     usage();
                 }
@@ -663,7 +670,7 @@ public class CommandLineImporter {
                 userSpecifiedNameAlreadySet = true;
                 break;
             }
-            case 23: {
+            case 91: {
                 if (userSpecifiedDescriptionAlreadySet) {
                     usage();
                 }

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -88,7 +88,7 @@ import ch.qos.logback.classic.ClassicConstants;
  */
 public class ManagedImportRequestI extends ImportRequest implements IRequest {
 
-    private static final long serialVersionUID = -303948503984L;
+    private static final long serialVersionUID = -303948503985L;
 
     private static Logger log = LoggerFactory.getLogger(ManagedImportRequestI.class);
 
@@ -133,6 +133,8 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
     private List<Annotation> annotationList = null;
 
     private boolean doThumbnails = true;
+
+    private boolean noStatsInfo = false;
 
     private String fileName = null;
 
@@ -215,6 +217,8 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             annotationList = settings.userSpecifiedAnnotationList;
             doThumbnails = settings.doThumbnails == null ? true :
                 settings.doThumbnails.getValue();
+            noStatsInfo = settings.noStatsInfo == null ? false :
+                settings.noStatsInfo.getValue();
 
             detectAutoClose();
 
@@ -570,7 +574,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
 
         store.updatePixels(pixList);
 
-        if (!reader.isMinMaxSet())
+        if (!reader.isMinMaxSet() && !noStatsInfo)
         {
             store.populateMinMax();
         }

--- a/components/common/test/ome/testing/ObjectFactory.java
+++ b/components/common/test/ome/testing/ObjectFactory.java
@@ -121,6 +121,7 @@ public class ObjectFactory {
             pi.setValue("RGB");
 
             pt.setValue("int8");
+            pt.setBitSize(8);
 
             dO.setValue("XYZTC");
 

--- a/components/rendering/src/omeis/providers/re/HSBStrategy.java
+++ b/components/rendering/src/omeis/providers/re/HSBStrategy.java
@@ -187,11 +187,14 @@ class HSBStrategy extends RenderingStrategy {
     	if (overlays != null)
     	{
     		QuantumDef def = new QuantumDef();  // Just to fulfill interface
+    		Pixels pixels = new Pixels();
     		PixelsType bitType = new PixelsType();
     		bitType.setValue(PlaneFactory.BIT);
+    		bitType.setBitSize(1);
+    		pixels.setPixelsType(bitType);
     		for (int i = 0; i < overlays.size(); i++)
     		{
-    			strats.add(new BinaryMaskQuantizer(def, bitType));
+    			strats.add(new BinaryMaskQuantizer(def, pixels));
     		}
     	}
         return strats;

--- a/components/rendering/src/omeis/providers/re/QuantumManager.java
+++ b/components/rendering/src/omeis/providers/re/QuantumManager.java
@@ -69,15 +69,12 @@ class QuantumManager {
      * 
      * @param qd
      *            The quantum definition which dictates what strategy to use.
-     * @param type
-     *            The pixels' type.
      * @param waves
      *            Rendering settings associated to each wavelength (channel).
      */
-    void initStrategies(QuantumDef qd, PixelsType type,
-            List<ChannelBinding> waves) {
+    void initStrategies(QuantumDef qd, List<ChannelBinding> waves) {
         ChannelBinding[] cb = waves.toArray(new ChannelBinding[waves.size()]);
-        initStrategies(qd, type, cb);
+        initStrategies(qd, cb);
     }
 
     /**
@@ -87,12 +84,10 @@ class QuantumManager {
      * 
      * @param qd
      *            The quantum definition which dictates what strategy to use.
-     * @param type
-     *            The pixels' type.
      * @param waves
      *            Rendering settings associated to each wavelength (channel).
      */
-    void initStrategies(QuantumDef qd, PixelsType type, ChannelBinding[] waves) {
+    void initStrategies(QuantumDef qd, ChannelBinding[] waves) {
         QuantumStrategy stg;
         double gMin, gMax;
         int w = 0;
@@ -101,10 +96,10 @@ class QuantumManager {
         double[] minmax;
         for (Iterator<Channel> i = metadata.iterateChannels(); i.hasNext();) {
             channel = i.next();
-            stg = factory.getStrategy(qd, type);
+            stg = factory.getStrategy(qd, metadata);
             StatsInfo statsInfo = channel.getStatsInfo();
             if (statsInfo == null) {
-                minmax = sf.initPixelsRange(type);
+                minmax = sf.initPixelsRange(metadata);
                 gMin = minmax[0];
                 gMax = minmax[1];
             } else {

--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -349,7 +349,7 @@ public class Renderer {
         QuantumDef qd = rndDef.getQuantization();
         quantumManager = new QuantumManager(metadata, quantumFactory);
         ChannelBinding[] cBindings = getChannelBindings();
-        quantumManager.initStrategies(qd, metadata.getPixelsType(), cBindings);
+        quantumManager.initStrategies(qd, cBindings);
 
         // Create and configure the codomain chain.
         codomainChain = new CodomainChain(qd.getCdStart().intValue(), qd
@@ -429,7 +429,7 @@ public class Renderer {
     public void updateQuantumManager() {
         QuantumDef qd = rndDef.getQuantization();
         ChannelBinding[] cb = getChannelBindings();
-        quantumManager.initStrategies(qd, metadata.getPixelsType(), cb);
+        quantumManager.initStrategies(qd, cb);
     }
 
     /**

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -247,6 +247,7 @@ public class StatsFactory {
         if (significantBits == null) {
             significantBits = type.getBitSize();
         }
+        significantBits = Math.min(significantBits, type.getBitSize());
         if (FormatTools.isSigned(bfPixelsType)) {
             minmax[0] = -Math.pow(2, significantBits - 1);
             minmax[1] = Math.pow(2,  significantBits - 1) - 1;

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -220,22 +220,40 @@ public class StatsFactory {
         return s;
     }
 
-
     /** 
      * Determines the minimum and maximum corresponding to the passed
-     * pixels type.
+     * pixels.
      * 
-     * @param type The pixels type to handle.
+     * @param metadata The pixels to handle.
      */
-    public double[] initPixelsRange(PixelsType type)
+    public double[] initPixelsRange(Pixels metadata)
     {
+        PixelsType type = metadata.getPixelsType();
         double[] minmax = new double[] {0, 1};
         if (type == null) return minmax;
         String typeAsString = type.getValue();
-        long[] values = FormatTools.defaultMinMax(
-                FormatTools.pixelTypeFromString(typeAsString));
-        minmax[0] = values[0];
-        minmax[1] = values[1];
+        int bfPixelsType = FormatTools.pixelTypeFromString(typeAsString);
+
+        // Handle floating point types first
+        if (FormatTools.isFloatingPoint(bfPixelsType)) {
+            long[] values = FormatTools.defaultMinMax(bfPixelsType);
+            minmax[0] = values[0];
+            minmax[1] = values[1];
+            return minmax;
+        }
+
+        // Use significant bits if they are available for integral pixel types.
+        Integer significantBits = metadata.getSignificantBits();
+        if (significantBits == null) {
+            significantBits = type.getBitSize();
+        }
+        if (FormatTools.isSigned(bfPixelsType)) {
+            minmax[0] = -Math.pow(2, significantBits - 1);
+            minmax[1] = Math.pow(2,  significantBits - 1) - 1;
+        } else {
+            minmax[0] = 0;
+            minmax[1] = Math.pow(2, significantBits) - 1;
+        }
         return minmax;
     }
 
@@ -258,7 +276,7 @@ public class StatsFactory {
         inputStart = 0;
         inputEnd = 1;
         if (stats == null) {
-            double[] values = initPixelsRange(metadata.getPixelsType());
+            double[] values = initPixelsRange(metadata);
             inputStart = values[0];
             inputEnd = values[1];
         } else {

--- a/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
+++ b/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
@@ -34,7 +34,7 @@ public class BinaryMaskQuantizer extends QuantumStrategy
     {
         super(qd, pixels);
         PixelsType type = pixels.getPixelsType();
-        if (!PlaneFactory.BIT.equals(type))
+        if (!PlaneFactory.BIT.equals(type.getValue()))
         {
         	throw new IllegalArgumentException(
         			"The type " + type.getValue() + " != 'bit'.");

--- a/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
+++ b/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
@@ -12,6 +12,7 @@ package omeis.providers.re.quantum;
 // Third-party libraries
 
 // Application-internal dependencies
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 import omeis.providers.re.data.PlaneFactory;
@@ -27,11 +28,12 @@ public class BinaryMaskQuantizer extends QuantumStrategy
      * Creates a new strategy.
      * 
      * @param qd Quantum definition object, contained mapping data.
-     * @param type The pixel type. Must be of type <code>bit</code>.
+     * @param type The pixels. Must be of type <code>bit</code>.
      */
-    public BinaryMaskQuantizer(QuantumDef qd, PixelsType type)
+    public BinaryMaskQuantizer(QuantumDef qd, Pixels pixels)
     {
-        super(qd, type);
+        super(qd, pixels);
+        PixelsType type = pixels.getPixelsType();
         if (!PlaneFactory.BIT.equals(type))
         {
         	throw new IllegalArgumentException(

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_32_bit.java
@@ -31,8 +31,8 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Range;
 
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
-import ome.model.enums.PixelsType;
 
 /**
  * Quantization process. In charge of building a look-up table for each active
@@ -207,11 +207,11 @@ public class Quantization_32_bit extends QuantumStrategy {
      *
      * @param qd
      *            Quantum definition object, contained mapping data.
-     * @param type
-     *            The pixel type;
+     * @param pixels
+     *            The pixels
      */
-    public Quantization_32_bit(QuantumDef qd, PixelsType type) {
-        super(qd, type);
+    public Quantization_32_bit(QuantumDef qd, Pixels pixels) {
+        super(qd, pixels);
         values = CacheBuilder.newBuilder()
                 .maximumSize(MAX-MIN+1)
                 .expireAfterWrite(10, TimeUnit.MINUTES)

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -12,8 +12,8 @@ package omeis.providers.re.quantum;
 // Third-party libraries
 
 // Application-internal dependencies
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
-import ome.model.enums.PixelsType;
 
 /**
  * Quantization process. In charge of building a look-up table for each active
@@ -285,10 +285,10 @@ public class Quantization_8_16_bit extends QuantumStrategy {
      * @param qd
      *            Quantum definition object, contained mapping data.
      * @param type
-     *            The pixel type;
+     *            The pixels
      */
-    public Quantization_8_16_bit(QuantumDef qd, PixelsType type) {
-        super(qd, type);
+    public Quantization_8_16_bit(QuantumDef qd, Pixels pixels) {
+        super(qd, pixels);
     }
 
     /**

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -26,8 +26,8 @@ package omeis.providers.re.quantum;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
-import ome.model.enums.PixelsType;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -170,10 +170,10 @@ public class Quantization_float extends QuantumStrategy {
      * @param qd
      *            Quantum definition object, contained mapping data.
      * @param type
-     *            The pixel type;
+     *            The pixels
      */
-    public Quantization_float(QuantumDef qd, PixelsType type) {
-        super(qd, type);
+    public Quantization_float(QuantumDef qd, Pixels pixels) {
+        super(qd, pixels);
         values = CacheBuilder.newBuilder()
                 .maximumSize(MAX-MIN+1)
                 .expireAfterWrite(10, TimeUnit.MINUTES)

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 
 
+import ome.model.core.Pixels;
 // Application-internal dependencies
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
@@ -137,11 +138,11 @@ public class QuantumFactory {
      * 
      * @param qd
      *            The definition to verify.
-     * @param type The pixels type to handle.
+     * @param type The pixels to handle.
      * @throws IllegalArgumentException
      *             If the check fails.
      */
-    private void verifyDef(QuantumDef qd, PixelsType type) {
+    private void verifyDef(QuantumDef qd, Pixels pixels) {
         if (qd == null) {
             throw new NullPointerException("No quantum definition.");
         }
@@ -182,19 +183,19 @@ public class QuantumFactory {
      * 
      * @param qd
      *            Defines the quantization context.
-     * @param type The pixels type to handle.
+     * @param pixels The pixels to handle.
      * @return A {@link QuantumStrategy} object suitable for the given pixels
      *         type.
      */
-    private QuantumStrategy getQuantization(QuantumDef qd, PixelsType type) {
-        String typeAsString = type.getValue();
+    private QuantumStrategy getQuantization(QuantumDef qd, Pixels pixels) {
+        String typeAsString = pixels.getPixelsType().getValue();
         if (PlaneFactory.INT32.equals(typeAsString) ||
                 PlaneFactory.UINT32.equals(typeAsString))
-            return new Quantization_32_bit(qd, type);
+            return new Quantization_32_bit(qd, pixels);
         else if (PlaneFactory.FLOAT_TYPE.equals(typeAsString) ||
                 PlaneFactory.DOUBLE_TYPE.equals(typeAsString))
-            return new Quantization_float(qd, type);
-        return new Quantization_8_16_bit(qd, type);
+            return new Quantization_float(qd, pixels);
+        return new Quantization_8_16_bit(qd, pixels);
     }
 
     /**
@@ -204,13 +205,13 @@ public class QuantumFactory {
      * @param qd
      *            Defines the quantization context. Mustn't be <code>null</code>
      *            and its values must have been properly specified.
-     * @param type The pixels type to handle.
+     * @param pixels The pixels to handle.
      * @return A {@link QuantumStrategy} suitable for the specified context.
      */
-    public QuantumStrategy getStrategy(QuantumDef qd, PixelsType type) {
-        verifyDef(qd, type);
+    public QuantumStrategy getStrategy(QuantumDef qd, Pixels pixels) {
+        verifyDef(qd, pixels);
         QuantumStrategy strg = null;
-        strg = getQuantization(qd, type);
+        strg = getQuantization(qd, pixels);
         if (strg == null) {
             throw new IllegalArgumentException("Unsupported strategy");
         }

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -14,9 +14,9 @@ package omeis.providers.re.quantum;
 // Application-internal dependencies
 import com.google.common.collect.Range;
 
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
-import ome.model.enums.PixelsType;
 import omeis.providers.re.data.PlaneFactory;
 import omeis.providers.re.metadata.StatsFactory;
 
@@ -103,8 +103,8 @@ public abstract class QuantumStrategy {
     /** Reference to a quantumDef object. */
     protected final QuantumDef qDef;
 
-    /** The type of pixels this strategy is for. */
-    protected final PixelsType type;
+    /** The pixels this strategy is for. */
+    protected final Pixels pixels;
 
     /** Reference to the value mapper. */
     protected QuantumMap valueMapper;
@@ -163,25 +163,26 @@ public abstract class QuantumStrategy {
         boolean b = false;
         if (min <= max) {
             double range = max - min;
-            if (PlaneFactory.in(type,
+            if (PlaneFactory.in(pixels.getPixelsType(),
             		new String[] { PlaneFactory.INT8, PlaneFactory.UINT8 })) {
                 if (range < 0x100) {
                     b = true;
                 }
             } else if (PlaneFactory
-                    .in(type, new String[] { PlaneFactory.INT16,
-                    		PlaneFactory.UINT16 })) {
+                    .in(pixels.getPixelsType(), new String[] {
+                            PlaneFactory.INT16, PlaneFactory.UINT16 })) {
                 if (range < 0x10000) {
                     b = true;
                 }
             } else if (PlaneFactory
-                    .in(type, new String[] { PlaneFactory.INT32,
-                            PlaneFactory.UINT32 })) {
+                    .in(pixels.getPixelsType(), new String[] {
+                            PlaneFactory.INT32, PlaneFactory.UINT32 })) {
                 if (range < 0x100000000L) {
                     b = true;
                 }
             } else if (PlaneFactory
-                    .in(type, new String[] { PlaneFactory.FLOAT_TYPE,
+                    .in(pixels.getPixelsType(), new String[] {
+                            PlaneFactory.FLOAT_TYPE,
                             PlaneFactory.DOUBLE_TYPE })) {
                 b = true;
             }
@@ -200,7 +201,7 @@ public abstract class QuantumStrategy {
     private void initPixelsRange(boolean withRange)
     {
         StatsFactory sf = new StatsFactory();
-        double[] values = sf.initPixelsRange(type);
+        double[] values = sf.initPixelsRange(pixels);
         pixelsTypeMin = values[0];
         pixelsTypeMax = values[1];
     }
@@ -209,9 +210,9 @@ public abstract class QuantumStrategy {
      * Creates a new instance.
      * 
      * @param qd The {@link QuantumDef} this strategy is for.
-     * @param pt The pixels type to handle.
+     * @param pixels The pixels to handle.
      */
-    protected QuantumStrategy(QuantumDef qd, PixelsType pt)
+    protected QuantumStrategy(QuantumDef qd, Pixels pixels)
     {
         windowStart = globalMin = 0.0;
         windowEnd = globalMax = 1.0;
@@ -222,10 +223,10 @@ public abstract class QuantumStrategy {
             throw new NullPointerException("No quantum definition");
         }
         this.qDef = qd;
-        if (pt == null) {
-            throw new NullPointerException("No pixel type");
+        if (pixels == null) {
+            throw new NullPointerException("No pixels");
         }
-        this.type = pt;
+        this.pixels = pixels;
         initPixelsRange(false);
     }
 

--- a/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
+++ b/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Glencoe Software, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omeis.providers.re.metadata;
+
+import ome.model.core.Pixels;
+import ome.model.enums.PixelsType;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test cases for {@link omeis.providers.re.metadata.StatsFactory}
+ * instances.
+ *
+ * @author Chris Allan <callan@glencoesoftware.com>
+ */
+@Test
+public class TestStatsFactory {
+
+    final StatsFactory statsFactory = new StatsFactory();
+
+    private Pixels createPixels(String value, Integer bitSize) {
+        Pixels pixels = new Pixels();
+        PixelsType pixelsType = new PixelsType(value);
+        pixelsType.setBitSize(bitSize);
+        pixels.setPixelsType(pixelsType);
+        return pixels;
+    }
+
+    public void testInitPixelsRangeInt8() {
+        Pixels pixels = createPixels("int8", 8);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], -128.0);
+        Assert.assertEquals(pixelsRange[1], 127.0);
+    }
+
+    public void testInitPixelsRangeInt16() {
+        Pixels pixels = createPixels("int16", 16);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], -32768.0);
+        Assert.assertEquals(pixelsRange[1], 32767.0);
+    }
+
+    public void testInitPixelsRangeInt32() {
+        Pixels pixels = createPixels("int32", 32);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        // We have to cast the assertions to double because of differences
+        // in precision that would cause test failures.
+        Assert.assertEquals(pixelsRange[0], (double) Integer.MIN_VALUE);
+        Assert.assertEquals(pixelsRange[1], (double) Integer.MAX_VALUE);
+    }
+
+    public void testInitPixelsRangeUInt8() {
+        Pixels pixels = createPixels("uint8", 8);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], 0.0);
+        Assert.assertEquals(pixelsRange[1], 255.0);
+    }
+
+    public void testInitPixelsRangeUInt16() {
+        Pixels pixels = createPixels("uint16", 16);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], 0.0);
+        Assert.assertEquals(pixelsRange[1], 65535.0);
+    }
+
+    public void testInitPixelsRangeUInt32() {
+        Pixels pixels = createPixels("uint32", 32);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], 0.0);
+        Assert.assertEquals(pixelsRange[1], (double) (Math.pow(2, 32) - 1));
+    }
+
+    public void testInitPixelsRangeFloat() {
+        Pixels pixels = createPixels("float", 32);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        // We have to cast the assertions to double because of differences
+        // in precision that would cause test failures.
+        Assert.assertEquals(pixelsRange[0], (double) Integer.MIN_VALUE);
+        Assert.assertEquals(pixelsRange[1], (double) Integer.MAX_VALUE);
+    }
+
+    public void testInitPixelsRangeDouble() {
+        Pixels pixels = createPixels("double", 64);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], (double) Integer.MIN_VALUE);
+        Assert.assertEquals(pixelsRange[1], (double) Integer.MAX_VALUE);
+    }
+}

--- a/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
+++ b/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
@@ -111,4 +111,14 @@ public class TestStatsFactory {
         Assert.assertEquals(pixelsRange[0], (double) Integer.MIN_VALUE);
         Assert.assertEquals(pixelsRange[1], (double) Integer.MAX_VALUE);
     }
+
+    public void testInitPixelsRange12Bit() {
+        Pixels pixels = createPixels("uint16", 16);
+        pixels.setSignificantBits(12);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], 0.0);
+        Assert.assertEquals(pixelsRange[1], 4095.0);
+    }
+
 }

--- a/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
+++ b/components/rendering/test/omeis/providers/re/metadata/TestStatsFactory.java
@@ -121,4 +121,12 @@ public class TestStatsFactory {
         Assert.assertEquals(pixelsRange[1], 4095.0);
     }
 
+    public void testInitPixelsRangeClamping() {
+        Pixels pixels = createPixels("uint16", 16);
+        pixels.setSignificantBits(32);
+
+        double[] pixelsRange = statsFactory.initPixelsRange(pixels);
+        Assert.assertEquals(pixelsRange[0], 0.0);
+        Assert.assertEquals(pixelsRange[1], 65535.0);
+    }
 }

--- a/components/rendering/test/unit.testng.xml
+++ b/components/rendering/test/unit.testng.xml
@@ -14,6 +14,7 @@
       <package name="ome.util.math.*"/>
       <package name="ome.util.mem.*"/>
       <package name="ome.util.tests.*"/>
+      <package name="omeis.providers.re.metadata.*"/>
     </packages>
   </test>
 

--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -540,7 +540,7 @@ public class PixelsService extends AbstractFileSystemService
         }
         // Note: since the OMERO.fs work, a pixels pyramid is only required
         // when the pixels set meets big image criteria.
-        if (!pixelsFileExists && originalFilePath != null)
+        if (!pixelsFileExists && requirePyramid && originalFilePath != null)
         {
             handleMissingStatsInfo(pixels);
         }

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -49,7 +49,6 @@ import ome.model.display.ChannelBinding;
 import ome.model.display.QuantumDef;
 import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
-import ome.model.enums.PixelsType;
 import ome.model.enums.RenderingModel;
 import ome.model.screen.PlateAcquisition;
 import ome.model.screen.Screen;
@@ -100,16 +99,16 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     /**
      * Returns the min/max depending on the pixels type if the values
      * have not seen stored.
-     * 
-     * @param type The pixels type
+     *
+     * @param pixels The pixels.
      * @return See above.
      */
-    private double[] initPixelsRange(PixelsType type)
+    private double[] initPixelsRange(Pixels pixels)
     {
-    	StatsFactory factory = new StatsFactory();
-    	return factory.initPixelsRange(type);
+        StatsFactory factory = new StatsFactory();
+        return factory.initPixelsRange(pixels);
     }
-    
+
     /**
      * Returns the Id of the currently logged in user. Opposed to ThumbnailBean,
      * here we do not support share contexts since this service requires a viable
@@ -838,7 +837,6 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         	StatsInfo stats;
         	double min, max;
             QuantumStrategy qs;
-            PixelsType pt = pixels.getPixelsType();
             double[] range;
             for (int w = 0; w < pixels.sizeOfChannels(); w++) {
                 // FIXME: This is where we need to have the ChannelBinding -->
@@ -848,7 +846,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             	channelBinding = channelBindings.get(w);
             	stats = pixels.getChannel(w).getStatsInfo();
             	if (stats == null) {
-            		range = initPixelsRange(pt);
+            		range = initPixelsRange(pixels);
             		min = range[0];
             		max = range[1];
             	} else {
@@ -856,7 +854,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
                 	max = stats.getGlobalMax().doubleValue();
             	}
             	if (Math.abs(min-max) < EPSILON) { //to be on the save side
-            		qs = quantumFactory.getStrategy(qDef, pt);
+            		qs = quantumFactory.getStrategy(qDef, pixels);
             		min = qs.getPixelsTypeMin();
             		max = qs.getPixelsTypeMax();
             	}
@@ -895,7 +893,6 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         ChannelBinding cb;
         double min, max;
         QuantumStrategy qs;
-        PixelsType pt = pixels.getPixelsType();
         for (int w = 0; w < pixels.sizeOfChannels(); w++) {
             // FIXME: This is where we need to have the ChannelBinding -->
             // Channel linkage. Without it, we have to assume that the order in
@@ -908,7 +905,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             min = sf.getInputStart();
             max = sf.getInputEnd();
         	if (Math.abs(min-max) < EPSILON) {
-        		qs = quantumFactory.getStrategy(qDef, pt);
+        		qs = quantumFactory.getStrategy(qDef, pixels);
         		min = qs.getPixelsTypeMin();
         		max = qs.getPixelsTypeMax();
         	}
@@ -1497,7 +1494,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
                     cb = settings.getChannelBinding(i);
                     stats = pixels.getChannel(i).getStatsInfo();
                     if (stats == null) {
-                    	range = initPixelsRange(pixels.getPixelsType());
+                    	range = initPixelsRange(pixels);
                     	min = range[0];
                     	max = range[1];
                     } else {

--- a/components/server/test/omeis/providers/re/utests/BaseRenderingTest.java
+++ b/components/server/test/omeis/providers/re/utests/BaseRenderingTest.java
@@ -119,6 +119,7 @@ public class BaseRenderingTest extends TestCase
 	{
 		PixelsType pixelsType = new PixelsType();
 		pixelsType.setValue("uint16");
+		pixelsType.setBitSize(16);
 		return pixelsType;
 	}
 	

--- a/components/server/test/omeis/providers/re/utests/OnTheFlyStrategy.java
+++ b/components/server/test/omeis/providers/re/utests/OnTheFlyStrategy.java
@@ -13,10 +13,11 @@ package omeis.providers.re.utests;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
+import ome.model.core.Pixels;
 // Application-internal dependencies
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
-import ome.model.enums.PixelsType;
 import omeis.providers.re.quantum.PolynomialMap;
 import omeis.providers.re.quantum.QuantizationException;
 import omeis.providers.re.quantum.QuantumMap;
@@ -142,10 +143,10 @@ public class OnTheFlyStrategy extends QuantumStrategy {
      * @param qd
      *            Quantum definition object, contained mapping data.
      * @param type
-     *            The pixel type;
+     *            The pixels
      */
-    public OnTheFlyStrategy(QuantumDef qd, PixelsType type) {
-        super(qd, type);
+    public OnTheFlyStrategy(QuantumDef qd, Pixels pixels) {
+        super(qd, pixels);
         
         min = (int) getGlobalMin();
         max = (int) getGlobalMax();

--- a/components/server/test/omeis/providers/re/utests/TestOnTheFly16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestOnTheFly16BitRenderer.java
@@ -20,7 +20,7 @@ public class TestOnTheFly16BitRenderer extends BaseRenderingTest
 	{
 		TestQuantumFactory qf = new TestQuantumFactory();
 		qf.setStrategy(new OnTheFlyStrategy(settings.getQuantization(),
-				                            pixels.getPixelsType()));
+				                            pixels));
 		return qf;
 	}
 

--- a/components/server/test/omeis/providers/re/utests/TestQuantumFactory.java
+++ b/components/server/test/omeis/providers/re/utests/TestQuantumFactory.java
@@ -12,8 +12,8 @@ package omeis.providers.re.utests;
 // Third-party libraries
 
 // Application-internal dependencies
+import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
-import ome.model.enums.PixelsType;
 import omeis.providers.re.quantum.Quantization_8_16_bit;
 import omeis.providers.re.quantum.QuantumFactory;
 import omeis.providers.re.quantum.QuantumStrategy;
@@ -31,12 +31,12 @@ public class TestQuantumFactory extends QuantumFactory {
     {
     	this.strategy = strategy;
     }
-    
-    public QuantumStrategy getStrategy(QuantumDef qd, PixelsType pixelsType)
+
+    public QuantumStrategy getStrategy(QuantumDef qd, Pixels pixels)
     {
     	if (strategy == null)
     	{
-    		strategy = new Quantization_8_16_bit(qd, pixelsType);
+    		strategy = new Quantization_8_16_bit(qd, pixels);
     	}
     	return strategy;
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard16BitRendererLUTSizes.java
@@ -42,7 +42,7 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
 	public void testPixelValues() throws Exception
 	{
 	    QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(0.0, data.getPixelValue(i));
@@ -75,7 +75,7 @@ public class TestStandard16BitRendererLUTSizes extends BaseRenderingTest
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertEquals(0.0, qs.getPixelsTypeMin());
         assertEquals(Math.pow(2, 16)-1, qs.getPixelsTypeMax());
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandard32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard32BitRenderer.java
@@ -23,7 +23,7 @@ public class TestStandard32BitRenderer extends BaseRenderingTest
     {
         TestQuantumFactory qf = new TestQuantumFactory();
         qf.setStrategy(new Quantization_32_bit(settings.getQuantization(),
-                pixels.getPixelsType()));
+                pixels));
         return qf;
     }
 
@@ -50,6 +50,7 @@ public class TestStandard32BitRenderer extends BaseRenderingTest
 	{
 		PixelsType pixelsType = new PixelsType();
 		pixelsType.setValue("uint32");
+		pixelsType.setBitSize(32);
 		return pixelsType;
 	}
 	

--- a/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesFullRange.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandard32BitRendererLUTSizesFullRange.java
@@ -24,7 +24,7 @@ public class TestStandard32BitRendererLUTSizesFullRange extends BaseRenderingTes
     {
         TestQuantumFactory qf = new TestQuantumFactory();
         qf.setStrategy(new Quantization_32_bit(settings.getQuantization(),
-                pixels.getPixelsType()));
+                pixels));
         return qf;
     }
 
@@ -64,6 +64,7 @@ public class TestStandard32BitRendererLUTSizesFullRange extends BaseRenderingTes
     {
         PixelsType pixelsType = new PixelsType();
         pixelsType.setValue("uint32");
+        pixelsType.setBitSize(32);
         return pixelsType;
     }
 
@@ -71,7 +72,7 @@ public class TestStandard32BitRendererLUTSizesFullRange extends BaseRenderingTes
     public void testPixelValues() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(0.0, data.getPixelValue(i));
@@ -91,7 +92,7 @@ public class TestStandard32BitRendererLUTSizesFullRange extends BaseRenderingTes
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertEquals(0.0, qs.getPixelsTypeMin());
         assertEquals(Math.pow(2, 32)-1, qs.getPixelsTypeMax());
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardDoubleRenderer.java
@@ -39,7 +39,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
     {
         TestQuantumFactory qf = new TestQuantumFactory();
         qf.setStrategy(new Quantization_float(settings.getQuantization(),
-                pixels.getPixelsType()));
+                pixels));
         return qf;
     }
     
@@ -85,6 +85,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
     {
         PixelsType pixelsType = new PixelsType();
         pixelsType.setValue("double");
+        pixelsType.setBitSize(64);
         return pixelsType;
     }
 
@@ -92,7 +93,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
     public void testPixelValues() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(0.0, data.getPixelValue(i));
@@ -113,7 +114,7 @@ public class TestStandardDoubleRenderer extends BaseRenderingTest
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertEquals(new Double(Integer.MIN_VALUE),
                 new Double(qs.getPixelsTypeMin()));
         assertEquals(new Double(Integer.MAX_VALUE),

--- a/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardFloatRenderer.java
@@ -39,7 +39,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     {
         TestQuantumFactory qf = new TestQuantumFactory();
         qf.setStrategy(new Quantization_float(settings.getQuantization(),
-                pixels.getPixelsType()));
+                pixels));
         return qf;
     }
     
@@ -85,6 +85,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     {
         PixelsType pixelsType = new PixelsType();
         pixelsType.setValue("float");
+        pixelsType.setBitSize(32);
         return pixelsType;
     }
 
@@ -92,7 +93,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     public void testPixelValues() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(0.0, data.getPixelValue(i));
@@ -114,7 +115,7 @@ public class TestStandardFloatRenderer extends BaseRenderingTest
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertTrue(Integer.MIN_VALUE == qs.getPixelsTypeMin());
         assertTrue(Integer.MAX_VALUE == qs.getPixelsTypeMax());
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned16BitRenderer.java
@@ -58,6 +58,7 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
     {
         PixelsType pixelsType = new PixelsType();
         pixelsType.setValue("int16");
+        pixelsType.setBitSize(16);
         return pixelsType;
     }
 
@@ -65,7 +66,7 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
     public void testPixelValues() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         int n = data.size();
         for (int i = 0; i < n/2; i++) {
             assertEquals(qs.getPixelsTypeMin(), data.getPixelValue(i));
@@ -86,7 +87,7 @@ public class TestStandardSigned16BitRenderer extends BaseRenderingTest
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertEquals(-Math.pow(2, 16)/2, qs.getPixelsTypeMin());
         assertEquals(Math.pow(2, 16)/2-1, qs.getPixelsTypeMax());
     }

--- a/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
+++ b/components/server/test/omeis/providers/re/utests/TestStandardSigned32BitRenderer.java
@@ -37,7 +37,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     {
         TestQuantumFactory qf = new TestQuantumFactory();
         qf.setStrategy(new Quantization_32_bit(settings.getQuantization(),
-                pixels.getPixelsType()));
+                pixels));
         return qf;
     }
 
@@ -77,6 +77,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     {
         PixelsType pixelsType = new PixelsType();
         pixelsType.setValue("int32");
+        pixelsType.setBitSize(32);
         return pixelsType;
     }
 
@@ -85,7 +86,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     {
         int n = data.size();
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         for (int i = 0; i < n/2; i++) {
             assertEquals(qs.getPixelsTypeMin(), data.getPixelValue(i));
         }
@@ -105,7 +106,7 @@ public class TestStandardSigned32BitRenderer extends BaseRenderingTest
     public void testPixelValuesRange() throws Exception
     {
         QuantumStrategy qs = quantumFactory.getStrategy(
-                settings.getQuantization(), pixels.getPixelsType());
+                settings.getQuantization(), pixels);
         assertEquals(-Math.pow(2, 32)/2, qs.getPixelsTypeMin());
         assertEquals(Math.pow(2, 32)/2-1, qs.getPixelsTypeMax());
     }

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -200,6 +200,7 @@ class AbstractRepoTest(lib.ITest):
     def create_settings(self):
         settings = omero.grid.ImportSettings()
         settings.doThumbnails = rbool(True)
+        settings.noStatsInfo = rbool(False)
         settings.userSpecifiedTarget = None
         settings.userSpecifiedName = None
         settings.userSpecifiedDescription = None


### PR DESCRIPTION
This PR adds a `--no_stats_info` option to OMERO.importer to allow for the disabling of minima and maxima calculation when not present as part of the Bio-Formats reader metadata. This is of particular benefit where the data volume being imported is extremely high (10s of GB) and the person importing the data is aware of the tradeoffs that apply. Under such conditions calculating global minima and maxima can take **hours**. We have already applied a similar strategy to images of the digital pathology domain.

The significant bits populated as part of the import process are now being used to inform the default dynamic range of the rendering engine if such metadata is available. Furthermore, certain areas of the code that did not populate the bit width when creating a `PixelsType` have been fixed. At least one area where the pixels type name was being compared incorrectly has also been fixed.

Unit and integration tests cover the semantic implementation outlined here. Functional testing will have to be discussed.

/cc @emilroz 