### PR TITLE
have C++ code use new graph requests

### DIFF
--- a/components/tools/OmeroCpp/test/integration/chgrp.cpp
+++ b/components/tools/OmeroCpp/test/integration/chgrp.cpp
@@ -16,6 +16,7 @@ using namespace std;
 using namespace omero;
 using namespace omero::api;
 using namespace omero::cmd;
+using namespace omero::cmd::graphs;
 using namespace omero::callbacks;
 using namespace omero::model;
 using namespace omero::rtypes;
@@ -41,14 +42,17 @@ TEST(ChgrpTest, testSimpleChgrp ) {
     image->setName( rstring("testSimpleChgrp") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    std::map<string, string> options;
-    ChgrpPtr chgrp = new Chgrp();
-    chgrp->type = "/Image";
-    chgrp->id = image->getId()->getValue();
-    chgrp->grp = g2->getId()->getValue();
-    chgrp->options = options;
+    LongList imageIds;
+    StringLongListMap objects;
+    ChildOptions options;
+    Chgrp2Ptr chgrpCmd = new Chgrp2();
+    imageIds.push_back( image->getId()->getValue() );
+    objects["Image"] = imageIds;
+    chgrpCmd->targetObjects = objects;
+    chgrpCmd->groupId = g2->getId()->getValue();
+    chgrpCmd->childOptions = options;
 
-    HandlePrx handle = sf->submit( chgrp );
+    HandlePrx handle = sf->submit( chgrpCmd );
     CmdCallbackIPtr cb = new CmdCallbackI(f.client, handle);
     ResponsePtr rsp = cb->loop(10, 500);
     ERRPtr err = ERRPtr::dynamicCast(rsp);

--- a/components/tools/OmeroCpp/test/integration/chgrp.cpp
+++ b/components/tools/OmeroCpp/test/integration/chgrp.cpp
@@ -42,8 +42,8 @@ TEST(ChgrpTest, testSimpleChgrp ) {
     image->setName( rstring("testSimpleChgrp") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    LongList imageIds;
-    StringLongListMap objects;
+    omero::api::LongList imageIds;
+    omero::api::StringLongListMap objects;
     ChildOptions options;
     Chgrp2Ptr chgrpCmd = new Chgrp2();
     imageIds.push_back( image->getId()->getValue() );

--- a/components/tools/OmeroCpp/test/integration/delete.cpp
+++ b/components/tools/OmeroCpp/test/integration/delete.cpp
@@ -35,8 +35,8 @@ TEST(DeleteTest, testSimpleDelete ) {
     image->setName( rstring("testSimpleDelete") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    LongList imageIds;
-    StringLongListMap objects;
+    omero::api::LongList imageIds;
+    omero::api::StringLongListMap objects;
     ChildOptions options;
     Delete2Ptr deleteCmd = new Delete2();
     imageIds.push_back( image->getId()->getValue() );

--- a/components/tools/OmeroCpp/test/integration/delete.cpp
+++ b/components/tools/OmeroCpp/test/integration/delete.cpp
@@ -8,6 +8,7 @@
 #include <omero/fixture.h>
 #include <omero/callbacks.h>
 #include <omero/all.h>
+#include <omero/cmd/Graphs.h>
 #include <string>
 #include <map>
 
@@ -15,12 +16,11 @@ using namespace std;
 using namespace omero;
 using namespace omero::api;
 using namespace omero::cmd;
+using namespace omero::cmd::graphs;
 using namespace omero::callbacks;
 using namespace omero::model;
 using namespace omero::rtypes;
 using namespace omero::sys;
-using namespace omero::cmd;
-
 
 
 TEST(DeleteTest, testSimpleDelete ) {
@@ -35,10 +35,17 @@ TEST(DeleteTest, testSimpleDelete ) {
     image->setName( rstring("testSimpleDelete") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    DeletePtr deleteCmd = new Delete("/Image", image->getId()->getValue(), StringMap());
+    LongList imageIds;
+    StringLongListMap objects;
+    ChildOptions options;
+    Delete2Ptr deleteCmd = new Delete2();
+    imageIds.push_back( image->getId()->getValue() );
+    objects["Image"] = imageIds;
+    deleteCmd->targetObjects = objects;
+    deleteCmd->childOptions = options;
 
     // Submit and wait for completion
-    HandlePrx handle = sf->submit(deleteCmd);
+    HandlePrx handle = sf->submit( deleteCmd );
     CmdCallbackIPtr cb = new CmdCallbackI(f.client, handle);
     ResponsePtr resp = cb->loop(10, 500);
 

--- a/components/tools/OmeroCpp/utils/chgrp.cpp
+++ b/components/tools/OmeroCpp/utils/chgrp.cpp
@@ -24,6 +24,7 @@ using namespace std;
 using namespace omero;
 using namespace omero::api;
 using namespace omero::cmd;
+using namespace omero::cmd::graphs;
 using namespace omero::callbacks;
 using namespace omero::model;
 using namespace omero::rtypes;
@@ -144,7 +145,7 @@ public:
     long id;
     long grp;
     long wait;
-    ChgrpPtr req;
+    Chgrp2Ptr req;
     ResponsePtr rsp;
     HandlePrx handle;
     CmdCallbackIPtr cb;
@@ -162,12 +163,15 @@ public:
         grp = strToNum<long>(grpstr);
         wait = strToNum<long>(waitstr);
 
-        map<string, string> options;
-        req = new Chgrp();
-        req->type = typestr;
-        req->id = id;
-        req->grp = grp;
-        req->options = options;
+        LongList objectIds;
+        StringLongListMap objects;
+        ChildOptions options;
+        req = new Chgrp2();
+        objectIds.push_back(id);
+        objects[typestr] = objectIds;
+        req->targetObjects = objects;
+        req->groupId = grp;
+        req->childOptions = options;
     }
 
     void ctrlc(int /*sig*/) {

--- a/components/tools/OmeroCpp/utils/chgrp.cpp
+++ b/components/tools/OmeroCpp/utils/chgrp.cpp
@@ -163,8 +163,8 @@ public:
         grp = strToNum<long>(grpstr);
         wait = strToNum<long>(waitstr);
 
-        LongList objectIds;
-        StringLongListMap objects;
+        omero::api::LongList objectIds;
+        omero::api::StringLongListMap objects;
         ChildOptions options;
         req = new Chgrp2();
         objectIds.push_back(id);


### PR DESCRIPTION
C++ tests run by CI should remain green.

*Update*: Also, now C++ standalone chgrp tool is updated. Just use plain typenames, no "/"-prefix.

--no-rebase