### PR TITLE
Reduce likelihood of test_inputs failing intermittently 

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -25,7 +25,6 @@
 """
 
 import library as lib
-import pytest
 import omero
 import omero.processor
 import omero.scripts
@@ -93,8 +92,6 @@ class TestInputs(lib.ITest):
             finally:
                 rfs.close()
 
-    @pytest.mark.intermittent(reason="Process still running.",
-                              ticket="12314")
     def testInputs(self):
         import logging
         logging.basicConfig(level=10)
@@ -109,7 +106,7 @@ class TestInputs(lib.ITest):
             cb = omero.scripts.ProcessCallbackI(self.root, process)
             try:
                 count = 100
-                while cb.block(500):
+                while cb.block(2000):
                     count -= 1
                     assert count != 0
                 rc = process.poll()

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_rand.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_rand.py
@@ -80,14 +80,15 @@ print val
 class TestRand(lib.ITest):
 
     def testRand(self):
-        scripts = self.root.getSession().getScriptService()
+        root_client = self.new_client(system=True)
+        scripts = root_client.sf.getScriptService()
         id = scripts.uploadScript(
             "/tests/rand_py/%s.py" % self.uuid(), SENDFILE)
         input = {"x": rlong(3), "y": rlong(3)}
-        impl = omero.processor.usermode_processor(self.root)
+        impl = omero.processor.usermode_processor(root_client)
         try:
             process = scripts.runScript(id, input, None)
-            cb = omero.scripts.ProcessCallbackI(self.root, process)
+            cb = omero.scripts.ProcessCallbackI(root_client, process)
             cb.block(2000)  # ms
             cb.close()
             try:


### PR DESCRIPTION
`test_inputs` uses a callback block time of 500ms while a similar test, `test_rand`, has 2000ms. Increasing the former to 2000 seems to make the test reproducibly pass locally. (Conversely, decreasing the latter to 500 causes that test to fail intermittently.)The only test here is whether this test passes in the CI builds.

—no-rebase
(though this could well be rebased if necessary)