### PR TITLE
RawFileStore sessions

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
@@ -182,6 +182,7 @@ _RawFileStoreOperations, ServiceFactoryAware, TieAware {
         final RawFileStorePrx rfsPrx = repoPrx.fileById(fileId, adjustedCtx);
         OpsDelegate ops = new OpsDelegate(be, rfsTie, this, rfsPrx);
         ops.setApplicationContext(ctx);
+        ops.setHolder(holder);
         tie.ice_delegate(ops);
         return true;
     }

--- a/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawFileStoreI.java
@@ -61,6 +61,11 @@ _RawFileStoreOperations, ServiceFactoryAware, TieAware {
 
     public void setServiceFactory(ServiceFactoryI sf) throws ServerError {
         this.sf = sf;
+        setHolder(sf.holder);
+    }
+
+    public ServiceFactoryI getServiceFactory() throws ServerError {
+        return this.sf;
     }
 
     public void setTie(TieBase tie) throws ServerError {

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -139,6 +139,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
                 ScriptProcessI process = new ScriptProcessI(factory, __current, ipPrx, ip, proc);
                 process.setApplicationContext(factory.context);
+                process.setHolder(factory.holder);
                 return process.getProxy();
             }
 
@@ -162,6 +163,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
                 ProcessorCallbackI callback = new ProcessorCallbackI(factory);
                 callback.setApplicationContext(factory.context);
+                callback.setHolder(factory.holder);
                 ProcessorPrx server = callback.activateAndWait(__current);
 
                 return server != null;

--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -602,7 +602,6 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
                     checked.getId(), checked, mode, __current);
             rfs = new RepoRawFileStoreI(be, service, adjustedCurr);
             rfs.setApplicationContext(this.context);
-            rfs.setHolder(rfs.getServiceFactory().holder);
         } catch (Throwable t) {
             if (t instanceof ServerError) {
                 throw (ServerError) t;

--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -602,6 +602,7 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
                     checked.getId(), checked, mode, __current);
             rfs = new RepoRawFileStoreI(be, service, adjustedCurr);
             rfs.setApplicationContext(this.context);
+            rfs.setHolder(rfs.getServiceFactory().holder);
         } catch (Throwable t) {
             if (t instanceof ServerError) {
                 throw (ServerError) t;


### PR DESCRIPTION
Fix for [Ticket 12687](https://trac.openmicroscopy.org/ome/ticket/12687)

The session created for downloading an original file is correctly closed but the ServantHolder still holds a reference to it, this is why - I guess on some automatic cleanup task - several hours later the server again tries to close the session, which raises the error in the log file.

It's a bit tricky to test. Without the PR you see a pattern like this in the Blitz log.
After downloading an original file:
```
2014-10-28 11:50:40,344 INFO  [                      omero.cmd.SessionI] (erver-2898) Added servant to adapter: df58a5b5-368c-41d1-a8f3-fd810faf5871/c0bb169e-a772-41d8-bb68-f141d72afcc9omero.api.RawFileStore(omero.api._RawFileStoreTie@fabde1db)
...
2014-10-28 11:50:43,654 WARN  [                      omero.cmd.SessionI] (erver-2898) Holder is null for df58a5b5-368c-41d1-a8f3-fd810faf5871/c0bb169e-a772-41d8-bb68-f141d72afcc9omero.api.RawFileStore(omero.api._RawFileStoreTie@2d25feb1)
2014-10-28 11:50:43,654 INFO  [                      omero.cmd.SessionI] (erver-2898) Unregistered servant:df58a5b5-368c-41d1-a8f3-fd810faf5871/c0bb169e-a772-41d8-bb68-f141d72afcc9omero.api.RawFileStore(omero.api._RawFileStoreTie@2d25feb1)
```
Several hours later you'll get:
```
2014-10-28 16:55:27,337 ERROR [                      omero.cmd.SessionI] (erver-2992) Error destroying servant: c0bb169e-a772-41d8-bb68-f141d72afcc9omero.api.RawFileStore=ome.services.blitz.impl.RawFileStoreI$OpsDelegate@2d25feb1
```

With the PR you should neither see the WARN nor the ERROR mentioned above in the Blitz.log. So probably just do an original file download in the morning and check again the Blitz.log file in the late afternoon for the WARN/ERROR.

--no-rebase