### PR TITLE
Disable delete action if a well field is selected

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -88,6 +88,7 @@ import pojos.FileData;
 import pojos.GroupData;
 import pojos.ImageData;
 import pojos.MultiImageData;
+import pojos.PlateAcquisitionData;
 import pojos.PlateData;
 import pojos.ProjectData;
 import pojos.ScreenData;
@@ -399,7 +400,7 @@ class BrowserComponent
     	else model.setSelectedDisplay(display, single);
     	if (oldDisplay != null && oldDisplay.equals(display)) {
     		ho = oldDisplay.getUserObject();
-    		if (ho instanceof PlateData)
+    		if (ho instanceof PlateData || ho instanceof PlateAcquisitionData)
     			firePropertyChange(SELECTED_TREE_NODE_DISPLAY_PROPERTY, null, 
             			display);
     	} else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserUI
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -2254,6 +2254,7 @@ class BrowserUI
 		//treeDisplay.removeTreeSelectionListener(selectionListener);
 		if (newSelection == null) {
 		    treeDisplay.clearSelection();
+		    controller.getAction(BrowserControl.DELETE).setEnabled(false);
 		} else {
 			TreePath[] paths = new TreePath[newSelection.length];
 			for (int i = 0; i < newSelection.length; i++) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -2251,8 +2251,8 @@ class BrowserUI
 	 */
 	void setFoundNode(TreeImageDisplay[] newSelection)
 	{
-		//treeDisplay.removeTreeSelectionListener(selectionListener);
 		if (newSelection == null) {
+		    model.setSelectedDisplay(null, true);
 		    treeDisplay.clearSelection();
 		    controller.getAction(BrowserControl.DELETE).setEnabled(false);
 		} else {


### PR DESCRIPTION
Fixes ticket: https://trac.openmicroscopy.org/ome/ticket/12795

Test:
Select a well and make sure the "Delete" action is disabled, in the context menu as well as in the "Screens" toolbar. Check that the action is enabled otherwise, e. g. if the Run or the Plate is selected.

--no-rebase