### PR TITLE
obj.py commands: map-get, map-set, null

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -408,8 +408,8 @@ Bash examples:
             "--file", help=SUPPRESS)
         parser.add_argument(
             "command", nargs="?",
-            choices=("new", "update", "null", "map-get",
-                     "map-set", "map-add", "map-edit"),
+            choices=("new", "update", "null",
+                     "map-get", "map-set"),
             help="operation to be performed")
         parser.add_argument(
             "Class", nargs="?",

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -34,7 +34,6 @@ import fileinput
 
 from omero_ext.argparse import SUPPRESS
 from omero.cli import BaseControl, CLI, ExceptionHandler
-from omero.model import NamedValue as NV
 from omero.rtypes import rlong
 
 
@@ -279,6 +278,8 @@ class NonFieldTxAction(TxAction):
 class MapSetTxAction(NonFieldTxAction):
 
     def on_go(self, ctx, args):
+
+        from omero.model import NamedValue as NV
 
         if len(self.tx_cmd.arg_list) != 5:
             ctx.die(335, "usage: map-set OBJ FIELD KEY VALUE")

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -34,6 +34,7 @@ import fileinput
 
 from omero_ext.argparse import SUPPRESS
 from omero.cli import BaseControl, CLI, ExceptionHandler
+from omero.model import NamedValue as NV
 from omero.rtypes import rlong
 
 
@@ -239,6 +240,84 @@ class UpdateObjectTxAction(TxAction):
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
 
+class MapBaseTxAction(TxAction):
+
+    def go(self, ctx, args):
+        import omero
+        self.tx_state.add(self)
+        c = ctx.conn(args)
+        q = c.sf.getQueryService()
+        self.obj, self.kls = self.instance(ctx)
+        if self.obj.id is None:
+            ctx.die(334, "No id given for %s. Use e.g. '%s:123'"
+                    % (self.kls, self.kls))
+        try:
+            self.obj = q.get(self.kls,
+                             self.obj.id.val,
+                             {"omero.group": "-1"})
+        except omero.ServerError:
+            ctx.die(334, "No object found: %s:%s" %
+                    (self.kls, self.obj.id.val))
+
+        self.on_go(ctx, args)
+
+
+class MapSetTxAction(MapBaseTxAction):
+
+    def on_go(self, ctx, args):
+        import omero
+        c = ctx.conn(args)
+        up = c.sf.getUpdateService()
+
+        if len(self.tx_cmd.arg_list) != 5:
+            ctx.die(335, "usage: map-set OBJ FIELD KEY VALUE")
+
+        field = self.tx_cmd.arg_list[2]
+        current = getattr(self.obj, field)
+        if current is None:
+            setattr(self.obj, field, [])
+
+        name, value = self.tx_cmd.arg_list[3:]
+        state = None
+        for nv in current:
+            if nv and nv.name == name:
+                nv.value = value
+                state = "SET"
+                break
+
+        if state != "SET":
+            current.append(NV(name, value))
+
+        try:
+            out = up.saveAndReturnObject(self.obj)
+        except omero.ServerError, se:
+            ctx.die(336, "Failed to update %s:%s - %s" %
+                    (self.kls, self.obj.id.val, se.message))
+        proxy = "%s:%s" % (self.kls, out.id.val)
+        self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
+
+
+class MapGetTxAction(MapBaseTxAction):
+
+    def on_go(self, ctx, args):
+
+        if len(self.tx_cmd.arg_list) != 4:
+            ctx.die(335, "usage: map-get OBJ FIELD KEY")
+
+        field = self.tx_cmd.arg_list[2]
+        current = getattr(self.obj, field)
+        if current is None:
+            setattr(self.obj, field, [])
+
+        name = self.tx_cmd.arg_list[3]
+        value = None
+        for nv in current:
+            if nv and nv.name == name:
+                value = nv.value
+
+        self.tx_state.set_value(value, dest=self.tx_cmd.dest)
+
+
 class TxState(object):
 
     def __init__(self, ctx):
@@ -283,6 +362,13 @@ Examples:
     $ bin/omero obj update Dataset:123 description=bar
     Dataset:123
 
+    $ bin/omero obj new MapAnnotation ns=example.com
+    MapAnnotation:456
+    $ bin/omero obj map-set MapAnnotation mapValue foo bar
+    MapAnnotation:456
+    $ bin/omero obj map-get MapAnnotation mapValue foo
+    bar
+
 Bash examples:
 
     $ project=$(bin/omero obj new Project name='my Project')
@@ -301,7 +387,8 @@ Bash examples:
             "--file", help=SUPPRESS)
         parser.add_argument(
             "command", nargs="?",
-            choices=("new", "update"),
+            choices=("new", "update", "map-get",
+                     "map-set", "map-add", "map-edit"),
             help="operation to be performed")
         parser.add_argument(
             "Class", nargs="?",
@@ -343,8 +430,12 @@ Bash examples:
         tx_cmd = TxCmd(tx_state, arg_list=arg_list, line=line)
         if tx_cmd.action == "new":
             return NewObjectTxAction(tx_state, tx_cmd)
-        if tx_cmd.action == "update":
+        elif tx_cmd.action == "update":
             return UpdateObjectTxAction(tx_state, tx_cmd)
+        elif tx_cmd.action == "map-set":
+            return MapSetTxAction(tx_state, tx_cmd)
+        elif tx_cmd.action == "map-get":
+            return MapGetTxAction(tx_state, tx_cmd)
         else:
             raise self.ctx.die(100, "Unknown command: %s" % tx_cmd)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -250,7 +250,7 @@ class NonFieldTxAction(TxAction):
         import omero
         self.tx_state.add(self)
         self.client = ctx.conn(args)
-        self.query  = self.client.sf.getQueryService()
+        self.query = self.client.sf.getQueryService()
         self.update = self.client.sf.getUpdateService()
         self.obj, self.kls = self.instance(ctx)
         if self.obj.id is None:
@@ -265,13 +265,13 @@ class NonFieldTxAction(TxAction):
 
         self.on_go(ctx, args)
 
-    def save_and_return(self):
+    def save_and_return(self, ctx):
         import omero
         try:
             out = self.update.saveAndReturnObject(self.obj)
         except omero.ServerError, se:
-            ctx.die(336, "Failed to update %s:%s - %s" %
-                    (self.kls, self.obj.id.val, se.message))
+            ctx.die(336, "Failed to update %s:%s - %s" % (
+                self.kls, self.obj.id.val, se.message))
         proxy = "%s:%s" % (self.kls, out.id.val)
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
@@ -279,7 +279,6 @@ class NonFieldTxAction(TxAction):
 class MapSetTxAction(NonFieldTxAction):
 
     def on_go(self, ctx, args):
-        import omero
 
         if len(self.tx_cmd.arg_list) != 5:
             ctx.die(335, "usage: map-set OBJ FIELD KEY VALUE")
@@ -300,7 +299,7 @@ class MapSetTxAction(NonFieldTxAction):
         if state != "SET":
             current.append(NV(name, value))
 
-        self.save_and_return()
+        self.save_and_return(ctx)
 
 
 class MapGetTxAction(NonFieldTxAction):
@@ -333,7 +332,7 @@ class NullTxAction(NonFieldTxAction):
 
         field = self.tx_cmd.arg_list[2]
         setattr(self.obj, field, None)
-        self.save_and_return()
+        self.save_and_return(ctx)
 
 
 class TxState(object):

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -134,3 +134,21 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "update", project, "description=bar"]
         self.go()
