### PR TITLE
Metadata panel followup

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -4471,13 +4471,25 @@ class EditorModel
     }
     
     /**
-     * Returns <code>true</code> if the file is an inplace import <code>false</code> otherwise.
+     * Returns the {@link ImportType}
      * @return See above.
      */
-    boolean isInplaceImport() {
-    	StructuredDataResults data = parent.getStructuredData();
-		if (data == null) return false;
-    	return CollectionUtils.isNotEmpty(data.getTransferLinks());
+    ImportType getImportType() {
+        StructuredDataResults data = parent.getStructuredData();
+        if (data != null) {
+            Collection<AnnotationData> tfl = data.getTransferLinks();
+            if (tfl != null) {
+                for (AnnotationData an : tfl) {
+                    if (AnnotationData.FILE_TRANSFER_NS.equals(an
+                            .getNameSpace())) {
+                        String content = an.getContent().toString();
+                        return ImportType.getImportType(content);
+                    }
+                }
+            }
+        }
+        // if nothing's specified it's the default UPLOAD import type
+        return ImportType.UPLOAD;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImportType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImportType.java
@@ -1,0 +1,102 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.metadata.editor;
+
+/**
+ * Enum to indicate the import type
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @since 5.1
+ */
+
+public enum ImportType {
+    
+    /** Copy */
+    COPY("ome.formats.importer.transfers.CopyFileTransfer", "cp"),
+    
+    /** Copy and remove source*/
+    COPYREMOVE("ome.formats.importer.transfers.CopyMoveFileTransfer", "cp_rm"),
+    
+    /** Soft link to file (file is *not* in data repository)*/
+    SOFTLINK("ome.formats.importer.transfers.SymlinkFileTransfer", "ln_s"), 
+    
+    /** Hard link to file */
+    HARDLINK("ome.formats.importer.transfers.HardlinkFileTransfer", "ln"),
+    
+    /** Hard link and remove source */
+    HARDLINKREMOVE("ome.formats.importer.transfers.MoveFileTransfer", "ln_rm"),
+    
+    /** Upload */
+    UPLOAD("ome.formats.importer.transfers.UploadFileTransfer", ""),
+    
+    /** Upload and remove source */
+    UPLOADREMOVE("ome.formats.importer.transfers.UploadRmFileTransfer", "upload_rm"),
+    
+    UNKNOWN("", "");
+    
+    /** The name of the ImportType */
+    String name = "";
+
+    /** The symbol (i. e. --transfer option used for import) */
+    String symbol = "";
+
+    ImportType() {
+    }
+
+    ImportType(String name, String symbol) {
+        this.name = name;
+        this.symbol = symbol;
+    }
+
+    /**
+     * Get the name of the ImportType
+     * 
+     * @return See above
+     */
+    public String getName() {
+        return name;
+    }
+    
+    /**
+     * Get the symbol (i. e. --transfer option used for import)
+     * 
+     * @return See above
+     */
+    public String getSymbol() {
+        return symbol;
+    }
+
+    /**
+     * Determines the ImportType by name
+     * 
+     * @param name
+     *            The name
+     * @return See above
+     */
+    public static ImportType getImportType(String name) {
+        for (ImportType t : ImportType.values())
+            if (t.getName().equals(name))
+                return t;
+        return UNKNOWN;
+    }
+    
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -158,7 +158,7 @@ public class PropertiesUI
     /** Maximum number of characters shown per line in the
      *  channel names component
      */
-    private static final int MAX_CHANNELNAMES_LENGTH_IN_CHARS = 100;
+    private static final int MAX_CHANNELNAMES_LENGTH_IN_CHARS = 40;
     
     /** Button to edit the name. */
 	private JToggleButton				editName;
@@ -869,9 +869,7 @@ public class PropertiesUI
         content.add(roiCountLabel, c);
         loadROICount(image);
         
-    	JPanel p = UIUtilities.buildComponentPanel(content);
-    	p.setBackground(UIUtilities.BACKGROUND_COLOR);
-        return p;
+        return content;
     }
     
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -748,7 +748,7 @@ public class PropertiesUI
 		c.fill = GridBagConstraints.NONE;
 		c.weightx = 1;
 		c.anchor = GridBagConstraints.NORTHWEST;
-		c.insets = new Insets(0, 2, 2, 2);
+		c.insets = new Insets(0, 0, 2, 2);
 		c.gridy = 0;
 		c.gridx = 0;
     	JLabel l = new JLabel();
@@ -780,8 +780,8 @@ public class PropertiesUI
         	content.add(value, c);
         	c.gridy++; 
 		} catch (Exception e) {
-			
 		}
+    	
     	label = UIUtilities.setTextFont(EditorUtil.XY_DIMENSION+":", Font.BOLD,
     			size);
     	value = UIUtilities.createComponent(null);
@@ -1064,8 +1064,10 @@ public class PropertiesUI
 			Timestamp crDate = dob.getCreated();
 			if (crDate != null) {
 				JLabel createDateLabel = new JLabel();
+				Font font = createDateLabel.getFont();
+                int size = font.getSize()-2;
 				createDateLabel.setFont((new JLabel()).getFont().deriveFont(
-						Font.BOLD));
+						Font.BOLD, size));
 				createDateLabel.setText(CREATIONDATE_TEXT
 						+ UIUtilities.formatDefaultDate(crDate));
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1058,6 +1058,7 @@ public class PropertiesUI
 		} else if (refObject instanceof DatasetData
 				|| refObject instanceof ProjectData
 				|| refObject instanceof PlateData
+				|| refObject instanceof PlateAcquisitionData
 				|| refObject instanceof ScreenData) {
 			DataObject dob = (DataObject) refObject;
 			

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -31,6 +31,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -51,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -1062,19 +1064,25 @@ public class PropertiesUI
 			
 			Timestamp crDate = dob.getCreated();
 			if (crDate != null) {
-				JLabel createDateLabel = new JLabel();
-				Font font = createDateLabel.getFont();
-                int size = font.getSize()-2;
-				createDateLabel.setFont((new JLabel()).getFont().deriveFont(
-						Font.BOLD, size));
-				createDateLabel.setText(CREATIONDATE_TEXT
-						+ UIUtilities.formatDefaultDate(crDate));
+                JLabel createDateLabel = new JLabel();
+                Font font = createDateLabel.getFont();
+                int size = font.getSize() - 2;
+                createDateLabel.setFont((new JLabel()).getFont().deriveFont(
+                        Font.BOLD, size));
+                createDateLabel.setText(CREATIONDATE_TEXT);
 
-				JPanel p = UIUtilities.buildComponentPanel(createDateLabel, 0,
-						0);
-				p.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-				p.setBackground(UIUtilities.BACKGROUND_COLOR);
-				add(p);
+                JLabel createDateValue = new JLabel();
+                createDateValue.setFont((new JLabel()).getFont().deriveFont(
+                        Font.PLAIN, size));
+                createDateValue.setText(UIUtilities.formatDefaultDate(crDate));
+
+                JPanel p = new JPanel();
+                p.setLayout(new GridLayout(1, 2));
+                p.add(createDateLabel);
+                p.add(createDateValue);
+                p.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+                p.setBackground(UIUtilities.BACKGROUND_COLOR);
+                add(p);
 			}
 		}
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TextualAnnotationComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TextualAnnotationComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.TextualAnnotationComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -123,7 +123,7 @@ class TextualAnnotationComponent
         area.setText(data.getText());
         area.setAllowOneClick(true);
         area.addPropertyChangeListener(this);
