### PR TITLE
Adjust graphs API usage in Insight

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -2659,8 +2659,10 @@ class OMEROGateway
                 idsThisClass.add(objectId);
             }
             /* now delete the objects */
-            Request request = Requests.delete(objectIds);
-            submit(Arrays.asList(request), ctx);
+            final Request request = Requests.delete(objectIds);
+            final client client = getConnector(ctx, true, false).getClient();
+            final HandlePrx handle = client.getSession().submit(request);
+            new RequestCallback(client, handle).loop(50, 250);
         } catch (Throwable t) {
             handleException(t, "Cannot delete the object.");
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5678,54 +5678,6 @@ class OMEROGateway
 		return new HashMap();
 	}
 
-	/**
-	 * Removes the description linked to the tags.
-	 *
-	 * @param ctx The security context.
-	 * @param tagID  The id of tag to handle.
-	 * @param userID The id of the user who annotated the tag.
-	 * @throws DSOutOfServiceException  If the connection is broken, or logged
-	 *                                  in.
-	 * @throws DSAccessException        If an error occurred while trying to
-	 *                                  retrieve data from OMEDS service.
-	 */
-	void removeTagDescription(SecurityContext ctx, long tagID, long userID)
-		throws DSOutOfServiceException, DSAccessException
-	{
-	    Connector c = getConnector(ctx, true, false);
-		try {
-		    IQueryPrx service = c.getQueryService();
-			String type = "ome.model.annotations.TextAnnotation";
-			ParametersI param = new ParametersI();
-			param.addLong("uid", userID);
-			param.addLong("id", tagID);
-
-			String sql =  "select link from AnnotationAnnotationLink as link ";
-			sql += "where link.parent.id = :id";
-			sql += " and link.child member of "+type;
-			sql += " and link.details.owner.id = :uid";
-
-			List l = service.findAllByQuery(sql, param);
-			//remove all the links if any
-			if (l != null) {
-				Iterator i = l.iterator();
-				AnnotationAnnotationLink link;
-				IObject child;
-				while (i.hasNext()) {
-					link = (AnnotationAnnotationLink) i.next();
-					child = link.getChild();
-					if (!((child instanceof TagAnnotation) ||
-						(child instanceof TermAnnotation)))  {
-						deleteObject(ctx, link);
-						deleteObject(ctx, child);
-					}
-				}
-			}
-		} catch (Exception e) {
-			handleException(e, "Cannot remove the tag description.");
-		}
-	}
-
 	/** Keeps the services alive. */
 	void keepSessionAlive()
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -2659,10 +2659,8 @@ class OMEROGateway
                 idsThisClass.add(objectId);
             }
             /* now delete the objects */
-            final Request request = Requests.delete(objectIds);
-            final client client = getConnector(ctx, true, false).getClient();
-            final HandlePrx handle = client.getSession().submit(request);
-            new RequestCallback(client, handle).loop(50, 250);
+            Request request = Requests.delete(objectIds);
+            submit(Arrays.asList(request), ctx);
         } catch (Throwable t) {
             handleException(t, "Cannot delete the object.");
         }
@@ -8453,7 +8451,7 @@ class OMEROGateway
 				entry = i.next();
 				data = entry.getKey();
 				l = entry.getValue();
