### PR TITLE
Revert "Travis container build" due to "137" exit code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,27 @@
 language: java
 
-jdk:
-  - openjdk7
-
-sudo: false
-
-matrix:
-      fast_finish: true
-
-addons:
-  apt_packages:
-    - git
-    - zeroc-ice34
-    - python-imaging
-    - python-numpy
-    - python-tables
-    - python-genshi
-    - cmake
-    - libgtest-dev
-
 env:
     - BUILD="build-python"
     - BUILD="build-java"
 
+matrix:
+      fast_finish: true
+
+jdk:
+  - openjdk7
+
 before_install:
+    - sudo apt-get -qq update
+    - travis_retry sudo apt-get install -qq git
+    - travis_retry sudo apt-get install -qq zeroc-ice34
+    - travis_retry sudo apt-get install -qq python-imaging python-numpy python-tables python-genshi
+    - if [[ $BUILD == 'build-cpp' ]]; then travis_retry sudo apt-get install -qq cmake libgtest-dev; fi
     - git config github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
     - git config --global user.email snoopycrimecop@gmail.com
     - git config --global user.name 'Snoopy Crime Cop'
-    - pip install --user scc pytest
-    - export PATH=$PATH:$HOME/.local/bin
+    - sudo pip install scc pytest
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8==2.4.0; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
 # retries the build due to:


### PR DESCRIPTION
Reverts openmicroscopy/openmicroscopy#3647

The container-based travis builds are now failing due to a "137" exit code, similar to the "247" exit code issues that we had recently (https://github.com/travis-ci/travis-ci/issues/2507). Since this destability causes frequent rebuilds, the time won by quicker start-ups is more than lost. Reverting.

For an example, see https://travis-ci.org/openmicroscopy/openmicroscopy/jobs/57021300

```
...
icegen2:

[copy] Copying 162 files to /home/travis/build/openmicroscopy/openmicroscopy/components/blitz/generated

[copy] Copying 162 files to /home/travis/build/openmicroscopy/openmicroscopy/components/blitz/generated

Killed

The command "./components/tools/travis-build java-build" failed 3 times.

The command "if [[ $BUILD == 'build-java' ]]; then travis_retry ./components/tools/travis-build java-build; fi" failed and exited with 137 during .

Your build has been stopped.
```