### PR TITLE
Uniform User/Group Menu

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/DataMenuItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/DataMenuItem.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.util.DataMenuItem
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -29,14 +29,15 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import javax.swing.Icon;
-import javax.swing.JCheckBox;
 
 //Third-party libraries
 
 //Application-internal dependencies
 import pojos.GroupData;
 import pojos.ExperimenterData;
+
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
+import org.openmicroscopy.shoola.util.ui.SelectableMenuItem;
 
 /**
  * Hosts the experimenter or the group to add to the menu.
@@ -46,7 +47,7 @@ import org.openmicroscopy.shoola.agents.util.EditorUtil;
  * @since 4.4
  */
 public class DataMenuItem
-    extends JCheckBox
+    extends SelectableMenuItem
     implements ActionListener
 {
 
@@ -91,8 +92,7 @@ public class DataMenuItem
      */
     public DataMenuItem(Object data, Icon icon, boolean canBeEnabled)
     {
-        if (data == null) 
-            throw new IllegalArgumentException("No data");
+        super(false, data.toString(), canBeEnabled);
         if (data instanceof ExperimenterData)
             setText(EditorUtil.formatExperimenter((ExperimenterData) data));
         else if (data instanceof GroupData)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupItem.java
@@ -164,7 +164,7 @@ public class GroupItem
         while (i.hasNext()) {
             item = i.next();
             ho = item.getDataObject();
-            if (item.isSelected() && ho instanceof ExperimenterData)
+            if (item.isChecked() && ho instanceof ExperimenterData)
                 users.add((ExperimenterData) ho);
         }
         return users;
@@ -186,13 +186,13 @@ public class GroupItem
             item = i.next();
             item.setEnabled(enabled);
             if (!enabled) {
-                item.setSelected(true);
+                item.setChecked(true);
             } else {
                 ho = item.getDataObject();
                 if (ho instanceof ExperimenterData) {
                     exp = (ExperimenterData) ho;
-                    item.setSelected(exp.getId() == userID);
-                } else item.setSelected(false);
+                    item.setChecked(exp.getId() == userID);
+                } else item.setChecked(false);
             }
         }
     }
@@ -216,16 +216,16 @@ public class GroupItem
                 data = i.next();
                 ho = data.getDataObject();
                 if (ho instanceof ExperimenterData && data.isEnabled()) {
-                    data.setSelected(select);
+                    data.setChecked(select);
                     long id = ((ExperimenterData) ho).getId();
                     //always keep the user currently logged in even if 
                     //select is false
                     if (id == userID) {
-                        data.setSelected(true);
+                        data.setChecked(true);
                     }
                 } else if (ho instanceof String) {
                     data.removePropertyChangeListener(this);
-                    data.setSelected(select);
+                    data.setChecked(select);
                     data.addPropertyChangeListener(this);
                 }
             }
@@ -241,7 +241,7 @@ public class GroupItem
                     if (ho instanceof ExperimenterData && data.isEnabled()) {
                         long id = ((ExperimenterData) ho).getId();
                         if (id == userID) {
-                            data.setSelected(true);
+                            data.setChecked(true);
                             break;
                         }
                     }
