### PR TITLE
build: Use long and short git revisions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -465,10 +465,13 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <arg value="openmicroscopy"/>
             <arg value="${omero.shortversion}"/>
             <arg value="${omero.plainversion}"/>
+            <arg value="${omero.vcs.shortrevision}"/>
             <arg value="${omero.vcs.revision}"/>
             <arg value="${omero.vcs.date}"/>
+            <arg value="${omero.vcs.date_unix}"/>
             <arg value="${release.shortversion}"/>
             <arg value="${release.version}"/>
+            <arg value="${vcs.shortrevision}"/>
             <arg value="${vcs.revision}"/>
             <arg value="${vcs.date}"/>
             <arg value="${vcs.date_unix}"/>

--- a/components/antlib/resources/version.xml
+++ b/components/antlib/resources/version.xml
@@ -22,7 +22,9 @@
         omero.shortversion      e.g. 5.0.0
 
         omero.vcs.revision      git commit hash
-        omero.vcs.date          git commit date
+        omero.vcs.shortrevision git commit hash (short form)
+        omero.vcs.date          git commit date (string)
+        omero.vcs.date_unix     git commit date (UNIX time)
 
         The omero.v namespace is for properties internal to this build file
         and should not be modified.
@@ -57,8 +59,10 @@
             <omero_v_was_preset property="omero.version"/>
             <omero_v_was_preset property="omero.plainversion"/>
             <omero_v_was_preset property="omero.shortversion"/>
+            <omero_v_was_preset property="omero.vcs.shortrevision"/>
             <omero_v_was_preset property="omero.vcs.revision"/>
             <omero_v_was_preset property="omero.vcs.date"/>
+            <omero_v_was_preset property="omero.vcs.date_unix"/>
 
             <!-- *OR* they'll be set by git -->
             <git command="describe" output="omero.v.git" failonerror="true">
@@ -83,11 +87,18 @@
             <property name="omero.version.source" value="git"/>
             <property name="omero.plainversion.source" value="git"/>
             <property name="omero.shortversion.source" value="git"/>
-            <git command="log" output="omero.vcs.revision" failonerror="true">
+            <git command="log" output="omero.vcs.shortrevision" failonerror="true">
               <args>
                 <arg value="-1"/>
                 <arg value="HEAD"/>
                 <arg value="--pretty=%h"/>
+              </args>
+            </git>
+            <git command="log" output="omero.vcs.revision" failonerror="true">
+              <args>
+                <arg value="-1"/>
+                <arg value="HEAD"/>
+                <arg value="--pretty=%H"/>
               </args>
             </git>
             <git command="log" output="omero.vcs.date" failonerror="true">
@@ -97,6 +108,14 @@
                 <arg value="--pretty=%ai"/>
               </args>
             </git>
+            <git command="log" output="omero.vcs.date_unix" failonerror="true">
+              <args>
+                <arg value="-1"/>
+                <arg value="${omero.vcs.revision}"/>
+                <arg value="--pretty=%at"/>
+              </args>
+            </git>
+            <property name="omero.vcs.shortrevision.source" value="git"/>
             <property name="omero.vcs.revision.source" value="git"/>
             <property name="omero.vcs.date.source" value="git"/>
         </try>
@@ -104,8 +123,10 @@
             <!-- *OR* we'll finally fall back to UNKNOWN -->
             <property name="omero.plainversion" value="UNKNOWN"/>
             <property name="omero.shortversion" value="UNKNOWN"/>
+            <property name="omero.vcs.shortrevision" value="UNKNOWN"/>
             <property name="omero.vcs.revision" value="UNKNOWN"/>
             <property name="omero.vcs.date" value="UNKNOWN"/>
+            <property name="omero.vcs.date_unix" value="UNKNOWN"/>
 
             <!-- And compose omero.version from those -->
             <property name="omero.version" value="${omero.plainversion}-ice${versions.ice_lib}"/>
