### PR TITLE
Reset defaults owners

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -68,6 +68,7 @@
         viewport.viewportmsg.html("Resetting...").show();
         $.getJSON(viewport.viewport_server + '/imgData/' + viewport.loadedImg.id + '/?getDefaults=true',
             function(data){
+                viewport.viewportmsg.hide();
                 viewport.loadedImg._load(data);
 
                 // seems we need to do a lot of work to update UI

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1716,8 +1716,9 @@ def reset_rdef_json(request, toOwners=False, conn=None, **kwargs):
     # get the first object and set the group to match
     conn.SERVICE_OPTS.setOmeroGroup('-1')
     o = conn.getObject(to_type, toids[0])
-    gid = o.getDetails().group.id.val
-    conn.SERVICE_OPTS.setOmeroGroup(gid)
+    if o is not None:
+        gid = o.getDetails().group.id.val
+        conn.SERVICE_OPTS.setOmeroGroup(gid)
 
     if toOwners:
         rv = rss.resetDefaultsByOwnerInSet(to_type, toids, conn.SERVICE_OPTS)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1712,12 +1712,19 @@ def reset_rdef_json(request, toOwners=False, conn=None, **kwargs):
     toids = map(lambda x: long(x), toids)
 
     rss = conn.getRenderingSettingsService()
-    if toOwners:
-        rss.resetDefaultsByOwnerInSet(to_type, toids)
-    else:
-        rss.resetDefaultsInSet(to_type, toids)
 
-    return {'OK': True}
+    # get the first object and set the group to match
+    conn.SERVICE_OPTS.setOmeroGroup('-1')
+    o = conn.getObject(to_type, toids[0])
+    gid = o.getDetails().group.id.val
+    conn.SERVICE_OPTS.setOmeroGroup(gid)
+
+    if toOwners:
+        rv = rss.resetDefaultsByOwnerInSet(to_type, toids, conn.SERVICE_OPTS)
+    else:
+        rv = rss.resetDefaultsInSet(to_type, toids, conn.SERVICE_OPTS)
+
+    return rv
 
 
 @login_required()

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -442,9 +442,9 @@ class TestCsrf(IWebTest):
             'to_type': 'image'
         }
 
-        _post_response(self.django_root_client, request_url, data,
+        _post_response(self.django_client, request_url, data,
                        status_code=403)
-        _csrf_post_response(self.django_root_client, request_url, data)
+        _csrf_post_response(self.django_client, request_url, data)
 
     def test_ome_tiff_script(self):
 

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -416,11 +416,11 @@ class TestCsrf(IWebTest):
         code.
         """
 
-        img = self.createTestImage()
+        img = self.createTestImage(session=self.sf)
 
         # Reset through webclient as it is calling directly
         # webgateway.reset_image_rdef_json
-        request_url = reverse('reset_owners_rdef_json')
+        request_url = reverse('reset_rdef_json')
         data = {
             'toids': img.id.val,
             'to_type': 'image'

--- a/components/tools/OmeroWeb/test/integration/weblibrary.py
+++ b/components/tools/OmeroWeb/test/integration/weblibrary.py
@@ -77,6 +77,8 @@ class IWebTest(lib.ITest):
 # Helpers
 def _post_response(django_client, request_url, data, status_code=403):
     response = django_client.post(request_url, data=data)
+    if response.status_code != status_code:
+        print response
     assert response.status_code == status_code
     return response
 
@@ -90,6 +92,8 @@ def _csrf_post_response(django_client, request_url, data, status_code=200):
 def _get_response(django_client, request_url, query_string, status_code=405):
     query_string = urlencode(query_string.items())
     response = django_client.get('%s?%s' % (request_url, query_string))
+    if response.status_code != status_code:
+        print response
     assert response.status_code == status_code
     return response
 

--- a/components/tools/OmeroWeb/test/integration/weblibrary.py
+++ b/components/tools/OmeroWeb/test/integration/weblibrary.py
@@ -77,9 +77,7 @@ class IWebTest(lib.ITest):
 # Helpers
 def _post_response(django_client, request_url, data, status_code=403):
     response = django_client.post(request_url, data=data)
-    if response.status_code != status_code:
-        print response
-    assert response.status_code == status_code
+    assert response.status_code == status_code, response
     return response
 
 
@@ -92,9 +90,7 @@ def _csrf_post_response(django_client, request_url, data, status_code=200):
 def _get_response(django_client, request_url, query_string, status_code=405):
     query_string = urlencode(query_string.items())
     response = django_client.get('%s?%s' % (request_url, query_string))
-    if response.status_code != status_code:
-        print response
-    assert response.status_code == status_code
+    assert response.status_code == status_code, response
     return response
 
 


### PR DESCRIPTION
Fix bug found today. To test:

 - View another user's data in a group that is **NOT** your default group
 - Using tree right-click menu, check that you can reset to "Imported" and "Owner's" settings on user's Dataset, Image, Plate & Run.