### PR TITLE
Blitz getattr with units

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1208,8 +1208,12 @@ class BlitzObjectWrapper (object):
                 def wrap():
                     rv = getattr(self._obj, attrName)
                     if hasattr(rv, 'val'):
-                        return (isinstance(rv.val, StringType)
-                                and rv.val.decode('utf8') or rv.val)
+                        if isinstance(rv.val, StringType):
+                            return rv.val.decode('utf8')
+                        # E.g. pixels.getPhysicalSizeX()
+                        if hasattr(rv, "_unit"):
+                            return rv
+                        return rv.val
                     elif isinstance(rv, omero.model.IObject):
                         return BlitzObjectWrapper(self._conn, rv)
                     return rv

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -187,6 +187,23 @@ class TestImage (object):
         assert author_testimg_generated.getPixelSizeX(
             units="NANOMETER") is None
 
+    def testUnitsGetValue(self):
+        """
+        Tests that methods which return Units won't break the
+        pre-units 5.0 API for Blitz Gateway (in the same way that
+        this is NOT broken for omero.model objects).
+        For 5.0 and 5.1, getValue() can be used to get the result.
+        """
+        sizeXMicrons = 0.10639449954032898
+        pixels = self.image.getPrimaryPixels()
+        # omero.model.pixels getPhysicalSizeX returns UnitsLengthI
+        # getValue() works with 5.0 and 5.1
+        sizeX = pixels._obj.getPhysicalSizeX().getValue()
+        assert sizeX == sizeXMicrons
+        # PixelsWrapper getPhysicalSizeX should also return UnitsLengthI
+        sizeX = pixels.getPhysicalSizeX().getValue()
+        assert sizeX == sizeXMicrons
+
     def testChannelWavelengthUnits(self, author_testimg_generated):
         """
         Tests Channel excitation / emmisssion wavelengths and units

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -203,6 +203,9 @@ class TestImage (object):
         # PixelsWrapper getPhysicalSizeX should also return UnitsLengthI
         sizeX = pixels.getPhysicalSizeX().getValue()
         assert sizeX == sizeXMicrons
+        # Also, direct access of attribute should return UnitsLengthI
+        sizeX = pixels.physicalSizeX.getValue()
+        assert sizeX == sizeXMicrons
 
     def testChannelWavelengthUnits(self, author_testimg_generated):
         """


### PR DESCRIPTION
In 5.1 the API for methods that return units is unchanged from 5.0. E.g.
```
# omero.model.pixelsI - this works in 5.0 and 5.1
pixels.getPhysicalSizeX().getValue()
```
However, in the Blitz Gateway this is now broken
```
# pixelsWrapper
pixels.getPhysicalSizeX().getValue()
AttributeError: 'UnitsLength' object has no attribute 'getValue'
```
We get this error in Make_Movie script (although this used to work until recently)?
This PR updates Blitz Gateway ``` __getattr__ ``` to handle units and includes a test:

```
$ cd OmeroPy
$ ./setup.py test -t test/integration/gatewaytest/test_image.py -k testUnitsGetValue
```

Check that tests are passing at https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration/ and Make_Movie script works.

--no-rebase