### PR TITLE
RenderingEngine: lookupTable getters/setters

### DIFF
--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -59,6 +59,8 @@ module omero {
                 idempotent Ice::IntSeq getRGBA(int w) throws ServerError;
                 idempotent void setActive(int w, bool active) throws ServerError;
                 idempotent bool isActive(int w) throws ServerError;
+                idempotent void setChannelLookupTable(int w, string lookup) throws ServerError;
+                idempotent string getChannelLookupTable(int w) throws ServerError;
                 void addCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
                 void updateCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
                 void removeCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
@@ -72,7 +74,6 @@ module omero {
                 idempotent double getPixelsTypeLowerBound(int w) throws ServerError;
 
             };
-
     };
 };
 

--- a/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
@@ -22,6 +22,7 @@ import omero.api.AMD_RenderingEngine_getAvailableFamilies;
 import omero.api.AMD_RenderingEngine_getAvailableModels;
 import omero.api.AMD_RenderingEngine_getChannelCurveCoefficient;
 import omero.api.AMD_RenderingEngine_getChannelFamily;
+import omero.api.AMD_RenderingEngine_getChannelLookupTable;
 import omero.api.AMD_RenderingEngine_getChannelNoiseReduction;
 import omero.api.AMD_RenderingEngine_getChannelStats;
 import omero.api.AMD_RenderingEngine_getChannelWindowEnd;
@@ -52,6 +53,7 @@ import omero.api.AMD_RenderingEngine_resetDefaultSettings;
 import omero.api.AMD_RenderingEngine_saveAsNewSettings;
 import omero.api.AMD_RenderingEngine_saveCurrentSettings;
 import omero.api.AMD_RenderingEngine_setActive;
+import omero.api.AMD_RenderingEngine_setChannelLookupTable;
 import omero.api.AMD_RenderingEngine_setChannelWindow;
 import omero.api.AMD_RenderingEngine_setCodomainInterval;
 import omero.api.AMD_RenderingEngine_setCompressionLevel;
@@ -445,5 +447,17 @@ public class RenderingEngineI extends AbstractPyramidServant implements
         callInvokerOnRawArgs(__cb, __current);
     }
 
+    @Override
+    public void getChannelLookupTable_async(
+            AMD_RenderingEngine_getChannelLookupTable __cb, int w,
+            Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, w);
+    }
 
+    @Override
+    public void setChannelLookupTable_async(
+            AMD_RenderingEngine_setChannelLookupTable __cb, int w,
+            String lookup, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, w, lookup);
+    }
 }

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -561,5 +561,9 @@ public interface RenderingEngine extends StatefulServiceInterface {
 
     public int[] getTileSize();
 
+    public void setChannelLookupTable(int w, String lookup);
+
+    public String getChannelLookupTable(int w);
+
 }
 

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1007,6 +1007,32 @@ public class RenderingBean implements RenderingEngine, Serializable {
     // ~ RendDefObj Delegation
     // =========================================================================
 
+    @RolesAllowed("user")
+    public String getChannelLookupTable(int w) {
+        rwl.readLock().lock();
+
+        try {
+            errorIfNullRenderingDef();
+            ChannelBinding[] cb = renderer.getChannelBindings();
+            return cb[w].getLookupTable();
+        } finally {
+            rwl.readLock().unlock();
+        }
+    }
+
+    @RolesAllowed("user")
+    public void setChannelLookupTable(int w, String lookup) {
+        rwl.readLock().lock();
+
+        try {
+            errorIfNullRenderingDef();
+            ChannelBinding[] cb = renderer.getChannelBindings();
+            cb[w].setLookupTable(lookup);
+        } finally {
+            rwl.readLock().unlock();
+        }
+    }
+
     /**
      * Implemented as specified by the {@link RenderingEngine} interface.
      * 

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -1820,4 +1820,53 @@ public class RenderingEngineTest extends AbstractServerTest {
         }
         re.close();
     }
+
+    /**
+     * Tests the retrieval of the lookup table info using the rendering
+     * engine.
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testRenderingEngineChannelLookupTable() throws Exception {
+        File f = File.createTempFile("testRenderingEngineGetters", "."
+                + OME_FORMAT);
+        XMLMockObjects xml = new XMLMockObjects();
+        XMLWriter writer = new XMLWriter();
+        writer.writeFile(f, xml.createImage(), true);
+        List<Pixels> pixels = null;
+        try {
+            pixels = importFile(f, OME_FORMAT);
+        } catch (Throwable e) {
+            throw new Exception("cannot import image", e);
+        }
+        Pixels p = pixels.get(0);
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        // retrieve the rendering def
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels1 = def.copyWaveRendering();
+        assertNotNull(channels1);
+        Iterator<ChannelBinding> i = channels1.iterator();
+        ChannelBinding c1;
+        int index = 0;
+        while (i.hasNext()) {
+            c1 = i.next();
+            assertEquals(null, c1.getLookupTable());
+            re.setChannelLookupTable(index, "foo");
+            assertEquals("foo", re.getChannelLookupTable(index));
+            index++;
+        }
+        re.saveCurrentSettings();
+        re.close();
+    }
 }


### PR DESCRIPTION
These methods will properly set the lookupTable
field on ChannelBinding. For the moment, that is
the extent of implementation for 5.1.0. A next
step will be to teach the RenderingEngine how to
make use of these properties.