### PR TITLE
Python tests library improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     - git config --global user.name 'Snoopy Crime Cop'
     - sudo pip install scc pytest
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8 pep8==1.5.7; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8==2.4.0; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
 # retries the build due to:

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -29,6 +29,7 @@ import time
 import weakref
 import logging
 import subprocess
+import pytest
 
 import Ice
 import Glacier2
@@ -125,6 +126,14 @@ class ITest(object):
             return p
         else:
             assert False, "Could not find OmeroPy/; searched %s" % searched
+
+    def skip_if(self, config_key, condition, message=None):
+        """Skip test if configuration does not meet condition"""
+        config_service = self.root.sf.getConfigService()
+        config_value = config_service.getConfigValue(config_key)
+        if condition(config_value):
+            pytest.skip(message or '%s:%s does not meet condition'
+                        % (config_key, config_value))
 
     @classmethod
     def uuid(self):

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -762,13 +762,14 @@ class ITest(object):
 
         if test_should_pass:
             if isinstance(rsp, ERR):
-                assert False,\
-                    "Found ERR when test_should_pass==true: %s (%s) params=%s" %\
-                    (rsp.category, rsp.name, rsp.parameters)
+                assert False, (
+                    "Found ERR when test_should_pass==true: %s (%s) params=%s"
+                    % (rsp.category, rsp.name, rsp.parameters))
             assert State.FAILURE not in prx.getStatus().flags
         else:
             if isinstance(rsp, OK):
-                assert False, "Found OK when test_should_pass==false: %s" % rsp
+                assert False, (
+                    "Found OK when test_should_pass==false: %s" % rsp)
             assert State.FAILURE in prx.getStatus().flags
 
         return rsp

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -261,7 +261,6 @@ class TestDownload(CLITest):
         cfg = cfg.getConfigValue("omero.policy.binary_access")
         assert cfg in [x.cfg for x in self.POLICY_FIXTURES]
 
-
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
                              ids=POLICY_FIXTURES)
     def testPolicyGlobalRestriction(self, tmpdir, fixture):

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -254,21 +254,20 @@ class TestDownload(CLITest):
                                    "member": (True, True, True)}),
     )
 
-    @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
-                             ids=POLICY_FIXTURES)
-    def testPolicyGlobalRestriction(self, tmpdir, fixture):
+    def testValidPolicy(self):
+        """Check that the config we have is at least tested by some fixture"""
 
-        # Check that the config we have is at least tested
-        # by *some* fixture
         cfg = self.root.sf.getConfigService()
         cfg = cfg.getConfigValue("omero.policy.binary_access")
         assert cfg in [x.cfg for x in self.POLICY_FIXTURES]
 
-        # But if this isn't a check for this particular
-        # config, then skip.
 
-        if cfg != fixture.cfg:
-            pytest.skip("Found binary access policy: %s" % cfg)
+    @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
+                             ids=POLICY_FIXTURES)
+    def testPolicyGlobalRestriction(self, tmpdir, fixture):
+        # Skip f this isn't a check for this particular
+        # config, then skip.
+        self.skip_if("omero.policy.binary_access", lambda x: x != fixture.cfg)
 
         group = self.new_group(perms='rwr---')
         self.do_restrictions(fixture, tmpdir, group)

--- a/components/tools/OmeroPy/test/integration/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_group.py
@@ -40,8 +40,6 @@ class TestGroup(CLITest):
     def setup_class(self):
         super(TestGroup, self).setup_class()
         self.cli.register("group", GroupControl, "TEST")
-        self.group1 = self.new_group()
-        self.user1 = self.new_user(group=self.group1)
         self.groups = self.sf.getAdminService().lookupGroups()
 
     def setup_method(self, method):
@@ -89,19 +87,18 @@ class TestGroup(CLITest):
         # Read from the stdout
         out, err = capsys.readouterr()
         ids = get_group_ids(out)
-        groupId = self.client.sf.getAdminService().getEventContext().groupId
-        assert ids == [groupId]
+        assert ids == [self.group.id.val]
 
     @pytest.mark.parametrize("groupfixture", GroupFixtures, ids=GroupNames)
     def testInfoArgument(self, capsys, groupfixture):
         self.args += ["info"]