@@ -265,18 +265,18 @@ public class GroupItem
             if (ho instanceof String) {
                 String v = (String) ho;
                 if (DataMenuItem.ALL_USERS_TEXT.equals(v)) {
-                    selectUsers(true, item.isSelected());
+                    selectUsers(true, item.isChecked());
                     i = usersItem.iterator();
-                    boolean b = item.isSelected();
+                    boolean b = item.isChecked();
                     while (i.hasNext()) {
                         item = i.next();
                         ho = item.getDataObject();
                         if (ho instanceof ExperimenterData && item.isEnabled()) {
                             exp = (ExperimenterData) ho;
-                            if (b) item.setSelected(b);
+                            if (b) item.setChecked(b);
                             else {
                                 if (exp.getId() != userID)
-                                    item.setSelected(b);
+                                    item.setChecked(b);
                             }
                         }
                     }
@@ -293,7 +293,7 @@ public class GroupItem
                         String v = (String) ho;
                         if (DataMenuItem.ALL_USERS_TEXT.equals(v)) {
                             item.removePropertyChangeListener(this);
-                            item.setSelected(all);
+                            item.setChecked(all);
                             item.addPropertyChangeListener(this);
                         }
                     }
@@ -306,7 +306,7 @@ public class GroupItem
                 firePropertyChange(USER_SELECTION_PROPERTY, null, this);
             } else {
                 //no longer select the group.
-                boolean selected = item.isSelected();
+                boolean selected = item.isChecked();
                 if (!selected && isMenuSelected()) {
                     setMenuSelected(false, false);
                 } else if (selected && !isMenuSelected()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -70,6 +70,8 @@ import javax.swing.SwingConstants;
 import javax.swing.border.BevelBorder;
 
 
+
+
 //Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -85,7 +87,6 @@ import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.cmd.ExperimenterVisitor;
 import org.openmicroscopy.shoola.agents.treeviewer.util.GroupItem;
 import org.openmicroscopy.shoola.agents.treeviewer.util.DataMenuItem;
-import org.openmicroscopy.shoola.agents.treeviewer.util.SaveResultsDialog;
 import org.openmicroscopy.shoola.agents.util.ViewerSorter;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptMenuItem;
@@ -93,6 +94,7 @@ import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.util.ui.ScrollablePopupMenu;
+import org.openmicroscopy.shoola.util.ui.SelectableMenuItem;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 import pojos.ExperimenterData;
@@ -526,27 +528,19 @@ class ToolBar
         long userID = model.getExperimenter().getId();
 
         //First add item to toggle between users and group display
-        DataMenuItem data = new DataMenuItem(DataMenuItem.USERS_TEXT, null);
-        data.setSelected(
-                model.getDisplayMode() == LookupNames.EXPERIMENTER_DISPLAY);
+        final SelectableMenuItem data = new SelectableMenuItem(
+                model.getDisplayMode() == LookupNames.EXPERIMENTER_DISPLAY,
+                DataMenuItem.USERS_TEXT, true);
         data.addPropertyChangeListener(new PropertyChangeListener() {
-
             @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
-                if (DataMenuItem.ITEM_SELECTED_PROPERTY.equals(name)) {
-                    DataMenuItem data = (DataMenuItem) evt.getNewValue();
-                    handleSelectionDisplay(data.isSelected());
+                if (SelectableMenuItem.SELECTION_PROPERTY.equals(name)) {
+                    handleSelectionDisplay(data.isMenuSelected());
                 }
             }
         });
-        JPanel panel = new JPanel();
-        panel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        panel.setBorder(null);
-        IconManager icons= IconManager.getInstance();
-        panel.add(new JLabel(icons.getIcon(IconManager.TRANSPARENT)));
-        panel.add(data);
-        popupMenu.add(panel);
+        popupMenu.add(data);
         popupMenu.add(new JSeparator());
         GroupItem item;
         GroupItem allGroup = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -297,28 +297,6 @@ class ToolBar
         }
     }
 
-    /** Handles the selection of groups.*/
-    private void handleGroupSelection()
-    {
-        int n = popupMenu.getComponentCount();
-        DataMenuItem item;
-        Component c;
-        List<GroupData> toAdd = new ArrayList<GroupData>();
-        List<GroupData> toRemove = new ArrayList<GroupData>();
-        for (int i = 0; i < n; i++) {
-            c = popupMenu.getComponent(i);
-            if (c instanceof DataMenuItem) {
-                item = (DataMenuItem) c;
-                if (item.isSelected()) {
-                    toAdd.add((GroupData) item.getDataObject());
-                } else {
-                    toRemove.add((GroupData) item.getDataObject());
-                }
-            }
-        }
-        controller.setSelectedGroups(toAdd, toRemove);
-    }
-
     /** 
      * Fires a search event
      */
@@ -398,7 +376,6 @@ class ToolBar
         ExperimenterData exp;
 
         DataMenuItem item, allUser;
-        JPanel list;
         
         boolean view = true;
         if (group != null) {
@@ -407,20 +384,17 @@ class ToolBar
                 view = model.isAdministrator() || model.isGroupOwner(group);
             }
         }
+        
+        List<DataMenuItem> list = new ArrayList<DataMenuItem>();
 
-        list = new JPanel();
-        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
         allUser = new DataMenuItem(DataMenuItem.ALL_USERS_TEXT, true);
         items.add(allUser);
