### PR TITLE
Fix CLI sessions file

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/script.py
+++ b/components/tools/OmeroPy/src/omero/plugins/script.py
@@ -717,7 +717,7 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
         else:
             client = self.ctx.conn(args)
             store = SessionsStore()
-            srv, usr, uuid = store.get_current()
+            srv, usr, uuid, port = store.get_current()
             props = store.get(srv, usr, uuid)
 
             from omero.scripts import parse_file

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -593,7 +593,7 @@ class SessionsControl(BaseControl):
 
     def file(self, args):
         store = self.store(args)
-        srv, usr, uuid = store.get_current()
+        srv, usr, uuid, port = store.get_current()
         if srv and usr and uuid:
             self.ctx.out(str(store.dir / srv / usr / uuid))
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -191,3 +191,10 @@ class TestSessions(CLITest):
         self.cli.invoke(self.args, strict=True)
         ec = self.cli.get_event_context()
         assert ec.groupName == group2.name.val
+
+    # File subcommand
+    # ========================================================================
+    def testFile(self):
+
+        self.args = ["sessions", "file"]
+        self.cli.invoke(self.args, strict=True)


### PR DESCRIPTION
Reported by @manics. The addition of last port in https://github.com/openmicroscopy/openmicroscopy/pull/3370 broke `bin/omero sessions file`.

This PR should fix this bug and add an integration test to extend our coverage.

--no-rebase