### PR TITLE
Downgrade

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/ExporterI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ExporterI.java
@@ -12,6 +12,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -44,6 +45,7 @@ import ome.services.formats.OmeroReader;
 import ome.services.util.Executor;
 import ome.system.ServiceFactory;
 import ome.util.messages.InternalMessage;
+import ome.xml.model.MetadataOnly;
 import ome.xml.model.OME;
 import ome.xml.model.OMEModel;
 import ome.xml.model.OMEModelImpl;
@@ -296,7 +298,11 @@ public class ExporterI extends AbstractCloseableAmdServant implements
                                 Object root = xmlMetadata.getRoot();
                                 if (root instanceof OME) {
                                     OME node = (OME) root;
-
+                                    //add metadata only so we have valid xml.
+                                    List<ome.xml.model.Image> images = node.copyImageList();
+                                    for (ome.xml.model.Image img : images) {
+                                        img.getPixels().setMetadataOnly(new MetadataOnly());
+                                    }
                                     try {
                                         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                                         DocumentBuilder parser = factory.newDocumentBuilder();

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -732,7 +732,7 @@ public class ExporterTest extends AbstractServerTest {
                 streams.add(this.getClass().getResourceAsStream(
                         "/transforms/"+j.next()));
             }
-            targets.add(new Target( streams, e.getKey()));
+            targets.add(new Target(streams, e.getKey()));
         }
         int index = 0;
         Iterator<Target> k = targets.iterator();

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
@@ -38,12 +39,15 @@ import javax.xml.transform.URIResolver;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.formats.tiff.TiffParser;
 import loci.formats.tiff.TiffSaver;
 import ome.specification.OmeValidator;
+import ome.specification.SchemaResolver;
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
 import omero.RType;
@@ -156,14 +160,14 @@ public class ExporterTest extends AbstractServerTest {
      *
      * @param input
      *            The input to validate
-     * @param schemas
-     *            The schemas to use.
      * @throws Exception
      *             Thrown if an error occurred during the validation
      */
-    private void validate(File input, StreamSource[] schemas) throws Exception {
-        OmeValidator theValidator = new OmeValidator();
-        theValidator.validateFile(input, schemas);
+    private void validate(File input) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        Document theDoc = builder.parse(input);
     }
 
     /**
@@ -766,7 +770,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -791,7 +795,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -816,7 +820,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -836,10 +840,7 @@ public class ExporterTest extends AbstractServerTest {
         File f = null;
         try {
             f = download(OME_XML, IMAGE);
-            StreamSource[] schemas = new StreamSource[1];
-            schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
-                    "/released-schema/"+currentSchema+"/ome.xsd"));
-            validate(f, schemas);
+            validate(f);
         } catch (Throwable e) {
             throw new Exception("Cannot validate the image: ", e);
         } finally {
@@ -855,10 +856,7 @@ public class ExporterTest extends AbstractServerTest {
         File f = null;
         try {
             f = download(OME_XML, IMAGE_ROI);
-            StreamSource[] schemas = new StreamSource[1];
-            schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
-                    "/released-schema/"+currentSchema+"/ome.xsd"));
-            validate(f, schemas);
+            validate(f);
         } catch (Throwable e) {
             throw new Exception("Cannot validate the image: ", e);
         } finally {
@@ -879,7 +877,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -905,7 +903,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -930,7 +928,7 @@ public class ExporterTest extends AbstractServerTest {
             //transform
             transformed = applyTransforms(f, target.getTransforms());
             //validate the file
-            validate(transformed, target.getSchemas());
+            validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
@@ -983,7 +981,7 @@ public class ExporterTest extends AbstractServerTest {
             transformedXML = File.createTempFile(RandomStringUtils.random(10),
                     "." + OME_XML);
             FileUtils.writeStringToFile(transformedXML, parser.getComment());
-            validate(transformedXML, target.getSchemas());
+            validate(transformedXML);
             //import the file
             importFile(result, OME_XML);
         } catch (Throwable e) {

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -42,6 +42,8 @@ import loci.common.RandomAccessOutputStream;
 import loci.formats.tiff.TiffParser;
 import loci.formats.tiff.TiffSaver;
 import ome.specification.OmeValidator;
+import ome.specification.XMLMockObjects;
+import ome.specification.XMLWriter;
 import omero.api.ExporterPrx;
 import omero.api.RawFileStorePrx;
 import omero.model.FileAnnotation;
@@ -192,6 +194,7 @@ public class ExporterTest extends AbstractServerTest {
      */
     private Image createImageToExport() throws Exception {
         // First create an image
+        /*
         Image image = mmFactory.createImage();
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
@@ -215,6 +218,21 @@ public class ExporterTest extends AbstractServerTest {
         m.setParent(f);
         m = (PixelsOriginalFileMapI) iUpdate.saveAndReturnObject(m);
         return image;
+        */
+        //create an import and image
+        File f = File.createTempFile(RandomStringUtils.random(10), "."
+                + OME_XML);
+        files.add(f);
+        XMLMockObjects xml = new XMLMockObjects();
+        XMLWriter writer = new XMLWriter();
+        writer.writeFile(f, xml.createImage(), true);
+        List<Pixels> pix = null;
+        try {
+            pix = importFile(f, OME_XML, true);
+            return pix.get(0).getImage();
+        } catch (Throwable e) {
+            throw new Exception("Cannot create image to import", e);
+        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -17,6 +17,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -171,11 +173,11 @@ public class ExporterTest extends AbstractServerTest {
         TransformerFactory factory;
         Transformer transformer;
         InputStream stream;
-        InputStream in = null;
-        OutputStream out = null;
-        File output;
         Iterator<InputStream> i = transforms.iterator();
+        String inputAsString = FileUtils.readFileToString(inputXML);
         try {
+            StringWriter writer;
+            StringReader reader;
             while (i.hasNext()) {
                 stream = i.next();
                 factory = TransformerFactory.newInstance();
@@ -183,22 +185,22 @@ public class ExporterTest extends AbstractServerTest {
                 Source src = new StreamSource(stream);
                 Templates template = factory.newTemplates(src);
                 transformer = template.newTransformer();
-                output = File.createTempFile(RandomStringUtils.random(10), "."
-                        + OME_XML);
-                out = new FileOutputStream(output);
-                in = new FileInputStream(inputXML);
-                transformer.transform(new StreamSource(in), new StreamResult(out));
-                files.add(output);
-                inputXML = output;
+                reader = new StringReader(inputAsString);
+                StreamSource srcIn = new StreamSource(reader);
+                writer = new StringWriter();
+                StreamResult result = new StreamResult(writer);
+                transformer.transform(srcIn, result);
+                inputAsString = result.getWriter().toString();
                 stream.close();
-                out.close();
-                in.close();
+                reader.close();
+                writer.close();
             }
         } catch (Exception e) {
             throw new Exception("Cannot apply transform", e);
         }
         File f = File.createTempFile(RandomStringUtils.random(10), "."+ OME_XML);
         FileUtils.copyFile(inputXML, f);
+        FileUtils.writeStringToFile(f, inputAsString);
         return f;
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -208,7 +208,6 @@ public class ExporterTest extends AbstractServerTest {
             throw new Exception("Cannot apply transform", e);
         }
         File f = File.createTempFile(RandomStringUtils.random(10), "."+ OME_XML);
-        FileUtils.copyFile(inputXML, f);
         FileUtils.writeStringToFile(f, inputAsString);
         return f;
     }
@@ -257,7 +256,6 @@ public class ExporterTest extends AbstractServerTest {
       //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
-        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithROI(), true);
@@ -268,6 +266,8 @@ public class ExporterTest extends AbstractServerTest {
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);
+        } finally {
+            if (f != null) f.delete();
         }
     }
 
@@ -282,7 +282,6 @@ public class ExporterTest extends AbstractServerTest {
         //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
-        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithAnnotatedAcquisitionData(), true);
@@ -293,6 +292,8 @@ public class ExporterTest extends AbstractServerTest {
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);
+        } finally {
+            if (f != null) f.delete();
         }
     }
 
@@ -307,7 +308,6 @@ public class ExporterTest extends AbstractServerTest {
         //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
-        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithAcquisitionData(), true);
@@ -318,6 +318,8 @@ public class ExporterTest extends AbstractServerTest {
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);
+        } finally {
+            if (f != null) f.delete();
         }
     }
 
