### PR TITLE
Clearsessions message

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -106,12 +106,15 @@ class WebControl(BaseControl):
             "Advanced use: Creates needed symlinks for static"
             " media files (Performed automatically by 'start')")
 
-        parser.add(
+        clearsessions = parser.add(
             sub, self.clearsessions,
             "Advanced use: Can be run as a cron job or directly to clean "
             "out expired sessions.\n See "
             "https://docs.djangoproject.com/en/1.6/topics/http/sessions/"
             "#clearing-the-session-store for more information.")
+        clearsessions.add_argument(
+            "--no-wait", action="store_true",
+            help="Do not wait on expired sessions clean-up")
 
         #
         # Developer
@@ -315,23 +318,23 @@ class WebControl(BaseControl):
         if rv != 0:
             self.ctx.die(607, "Failed to collect static content.\n")
 
-    def clearsessions(self, args, wait=True):
+    def clearsessions(self, args):
         """Clean out expired sessions."""
         self.ctx.out("Clearing expired sessions. This may take some time... ")
         location = self._get_python_dir() / "omeroweb"
-        args = [sys.executable, "manage.py", "clearsessions"]
-        if wait:
-            rv = self.ctx.call(args, cwd=location)
+        cmd = [sys.executable, "manage.py", "clearsessions"]
+        if not args.no_wait:
+            rv = self.ctx.call(cmd, cwd=location)
             if rv != 0:
                 self.ctx.die(607, "Failed to clear sessions.\n")
             self.ctx.out("[OK]")
         else:
-            self.ctx.popen(args, cwd=location)
+            self.ctx.popen(cmd, cwd=location)
 
     def start(self, args):
         self.collectstatic()
         if not args.keep_sessions:
-            self.clearsessions(args, wait=args.no_wait)
+            self.clearsessions(args)
         import omeroweb.settings as settings
         link = ("%s:%s" % (settings.APPLICATION_SERVER_HOST,
                            settings.APPLICATION_SERVER_PORT))
@@ -489,7 +492,7 @@ using bin\omero web start on Windows with FastCGI.
 
         self.collectstatic()
         if not args.keep_sessions:
-            self.clearsessions(args, wait=args.no_wait)
+            self.clearsessions(args)
 
         web_iis = self._get_python_dir() / "omero_web_iis.py"
         cmd = [sys.executable, str(web_iis)]

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -311,19 +311,23 @@ class WebControl(BaseControl):
         if rv != 0:
             self.ctx.die(607, "Failed to collect static content.\n")
 
-    def clearsessions(self, args):
+    def clearsessions(self, args, wait=True):
         """Clean out expired sessions."""
         self.ctx.out("Clearing expired sessions. This may take some time... ")
         location = self._get_python_dir() / "omeroweb"
         args = [sys.executable, "manage.py", "clearsessions"]
-        rv = self.ctx.call(args, cwd=location)
-        if rv != 0:
-            self.ctx.die(607, "Failed to clear sessions.\n")
+        if wait:
+            rv = self.ctx.call(args, cwd=location)
+            if rv != 0:
+                self.ctx.die(607, "Failed to clear sessions.\n")
+            self.ctx.out("[OK]")
+        else:
+            self.ctx.popen(args, cwd=location)
 
     def start(self, args):
         self.collectstatic()
         if not args.skip_clear_sessions:
-            self.clearsessions(args)
+            self.clearsessions(args, wait=False)
         import omeroweb.settings as settings
         link = ("%s:%s" % (settings.APPLICATION_SERVER_HOST,
                            settings.APPLICATION_SERVER_PORT))
@@ -481,7 +485,7 @@ using bin\omero web start on Windows with FastCGI.
 
         self.collectstatic()
         if not args.skip_clear_sessions:
-            self.clearsessions(args)
+            self.clearsessions(args, wait=False)
 
         web_iis = self._get_python_dir() / "omero_web_iis.py"
         cmd = [sys.executable, str(web_iis)]

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -68,9 +68,13 @@ class WebControl(BaseControl):
         iis.add_argument("--remove", action="store_true", default=False)
 
         for x in (start, restart, iis):
-            x.add_argument(
-                "--skip-clear-sessions", action="store_true",
+            group = x.add_mutually_exclusive_group()
+            group.add_argument(
+                "--keep-sessions", action="store_true",
                 help="Skip clean-up of expired sessions at startup")
+            group.add_argument(
+                "--no-wait", action="store_true",
+                help="Do not wait on expired sessions clean-up")
 
         #
         # Advanced
@@ -326,8 +330,8 @@ class WebControl(BaseControl):
 
     def start(self, args):
         self.collectstatic()
-        if not args.skip_clear_sessions:
-            self.clearsessions(args, wait=False)
+        if not args.keep_sessions:
+            self.clearsessions(args, wait=args.no_wait)
         import omeroweb.settings as settings
         link = ("%s:%s" % (settings.APPLICATION_SERVER_HOST,
                            settings.APPLICATION_SERVER_PORT))
@@ -484,8 +488,8 @@ using bin\omero web start on Windows with FastCGI.
             self.ctx.die(2, "'iis' command is for Windows only")
 
         self.collectstatic()
-        if not args.skip_clear_sessions:
-            self.clearsessions(args, wait=False)
+        if not args.keep_sessions:
+            self.clearsessions(args, wait=args.no_wait)
 
         web_iis = self._get_python_dir() / "omero_web_iis.py"
         cmd = [sys.executable, str(web_iis)]

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -306,6 +306,7 @@ class WebControl(BaseControl):
 
     def clearsessions(self, args):
         """Clean out expired sessions."""
+        self.ctx.out("Clearing expired sessions. This may take time... ")
         location = self._get_python_dir() / "omeroweb"
         args = [sys.executable, "manage.py", "clearsessions"]
         rv = self.ctx.call(args, cwd=location)


### PR DESCRIPTION
Reported by @kennethgillen during a production server upgrade to 5.1.0. With https://github.com/openmicroscopy/openmicroscopy/pull/3415, the start of OMERO.web now automatically performs a cleanup of the expired Django sessions. This step can be time consuming especially if the number of stale sessions is large. Additionally, there is no logging information for system administrators which may be misinterpreted as the inability for OMERO.web to start.

This PR:
- adds some basic logging information for the sessions clean-up step. Because it is fully delegated to Django there does not seem to be an easy way to have either a time estimate or a progression status /cc @aleksandra-tarkowska ?
- adds an optional `--keep-sessions` flag to skip the expired sessions clean-up in `start`, `restart` and `iis` subcommands.
- add an optional `--no-wait` flag to use `popen` rather than `call` when calling `clearsessions` in `start`, `restart` and `iis` subcommands to prevent hanging the Web restart

/cc @chris-allan 
