### PR TITLE
Remove version and patch prompts from `omero db script`

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -200,14 +200,6 @@ class TestDatabase(object):
         getpass.getpass("Please re-enter %s" %
                         self.password_ending(user, id)).AndReturn(pw)
 
-    def expectVersion(self, version):
-        raw_input("Please enter omero.db.version [%s]: " %
-                  self.data["version"]).AndReturn(version)
-
-    def expectPatch(self, patch):
-        raw_input("Please enter omero.db.patch [%s]: " %
-                  self.data["patch"]).AndReturn(patch)
-
     def password_output(self, user_id, no_salt):
         update_msg = "UPDATE password SET hash = \'%s\'" \
             " WHERE experimenter_id  = %s;"


### PR DESCRIPTION
- `omero db script`: only prompts for the root password
- `omero db script --password ome`: Shouldn't prompt for anything
- `omero db script --version DBVERSION --patch DBPATCH`: Set db.version and db.patch for developers
- `omero db script DBVERSION DBPATCH`: Old deprecated behaviour (positional args)
- All other existing flags should continue to work

https://trello.com/c/8PPlaBmP/456-remove-compulsory-version-patch-args-from-db-script
--no-rebase