### PR TITLE
psql: Correct version error message to pretty-print version

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-header.vm
+++ b/components/dsl/resources/ome/dsl/psql-header.vm
@@ -20,6 +20,16 @@ BEGIN;
 -- check PostgreSQL server version and database encoding
 --
 
+CREATE OR REPLACE FUNCTION db_pretty_version(version INTEGER) RETURNS text AS $$
+DECLARE
+    textver TEXT;
+
+BEGIN
+    textver = (version/10000)::text || '.' || ((version/100)%%100)::text || '.' || (version%%100)::text;
+    RETURN textver;
+
+END;$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION assert_db_server_prerequisites(version_prereq INTEGER) RETURNS void AS $$
 
 DECLARE
@@ -31,7 +41,7 @@ BEGIN
     SELECT pg_encoding_to_char(encoding) INTO STRICT char_encoding FROM pg_database WHERE datname = current_database();
 
     IF version_num < version_prereq THEN
-        RAISE EXCEPTION 'database server version %% is less than OMERO prerequisite %%', version_num, version_prereq;
+        RAISE EXCEPTION 'PostgreSQL database server version %% is less than OMERO prerequisite %%', db_pretty_version(version_num), db_pretty_version(version_prereq);
     END IF;
 
     IF char_encoding != 'UTF8' THEN
@@ -42,6 +52,7 @@ END;$$ LANGUAGE plpgsql;
 
 SELECT assert_db_server_prerequisites(90200);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
+DROP FUNCTION db_pretty_version(version INTEGER);
 
 
 CREATE DOMAIN nonnegative_int AS INTEGER CHECK (VALUE >= 0);

--- a/sql/psql/OMERO5.1DEV__11/OMERO5.1DEV__10.sql
+++ b/sql/psql/OMERO5.1DEV__11/OMERO5.1DEV__10.sql
@@ -47,6 +47,16 @@ DROP FUNCTION omero_assert_db_version(varchar, int);
 -- check PostgreSQL server version and database encoding
 --
 
+CREATE OR REPLACE FUNCTION db_pretty_version(version INTEGER) RETURNS text AS $$
+DECLARE
+    textver TEXT;
+
+BEGIN
+    textver = (version/10000)::text || '.' || ((version/100)%100)::text || '.' || (version%100)::text;
+    RETURN textver;
+
+END;$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION assert_db_server_prerequisites(version_prereq INTEGER) RETURNS void AS $$
 
 DECLARE
@@ -58,7 +68,7 @@ BEGIN
     SELECT pg_encoding_to_char(encoding) INTO STRICT char_encoding FROM pg_database WHERE datname = current_database();
 
     IF version_num < version_prereq THEN
-        RAISE EXCEPTION 'database server version % is less than OMERO prerequisite %', version_num, version_prereq;
+        RAISE EXCEPTION 'PostgreSQL database server version % is less than OMERO prerequisite %', db_pretty_version(version_num), db_pretty_version(version_prereq);
     END IF;
 
     IF char_encoding != 'UTF8' THEN
@@ -69,6 +79,7 @@ END;$$ LANGUAGE plpgsql;
 
 SELECT assert_db_server_prerequisites(84000);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
+DROP FUNCTION db_pretty_version(version INTEGER);
 
 
 INSERT INTO dbpatch (currentVersion, currentPatch,   previousVersion,     previousPatch)

--- a/sql/psql/OMERO5.1DEV__18/OMERO5.1DEV__17.sql
+++ b/sql/psql/OMERO5.1DEV__18/OMERO5.1DEV__17.sql
@@ -47,6 +47,16 @@ DROP FUNCTION omero_assert_db_version(varchar, int);
 -- check PostgreSQL server version and database encoding
 --
 
+CREATE OR REPLACE FUNCTION db_pretty_version(version INTEGER) RETURNS text AS $$
+DECLARE
+    textver TEXT;
+
+BEGIN
+    textver = (version/10000)::text || '.' || ((version/100)%100)::text || '.' || (version%100)::text;
+    RETURN textver;
+
+END;$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION assert_db_server_prerequisites(version_prereq INTEGER) RETURNS void AS $$
 
 DECLARE
@@ -58,7 +68,7 @@ BEGIN
     SELECT pg_encoding_to_char(encoding) INTO STRICT char_encoding FROM pg_database WHERE datname = current_database();
 
     IF version_num < version_prereq THEN
-        RAISE EXCEPTION 'database server version % is less than OMERO prerequisite %', version_num, version_prereq;
+        RAISE EXCEPTION 'PostgreSQL database server version % is less than OMERO prerequisite %', db_pretty_version(version_num), db_pretty_version(version_prereq);
     END IF;
 
     IF char_encoding != 'UTF8' THEN
@@ -69,6 +79,7 @@ END;$$ LANGUAGE plpgsql;
 
 SELECT assert_db_server_prerequisites(84000);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
+DROP FUNCTION db_pretty_version(version INTEGER);
 
 
 INSERT INTO dbpatch (currentVersion, currentPatch,   previousVersion,     previousPatch)

--- a/sql/psql/OMERO5.1__1/psql-header.sql
+++ b/sql/psql/OMERO5.1__1/psql-header.sql
@@ -20,6 +20,16 @@ BEGIN;
 -- check PostgreSQL server version and database encoding
 --
 
+CREATE OR REPLACE FUNCTION db_pretty_version(version INTEGER) RETURNS text AS $$
+DECLARE
+    textver TEXT;
+
+BEGIN
+    textver = (version / 10000)::text || '.' || ((version/100)%%100)::text || '.' || (version%%100)::text;
+    RETURN textver;
+
+END;$$ LANGUAGE plpgsql;
+
 CREATE FUNCTION assert_db_server_prerequisites(version_prereq INTEGER) RETURNS void AS $$
 
 DECLARE
@@ -31,7 +41,7 @@ BEGIN
     SELECT pg_encoding_to_char(encoding) INTO STRICT char_encoding FROM pg_database WHERE datname = current_database();
 
     IF version_num < version_prereq THEN
-        RAISE EXCEPTION 'database server version %% is less than OMERO prerequisite %%', version_num, version_prereq;
+        RAISE EXCEPTION 'PostgreSQL database server version %% is less than OMERO prerequisite %%', db_pretty_version(version_num), db_pretty_version(version_prereq);
     END IF;
 
     IF char_encoding != 'UTF8' THEN
@@ -42,6 +52,7 @@ END;$$ LANGUAGE plpgsql;
 
 SELECT assert_db_server_prerequisites(90200);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
+DROP FUNCTION db_pretty_version(version INTEGER);
 
 
 CREATE DOMAIN nonnegative_int AS INTEGER CHECK (VALUE >= 0);


### PR DESCRIPTION
Make the error message for a too-old db server version a bit more friendly:
- Include the name "PostgreSQL" rather than the generic "database"
- Pretty-print version numbers rather than using a bare integer
- Use a simple PL/pgSQL function to format the integer version

--------

Testing: Run the db script on an old server, you'll see a message like this:

```
psql:OMERO5.1__1.sql:53: ERROR:  PostgreSQL database server version 9.1.13 is less than OMERO prerequisite 9.2.0
```