### PR TITLE
Restrict download (Take 2)

### DIFF
--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -253,9 +253,9 @@ module omero {
       /**
        * Extended restriction name which may be applied to images and other
        * downloadable materials. This string can also be found in the
-       * ome.security.policy.DownloadPolicy class.
+       * ome.security.policy.BinaryAccessPolicy class.
        **/
-      const string DOWNLOAD = "RESTRICT-DOWNLOAD";
+      const string BINARYACCESS = "RESTRICT-BINARY-ACCESS";
     };
 
     module projection {

--- a/components/model/resources/mappings/acquisition.ome.xml
+++ b/components/model/resources/mappings/acquisition.ome.xml
@@ -105,6 +105,7 @@
 			<optional name="hasher" type="ome.model.enums.ChecksumAlgorithm"/>
 			<optional name="hash" type="string"/>
 			<optional name="mimetype" type="string"/>
+			<zeromany name="filesetEntries" type="ome.model.fs.FilesetEntry" inverse="originalFile"/>
 			<!--
 			Has a default set at the DB level of application/octet-stream.
 			Internal values in use are:

--- a/components/model/src/ome/model/internal/NamedValue.java
+++ b/components/model/src/ome/model/internal/NamedValue.java
@@ -87,11 +87,33 @@ public class NamedValue implements Serializable, Primitive {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        final int prime = 139;
         int result = 1;
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NamedValue other = (NamedValue) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
     }
 
     @Override

--- a/components/server/resources/ome/services/hibernate.xml
+++ b/components/server/resources/ome/services/hibernate.xml
@@ -96,7 +96,8 @@
     Scope: private
     </description>
     <constructor-arg ref="sessionHandler"/>
-    <constructor-arg ref="basicACLVoter"/>
+    <constructor-arg ref="aclVoter"/>
+    <constructor-arg ref="currentDetails"/>
   </bean>
   
   <bean id="sessionHandler" class="ome.tools.hibernate.SessionHandler">

--- a/components/server/resources/ome/services/sec-primitives.xml
+++ b/components/server/resources/ome/services/sec-primitives.xml
@@ -75,7 +75,7 @@
 
   <bean id="defaultPolicyService" class="ome.security.policy.DefaultPolicyService"/>
 
-  <bean id="RESTRICT-DOWNLOAD" class="ome.security.policy.DownloadPolicy">
+  <bean id="RESTRICT-BINARY-ACCESS" class="ome.security.policy.BinaryAccessPolicy">
     <constructor-arg>
       <set>
         <value>ome.model.annotations.FileAnnotation</value>
@@ -86,7 +86,7 @@
       </set>
     </constructor-arg>
     <constructor-arg ref="aclVoter"/>
-    <constructor-arg value="${omero.policy.download}"/>
+    <constructor-arg value="${omero.policy.binary_access}"/>
   </bean>
 
   <bean id="aclVoter" class="ome.security.CompositeACLVoter">
@@ -94,14 +94,14 @@
     <constructor-arg ref="sharingACLVoter"/>
     <constructor-arg ref="basicACLVoter"/>
   </bean>
-    
+
   <bean id="sharingACLVoter" class="ome.security.sharing.SharingACLVoter">
     <constructor-arg ref="systemTypes"/>
     <constructor-arg ref="currentDetails"/>
     <constructor-arg ref="shareStore"/>
     <constructor-arg ref="tokenHolder"/>
   </bean>
-  
+
   <bean id="basicACLVoter" class="ome.security.basic.BasicACLVoter">
     <constructor-arg ref="currentDetails"/>
     <constructor-arg ref="systemTypes"/>
@@ -111,7 +111,7 @@
     <constructor-arg ref="roles"/>
   </bean>
 
-  <bean name="sessionCache" class="ome.services.sessions.state.SessionCache">  
+  <bean name="sessionCache" class="ome.services.sessions.state.SessionCache">
     <property name="cacheManager"  ref="cacheManager"/>
     <property name="updateInterval" value="${omero.sessions.sync_force}"/><!-- ms -->
   </bean>
@@ -133,7 +133,7 @@
   <bean id="methodSecurity" class="ome.security.basic.BasicMethodSecurity">
     <property name="sessionManager" ref="sessionManager"/>
   </bean>
-  
+
   <!-- Throttling primitives -->
 
   <bean id="threadCounterFactory" class="ome.services.sessions.stats.CounterFactory">
@@ -145,7 +145,7 @@
   <bean id="sessionCounterFactory" class="ome.services.sessions.stats.CounterFactory"/>
 
   <!--
-  The following stats types 
+  The following stats types
   -->
 
   <bean id="perSessionStats" class="ome.services.sessions.stats.PerSessionStats">

--- a/components/server/src/ome/security/ACLEventListener.java
+++ b/components/server/src/ome/security/ACLEventListener.java
@@ -10,14 +10,14 @@ package ome.security;
 // Java imports
 
 // Third-party imports
+import java.util.Set;
+
 import ome.annotations.RevisionDate;
 import ome.annotations.RevisionNumber;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
 import ome.tools.hibernate.HibernateUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.hibernate.event.PostDeleteEvent;
 import org.hibernate.event.PostDeleteEventListener;
 import org.hibernate.event.PostInsertEvent;
@@ -34,6 +34,8 @@ import org.hibernate.event.PreLoadEvent;
 import org.hibernate.event.PreLoadEventListener;
 import org.hibernate.event.PreUpdateEvent;
 import org.hibernate.event.PreUpdateEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * responsible for intercepting all pre-INSERT, pre-UPDATE, pre-DELETE, and
@@ -103,6 +105,9 @@ public class ACLEventListener implements
             if (!aclVoter.allowLoad(event.getSession(), o.getClass(), o.getDetails(), o.getId())) {
                 aclVoter.throwLoadViolation(o);
             }
+            Set<String> restrictions = aclVoter.restrictions(o);
+            ((IObject) entity).getDetails().getPermissions()
+                .addExtendedRestrictions(restrictions);
         }
     }
 

