### PR TITLE
Upgrade settings toplinks

### DIFF
--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -213,6 +213,8 @@ class ConfigXml(object):
                         toplinks = defaultlinks + toplinks
                         val = json.dumps(toplinks)
                         x.set("value", val)
+                    if x.get("name") == self.KEY:
+                        x.set("value", self.VERSION)
 
     def version_fix(self, props, version):
         """

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -201,13 +201,15 @@ class ConfigXml(object):
                     if x.get("name") == "omero.web.ui.top_links":
                         val = x.get("value", "")
                         toplinks = json.loads(val)
-                        defaultlinks = [["Data", "webindex",
-                            {"title": "Browse Data via Projects, Tags etc"}],
+                        defaultlinks = [
+                            ["Data", "webindex",
+                                {"title":
+                                 "Browse Data via Projects, Tags etc"}],
                             ["History", "history",
-                            {"title": "History"}],
+                                {"title": "History"}],
                             ["Help", "http://help.openmicroscopy.org/",
-                            {"target": "new", "title":
-                            "Open OMERO user guide in a new tab"}]]
+                                {"target": "new", "title":
+                                    "Open OMERO user guide in a new tab"}]]
                         toplinks = defaultlinks + toplinks
                         val = json.dumps(toplinks)
                         x.set("value", val)

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -28,6 +28,7 @@ import xml.dom.minidom
 from xml.etree.ElementTree import XML, Element, SubElement, Comment
 from xml.etree.ElementTree import tostring
 from omero_ext import portalocker
+import json
 
 
 class Environment(object):
@@ -116,6 +117,7 @@ class ConfigXml(object):
             self.XML = XML(text)
             try:
                 self.version_check()
+                self.toplinks_check()
             except:
                 self.close()
                 raise
@@ -190,6 +192,24 @@ class ConfigXml(object):
             version = self.version(k)
             if version != self.VERSION:
                 self.version_fix(v, version)
+
+    def toplinks_check(self):
+        for k, v in self.properties(None, True):
+            if v is not None:
+                for x in v.getchildren():
+                    if x.get("name") == "omero.web.ui.top_links":
+                        val = x.get("value", "")
+                        toplinks = json.loads(val)
+                        defaultlinks = [["Data", "webindex",
+                            {"title": "Browse Data via Projects, Tags etc"}],
+                            ["History", "history",
+                            {"title": "History"}],
+                            ["Help", "http://help.openmicroscopy.org/",
+                            {"target": "new", "title":
+                            "Open OMERO user guide in a new tab"}]]
+                        toplinks = defaultlinks + toplinks
+                        val = json.dumps(toplinks)
+                        x.set("value", val)
 
     def version_fix(self, props, version):
         """

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -81,7 +81,7 @@ class ConfigXml(object):
     in etc/grid. For a copy of the dict, use "as_map"
     """
     KEY = "omero.config.version"
-    VERSION = "4.2.1"
+    VERSION = "5.1.0"
     INTERNAL = "__ACTIVE__"
     DEFAULT = "omero.config.profile"
     IGNORE = (KEY, DEFAULT)
@@ -190,12 +190,13 @@ class ConfigXml(object):
     def version_check(self):
         for k, v in self.properties(None, True):
             version = self.version(k)
-            if version != self.VERSION:
+            if version == "4.2.0":
                 self.version_fix(v, version)
 
     def toplinks_check(self):
         for k, v in self.properties(None, True):
-            if v is not None:
+            version = self.version(k)
+            if version == "4.2.1" and v is not None:
                 for x in v.getchildren():
                     if x.get("name") == "omero.web.ui.top_links":
                         val = x.get("value", "")

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -297,7 +297,6 @@ class TestConfig(object):
         finally:
             config.close()
 
-
     def testReadOnlyConfigSimple(self):
         p = create_path()
         p.chmod(0444)  # r--r--r--

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -196,7 +196,7 @@ class TestConfig(object):
         config = ConfigXml(filename=str(p))
         m = config.as_map()
         for k, v in m.items():
-            assert "4.2.1" == v
+            assert "5.1.0" == v
 
     def testOldVersionDetected(self):
         p = create_path()

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -243,7 +243,6 @@ class TestConfig(object):
             m = config.as_map()
             assert "member=@{dn}" == m["omero.ldap.new_user_group"]
             assert "member=@{dn}" == m["omero.ldap.new_user_group_2"]
-            assert True is False
         finally:
             config.close()
 
@@ -288,9 +287,7 @@ class TestConfig(object):
             config.close()
 
         # After config.close() calls config.save() new version should be 5.1.0
-        # NB: this ONLY works if we specify "__ACTIVE__" which is not what
-        # happens in real usage
-        config = ConfigXml(filename=str(p), env_config="__ACTIVE__")
+        config = ConfigXml(filename=str(p), env_config="default")
         try:
             # Check version has been updated
             assert config.version() == "5.1.0"

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -287,6 +287,20 @@ class TestConfig(object):
         finally:
             config.close()
 
+        # After config.close() calls config.save() new version should be 5.1.0
+        # NB: this ONLY works if we specify "__ACTIVE__" which is not what
+        # happens in real usage
+        config = ConfigXml(filename=str(p), env_config="__ACTIVE__")
+        try:
+            # Check version has been updated
+            assert config.version() == "5.1.0"
+            m = config.as_map()
+            # And that top_links has not been modified further
+            assert m["omero.web.ui.top_links"] == afterUpdate
+        finally:
+            config.close()
+
+
     def testReadOnlyConfigSimple(self):
         p = create_path()
         p.chmod(0444)  # r--r--r--

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -272,7 +272,7 @@ class TestConfig(object):
             # Include a property to indicate version is post-4.2.0
             SubElement(
                 properties, "property", name="omero.config.version",
-                value="4.2.0")
+                value="4.2.1")
             SubElement(
                 properties, "property", name="omero.web.ui.top_links",
                 value=beforeUpdate)

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -243,6 +243,47 @@ class TestConfig(object):
             m = config.as_map()
             assert "member=@{dn}" == m["omero.ldap.new_user_group"]
             assert "member=@{dn}" == m["omero.ldap.new_user_group_2"]
+            assert True is False
+        finally:
+            config.close()
+
+    def testSettings510Upgrade(self):
+        """
+        When upgraded 5.0.x properties to 5.1.0 or later,
+        if omero.web.ui.top_links is set, we need to prepend
+        'Data', 'History' and 'Help' links
+        """
+
+        beforeUpdate = '[["Figure", "figure_index"]]'
+        afterUpdate = '[["Data", "webindex", ' \
+            '{"title": "Browse Data via Projects, Tags etc"}], ' \
+            '["History", "history", ' \
+            '{"title": "History"}], ' \
+            '["Help", "http://help.openmicroscopy.org/", ' \
+            '{"target": "new", "title": ' \
+            '"Open OMERO user guide in a new tab"}], ' \
+            '["Figure", "figure_index"]]'
+        p = create_path()
+
+        XML = Element("icegrid")
+        active = SubElement(XML, "properties", id="__ACTIVE__")
+        default = SubElement(XML, "properties", id="default")
+        for properties in (active, default):
+            # Include a property to indicate version is post-4.2.0
+            SubElement(
+                properties, "property", name="omero.config.version",
+                value="4.2.0")
+            SubElement(
+                properties, "property", name="omero.web.ui.top_links",
+                value=beforeUpdate)
+        string = tostring(XML, 'utf-8')
+        txt = xml.dom.minidom.parseString(string).toprettyxml("  ", "\n", None)
+        p.write_text(txt)
+
+        config = ConfigXml(filename=str(p), env_config="default")
+        try:
+            m = config.as_map()
+            assert m["omero.web.ui.top_links"] == afterUpdate
         finally:
             config.close()
 


### PR DESCRIPTION
This was previously opened as #3579.

To test:
 - BEFORE building with this PR, set top_links to have a single link, E.g.
```
$ bin/omero config set omero.web.ui.top_links '[["Test", "www.ome.org"]]'
```
 - Webclient should only show a single 'Test' link in header.
 - Now upgrade / build with this PR and start OMERO.
 - Should see "Data", "History", "Help", "Test" links at top of webclient.
 - restart the server again and check that more links are not added!
 - Open dist/etc/grid/config.xml and check for 2 version blocks that state "5.1.0" (under 2 different ```<properties>``` blocks)

```
<property name="omero.config.version" value="5.1.0" />
```

Tests should also pass:
```
$ cd OmeroPy
$ ./setup.py test -t test/unit/test_config.py
```

--no-rebase