### PR TITLE
Preserve map ann table layout with long strings

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -842,6 +842,8 @@
     }
     .keyValueTable td, .keyValueTable th {
         width: 50%;
+        max-width: 100px;    /* still expands to 50% */
+        overflow: hidden;
         padding: 2px 5px !important;
         color: hsl(210,10%,30%) !important;
         vertical-align: middle;


### PR DESCRIPTION
From https://trac.openmicroscopy.org/ome/ticket/12783

This fixes the layout of the map annotation table with long Key Value strings.

To test, enter long text strings into the Key and Value fields.
Text that is too big for the table will simply be hidden, and the Key / Value table cells will remain at 50% width of the table.

![screen shot 2015-03-16 at 15 50 29](https://cloud.githubusercontent.com/assets/900055/6670006/3d3409de-cbf4-11e4-9c83-438239c0df8b.png)

--no-rebase