### PR TITLE
Optimize and fix original file paths

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2829,7 +2829,9 @@ class _BlitzGateway (object):
                 '   where i_image.id in (:ids)'\
                 ')'
         queryService = self.getQueryService()
-        count, size = queryService.projection(query, params, self.SERVICE_OPTS)[0]
+        count, size = queryService.projection(
+            query, params, self.SERVICE_OPTS
+        )[0]
         if size is None:
             size = 0
 
@@ -2876,7 +2878,9 @@ class _BlitzGateway (object):
                 '    where i_link.child.image.id in (:ids)'\
                 ')'
         queryService = self.getQueryService()
-        count, size = queryService.projection(query, params, self.SERVICE_OPTS)[0]
+        count, size = queryService.projection(
+            query, params, self.SERVICE_OPTS
+        )[0]
         if size is None:
             size = 0
         return {'fileset': False, 'count': unwrap(count), 'size': unwrap(size)}
@@ -8804,7 +8808,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         for original_file in original_files:
             yield OriginalFileWrapper(self._conn, original_file)
 
-    def getImportedImageFilePaths (self):
+    def getImportedImageFilePaths(self):
         """
         Returns a generator of path strings corresponding to the Imported
         image files that created this image, if available.

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2824,7 +2824,6 @@ class _BlitzGateway (object):
                 'from FilesetEntry as fse where fse.id in ('\
                 '   select distinct(i_fse.id) from FilesetEntry as i_fse '\
                 '   join i_fse.fileset as i_fileset'\
-                '   join i_fse.originalFile '\
                 '   join i_fileset.images as i_image '\
                 '   where i_image.id in (:ids)'\
                 ')'

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2830,6 +2830,8 @@ class _BlitzGateway (object):
                 ')'
         queryService = self.getQueryService()
         count, size = queryService.projection(query, params, self.SERVICE_OPTS)[0]
+        if size is None:
+            size = 0
 
         query = 'select ann.id, ann.ns, ann.textValue '\
                 'from Fileset as fileset '\

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -179,6 +179,11 @@ class TestFileset(object):
         for image in fileset_with_images.copyImages():
             assert image.getFileset() is not None
 
+    def testGetImportedImageFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            files = list(image.getImportedImageFiles())
+            assert len(files) == 4
+
 
 class TestArchivedOriginalFiles(object):
 
@@ -246,3 +251,9 @@ class TestArchivedOriginalFiles(object):
     def testGetFileset(self, gatewaywrapper, images_with_original_files):
         for image in images_with_original_files:
             assert image.getFileset() is None
+
+    def testGetImportedImageFiles(
+            self, gatewaywrapper, images_with_original_files):
+        for image in images_with_original_files:
+            files = list(image.getImportedImageFiles())
+            assert len(files) == 2

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -63,16 +63,19 @@ def images_with_original_files(request, gatewaywrapper):
     gatewaywrapper.loginAsAuthor()
     gw = gatewaywrapper.gateway
     update_service = gw.getUpdateService()
+    original_files = list()
+    for original_file_index in range(2):
+        original_file = OriginalFileI()
+        original_file.name = rstring(
+            'filename_%d.ext' % original_file_index
+        )
+        original_file.path = rstring('/server/path/')
+        original_file.size = rlong(50L)
+        original_files.append(original_file)
     images = list()
     for image_index in range(2):
         image = create_image(image_index)
-        for original_file_index in range(2):
-            original_file = OriginalFileI()
-            original_file.name = rstring(
-                'filename_%d.ext' % original_file_index
-            )
-            original_file.path = rstring('/server/path/')
-            original_file.size = rlong(50L)
+        for original_file in original_files:
             image.getPrimaryPixels().linkOriginalFile(original_file)
         images.append(image)
     image_ids = update_service.saveAndReturnIds(images)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -29,23 +29,122 @@
 
 import pytest
 
+from omero.model import ImageI, PixelsI, FilesetI, FilesetEntryI, \
+    OriginalFileI, DimensionOrderI, PixelsTypeI, CommentAnnotationI, \
+    LongAnnotationI
+from omero.rtypes import rstring, rlong, rint, rtime
+from uuid import uuid4
+
+
+def uuid():
+    return str(uuid4())
+
+
+@pytest.fixture()
+def fileset_with_images(request, gatewaywrapper):
+    """Creates and returns a Fileset with associated Images."""
+    gatewaywrapper.loginAsAuthor()
+    update_service = gatewaywrapper.gateway.getUpdateService()
+    fileset = FilesetI()
+    fileset.templatePrefix = rstring('')
+    for image_index in range(2):
+        image = ImageI()
+        image.name = rstring('%s_%d' % (uuid(), image_index))
+        image.acquisitionDate = rtime(0)
+        pixels = PixelsI()
+        pixels.sha1 = rstring('')
+        pixels.sizeX = rint(1)
+        pixels.sizeY = rint(1)
+        pixels.sizeZ = rint(1)
+        pixels.sizeC = rint(1)
+        pixels.sizeT = rint(1)
+        pixels.dimensionOrder = DimensionOrderI(1L, False)  # XYZCT
+        pixels.pixelsType = PixelsTypeI(1L, False)  # bit
+        for index in range(2):
+            fileset_entry = FilesetEntryI()
+            fileset_entry.clientPath = rstring(
+                '/client/path/filename_%d.ext' % index
+            )
+            original_file = OriginalFileI()
+            original_file.name = rstring('filename_%d.ext' % index)
+            original_file.path = rstring('/server/path/')
+            original_file.size = rlong(50L)
+            fileset_entry.originalFile = original_file
+            fileset.addFilesetEntry(fileset_entry)
+        image.addPixels(pixels)
+        fileset.addImage(image)
+    comment_annotation = CommentAnnotationI()
+    comment_annotation.ns = rstring('comment_annotation')
+    comment_annotation.textValue = rstring('textValue')
+    long_annotation = LongAnnotationI()
+    long_annotation.ns = rstring('long_annotation')
+    long_annotation.longValue = rlong(1L)
+    fileset.linkAnnotation(comment_annotation)
+    fileset.linkAnnotation(long_annotation)
+    fileset = update_service.saveAndReturnObject(fileset)
+    return gatewaywrapper.gateway.getObject('Fileset', fileset.id.val)
+
 
 class TestFileset(object):
 
-    @pytest.fixture(autouse=True)
-    def setUp(self, gatewaywrapper):
-        gatewaywrapper.loginAsAuthor()
-        self.TESTIMG = gatewaywrapper.getTestImage()
+    def assertFilesetFilesInfo(self, files_info):
+        assert files_info['fileset'] is True
+        assert files_info['count'] == 4
+        assert files_info['size'] == 200
+        assert len(files_info['annotations']) == 2
+        for annotation in files_info['annotations']:
+            ns = annotation['ns']
+            if ns == 'comment_annotation':
+                assert annotation['value'] == 'textValue'
+            elif ns == 'long_annotation':
+                pass
+            else:
+                pytest.fail('Unexpected namespace: %r' % ns)
 
-    @pytest.mark.broken(ticket="11610")
-    def testFileset(self):
-        image = self.TESTIMG
+    def testCountArchivedFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            assert image.countArchivedFiles() == 0
 
-        # Assume image is not imported pre-FS
-        filesCount = image.countFilesetFiles()
-        assert filesCount > 0, \
-            "Imported image should be linked to original files"
+    def testCountFilesetFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            assert image.countFilesetFiles() == 4
 
-        # List the 'imported image files' (from fileset), check the number
-        filesInFileset = list(image.getImportedImageFiles())
-        assert filesCount == len(filesInFileset)
+    def testCountImportedImageFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            assert image.countImportedImageFiles() == 4
+
+    def testGetImportedFilesInfo(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            files_info = image.getImportedFilesInfo()
+            self.assertFilesetFilesInfo(files_info)
+
+    def testGetArchivedFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            len(list(image.getArchivedFiles())) == 4
+
+    def testGetImportedImageFiles(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            len(list(image.getImportedImageFiles())) == 4
+
+    def testGetArchivedFilesInfo(self, gatewaywrapper, fileset_with_images):
+        gw = gatewaywrapper.gateway
+        for image in fileset_with_images.copyImages():
+            files_info = gw.getArchivedFilesInfo([image.id])
+            assert files_info == {'fileset': False, 'count': 0, 'size': 0}
+
+    def testGetFilesetFilesInfo(self, gatewaywrapper, fileset_with_images):
+        gw = gatewaywrapper.gateway
+        for image in fileset_with_images.copyImages():
+            files_info = gw.getFilesetFilesInfo([image.id])
+            self.assertFilesetFilesInfo(files_info)
+
+    def testGetFilesetFilesInfoMultiple(
+            self, gatewaywrapper, fileset_with_images):
+        gw = gatewaywrapper.gateway
+        image_ids = [v.id for v in fileset_with_images.copyImages()]
+        files_info = gw.getFilesetFilesInfo(image_ids)
+        self.assertFilesetFilesInfo(files_info)
+
+    def testGetFileset(self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            assert image.getFileset() is not None

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -179,11 +179,6 @@ class TestFileset(object):
         for image in fileset_with_images.copyImages():
             assert image.getFileset() is not None
 
-    def testGetImportedImageFiles(self, gatewaywrapper, fileset_with_images):
-        for image in fileset_with_images.copyImages():
-            files = list(image.getImportedImageFiles())
-            assert len(files) == 4
-
     def testGetImportedImageFilePaths(
             self, gatewaywrapper, fileset_with_images):
         for image in fileset_with_images.copyImages():
@@ -202,6 +197,7 @@ class TestFileset(object):
                 '/client/path/filename_1.ext',
                 '/client/path/filename_1.ext'
             ]
+
 
 class TestArchivedOriginalFiles(object):
 
@@ -269,12 +265,6 @@ class TestArchivedOriginalFiles(object):
     def testGetFileset(self, gatewaywrapper, images_with_original_files):
         for image in images_with_original_files:
             assert image.getFileset() is None
-
-    def testGetImportedImageFiles(
-            self, gatewaywrapper, images_with_original_files):
-        for image in images_with_original_files:
-            files = list(image.getImportedImageFiles())
-            assert len(files) == 2
 
     def testGetImportedImageFilePaths(
             self, gatewaywrapper, images_with_original_files):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -184,6 +184,24 @@ class TestFileset(object):
             files = list(image.getImportedImageFiles())
             assert len(files) == 4
 
+    def testGetImportedImageFilePaths(
+            self, gatewaywrapper, fileset_with_images):
+        for image in fileset_with_images.copyImages():
+            paths = image.getImportedImageFilePaths()
+            paths['server_paths'].sort()
+            assert paths['server_paths'] == [
+                '/server/path/filename_0.ext',
+                '/server/path/filename_0.ext',
+                '/server/path/filename_1.ext',
+                '/server/path/filename_1.ext'
+            ]
+            paths['client_paths'].sort()
+            assert paths['client_paths'] == [
+                '/client/path/filename_0.ext',
+                '/client/path/filename_0.ext',
+                '/client/path/filename_1.ext',
+                '/client/path/filename_1.ext'
+            ]
 
 class TestArchivedOriginalFiles(object):
 
@@ -257,3 +275,14 @@ class TestArchivedOriginalFiles(object):
         for image in images_with_original_files:
             files = list(image.getImportedImageFiles())
             assert len(files) == 2
+
+    def testGetImportedImageFilePaths(
+            self, gatewaywrapper, images_with_original_files):
+        for image in images_with_original_files:
+            paths = image.getImportedImageFilePaths()
+            paths['server_paths'].sort()
+            assert paths['server_paths'] == [
+                '/server/path/filename_0.ext',
+                '/server/path/filename_1.ext',
+            ]
+            assert len(paths['client_paths']) == 0


### PR DESCRIPTION
This PR includes various performance improvements to the stack required to extract original file paths from the server via the `/webgateway/original_file_paths/...` OMERO.web JSON endpoint. Without these or similar changes there is the very real scenario where requesting the original file paths could **crash** your server due to the sheer amount and complexity of data being processed.

The "real world" example dataset which spurred the need for the improvements has 4608 Images (384 Wells, 12 Fields) and 4608 OriginalFiles (one per field) associated with the same Fileset. Half that number is needed to run a server out of memory with a 1GB heap. Call tree is as follows:

```
original_file_paths()
\___ _ImageWrapper.getImportedImageFiles()
\___ _ImageWrapper.getFileset()
\___ _ImageWrapper.countFilesetFiles()
\___ BlitzGateway.getFilesetFilesInfo()
```

The first set of improvements are to the fileset and archive file count methods, `getFilesetFileInfo()` and `getArchivedFilesInfo()`, on the gateway. Before:

```
...
In [25]: print datetime.now()
2015-04-03 08:45:46.464612

In [26]: gw.getFilesetFilesInfo([66101])

Out[26]: {'count': 4608, 'size': 6564240074L}

In [27]: print datetime.now()
2015-04-03 08:45:49.193313
...
```

After (14ee8844e62c434d8c4b827735a3d10424abc1b4):

```
In [12]: print datetime.now()
2015-04-03 14:38:57.178159

In [13]: gw.getFilesetFilesInfo([66101])
Out[13]: {'count': 4608L, 'size': 6564240074L}

In [14]: print datetime.now()
2015-04-03 14:38:57.371813
```

~2.7seconds vs. ~190ms (~14x speedup)

The second set of improvements are to the original file load method `getImportedImageFiles()` on the image wrapper. Before, even with a 2GB heap the aforementioned dataset causes out of memory and GC overhead limit exceptions. This is likely due to the multiplicity of the queries performed and the complexity of the object graph. The number of objects loaded would be >20,000.

After (1356aff4c2f3f18728cce5a0cc67973248285777):

```
In [11]: print datetime.now()
2015-04-03 19:04:43.403131

In [12]: files = list(image.getImportedImageFiles())
print datetime.now()

In [13]: print datetime.now()
2015-04-03 19:04:49.463482
```

~6seconds.

These projection changes complete the speedup.

After (27ce963e1a7e8a97ac346c3d68982f44855a2bf4), run on `localhost`:

```
$ time curl "https://localhost/webgateway/original_file_paths/66101/?server=1&username=...&password=..." &> /dev/null

real	0m0.356s
user	0m0.024s
sys	0m0.037s
```

~350ms

Integration tests cover the affected code paths. /cc @ximenesuk 

To be reviewed by @will-moore and/or @aleksandra-tarkowska.

/cc @jballanc, @knabar, @emilroz, @jburel, @sbesson 