### PR TITLE
Bugfix open FileAnnotation

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -148,9 +148,6 @@ class DocComponent
 	/** Button to download the file linked to the annotation. */
 	private JMenuItem		downloadButton;
 	
-	/** Button to open the file linked to the annotation. */
-	private JMenuItem		openButton;
-	
 	/** Button to display information. */
 	private JMenuItem		infoButton;
 	
@@ -226,10 +223,6 @@ class DocComponent
 				downloadButton.setEnabled(false);
 				downloadButton.setVisible(false);
 			}
-			if (openButton != null) {
-				openButton.setEnabled(false);
-				openButton.setVisible(false);
-			}
 			return count > 0;
 		}
 		boolean b = false;
@@ -255,12 +248,6 @@ class DocComponent
 			downloadButton.setVisible(b);
 			if (b) count++;
 		}
-		if (openButton != null) {
-			b = true;
-			openButton.setEnabled(b);
-			openButton.setVisible(b);
-			if (b) count++;
-		}
 		return count > 0;
 	}
 
@@ -277,7 +264,6 @@ class DocComponent
 			if (editButton != null) popMenu.add(editButton);
 			if (unlinkButton != null) popMenu.add(unlinkButton);
 			if (downloadButton != null) popMenu.add(downloadButton);
-			if (openButton != null) popMenu.add(openButton);
 			if (infoButton != null) popMenu.add(infoButton);
 		}
 		popMenu.show(invoker, p.x, p.y);
@@ -514,12 +500,6 @@ class DocComponent
 				downloadButton.addActionListener(this);
 				
 				String ns = fa.getNameSpace();
-				openButton = new JMenuItem(icons.getIcon(
-						IconManager.VIEW_DOC_12));
-				openButton.setText("View");
-				openButton.setToolTipText("View the file.");
-				openButton.setActionCommand(""+OPEN);
-				openButton.addActionListener(this);
 				if (FileAnnotationData.COMPANION_FILE_NS.equals(ns) ||
 					FileAnnotationData.MEASUREMENT_NS.equals(ns))
 					unlinkButton = null;
@@ -707,7 +687,6 @@ class DocComponent
 		if (unlinkButton != null) count++;
 		if (downloadButton != null) count++;
 		if (infoButton != null) count++;
-		if (openButton != null) count++;
 		if (count > 0 && data != null) {
 			menuButton.setEnabled(true);
 			if (model.isAcrossGroups()) menuButton.setEnabled(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FigureDialog.java
@@ -65,6 +65,7 @@ import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButton;
@@ -477,26 +478,23 @@ public class FigureDialog
 	{
 		if (optionMenu != null) return optionMenu;
 		optionMenu = new JPopupMenu();
-		optionMenu.add(createButton("Download", DOWNLOAD));
-		optionMenu.add(createButton("View", VIEW));
+		optionMenu.add(createMenuItem("Download", DOWNLOAD));
+		optionMenu.add(createMenuItem("View", VIEW));
 		return optionMenu;
 	}
 	
 	/**
-	 * Creates a button.
+	 * Creates a menu item.
 	 * 
 	 * @param text The text of the button.
 	 * @param actionID The action command id.
-	 * @param l The action listener.
 	 * @return See above.
 	 */
-	private JButton createButton(String text, int actionID)
+	private JMenuItem createMenuItem(String text, int actionID)
     {
-    	JButton b = new JButton(text);
+	    JMenuItem b = new JMenuItem(text);
 		b.setActionCommand(""+actionID);
 		b.addActionListener(this);
-		b.setOpaque(false);
-		UIUtilities.unifiedButtonLookAndFeel(b);
 		return b;
     }
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
@@ -37,9 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-//Third-party libraries
+import javax.activation.FileDataSource;
 
+//Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
+
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
@@ -1092,18 +1094,11 @@ class TreeViewerModel
 			return TreeViewerFactory.IMAGE_NOT_ARCHIVED;
 		} else if (object instanceof FileAnnotationData) {
 			FileAnnotationData fa = (FileAnnotationData) object;
-			File f = new File(fa.getFileName());
-			/*
-			MimetypesFileTypeMap map = new MimetypesFileTypeMap();
-			type = map.getContentType(f);
-			f.delete();
-			return type;
-			*/
+			FileDataSource fds = new FileDataSource(fa.getFileName());
+            String type = fds.getContentType();
+            return type;
 		}
-		//MimetypesFileTypeMap map = new MimetypesFileTypeMap();
-		//String type = map.getContentType(f);
-		//f.delete();
-		return null;//type;
+		return null;
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2012 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -80,26 +80,17 @@ public class LinuxApplicationDataExtractor implements ApplicationDataExtractor
 				applicationPath);
 	}
 
