### PR TITLE
CLI session unit tests

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -347,7 +347,11 @@ class SessionsControl(BaseControl):
                                            args.key, props)
             action = "Joined"
             if not rv:
-                self.ctx.die(523, "Bad session key")
+                if port:
+                    msg = "Cannot join %s on %s:%s." % (args.key, server, port)
+                else:
+                    msg = "Cannot join %s on %s." % (args.key, server)
+                self.ctx.die(523, "Bad session key. %s" % msg)
         elif not create:
             available = store.available(server, name)
             for uuid in available:

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -409,7 +409,7 @@ class SessionsControl(BaseControl):
         if exists:
             conflicts = store.conflicts(server, name, uuid, props)
             if conflicts:
-                self.ctx.dbg("Skipping %s due to conflicts: %s"
+                self.ctx.err("Skipping %s due to conflicts: %s"
                              % (uuid, conflicts))
                 return None
 

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -339,7 +339,7 @@ class SessionsControl(BaseControl):
                 # ticket:5975 : If this is the case, then this session key
                 # did not come from a CLI login, and so we're not going to
                 # modify the value returned by store.get_current()
-                self.ctx.dbg("No name found for %s." % args.key)
+                self.ctx.dbg("No local session file found for %s." % args.key)
                 rv = self.attach(store, server, args.key, args.key, props,
                                  False, set_current=False)
             else:
@@ -409,8 +409,9 @@ class SessionsControl(BaseControl):
         if exists:
             conflicts = store.conflicts(server, name, uuid, props)
             if conflicts:
-                self.ctx.err("Skipping %s due to conflicts: %s"
-                             % (uuid, conflicts))
+                self.ctx.err(
+                    "Failed to join session %s due to property conflicts: %s"
+                    % (uuid, conflicts))
                 return None
 
         return self.attach(store, server, name, uuid, props, exists)

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -127,7 +127,9 @@ class SessionsStore(object):
                     new == str(omero.constants.GLACIER2PORT)):
                 continue
             elif old != new:
-                conflicts += (key + (":%s!=%s;" % (old, new)))
+                if conflicts != "":
+                    conflicts += "; "
+                conflicts += (key + (": %s!=%s" % (old, new)))
         return conflicts
 
     def remove(self, host, name, uuid):

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -129,7 +129,7 @@ class SessionsStore(object):
             elif old != new:
                 if conflicts != "":
                     conflicts += "; "
-                conflicts += (key + (": %s!=%s" % (old, new)))
+                conflicts += "%s: %s!=%s" % (key, old, new)
         return conflicts
 
     def remove(self, host, name, uuid):

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -660,18 +660,15 @@ class TestSessions(object):
         MOCKKEY = "MOCKKEY%s" % uuid.uuid4()
 
         # Try with session when it's still available
-        cli.creates_client(sess=MOCKKEY, new=True)
+        cli.creates_client(sess=MOCKKEY, new=True, port=port)
 
-        conn_args = self.get_conn_args(connection, name=None, port=None)
+        conn_args = self.get_conn_args(connection, name=None, port=port)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
         cli.set_client(None)  # Forcing new instance
         cli.creates_client(sess=MOCKKEY, new=False)
         conn_args = self.get_conn_args(connection, port=port)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
 
-    def assert5975(self, key, cli):
-        host, name, uuid, port = cli.STORE.get_current()
-        assert key != name
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     def test5975(self, connection):
@@ -684,10 +681,12 @@ class TestSessions(object):
         cli.creates_client(sess=key, new=True)
         conn_args = self.get_conn_args(connection, name=None)
         cli.invoke(["s", "login", "-k", "%s" % key] + conn_args)
-        self.assert5975(key, cli)
+        host, name, uuid, port = cli.STORE.get_current()
+        assert key != name
 
         cli.invoke("s logout")
-        self.assert5975(key, cli)
+        host, name, uuid, port = cli.STORE.get_current()
+        assert key != name
 
 
 class TestParseConn(object):

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -519,7 +519,7 @@ class TestSessions(object):
     @pytest.mark.parametrize('port', [
         (None, 14064), (14064, None), (4064, None), (4064, 14064)])
     @pytest.mark.parametrize('group', [None, "mygroup"])
-    def testSessionReattachFailsPort(self, connection, port, group):
+    def testSessionReattachFailsPort(self, connection, port, group, capsys):
         """
         Test session re-attachment with a wrong port fails
         """
