### PR TITLE
RFC: Deprecate IUpdate.deleteObject API method

### DIFF
--- a/components/blitz/resources/omero/api/IUpdate.ice
+++ b/components/blitz/resources/omero/api/IUpdate.ice
@@ -28,6 +28,7 @@ module omero {
                 void saveArray(IObjectList graph) throws ServerError;
                 IObjectList saveAndReturnArray(IObjectList graph) throws ServerError;
                 omero::sys::LongList saveAndReturnIds(IObjectList graph) throws ServerError;
+                ["deprecated:use omero::cmd::Delete2 instead"]
                 void deleteObject(omero::model::IObject row) throws ServerError;
                 idempotent void indexObject(omero::model::IObject row) throws ServerError;
             };

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -35,6 +35,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2585,18 +2586,11 @@ class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IUpdate#deleteObject(IObject)
 	 */
 	void deleteObject(SecurityContext ctx, IObject object)
 		throws DSOutOfServiceException, DSAccessException
 	{
-        Connector c = getConnector(ctx, true, false);
-		try {
-		    IUpdatePrx service = c.getUpdateService();
-			service.deleteObject(object);
-		} catch (Throwable t) {
-			handleException(t, "Cannot delete the object.");
-		}
+	    deleteObjects(ctx, Collections.singletonList(object));
 	}
 
 	/**
@@ -2607,22 +2601,42 @@ class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or logged in
 	 * @throws DSAccessException       If an error occurred while trying to
 	 *                                 retrieve data from OMERO service.
-	 * @see IUpdate#deleteObject(IObject)
 	 */
 	void deleteObjects(SecurityContext ctx, List<IObject> objects)
 		throws DSOutOfServiceException, DSAccessException
 	{
-        Connector c = getConnector(ctx, true, false);
-		try {
-		    IUpdatePrx service = c.getUpdateService();
-			Iterator<IObject> i = objects.iterator();
-			//TODO: need method
-			while (i.hasNext())
-				service.deleteObject(i.next());
-
-		} catch (Throwable t) {
-			handleException(t, "Cannot delete the object.");
-		}
+        try {
+            /* convert the list of objects to lists of IDs by OMERO model class name */
+            final Map<String, List<Long>> objectIds = new HashMap<String, List<Long>>();
+            for (final IObject object : objects) {
+                /* determine actual model class name for this object */
+                Class<? extends IObject> objectClass = object.getClass();
+                while (true) {
+                    final Class<?> superclass = objectClass.getSuperclass();
+                    if (IObject.class == superclass) {
+                        break;
+                    } else {
+                        objectClass = superclass.asSubclass(IObject.class);
+                    }
+                }
+                final String objectClassName = objectClass.getSimpleName();
+                /* then add the object's ID to the list for that class name */
+                final Long objectId = object.getId().getValue();
+                List<Long> idsThisClass = objectIds.get(objectClassName);
+                if (idsThisClass == null) {
+                    idsThisClass = new ArrayList<Long>();
+                    objectIds.put(objectClassName, idsThisClass);
+                }
+                idsThisClass.add(objectId);
+            }
+            /* now delete the objects */
+            final Request request = Requests.delete(objectIds);
+            final client client = getConnector(ctx, true, false).getClient();
+            final HandlePrx handle = client.getSession().submit(request);
+            new RequestCallback(client, handle).loop(50, 250);
+        } catch (Throwable t) {
+            handleException(t, "Cannot delete the object.");
+        }
 	}
 
 	/**
@@ -7225,7 +7239,7 @@ class OMEROGateway
 								}
 								if (shapeIndex !=-1) {
 									if (!removed.contains(coord))
-										updateService.deleteObject(serverShape);
+										deleteObject(ctx, serverShape);
 									serverRoi.addShape(
 											(Shape) shape.asIObject());
 								} else {


### PR DESCRIPTION
Deprecates `IUpdate.deleteObject` arising from discussion on https://trac.openmicroscopy.org/ome/ticket/2683. Definitely make sure that Insight object-delete options still work: this isn't the button for deleting images, datasets, etc., but instead subtler uses, like in cut/unlink or in changing / removing shapes in ROIs. In checking deletion, ensure that *only* the correct object(s) was deleted.

--no-rebase