@@ -549,9 +551,11 @@ public class ExporterTest extends AbstractServerTest {
                 }
             } catch (Exception e) {
                 if (stream != null) stream.close();
+                if (f != null) f.delete();
                 throw new Exception("Unable to download image", e);
             }
         } catch (IOException e) {
+            if (f != null) f.delete();
             throw new Exception("Unable to download image", e);
         } finally {
             if (store != null) store.close();
@@ -1093,6 +1097,7 @@ public class ExporterTest extends AbstractServerTest {
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
         }
     }
 
@@ -1122,6 +1127,7 @@ public class ExporterTest extends AbstractServerTest {
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
         }
     }
 
@@ -1129,6 +1135,7 @@ public class ExporterTest extends AbstractServerTest {
      * Test the upgrade of an image with annotated acquisition.
      * @throws Exception Thrown if an error occurred.
      */
+
     @Test(dataProvider = "createUpgrade")
     public void testUpgradeImageWithAnnotatedAcquisition(Target target) throws Exception {
         File f = null;
@@ -1151,9 +1158,10 @@ public class ExporterTest extends AbstractServerTest {
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
         }
     }
-    
+
     class Target {
 
         /** The transforms to apply.*/

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -142,6 +142,9 @@ public class ExporterTest extends AbstractServerTest {
     /** The various transforms read from the configuration file.*/
     private Map<String, List<String>> sheets;
 
+    /** The current schema.*/
+    private String currentSchema;
+
     /**
      * Validates the specified input.
      *
@@ -672,10 +675,10 @@ public class ExporterTest extends AbstractServerTest {
         try {
             DocumentBuilder builder = dbf.newDocumentBuilder();
             Document doc = builder.parse(stream);
-            String current = doc.getDocumentElement().getAttribute(CURRENT);
-            if (StringUtils.isBlank(current))
+            currentSchema = doc.getDocumentElement().getAttribute(CURRENT);
+            if (StringUtils.isBlank(currentSchema))
                 throw new Exception("No schema specified.");
-            return extractCurrentSchema(current, doc);
+            return extractCurrentSchema(currentSchema, doc);
         } catch (Exception e) {
             throw new Exception("Unable to parse the catalog.", e);
         }
@@ -764,6 +767,44 @@ public class ExporterTest extends AbstractServerTest {
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();
+        }
+    }
+
+    /**
+     * Test if an image validates.
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testValidateImageWithAcquisition() throws Exception {
+        File f = null;
+        try {
+            f = download(OME_XML, IMAGE);
+            StreamSource[] schemas = new StreamSource[1];
+            schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
+                    "/released-schema/"+currentSchema+"/ome.xsd"));
+            validate(f, schemas);
+        } catch (Throwable e) {
+            throw new Exception("Cannot validate the image: ", e);
+        } finally {
+            if (f != null) f.delete();
+        }
+    }
+
+    /**
+     * Test if an image validates.
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testValidateImageWithROI() throws Exception {
+        File f = null;
+        try {
+            f = download(OME_XML, IMAGE_ROI);
+            StreamSource[] schemas = new StreamSource[1];
+            schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
+                    "/released-schema/"+currentSchema+"/ome.xsd"));
+            validate(f, schemas);
+        } catch (Throwable e) {
+            throw new Exception("Cannot validate the image: ", e);
+        } finally {
+            if (f != null) f.delete();
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -1,11 +1,12 @@
 /*
  * $Id$
  *
- *   Copyright 2006-2010 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package integration;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -216,7 +217,7 @@ public class ExporterTest extends AbstractServerTest {
         // now read
         byte[] values = exporter.read(0, (int) size);
         assertNotNull(values);
-        assertTrue(values.length == size);
+        assertEquals(values.length, size);
         exporter.close();
     }
 
@@ -241,7 +242,7 @@ public class ExporterTest extends AbstractServerTest {
         // now read
         byte[] values = exporter.read(0, (int) size);
         assertNotNull(values);
-        assertTrue(values.length == size);
+        assertEquals(values.length, size);
         exporter.close();
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -406,7 +406,7 @@ public class ExporterTest extends AbstractServerTest {
 
     /**
      * Tests to export an image as OME-TIFF. The image has an annotation linked
-     * to it.
+     * to it. Downgrade the image.
      *
      * @throws Exception
      *             Thrown if an error occurred.
@@ -439,15 +439,14 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Tests to export an image as OME-TIFF. The image has an annotation linked
-     * to it.
+     * Tests to export an image as OME-TIFF.
      *
      * @throws Exception
      *             Thrown if an error occurred.
      * @see RawFileStoreTest#testUploadFile()
      */
     @Test
-    public void testExportAsOMETIFFWithoutAnnotation() throws Exception {
+    public void testExportAsOMETIFF() throws Exception {
         // First create an image
         Image image = createImageToExport();
 
@@ -813,7 +812,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image as OME-XML.
+     * Test the downgrade of an image with acquisition data.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -838,7 +837,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image as OME-XML.
+     * Test the downgrade of an image with ROi.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -863,7 +862,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image as OME-XML with annotated acquisition data 
+     * Test the downgrade of an image with annotated acquisition data 
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -888,7 +887,7 @@ public class ExporterTest extends AbstractServerTest {
     }
     
     /**
-     * Test if an image validates.
+     * Test if an image built with current schema validates.
      * @throws Exception Thrown if an error occurred.
      */
     public void testValidateImageWithAcquisition() throws Exception {
@@ -904,7 +903,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test if an image validates.
+     * Test if an image with ROI built with current schema validates.
      * @throws Exception Thrown if an error occurred.
      */
     public void testValidateImageWithROI() throws Exception {
@@ -920,7 +919,24 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image as OME-XML.
+     * Test if an image with annotated acquisition data built with current
+     * schema validates.
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testValidateImageWithAnnotatedAcquisition() throws Exception {
+        File f = null;
+        try {
+            f = download(OME_XML, IMAGE_ANNOTATED_DATA);
+            validate(f);
+        } catch (Throwable e) {
+            throw new Exception("Cannot validate the image: ", e);
+        } finally {
+            if (f != null) f.delete();
+        }
+    }
+
+    /**
+     * Test the export of an image as OME-XML. Downgrade it.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -945,7 +961,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image as OME-XML.
+     * Test the export of an image as OME-XML. Downgrade it.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -971,7 +987,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the export of an image with ROI as OME-XML.
+     * Test the export of an image with ROI as OME-XML. Downgrade it.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createTransform")
@@ -996,8 +1012,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Tests to export an image as OME-TIFF. The image has an annotation linked
-     * to it.
+     * Tests to export an image as OME-TIFF and downgrade it.
      *
      * @throws Exception
      *             Thrown if an error occurred.

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -571,6 +571,7 @@ public class ExporterTest extends AbstractServerTest {
         File f = null;
         File transformed = null;
         File inputXML = null;
+        File transformedXML = null;
         File result = null;
         RandomAccessInputStream in = null;
         RandomAccessOutputStream out = null;
@@ -592,8 +593,13 @@ public class ExporterTest extends AbstractServerTest {
             saver.setBigTiff(parser.isBigTiff());
             in = new RandomAccessInputStream(path);
             saver.overwriteComment(in, FileUtils.readFileToString(transformed));
+            
             //validate the OME-TIFF
-            validate(result, target.getSchemas());
+            parser = new TiffParser(result.getAbsolutePath());
+            transformedXML = File.createTempFile(RandomStringUtils.random(10),
+                    "." + OME_XML);
+            FileUtils.writeStringToFile(transformedXML, parser.getComment());
+            validate(transformedXML, target.getSchemas());
             //import the file
             importFile(result, OME_XML);
         } catch (Throwable e) {
@@ -603,6 +609,7 @@ public class ExporterTest extends AbstractServerTest {
             if (transformed != null) transformed.delete();
             if (inputXML != null) inputXML.delete();
             if (result != null) result.delete();
+            if (transformedXML != null) transformedXML.delete();
             if (in != null) in.close();
         }
     }

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -39,8 +39,6 @@ import javax.xml.transform.URIResolver;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
@@ -164,10 +162,8 @@ public class ExporterTest extends AbstractServerTest {
      *             Thrown if an error occurred during the validation
      */
     private void validate(File input) throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        DocumentBuilder builder = dbf.newDocumentBuilder();
-        Document theDoc = builder.parse(new FileInputStream(input));
+        OmeValidator validator = new OmeValidator();
+        validator.parseFile(input);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -17,7 +17,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -249,7 +248,7 @@ public class ExporterTest extends AbstractServerTest {
                 + OME_XML);
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        writer.writeFile(f, xml.createImageWithROI(), true);
         List<Pixels> pix = null;
         try {
             // method tested in ImporterTest
@@ -740,7 +739,32 @@ public class ExporterTest extends AbstractServerTest {
             if (transformed != null) transformed.delete();
         }
     }
-    
+
+    /**
+     * Test the export of an image as OME-XML.
+     * @throws Exception Thrown if an error occurred.
+     */
+    @Test(dataProvider = "createTransform")
+    public void testDowngradeImageWithROI(Target target) throws Exception {
+        File f = null;
+        File transformed = null;
+        try {
+            f = download(OME_XML, IMAGE_ROI);
+            //transform
+            transformed = applyTransforms(f, target.getTransforms());
+            //validate the file
+            validate(transformed, target.getSchemas());
+            //import the file
+            importFile(transformed, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot downgrade image: "+target.getSource(),
+                    e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+        }
+    }
+
     /**
      * Test the export of an image as OME-XML.
      * @throws Exception Thrown if an error occurred.

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -167,7 +167,7 @@ public class ExporterTest extends AbstractServerTest {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
         DocumentBuilder builder = dbf.newDocumentBuilder();
-        Document theDoc = builder.parse(input);
+        Document theDoc = builder.parse(new FileInputStream(input));
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -145,7 +145,7 @@ public class ExporterTest extends AbstractServerTest {
     private static final int IMAGE_ANNOTATED_DATA = 2;
 
     /** The various transforms read from the configuration file.*/
-    private Map<String, List<String>> sheets;
+    private Map<String, List<String>> downgrades;
 
     /** The current schema.*/
     private String currentSchema;
@@ -327,7 +327,7 @@ public class ExporterTest extends AbstractServerTest {
     @BeforeClass
     protected void setUp() throws Exception {
         super.setUp();
-        sheets = currentSchema();
+        downgrades = currentSchema();
     }
 
     /**
@@ -338,7 +338,7 @@ public class ExporterTest extends AbstractServerTest {
     @Override
     @AfterClass
     public void tearDown() throws Exception {
-        sheets.clear();
+        downgrades.clear();
     }
 
     /**
@@ -671,6 +671,7 @@ public class ExporterTest extends AbstractServerTest {
         NodeList t;
         Map<String, List<String>> transforms =
                 new HashMap<String, List<String>>();
+        Map<String, List<String>> umap;
         for (int i = 0; i < list.getLength(); ++i) {
             n = (Element) list.item(i);
             map = n.getAttributes();
@@ -681,6 +682,17 @@ public class ExporterTest extends AbstractServerTest {
                         t = n.getElementsByTagName(TARGET);
                         for (int k = 0; k < t.getLength(); k++) {
                             parseTarget((Element) t.item(k), transforms);
+                        }
+                    } else {
+                        NodeList upgrades = n.getElementsByTagName("upgrades");
+                        umap = new HashMap<String, List<String>>();
+                        for (int k = 0; k < upgrades.getLength(); k++) {
+                            Element node = (Element) upgrades.item(k);
+                            NodeList tt = node.getElementsByTagName(TARGET);
+                            for (int l = 0; l < tt.getLength(); l++) {
+                                parseTarget((Element) tt.item(l), umap);
+                            }
+                            
                         }
                     }
                 }
@@ -722,7 +734,7 @@ public class ExporterTest extends AbstractServerTest {
         List<String> l;
         Iterator<String> j;
         Entry<String, List<String>> e;
-        Iterator<Entry<String, List<String>>> i = sheets.entrySet().iterator();
+        Iterator<Entry<String, List<String>>> i = downgrades.entrySet().iterator();
         while (i.hasNext()) {
             e = i.next();
             l = e.getValue();
@@ -732,7 +744,7 @@ public class ExporterTest extends AbstractServerTest {
                 streams.add(this.getClass().getResourceAsStream(
                         "/transforms/"+j.next()));
             }
-            targets.add(new Target(streams, e.getKey()));
+            targets.add(new Target(streams, e.getKey(), null));
         }
         int index = 0;
         Iterator<Target> k = targets.iterator();
@@ -992,17 +1004,20 @@ public class ExporterTest extends AbstractServerTest {
         /** The source schema.*/
         private String source;
 
+        /** The target schema.*/
+        private String target;
+
         /**
          * Creates a new instance.
          *
-         * @param schemas The schema used to validate the change.
          * @param transforms The transforms to apply.
          * @param source The source schema.
          */
-        Target(List<InputStream> transforms, String source)
+        Target(List<InputStream> transforms, String target, String source)
         {
             this.transforms = transforms;
             this.source = source;
+            this.target = target;
         }
 
         /**
@@ -1018,6 +1033,13 @@ public class ExporterTest extends AbstractServerTest {
          * @return See above.
          */
         String getSource() { return source; }
+
+        /**
+         * Returns the target schema.
+         *
+         * @return See above.
+         */
+        String getTarget() { return target; }
 
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -1053,7 +1053,35 @@ public class ExporterTest extends AbstractServerTest {
         }
     }
 
-    
+    /**
+     * Test the upgrade of an image.
+     * @throws Exception Thrown if an error occurred.
+     */
+    @Test(dataProvider = "createUpgrade")
+    public void testUpgradeImageWithAcquisition(Target target) throws Exception {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = download(OME_XML, IMAGE); //2015 image
+            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file.
+            upgraded = applyTransforms(transformed, target.getTransforms());
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot upgrade image: "+target.getSource(),
+                    e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+        }
+    }
+
     class Target {
 
         /** The transforms to apply.*/

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -261,6 +261,7 @@ public class ExporterTest extends AbstractServerTest {
       //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
+        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithROI(), true);
@@ -285,6 +286,7 @@ public class ExporterTest extends AbstractServerTest {
         //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
+        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithAnnotatedAcquisitionData(), true);
@@ -309,6 +311,7 @@ public class ExporterTest extends AbstractServerTest {
         //create an import and image
         File f = File.createTempFile(RandomStringUtils.random(10), "."
                 + OME_XML);
+        f.deleteOnExit();
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         writer.writeFile(f, xml.createImageWithAcquisitionData(), true);

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -199,7 +199,7 @@ public class ExporterTest extends AbstractServerTest {
                 writer = new StringWriter();
                 StreamResult result = new StreamResult(writer);
                 transformer.transform(srcIn, result);
-                inputAsString = result.getWriter().toString();
+                inputAsString = writer.getBuffer().toString();
                 stream.close();
                 reader.close();
                 writer.close();

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -514,7 +514,6 @@ public class ExporterTest extends AbstractServerTest {
             l.add(omero.rtypes.rlong(id));
             param.add("imageIds", omero.rtypes.rlist(l));
 
-            
             param.map.put("id", omero.rtypes.rlong(
                     image.getPrimaryPixels().getId().getValue()));
             List<IObject> files = svc.findAllByQuery(createFileSetQuery(),
@@ -1054,7 +1053,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the upgrade of an image.
+     * Test the upgrade of an image with acquisition data.
      * @throws Exception Thrown if an error occurred.
      */
     @Test(dataProvider = "createUpgrade")
@@ -1082,6 +1081,64 @@ public class ExporterTest extends AbstractServerTest {
         }
     }
 
+    /**
+     * Test the upgrade of an image with ROI.
+     * @throws Exception Thrown if an error occurred.
+     */
+    @Test(dataProvider = "createUpgrade")
+    public void testUpgradeImageWithROI(Target target) throws Exception {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = download(OME_XML, IMAGE_ROI); //2015 image
+            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file.
+            upgraded = applyTransforms(transformed, target.getTransforms());
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot upgrade image: "+target.getSource(),
+                    e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+        }
+    }
+
+    /**
+     * Test the upgrade of an image with annotated acquisition.
+     * @throws Exception Thrown if an error occurred.
+     */
+    @Test(dataProvider = "createUpgrade")
+    public void testUpgradeImageWithAnnotatedAcquisition(Target target) throws Exception {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = download(OME_XML, IMAGE_ANNOTATED_DATA); //2015 image
+            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file.
+            upgraded = applyTransforms(transformed, target.getTransforms());
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot upgrade image: "+target.getSource(),
+                    e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+        }
+    }
+    
     class Target {
 
         /** The transforms to apply.*/

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -94,6 +94,9 @@ public class ExporterTest extends AbstractServerTest {
     /** The catalog file to find. */
     private static String CATALOG = "/transforms/ome-transforms.xml";
 
+    /** The conversion file to find. */
+    private static String UNITS_CONVERSION = "/transforms/units-conversion.xsl";
+
     /** The <i>name</i> attribute. */
     private static String CURRENT = "current";
 
@@ -676,9 +679,10 @@ public class ExporterTest extends AbstractServerTest {
     class Resolver implements URIResolver {
 
         @Override
-        public Source resolve(String href, String base) throws TransformerException {
+        public Source resolve(String href, String base)
+                throws TransformerException {
             InputStream s = this.getClass().getResourceAsStream(
-                    "/transforms/units-conversion.xsl");
+                    UNITS_CONVERSION);
             return new StreamSource(s);
         }
     }

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -188,6 +188,64 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
+     * Tests to export an image as OME-XML.
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     * @see RawFileStoreTest#testUploadFile()
+     */
+    @Test
+    public void testExportAsOMEXML() throws Exception {
+        // First create an image
+        Image image = createImageToExport();
+
+        // now export
+        ExporterPrx exporter = factory.createExporter();
+        exporter.addImage(image.getId().getValue());
+        long size = exporter.generateXml();
+        assertTrue(size > 0);
+        // now read
+        byte[] values = exporter.read(0, (int) size);
+        assertNotNull(values);
+        assertEquals(values.length, size);
+        exporter.close();
+    }
+
+    /**
+     * Tests to export an image as OME-XML. The image has an annotation linked
+     * to it.
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     * @see RawFileStoreTest#testUploadFile()
+     */
+    @Test
+    public void testExportAsOMEXMLWithAnnotation() throws Exception {
+        // First create an image
+        Image image = createImageToExport();
+
+        // Need to have an annotation otherwise does not work
+        FileAnnotationI fa = new FileAnnotationI();
+        fa.setDescription(omero.rtypes.rstring("test"));
+        FileAnnotation a = (FileAnnotation) iUpdate.saveAndReturnObject(fa);
+        ImageAnnotationLinkI l = new ImageAnnotationLinkI();
+        l.setChild(a);
+        l.setParent(new ImageI(image.getId().getValue(), false));
+        iUpdate.saveAndReturnObject(l);
+
+        // now export
+        ExporterPrx exporter = factory.createExporter();
+        exporter.addImage(image.getId().getValue());
+        long size = exporter.generateXml();
+        assertTrue(size > 0);
+        // now read
+        byte[] values = exporter.read(0, (int) size);
+        assertNotNull(values);
+        assertEquals(values.length, size);
+        exporter.close();
+    }
+
+    /**
      * Tests to export an image as OME-TIFF. The image has an annotation linked
      * to it.
      *

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -739,6 +739,8 @@ public class ExporterTest extends AbstractServerTest {
             return extractCurrentSchema(currentSchema, doc);
         } catch (Exception e) {
             throw new Exception("Unable to parse the catalog.", e);
+        } finally {
+            if (stream != null) stream.close();
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -742,10 +742,7 @@ public class ExporterTest extends AbstractServerTest {
                 streams.add(this.getClass().getResourceAsStream(
                         "/transforms/"+j.next()));
             }
-            StreamSource[] schemas = new StreamSource[1];
-            schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
-                    "/released-schema/"+e.getKey()+"/ome.xsd"));
-            targets.add(new Target(schemas, streams, e.getKey()));
+            targets.add(new Target( streams, e.getKey()));
         }
         int index = 0;
         Iterator<Target> k = targets.iterator();
@@ -999,9 +996,6 @@ public class ExporterTest extends AbstractServerTest {
 
     class Target {
 
-        /** The schema used to validate the change.*/
-        private StreamSource[] schemas;
-
         /** The transforms to apply.*/
         private List<InputStream> transforms;
 
@@ -1015,20 +1009,11 @@ public class ExporterTest extends AbstractServerTest {
          * @param transforms The transforms to apply.
          * @param source The source schema.
          */
-        Target(StreamSource[] schemas, List<InputStream> transforms,
-                String source)
+        Target(List<InputStream> transforms, String source)
         {
-            this.schemas = schemas;
             this.transforms = transforms;
             this.source = source;
         }
-
-        /**
-         * Returns the schema used to validate.
-         *
-         * @return See above.
-         */
-        StreamSource[] getSchemas() { return schemas; }
 
         /**
          * Returns the transforms to apply.

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -144,9 +144,6 @@ public class ExporterTest extends AbstractServerTest {
      */
     private static final int IMAGE_ANNOTATED_DATA = 2;
 
-    /** The collection of files that have to be deleted. */
-    private List<File> files;
-
     /** The various transforms read from the configuration file.*/
     private Map<String, List<String>> sheets;
 
@@ -330,7 +327,6 @@ public class ExporterTest extends AbstractServerTest {
     @BeforeClass
     protected void setUp() throws Exception {
         super.setUp();
-        files = new ArrayList<File>();
         sheets = currentSchema();
     }
 
@@ -342,11 +338,6 @@ public class ExporterTest extends AbstractServerTest {
     @Override
     @AfterClass
     public void tearDown() throws Exception {
-        Iterator<File> i = files.iterator();
-        while (i.hasNext()) {
-            i.next().delete();
-        }
-        files.clear();
         sheets.clear();
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -530,7 +530,7 @@ public class ExporterTest extends AbstractServerTest {
             StreamSource[] schemas = new StreamSource[1];
             schemas[0] = new StreamSource(this.getClass().getResourceAsStream(
                     "/released-schema/"+e.getKey()+"/ome.xsd"));
-            targets.add(new Target(schemas, streams));
+            targets.add(new Target(schemas, streams, e.getKey()));
         }
         int index = 0;
         Iterator<Target> k = targets.iterator();
@@ -559,10 +559,11 @@ public class ExporterTest extends AbstractServerTest {
             //import the file
             importFile(transformed, OME_XML);
         } catch (Throwable e) {
-            throw new Exception("cannot downgrade image", e);
+            throw new Exception("Cannot downgrade image: "+target.getSource(),
+                    e);
         } finally {
             if (f != null) f.delete();
-            //if (transformed != null) transformed.delete();
+            if (transformed != null) transformed.delete();
         }
     }
 
@@ -611,7 +612,8 @@ public class ExporterTest extends AbstractServerTest {
             //import the file
             importFile(result, OME_XML);
         } catch (Throwable e) {
-            throw new Exception("cannot downgrade image", e);
+            throw new Exception("Cannot downgrade image: "+target.getSource(),
+                    e);
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();
@@ -625,21 +627,27 @@ public class ExporterTest extends AbstractServerTest {
     class Target {
 
         /** The schema used to validate the change.*/
-        StreamSource[] schemas;
+        private StreamSource[] schemas;
 
         /** The transforms to apply.*/
-        List<InputStream> transforms;
+        private List<InputStream> transforms;
+
+        /** The source schema.*/
+        private String source;
 
         /**
          * Creates a new instance.
          *
          * @param schemas The schema used to validate the change.
          * @param transforms The transforms to apply.
+         * @param source The source schema.
          */
-        Target(StreamSource[] schemas, List<InputStream> transforms) 
+        Target(StreamSource[] schemas, List<InputStream> transforms,
+                String source)
         {
             this.schemas = schemas;
             this.transforms = transforms;
+            this.source = source;
         }
 
         /**
@@ -655,6 +663,14 @@ public class ExporterTest extends AbstractServerTest {
          * @return See above.
          */
         List<InputStream> getTransforms() { return transforms; }
+
+        /**
+         * Returns the source schema.
+         *
+         * @return See above.
+         */
+        String getSource() { return source; }
+
     }
 
     class Resolver implements URIResolver {


### PR DESCRIPTION
Reactivate the tests validating the OME-XML and OME-TIFF export and downgrade
Previously limited to the latest stylesheet (hard-coded)
All possible downgrades are now read from the catalog file.
Few tests are still failing i.e. going back to schema 2008-09 and prior.
Still some work to do i.e. review certain stylesheets conversion

to run test
```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/ExporterTest
```
Related PR https://github.com/openmicroscopy/bioformats/pull/1668
cc @qidane @joshmoore @pwalczysko 

--no-rebase