-        //area.wrapText(getSize().width);
+        area.setWrapWord(true);
         addComponentListener(new ComponentAdapter() {
 
 			public void componentResized(ComponentEvent e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -746,7 +746,7 @@ class ToolBar
         void displayFileset() {
             SwingUtilities.convertPointToScreen(location, component);
             FilesetInfoDialog d = new FilesetInfoDialog();
-            d.setData(model.getFileset(), model.isInplaceImport());
+            d.setData(model.getFileset(), model.getImportType());
             d.pack();
             if (location != null) {
                 location = new Point(location.x - d.getSize().width,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
@@ -35,6 +35,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.openmicroscopy.shoola.agents.metadata.editor.ImportType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.tdialog.TinyDialog;
 
@@ -66,10 +67,10 @@ public class FilesetInfoDialog extends TinyDialog {
      * 
      * @param set
      *            The fileset which paths should be shown
-     * @param inPlaceImport
-     *            Flag if this is an inplace import
+     * @param importType
+     *            The import type
      */
-    public void setData(Set<FilesetData> set, boolean inPlaceImport) {
+    public void setData(Set<FilesetData> set, ImportType importType) {
         if (set == null)
             return;
 
@@ -100,24 +101,26 @@ public class FilesetInfoDialog extends TinyDialog {
             content.add(sep, c);
             c.gridy++;
 
-            String header = inPlaceImport ? "Imported with <b>--transfer=ln</b> from:" : "Imported from:";
+            String header = (importType == ImportType.HARDLINK || importType == ImportType.SOFTLINK) ? "Imported with <b>--transfer="
+                    + importType.getSymbol() + "</b> from:"
+                    : "Imported from:";
+            
             ExpandableTextPane t1 = new ExpandableTextPane();
             t1.setBackground(UIUtilities.BACKGROUND_COLOR);
-            t1.setText(header+"<br/>"+getOriginPaths(set));
+            t1.setText(header + "<br/>" + getOriginPaths(set));
             content.add(t1, c);
             c.gridy++;
 
-            if (!inPlaceImport) {
-                JSeparator sep2 = new JSeparator(JSeparator.HORIZONTAL);
-                sep2.setBackground(UIUtilities.BACKGROUND_COLOR);
-                content.add(sep2, c);
-                c.gridy++;
+            JSeparator sep2 = new JSeparator(JSeparator.HORIZONTAL);
+            sep2.setBackground(UIUtilities.BACKGROUND_COLOR);
+            content.add(sep2, c);
+            c.gridy++;
 
-                ExpandableTextPane t2 = new ExpandableTextPane();
-                t2.setBackground(UIUtilities.BACKGROUND_COLOR);
-                t2.setText("Path on server:<br/>"+getServerPaths(set));
-                content.add(t2, c);
-            }
+            ExpandableTextPane t2 = new ExpandableTextPane();
+            t2.setBackground(UIUtilities.BACKGROUND_COLOR);
+            t2.setText("Path on server:<br/>" + getServerPaths(set));
+            content.add(t2, c);
+            
         }
 
         setCanvas(new JScrollPane(content));

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2465,13 +2465,19 @@ public class EditorUtil
     {
         String date = "";
         Timestamp time = null;
-        if (object == null) return date;
+        if (object == null) 
+            return date;
+        
         if (object instanceof AnnotationData)
             time = ((AnnotationData) object).getLastModified();
         else if (object instanceof ImageData)
             time = getAcquisitionTime((ImageData) object);
-        else time = object.getCreated();
-        if (time != null) date = UIUtilities.formatDefaultDate(time);
+        else 
+            time = object.getCreated();
+        
+        if (time != null && time.getTime()>0) 
+            date = UIUtilities.formatDefaultDate(time);
+        
         return date;
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiComponent.java
@@ -505,15 +505,15 @@ public class OMEWikiComponent
 	 */
 	public void wrapText(int width, String newLineStr)
 	{
-		if (!wrapWord || pane == null) return;
+		if (pane == null) 
+		    return;
 		String value = getText();
 		if (value == null) return;
 		value = prepare(value, false);
 		FontMetrics fm = getFontMetrics(getFont());
 		int charWidth = fm.charWidth('m');
 		columns = (int) (1.5 * width) / charWidth;
-		setText(CommonsLangUtils.wrap(value, columns, newLineStr, false));
-
+		setText(CommonsLangUtils.wrap(value, columns, newLineStr, wrapWord));
 	}
 	
 	/**


### PR DESCRIPTION
Fixes some issues with the metadata panel:
- Use same font style for "creation date" label as for "acquisition date", "creation date", etc. **Test: Check font style of the "creation date" label**
- Show "creation date" also for plate runs (PlateAcquisitions) **Test: Make sure "creation date" label is shown for plate runs**
- FilesetInfoDialog (accessed via the "../../" icon) now shows the real inplace import option used (ln or ln_s) **Test: Import an image with `--transfer=ln_s` and one with `transfer=ln` and check that these options are shown in the FilesetInfoDialog**
- Reduced the linebreak threshold for channel names; long channel names and/or images with many channels made the channel names label quite big, so you heavily had to use the horizontal scrollbar. **Test: Open an image with lots of channels or one with very long channel names; make sure this does not spoil the metadata panel layout**
- Wrap long comments regardless of whitespaces; if a comment had a very long text string without whitespace, it was not broken into several lines and like the previous point, caused the appearance of the very long horizontal scrollbar. **Test: Add a very long text string (without white spaces) as comment; make sure this does not spoil the metadata panel layout**
- Avoid showing acquisition date "1970-01-01" if timestamp is zero. **Test: Open an image which has an acquisition date, but with value zero; make sure acquisition date label is not shown; unfortunately I can't remember which file I used for testing. Is it possible to create an artificial one?**

