### PR TITLE
DnD move dataset

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4484,6 +4484,9 @@ class TreeViewerComponent
 	                        if (exp.getId() == userID) {
 	                            target = null;
 	                            list.add(n);
+	                            data = (DataObject) os;
+	                            if (!groupIds.contains(data.getGroupId()))
+                                    groupIds.add(data.getGroupId());
 	                        }
 	                    } else {
 	                        if (canEdit(os)) {


### PR DESCRIPTION
Allow to move dataset out of project via DnD.
see https://trac.openmicroscopy.org/ome/ticket/11083

To test:
 * Select a dataset in a Project
 * Move the dataset out of the project using DnD
 * The action should be performed w/o dialog popping up