### PR TITLE
projection combobox

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
@@ -526,8 +526,7 @@ class ControlPane
             names[index] = entry.getValue();
             index++;
         }
-        projectionTypesBox = EditorUtil.createComboBox(names, 0,
-                getBackground());
+        projectionTypesBox = new JComboBox(names);
         projectionTypesBox.setBackground(getBackground());
         projectionTypesBox.setToolTipText(PROJECTION_DESCRIPTION);
         projectionTypesBox.setActionCommand(""+TYPE);


### PR DESCRIPTION
Use normal combobox.
see https://trac.openmicroscopy.org/ome/ticket/11742
To test:
 * Select an image with several z
 * Open the full viewer.
 * Go to the projection tab.
 * Check that the options are displayed in a general combobox.