@@ -114,17 +135,21 @@
             <property name="omero.shortversion.source" value="ant"/>
             <property name="omero.version.source" value="ant"/>
             <property name="omero.vcs.revision.source" value="ant"/>
+            <property name="omero.vcs.shortrevision.source" value="ant"/>
             <property name="omero.vcs.date.source" value="ant"/>
+            <property name="omero.vcs.date_unix.source" value="ant"/>
         </catch>
     </trycatch>
 
     <target name="version-info">
-        <echo>Git describe output:    ${omero.v.git}</echo>
-        <echo>Official:               ${omero.version} (${omero.version.source})</echo>
-        <echo>Plain:                  ${omero.plainversion} (${omero.plainversion.source})</echo>
-        <echo>Short:                  ${omero.shortversion} (${omero.shortversion.source})</echo>
-        <echo>Git revision:           ${omero.vcs.revision} (${omero.vcs.revision.source})</echo>
-        <echo>Git revision date:      ${omero.vcs.date} (${omero.vcs.date.source})</echo>
+        <echo>Git describe output:      ${omero.v.git}</echo>
+        <echo>Official:                 ${omero.version} (${omero.version.source})</echo>
+        <echo>Plain:                    ${omero.plainversion} (${omero.plainversion.source})</echo>
+        <echo>Short:                    ${omero.shortversion} (${omero.shortversion.source})</echo>
+        <echo>Git short revision:       ${omero.vcs.shortrevision} (${omero.vcs.shortrevision.source})</echo>
+        <echo>Git revision:             ${omero.vcs.revision} (${omero.vcs.revision.source})</echo>
+        <echo>Git revision date:        ${omero.vcs.date} (${omero.vcs.date.source})</echo>
+        <echo>Git revision date (UNIX): ${omero.vcs.date_unix} (${omero.vcs.date_unix.source})</echo>
     </target>
 
 </project>

--- a/components/antlib/scripts/source-archive.py
+++ b/components/antlib/scripts/source-archive.py
@@ -27,6 +27,7 @@ GITVERSION_XML = """<?xml version="1.0" encoding="utf-8"?>
 <project name="gitversion" basedir=".">
     <property name="omero.shortversion" value="%s"/>
     <property name="omero.plainversion" value="%s"/>
+    <property name="omero.vcs.shortrevision" value="%s"/>
     <property name="omero.vcs.revision" value="%s"/>
     <property name="omero.vcs.date" value="%s"/>
 
@@ -34,20 +35,24 @@ GITVERSION_XML = """<?xml version="1.0" encoding="utf-8"?>
     <property name="omero.shortversion.source" value="embedded"/>
     <property name="omero.plainversion.source" value="embedded"/>
     <property name="omero.vcs.revision.source" value="embedded"/>
+    <property name="omero.vcs.shortrevision.source" value="embedded"/>
     <property name="omero.vcs.date.source" value="embedded"/>
 </project>
 """
 
 GITVERSION_CMAKE = """set(OME_VERSION "%s")
 set(OME_VERSION_SHORT "%s")
+set(OME_VCS_SHORTREVISION "%s")
 set(OME_VCS_REVISION "%s")
 set(OME_VCS_DATE "%s")
+set(OME_VCS_DATE_S "%s")
 """
 
 BF_GITVERSION_XML = """<?xml version="1.0" encoding="utf-8"?>
 <project name="gitversion" basedir=".">
     <property name="release.version" value="%s"/>
     <property name="release.shortversion" value="%s"/>
+    <property name="vcs.shortrevision" value="%s"/>
     <property name="vcs.revision" value="%s"/>
     <property name="vcs.date" value="%s"/>
 </project>
@@ -55,6 +60,7 @@ BF_GITVERSION_XML = """<?xml version="1.0" encoding="utf-8"?>
 
 BF_GITVERSION_CMAKE = """set(OME_VERSION "%s")
 set(OME_VERSION_SHORT "%s")
+set(OME_VCS_SHORTREVISION "%s")
 set(OME_VCS_REVISION "%s")
 set(OME_VCS_DATE %s)
 set(OME_VCS_DATE_S "%s")
