### PR TITLE
Fixed NPE in importer only startup

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -620,7 +620,7 @@ public class DataServicesFactory
                 Registry agentReg;
                 for (Object agent : agents) {
                     agentReg = ((AgentInfo) agent).getRegistry();
-                    if (agentReg.lookup(key) == null)
+                    if (agentReg != null && agentReg.lookup(key) == null)
                         agentReg.bind(key, props.get(key));
                 }
             }


### PR DESCRIPTION
This fixes a NPE which is thrown on startup of OMERO.Importer client

Test: Just start OMERO.Importer client
