### PR TITLE
Import as thumbnail

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -874,7 +874,8 @@ class ImporterComponent
             if (l.size() > FileImportComponent.MAX_THUMBNAILS) {
                 l = l.subList(0, FileImportComponent.MAX_THUMBNAILS);
             }
-            model.fireImportResultLoading(l, klass, component);
+            model.fireImportResultLoading(l, klass, component,
+                    component.getImportableFile().getUser());
         }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -494,10 +494,18 @@ class ImporterModel
 	 * @param pixels The objects to load.
 	 * @param type The type of data to handle.
 	 * @param component The component the result is for.
+	 * @param user The experimenter to import data for.
 	 */
 	void fireImportResultLoading(Collection<DataObject> pixels, Class<?> type,
-			Object component)
+			Object component, ExperimenterData user)
 	{
+	    if (user != null) {
+	        long currentUser = ImporterAgent.getUserDetails().getId();
+	        if (currentUser != user.getId()) {
+	            ctx.setExperimenter(user);
+	            ctx.sudo();
+	        }
+        }
 		ImportResultLoader loader = new ImportResultLoader(this.component, ctx,
 				pixels, type, component);
 		loader.load();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1852,7 +1852,17 @@ class OmeroImageServiceImpl
 			throws DSAccessException, DSOutOfServiceException
 	{
 		if (ctx == null) return null;
+		//check import as
 		Connector c = gateway.getConnector(ctx, true, false);
+		ExperimenterData exp = ctx.getExperimenterData();
+        if (exp != null && ctx.isSudo()) {
+            try {
+                c = c.getConnector(exp.getUserName());
+            } catch (Throwable e) {
+                throw new DSOutOfServiceException(
+                        "Cannot create ThumbnailStore", e);
+            }
+        }
 		// Pass close responsibility off to the caller.
 		return c.getThumbnailService();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
@@ -229,6 +229,7 @@ public class ImportableFile
 		newObject.file = this.file;
 		newObject.refNode = this.refNode;
 		newObject.group = this.group;
+		newObject.user = this.user;
 		newObject.status = new StatusLabel(this.file);
 		return newObject;
 	}


### PR DESCRIPTION
Problem noticed when retesting ticket https://trac.openmicroscopy.org.uk/ome/ticket/12676
A black thumbnail could be displayed when importing for other
to test:
 * log as admin or group owner
 * Select a folder
 * Import as a user from the group.
 * Check that thumbnails are not black.