@@ -62,22 +68,27 @@ set(OME_VCS_DATE_S "%s")
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 12:
+    if len(sys.argv) != 15:
         raise Exception(
-            'Usage: %s releasename shortversion fullversion vcs-revision'
-            ' vcs-date bf_shortversion bf_version bf_revision targetdir')
+            'Usage: %s releasename shortversion fullversion'
+            ' vcs-shortrevision vcs-revision vcs-date vcs-date-unix'
+            ' bf_shortversion bf_version bf_shortrevision bf_revision'
+            ' bf_vcs-date bf_vcs-date-unix targetdir')
 
     release = sys.argv[1]
     shortversion = sys.argv[2]
     version = sys.argv[3]
-    vcs_revision = sys.argv[4]
-    vcs_date = sys.argv[5]
-    bf_shortversion = sys.argv[6]
-    bf_version = sys.argv[7]
-    bf_vcs_revision = sys.argv[8]
-    bf_vcs_date = sys.argv[9]
-    bf_vcs_date_unix = sys.argv[10]
-    target = os.path.abspath(sys.argv[11])
+    vcs_shortrevision = sys.argv[4]
+    vcs_revision = sys.argv[5]
+    vcs_date = sys.argv[6]
+    vcs_date_unix = sys.argv[7]
+    bf_shortversion = sys.argv[8]
+    bf_version = sys.argv[9]
+    bf_vcs_shortrevision = sys.argv[10]
+    bf_vcs_revision = sys.argv[11]
+    bf_vcs_date = sys.argv[12]
+    bf_vcs_date_unix = sys.argv[13]
+    target = os.path.abspath(sys.argv[14])
     release = "%s-%s" % (release, version)
 
     if not os.path.isdir('.git'):
@@ -141,17 +152,20 @@ if __name__ == "__main__":
     # Embed release number
     basezip.writestr(
         "%s/components/antlib/resources/gitversion.xml" % release,
-        GITVERSION_XML % (shortversion, version, vcs_revision, vcs_date))
+        GITVERSION_XML % (shortversion, version, vcs_shortrevision,
+                          vcs_revision, vcs_date))
     basezip.writestr(
         "%s/components/tools/OmeroCpp/cmake/GitVersion.cmake" % release,
-        GITVERSION_CMAKE % (version, shortversion, vcs_revision, vcs_date))
+        GITVERSION_CMAKE % (version, shortversion, vcs_shortrevision,
+                            vcs_revision, vcs_date_unix, vcs_date))
 
     basezip.writestr(
         "%s/components/bioformats/ant/gitversion.xml" % (release),
-        BF_GITVERSION_XML % (bf_version, bf_shortversion, bf_vcs_revision,
+        BF_GITVERSION_XML % (bf_version, bf_shortversion,
+                             bf_vcs_shortrevision, bf_vcs_revision,
                              bf_vcs_date))
     basezip.writestr(
         "%s/components/bioformats/cpp/cmake/GitVersion.cmake" % (release),
         BF_GITVERSION_CMAKE % (
-            bf_version, bf_shortversion, bf_vcs_revision, bf_vcs_date_unix,
-            bf_vcs_date))
+            bf_version, bf_shortversion, bf_vcs_shortrevision,
+            bf_vcs_revision, bf_vcs_date_unix, bf_vcs_date))

--- a/components/tools/OmeroCpp/cmake/Version.cmake
+++ b/components/tools/OmeroCpp/cmake/Version.cmake
@@ -39,6 +39,7 @@ cmake_policy(SET CMP0007 NEW)
 function(ome_version)
   set(OME_VERSION UNKNOWN)
   set(OME_VERSION_SHORT UNKNOWN)
+  set(OME_VCS_SHORTREVISION UNKNOWN)
   set(OME_VCS_REVISION UNKNOWN)
   set(OME_VCS_DATE UNKNOWN)
   set(OME_VCS_DATE_S UNKNOWN)