-				String key = PojoMapper.convertTypeForSearchByQuery(data.getClass());
+				String key = PojoMapper.getGraphType(data.getClass());
 				List<Long> values = objects.get(key);
 				if(values==null) {
 				    values = new ArrayList<Long>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -140,7 +140,6 @@ import omero.api.SearchPrx;
 import omero.api.ServiceFactoryPrx;
 import omero.api.StatefulServiceInterfacePrx;
 import omero.api.ThumbnailStorePrx;
-import omero.cmd.Chgrp;
 import omero.cmd.Chmod;
 import omero.cmd.HandlePrx;
 import omero.cmd.Request;
@@ -8402,6 +8401,22 @@ class OMEROGateway
 	}
 
 	/**
+	 * Checks if there is alreay a {@link Save} object for the same
+	 * {@link IObject} in <code>saves</code> list. 
+	 * @param save The Save to look for
+	 * @param saves The collection of Saves to look in
+	 * @return <code>true</code> if it's already in the list, <code>
+	 *     false</code> otherwise.
+	 */
+	private boolean contains(Save save, List<Save> saves) {
+	    for(Save save2 : saves) {
+	        if(save2.obj == save.obj)
+	            return true;
+	    }
+	    return false;
+	}
+	
+	/**
 	 * Moves data between groups.
 	 *
 	 * @param ctx The security context of the source group.
@@ -8417,8 +8432,11 @@ class OMEROGateway
 			Map<DataObject, List<IObject>> map, Map<String, String> options)
 		throws DSOutOfServiceException, DSAccessException
 	{
+	    // map ~ Map<'Object to move', 'Destinations to move the object to'>
 		Connector c = getConnector(ctx, true, true);
-		if (c == null) return null; // TODO:
+		if (c == null) 
+		    return null; 
+		
 		try {
 		    IAdminPrx svc = c.getAdminService();
 			Entry<DataObject, List<IObject>> entry;
@@ -8429,82 +8447,31 @@ class OMEROGateway
 			Iterator<IObject> j;
 			List<Request> commands = new ArrayList<Request>();
 			List<Save> saves = new ArrayList<Save>();
-			Chgrp cmd;
-			long id;
 			Save save;
-			Map<Long, List<IObject>> images = new HashMap<Long, List<IObject>>();
+			Map<String, List<Long>> objects = new HashMap<String, List<Long>>();
 			while (i.hasNext()) {
 				entry = i.next();
 				data = entry.getKey();
 				l = entry.getValue();
-				if (data instanceof ImageData) {
-					images.put(data.getId(), l);
-				} else {
-					cmd = new Chgrp(createDeleteCommand(
-						data.getClass().getName()), data.getId(), options,
-						target.getGroupID());
-					commands.add(cmd);
-					j = l.iterator();
-					while (j.hasNext()) {
-						save = new Save();
-						save.obj = j.next();
-						saves.add(save);
-					}
+				String key = PojoMapper.convertTypeForSearchByQuery(data.getClass());
+				List<Long> values = objects.get(key);
+				if(values==null) {
+				    values = new ArrayList<Long>();
+				    objects.put(key, values);
 				}
+				values.add(data.getId());
+				
+				for (IObject obj : l) {
+                  save = new Save();
+                  save.obj = obj;
+                    if (!contains(save, saves))
+                        saves.add(save);
+              }
 			}
-			if (images.size() > 0) {
-				Set<DataObject> fsList = getFileSet(ctx, images.keySet());
-				List<Long> all = new ArrayList<Long>();
-				Iterator<DataObject> kk = fsList.iterator();
-				FilesetData fs;
-				long imageId;
-				List<Long> imageIds;
-				Iterator<Long> ii;
-				while (kk.hasNext()) {
-					fs = (FilesetData) kk.next();
-					imageIds = fs.getImageIds();
-					if (imageIds.size() > 0) {
-						imageId = imageIds.get(0);
-						cmd = new Chgrp(createDeleteCommand(
-								FilesetData.class.getName()), fs.getId(),
-								options, target.getGroupID());
-						commands.add(cmd);
-						all.addAll(imageIds);
-						ii = imageIds.iterator();
-						while (ii.hasNext()) {
-							l = images.get(ii.next());
-							j = l.iterator();
-							while (j.hasNext()) {
-								save = new Save();
-								save.obj = j.next();
-								saves.add(save);
-							}
-						}
-					}
-				}
-
-				//Now check that all the ids are covered.
-				Entry<Long, List<IObject>> ee;
-				Iterator<Entry<Long, List<IObject>>> e =
-						images.entrySet().iterator();
-				while (e.hasNext()) {
-					ee = e.next();
-					if (!all.contains(ee.getKey())) { //pre-fs data.
-						cmd = new Chgrp(createDeleteCommand(
-								ImageData.class.getName()), ee.getKey(),
-								options, target.getGroupID());
-						commands.add(cmd);
-						l = images.get(ee.getKey());
-						j = l.iterator();
-						while (j.hasNext()) {
-							save = new Save();
-							save.obj = j.next();
-							saves.add(save);
-						}
-					}
-				}
-			}
+			
+			commands.add(Requests.chgrp(objects, target.getGroupID()));
 			commands.addAll(saves);
+			
 			return c.submit(commands, target);
 		} catch (Throwable e) {
 			handleException(e, "Cannot transfer the data.");

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -28,9 +28,7 @@ package org.openmicroscopy.shoola.env.data;
 import java.io.File;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -40,8 +38,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 //Application-internal dependencies
-import omero.cmd.Delete;
 import omero.cmd.Request;
+import omero.cmd.graphs.ChildOption;
 import omero.model.Annotation;
 import omero.model.AnnotationAnnotationLink;
 import omero.model.Dataset;
@@ -81,11 +79,11 @@ import org.openmicroscopy.shoola.env.data.util.SearchParameters;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 
+import pojos.AnnotationData;
 import pojos.DataObject;
 import pojos.DatasetData;
 import pojos.ExperimenterData;
 import pojos.FileAnnotationData;
-import pojos.FilesetData;
 import pojos.GroupData;
 import pojos.ImageData;
 import pojos.PermissionData;
@@ -929,140 +927,95 @@ class OmeroDataServiceImpl
 		return gateway.loadPlateWells(ctx, plateID, acquisitionID);
 	}
 
-	/**
-	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#delete(SecurityContext, Collection)
-	 */
-	public RequestCallback delete(SecurityContext ctx,
-			Collection<DeletableObject> objects)
-		throws DSOutOfServiceException, DSAccessException, ProcessException
-	{
-		if (CollectionUtils.isEmpty(objects) || ctx == null) return null;
-		Iterator<DeletableObject> i = objects.iterator();
-		DeletableObject object;
-		List<DeletableObject> l = new ArrayList<DeletableObject>();
-		while (i.hasNext()) {
-			object = i.next();
-			if (object.getGroupId() == ctx.getGroupID()) {
-				l.add(object);
-			}
-		}
-		if (l.size() == 0) return null;
-		i = l.iterator();
-		List<Request> commands = new ArrayList<Request>();
-		Delete cmd;
-		Map<String, String> options;
-		DataObject data;
-		List<Class> annotations;
-		Iterator<Class> j;
-		List<DataObject> contents;
-		String ns;
-		Iterator<DataObject> k;
-		Map<Long, Map<String, String>>
-		images = new HashMap<Long, Map<String, String>>();
-		while (i.hasNext()) {
-			contents = null;
-			object = i.next();
-			data = object.getObjectToDelete();
-			annotations = object.getAnnotations();
-			options = null;
-			if (!CollectionUtils.isEmpty(annotations)) {
-				options = new HashMap<String, String>();
-				j = annotations.iterator();
-				while (j.hasNext()) {
-					options.put(gateway.createDeleteOption(j.next().getName()),
-							OMEROGateway.KEEP);
-				}
-			}
-			if (!object.deleteContent()) {
-				if (options == null)
-					options = new HashMap<String, String>();
-				if (data instanceof DatasetData) {
-					options.put(gateway.createDeleteCommand(
-							ImageData.class.getName()),
-							OMEROGateway.KEEP);
-				} else if (data instanceof ProjectData) {
-					options.put(gateway.createDeleteCommand(
-							DatasetData.class.getName()),
-							OMEROGateway.KEEP);
-					options.put(gateway.createDeleteCommand(
-							ImageData.class.getName()),
-							OMEROGateway.KEEP);
-				} else if (data instanceof ScreenData) {
-					options.put(gateway.createDeleteCommand(
-							PlateData.class.getName()),
-							OMEROGateway.KEEP);
-					options.put(gateway.createDeleteCommand(
-							WellData.class.getName()),
-							OMEROGateway.KEEP);
-					options.put(gateway.createDeleteCommand(
-							PlateAcquisitionData.class.getName()),
-							OMEROGateway.KEEP);
-					options.put(gateway.createDeleteCommand(
-							ImageData.class.getName()),
-							OMEROGateway.KEEP);
-				} else if (data instanceof TagAnnotationData) {
-					options = null;
-					ns = ((TagAnnotationData) data).getNameSpace();
-					if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(ns)) {
-						contents = deleteTagSet(ctx, data.getId());
-					}
-				}
-			}
-			if (data instanceof ImageData) {
-				images.put(data.getId(), options);
-			} else {
-				cmd = new Delete(gateway.createDeleteCommand(
-						data.getClass().getName()), data.getId(), options);
-				commands.add(cmd);
-				if (contents != null && contents.size() > 0) {
-					k = contents.iterator();
-					DataObject d;
-					while (k.hasNext()) {
-						d = k.next();
-						cmd = new Delete(gateway.createDeleteCommand(
-								d.getClass().getName()), d.getId(), options);
-						commands.add(cmd);
-					}
-				}
-			}
-		}
-		if (images.size() > 0) {
-			Set<DataObject> fsList = gateway.getFileSet(ctx, images.keySet());
-			List<Long> all = new ArrayList<Long>();
-			Iterator<DataObject> kk = fsList.iterator();
-			FilesetData fs;
-			long imageId;
-			List<Long> imageIds;
-			while (kk.hasNext()) {
-				fs = (FilesetData) kk.next();
-				imageIds = fs.getImageIds();
-				if (imageIds.size() > 0) {
-					imageId = imageIds.get(0);
-					cmd = new Delete(gateway.createDeleteCommand(
-							FilesetData.class.getName()), fs.getId(),
-							images.get(imageId));
-					commands.add(cmd);
-					all.addAll(imageIds);
-				}
-			}
+    /**
+     * Implemented as specified by {@link OmeroDataService}.
+     * 
+     * @see OmeroDataService#delete(SecurityContext, Collection)
+     */
+    public RequestCallback delete(SecurityContext ctx,
+            Collection<DeletableObject> objects)
+            throws DSOutOfServiceException, DSAccessException, ProcessException {
+        if (CollectionUtils.isEmpty(objects) || ctx == null)
+            return null;
 
-			//Now check that all the ids are covered.
-			Entry<Long, Map<String, String>> entry;
-			Iterator<Entry<Long, Map<String, String>>> e =
-				images.entrySet().iterator();
-			while (e.hasNext()) {
-				entry = e.next();
-				if (!all.contains(entry.getKey())) { //pre-fs data.
-					cmd = new Delete(gateway.createDeleteCommand(
-							ImageData.class.getName()), entry.getKey(),
-							entry.getValue());
-					commands.add(cmd);
-				}
-			}
-		}
-		return gateway.submit(commands, ctx);
-	}
+        Iterator<DeletableObject> it = objects.iterator();
+        DeletableObject object;
+        while (it.hasNext()) {
+            object = it.next();
+            if (object.getGroupId() != ctx.getGroupID()) {
+                it.remove();
+            }
+        }
+        if (objects.size() == 0)
+            return null;
+
+        Map<String, List<Long>> toDelete = new HashMap<String, List<Long>>();
+        Map<String, List<ChildOption>> options = new HashMap<String, List<ChildOption>>();
+
+        for (DeletableObject delo : objects) {
+            List<ChildOption> opts = new ArrayList<ChildOption>();
+            DataObject data = delo.getObjectToDelete();
+
+            if (!CollectionUtils.isEmpty(delo.getAnnotations())) {
+                opts.add(Requests.option(null,
+                        PojoMapper.getGraphType(AnnotationData.class)));
+            }
+
+            if (!delo.deleteContent()) {
+                if (data instanceof DatasetData) {
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(ImageData.class)));
+                } else if (data instanceof ProjectData) {
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(DatasetData.class)));
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(ImageData.class)));
+                } else if (data instanceof ScreenData) {
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(PlateData.class)));
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(WellData.class)));
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(PlateAcquisitionData.class)));
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(ImageData.class)));
+                } else if (data instanceof PlateData) {
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(PlateAcquisitionData.class)));
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(ImageData.class)));
+                } else if (data instanceof PlateAcquisitionData) {
+                    opts.add(Requests.option(null,
+                            PojoMapper.getGraphType(ImageData.class)));
+                }
+
+                else if (data instanceof TagAnnotationData) {
+                    String ns = ((TagAnnotationData) data).getNameSpace();
+                    if (TagAnnotationData.INSIGHT_TAGSET_NS.equals(ns)) {
+                        deleteTagSet(ctx, data.getId());
+                    }
+                }
+            }
+
+            String type = PojoMapper.getGraphType(data.getClass());
+            List<Long> ids = toDelete.get(type);
+            if (ids == null) {
+                ids = new ArrayList<Long>();
+                toDelete.put(type, ids);
+            }
+            ids.add(delo.getObjectToDelete().getId());
+
+            options.put(type, opts);
+        }
+
+        List<Request> cmds = new ArrayList<Request>();
+        for (String type : toDelete.keySet()) {
+            cmds.add(Requests.delete(type, toDelete.get(type),
+                    options.get(type)));
+        }
+
+        return gateway.submit(cmds, ctx);
+    }
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
@@ -450,6 +450,8 @@ public class PojoMapper
         // other
         if (dataType.equals(ImageData.class))
             return Image.class.getSimpleName();