--- a/components/server/src/ome/security/ACLVoter.java
+++ b/components/server/src/ome/security/ACLVoter.java
@@ -183,4 +183,10 @@ public interface ACLVoter {
      * @return
      */
     Set<String> restrictions(IObject object);
+
+    /**
+     * Gives the {@link ACLVoter} instance a chance to act on the {@link IObject}
+     * <em>after</em> the transaction but before finishing the AOP stack.
+     */
+    void postProcess(IObject obj);
 }

--- a/components/server/src/ome/security/ACLVoter.java
+++ b/components/server/src/ome/security/ACLVoter.java
@@ -12,7 +12,7 @@ package ome.security;
 // Third-party libraries
 
 // Application-internal dependencies
-import org.hibernate.Session;
+import java.util.Set;
 
 import ome.annotations.RevisionDate;
 import ome.annotations.RevisionNumber;
@@ -20,6 +20,8 @@ import ome.conditions.SecurityViolation;
 import ome.model.IObject;
 import ome.model.internal.Details;
 import ome.system.EventContext;
+
+import org.hibernate.Session;
 
 /**
  * helper security interface for all decisions on access control
@@ -173,4 +175,12 @@ public interface ACLVoter {
      */
     void throwDeleteViolation(IObject iObject) throws SecurityViolation;
 
+    /**
+     * Provide the active restrictions for this {@link IObject}.
+     *
+     * See {@link ome.security.policy.PolicyService for further details.
+     * @param object
+     * @return
+     */
+    Set<String> restrictions(IObject object);
 }

--- a/components/server/src/ome/security/CompositeACLVoter.java
+++ b/components/server/src/ome/security/CompositeACLVoter.java
@@ -102,4 +102,8 @@ public class CompositeACLVoter implements ACLVoter {
     public Set<String> restrictions(IObject object) {
         return choose().restrictions(object);
     }
+
+    public void postProcess(IObject object) {
+        choose().postProcess(object);
+    }
 }

--- a/components/server/src/ome/security/CompositeACLVoter.java
+++ b/components/server/src/ome/security/CompositeACLVoter.java
@@ -7,6 +7,8 @@
 
 package ome.security;
 
+import java.util.Set;
+
 import ome.api.IShare;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
@@ -96,4 +98,8 @@ public class CompositeACLVoter implements ACLVoter {
         choose().throwUpdateViolation(object);
     }
 
+    @Override
+    public Set<String> restrictions(IObject object) {
+        return choose().restrictions(object);
+    }
 }

