### PR TITLE
Final import mode

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -371,6 +371,7 @@ public class CommandLineImporter {
             + "          ln              \t# Use hard-link.\n"
             + "          ln_s            \t# Use soft-link.\n"
             + "          ln_rm           \t# Caution! Hard-link followed by source deletion.\n"
+            + "          ln_s_rm         \t# Caution! Soft-link followed by source deletion.\n"
             + "          cp              \t# Use local copy command.\n"
             + "          cp_rm           \t# Caution! Copy followed by source deletion.\n\n"
             + "\n"

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2009-2014 University of Dundee & Open Microscopy Environment.
+ *   Copyright (C) April 1st 2015 University of Dundee & Open Microscopy Environment.
  *   All rights reserved.
  *
  *   Use is subject to license terms supplied in LICENSE.txt

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) April 1st 2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
@@ -50,6 +50,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
         ln(HardlinkFileTransfer.class),
         ln_rm(MoveFileTransfer.class),
         ln_s(SymlinkFileTransfer.class),
+        ln_s_rm(RemoveFileTransfer.class),
         cp(CopyFileTransfer.class),
         cp_rm(CopyMoveFileTransfer.class),
         upload(UploadFileTransfer.class),

--- a/components/blitz/src/ome/formats/importer/transfers/RemoveFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/RemoveFileTransfer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) April 1st 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.formats.importer.transfers;
+
+import java.util.List;
+
+/**
+ * Local-only file transfer mechanism which makes use of symlinking
+ * followed by the deletion of the original source file.
+ *
+ * @since 5.1
+ */
+public class RemoveFileTransfer extends SymlinkFileTransfer {
+
+    /**
+     * Deletes all symlinked files if there were no errors.
+     */
+    @Override
+    public void afterTransfer(int errors, List<String> srcFiles) throws CleanupFailure {
+        deleteTransferredFiles(errors, srcFiles);
+    }
+}

--- a/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) April 1st 2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify

--- a/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -65,7 +65,7 @@ public class SymlinkFileTransfer extends AbstractExecFileTransfer {
     /**
      * No cleanup is needed for soft-linking.
      */
-    public void afterTransfer(int errors, List<String> srcFiles) {
+    public void afterTransfer(int errors, List<String> srcFiles) throws CleanupFailure {
         // no-op
     }
 }

--- a/components/tools/OmeroPy/src/omero/fs/__init__.py
+++ b/components/tools/OmeroPy/src/omero/fs/__init__.py
@@ -13,6 +13,7 @@ TRANSFERS = {
     "ome.formats.importer.transfers.HardlinkFileTransfer": "ln",
     "ome.formats.importer.transfers.MoveFileTransfer": "ln_rm",
     "ome.formats.importer.transfers.SymlinkFileTransfer": "ln_s",
+    "ome.formats.importer.transfers.RemoveFileTransfer": "ln_s_rm",
     "ome.formats.importer.transfers.UploadRmFileTransfer": "upload_rm",
     "ome.formats.importer.transfers.UploadFileTransfer": "",
     }

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -25,7 +25,7 @@ from omero.plugins.fs import FsControl
 
 import pytest
 
-transfers = ['ln_s', 'ln', 'ln_rm', 'cp', 'cp_rm']
+transfers = ['ln_s', 'ln_s_rm', 'ln', 'ln_rm', 'cp', 'cp_rm']
 repos = ['Managed', 'Public', 'Script']
 
 


### PR DESCRIPTION
Hitherto the import modes have lacked a certain symmetry. This PR fixes that unfortunate shortcoming by adding the final import mode, thus completing the symmetric set and restoring necessary beauty to import. This final mode is `ln_s_rm`, a symlink followed by a deletion of the original files.

Testing
-------

To test this PR use the command line import with the transfer option `ln_s_rm`, ie

```
bin/omero import -- --transfer=ln_s_rm path/to/image/file
```

The console output should confirm that the correct mode is used, that the image is transferred and imported and that the original image files are successfully deleted.

A further useful sanity check would be to view the imported image in one of the clients.

Caution: given that this is a `rm` mode in-place import you should fully understand the side effects of this import mode and not test it using the only copies of valuable images.

--no-rebase
