### PR TITLE
Filter MapAnnotations

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
@@ -104,16 +104,16 @@ class AnnotationDataUI
 {
 
 	/** Indicates to display all the annotations linked to the object. */
-	private static final int				SHOW_ALL = 0;
+	public static final int				SHOW_ALL = 0;
 	
 	/** 
 	 * Indicates to display the annotations linked by current user to 
 	 * the object. 
 	 */
-	private static final int				ADDED_BY_ME = 1;
+	public static final int				ADDED_BY_ME = 1;
 	
 	/** Indicates to display the annotations linked by others to the object. */
-	private static final int				ADDED_BY_OTHERS = 2;
+	public static final int				ADDED_BY_OTHERS = 2;
 	
 	/** The maximum number of elements displayed at a time. */
 	private static final int				MAX = 3;
@@ -568,7 +568,7 @@ class AnnotationDataUI
 		c.gridy++;
 
 		if(!model.isMultiSelection()) {
-			mapsPane.reload();
+			mapsPane.reload(filter);
 			content.add(mapsPane, c);
 			c.gridy++;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -453,7 +453,7 @@ class DocComponent
 		
 		Timestamp created = annotation.getCreated();
 		if(created !=null) {
-		    tt.addLine("Date", UIUtilities.formatShortDateTime(created), true);
+		    tt.addLine("Date", UIUtilities.formatDefaultDate(created), true);
 		}
 		
 		if (data instanceof FileAnnotationData) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -54,10 +54,12 @@ import javax.swing.SwingUtilities;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 import omero.model.OriginalFile;
+
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.util.DataObjectListCellRenderer;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
+import org.openmicroscopy.shoola.agents.util.ToolTipGenerator;
 import org.openmicroscopy.shoola.agents.util.editorpreview.PreviewPanel;
 import org.openmicroscopy.shoola.agents.util.ui.EditorDialog;
 import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
@@ -312,19 +314,19 @@ class DocComponent
 	/**
 	 * Adds the experimenters who use the annotation if any.
 	 * 
-	 * @param buf The buffer
+	 * @param tt The {@link ToolTipGenerator} to add the information on to
 	 * @param annotation The annotation to handle.
 	 */
-	private void checkAnnotators(StringBuffer buf, AnnotationData annotation)
+	private void checkAnnotators(ToolTipGenerator tt, AnnotationData annotation)
 	{
 		List<ExperimenterData> annotators = model.getAnnotators(annotation);
 		if (annotators.size() == 0) return;
 		Iterator<ExperimenterData> i = annotators.iterator();
 		ExperimenterData annotator;
-		buf.append("<b>Linked by:</b><br>");
+		tt.addLine("Linked by:", true);
 		while (i.hasNext()) {
 			annotator =  i.next();
-			buf.append(EditorUtil.formatExperimenter(annotator)+"<br>");
+			tt.addLine(EditorUtil.formatExperimenter(annotator));
 		}
 		if (annotators.size() > 1) {
 			String text = label.getText();
@@ -376,8 +378,7 @@ class DocComponent
 	 */
 	private String formatToolTip(AnnotationData annotation, String name)
 	{
-		StringBuffer buf = new StringBuffer();
-		buf.append("<html><body>");
+		ToolTipGenerator tt = new ToolTipGenerator();
 		if (model.isMultiSelection()) {
 			Map<DataObject, Boolean> m = null;
 			Entry<DataObject, Boolean> e;
@@ -405,115 +406,70 @@ class DocComponent
 				if (k.next().booleanValue())
 					n++;
 			}
-			buf.append(text);
-			buf.append(n);
+			tt.addLineNoBr(text+""+n+" ");
 			int index = 0;
 			String s;
 			while (j.hasNext()) {
 				e = j.next();
 				if (index == 0) {
-					buf.append(" ");
-					buf.append("<b>");
-					buf.append(model.getObjectTypeAsString(e.getKey()));
-					if (n > 1) buf.append("s");
-					buf.append(":</b>");
-					buf.append("<br>");
+				    tt.addLine(model.getObjectTypeAsString(e.getKey())+"s", true);
 					index++;
 				}
-				buf.append("<b>");
-				buf.append("ID ");
-				buf.append(e.getKey().getId());
-				buf.append(":</b> ");
-				buf.append(UIUtilities.formatPartialName(
-						model.getObjectName(e.getKey())));
+				tt.addLine("ID "+e.getKey().getId(), UIUtilities.formatPartialName(
+                        model.getObjectName(e.getKey())), true);
 				//Indicates who annotates the object if not the user
 				//currently logged in.
 				s = formatAnnotators(e.getKey(), annotation);
-				if (s != null) buf.append(s);
-				buf.append("<br>");
+				if (s != null) 
+				    tt.addLine(s);
 			}
-			buf.append("</body></html>");
-			return buf.toString();
+			return tt.toString();
 		}
 		
 		if (name != null) {
-			buf.append("<b>");
-			buf.append("Name: ");
-			buf.append("</b>");
-			buf.append(name);
-			buf.append("<br>");
+		    tt.addLine("Name", name, true);
 		}
 		
 		ExperimenterData exp = null;
 		
 		if(annotation.getId()>0) {
 			exp = model.getOwner(annotation);
-			buf.append("<b>");
-			buf.append("ID: ");
-			buf.append("</b>");
-			buf.append(annotation.getId());
-			buf.append("<br>");
+			tt.addLine("ID", ""+annotation.getId(), true);
 		}
 		
 		String ns = annotation.getNameSpace();
 		if(!CommonsLangUtils.isEmpty(ns) && !isInternalNS(ns)) {
-			buf.append("<b>");
-			buf.append("Namespace: ");
-			buf.append("</b>");
-			buf.append(ns);
-			buf.append("<br>");
+		    tt.addLine("Namespace", ns, true);
 		}
 		
 		String desc = annotation.getDescription();
 		if(!CommonsLangUtils.isEmpty(desc)) {
-			buf.append("<b>");
-			buf.append("Description: ");
-			buf.append("</b>");
-			buf.append(desc);
-			buf.append("<br>");
+		    tt.addLine("Description", desc, true);
 		}
 		
 		if(exp!=null) {
-			buf.append("<b>");
-			buf.append("Owner: ");
-			buf.append("</b>");
-			buf.append(EditorUtil.formatExperimenter(exp));
-			buf.append("<br>");
+		    tt.addLine("Owner", EditorUtil.formatExperimenter(exp), true);
 		}
 		
 		Timestamp created = annotation.getCreated();
 		if(created !=null) {
-			buf.append("<b>");
-			buf.append("Date: ");
-			buf.append("</b>");
-			buf.append(UIUtilities.formatShortDateTime(created));
-			buf.append("<br>");
+		    tt.addLine("Date", UIUtilities.formatShortDateTime(created), true);
 		}
 		
 		if (data instanceof FileAnnotationData) {
-				buf.append("<b>");
-				buf.append("File ID: ");
-				buf.append("</b>");
-				FileAnnotationData fa = (FileAnnotationData) data;
-				buf.append(fa.getFileID());
-				buf.append("<br>");
-				buf.append("<b>");
-			buf.append("Size: ");
-			buf.append("</b>");
-			//size not kb
-			long size = ((FileAnnotationData) annotation).getFileSize();
-			buf.append(UIUtilities.formatFileSize(size));
-			buf.append("<br>");
-			checkAnnotators(buf, annotation);
+		    FileAnnotationData fa = (FileAnnotationData) data;
+		    long size = ((FileAnnotationData) annotation).getFileSize();
+		    tt.addLine("File ID", ""+fa.getFileID(), true);
+		    tt.addLine("Size", UIUtilities.formatFileSize(size)+"kb", true);
+			checkAnnotators(tt, annotation);
 		} else if (data instanceof TagAnnotationData || data instanceof
 				XMLAnnotationData || data instanceof TermAnnotationData ||
 				data instanceof LongAnnotationData ||
 				data instanceof DoubleAnnotationData ||
 				data instanceof BooleanAnnotationData) {
-			checkAnnotators(buf, annotation);
+			checkAnnotators(tt, annotation);
 		}
-		buf.append("</body></html>");
-		return buf.toString();
+		return tt.toString();
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -438,7 +438,7 @@ class DocComponent
 		}
 		
 		String ns = annotation.getNameSpace();
-		if(!CommonsLangUtils.isEmpty(ns) && !isInternalNS(ns)) {
+		if(!CommonsLangUtils.isEmpty(ns) && !EditorUtil.isInternalNS(ns)) {
 		    tt.addLine("Namespace", ns, true);
 		}
 		
@@ -470,17 +470,6 @@ class DocComponent
 			checkAnnotators(tt, annotation);
 		}
 		return tt.toString();
-	}
-
-	/**
-	 * Checks if the given namespace is an internal one.
-	 * 
-	 * @param ns
-	 *            The namespace to check
-	 * @return See above
-	 */
-	private boolean isInternalNS(String ns) {
-		return ns.startsWith("openmicroscopy.org") || ns.startsWith("omero.");
 	}
 	
 	/** Initializes the various buttons. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
@@ -434,7 +434,7 @@ public class MapAnnotationsComponent extends JPanel implements
         
         Timestamp created = ma.getCreated();
         if(created !=null) {
-            tt.addLine("Date", UIUtilities.formatShortDateTime(created), true);
+            tt.addLine("Date", UIUtilities.formatDefaultDate(created), true);
         }
         
         return tt.toString();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapAnnotationsComponent.java
@@ -36,6 +36,7 @@ import java.awt.event.FocusListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,8 +65,10 @@ import org.openmicroscopy.shoola.agents.metadata.editor.maptable.MapTableModel;
 import org.openmicroscopy.shoola.agents.metadata.editor.maptable.MapTableSelectionModel;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerFactory;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
+import org.openmicroscopy.shoola.agents.util.ToolTipGenerator;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
+import pojos.ExperimenterData;
 import pojos.MapAnnotationData;
 
 /**
@@ -375,6 +378,7 @@ public class MapAnnotationsComponent extends JPanel implements
 				JPanel p = new JPanel();
 				p.setBackground(UIUtilities.BACKGROUND_COLOR);
 				UIUtilities.setBoldTitledBorder(title, p);
+				p.setToolTipText(generateToolTip(ma));
 				p.setLayout(new BorderLayout());
 				t = createMapTable(ma);
 
@@ -405,6 +409,37 @@ public class MapAnnotationsComponent extends JPanel implements
 		adjustScrollPane();
 	}
 
+	private String generateToolTip(MapAnnotationData ma) {
+	    ToolTipGenerator tt = new ToolTipGenerator();
+        ExperimenterData exp = null;
+        
+        if(ma.getId()>0) {
+            exp = model.getOwner(ma);
+            tt.addLine("ID", ""+ma.getId(), true);
+        }
+        
+        String ns = ma.getNameSpace();
+        if(!CommonsLangUtils.isEmpty(ns) && !EditorUtil.isInternalNS(ns)) {
+            tt.addLine("Namespace", ns, true);
+        }
+        
+        String desc = ma.getDescription();
+        if(!CommonsLangUtils.isEmpty(desc)) {
+            tt.addLine("Description", desc, true);
+        }
+        
+        if(exp!=null) {
+            tt.addLine("Owner", EditorUtil.formatExperimenter(exp), true);
+        }
+        
+        Timestamp created = ma.getCreated();
+        if(created !=null) {
+            tt.addLine("Date", UIUtilities.formatShortDateTime(created), true);
+        }
+        
+        return tt.toString();
+	}
+	
 	/**
 	 * En-/Disables the toolbar buttons with respect to the current model state
 	 */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2661,4 +2661,15 @@ public class EditorUtil
         }
         return false;
     }
