### PR TITLE
Log null statsInfo at 'debug' instead of 'error'

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6626,7 +6626,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         """
         si = self._obj.getStatsInfo()
         if si is None:
-            logger.error("getStatsInfo() is null. See #9695")
+            logger.debug("getStatsInfo() is null. See #9695")
             try:
                 minVals = {'int8': -128, 'uint8': 0, 'int16': -32768,
                            'uint16': 0, 'int32': -32768, 'uint32': 0,
@@ -6647,7 +6647,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         """
         si = self._obj.getStatsInfo()
         if si is None:
-            logger.error("getStatsInfo() is null. See #9695")
+            logger.debug("getStatsInfo() is null. See #9695")
             try:
                 maxVals = {'int8': 127, 'uint8': 255, 'int16': 32767,
                            'uint16': 65535, 'int32': 32767, 'uint32': 65535,

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6626,7 +6626,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         """
         si = self._obj.getStatsInfo()
         if si is None:
-            logger.debug("getStatsInfo() is null. See #9695")
+            logger.info("getStatsInfo() is null. See #9695")
             try:
                 minVals = {'int8': -128, 'uint8': 0, 'int16': -32768,
                            'uint16': 0, 'int32': -32768, 'uint32': 0,
@@ -6647,7 +6647,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         """
         si = self._obj.getStatsInfo()
         if si is None:
-            logger.debug("getStatsInfo() is null. See #9695")
+            logger.info("getStatsInfo() is null. See #9695")
             try:
                 maxVals = {'int8': 127, 'uint8': 255, 'int16': 32767,
                            'uint16': 65535, 'int32': 32767, 'uint32': 65535,


### PR DESCRIPTION
Since it's no longer an error to have no stats info (see https://github.com/openmicroscopy/openmicroscopy/pull/3580) we should log this merely at 'debug' level instead of 'error'.

To test:
 - Import image with no stats
 - Open in web - observe Web log for lack of errors.

--no-rebase.