### PR TITLE
Clean up mask rendering

### DIFF
--- a/components/blitz/resources/omero/ROMIO.ice
+++ b/components/blitz/resources/omero/ROMIO.ice
@@ -11,6 +11,7 @@
 
 #include <omero/ServerErrors.ice>
 #include <Ice/BuiltinSequences.ice>
+#include <omero/Collections.ice>
 
 module omero
 {
@@ -59,6 +60,18 @@ module romio
       int t;
       RegionDef region;
       int stride;
+    };
+
+    /**
+     * Extends PlaneDef by an option to toggle server side Mask rendering. By
+     * default all masks attached to the image fulfilling rendering criteria,
+     * will be rendered. This criteria is currently masks with a width and
+     * height equal to those of the image.
+     **/
+    class PlaneDefWithMasks extends PlaneDef
+    {
+      /** Optional (currently unimplemented) list of Masks to render. */
+      omero::api::LongList shapeIds;
     };
 
     class CodomainMapContext

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -33,7 +33,7 @@ module omero {
                 idempotent void lookupPixels(long pixelsId) throws ServerError;
                 idempotent bool lookupRenderingDef(long pixelsId) throws ServerError;
                 idempotent void loadRenderingDef(long renderingDefId) throws ServerError;
-                idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
+                ["deprecated: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
                 idempotent void load() throws ServerError;
                 idempotent void setModel(omero::model::RenderingModel model) throws ServerError;
                 idempotent omero::model::RenderingModel getModel() throws ServerError;

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -58,6 +58,7 @@ import omero.model.NamedValue;
 import omero.model.PermissionsI;
 import omero.romio.BlueBand;
 import omero.romio.GreenBand;
+import omero.romio.PlaneDefWithMasks;
 import omero.romio.RedBand;
 import omero.romio.XY;
 import omero.romio.XZ;
@@ -560,6 +561,12 @@ public class IceMapper extends ome.util.ModelMapper implements
         omero.romio.RegionDef r = def.region;
         if (r != null) {
         	pd.setRegion(new RegionDef(r.x, r.y, r.width, r.height));
+        }
+        if (def instanceof PlaneDefWithMasks) {
+            pd.setRenderShapes(true);
+            if (((PlaneDefWithMasks) def).shapeIds != null) {
+                pd.setShapeIds(((PlaneDefWithMasks) def).shapeIds);
+            }
         }
         switch (def.slice) {
         case XY.value:

--- a/components/common/src/omeis/providers/re/data/PlaneDef.java
+++ b/components/common/src/omeis/providers/re/data/PlaneDef.java
@@ -9,6 +9,8 @@ package omeis.providers.re.data;
 
 // Java imports
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 // Third-party libraries
 
@@ -70,10 +72,16 @@ public class PlaneDef implements Serializable {
 
     /** The region to retrieve i.e. a rectangular section of the plane. */
     private RegionDef region;
-    
+
     /** The step size. */
     private int stride;
-    
+
+    /** Render shapes (masks) assosiated with this plane? */
+    private boolean renderShapes;
+
+    /** List of shape Ids to render. */
+    private List<Long> shapeIds;
+
     /**
      * Creates a new instance. This new object will identify the plane belonging
      * to the set specified by <code>slice</code> and <code>t</code> and
@@ -105,6 +113,8 @@ public class PlaneDef implements Serializable {
         }
         this.t = t;
         stride = 0;
+        renderShapes = false;
+        shapeIds = new ArrayList<Long>();
     }
 
     /**
@@ -250,7 +260,43 @@ public class PlaneDef implements Serializable {
      * @return See above.
      */
     public int getStride() { return stride; }
-    
+
+    /**
+     * Returns weather or not the shapes (masks) will be rendered.
+     * 
+     * @return See above.
+     */
+    public boolean getRenderShapes() {
+        return renderShapes;
+    }
+
+    /**
+     * Sets weather or not to render the shapes (masks).
+     * 
+     * @param renderShapes The value to set.
+     */
+    public void setRenderShapes(boolean renderShapes) {
+        this.renderShapes = renderShapes;
+    }
+
+    /**
+     * Returns weather or not the shapes (masks) will be rendered.
+     * 
+     * @return See above.
+     */
+    public List<Long> getShapeIds() {
+        return shapeIds;
+    }
+
+    /**
+     * Sets weather or not to render the shapes (masks).
+     * 
+     * @param renderShapes The value to set.
+     */
+    public void setShapeIds(List<Long> shapeIds) {
+        this.shapeIds = shapeIds;
+    }
+
     /**
      * Overridden to reflect equality of abstract values (data object) as
      * opposite to object identity.
@@ -350,6 +396,8 @@ public class PlaneDef implements Serializable {
         if (region != null) {
             buf.append("; Region: " + region.toString());
         }
+        buf.append(", renderShapes=" + renderShapes);
+        buf.append(", shapeIds=" + shapeIds);
         return buf.toString();
     }
 

--- a/components/common/src/omeis/providers/re/data/PlaneDef.java
+++ b/components/common/src/omeis/providers/re/data/PlaneDef.java
@@ -262,7 +262,7 @@ public class PlaneDef implements Serializable {
     public int getStride() { return stride; }
 
     /**
-     * Returns weather or not the shapes (masks) will be rendered.
+     * Returns whether or not the shapes (masks) will be rendered.
      * 
      * @return See above.
      */
@@ -271,7 +271,7 @@ public class PlaneDef implements Serializable {
     }
 
     /**
-     * Sets weather or not to render the shapes (masks).
+     * Sets whether or not to render the shapes (masks).
      * 
      * @param renderShapes The value to set.
      */
@@ -280,7 +280,7 @@ public class PlaneDef implements Serializable {
     }
 
     /**
-     * Returns weather or not the shapes (masks) will be rendered.
+     * Returns whether or not the shapes (masks) will be rendered.
      * 
      * @return See above.
      */
@@ -289,7 +289,7 @@ public class PlaneDef implements Serializable {
     }
 
     /**
-     * Sets weather or not to render the shapes (masks).
+     * Sets whether or not to render the shapes (masks).
      * 
      * @param renderShapes The value to set.
      */

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1951,8 +1951,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 " and m.y = 0 " +
                 " and m.theZ = :theZ " +
                 " and m.theT = :theT" +
-                " and m.theC in :channelIds" +
-                " and m.id in :shapeIds";
+                " and m.theC in (:channelIds)" +
+                " and m.id in (:shapeIds)";
         return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
                 new Executor.SimpleWork(this,"getMaskList")
         {

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1923,9 +1923,13 @@ public class RenderingBean implements RenderingEngine, Serializable {
         final long height = pixelsObj.getSizeY();
         final long z = pd.getZ();
         final long t = pd.getT();
-        // What to do about sizeC???????
-        final Map<byte[], Integer> maskMap =
-                new LinkedHashMap<byte[], Integer>();
+
+        List<Long> channelIds = new ArrayList<Long>();
+        for (int c = 0; c < pixelsObj.getSizeC(); c++) {
+            if (rendDefObj.getChannelBinding(c).getActive()) {
+                channelIds.add((long) c);
+            }
+        }
 
         final Parameters params = new Parameters();
         params.addLong("pid", pid);
@@ -1933,6 +1937,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
         params.addLong("height", height);
         params.addLong("theZ", z);
         params.addLong("theT", t);
+        params.addList("channelIds", channelIds);
         params.addList("shapeIds", pd.getShapeIds());
         final String query =
                 "select m from Mask as m " +
@@ -1944,6 +1949,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 " and m.y = 0 " +
                 " and m.theZ = :theZ " +
                 " and m.theT = :theT" +
+                " and m.theC in :channelIds" +
                 " and m.id in :shapeIds";
         return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
                 new Executor.SimpleWork(this,"getMaskList")
@@ -1967,12 +1973,20 @@ public class RenderingBean implements RenderingEngine, Serializable {
         final long z = pd.getZ();
         final long t = pd.getT();
 
+        List<Long> channelIds = new ArrayList<Long>();
+        for (int c = 0; c < pixelsObj.getSizeC(); c++) {
+            if (rendDefObj.getChannelBinding(c).getActive()) {
+                channelIds.add((long) c);
+            }
+        }
+
         final Parameters params = new Parameters();
         params.addLong("pid", pid);
         params.addLong("width", width);
         params.addLong("height", height);
         params.addLong("theZ", z);
         params.addLong("theT", t);
+        params.addList("channelIds", channelIds);
         final String query =
                 "select m from Mask as m " +
                 "join m.roi as r join r.image as i where " +
@@ -1982,7 +1996,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 " and m.x = 0 " +
                 " and m.y = 0 " +
                 " and m.theZ = :theZ " +
-                " and m.theT = :theT";
+                " and m.theT = :theT" +
+                " and m.theC in :channelIds";
         return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
                 new Executor.SimpleWork(this,"getMaskList")
         {
@@ -2007,7 +2022,6 @@ public class RenderingBean implements RenderingEngine, Serializable {
             masks = getMasksById(pd);
         }
 
-        // What to do about sizeC???????
         final Map<byte[], Integer> maskMap =
                 new LinkedHashMap<byte[], Integer>();
 

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -41,6 +42,8 @@ import ome.model.display.QuantumDef;
 import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
+import ome.model.internal.Permissions;
+import ome.model.roi.Mask;
 import ome.parameters.Parameters;
 import ome.security.SecuritySystem;
 import ome.services.util.Executor;
@@ -457,6 +460,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
         rwl.readLock().lock();
 
         try {
+            final Map<byte[], Integer> overlays = getMasks(pd);
+            renderer.setOverlays(overlays);
             errorIfInvalidState();
             return renderer.render(pd);
         } catch (IOException e) {
@@ -480,6 +485,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
         rwl.writeLock().lock();
 
         try {
+            final Map<byte[], Integer> overlays = getMasks(pd);
+            renderer.setOverlays(overlays);
             errorIfInvalidState();
             checkPlaneDef(pd);
             if (resolutionLevel != null)
@@ -509,6 +516,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         ByteArrayOutputStream byteStream = null;
         try {
+            final Map<byte[], Integer> overlays = getMasks(pd);
+            renderer.setOverlays(overlays);
         	int stride = pd.getStride();
         	if (stride < 0) stride = 0;
         	stride++;
@@ -1897,5 +1906,111 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 tb.getThumbnailByLongestSide(96);
                 return null;
         }});
+    }
+
+    /**
+     * Get Masks attached to the image for rendering filtered by the user.
+     */
+    private List<IObject> getMasksById(PlaneDef pd) {
+        long pid = pixelsObj.getId();
+        final long width = pixelsObj.getSizeX();
+        final long height = pixelsObj.getSizeY();
+        final long z = pd.getZ();
+        final long t = pd.getT();
+        // What to do about sizeC???????
+        final Map<byte[], Integer> maskMap =
+                new LinkedHashMap<byte[], Integer>();
+
+        final Parameters params = new Parameters();
+        params.addLong("pid", pid);
+        params.addLong("width", width);
+        params.addLong("height", height);
+        params.addLong("theZ", z);
+        params.addLong("theT", t);
+        params.addList("shapeIds", pd.getShapeIds());
+        final String query =
+                "select m from Mask as m " +
+                "join m.roi as r join r.image as i where " +
+                "i.pixels.id = :pixelsId " +
+                " and m.width = :width " +
+                " and m.height = :height " +
+                " and m.x = 0 " +
+                " and m.y = 0 " +
+                " and m.theZ = :theZ " +
+                " and m.theT = :theT" +
+                " and m.id in :shapeIds";
+        return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
+                new Executor.SimpleWork(this,"getMaskList")
+        {
+            @Transactional(readOnly = true)
+            public List<IObject> doWork(Session session, ServiceFactory sf) {
+                return sf.getQueryService().findAllByQuery(
+                        query, params
+                );
+            }
+        });
+    }
+
+    /**
+     * Get all the Masks attached to the image for rendering.
+     */
+    private List<IObject> getAllMasks(PlaneDef pd) {
+        long pid = pixelsObj.getId();
+        final long width = pixelsObj.getSizeX();
+        final long height = pixelsObj.getSizeY();
+        final long z = pd.getZ();
+        final long t = pd.getT();
+
+        final Parameters params = new Parameters();
+        params.addLong("pid", pid);
+        params.addLong("width", width);
+        params.addLong("height", height);
+        params.addLong("theZ", z);
+        params.addLong("theT", t);
+        final String query =
+                "select m from Mask as m " +
+                "join m.roi as r join r.image as i where " +
+                "i.pixels.id = :pixelsId " +
+                " and m.width = :width " +
+                " and m.height = :height " +
+                " and m.x = 0 " +
+                " and m.y = 0 " +
+                " and m.theZ = :theZ " +
+                " and m.theT = :theT";
+        return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
+                new Executor.SimpleWork(this,"getMaskList")
+        {
+            @Transactional(readOnly = true)
+            public List<IObject> doWork(Session session, ServiceFactory sf) {
+                return sf.getQueryService().findAllByQuery(
+                        query, params
+                );
+            }
+        });
+    }
+
+    /**
+     * Get Mask attached to the image for rendering.
+     */
+    private Map<byte[], Integer> getMasks(PlaneDef pd) {
+        List<IObject> masks = new ArrayList<IObject>();
+        if (pd.getShapeIds().isEmpty()) {
+            masks = getAllMasks(pd);
+        }
+        else {
+            masks = getMasksById(pd);
+        }
+
+        // What to do about sizeC???????
+        final Map<byte[], Integer> maskMap =
+                new LinkedHashMap<byte[], Integer>();
+
+        for (int i = 0; i < masks.size(); i++) {
+           maskMap.put(
+                   ((Mask) masks.get(i)).getBytes(),
+                   ((Mask) masks.get(i)).getFillColor()
+           );
+        }
+        return maskMap;
     }
 }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -461,7 +461,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         try {
             final Map<byte[], Integer> overlays = getMasks(pd);
-            renderer.setOverlays(overlays);
+            if (overlays.size() > 0) {
+                renderer.setOverlays(overlays);
+            }
             errorIfInvalidState();
             return renderer.render(pd);
         } catch (IOException e) {
@@ -486,7 +488,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         try {
             final Map<byte[], Integer> overlays = getMasks(pd);
-            renderer.setOverlays(overlays);
+            if (overlays.size() > 0) {
+                renderer.setOverlays(overlays);
+            }
             errorIfInvalidState();
             checkPlaneDef(pd);
             if (resolutionLevel != null)
@@ -517,7 +521,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
         ByteArrayOutputStream byteStream = null;
         try {
             final Map<byte[], Integer> overlays = getMasks(pd);
-            renderer.setOverlays(overlays);
+            if (overlays.size() > 0) {
+                renderer.setOverlays(overlays);
+            }
         	int stride = pd.getStride();
         	if (stride < 0) stride = 0;
         	stride++;

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -416,6 +416,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
      * Implemented as specified by the {@link RenderingEngine} interface.
      * 
      * @see RenderingEngine#setOverlays()
+     * @deprecated As of release 5.1.0, replaced by
+     * {@link omeis.providers.re.data.PlaneDef#setShapeIds(List)}.
      */
     @RolesAllowed("user")
     public void setOverlays(Map<byte[], Integer> overlays)

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -2017,15 +2017,16 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     private Map<byte[], Integer> getMasks(PlaneDef pd) {
         List<IObject> masks = new ArrayList<IObject>();
+        Map<byte[], Integer> maskMap = new LinkedHashMap<byte[], Integer>();
+
+        if (!pd.getRenderShapes()) {
+            return maskMap;
+        }
         if (pd.getShapeIds().isEmpty()) {
             masks = getAllMasks(pd);
-        }
-        else {
+        } else {
             masks = getMasksById(pd);
         }
-
-        final Map<byte[], Integer> maskMap =
-                new LinkedHashMap<byte[], Integer>();
 
         for (int i = 0; i < masks.size(); i++) {
            maskMap.put(

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1999,7 +1999,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 " and m.y = 0 " +
                 " and m.theZ = :theZ " +
                 " and m.theT = :theT" +
-                " and m.theC in :channelIds";
+                " and m.theC in (:channelIds)";
         return (List<IObject>) ex.execute(/*ex*/null/*principal*/,
                 new Executor.SimpleWork(this,"getMaskList")
         {


### PR DESCRIPTION
This PR cleans up mask rendering by adding a new `PlaneDefWithMasks` subclass of `PlaneDef` and deprecating the unused, ugly and broken `setOverlays()` method on the rendering engine. This was discussed as the best way forward for the 5.1.0 milestone with @jburel and @joshmoore.

There should be no affect on the clients as none of them were using this logic. Intentions are to expand and make use of this API in 5.1.1 or later. Getting the API changes in for 5.1.0 was paramount. For the moment the old code stands as it is, parts of it are fixed by #3580, and some new example code has been added that works against Mask shapes matching the previous rendering criteria associated with the current image.

Review should be performed by @jburel and @joshmoore.

/cc @emilroz 