@@ -56,6 +57,14 @@ function(ome_version)
     endif(NOT GIT_FOUND)
 
     execute_process(COMMAND "${GIT_EXECUTABLE}" log -1 HEAD --pretty=%h
+      OUTPUT_VARIABLE commit_hash_short RESULT_VARIABLE git_log_fail ERROR_QUIET
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    if (git_log_fail)
+      message(FATAL_ERROR "Could not obtain release commit hash from git")
+    endif (git_log_fail)
+    string(REPLACE "\n" "" commit_hash_short "${commit_hash_short}")
+
+    execute_process(COMMAND "${GIT_EXECUTABLE}" log -1 HEAD --pretty=%H
       OUTPUT_VARIABLE commit_hash RESULT_VARIABLE git_log_fail ERROR_QUIET
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     if (git_log_fail)
@@ -79,6 +88,7 @@ function(ome_version)
     endif (git_log_fail)
     string(REPLACE "\n" "" commit_date_unix "${commit_date_unix}")
 
+    set(OME_VCS_SHORTREVISION ${commit_hash_short} PARENT_SCOPE)
     set(OME_VCS_REVISION ${commit_hash} PARENT_SCOPE)
     set(OME_VCS_DATE ${commit_date_unix} PARENT_SCOPE)
     set(OME_VCS_DATE_S ${commit_date_string} PARENT_SCOPE)
@@ -109,6 +119,11 @@ function(ome_version)
       endif(NOT describe_fail)
     endif(NOT describe_exact_fail)
   endif(EXISTS "${PROJECT_SOURCE_DIR}/components/tools/OmeroCpp/cmake/GitVersion.cmake")
+
+  set(OME_VCS_SHORTREVISION "${OME_VCS_SHORTREVISION}" PARENT_SCOPE)
+  set(OME_VCS_REVISION "${OME_VCS_REVISION}" PARENT_SCOPE)
+  set(OME_VCS_DATE "${OME_VCS_DATE}" PARENT_SCOPE)
+  set(OME_VCS_DATE_S "${OME_VCS_DATE_S}" PARENT_SCOPE)
 
   string(REGEX MATCH "^v\\.?(.*)" commit_valid1 ${OME_VERSION})
   if (commit_valid1)
@@ -141,6 +156,6 @@ endfunction(ome_version)
 ome_version()
 
 message(STATUS "Configuring openmicroscopy version ${OME_VERSION}")
-if(OME_VCS_REVISION AND OME_VCS_DATE_S)
-  message(STATUS "Using git commit ${OME_VCS_REVISION} on ${OME_VCS_DATE_S}")
-endif(OME_VCS_REVISION AND OME_VCS_DATE_S)
+if(OME_VCS_SHORTREVISION AND OME_VCS_DATE_S)
+  message(STATUS "Using git commit ${OME_VCS_SHORTREVISION} on ${OME_VCS_DATE_S}")
+endif()


### PR DESCRIPTION
The git version used by various git commands in `components/antlib/resources/version.xml` was a short 6-digit form of the commit hash.  This is too short to use without risk of clashes.  This PR adds a long form of the hash and uses that instead; a short revision copy of the hash is retained for user display where needed.

I also noticed we weren't saving the UNIX release date for cmake, so that's also fixed here.

See also: https://github.com/openmicroscopy/bioformats/pull/1664/files

--no-rebase

/cc @sbesson 

--------

Testing:

Check the content of `components/antlib/resources/gitversion.xml` `components/tools/OmeroCpp/cmake/GitVersion.cmake`, `components/bioformats/ant/gitversion.xml` and `components/bioformats/cpp/cmake/GitVersion.cmake`; these should have short and long git versions.

Check the content of `components/tools/OmeroCpp/cmake/GitVersion.cmake`; this should have both a string and numeric release date.

Check `ant version-info` in the source tree and unpacked zip.

Check the `cmake` output for the source tree and unpacked zip.  This should have two lines in the first few lines of the output ("Configuring openmicroscopy...") containing the version, commit hash and release date.  It should be identical for both cases.