-	/**
-	 * @param location
-	 *            the location pointing to the file to be opened
-	 * @returns the command string to launch the default application for the
-	 *          file specified by {@code location} on Gnome based desktop will
-	 *          use gnome-open and on KDE based will use kde-open
-	 */
-	public String[] getDefaultOpenCommandFor(URL location) {
-		String desktopEnvironment = System.getenv("XGB_DESKTOP");
-
-		String[] defaultCommands = new String[0];
-
-		if (desktopEnvironment.equalsIgnoreCase("unity")
-				|| desktopEnvironment.equalsIgnoreCase("gnome")) {
-			defaultCommands = new String[] { "gnome-open", location.toString() };
-		} else if (desktopEnvironment.equalsIgnoreCase("kde")) {
-			defaultCommands = new String[] { "kde-open", location.toString() };
-		}
-
-		return defaultCommands;
-	}
+    /**
+     * @param location
+     *            the location pointing to the file to be opened
+     * @returns the command string to launch the default application for the
+     *          file specified by {@code location} on Gnome based desktop will
+     *          use gnome-open and on KDE based will use kde-open
+     */
+    public String[] getDefaultOpenCommandFor(URL location) {
+        String[] defaultCommands = new String[] { "xdg-open",
+                location.toString() };
+        return defaultCommands;
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
@@ -84,8 +84,8 @@ public class LinuxApplicationDataExtractor implements ApplicationDataExtractor
      * @param location
      *            the location pointing to the file to be opened
      * @returns the command string to launch the default application for the
-     *          file specified by {@code location} on Gnome based desktop will
-     *          use gnome-open and on KDE based will use kde-open
+     *          file specified by {@code location} with xdg-open which should
+     *          be available on all freedesktop.org compliant linux desktops
      */
     public String[] getDefaultOpenCommandFor(URL location) {
         String[] defaultCommands = new String[] { "xdg-open",

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FilesLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FilesLoader.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.views.calls.FilesLoader 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -110,6 +110,7 @@ public class FilesLoader
     /**
      * Creates a {@link BatchCall} to download a file previously loaded.
      *
+     * @param file The file to save the file to
      * @param id The id of the file annotation to download.
      * @return The {@link BatchCall}.
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FilesLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FilesLoader.java
@@ -113,7 +113,7 @@ public class FilesLoader
      * @param id The id of the file annotation to download.
      * @return The {@link BatchCall}.
      */
-    private BatchCall makeFileBatchCall(final long id)
+    private BatchCall makeFileBatchCall(final File file, final long id)
     {
     	return new BatchCall("Downloading files.") {
     		public void doCall() throws Exception
@@ -121,8 +121,7 @@ public class FilesLoader
     			OmeroMetadataService service = context.getMetadataService();
     			FileAnnotationData fa = (FileAnnotationData)
     					service.loadAnnotation(ctx, id);
-    			result = service.downloadFile(ctx, new File(fa.getFileName()),
-    					fa.getFileID());
+    			result = service.downloadFile(ctx, file, fa.getFileID());
     		}
     	};
     }
@@ -301,7 +300,7 @@ public class FilesLoader
     {
     	this.ctx = ctx;
     	if (file == null || index == FILE_ANNOTATION)
-    		loadCall = makeFileBatchCall(fileID);
+    		loadCall = makeFileBatchCall(file, fileID);
     	else {
     		if (index == METADATA_FROM_IMAGE)
     			loadCall = makeFromImageBatchCall(file, fileID);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -110,7 +110,7 @@ public class OpenObjectLoader
     		path += fa.getFileName();
     		f = new File(path);
     		f.deleteOnExit();
-    		handle = mhView.loadFile(ctx, f, fa.getFileID(), 
+    		handle = mhView.loadFile(ctx, f, fa.getId(), 
     				FileLoader.FILE_ANNOTATION, this);
     	}
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -127,6 +127,12 @@ public class OpenObjectLoader
     	}
     }
     
+    @Override
+    protected void onException(String message, Throwable ex) {
+        super.onException(message, ex);
+        activity.notifyError("Error- Could not load object", ex.getMessage(), ex);
+    }
+
     /**
      * Cancels the ongoing data retrieval.
      * @see UserNotifierLoader#cancel()

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.OpenObjectLoader 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Fixes [Ticket 12028](https://trac.openmicroscopy.org/ome/ticket/12028) and some other issues with "Open with" functionality
- Removes the "View" button (doesn't have a function anymore)
- Fixes a bug with respect to "Open with" file attachments
- Fixes the "View" issues in Import and Script dialog on Linux 
- End the "Open with" activity if an error occurs
- Fixes a problem with mimetype detection and mimetype-application association

Test (on multiple platforms if possible, but focus on Linux)
- Attach a File to an image (dataset, whatever). Select the image and make sure that there is no "View" button anymore in the attachment popup menu (right hand side metadata panel)
- Open the Attachments view in the left hand side panel. Select an attachment and open it with "Open with...". Check that the file type <-> application association is stored, i. e. if you open the "Open with" menu again on the same file type, your previously chosen application is listed in the sub menu.
- Select an Image, click on the Publishing button in metadata panel toolbar to open the Script dialog for any script; on the popup menu at the bottom left select "View". The script should be opened in your default desktop text editor
- Import an image. In the Importer dialog, click on "View" -> "Import Log"; the import log should open in your default desktop text editor
- Select a big image (to provoke an error), select "Open with". The activity should start and immediately end with an error (before: the activity status kept on spinning).

--no-rebase
