### PR TITLE
Download original files

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -373,11 +373,9 @@ class EditorModel
 	        IconManager icons = IconManager.getInstance();
 	        Icon icon = icons.getIcon(IconManager.DOWNLOAD_22);
 	        SecurityContext ctx = getSecurityContext();
-	        while (i.hasNext()) {
-	            p = new DownloadArchivedActivityParam(file, i.next(), icon);
-	            p.setOverride(override);
-	            un.notifyActivity(ctx, p);
-	        }
+            p = new DownloadArchivedActivityParam(file, images, icon);
+            p.setOverride(override);
+            un.notifyActivity(ctx, p);
 	    }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
@@ -155,25 +155,33 @@ public class DownloadAction
         JFrame f = TreeViewerAgent.getRegistry().getTaskBar().getFrame();
 
         int type = FileChooser.SAVE;
-
         List<FileFilter> filters = new ArrayList<FileFilter>();
         filters.add(new ZipFilter());
+        boolean all = false;
+        
+        if(node.getUserObject() instanceof FileAnnotationData) {
+            type = FileChooser.FOLDER_CHOOSER;
+            filters = null;
+            all = true;
+        }
         
         FileChooser chooser = new FileChooser(f, type,
                 FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION,
-                filters, false);
+                filters, all);
         try {
             if (UIUtilities.getDefaultFolder() != null)
                 chooser.setCurrentDirectory(UIUtilities.getDefaultFolder());
         } catch (Exception ex) {
         }
         
-        final File file = UIUtilities.generateFileName(
-                UIUtilities.getDefaultFolder(), browser
-                        .getSelectedDataObjects().size() > 1 ? "Original_Files"
-                        : "Original_File", "zip");
+        if(type == FileChooser.SAVE) {
+            File file = UIUtilities.generateFileName(
+                    UIUtilities.getDefaultFolder(), browser
+                            .getSelectedDataObjects().size() > 1 ? "Original_Files"
+                            : "Original_File", "zip");
+            chooser.setSelectedFile(file);
+        }
         
-        chooser.setSelectedFile(file);
         chooser.setCheckOverride(true);
         IconManager icons = IconManager.getInstance();
         chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewerComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -63,7 +63,6 @@ import org.openmicroscopy.shoola.agents.events.treeviewer.DisplayModeEvent;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerFactory;
-import org.openmicroscopy.shoola.agents.metadata.view.RndSettingsPasted;
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
 import org.openmicroscopy.shoola.agents.treeviewer.ImageChecker.ImageCheckerType;
 import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
@@ -3651,18 +3650,16 @@ class TreeViewerComponent
 	        }
 	    }
 	    if (archived.size() > 0) {
-	        Iterator<ImageData> j = archived.iterator();
-	        DownloadArchivedActivityParam p;
-	        UserNotifier un =
-	                MetadataViewerAgent.getRegistry().getUserNotifier();
-	        IconManager icons = IconManager.getInstance();
-	        Icon icon = icons.getIcon(IconManager.DOWNLOAD_22);
-	        SecurityContext ctx = getSecurityContext();
-	        while (j.hasNext()) {
-	            p = new DownloadArchivedActivityParam(folder, j.next(), icon);
-	            p.setOverride(override);
-	            un.notifyActivity(ctx, p);
-	        }
+            UserNotifier un = MetadataViewerAgent.getRegistry()
+                    .getUserNotifier();
+            IconManager icons = IconManager.getInstance();
+            Icon icon = icons.getIcon(IconManager.DOWNLOAD_22);
+            SecurityContext ctx = getSecurityContext();
+
+            DownloadArchivedActivityParam p = new DownloadArchivedActivityParam(
+                    folder, archived, icon);
+            p.setOverride(override);
+            un.notifyActivity(ctx, p);
 	    }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -541,8 +541,7 @@ class TreeViewerComponent
 		IconManager icons = IconManager.getInstance();
 		DownloadActivityParam activity = new DownloadActivityParam(f,
 				folder, icons.getIcon(IconManager.DOWNLOAD_22));
-		if (override)
-			activity.setFileName(fa.getFileName());
+		activity.setFileName(fa.getFileName());
 
 		un.notifyActivity(model.getSecurityContext(), activity);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.model.DownloadArchivedActivityParam 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -31,6 +31,7 @@ import java.util.List;
 import javax.swing.Icon;
 
 //Third-party libraries
+
 
 //Application-internal dependencies
 import pojos.ImageData;
@@ -67,7 +68,7 @@ public class DownloadArchivedActivityParam
      * Creates a new instance.
      * 
      * @param location The file to download the content into.
