### PR TITLE
C++: add conversions.h to CMakeLists.txt

### DIFF
--- a/components/tools/OmeroCpp/CMakeLists.txt
+++ b/components/tools/OmeroCpp/CMakeLists.txt
@@ -347,6 +347,7 @@ set(OMERO_CLIENT_STATIC_HEADERS
     src/omero/callbacks.h
     src/omero/client.h
     src/omero/clientF.h
+    src/omero/conversions.h
     src/omero/min.h
     src/omero/ObjectFactory.h)
 


### PR DESCRIPTION
Without conversions.h in lib/include/omero, compiling
a client is all but impossible.

cc: @rleigh-dundee @emilroz