### PR TITLE
Stylesheets test

### DIFF
--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -46,6 +46,7 @@ import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.formats.tiff.TiffParser;
 import loci.formats.tiff.TiffSaver;
+import ome.services.blitz.util.CurrentPlatform;
 import ome.specification.OmeValidator;
 import ome.specification.SchemaResolver;
 import ome.specification.XMLMockObjects;
@@ -343,8 +344,7 @@ public class ExporterTest extends AbstractServerTest {
         super.setUp();
         upgrades = new HashMap<String, List<String>>();
         downgrades = currentSchema();
-        String osName = System.getProperty("os.name").toLowerCase();
-        windowsOS = osName.startsWith("windows");
+        windowsOS = CurrentPlatform.isWindows();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -99,10 +99,10 @@ public class ExporterTest extends AbstractServerTest {
     private static final int INC = 262144;
 
     /** The catalog file to find. */
-    private static final String CATALOG = "/transforms/ome-transforms.xml";
+    private static final String CATALOG = "ome-transforms.xml";
 
     /** The conversion file to find.*/
-    private static final String UNITS_CONVERSION = "/transforms/units-conversion.xsl";
+    private static final String UNITS_CONVERSION = "units-conversion.xsl";
 
     /** The <i>name</i> attribute. */
     private static final String CURRENT = "current";
@@ -659,7 +659,7 @@ public class ExporterTest extends AbstractServerTest {
      */
     private Map<String, List<String>> currentSchema() throws Exception
     {
-        InputStream stream = this.getClass().getResourceAsStream(CATALOG);
+        InputStream stream = getStream(CATALOG);
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         try {
             DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -1242,7 +1242,7 @@ public class ExporterTest extends AbstractServerTest {
         @Override
         public Source resolve(String href, String base)
                 throws TransformerException {
-            stream = this.getClass().getResourceAsStream(UNITS_CONVERSION);
+            stream = getStream(UNITS_CONVERSION);
             return new StreamSource(stream);
         }
     }

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -1099,7 +1099,7 @@ public class ExporterTest extends AbstractServerTest {
 
     // Path not in ome-transforms but stylesheets are available
     /**
-     * Test the upgrade of an image from 2003-FC to 2008-09
+     * Test the upgrade of an image from 2003-FC to 2008-09.
      * @throws Exception Thrown if an error occurred.
      */
     public void testUpgradeImage2003FCto200809() throws Exception
@@ -1112,7 +1112,7 @@ public class ExporterTest extends AbstractServerTest {
             List<InputStream> transforms = retrieveDowngrade("2003-FC");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
-            //now upgrade the file. to 2008-09
+            //now upgrade the file to 2008-09
             List<InputStream> upgrades = new ArrayList<InputStream>();
             upgrades.add(getStream("2003-FC-to-2008-09.xsl"));
             upgraded = applyTransforms(transformed, upgrades);
@@ -1129,10 +1129,8 @@ public class ExporterTest extends AbstractServerTest {
         }
     }
 
-
-
     /**
-     * Test the upgrade of an image from 2007-06 to 2008-02
+     * Test the upgrade of an image from 2007-06 to 2008-02.
      * @throws Exception Thrown if an error occurred.
      */
     public void testUpgradeImage200706to200802() throws Exception
@@ -1145,7 +1143,7 @@ public class ExporterTest extends AbstractServerTest {
             List<InputStream> transforms = retrieveDowngrade("2007-06");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
-            //now upgrade the file. to 2008-09
+            //now upgrade the file to 2008-02
             List<InputStream> upgrades = new ArrayList<InputStream>();
             upgrades.add(getStream("2007-06-to-2008-02.xsl"));
             upgraded = applyTransforms(transformed, upgrades);
@@ -1163,7 +1161,7 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
-     * Test the upgrade of an image from 2007-06 to 2008-09
+     * Test the upgrade of an image from 2007-06 to 2008-09.
      * @throws Exception Thrown if an error occurred.
      */
     public void testUpgradeImage200706to200809() throws Exception
@@ -1176,7 +1174,7 @@ public class ExporterTest extends AbstractServerTest {
             List<InputStream> transforms = retrieveDowngrade("2007-06");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
-            //now upgrade the file. to 2008-09
+            //now upgrade the file to 2008-09
             List<InputStream> upgrades = new ArrayList<InputStream>();
             upgrades.add(getStream("2007-06-to-2008-09.xsl"));
             upgraded = applyTransforms(transformed, upgrades);

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -182,11 +182,12 @@ public class ExporterTest extends AbstractServerTest {
         File output;
         InputStream in = null;
         OutputStream out = null;
-        try {
-            while (i.hasNext()) {
-                stream = i.next();
+        Resolver resolver = null;
+        while (i.hasNext()) {
+            stream = i.next();
+            try {
                 factory = TransformerFactory.newInstance();
-                Resolver resolver = new Resolver();
+                resolver = new Resolver();
                 factory.setURIResolver(resolver);
                 output = File.createTempFile(
                         RandomStringUtils.random(100, false, true),
@@ -201,13 +202,14 @@ public class ExporterTest extends AbstractServerTest {
                 transformer.transform(new StreamSource(in),
                         new StreamResult(out));
                 inputXML = output;
-                stream.close();
-                out.close();
-                in.close();
-                resolver.close();
+            } catch (Exception e) {
+                throw new Exception("Cannot apply transform", e);
+            } finally {
+                if (stream != null) stream.close();
+                if (out != null) out.close();
+                if (in != null) in.close();
+                if (resolver != null) resolver.close();
             }
-        } catch (Exception e) {
-            throw new Exception("Cannot apply transform", e);
         }
         File f = File.createTempFile(
                 RandomStringUtils.random(100, false, true), "."+ OME_XML);

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -41,6 +41,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import loci.common.Constants;
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.formats.tiff.TiffParser;
@@ -196,7 +197,7 @@ public class ExporterTest extends AbstractServerTest {
                 Source src = new StreamSource(stream);
                 Templates template = factory.newTemplates(src);
                 transformer = template.newTransformer();
-                transformer.setParameter(OutputKeys.ENCODING, "UTF-8");
+                transformer.setParameter(OutputKeys.ENCODING, Constants.ENCODING);
                 out = new FileOutputStream(output);
                 in = new FileInputStream(inputXML);
                 transformer.transform(new StreamSource(in),
@@ -976,18 +977,19 @@ public class ExporterTest extends AbstractServerTest {
         RandomAccessOutputStream tiffOutput = null;
         File tiffXML = null;
         try {
-            String encoding = "UTF-8";
             f = export(OME_TIFF, IMAGE);
             //extract XML and copy to tmp file
             String path = f.getAbsolutePath();
             TiffParser parser = new TiffParser(path);
             inputXML = File.createTempFile(RandomStringUtils.random(100, false,
                     true),"." + OME_XML);
-            FileUtils.writeStringToFile(inputXML, parser.getComment(), encoding);
+            FileUtils.writeStringToFile(inputXML, parser.getComment(),
+                    Constants.ENCODING);
             //transform XML
             transformed = applyTransforms(inputXML, target.getTransforms());
             validate(transformed);
-            String comment = FileUtils.readFileToString(transformed, encoding);
+            String comment = FileUtils.readFileToString(transformed,
+                    Constants.ENCODING);
 
             tiffOutput = new RandomAccessOutputStream(path);
             TiffSaver saver = new TiffSaver(tiffOutput, path);

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -697,8 +697,7 @@ public class ExporterTest extends AbstractServerTest {
             List<InputStream> streams = new ArrayList<InputStream>();
             j = l.iterator();
             while (j.hasNext()) {
-                streams.add(this.getClass().getResourceAsStream(
-                        "/transforms/"+j.next()));
+                streams.add(getStream(j.next()));
             }
             targets.add(new Target(streams, e.getKey()));
         }
@@ -730,6 +729,17 @@ public class ExporterTest extends AbstractServerTest {
     }
 
     /**
+     * Retrieve the input stream.
+     *
+     * @param name The name of the stream.
+     * @return See above.
+     */
+    private InputStream getStream(String name)
+    {
+        return this.getClass().getResourceAsStream("/transforms/"+name);
+    }
+
+    /**
      * Returns the list of transformations to generate the file to upgrade.
      *
      * @param target The schema to start from for the upgrade.
@@ -742,8 +752,7 @@ public class ExporterTest extends AbstractServerTest {
         List<InputStream> streams = new ArrayList<InputStream>();
         Iterator<String> j = list.iterator();
         while (j.hasNext()) {
-            streams.add(this.getClass().getResourceAsStream(
-                    "/transforms/"+j.next()));
+            streams.add(getStream(j.next()));
         }
         return streams;
     }
@@ -1062,7 +1071,6 @@ public class ExporterTest extends AbstractServerTest {
      * Test the upgrade of an image with annotated acquisition.
      * @throws Exception Thrown if an error occurred.
      */
-
     @Test(dataProvider = "createUpgrade")
     public void testUpgradeImageWithAnnotatedAcquisition(Target target) throws Exception {
         File f = null;
@@ -1082,6 +1090,102 @@ public class ExporterTest extends AbstractServerTest {
         } catch (Throwable e) {
             throw new Exception("Cannot upgrade image: "+target.getSource(),
                     e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
+        }
+    }
+
+    // Path not in ome-transforms but stylesheets are available
+    /**
+     * Test the upgrade of an image from 2003-FC to 2008-09
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testUpgradeImage2003FCto200809() throws Exception
+    {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = createImageFile(IMAGE); //2015 image
+            List<InputStream> transforms = retrieveDowngrade("2003-FC");
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file. to 2008-09
+            List<InputStream> upgrades = new ArrayList<InputStream>();
+            upgrades.add(getStream("2003-FC-to-2008-09.xsl"));
+            upgraded = applyTransforms(transformed, upgrades);
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot transform image to 2008-09 ", e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
+        }
+    }
+
+
+
+    /**
+     * Test the upgrade of an image from 2007-06 to 2008-02
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testUpgradeImage200706to200802() throws Exception
+    {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = createImageFile(IMAGE); //2015 image
+            List<InputStream> transforms = retrieveDowngrade("2007-06");
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file. to 2008-09
+            List<InputStream> upgrades = new ArrayList<InputStream>();
+            upgrades.add(getStream("2007-06-to-2008-02.xsl"));
+            upgraded = applyTransforms(transformed, upgrades);
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot transform image to 2008-02", e);
+        } finally {
+            if (f != null) f.delete();
+            if (transformed != null) transformed.delete();
+            if (upgraded != null) upgraded.delete();
+        }
+    }
+
+    /**
+     * Test the upgrade of an image from 2007-06 to 2008-09
+     * @throws Exception Thrown if an error occurred.
+     */
+    public void testUpgradeImage200706to200809() throws Exception
+    {
+        File f = null;
+        File transformed = null;
+        File upgraded = null;
+        try {
+            f = createImageFile(IMAGE); //2015 image
+            List<InputStream> transforms = retrieveDowngrade("2007-06");
+            //Create file to upgrade
+            transformed = applyTransforms(f, transforms);
+            //now upgrade the file. to 2008-09
+            List<InputStream> upgrades = new ArrayList<InputStream>();
+            upgrades.add(getStream("2007-06-to-2008-09.xsl"));
+            upgraded = applyTransforms(transformed, upgrades);
+            //validate the file
+            validate(upgraded);
+            //import the file
+            importFile(upgraded, OME_XML);
+        } catch (Throwable e) {
+            throw new Exception("Cannot transform image to 2008-09", e);
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -150,6 +150,9 @@ public class ExporterTest extends AbstractServerTest {
     /** The current schema.*/
     private String currentSchema;
 
+    /** Flag indicating if the platform is Windows or not.*/
+    private boolean windowsOS;
+
     /**
      * Validates the specified input.
      *
@@ -340,6 +343,8 @@ public class ExporterTest extends AbstractServerTest {
         super.setUp();
         upgrades = new HashMap<String, List<String>>();
         downgrades = currentSchema();
+        String osName = System.getProperty("os.name").toLowerCase();
+        windowsOS = osName.startsWith("windows");
     }
 
     /**
@@ -739,6 +744,10 @@ public class ExporterTest extends AbstractServerTest {
      */
     private InputStream getStream(String name)
     {
+        if (windowsOS) {
+            return this.getClass().getClassLoader().getResourceAsStream(
+                    "transforms/"+name);
+        }
         return this.getClass().getResourceAsStream("/transforms/"+name);
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -1134,7 +1134,7 @@ public class ExporterTest extends AbstractServerTest {
             //import the file
             importFile(upgraded, OME_XML);
         } catch (Throwable e) {
-            throw new Exception("Cannot transform image to 2008-09 ", e);
+            throw new Exception("Cannot transform image to 2008-09", e);
         } finally {
             if (f != null) f.delete();
             if (transformed != null) transformed.delete();


### PR DESCRIPTION
Add more tests for stylesheets not used in the catalog (3 stylesheets), Last round of tests to fully covered all stylesheets.
if you want to run the test locally, use
```
./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/ExporterTest
```

Check that https://ci.openmicroscopy.org/view/5.1/job/OMERO-5.1-merge-integration-java/ is green