-     * @param images The archived images to download.
+     * @param image The archived images to download.
      * @param icon The icon associated to the parameters.
      */
     public DownloadArchivedActivityParam(File location, List<ImageData> images,
@@ -110,7 +111,7 @@ public class DownloadArchivedActivityParam
     public File getLocation() { return location; }
     
     /**
-     * Returns the archived images to download.
+     * Returns the archived image to download.
      * 
      * @return See above.
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.model.DownloadArchivedActivityParam 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -26,6 +26,7 @@ package org.openmicroscopy.shoola.env.data.model;
 
 //Java imports
 import java.io.File;
+import java.util.List;
 
 import javax.swing.Icon;
 
@@ -57,7 +58,7 @@ public class DownloadArchivedActivityParam
     private File location;
     
     /** The collection of archived images to download. */
-    private ImageData image;
+    private List<ImageData> images;
     
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
@@ -66,14 +67,14 @@ public class DownloadArchivedActivityParam
      * Creates a new instance.
      * 
      * @param location The file to download the content into.
-     * @param image The archived images to download.
+     * @param images The archived images to download.
      * @param icon The icon associated to the parameters.
      */
-    public DownloadArchivedActivityParam(File location, ImageData image,
+    public DownloadArchivedActivityParam(File location, List<ImageData> images,
     		Icon icon)
     {
     	this.location = location;
-    	this.image = image;
+    	this.images = images;
     	this.icon = icon;
     	this.override = false;
     }
@@ -109,10 +110,10 @@ public class DownloadArchivedActivityParam
     public File getLocation() { return location; }
     
     /**
-     * Returns the archived image to download.
+     * Returns the archived images to download.
      * 
      * @return See above.
      */
-    public ImageData getImage() { return image; }
+    public List<ImageData> getImages() { return images; }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.views.MetadataHandlerView 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -303,7 +303,7 @@ public interface MetadataHandlerView
 	 * Loads the archived files related to the specified image.
 	 * 
 	 * @param ctx The security context.
-	 * @param imageID The id of the pixels set related to the image.
+	 * @param imageIDs The ids of the pixels set related to the image.
 	 * @param location The location where to store the files.
 	 * @param name The name of the image.
 	 * @param override Flag indicating to override the existing file if it
@@ -311,8 +311,8 @@ public interface MetadataHandlerView
 	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
-	public CallHandle loadArchivedImage(SecurityContext ctx, long imageID,
-		File location, String name, boolean override,
+	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
+		File location, boolean override,
 		AgentEventListener observer);
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.views.MetadataHandlerViewImpl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -245,14 +245,14 @@ class MetadataHandlerViewImpl
 
 	/**
 	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadOriginalImage(SecurityContext, long, File,
+	 * @see MetadataHandlerView#loadOriginalImage(SecurityContext, List, File,
 	 * String, boolean, AgentEventListener)
 	 */
-	public CallHandle loadArchivedImage(SecurityContext ctx, long imageID,
-			File path, String name, boolean override,
+	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
+			File path, boolean override,
 			AgentEventListener observer)
 	{
-		BatchCallTree cmd = new ArchivedImageLoader(ctx, imageID, name, path,
+		BatchCallTree cmd = new ArchivedImageLoader(ctx, imageIDs, path,
 		        override);
 		return cmd.exec(observer);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -33,7 +33,6 @@ import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
@@ -57,17 +56,14 @@ public class ArchivedLoader
     /** Handle to the asynchronous call so that we can cancel it. */
     private CallHandle handle;
 
-    /** The archived image to load. */
-    private ImageData image;
+    /** The archived images to load. */
+    private List<ImageData> images;
 
     /** The file where to download the content of the image. */
     private File file;
 
     /** Flag indicating that the export has been marked to be cancel.*/
     private boolean cancelled;
-
-    /** The name of the saved image.*/
-    private String name;
 
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
@@ -89,7 +85,7 @@ public class ArchivedLoader
      *               Mustn't be <code>null</code>.
      * @param registry Convenience reference for subclasses.
      * @param ctx The security context.
-     * @param image The image to export.
+     * @param images The images to export.
      * @param name The name of the saved image.
      * @param file The location where to download the image.
      * @param override Flag indicating to override the existing file if it
@@ -97,15 +93,14 @@ public class ArchivedLoader
      * @param activity The activity associated to this loader.
      */
 	public ArchivedLoader(UserNotifier viewer, Registry registry,
-			SecurityContext ctx, ImageData image, String name, File file,
+			SecurityContext ctx, List<ImageData> images, File file,
 			boolean override, ActivityComponent activity)
 	{
 		super(viewer, registry, ctx, activity);
-		if (image == null)
+		if (images == null)
 			throw new IllegalArgumentException("Image not valid.");
-		this.image = image;
+		this.images = images;
 		this.file = file;
-		this.name = name;
 		this.override = override;
 	}
 
@@ -115,8 +110,11 @@ public class ArchivedLoader
 	 */
 	public void load()
 	{
-	    if (CommonsLangUtils.isEmpty(name)) name = image.getName();
-	    handle = mhView.loadArchivedImage(ctx, image.getId(), file, name,
+	    List<Long> imageIds = new ArrayList<Long>(images.size());
+	    for(ImageData d : images)
+	        imageIds.add(d.getId());
+	    
+	    handle = mhView.loadArchivedImage(ctx, imageIds, file,
 	            override, this);
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DownloadArchivedActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -101,13 +101,8 @@ public class DownloadArchivedActivity
 	protected UserNotifierLoader createLoader()
 	{
 	    File f = parameters.getLocation();
-	    String name = "";
-        if (f.isFile() || !f.exists()) {
-            name = FilenameUtils.removeExtension(f.getName());
-            f = f.getParentFile();
-        }
 		loader = new ArchivedLoader(viewer, registry, ctx,
-		        parameters.getImage(), name, f, parameters.isOverride(), this);
+		        parameters.getImages(), f, parameters.isOverride(), this);
 		return loader;
 	}
 


### PR DESCRIPTION
There were several issues with the Download dialog, e. g. it claimed you could modify the name but didn't use the modified name ([Ticket 12784](https://trac.openmicroscopy.org.uk/ome/ticket/12784)), if multiple images were selected the first image was zipped but not the other ones, etc. With this PR the file(s) will always be zipped (name of zip file can be modified), and it also unifies the dialog when invoked from different places (Metadata panel, treeviewer, etc.). Also fixes an issue with download of file annotations from the tree viewer (previously it picked the destination folder name as file name).
Test:
- Check that download of original images (with single and multiple selection) works, initiated from all possible places (left hand side tree viewer, central data browser and right hand side metadata panel)
- Check that the download of file annotations works, from metadata panel and tree viewer (tab "Attachments", check single and multi selection)

--no-rebase