+
+    def test_map_mods(self):
+        self.args = self.login_args() + [
+            "obj", "new", "MapAnnotation", "ns=test"]
+        state = self.go()
+        ann = state.get_row(0)
+
+        self.args = self.login_args() + [
+            "obj", "map-set", ann, "mapValue", "foo", "bar"]
+        state = self.go()
+        ann2 = state.get_row(0)
+        assert ann == ann2
+
+        self.args = self.login_args() + [
+            "obj", "map-get", ann, "mapValue", "foo"]
+        state = self.go()
+        val = state.get_row(0)
+        assert val == "bar"

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -152,3 +152,18 @@ class TestObj(CLITest):
         state = self.go()
         val = state.get_row(0)
         assert val == "bar"
+
+    def test_nulling(self):
+        self.args = self.login_args() + [
+            "obj", "new", "MapAnnotation", "ns=test"]
+        state = self.go()
+        ann = state.get_row(0)
+
+        self.args = self.login_args() + [
+            "obj", "null", ann, "ns"]
+        state = self.go()
+        ann2 = state.get_row(0)
+        assert ann == ann2
+        type, id = ann.split(":")
+        ann3 = self.client.sf.getQueryService().get(type, int(id))
+        assert ann3.ns is None


### PR DESCRIPTION
Three new commands have been added to obj.py to enable the testing of https://github.com/openmicroscopy/openmicroscopy/pull/3593 :

 * `bin/omero obj map-set CLASS:ID FIELD KEY VALUE`
 * `bin/omero obj map-get CLASS:ID FIELD`
 * `bin/omero obj null CLASS:ID FIELD`

Integration tests are in place, but minor local testing is welcome. Help is provided via `bin/omero obj -h`

cc: @ximenesuk @pwalczysko 