### PR TITLE
training java

### DIFF
--- a/examples/Training/java/src/training/ReadData.java
+++ b/examples/Training/java/src/training/ReadData.java
@@ -217,10 +217,15 @@ public class ReadData
 
 		//Get Pixel Size for the above Image
 		Length sizeX = pixels.getPixelSizeX(null);
-		System.err.println("Pixel Size X:" + sizeX.getValue() + sizeX.getSymbol());
+		if (sizeX != null) {
+		    System.err.println("Pixel Size X:" + sizeX.getValue() + sizeX.getSymbol());
+		}
+		
 		//To get the size the size with different units, E.g. Angstroms
 		Length sizeXang = pixels.getPixelSizeX(UnitsLength.ANGSTROM);
-		System.err.println("Pixel Size X:" + sizeXang.getValue() + sizeXang.getSymbol());
+		if (sizeXang != null) {
+		    System.err.println("Pixel Size X:" + sizeXang.getValue() + sizeXang.getSymbol());
+		}
 	}
 	
 	/** 

--- a/examples/Training/java/src/training/util/DoubleConverter.java
+++ b/examples/Training/java/src/training/util/DoubleConverter.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.env.rnd.data.DoubleConverter 
+ * training.util.DoubleConverter 
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.

--- a/examples/Training/java/src/training/util/FloatConverter.java
+++ b/examples/Training/java/src/training/util/FloatConverter.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.env.rnd.data.FloatConverter 
+ * training.util.FloatConverter 
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.

--- a/examples/Training/java/src/training/util/IntConverter.java
+++ b/examples/Training/java/src/training/util/IntConverter.java
@@ -1,6 +1,5 @@
 /*
- * org.openmicroscopy.shoola.env.rnd.data.IntConverter 
- *
+ * training.util.IntConverter
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
  *

--- a/examples/Training/java/src/training/util/Plane2D.java
+++ b/examples/Training/java/src/training/util/Plane2D.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.env.rnd.data.Plane2D 
+ * training.util.Plane2D 
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.

--- a/examples/Training/java/src/training/util/ReadOnlyByteArray.java
+++ b/examples/Training/java/src/training/util/ReadOnlyByteArray.java
@@ -1,6 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.mem.ReadOnlyByteArray
- *
+ * training.util.ReadOnlyByteArray
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
  *

--- a/examples/Training/java/src/training/util/UintConverter.java
+++ b/examples/Training/java/src/training/util/UintConverter.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.env.rnd.data.UintConverter 
+ * training.util.UintConverter 
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.


### PR DESCRIPTION
* Handle NPE if fake image is used.

Check the output of https://ci.openmicroscopy.org/job/OMERO-5.1-merge-training and make sure that the following error is no longer displayed
```
image:4386 test.fake
5
10
3
512
512
java.lang.NullPointerException
	at training.ReadData.loadImage(ReadData.java:220)
	at training.ReadData.<init>(ReadData.java:342)
	at training.Setup.<init>(Setup.java:132)
	at training.Setup.main(Setup.java:145)
```