### PR TITLE
Handle failure if target container is in different group.

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -1903,6 +1903,10 @@ public class OMEROMetadataStoreClient
                             klass.getName(), id));
             }
             long grpID = obj.getDetails().getGroup().getId().getValue();
+            if (grpID != eventContext.groupId) {
+                throw new RuntimeException(String.format("Target container in group: %s, not current group: %s",
+                            grpID, eventContext.groupId));
+            }
             setCurrentGroup(grpID);
             return obj;
         }

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -26,6 +26,7 @@ import pytest
 import stat
 import re
 import omero
+from omero.cli import NonZeroReturnCode
 from omero.rtypes import rstring
 
 
@@ -560,8 +561,13 @@ class TestImport(CLITest):
 
         assert obj
 
-    @pytest.mark.broken(ticket="11539")
     def testTargetInDifferentGroup(self, tmpdir, capfd):
+        """
+        The workflow this test exercises is currently broken. Until
+        it is investigated and fixed the error is trapped early and
+        an exception is raised. The test is modified to test for this
+        fail case. See ticket 12781 (and 11539).
+        """
         new_group = self.new_group(experimenters=[self.user])
         self.sf.getAdminService().getEventContext()  # Refresh
         dataset = omero.model.DatasetI()
@@ -576,8 +582,10 @@ class TestImport(CLITest):
         self.args += ['-d', '%s' % dataset.id.val]
 
         # Invoke CLI import command and retrieve stdout/stderr
-        self.cli.invoke(self.args, strict=True)
-        o, e = capfd.readouterr()
-        obj = self.get_object(e, 'Image')
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
 
-        assert obj.details.id.val == new_group.id.val
+        # o, e = capfd.readouterr()
+        # obj = self.get_object(e, 'Image')
+
+        # assert obj.details.id.val == new_group.id.val


### PR DESCRIPTION
This PR mitigates the effect of bug described in https://trac.openmicroscopy.org.uk/ome/ticket/12781 It catches the error early and thus avoids the creation of a Fileset and the upload of files for what is a doomed import.

Test via a user who is a member of more than one group. From the CLI try importing into a Dataset in a group other than the one the user is logged in to. It should fail with a meaningful error message. Try a Dataset in the current group, that should work okay. Switching group using `omero sessions` should allow the failed import to succeed. Importing without a target Dataset should succeed. The same applies to Screens. Import via Insight is unaffected.

For example:
```
$ omero import -d 2 ~/Work/Images/dv/CFPNEAT01_R3D.dv
...
Created session 492c2565-dcdb-4d51-95cd-1c6601679506 (user-0@localhost:4064). Idle timeout: 10.0 min. Current group: pg-0
...
2015-03-24 17:43:38,600 6143       [      main] ERROR  formats.importer.cli.CommandLineImporter - Error during import process.
java.lang.RuntimeException: Target container in group: 4, not current group: 3
...

$ omero import -d 1 ~/Work/Images/dv/CFPNEAT01_R3D.dv
Using session 492c2565-dcdb-4d51-95cd-1c6601679506 (user-0@localhost:4064). Idle timeout: 10.0 min. Current group: pg-0
...
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:08.362

$ omero sessions group 4
Using session 492c2565-dcdb-4d51-95cd-1c6601679506 (user-0@localhost:4064). Idle timeout: 10.0 min. Current group: pg-0
Group 'pg-0' (id=3) switched to 'rog-0' (id=4)
$ omero import -d 2 ~/Work/Images/dv/CFPNEAT01_R3D.dv
Using session 492c2565-dcdb-4d51-95cd-1c6601679506 (user-0@localhost:4064). Idle timeout: 10.0 min. Current group: rog-0
...
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:04.680
```

--no-rebase