### PR TITLE
fixing deprecated warning

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -349,9 +349,7 @@ def load_template(request, menu, conn=None, url=None, **kwargs):
     # validate experimenter is in the active group
     active_group = request.session.get('active_group') or conn.getEventContext().groupId
     # prepare members of group...
-    s = conn.groupSummary(active_group)
-    leaders = s["leaders"]
-    members = s["colleagues"]
+    leaders, members = conn.getObject("ExperimenterGroup", active_group).groupSummary()
     userIds = [u.id for u in leaders]
     userIds.extend( [u.id for u in members] )
     users = []


### PR DESCRIPTION
Test locally, log in to webclient and check the console

```
[16/Mar/2015 10:16:48] "POST /webclient/login/?url=%2Fwebclient%2F HTTP/1.1" 302 0
dist/lib/python/omero/gateway/__init__.py:2757: DeprecationWarning: Deprecated. Use ExperimenterGroupWrapper.groupSummary()
  DeprecationWarning)

[16/Mar/2015 10:16:49] "GET /webclient/ HTTP/1.1" 200 115697
```

This should **disappear**

--no-rebase