+    
+    /**
+     * Checks if the given namespace is an internal one.
+     * 
+     * @param ns
+     *            The namespace to check
+     * @return See above
+     */
+    public static boolean isInternalNS(String ns) {
+        return ns.startsWith("openmicroscopy.org") || ns.startsWith("omero.");
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ToolTipGenerator.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ToolTipGenerator.java
@@ -1,0 +1,135 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.util;
+
+//Java imports
+
+/**
+ * Utility class which makes it easier to generate html tooltip text by
+ * encapsulating the {@link StringBuilder} operations
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @since 5.1
+ */
+public class ToolTipGenerator {
+
+    /* The buffer holding the current text */
+    private StringBuilder sb;
+
+    /**
+     * Creates a new instance
+     */
+    public ToolTipGenerator() {
+        sb = new StringBuilder();
+        sb.append("<html><body>");
+    }
+
+    /**
+     * Adds text without a linebreak
+     * 
+     * @param line
+     *            The text to add
+     */
+    public void addLineNoBr(String line) {
+        addLineNoBr(line, false);
+    }
+
+    /**
+     * Adds text without a linebreak
+     * 
+     * @param line
+     *            The text to add
+     * @param bold
+     *            Pass <code>true</code> to make the text bold
+     */
+    public void addLineNoBr(String line, boolean bold) {
+        if (bold)
+            sb.append("<b>");
+        sb.append(line);
+        if (bold)
+            sb.append("</b>");
+    }
+
+    /**
+     * Adds a new line
+     * 
+     * @param line
+     *            The text to add
+     */
+    public void addLine(String line) {
+        addLine(line, false);
+    }
+
+    /**
+     * Adds a new line
+     * 
+     * @param line
+     *            The text to add
+     * @param bold
+     *            Pass <code>true</code> to make the text bold
+     */
+    public void addLine(String line, boolean bold) {
+        if (bold)
+            sb.append("<b>");
+        sb.append(line);
+        if (bold)
+            sb.append("</b>");
+        sb.append("<br/>");
+    }
+
+    /**
+     * Adds a new line in the form 'key: value'
+     * 
+     * @param key
+     *            The key text
+     * @param value
+     *            The value text
+     */
+    public void addLine(String key, String value) {
+        addLine(key, value, false);
+    }
+
+    /**
+     * Adds a new line in the form 'key: value'
+     * 
+     * @param key
+     *            The key text
+     * @param value
+     *            The value text
+     * @param bold
+     *            Pass <code>true</code> to make the key text bold
+     */
+    public void addLine(String key, String value, boolean bold) {
+        if (bold)
+            sb.append("<b>");
+        sb.append(key + ": ");
+        if (bold)
+            sb.append("</b>");
+        sb.append(value);
+        sb.append("<br/>");
+    }
+
+    @Override
+    public String toString() {
+        return sb.toString() + "</body></html>";
+    }
+}


### PR DESCRIPTION
Modifies MapAnnotation panel so that it takes the 'show all', 'added by me' and 'added by others' filter into account. Also adds a tooltip to the MapAnnotation panel (Tooltip is active on the title border around the MapAnnotations panel, which means the user's own MapAnnotation doesn't have a tooltip).

Test: Check that the "Show all", "Show added by me" and "Show added by others" filter in the Annotations panel works for MapAnnotations like it does for all other kinds of annotations. Check that the tooltip is shown when you hover of the titled border of another user's MapAnnotation.

See [Ticket 12752](https://trac.openmicroscopy.org/ome/ticket/12752)