@@ -539,12 +539,15 @@ class TestSessions(object):
             connection, name=None, port=port[1], group=group)
         with pytest.raises(NonZeroReturnCode):
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
+        out, err = capsys.readouterr()
+        msg = 'Skipping %s due to conflicts: omero.port:%s!=%s;'
+        assert err.splitlines()[-2] == msg % (MOCKKEY, port[0], port[1])
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     @pytest.mark.parametrize('port', [None, 4064, 14064])
     @pytest.mark.parametrize('group', [
         (None, "mygroup"), ("mygroup", None), ("mygroup", "mygroup2")])
-    def testSessionReattachFailsGroup(self, connection, port, group):
+    def testSessionReattachFailsGroup(self, connection, port, group, capsys):
         """
         Test session re-attachment with a wrong group fails
         """
@@ -564,6 +567,9 @@ class TestSessions(object):
             connection, name=None, port=port, group=group[1])
         with pytest.raises(NonZeroReturnCode):
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
+        out, err = capsys.readouterr()
+        msg = 'Skipping %s due to conflicts: omero.group:%s!=%s;'
+        assert err.splitlines()[-2] == msg % (MOCKKEY, group[0], group[1])
 
     @pytest.mark.parametrize('port', [None, 4064])
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -465,6 +465,25 @@ class TestSessions(object):
 
         del cli
 
+    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize('port', [None, 4064, 14064])
+    def testSessionReattachWorks(self, connection, port):
+        """
+        Test session re-attachment
+        """
+        cli = MyCLI()
+        MOCKKEY = "%s" % uuid.uuid4()
+
+        # Connect using the session key (create a local session file)
+        cli.creates_client(sess=MOCKKEY, port=port)
+        key_conn_args = self.get_conn_args(connection, name=None, port=port)
+        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
+
+        # Force new CLI instance using the same connection arguments
+        cli.set_client(None)
+        cli.creates_client(sess=MOCKKEY, new=False)
+        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
+
     @pytest.mark.parametrize('port', [None, 4064])
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     def testCopiedSessionWorks(self, connection, port):

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -289,6 +289,7 @@ class TestStore(object):
 class TestSessions(object):
 
     CONNECTION_TYPES = ["string", "prefixed_string", "options"]
+    ALL_PORTS = [None, 4064, 14064]
     # The following attributes define list of tuples for testing session
     # re-attachment.
     # The first element of each tuple correspond to the value stored in the
@@ -497,7 +498,7 @@ class TestSessions(object):
         del cli
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', [None, 4064, 14064])
+    @pytest.mark.parametrize('port', ALL_PORTS)
     @pytest.mark.parametrize('group', [None, "mygroup"])
     def testSessionReattachSameArguments(self, connection, port, group):
         """
@@ -541,7 +542,7 @@ class TestSessions(object):
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', [None, 4064, 14064])
+    @pytest.mark.parametrize('port', ALL_PORTS)
     @pytest.mark.parametrize('group', [None, "mygroup"])
     def testSessionReattachServerMismatch(self, connection, port, group):
         """
@@ -592,7 +593,7 @@ class TestSessions(object):
         assert err.splitlines()[-2] == msg % (MOCKKEY, port[0], port[1])
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', [None, 4064, 14064])
+    @pytest.mark.parametrize('port', ALL_PORTS)
     @pytest.mark.parametrize('group', CONFLICTING_GROUPS)
     def testSessionReattachFailsGroup(self, connection, port, group, capsys):
         """
@@ -648,7 +649,7 @@ class TestSessions(object):
         assert err.splitlines()[-2] == msg % (
             MOCKKEY, group[0], group[1], port[0], port[1])
 
-    @pytest.mark.parametrize('port', [None, 4064])
+    @pytest.mark.parametrize('port', ALL_PORTS)
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     def testCopiedSessionWorks(self, connection, port):
         """


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-April/005225.html

This PR does not modify the existing behavior/limitations of the CLI sessions rejoining logic but extends the unit test coverage for session key-based connection in preparation of future improvements/bug fixes. 

Summary of main changes:
- unit tests are added to cover multiple scenarios of session re-attachments (with/without port/group properties). The stored/passed properties are stored as tuples of the test class for clarity.
- the error message in the case of conflicting properties is reviewed and promoted to `self.ctx.err()` level so that it appears more systematically for debugging purposes /cc @PaulVanSchayck

To test this PR:
- check all the unit tests are passing
- try a conflicting property scenario for session rejoining and check the conflicting message is displayed by default and is sensible