### PR TITLE
adding build year to index templates (rebased onto dev_5_0)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -35,6 +35,7 @@ from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
 
+from omero_version import build_year
 from omero_version import omero_version
 
 from omeroweb.webclient.decorators import render_response
@@ -43,7 +44,7 @@ from omeroweb.webclient.decorators import render_response
 @never_cache
 @render_response()
 def custom_index(request, conn=None, **kwargs):
-    context = {"version": omero_version}
+    context = {"version": omero_version, 'build_year': build_year}
 
     if settings.INDEX_TEMPLATE is not None:
         try:
@@ -64,7 +65,7 @@ def custom_index(request, conn=None, **kwargs):
 @never_cache
 @render_response()
 def index(request, conn=None, **kwargs):
-    context = {"version": omero_version}
+    context = {"version": omero_version, 'build_year': build_year}
 
     if settings.WEBSTART_TEMPLATE is not None:
         try:


### PR DESCRIPTION

This is the same as gh-3644 but rebased onto dev_5_0.

----

Minor fix adding build year to index template.

To test it go to:
 - https://octopus..../merge/index/
 - https://octopus.../merge/webstart/

check if 2007-2015 appears in a footer

                