### PR TITLE
Edit root user

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -526,8 +526,11 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                 institution = form.cleaned_data['institution']
                 admin = form.cleaned_data['administrator']
                 active = form.cleaned_data['active']
-                if experimenter.getId() == conn.getUserId():
-                    active = True   # don't allow user to disable themselves!
+                rootId = conn.getAdminService().getSecurityRoles().rootId
+                # User can't disable themselves or 'root'
+                if experimenter.getId() in [conn.getUserId(), rootId]:
+                    # disabled checkbox not in POST: do it manually
+                    active = True
                 defaultGroup = form.cleaned_data['default_group']
                 otherGroups = form.cleaned_data['other_groups']
 


### PR DESCRIPTION
See: http://trac.openmicroscopy.org/ome/ticket/12821

When another admin is editing 'root' user, the "Active" checkbox is disabled (since you can't disabled 'root'). But in the form handling, the disabled checkbox is ignored, so this was trying to disable 'root' and gives a security violation.
Now we manually check if we're editing 'root' and don't try to disable if we are.
To test:
 - Log in as an admin (not 'root') and make any change to root user and submit the form. Should see no exception. Check save has worked.