-        if (view) list.add(allUser);
-        p.add(UIUtilities.buildComponentPanel(list));
+        if (view) p.add(allUser);
         int count = 0;
         int total = 0;
         if (CollectionUtils.isNotEmpty(l)) {
             total += l.size();
             i = l.iterator();
-            list = new JPanel();
-            list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
             while (i.hasNext()) {
                 exp = (ExperimenterData) i.next();
                 if (view || exp.getId() == loggedUserID) {
@@ -432,9 +406,11 @@ class ToolBar
                     list.add(item);
                 }
             }
-            if (list.getComponentCount() > 0) {
+            if (list.size() > 0) {
                 p.add(formatHeader("Group owners"));
-                p.add(UIUtilities.buildComponentPanel(list));
+                for(DataMenuItem dmi : list)
+                    p.add(dmi);
+                list.clear();
             }
         }
 
@@ -442,8 +418,6 @@ class ToolBar
         if (CollectionUtils.isNotEmpty(l)) {
             total += l.size();
             i = l.iterator();
-            list = new JPanel();
-            list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
             while (i.hasNext()) {
                 exp = (ExperimenterData) i.next();
                 if (view || exp.getId() == loggedUserID) {
@@ -455,9 +429,10 @@ class ToolBar
                     list.add(item);
                 }
             }
-            if (list.getComponentCount() > 0) {
+            if (list.size() > 0) {
                 p.add(formatHeader("Members"));
-                p.add(UIUtilities.buildComponentPanel(list));
+                for(DataMenuItem dmi : list)
+                    p.add(dmi);
             }
         }
         allUser.setSelected(total != 0 && total == count);
@@ -536,7 +511,7 @@ class ToolBar
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 if (SelectableMenuItem.SELECTION_PROPERTY.equals(name)) {
-                    handleSelectionDisplay(data.isMenuSelected());
+                    handleSelectionDisplay(data.isSelected());
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -399,8 +399,8 @@ class ToolBar
                 exp = (ExperimenterData) i.next();
                 if (view || exp.getId() == loggedUserID) {
                     item = new DataMenuItem(exp, true);
-                    item.setSelected(users.contains(exp.getId()));
-                    if (item.isSelected()) count++;
+                    item.setChecked(users.contains(exp.getId()));
+                    if (item.isChecked()) count++;
                     item.addPropertyChangeListener(groupItem);
                     items.add(item);
                     list.add(item);
@@ -422,8 +422,8 @@ class ToolBar
                 exp = (ExperimenterData) i.next();
                 if (view || exp.getId() == loggedUserID) {
                     item = new DataMenuItem(exp, true);
-                    item.setSelected(users.contains(exp.getId()));
-                    if (item.isSelected()) count++;
+                    item.setChecked(users.contains(exp.getId()));
+                    if (item.isChecked()) count++;
                     item.addPropertyChangeListener(groupItem);
                     items.add(item);
                     list.add(item);
@@ -435,7 +435,7 @@ class ToolBar
                     p.add(dmi);
             }
         }
-        allUser.setSelected(total != 0 && total == count);
+        allUser.setChecked(total != 0 && total == count);
         allUser.addPropertyChangeListener(groupItem);
         JScrollPane pane = new JScrollPane(p);
         Dimension d = p.getPreferredSize();
@@ -511,7 +511,7 @@ class ToolBar
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 if (SelectableMenuItem.SELECTION_PROPERTY.equals(name)) {
-                    handleSelectionDisplay(data.isSelected());
+                    handleSelectionDisplay(data.isChecked());
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
@@ -21,6 +21,9 @@
 package org.openmicroscopy.shoola.util.ui;
 
 //Java imports
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 
 import javax.swing.Icon;
@@ -44,11 +47,14 @@ public class SelectableMenuItem extends JMenuItem {
     /** The default deselected icon. */
     private static final Icon DEFAULT_DESELECTED;
 
+    public static Color BG_COLOR;
+    
     static {
         IconManager icons = IconManager.getInstance();
         DEFAULT_DESELECTED = icons.getIcon(IconManager.NOT_SELECTED);
         DEFAULT_SELECTED = icons.getIcon(IconManager.SELECTED);
         SELECTION_PROPERTY = "SelectableMenuItem.SELECTION_PROPERTY";
+        BG_COLOR = (new JMenuItem()).getBackground();
     }
 
     /** The icon used when the menuitem is selected. */
@@ -60,6 +66,8 @@ public class SelectableMenuItem extends JMenuItem {
     /** Flag indicating if the menuitem is selectable or not. */
     private boolean selectable;
 
+    private boolean fireProperty = true;
+    
     /**
      * Creates a new instance.
      *
@@ -132,10 +140,16 @@ public class SelectableMenuItem extends JMenuItem {
     @Override
     protected void processMouseEvent(MouseEvent e) {
         // All MouseEvents have to be caught, because the JMenuItem's
-        // MouseListeners shall not be triggered!
+        // MouseListeners shall not be triggered (i. e. makes sure the popup
+        // menu stays open)!
         if (e.getButton() == MouseEvent.BUTTON1 && selectable) {
-            setMenuSelected(!isMenuSelected(), true);
+            setSelected(!isSelected());
             repaint();
+            
+            // but the ActionListeners have to triggered
+            for(ActionListener l : getActionListeners()) {
+                l.actionPerformed(new ActionEvent(this, 0, ""));
+            }
         }
     }
 
@@ -160,37 +174,27 @@ public class SelectableMenuItem extends JMenuItem {
         super(text);
         this.selectedIcon = selectedIcon;
         this.deselectedIcon = deselectedIcon;
-        setMenuSelected(selected, false);
+        fireProperty = false;
+        setSelected(selected);
+        fireProperty = true;
         this.selectable = selectable;
+        setBackground(BG_COLOR);
     }
-
-    /**
-     * Returns <code>true</code> if the menu is selected, <code>false</code>
-     * otherwise.
-     *
-     * @return See above.
-     */
-    public boolean isMenuSelected() {
+    
+    @Override
+    public boolean isSelected() {
         return getIcon() == selectedIcon;
     }
 
-    /**
-     * Sets the icon corresponding to the specified value.
-     *
-     * @param selected
-     *            Pass <code>true</code> to select the menu, <code>false</code>
-     *            otherwise.
-     * @param fireProperty
-     *            Pass <code>true</code> to fire a property, <code>false</code>
-     *            otherwise.
-     */
-    public void setMenuSelected(boolean selected, boolean fireProperty) {
-        if (selected)
+    
+    @Override
+    public void setSelected(boolean b) {
+        if (b)
             setIcon(selectedIcon);
         else
             setIcon(deselectedIcon);
         if (fireProperty) {
-            firePropertyChange(SELECTION_PROPERTY, !selected, selected);
+            firePropertyChange(SELECTION_PROPERTY, !b, b);
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
@@ -1,0 +1,207 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.util.ui;
+
+//Java imports
+import java.awt.event.MouseEvent;
+
+import javax.swing.Icon;
+import javax.swing.JMenuItem;
+
+/**
+ * The purpose of this class is to get a JCheckboxMenuItem with the same style
+ * as the {@link SelectableMenu}
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class SelectableMenuItem extends JMenuItem {
+
+    /** Bound property indicating that menuitem is selected. */
+    public static final String SELECTION_PROPERTY;
+
+    /** The default selected icon. */
+    private static final Icon DEFAULT_SELECTED;
+
+    /** The default deselected icon. */
+    private static final Icon DEFAULT_DESELECTED;
+
+    static {
+        IconManager icons = IconManager.getInstance();
+        DEFAULT_DESELECTED = icons.getIcon(IconManager.NOT_SELECTED);
+        DEFAULT_SELECTED = icons.getIcon(IconManager.SELECTED);
+        SELECTION_PROPERTY = "SelectableMenuItem.SELECTION_PROPERTY";
+    }
+
+    /** The icon used when the menuitem is selected. */
+    private Icon selectedIcon;
+
+    /** The icon used when the menuitem is not selected. */
+    private Icon deselectedIcon;
+
+    /** Flag indicating if the menuitem is selectable or not. */
+    private boolean selectable;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param selectedIcon
+     *            The icon used when the menu is selected.
+     * @param deselectedIcon
+     *            The icon used when the menu is not selected.
+     * @param selectable
+     *            Pass <code>true</code> to allow user selection,
+     *            <code>false</code> otherwise.
+     */
+    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
+            boolean selectable) {
+        this(selectedIcon, deselectedIcon, false, "", selectable);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param selectedIcon
+     *            The icon used when the menu is selected.
+     * @param deselectedIcon
+     *            The icon used when the menu is not selected.
+     * @param text
+     *            The text of the menu.
+     * @param selectable
+     *            Pass <code>true</code> to allow user selection,
+     *            <code>false</code> otherwise.
+     */
+    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
+            String text, boolean selectable) {
+        this(selectedIcon, deselectedIcon, false, text, selectable);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param selectedIcon
+     *            The icon used when the menu is selected.
+     * @param deselectedIcon
+     *            The icon used when the menu is not selected.
+     * @param selected
+     *            Pass <code>true</code> to select the menu, <code>false</code>
+     *            otherwise.
+     * @param selectable
+     *            Pass <code>true</code> to allow user selection,
+     *            <code>false</code> otherwise.
+     */
+    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
+            boolean selected, boolean selectable) {
+        this(selectedIcon, deselectedIcon, selected, "", selectable);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param selected
+     *            Pass <code>true</code> to select the menu, <code>false</code>
+     *            otherwise.
+     * @param text
+     *            The text of the menu.
+     * @param selectable
+     *            Pass <code>true</code> to allow user selection,
+     *            <code>false</code> otherwise.
+     */
+    public SelectableMenuItem(boolean selected, String text, boolean selectable) {
+        this(DEFAULT_SELECTED, DEFAULT_DESELECTED, selected, text, selectable);
+    }
+
+    @Override
+    protected void processMouseEvent(MouseEvent e) {
+        // All MouseEvents have to be caught, because the JMenuItem's
+        // MouseListeners shall not be triggered!
+        if (e.getButton() == MouseEvent.BUTTON1 && selectable) {
+            setMenuSelected(!isMenuSelected(), true);
+            repaint();
+        }
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param selectedIcon
+     *            The icon used when the menu is selected.
+     * @param deselectedIcon
+     *            The icon used when the menu is not selected.
+     * @param selected
+     *            Pass <code>true</code> to select the menu, <code>false</code>
+     *            otherwise.
+     * @param text
+     *            The text of the menu.
+     * @param selectable
+     *            Pass <code>true</code> to allow user selection,
+     *            <code>false</code> otherwise.
+     */
+    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
+            boolean selected, String text, boolean selectable) {
+        super(text);
+        this.selectedIcon = selectedIcon;
+        this.deselectedIcon = deselectedIcon;
+        setMenuSelected(selected, false);
+        this.selectable = selectable;
+    }
+
+    /**
+     * Returns <code>true</code> if the menu is selected, <code>false</code>
+     * otherwise.
+     *
+     * @return See above.
+     */
+    public boolean isMenuSelected() {
+        return getIcon() == selectedIcon;
+    }
+
+    /**
+     * Sets the icon corresponding to the specified value.
+     *
+     * @param selected
+     *            Pass <code>true</code> to select the menu, <code>false</code>
+     *            otherwise.
+     * @param fireProperty
+     *            Pass <code>true</code> to fire a property, <code>false</code>
+     *            otherwise.
+     */
+    public void setMenuSelected(boolean selected, boolean fireProperty) {
+        if (selected)
+            setIcon(selectedIcon);
+        else
+            setIcon(deselectedIcon);
+        if (fireProperty) {
+            firePropertyChange(SELECTION_PROPERTY, !selected, selected);
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if the item can be selected, <code>false</code>
+     * otherwise.
+     *
+     * @return See above.
+     */
+    public boolean isSelectable() {
+        return selectable;
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/SelectableMenuItem.java
@@ -21,7 +21,6 @@
 package org.openmicroscopy.shoola.util.ui;
 
 //Java imports
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -46,26 +45,23 @@ public class SelectableMenuItem extends JMenuItem {
 
     /** The default deselected icon. */
     private static final Icon DEFAULT_DESELECTED;
-
-    public static Color BG_COLOR;
     
     static {
         IconManager icons = IconManager.getInstance();
         DEFAULT_DESELECTED = icons.getIcon(IconManager.NOT_SELECTED);
         DEFAULT_SELECTED = icons.getIcon(IconManager.SELECTED);
         SELECTION_PROPERTY = "SelectableMenuItem.SELECTION_PROPERTY";
-        BG_COLOR = (new JMenuItem()).getBackground();
     }
 
     /** The icon used when the menuitem is selected. */
-    private Icon selectedIcon;
+    private Icon checkedIcon;
 
     /** The icon used when the menuitem is not selected. */
-    private Icon deselectedIcon;
+    private Icon uncheckedIcon;
 
     /** Flag indicating if the menuitem is selectable or not. */
-    private boolean selectable;
-
+    private boolean checkable;
+    
     private boolean fireProperty = true;
     
     /**
@@ -116,9 +112,9 @@ public class SelectableMenuItem extends JMenuItem {
      *            Pass <code>true</code> to allow user selection,
      *            <code>false</code> otherwise.
      */
-    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
-            boolean selected, boolean selectable) {
-        this(selectedIcon, deselectedIcon, selected, "", selectable);
+    public SelectableMenuItem(Icon checkedIcon, Icon uncheckedIcon,
+            boolean checked, boolean checkable) {
+        this(checkedIcon, uncheckedIcon, checked, "", checkable);
     }
 
     /**
@@ -142,13 +138,13 @@ public class SelectableMenuItem extends JMenuItem {
         // All MouseEvents have to be caught, because the JMenuItem's
         // MouseListeners shall not be triggered (i. e. makes sure the popup
         // menu stays open)!
-        if (e.getButton() == MouseEvent.BUTTON1 && selectable) {
-            setSelected(!isSelected());
+        if (e.getButton() == MouseEvent.BUTTON1 && checkable) {
+            setChecked(!isChecked());
             repaint();
             
             // but the ActionListeners have to triggered
             for(ActionListener l : getActionListeners()) {
-                l.actionPerformed(new ActionEvent(this, 0, ""));
+                l.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
             }
         }
     }
@@ -169,43 +165,30 @@ public class SelectableMenuItem extends JMenuItem {
      *            Pass <code>true</code> to allow user selection,
      *            <code>false</code> otherwise.
      */
-    public SelectableMenuItem(Icon selectedIcon, Icon deselectedIcon,
-            boolean selected, String text, boolean selectable) {
+    public SelectableMenuItem(Icon checkedIcon, Icon uncheckedIcon,
+            boolean checked, String text, boolean checkable) {
         super(text);
-        this.selectedIcon = selectedIcon;
-        this.deselectedIcon = deselectedIcon;
+        this.checkedIcon = checkedIcon;
+        this.uncheckedIcon = uncheckedIcon;
         fireProperty = false;
-        setSelected(selected);
+        setChecked(checked);
         fireProperty = true;
-        this.selectable = selectable;
-        setBackground(BG_COLOR);
+        this.checkable = checkable;
     }
     
-    @Override
-    public boolean isSelected() {
-        return getIcon() == selectedIcon;
+    public boolean isChecked() {
+        return getIcon() == checkedIcon;
     }
 
-    
-    @Override
-    public void setSelected(boolean b) {
+    public void setChecked(boolean b) {
         if (b)
-            setIcon(selectedIcon);
+            setIcon(checkedIcon);
         else
-            setIcon(deselectedIcon);
+            setIcon(uncheckedIcon);
+        
         if (fireProperty) {
             firePropertyChange(SELECTION_PROPERTY, !b, b);
         }
-    }
-
-    /**
-     * Returns <code>true</code> if the item can be selected, <code>false</code>
-     * otherwise.
-     *
-     * @return See above.
-     */
-    public boolean isSelectable() {
-        return selectable;
     }
 
 }


### PR DESCRIPTION
Fixes [Ticket 12042](https://trac.openmicroscopy.org/ome/ticket/12042)

In the user/group menu different items were used (JCheckBoxes, custom JCheckBox menu items, etc.); on OSX they appeared to look the same, but you could see the difference on Windows. With this PR only the customized JCheckBox style menu item will be used in the popup menu.

Test: Make sure that on all platforms, OSX, Windows and Linux, the user/group menu in the main toolbar has a uniform style.

--no-rebase