### PR TITLE
Avoid ResampleOp ArrayIndexOutOfBoundsExceptions

### DIFF
--- a/components/server/src/ome/logic/JavaImageScalingService.java
+++ b/components/server/src/ome/logic/JavaImageScalingService.java
@@ -44,13 +44,17 @@ public class JavaImageScalingService implements IScale {
             float yScale) {
         int thumbHeight = (int) (image.getHeight() * yScale);
         int thumbWidth = (int) (image.getWidth() * xScale);
+        if (thumbHeight < 3)
+            thumbHeight = 3;
+        if (thumbWidth < 3)
+            thumbWidth = 3;
+        
         log.info("Scaling to: " + thumbHeight + "x" + thumbWidth);
-
+        
         StopWatch s1 = new Slf4JStopWatch("java-image-scaling.resampleOp");
         BufferedImage toReturn;
-        if (thumbWidth >= 3 && thumbHeight >= 3) {
+        if (image.getHeight() >= 3 && image.getWidth() >= 3) {
             ResampleOp resampleOp = new ResampleOp(thumbWidth, thumbHeight);
-            // resampleOp.setNumberOfThreads(4);
             toReturn = resampleOp.filter(image, null);
         } else {
             toReturn = new BufferedImage(thumbWidth, thumbHeight,


### PR DESCRIPTION
Fixes (hopefully this time finally) the ArrayIndexOutOfBoundsExceptions in master.err noticed by @joshmoore . Ensures that thumbnails are at least 3x3 pixels and that ResampleOp is only used for images >=  3x3 pixels.

Test: I don't really know what triggered these errors (integration tests maybe?), must have to do with images < 3px in width or height. Probably just review code and watch out in master.err for these errors.

--no-rebase
