### PR TITLE
update some delete examples

### DIFF
--- a/examples/Delete/FileAnnotationDelete.java
+++ b/examples/Delete/FileAnnotationDelete.java
@@ -1,25 +1,21 @@
-import omero.LockTimeout;
 import omero.ServerError;
-import omero.cmd.Delete;
-import omero.cmd.DoAll;
-import omero.cmd.Request;
-import omero.cmd.OK;
 import omero.cmd.CmdCallbackI;
+import omero.cmd.Delete2;
+import omero.cmd.OK;
 import omero.cmd.Response;
 import omero.api.ServiceFactoryPrx;
-import omero.grid.DeleteCallbackI;
 import omero.model.*;
 import static omero.rtypes.*;
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
- * Uses the default {@link DeleteCallbackI} instance
+ * Uses a {@link Delete2} request instance
  * to delete a FileAnnotation along with its associated
  * OriginalFile and any annotation links.
  */
@@ -44,15 +40,14 @@ public class FileAnnotationDelete {
             fa = (FileAnnotation) d.linkedAnnotationList().get(0);
 
 
-            Delete dc = new Delete("/Annotation", fa.getId().getValue(), null);
-            List<Request> commands = new ArrayList<Request>();
-            commands.add(dc);
-            DoAll all = new DoAll();
-            all.requests = commands;
+            Delete2 deleteCmd = new Delete2();
+            List<Long> ids = Collections.singletonList(fa.getId().getValue());
+            deleteCmd.targetObjects = new HashMap<String, List<Long>>();
+            deleteCmd.targetObjects.put("Annotation", ids);
             Map<String, String> callContext = new HashMap<String, String>();
             CmdCallbackI cb = null;
             try {
-                cb = new CmdCallbackI(c, s.submit(all, callContext));
+                cb = new CmdCallbackI(c, s.submit(deleteCmd, callContext));
                 cb.loop(10, 500);
                 Response rsp = cb.getResponse();
                 if (rsp instanceof OK) {

--- a/examples/Delete/FileAnnotationDelete.py
+++ b/examples/Delete/FileAnnotationDelete.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Uses the default {@link DeleteCallbackI} instance.
+Uses a omero.cmd.Delete2 request instance
 to delete a FileAnnotation along with its associated
 OriginalFile and any annotation links.
 """
@@ -31,14 +31,10 @@ try:
     link = s.getUpdateService().saveAndReturnObject(link)
     fa = link.child
 
-    graph_spec = "/Annotation"
-    options = {}
-    delCmd = omero.cmd.Delete(graph_spec, long(fa.id.val), options)
+    to_delete = {"Annotation": [fa.id.val]}
+    delCmd = omero.cmd.Delete2(targetObjects=to_delete)
 
-    dcs = [delCmd]
-    doall = omero.cmd.DoAll()
-    doall.requests = dcs
-    handle = s.submit(doall)
+    handle = s.submit(delCmd)
 
     callback = None
     try:

--- a/examples/Training/java/src/training/DeleteData.java
+++ b/examples/Training/java/src/training/DeleteData.java
@@ -2,7 +2,7 @@
  * training.DeleteData 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -26,11 +26,13 @@ package training;
 
 
 //Java imports
-import java.util.Arrays;
-//Third-party libraries
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-//Application-internal dependencies
-import omero.cmd.Delete;
+//OMERO dependencies
+import omero.cmd.Delete2;
 import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.model.Image;
@@ -74,9 +76,12 @@ public class DeleteData
 		img.setDescription(omero.rtypes.rstring("descriptionImage1"));
 		img = (Image) connector.getUpdateService().saveAndReturnObject(img);
 		
-		Delete[] cmds = new Delete[1];
-		cmds[0] = new Delete("/Image", img.getId().getValue(), null);
-		Response rsp = connector.submit(Arrays.<Request>asList(cmds));
+		Delete2 deleteCmd = new Delete2();
+		List<Long> ids = Collections.singletonList(img.getId().getValue());
+		deleteCmd.targetObjects = new HashMap<String, List<Long>>();
+		deleteCmd.targetObjects.put("Image", ids);
+		List<Request> requests = Collections.<Request>singletonList(deleteCmd);
+		Response rsp = connector.submit(requests);
 		System.err.println(rsp);
 	}
 	/**


### PR DESCRIPTION
Updates some examples to use `Delete2`, now that `Delete` is deprecated. Examples should still compile and run.

(I am happy to accept corresponding `examples/Training/matlab/DeleteData.m` fixes against this branch.)

--no-rebase