### PR TITLE
Download_as closes RE

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2009,6 +2009,8 @@ def download_as(request, iid=None, conn=None, **kwargs):
                     imgPathName = makeImageName(
                         img.getName(), format, temp_zip_dir)
                     pilImg.save(imgPathName)
+                    # Close RenderingEngine
+                    img._re.close()
                 # create zip
                 zip_file = zipfile.ZipFile(temp, 'w', zipfile.ZIP_DEFLATED)
                 try:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1936,7 +1936,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
     return HttpResponse(rsp)
 
 
-@login_required(doConnectionCleanup=False)
+@login_required()
 def download_as(request, iid=None, conn=None, **kwargs):
     """
     Downloads the image as a single jpeg/png/tiff or as a zip (if more than

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2005,12 +2005,14 @@ def download_as(request, iid=None, conn=None, **kwargs):
             try:
                 for img in images:
                     z = t = None
-                    pilImg = img.renderImage(z, t)
-                    imgPathName = makeImageName(
-                        img.getName(), format, temp_zip_dir)
-                    pilImg.save(imgPathName)
-                    # Close RenderingEngine
-                    img._re.close()
+                    try:
+                        pilImg = img.renderImage(z, t)
+                        imgPathName = makeImageName(
+                            img.getName(), format, temp_zip_dir)
+                        pilImg.save(imgPathName)
+                    finally:
+                        # Close RenderingEngine
+                        img._re.close()
                 # create zip
                 zip_file = zipfile.ZipFile(temp, 'w', zipfile.ZIP_DEFLATED)
                 try:


### PR DESCRIPTION
This fixes http://trac.openmicroscopy.org/ome/ticket/12794 which is due to a couple of bugs in webgateway/download_as for batch exporting images as PNG, JPG etc. See https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7766

We were using ``` @login_required(doConnectionCleanup=False) ``` incorrectly here, since we are not streaming data from OMERO directly (don't need to keep services open once the request returns and streaming starts). This meant that open Rendering Engines were not getting closed.

We were also failing to call image._re.close() for each image after rendering and saving into the zip folder. For each image, a new ProxyObjectWrapper for each rendering engine was getting created but the underlying rendering engines were not getting closed each time.

Both these issues are fixed now.
Need to test that all "Export As" functionality is still working.

Potential backport https://trello.com/c/tgJwB05l/188-5-0-9-potential-backports

--no-rebase