### PR TITLE
Use try/catch to test for access to window.opener

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1322,7 +1322,17 @@
 
 
     // Check the Parent window for Previous / Next images...
-    if (window.opener && window.opener.$) {
+    parentWindow = false;
+    try {
+      // might get permission exception if window was opened from another website
+      if (window.opener && window.opener.$) {
+        parentWindow = true;
+      }
+    }
+    catch(err) {
+      console.log("window.opener not accessible");
+    }
+    if (parentWindow) {
       var $currentImg = window.opener && window.opener.$("#image_icon-{{ image.id }}"),
           prevImgId, nextImgId;
       if ($currentImg.length === 1) {


### PR DESCRIPTION
This fixes issue mentioned at https://github.com/openmicroscopy/openmicroscopy/commit/583a5facc3e2c2323369d41c468a6b6e3dee48b8#commitcomment-10645482

NB: you can see this bug on nightshade by trying the image viewer popup at http://www.lifesci.dundee.ac.uk/gre/staff/professor-jason-swedlow-frse

To test, you need to have a window open viewer at another site.

E.g. log in to nightshade, open an image viewer, copy the url and use it to create an html file like this (replace the url), save locally "test.html" then open test.html in a browser and click the link.

```
<html>
<a href="#" onClick="window.open('http://localhost:4080/webclient/img_detail/6702/'); return false;">Open Viewer</a>
</html>
```

Should see the image viewer working OK.