### PR TITLE
session cookie domain

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -396,6 +396,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
          86400,
          int,
          "The age of session cookies, in seconds."],
+    "omero.web.session_cookie_domain":
+        ["SESSION_COOKIE_DOMAIN",
+         None,
+         leave_none_unset,
+         "The domain to use for session cookies"],
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -401,6 +401,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
          None,
          leave_none_unset,
          "The domain to use for session cookies"],
+    "omero.web.session_cookie_name":
+        ["SESSION_COOKIE_NAME",
+         None,
+         leave_none_unset,
+         "The name to use for session cookies"],
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
 


### PR DESCRIPTION
1. This should help with side effect reported in https://trello.com/c/aRDoP7dC/355-omero-web-startup-review-default-ip. To test:
 - add
 ```
bin/omero config set omero.web.session_cookie_domain "localhost"
 ```
 - open private windows in your webbrowser
 - go to localhost:4080, and log in. All shoudl be as normal
 - if you have another domain configured on you machine use it, otherwise go to 127.0.0.1:4080 and log in. you should be back to your login page without any error message. that means you cookie wasn't save.

 if you remove ```omero.web.session_cookie_domain``` you should be able to log in from all possible domains assigned to the same machine

1.  This should also resolve issue reported in https://github.com/openmicroscopy/openmicroscopy/pull/3629#issuecomment-82874726. To test:
 - remove all cookies created for your local domain in your webbrowser
 - add
 ```
bin/omero config set omero.web.session_cookie_name "myowncookiename"
 ```
 - check if you log in to web cookie name has changed

cc @sbesson 

--no-rebase