--- a/components/server/src/ome/security/auth/SimpleRoleProvider.java
+++ b/components/server/src/ome/security/auth/SimpleRoleProvider.java
@@ -287,6 +287,7 @@ public class SimpleRoleProvider implements RoleProvider {
         copy.setDescription(g.getDescription());
         copy.setName(g.getName());
         copy.setLdap(g.getLdap());
+        copy.setConfig(g.getConfig());
         copy.getDetails().copy(sec.newTransientDetails(g));
         copy.getDetails().setPermissions(g.getDetails().getPermissions());
         // TODO see shallow copy comment on copy user

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -395,10 +395,6 @@ public class BasicACLVoter implements ACLVoter {
 
     }
 
-    public EventContext getEventContext() {
-        return this.currentUser.getCurrentEventContext();
-    }
-
     @Override
     public Set<String> restrictions(IObject object) {
         return policyService.listActiveRestrictions(object);

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -13,6 +13,9 @@ package ome.security.basic;
 import static ome.model.internal.Permissions.Role.GROUP;
 import static ome.model.internal.Permissions.Role.USER;
 import static ome.model.internal.Permissions.Role.WORLD;
+
+import java.util.Set;
+
 import ome.annotations.RevisionDate;
 import ome.annotations.RevisionNumber;
 import ome.conditions.GroupSecurityViolation;
@@ -396,6 +399,11 @@ public class BasicACLVoter implements ACLVoter {
         return this.currentUser.getCurrentEventContext();
     }
 
+    @Override
+    public Set<String> restrictions(IObject object) {
+        return policyService.listActiveRestrictions(object);
+    }
+
     public void postProcess(IObject object) {
         if (object.isLoaded()) {
             Details details = object.getDetails();
@@ -415,8 +423,7 @@ public class BasicACLVoter implements ACLVoter {
             // are currently being shared, the safest solution
             // is to always produce a copy.
             Permissions copy = new Permissions(p);
-            copy.copyRestrictions(allow,
-                    policyService.listActiveRestrictions(object));
+            copy.copyRestrictions(allow, restrictions(object));
             details.setPermissions(copy); // #9635
         }
     }

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -237,6 +237,7 @@ public class OmeroInterceptor implements Interceptor {
                 return;
             }
 
+            boolean equals = true;
             if (list.size() == snapshot.size()) {
                 for (int i = 0; i < list.size(); i++) {
                     if (list.get(i) == null) {
@@ -253,11 +254,14 @@ public class OmeroInterceptor implements Interceptor {
                     }
                     // If we reach this point, there's a non-match and the
                     // bumping of the version number should proceed.
+                    equals = false;
                     break;
                 }
                 // The two lists were found to be equal, do not bump the
                 // version number;
-                return;
+                if (equals) {
+                    return;
+                }
             }
 
             // https://hibernate.atlassian.net/browse/HHH-4897 workaround:

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -46,6 +46,7 @@ import ome.model.core.Pixels;
 import ome.model.display.RenderingDef;
 import ome.model.display.Thumbnail;
 import ome.model.internal.Details;
+import ome.model.internal.NamedValue;
 import ome.model.internal.Permissions;
 import ome.model.internal.Permissions.Right;
 import ome.model.internal.Permissions.Role;
@@ -233,6 +234,29 @@ public class OmeroInterceptor implements Interceptor {
 
             if (list.size() == 0 && snapshot.size() == 0) {
                 // Nothing here, so we don't care
+                return;
+            }
+
+            if (list.size() == snapshot.size()) {
+                for (int i = 0; i < list.size(); i++) {
+                    if (list.get(i) == null) {
+                        if (snapshot.get(i) == null) {
+                            continue;
+                        }
+                    } else { // first element is not null
+                        Object lhs = list.get(i);
+                        if (lhs instanceof NamedValue) {
+                            if (((NamedValue) lhs).equals(snapshot.get(i))) {
+                                continue;
+                            }
+                        }
+                    }
+                    // If we reach this point, there's a non-match and the
+                    // bumping of the version number should proceed.
+                    break;
+                }
+                // The two lists were found to be equal, do not bump the
+                // version number;
                 return;
             }
 

--- a/components/server/src/ome/security/policy/BinaryAccessPolicy.java
+++ b/components/server/src/ome/security/policy/BinaryAccessPolicy.java
@@ -99,7 +99,7 @@ public class BinaryAccessPolicy extends BasePolicy {
 
             if (global.contains("-image") || group.contains("-image")) {
                 return true;
-            } else if (!(global.contains("+plate") || group.contains("+plate"))) {
+            } else if (global.contains("-plate") || group.contains("-plate")) {
                 return true;
             }
         }

--- a/components/server/src/ome/security/policy/BinaryAccessPolicy.java
+++ b/components/server/src/ome/security/policy/BinaryAccessPolicy.java
@@ -88,11 +88,14 @@ public class BinaryAccessPolicy extends BasePolicy {
             }
         }
 
-        if (obj instanceof Plate ||
+        if (obj instanceof Image) {
+            if (global.contains("-image") || group.contains("-image")) {
+                return true;
+            }
+        } else if (obj instanceof Plate ||
             obj instanceof PlateAcquisition ||
             obj instanceof Well ||
-            obj instanceof WellSample ||
-            obj instanceof Image) {
+            obj instanceof WellSample) {
 
             if (global.contains("-image") || group.contains("-image")) {
                 return true;

--- a/components/server/src/ome/security/policy/BinaryAccessPolicy.java
+++ b/components/server/src/ome/security/policy/BinaryAccessPolicy.java
@@ -39,23 +39,23 @@ import ome.security.ACLVoter;
  *  standard permission permission and is intended to allow customizing who
  *  has access to widely shared data.
  */
-public class DownloadPolicy extends BasePolicy {
+public class BinaryAccessPolicy extends BasePolicy {
 
     /**
      * This string can also be found in the Constants.ice file in the
      * blitz package.
      */
-    public final static String NAME = "RESTRICT-DOWNLOAD";
+    public final static String NAME = "RESTRICT-BINARY-ACCESS";
 
     private final ACLVoter voter;
 
     private final List<String> config;
 
-    public DownloadPolicy(Set<Class<IObject>> types, ACLVoter voter) {
+    public BinaryAccessPolicy(Set<Class<IObject>> types, ACLVoter voter) {
         this(types, voter, null);
     }
 
-    public DownloadPolicy(Set<Class<IObject>> types, ACLVoter voter,
+    public BinaryAccessPolicy(Set<Class<IObject>> types, ACLVoter voter,
             String[] config) {
         super(types);
         this.voter = voter;
@@ -89,7 +89,7 @@ public class DownloadPolicy extends BasePolicy {
         if (grp != null && grp.getConfig() != null && grp.getConfig().size() > 0) {
             Set<String> rv = null;
             for (NamedValue nv : grp.getConfig()) {
-                if ("omero.policy.download".equals(nv.getName())) {
+                if ("omero.policy.binary_access".equals(nv.getName())) {
                     if (rv == null) {
                         rv = new HashSet<String>();
                     }

--- a/components/server/src/ome/security/sharing/SharingACLVoter.java
+++ b/components/server/src/ome/security/sharing/SharingACLVoter.java
@@ -18,7 +18,6 @@ import ome.security.SystemTypes;
 import ome.security.basic.CurrentDetails;
 import ome.security.basic.TokenHolder;
 import ome.services.sharing.ShareStore;
-import ome.system.EventContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,6 +115,11 @@ public class SharingACLVoter implements ACLVoter {
     @Override
     public Set<String> restrictions(IObject object) {
         return null;
+    }
+
+    @Override
+    public void postProcess(IObject object) {
+        return;
     }
 
     // Helpers

--- a/components/server/src/ome/security/sharing/SharingACLVoter.java
+++ b/components/server/src/ome/security/sharing/SharingACLVoter.java
@@ -7,6 +7,8 @@
 
 package ome.security.sharing;
 
+import java.util.Set;
+
 import ome.api.IShare;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
@@ -109,6 +111,11 @@ public class SharingACLVoter implements ACLVoter {
 
     public void throwDeleteViolation(IObject iObject) throws SecurityViolation {
         throwDisabled("Delete");
+    }
+
+    @Override
+    public Set<String> restrictions(IObject object) {
+        return null;
     }
 
     // Helpers

--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -40,15 +40,15 @@ import ome.conditions.SecurityViolation;
 import ome.io.nio.FileBuffer;
 import ome.io.nio.OriginalFilesService;
 import ome.model.core.OriginalFile;
-import ome.security.policy.DownloadPolicy;
+import ome.security.policy.BinaryAccessPolicy;
 import ome.util.ShallowCopy;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -406,7 +406,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
     @RolesAllowed("user")
     public byte[] read(long position, int length) {
         errorIfNotLoaded();
-        sec.checkRestriction(DownloadPolicy.NAME, file);
+        sec.checkRestriction(BinaryAccessPolicy.NAME, file);
 
         byte[] rawBuf = new byte[length];
         ByteBuffer buf = ByteBuffer.wrap(rawBuf);

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -147,9 +147,11 @@ class ITest(object):
         return str(create_path())
 
     @classmethod
-    def new_group(self, experimenters=None, perms=None, config=None):
+    def new_group(self, experimenters=None, perms=None,
+                  config=None, gname=None):
         admin = self.root.sf.getAdminService()
-        gname = self.uuid()
+        if gname is None:
+            gname = self.uuid()
         group = ExperimenterGroupI()
         group.name = rstring(gname)
         group.ldap = rbool(False)
@@ -446,7 +448,8 @@ class ITest(object):
 
     @classmethod
     def new_user(self, group=None, perms=None,
-                 owner=False, system=False):
+                 owner=False, system=False, uname=None,
+                 email=None):
         """
         :owner: If user is to be an owner of the created group
         :system: If user is to be a system admin
@@ -456,7 +459,8 @@ class ITest(object):
             raise Exception("No root client. Cannot create user")
 
         adminService = self.root.getSession().getAdminService()
-        name = self.uuid()
+        if uname is None:
+            uname = self.uuid()
 
         # Create group if necessary
         if not group:
@@ -467,15 +471,16 @@ class ITest(object):
 
         # Create user
         e = ExperimenterI()
-        e.omeName = rstring(name)
-        e.firstName = rstring(name)
-        e.lastName = rstring(name)
+        e.omeName = rstring(uname)
+        e.firstName = rstring(uname)
+        e.lastName = rstring(uname)
         e.ldap = rbool(False)
+        e.email = rstring(email)
         listOfGroups = list()
         listOfGroups.append(adminService.lookupGroup('user'))
         uid = adminService.createExperimenterWithPassword(
-            e, rstring(name), g, listOfGroups)
-        e = adminService.lookupExperimenter(name)
+            e, rstring(uname), g, listOfGroups)
+        e = adminService.lookupExperimenter(uname)
         if owner:
             adminService.setGroupOwner(g, e)
         if system:
@@ -484,7 +489,8 @@ class ITest(object):
         return adminService.getExperimenter(uid)
 
     def new_client(self, group=None, user=None, perms=None,
-                   owner=False, system=False, session=None, password=None):
+                   owner=False, system=False, session=None,
+                   password=None, email=None):
         """
         Like new_user() but returns an active client.
 
@@ -503,7 +509,8 @@ class ITest(object):
             if user is not None:
                 user, name = self.user_and_name(user)
             else:
-                user = self.new_user(group, perms, owner=owner, system=system)
+                user = self.new_user(group, perms, owner=owner,
+                                     system=system, email=email)
             props["omero.user"] = user.omeName.val
             if password is not None:
                 props["omero.pass"] = password

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -242,13 +242,16 @@ class ITest(object):
     the file and then return the image.
     """
 
-    def importSingleImage(self, name=None, client=None):
+    def importSingleImage(self, name=None, client=None,
+                          with_companion=False, **kwargs):
         if client is None:
             client = self.client
         if name is None:
             name = "importSingleImage"
 
-        images = self.importMIF(1, name=name, client=client)
+        images = self.importMIF(1, name=name, client=client,
+                                with_companion=with_companion,
+                                **kwargs)
         return images[0]
 
     """

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -147,12 +147,13 @@ class ITest(object):
         return str(create_path())
 
     @classmethod
-    def new_group(self, experimenters=None, perms=None):
+    def new_group(self, experimenters=None, perms=None, config=None):
         admin = self.root.sf.getAdminService()
         gname = self.uuid()
         group = ExperimenterGroupI()
         group.name = rstring(gname)
         group.ldap = rbool(False)
+        group.config = config
         if perms:
             group.details.permissions = PermissionsI(perms)
         gid = admin.createGroup(group)

--- a/components/tools/OmeroPy/src/omero/plugins/download.py
+++ b/components/tools/OmeroPy/src/omero/plugins/download.py
@@ -51,7 +51,7 @@ class DownloadControl(BaseControl):
         client = self.ctx.conn(args)
         orig_file = self.get_file(client.sf, args.object)
         perms = orig_file.details.permissions
-        name = omero.constants.permissions.DOWNLOAD
+        name = omero.constants.permissions.BINARYACCESS
 
         if perms.isRestricted(name):
             self.ctx.die(66, ("Download of OriginalFile:"

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -264,7 +264,7 @@ class TestDownload(CLITest):
 
         tmpfile = tmpdir.join('%s.test' % fixture)
         cfg = self.root.sf.getConfigService()
-        cfg = cfg.getConfigValue("omero.policy.download")
+        cfg = cfg.getConfigValue("omero.policy.binary_access")
 
         # Check that the config we have is at least tested
         # by *some* fixture
@@ -272,11 +272,11 @@ class TestDownload(CLITest):
         # But if this isn't a check for this particular
         # config, then skip.
         if cfg != fixture.cfg:
-            pytest.skip("Found download policy: %s" % cfg)
+            pytest.skip("Found binary access policy: %s" % cfg)
 
         config = None
         if fixture.grp is not None:
-            config = [NV("omero.policy.download", fixture.grp)]
+            config = [NV("omero.policy.binary_access", fixture.grp)]
 
         group = self.new_group(perms='rwr---', config=config)
         upper = self.new_client(group=group)
@@ -292,7 +292,7 @@ class TestDownload(CLITest):
         downer_q = downer.sf.getQueryService()
         downer_f = downer_q.get("OriginalFile", ofile.id.val)
         assert downer_f.details.permissions.isRestricted(
-            omero.constants.permissions.DOWNLOAD) != fixture.will_pass
+            omero.constants.permissions.BINARYACCESS) != fixture.will_pass
 
         self.args = ["download"]
         self.args += self.login_args(downer)

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -233,12 +233,16 @@ class TestDownload(CLITest):
                 self.ofile and 1 or 0,
                 self.plate and 1 or 0)
 
+    POLICY_DEF = "+read,+write,+image"
     POLICY_NONE = "-read,-write,-image,-plate"
     POLICY_NORDR = "-read,+write,+image,-plate"
-    POLICY_NOSPW = "+read,+write,+image,-plate"  # Default
+    POLICY_NOSPW = "+read,+write,+image,-plate"
     POLICY_ALL = "+read,+write,+image,+plate"
 
     POLICY_FIXTURES = (
+        PolicyFixture(POLICY_DEF, "owner", True, True, False),
+        PolicyFixture(POLICY_DEF, "admin", True, True, False),
+        PolicyFixture(POLICY_DEF, "owner", True, True, False),
         PolicyFixture(POLICY_NONE, "owner", False, False, False),
         PolicyFixture(POLICY_NONE, "admin", False, False, False),
         PolicyFixture(POLICY_NONE, "member", False, False, False),
@@ -248,11 +252,9 @@ class TestDownload(CLITest):
         PolicyFixture(POLICY_NOSPW, "owner", True, True, False),
         PolicyFixture(POLICY_NOSPW, "admin", True, True, False),
         PolicyFixture(POLICY_NOSPW, "member", True, True, False),
-        # The following are plate==False due to the
-        # pessimism of the default server config.
-        PolicyFixture(POLICY_ALL, "owner", True, True, False),
-        PolicyFixture(POLICY_ALL, "admin", True, True, False),
-        PolicyFixture(POLICY_ALL, "owner", True, True, False),
+        PolicyFixture(POLICY_ALL, "owner", True, True, True),
+        PolicyFixture(POLICY_ALL, "admin", True, True, True),
+        PolicyFixture(POLICY_ALL, "owner", True, True, True),
     )
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -274,7 +274,7 @@ class TestDownload(CLITest):
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
                              ids=POLICY_FIXTURES)
-    def testPolicyGrouplRestriction(self, tmpdir, fixture):
+    def testPolicyGroupRestriction(self, tmpdir, fixture):
         parts = fixture.cfg.split(",")
         config = [NV("omero.policy.binary_access", x) for x in parts]
         group = self.new_group(perms='rwr---', config=config)
@@ -303,7 +303,8 @@ class TestDownload(CLITest):
         for kls, oid, will_pass in (
             ("OriginalFile", ofile.id.val, fixture.ofile),
             ("Image", image.id.val, fixture.image),
-            ("Plate", plate.id.val, fixture.plate),):
+            ("Plate", plate.id.val, fixture.plate),
+        ):
 
             obj = downer_q.get(kls, oid)
             perms = obj.details.permissions

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -248,9 +248,11 @@ class TestDownload(CLITest):
         PolicyFixture(POLICY_NOSPW, "owner", True, True, False),
         PolicyFixture(POLICY_NOSPW, "admin", True, True, False),
         PolicyFixture(POLICY_NOSPW, "member", True, True, False),
-        PolicyFixture(POLICY_ALL, "owner", True, True, True),
-        PolicyFixture(POLICY_ALL, "admin", True, True, True),
-        PolicyFixture(POLICY_ALL, "owner", True, True, True),
+        # The following are plate==False due to the
+        # pessimism of the default server config.
+        PolicyFixture(POLICY_ALL, "owner", True, True, False),
+        PolicyFixture(POLICY_ALL, "admin", True, True, False),
+        PolicyFixture(POLICY_ALL, "owner", True, True, False),
     )
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -964,7 +964,7 @@ class TestPermissionProjections(lib.ITest):
 
         # Check if this test should run
         x = self.root.sf.getConfigService().getConfigValue(
-            "omero.policy.download")
+            "omero.policy.binary_access")
 
         if x != "repository":
             pytest.skip("Not repository")

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -634,7 +634,7 @@ DEPRECATED_SETTINGS_MAPPINGS = {
         ["PLATE_DOWNLOAD_ENABLED",
          "false",
          parse_boolean,
-         ("Use omero.policy.download instead to restrict download.")],
+         ("Use omero.policy.binary_access instead to restrict download.")],
 }
 
 del CUSTOM_HOST

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -108,17 +108,18 @@ omero.security.trustStorePassword=
 omero.policy.bean=defaultPolicyService
 
 # Configuration for the policy of whether users
-# can access binary files from disk. Typically
-# this will be done via downloading the files.
+# can access binary files from disk. Binary access
+# includes all attempts to download a file from the
+# UI.
 #
 # The individual components of the string include:
-#
-#  * read - whether or not users who have READ
-#    access to the objects can access the binary.
 #
 #  * write - whether or not users who have WRITE
 #    access to the objects can access the binary.
 #    This includes group and system administrators.
+#
+#  * read - whether or not users who have READ
+#    access to the objects can access the binary.
 #
 #  * image - whether or not images are to be considered
 #    accessible as a rule.
@@ -127,8 +128,25 @@ omero.policy.bean=defaultPolicyService
 #    objects are to be considered accessible as a rule.
 #    This includes wells, well samples, and plate runs.
 #
-# Note: earlier components which are disabled may override
-# later ones.
+# Though the order of the components of the property
+# are not important, the order that they are listed above
+# roughly corresponds to their priority. E.g. a -write
+# value will override +plate.
+#
+# Example 1: "-read,+write,+image,-plate" only owners
+#            of an image and admins can download it.
+#
+# Example 2: "-read,-write,-image,-plate" no downloading
+#            is possible.
+#
+# Configuration properties of the same name can be applied
+# to individual groups as well. E.g. adding,
+# omero.policy.binary_access=-read to a group, you can
+# prevent group-members from downloading original files.
+#
+# Configuration is pessimistic: if there is a negative
+# *either* on the group *or* at the server-level, the
+# restriction will be applied.
 #
 omero.policy.binary_access=+read,+write,+image,-plate
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -108,15 +108,29 @@ omero.security.trustStorePassword=
 omero.policy.bean=defaultPolicyService
 
 # Configuration for the policy of whether users
-# can access original files. Typical values
-# include:
+# can access binary files from disk. Typically
+# this will be done via downloading the files.
 #
-#  * "" (empty string) - permission-based.
-#  * "none" - no downloads are permitted.
-#  * "repository" - off by default, but can
-#       be enabled on a per-group or -user
-#       basis.
-omero.policy.binary_access=
+# The individual components of the string include:
+#
+#  * read - whether or not users who have READ
+#    access to the objects can access the binary.
+#
+#  * write - whether or not users who have WRITE
+#    access to the objects can access the binary.
+#    This includes group and system administrators.
+#
+#  * image - whether or not images are to be considered
+#    accessible as a rule.
+#
+#  * plate - whether or not plates and contained HCS
+#    objects are to be considered accessible as a rule.
+#    This includes wells, well samples, and plate runs.
+#
+# Note: earlier components which are disabled may override
+# later ones.
+#
+omero.policy.binary_access=+read,+write,+image,-plate
 
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -116,7 +116,7 @@ omero.policy.bean=defaultPolicyService
 #  * "repository" - off by default, but can
 #       be enabled on a per-group or -user
 #       basis.
-omero.policy.download=
+omero.policy.binary_access=
 
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -114,19 +114,19 @@ omero.policy.bean=defaultPolicyService
 #
 # The individual components of the string include:
 #
-#  * write - whether or not users who have WRITE
-#    access to the objects can access the binary.
-#    This includes group and system administrators.
+# - write - whether or not users who have WRITE
+#   access to the objects can access the binary.
+#   This includes group and system administrators.
 #
-#  * read - whether or not users who have READ
-#    access to the objects can access the binary.
+# - read - whether or not users who have READ
+#   access to the objects can access the binary.
 #
-#  * image - whether or not images are to be considered
-#    accessible as a rule.
+# - image - whether or not images are to be considered
+#   accessible as a rule.
 #
-#  * plate - whether or not plates and contained HCS
-#    objects are to be considered accessible as a rule.
-#    This includes wells, well samples, and plate runs.
+# - plate - whether or not plates and contained HCS
+#   objects are to be considered accessible as a rule.
+#   This includes wells, well samples, and plate runs.
 #
 # Though the order of the components of the property
 # are not important, the order that they are listed above
@@ -134,10 +134,10 @@ omero.policy.bean=defaultPolicyService
 # value will override +plate.
 #
 # Example 1: "-read,+write,+image,-plate" only owners
-#            of an image and admins can download it.
+# of an image and admins can download it.
 #
 # Example 2: "-read,-write,-image,-plate" no downloading
-#            is possible.
+# is possible.
 #
 # Configuration properties of the same name can be applied
 # to individual groups as well. E.g. adding,

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -146,9 +146,11 @@ omero.policy.bean=defaultPolicyService
 #
 # Configuration is pessimistic: if there is a negative
 # *either* on the group *or* at the server-level, the
-# restriction will be applied.
+# restriction will be applied. A missing value at the
+# server restricts the setting but allows the server
+# to override.
 #
-omero.policy.binary_access=+read,+write,+image,-plate
+omero.policy.binary_access=+read,+write,+image
 
 
 #############################################


### PR DESCRIPTION
This PR aims to build on gh-3543 by:
 * [x] allowing group settings (`ExperimenterGroup.confg`) to modify the `DownloadPolicy`
 * [x] ~~allow the `DownloadPolicy` to be driven by the size of files to be downloaded.~~

cc: @pwalczysko @aleksandra-tarkowska 

#### Expected behavior ####

##### (A) +read,+write,+image (default) #####

 * For plates, in the UIs the Download and Download Original Metadata menus are missing. If a group enables `+plate`, then the UI menus will come back.
 * All the downloads of non-plate data should work as before.

##### (A2) +read,+write,+image,-plate #####

 * Like (A), but no override is possible for individual groups.

##### (B) -read,+write,+image,-plate #####

 * As (B) above, but download will be restricted for members of the group who:
   * are not the owners of an image (assuming a non-`rwrw--` group)
   * are not owners of the group
   * are not in the system group

##### (C) +read,+write,+image,+plate #####

 * Downloads should be **enabled** for all objects.
 * A single group can disable plate imports by setting `-plate`.

##### (D) -read,-write,-image,-plate #####

 * Downloads should be **disabled** for all objects. (Just setting `-write` is sufficient for this setting, which is equivalent to "none" from gh-3545)

#### CLI testing tip ####

With https://github.com/openmicroscopy/openmicroscopy/pull/3600, it's possible to set a particular flag on the group:
```
  # To enable plate download (regardless of server setting)
  bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access +plate

  # To disable group-member download (regardless of server setting)
  bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access -read

  Etc.
```
So, to test each of the scenarios above, use (in order):
 * (A) `bin/omero obj null ExperimenterGroup:$ID config`
 * (A2) `bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access -plate`
 * (B) `bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access -read`
 * (C) `bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access +plate`
 * (D) `bin/omero obj map-set ExperimenterGroup:$ID config omero.policy.binary_access -write`

Note: *only one such value can be set at a time via `map-set`.*