+        if (dataType.equals(ROIData.class))
+            return Roi.class.getSimpleName();
 
         throw new IllegalArgumentException("type not supported");
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/PojoMapper.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.util.PojoMapper
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -42,6 +42,7 @@ import java.util.Map.Entry;
 
 //Application-internal dependencies
 import omero.RString;
+import omero.model.Annotation;
 import omero.model.BooleanAnnotation;
 import omero.model.BooleanAnnotationI;
 import omero.model.CommentAnnotation;
@@ -81,6 +82,7 @@ import omero.model.Well;
 import omero.model.WellI;
 import omero.model.WellSample;
 import omero.model.XmlAnnotation;
+import pojos.AnnotationData;
 import pojos.BooleanAnnotationData;
 import pojos.DataObject;
 import pojos.DatasetData;
@@ -399,6 +401,56 @@ public class PojoMapper
         else if (nodeType.equals(Plate.class)
                 || nodeType.equals(PlateData.class))
             return Plate.class.getSimpleName();
+        throw new IllegalArgumentException("type not supported");
+    }
+    
+    /**
+     * Returns the name of the data type which has to used for Graph actions,
+     * see {@link Requests}
+     * 
+     * @param dataType
+     * @return See above
+     */
+    public static String getGraphType(Class<? extends DataObject> dataType) {
+
+        // containers
+        if (dataType.equals(DatasetData.class))
+            return Dataset.class.getSimpleName();
+        if (dataType.equals(ProjectData.class))
+            return Project.class.getSimpleName();
+        if (dataType.equals(ScreenData.class))
+            return Screen.class.getSimpleName();
+        if (dataType.equals(WellData.class))
+            return Well.class.getSimpleName();
+        if (dataType.equals(PlateData.class))
+            return Plate.class.getSimpleName();
+        if (dataType.equals(PlateAcquisitionData.class))
+            return PlateAcquisition.class.getSimpleName();
+
+        // annotations
+        if (dataType.equals(AnnotationData.class))
+            return Annotation.class.getSimpleName();
+        if (dataType.equals(TagAnnotationData.class))
+            return TagAnnotation.class.getSimpleName();
+        if (dataType.equals(BooleanAnnotationData.class))
+            return BooleanAnnotation.class.getSimpleName();
+        if (dataType.equals(TermAnnotationData.class))
+            return TermAnnotation.class.getSimpleName();
+        if (dataType.equals(FileAnnotationData.class))
+            return FileAnnotation.class.getSimpleName();
+        if (dataType.equals(TextualAnnotationData.class))
+            return CommentAnnotation.class.getSimpleName();
+        if (dataType.equals(MapAnnotationData.class))
+            return MapAnnotation.class.getSimpleName();
+        if (dataType.equals(TimeAnnotationData.class))
+            return TimestampAnnotation.class.getSimpleName();
+        if (dataType.equals(XMLAnnotationData.class))
+            return XmlAnnotation.class.getSimpleName();
+
+        // other
+        if (dataType.equals(ImageData.class))
+            return Image.class.getSimpleName();
+
         throw new IllegalArgumentException("type not supported");
     }
     


### PR DESCRIPTION
Use the new graphs API in Insight, see #3515

Changed the OMEROGateway to use Chgrp2 instead of old Chgrp.

With respect to the other commands:
- Use of Delete2 was already added to OMEROGateway by @mtbc , right?
- Chown2: Couldn't find any reference to Chown in Insight. Is it actually used at all in Insight, @jburel ?

Test:
- Use the "Move to Group" function on different objects
- Try to delete various data types (Images, Project, Projects with Datasets, etc.)

--no-rebase