-        self.args += groupfixture.get_arguments(self.group1)
+        self.args += groupfixture.get_arguments(self.group)
         self.cli.invoke(self.args, strict=True)
 
         # Read from the stdout
         out, err = capsys.readouterr()
         ids = get_group_ids(out)
-        assert ids == [self.group1.id.val]
+        assert ids == [self.group.id.val]
 
     def testInfoInvalidGroup(self, capsys):
         self.args += ["info"]
@@ -117,18 +114,17 @@ class TestGroup(CLITest):
 
         out, err = capsys.readouterr()
         ids = get_user_ids(out)
-        userId = self.sf.getAdminService().getEventContext().userId
-        assert ids == [userId]
+        assert ids == [self.user.id.val]
 
     @pytest.mark.parametrize("groupfixture", GroupFixtures, ids=GroupNames)
     def testListUsersArgument(self, capsys, groupfixture):
         self.args += ["listusers"]
-        self.args += groupfixture.get_arguments(self.group1)
+        self.args += groupfixture.get_arguments(self.group)
         self.cli.invoke(self.args, strict=True)
 
         out, err = capsys.readouterr()
         ids = get_user_ids(out)
-        assert ids == [self.user1.id.val]
+        assert ids == [self.user.id.val]
 
     def testListUsersInvalidArgument(self, capsys):
         self.args += ["listgroups"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -48,8 +48,6 @@ class TestUser(CLITest):
     def setup_class(self):
         super(TestUser, self).setup_class()
         self.cli.register("user", UserControl, "TEST")
-        self.group1 = self.new_group()
-        self.user1 = self.new_user(group=self.group1)
         self.users = self.sf.getAdminService().lookupExperimenters()
 
     def setup_method(self, method):
@@ -102,19 +100,18 @@ class TestUser(CLITest):
         # Read from the stdout
         out, err = capsys.readouterr()
         ids = get_user_ids(out)
-        userId = self.client.sf.getAdminService().getEventContext().userId
-        assert ids == [userId]
+        assert ids == [self.user.id.val]
 
     @pytest.mark.parametrize("userfixture", UserFixtures, ids=UserNames)
     def testInfoArgument(self, capsys, userfixture):
         self.args += ["info"]
-        self.args += userfixture.get_arguments(self.user1)
+        self.args += userfixture.get_arguments(self.user)
         self.cli.invoke(self.args, strict=True)
 
         # Read from the stdout
         out, err = capsys.readouterr()
         ids = get_user_ids(out)
-        assert ids == [self.user1.id.val]
+        assert ids == [self.user.id.val]
 
     def testInfoInvalidUser(self, capsys):
         self.args += ["info"]
@@ -130,20 +127,19 @@ class TestUser(CLITest):
 
         out, err = capsys.readouterr()
         ids = get_group_ids(out)
-        groupId = self.sf.getAdminService().getEventContext().groupId
         roles = self.sf.getAdminService().getSecurityRoles()
-        assert ids == [roles.userGroupId, groupId]
+        assert ids == [roles.userGroupId, self.group.id.val]
 
     @pytest.mark.parametrize("userfixture", UserFixtures, ids=UserNames)
     def testListGroupsArgument(self, capsys, userfixture):
         self.args += ["listgroups"]
-        self.args += userfixture.get_arguments(self.user1)
+        self.args += userfixture.get_arguments(self.user)
         self.cli.invoke(self.args, strict=True)
 
         out, err = capsys.readouterr()
         ids = get_group_ids(out)
         roles = self.sf.getAdminService().getSecurityRoles()
-        assert ids == [roles.userGroupId, self.group1.id.val]
+        assert ids == [roles.userGroupId, self.group.id.val]
 
     def testListGroupsInvalidArgument(self, capsys):
         self.args += ["listgroups"]
@@ -176,7 +172,7 @@ class TestUser(CLITest):
     @pytest.mark.parametrize("is_unicode", [True, False])
     def testPassword(self, is_unicode):
         self.args += ["password"]
-        login = self.sf.getAdminService().getEventContext().userName
+        login = self.ctx.userName
         if is_unicode:
             password = "ążćę"
         else:

--- a/components/tools/OmeroPy/test/integration/cmdtest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/cmdtest/test_chgrp.py
@@ -33,14 +33,9 @@ class TestChgrp(lib.ITest):
 
     def testChgrpImage(self):
 
-        # One user in two groups
-        client, exp = self.new_client_and_user()
-        update = client.sf.getUpdateService()
-        query = client.sf.getQueryService()
-
         # Data Setup
         img = self.new_image()
-        img = update.saveAndReturnObject(img)
+        img = self.update.saveAndReturnObject(img)
 
         # New method
         chgrp = omero.cmd.Chgrp(type="/Image", id=img.id.val, options=None)
@@ -49,4 +44,4 @@ class TestChgrp(lib.ITest):
         cb.loop(20, 750)
 
         # Check Data
-        query.get("Image", img.id.val)
+        self.query.get("Image", img.id.val)

--- a/components/tools/OmeroPy/test/integration/cmdtest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/cmdtest/test_chgrp.py
@@ -39,8 +39,8 @@ class TestChgrp(lib.ITest):
 
         # New method
         chgrp = omero.cmd.Chgrp(type="/Image", id=img.id.val, options=None)
-        handle = client.sf.submit(chgrp)
-        cb = CmdCallbackI(client, handle)
+        handle = self.sf.submit(chgrp)
+        cb = CmdCallbackI(self.client, handle)
         cb.loop(20, 750)
 
         # Check Data

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_repo.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_repo.py
@@ -39,13 +39,13 @@ class TestScriptRepo(lib.ITest):
         assert repo
 
     def testGetOfficialScripts(self):
-        scriptService = self.client.sf.getScriptService()
+        scriptService = self.sf.getScriptService()
         officialScripts = scriptService.getScripts()
         count = len(officialScripts)
         assert count > 0
 
     def testGetUserScripts(self):
-        scriptService = self.client.sf.getScriptService()
+        scriptService = self.sf.getScriptService()
         myUserScripts = scriptService.getUserScripts([])
         sid = scriptService.uploadScript(
             "/test/foo.py",
@@ -63,8 +63,7 @@ class TestScriptRepo(lib.ITest):
 
     @pytest.mark.broken(ticket="11494")
     def testGetGroupScripts(self):
-        scriptService = self.client.sf.getScriptService()
-        grp = omero.model.ExperimenterGroupI(self.group.id.val, False)
+        scriptService = self.sf.getScriptService()
         client = self.new_client(self.group)
 
         sid = client.sf.getScriptService().uploadScript(
@@ -74,7 +73,8 @@ class TestScriptRepo(lib.ITest):
             OS.client("testGetGroupScripts")
             """)
 
-        myGroupScripts = scriptService.getUserScripts([grp])
+        myGroupScripts = scriptService.getUserScripts(
+            [omero.model.ExperimenterGroupI(self.group.id.val, False)])
         assert sid in [x.id.val for x in myGroupScripts]
 
     def testCantUndulyLoadScriptRepoFromUuid(self):

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_repo.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_repo.py
@@ -38,42 +38,34 @@ class TestScriptRepo(lib.ITest):
         repo = sr.getScriptRepository()
         assert repo
 
-    def scriptPrx(self):
-        return self.client.sf.getScriptService()
-
     def testGetOfficialScripts(self):
-        prx = self.scriptPrx()
-        officialScripts = prx.getScripts()
+        scriptService = self.client.sf.getScriptService()
+        officialScripts = scriptService.getScripts()
         count = len(officialScripts)
         assert count > 0
 
     def testGetUserScripts(self):
-        prx = self.scriptPrx()
-        myUserScripts = prx.getUserScripts([])
-        sid = prx.uploadScript(
+        scriptService = self.client.sf.getScriptService()
+        myUserScripts = scriptService.getUserScripts([])
+        sid = scriptService.uploadScript(
             "/test/foo.py",
             """if True:
             import omero, omero.scripts as OS
             OS.client("name")
             """)
 
-        myUserScripts = prx.getUserScripts([])
+        myUserScripts = scriptService.getUserScripts([])
         assert sid in [x.id.val for x in myUserScripts]
 
-        admin = self.client.sf.getAdminService()
-        oid = admin.getEventContext().userId
-        myUserScripts = prx.getUserScripts(
-            [omero.model.ExperimenterI(oid, False)])
+        myUserScripts = scriptService.getUserScripts(
+            [omero.model.ExperimenterI(self.user.id.val, False)])
         assert sid in [x.id.val for x in myUserScripts]
 
     @pytest.mark.broken(ticket="11494")
     def testGetGroupScripts(self):
-        prx = self.scriptPrx()
-        admin = self.client.sf.getAdminService()
-        gid = admin.getEventContext().groupId
-        gname = admin.getEventContext().groupName
-        grp = omero.model.ExperimenterGroupI(gid, False)
-        client = self.new_client(gname)
+        scriptService = self.client.sf.getScriptService()
+        grp = omero.model.ExperimenterGroupI(self.group.id.val, False)
+        client = self.new_client(self.group)
 
         sid = client.sf.getScriptService().uploadScript(
             "/test/otheruser.py",
@@ -82,7 +74,7 @@ class TestScriptRepo(lib.ITest):
             OS.client("testGetGroupScripts")
             """)
 
-        myGroupScripts = prx.getUserScripts([grp])
+        myGroupScripts = scriptService.getUserScripts([grp])
         assert sid in [x.id.val for x in myGroupScripts]
 
     def testCantUndulyLoadScriptRepoFromUuid(self):

--- a/components/tools/OmeroPy/test/integration/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/test_admin.py
@@ -33,25 +33,22 @@ from omero.rtypes import rstring
 class TestAdmin(lib.ITest):
 
     def testGetGroup(self):
-        a = self.client.getSession().getAdminService()
+        a = self.sf.getAdminService()
         l = a.lookupGroups()
         g = a.getGroup(l[0].getId().val)
         assert 0 != g.sizeOfGroupExperimenterMap()
 
     def testSetGroup(self):
-        a = self.client.getSession().getAdminService()
-        ec = a.getEventContext()
-        uid = ec.userId
-
         # Add user to new group to test setting default
-        e = a.getExperimenter(uid)
+        uid = self.user.id.val
+        e = self.sf.getAdminService().getExperimenter(uid)
         admin = self.root.sf.getAdminService()
         grp = self.new_group()
         admin.addGroups(e, [grp])
 
-        a.setDefaultGroup(e, grp)
+        admin.setDefaultGroup(e, grp)
 
-        dg = self.client.getSession().getAdminService().getDefaultGroup(uid)
+        dg = self.sf.getAdminService().getDefaultGroup(uid)
         assert dg.id.val == grp.id.val
 
     def testChangePassword(self):
@@ -147,9 +144,8 @@ class TestAdmin(lib.ITest):
         """
         Tests the "freshness" of the iAdmin.getEventContext() call.
         """
-        client = self.new_client()
         group = self.new_group()
-        admin = client.sf.getAdminService()
+        admin = self.sf.getAdminService()
         root_admin = self.root.sf.getAdminService()
 
         ec1 = admin.getEventContext()

--- a/components/tools/OmeroPy/test/integration/test_counts.py
+++ b/components/tools/OmeroPy/test/integration/test_counts.py
@@ -33,7 +33,6 @@ from omero.rtypes import rstring, rtime
 class TestCounts(lib.ITest):
 
     def testBasicUsage(self):
-        usr = self.client.sf.getAdminService().getEventContext().userId
 
         img = ImageI()
         img.name = rstring("name")
@@ -41,14 +40,11 @@ class TestCounts(lib.ITest):
         tag = TagAnnotationI()
         img.linkAnnotation(tag)
 
-        img = self.client.sf.getUpdateService().saveAndReturnObject(img)
+        img = self.update.saveAndReturnObject(img)
 
-        img = self.client.sf.getQueryService().findByQuery(
-            """
-            select img from Image img
-            join fetch img.annotationLinksCountPerOwner
-            where img.id = %s
-            """ % (img.id.val), None
-            )
+        img = self.query.findByQuery(
+            "select img from Image img "
+            "join fetch img.annotationLinksCountPerOwner "
+            "where img.id = %s" % (img.id.val), None)
         assert img
-        assert img.getAnnotationLinksCountPerOwner()[usr] > 0
+        assert img.getAnnotationLinksCountPerOwner()[self.ctx.userId] > 0

--- a/components/tools/OmeroPy/test/integration/test_itimeline.py
+++ b/components/tools/OmeroPy/test/integration/test_itimeline.py
@@ -20,13 +20,8 @@ from omero.rtypes import rint, rlong, rstring, rtime
 class TestITimeline(lib.ITest):
 
     def testGeneral(self):
-        client, user = self.new_client_and_user()
-        sf = client.sf
-
-        uuid = sf.getAdminService().getEventContext().sessionUuid
-        admin = sf.getAdminService()
-        update = sf.getUpdateService()
-        timeline = sf.getTimelineService()
+        uuid = self.ctx.sessionUuid
+        timeline = self.sf.getTimelineService()
 
         im_ids = dict()
         for i in range(0, 10):
@@ -37,7 +32,7 @@ class TestITimeline(lib.ITest):
             img.setAcquisitionDate(rtime(acquired))
 
             # default permission 'rw----':
-            img = update.saveAndReturnObject(img)
+            img = self.update.saveAndReturnObject(img)
             img.unload()
 
             im_ids[i] = [img.id.val, acquired]
@@ -49,8 +44,8 @@ class TestITimeline(lib.ITest):
         p = omero.sys.Parameters()
         p.map = {}
         f = omero.sys.Filter()
-        f.ownerId = rlong(admin.getEventContext().userId)
-        f.groupId = rlong(admin.getEventContext().groupId)
+        f.ownerId = rlong(self.ctx.userId)
+        f.groupId = rlong(self.ctx.groupId)
         p.theFilter = f
 
         M = timeline.countByPeriod
@@ -65,8 +60,8 @@ class TestITimeline(lib.ITest):
         p2 = omero.sys.Parameters()
         p2.map = {}
         f2 = omero.sys.Filter()
-        f2.ownerId = rlong(admin.getEventContext().userId)
-        f2.groupId = rlong(admin.getEventContext().groupId)
+        f2.ownerId = rlong(self.ctx.userId)
+        f2.groupId = rlong(self.ctx.groupId)
         f2.limit = rint(5)
         p2.theFilter = f2
 
@@ -97,14 +92,11 @@ class TestITimeline(lib.ITest):
         can see these events in timeline.
         """
 
-        group = self.new_group(perms="rwr---")
-        client1 = self.new_client(group=group)
-        client2 = self.new_client(group=group)
+        client2 = self.new_client(group=self.group)
 
         # log in as first user & create images
-        update1 = client1.sf.getUpdateService()
-        timeline1 = client1.sf.getTimelineService()
-        admin1 = client1.sf.getAdminService()
+        timeline1 = self.sf.getTimelineService()
+        admin1 = self.sf.getAdminService()
 
         im_ids = dict()
         for i in range(0, 10):
@@ -115,7 +107,7 @@ class TestITimeline(lib.ITest):
             img.setAcquisitionDate(rtime(acquired))
 
             # default permission 'rw----':
-            img = update1.saveAndReturnObject(img)
+            img = self.update.saveAndReturnObject(img)
             img.unload()
 
             im_ids[i] = [img.id.val, acquired]
@@ -124,8 +116,8 @@ class TestITimeline(lib.ITest):
         start = acquired - 86400
         end = acquired + 1
 
-        ownerId = rlong(admin1.getEventContext().userId)
-        groupId = rlong(admin1.getEventContext().groupId)
+        ownerId = rlong(self.ctx.userId)
+        groupId = rlong(self.ctx.groupId)
 
         def assert_timeline(timeline, start, end, ownerId=None, groupId=None):
             p = omero.sys.Parameters()
@@ -292,13 +284,12 @@ class TestITimeline(lib.ITest):
 
     def test3234(self):
 
-        user_context = self.client.sf.getAdminService().getEventContext()
-        user_object = omero.model.ExperimenterI(user_context.userId, False)
+        user_object = omero.model.ExperimenterI(self.ctx.userId, False)
 
         share = self.root.sf.getShareService()
         share.createShare(
             "description", None, None, [user_object], None, True)
 
-        timeline = self.client.sf.getTimelineService()
+        timeline = self.sf.getTimelineService()
         timeline.getMostRecentShareCommentLinks(None)
         timeline.getMostRecentShareCommentLinks(None, {"omero.group": "-1"})

--- a/components/tools/OmeroPy/test/integration/test_itimeline.py
+++ b/components/tools/OmeroPy/test/integration/test_itimeline.py
@@ -96,14 +96,13 @@ class TestITimeline(lib.ITest):
 
         # log in as first user & create images
         timeline1 = self.sf.getTimelineService()
-        admin1 = self.sf.getAdminService()
 
         im_ids = dict()
         for i in range(0, 10):
             # create image
             acquired = long(time.time() * 1000)
             img = omero.model.ImageI()
-            img.setName(rstring('test-img-%s' % (client1.sf)))
+            img.setName(rstring('test-img-%s' % (self.sf)))
             img.setAcquisitionDate(rtime(acquired))
 
             # default permission 'rw----':

--- a/components/tools/OmeroPy/test/integration/test_mail.py
+++ b/components/tools/OmeroPy/test/integration/test_mail.py
@@ -32,7 +32,7 @@ import omero
 class TestMail(lib.ITest):
 
     def skipIfNot(self):
-        self.skip_if("omero.mail.fake", lambda x: str(x).lower != "true",
+        self.skip_if("omero.mail.fake", lambda x: str(x).lower() != "true",
                      message="omero.mail.fake not configured")
 
         # If active, we make sure there is an admin

--- a/components/tools/OmeroPy/test/integration/test_mail.py
+++ b/components/tools/OmeroPy/test/integration/test_mail.py
@@ -26,17 +26,14 @@
 """
 
 import library as lib
-import pytest
 import omero
 
 
 class TestMail(lib.ITest):
 
     def skipIfNot(self):
-        cfg = self.root.sf.getConfigService()
-        cfg = cfg.getConfigValue("omero.mail.fake")
-        if "true" != str(cfg).lower():
-            pytest.skip("omero.mail.fake not configured")
+        self.skip_if("omero.mail.fake", lambda x: str(x).lower != "true",
+                     message="omero.mail.fake not configured")
 
         # If active, we make sure there is an admin
         # who will definitely have an email

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -963,11 +963,8 @@ class TestPermissionProjections(lib.ITest):
     def testExtendedRestrictions(self, obj):
 
         # Check if this test should run
-        x = self.root.sf.getConfigService().getConfigValue(
-            "omero.policy.binary_access")
-
-        if x != "repository":
-            pytest.skip("Not repository")
+        self.skip_if("omero.policy.binary_access",
+                     lambda x: x != "repository")
 
         # Now set up a shared group
         admin = self.sf.getAdminService()

--- a/components/tools/OmeroPy/test/integration/test_rawfilestore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawfilestore.py
@@ -109,12 +109,12 @@ class TestRFS(lib.ITest):
         rfs.close()
         assert "0123" == buf
 
-    def dummy_file(self, client):
+    def dummy_file(self):
         """
         Create an object of size 4
         """
-        ofile = self.file(client=client)
-        rfs = client.sf.createRawFileStore()
+        ofile = self.file(client=self.client)
+        rfs = self.sf.createRawFileStore()
         try:
             rfs.setFileId(ofile.id.val)
             rfs.write("0123", 0, 4)
@@ -130,7 +130,7 @@ class TestRFS(lib.ITest):
 
         # Synthetically null the size
         ofile.size = None
-        self.getUpdateService().saveObject(ofile)
+        self.update.saveObject(ofile)
 
         # Assert the size is null
         ofile = self.query.get("OriginalFile", ofile.id.val)

--- a/components/tools/OmeroPy/test/integration/test_rawfilestore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawfilestore.py
@@ -51,7 +51,7 @@ class TestRFS(lib.ITest):
     @pytest.mark.broken(ticket="11534")
     def testTicket1961WithKillSession(self):
         ofile = self.file()
-        grp = self.client.sf.getAdminService().getEventContext().groupName
+        grp = self.ctx.groupName
         session = self.client.sf.getSessionService().createUserSession(
             1 * 1000, 10000, grp)
         properties = self.client.getPropertyMap()
@@ -126,19 +126,18 @@ class TestRFS(lib.ITest):
 
     def testNullSize11743(self):
 
-        client = self.new_client()
-        ofile = self.dummy_file(client)
+        ofile = self.dummy_file()
 
         # Synthetically null the size
         ofile.size = None
-        client.sf.getUpdateService().saveObject(ofile)
+        self.getUpdateService().saveObject(ofile)
 
         # Assert the size is null
-        ofile = client.sf.getQueryService().get("OriginalFile", ofile.id.val)
+        ofile = self.query.get("OriginalFile", ofile.id.val)
         assert ofile.size is None
 
         # Show that the size can be loaded from the service
-        rfs = client.sf.createRawFileStore()
+        rfs = self.sf.createRawFileStore()
         try:
             rfs.setFileId(ofile.id.val)
             assert 4 == rfs.size()
@@ -149,9 +148,8 @@ class TestRFS(lib.ITest):
             rfs.close()
 
     def testGetFileId(self):
-        client = self.new_client()
-        ofile = self.dummy_file(client)
-        rfs = client.sf.createRawFileStore()
+        ofile = self.dummy_file()
+        rfs = self.sf.createRawFileStore()
         try:
             rfs.getFileId()
             rfs.setFileId(ofile.id.val)

--- a/components/tools/OmeroPy/test/integration/test_simple.py
+++ b/components/tools/OmeroPy/test/integration/test_simple.py
@@ -15,7 +15,13 @@ import library as lib
 
 class TestSimple(lib.ITest):
 
-    def testCurrentUser(self):
-        admin = self.client.sf.getAdminService()
-        ec = admin.getEventContext()
-        assert ec
+    DEFAULT_PERMS = 'rwra--'  # Override DEFAULT_PERMS of ITest
+
+    def testUserId(self):
+        assert self.ctx.userId == self.user.id.val
+
+    def testGroupId(self):
+        assert self.ctx.groupId == self.group.id.val
+
+    def testGroupPermissions(self):
+        assert str(self.group.details.permissions) == self.DEFAULT_PERMS

--- a/components/tools/OmeroWeb/test/integration/test_chgrp.py
+++ b/components/tools/OmeroWeb/test/integration/test_chgrp.py
@@ -47,11 +47,12 @@ class TestChgrp(IWebTest):
         """Returns a logged in Django test client."""
         super(TestChgrp, cls).setup_class()
         # Add user to secondary group
-        userName = cls.sf.getAdminService().getEventContext().userName
-        cls.group2 = cls.new_group(experimenters=[userName], perms=PRIVATE)
+        cls.group2 = cls.new_group(
+            experimenters=[cls.ctx.userName], perms=PRIVATE)
         # Refresh client
-        cls.sf.getAdminService().getEventContext()
-        cls.django_client = cls.new_django_client(userName, userName)
+        cls.ctx = cls.sf.getAdminService().getEventContext()
+        cls.django_client = cls.new_django_client(
+            cls.ctx.userName, cls.ctx.userName)
 
     def get_django_client(self, credentials):
         if credentials == 'user':

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -624,10 +624,11 @@ class TestCsrf(IWebTest):
         self.add_groups(experimenter=self.user, groups=[self.group],
                         owner=True)
 
-        request_url = reverse('wamanagegroupownerid', args=["save", group_id])
+        request_url = reverse('wamanagegroupownerid',
+                              args=["save", self.group.id.val])
         data = {
-            "members": user_id,
-            "owners": user_id,
+            "members": self.user.id.val,
+            "owners": self.user.id.val,
             "permissions": 0
         }
         _post_response(self.django_client, request_url, data)

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -146,9 +146,7 @@ class TestCsrf(IWebTest):
 
     def test_move_data(self):
 
-        user_id = self.sf.getAdminService().getEventContext().userId
-        user = self.sf.getAdminService().getExperimenter(user_id)
-        group_id = self.new_group(experimenters=[user]).id.val
+        group_id = self.new_group(experimenters=[self.user]).id.val
 
         request_url = reverse('chgrp')
         data = {
@@ -312,13 +310,11 @@ class TestCsrf(IWebTest):
 
     def test_basket_actions(self):
 
-        user_to_share = self.new_user()
-
         # Create discussion
         request_url = reverse("basket_action", args=["createdisc"])
         data = {
             'enable': 'on',
-            'members': user_to_share.id.val,
+            'members': self.user.id.val,
             'message': 'foobar'
         }
         _post_response(self.django_client, request_url, data)
@@ -330,7 +326,7 @@ class TestCsrf(IWebTest):
         data = {
             'enable': 'on',
             'image': img.id.val,
-            'members': user_to_share.id.val,
+            'members': self.user.id.val,
             'message': 'foobar'
         }
 
@@ -348,7 +344,7 @@ class TestCsrf(IWebTest):
         _csrf_post_response(self.django_client, request_url, data)
 
         sid = self.sf.getShareService().createShare(
-            "foobar", rtime(None), images, [user_to_share], [], True)
+            "foobar", rtime(None), images, [self.user], [], True)
 
         request_url = reverse("manage_action_containers",
                               args=["save", "share", sid])
@@ -356,7 +352,7 @@ class TestCsrf(IWebTest):
         data = {
             'enable': 'on',
             'image': [i.id.val for i in images],
-            'members': user_to_share.id.val,
+            'members': self.user.id.val,
             'message': 'another foobar'
         }
         _post_response(self.django_client, request_url, data)
@@ -492,16 +488,13 @@ class TestCsrf(IWebTest):
     # ADMIN
     def test_myaccount(self):
 
-        user_id = self.sf.getAdminService().getEventContext().userId
-        user = self.sf.getAdminService().getExperimenter(user_id)
-
         request_url = reverse('wamyaccount', args=["save"])
         data = {
-            "omename": user.omeName.val,
-            "first_name": user.omeName.val,
-            "last_name": user.lastName.val,
+            "omename": self.user.omeName.val,
+            "first_name": self.user.omeName.val,
+            "last_name": self.user.lastName.val,
             "institution": "foo bar",
-            "default_group": user.copyGroupExperimenterMap()[0].parent.id.val
+            "default_group": self.group.id.val
         }
         _post_response(self.django_client, request_url, data)
         _csrf_post_response(self.django_client, request_url, data,
@@ -509,7 +502,7 @@ class TestCsrf(IWebTest):
 
     def test_avatar(self):
 
-        user_id = self.sf.getAdminService().getEventContext().userId
+        user_id = self.user.id.val
 
         # Due to EOF both posts must be test separately
         # Bad post
@@ -628,12 +621,8 @@ class TestCsrf(IWebTest):
 
     def test_edit_group_by_owner(self):
 
-        user_id = self.sf.getAdminService().getEventContext().userId
-        user = self.sf.getAdminService().getExperimenter(user_id)
-        group_id = self.sf.getAdminService().getEventContext().groupId
-        group = self.sf.getAdminService().getGroup(group_id)
-
-        self.add_groups(experimenter=user, groups=[group], owner=True)
+        self.add_groups(experimenter=self.user, groups=[self.group],
+                        owner=True)
 
         request_url = reverse('wamanagegroupownerid', args=["save", group_id])
         data = {

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -37,16 +37,11 @@ class TestImgDetail(IWebTest):
         """
         Download of archived files for a non-SPW Image.
         """
-        client = self.client
-
-        admin = client.sf.getAdminService()
-        user = admin.getExperimenter(admin.getEventContext().userId)
-        userName = "%s %s" % (user.getFirstName().val, user.getLastName().val)
+        userName = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
 
         # Import "tinyTest.d3d.dv" and get ImageID
-        pids = self.import_image(client=client)
-        pixels = client.getSession().getQueryService().get("Pixels",
-                                                           long(pids[0]))
+        pids = self.import_image(client=self.client)
+        pixels = self.query.get("Pixels", long(pids[0]))
         iid = pixels.image.id.val
 
         json_url = reverse('webgateway.views.imageData_json', args=[iid])

--- a/components/tools/OmeroWeb/test/integration/weblibrary.py
+++ b/components/tools/OmeroWeb/test/integration/weblibrary.py
@@ -39,7 +39,7 @@ class IWebTest(lib.ITest):
         """Returns a logged in Django test client."""
         super(IWebTest, cls).setup_class()
         cls.django_clients = []
-        omeName = cls.sf.getAdminService().getEventContext().userName
+        omeName = cls.ctx.userName
         cls.django_client = cls.new_django_client(omeName, omeName)
         rootpass = cls.root.ic.getProperties().getProperty('omero.rootpass')
         cls.django_root_client = cls.new_django_client("root", rootpass)


### PR DESCRIPTION
This PR provides various improvements for the Python/Web integration tests requested in https://trello.com/c/99yzWP3v

Major changes:
- `ITest` now defines a `DEFAULT_PERMS` which can be overriden by test classes requiring a different default permission for the group
- the user, group and context initially created by `ITest.setup_class()` are stored as attributes of the class
- a generic `ITest.skip_if(config, condition)` is introduced allowing to skip tests conditionally based on a server configuration

Most integration tests should be modified to make use of these features. Some unnecessary user/client creation are removed from tests. To review this PR, check all Python/Web integration tests are passing. A corresponding documentation PR will need to be opened to describe these additions in the writing tests section.

--no-rebase