### PR TITLE
Import ome tiff

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -23,7 +23,6 @@
 package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
 //Java imports
-import ij.IJ;
 import ij.WindowManager;
 import info.clearthought.layout.TableLayout;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -187,7 +187,7 @@ public class FileObject
             buffer.append(" splitz=false");
             buffer.append(" splitc=false");
             buffer.append(" splitt=false");
-            buffer.append(" saveroi=true");
+            buffer.append(" saveroi=false");
             buffer.append(" compression="+CompressionType.UNCOMPRESSED.getCompression());
             buffer.append(" imageid="+img.getID()+" ");
             IJ.runPlugIn("loci.plugins.LociExporter", buffer.toString());


### PR DESCRIPTION
Do not save the roi in the ome-tiff.
To test:
 * Open a local image in ImageJ
 * Crop the image
 * Draw rois on the cropped image. Add them as overlays or add them to the roi manager
 * Save the cropped image to omero
 * The cropped image will be imported as ome-tiff
 * Check that the ROIs are imported but they are not included into the ome-tiff
 * To check that the rois are not included in the ome-tiff. Download the original file
 * Open the ome-tiff and check the XML part of it does not content any roi.