### PR TITLE
Add m5 version history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,21 @@
 OMERO version history
 =====================
 
+5.1.0-m5 (March 2015)
+---------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.1.0. Use at your own risk**.
+
+Changes include:
+
+-  implementation of OMERO.mail for emailing users via the server
+-  performance improvements for importing large datasets
+-  support for limiting the download of original files
+-  various fixes for searching and filtering map annotations and converting
+   between units
+-  deprecation of IUpdate.deleteObject API method
+
 5.1.0-m4 (February 2015)
 ------------------------
 

--- a/history.txt
+++ b/history.txt
@@ -15,6 +15,8 @@ Changes include:
 -  various fixes for searching and filtering map annotations and converting
    between units
 -  deprecation of IUpdate.deleteObject API method
+-  versioning of all JavaScript files to fix browser refresh problems
+-  clarifying usage of OMERO.web views and templates including RequestContext
 
 5.1.0-m4 (February 2015)
 ------------------------


### PR DESCRIPTION
OMERO 5.1.0-m5 version history to be auto-generated in the docs

--no-rebase

cc @sbesson @jburel @joshmoore 