### PR TITLE
remove concurrent hashmap

### DIFF
--- a/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
+++ b/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
@@ -9,7 +9,6 @@ package ome.services.blitz.fire;
 
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -32,7 +31,6 @@ import ome.security.SecuritySystem;
 import ome.services.blitz.impl.ServiceFactoryI;
 import ome.services.blitz.util.ConvertToBlitzExceptionMessage;
 import ome.services.blitz.util.FindServiceFactoryMessage;
-import ome.services.blitz.util.RegisterServantMessage;
 import ome.services.blitz.util.UnregisterServantMessage;
 import ome.services.messages.DestroySessionMessage;
 import ome.services.sessions.SessionManager;

--- a/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
+++ b/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 
 import com.google.common.cache.Cache;
@@ -39,6 +38,7 @@ import ome.services.util.Executor;
 import ome.system.OmeroContext;
 import ome.system.Principal;
 import ome.system.Roles;
+import ome.util.messages.InternalMessage;
 import ome.util.messages.MessageException;
 
 import omero.ApiUsageException;
@@ -62,7 +62,7 @@ import omero.util.ServantHolder;
  * @since 3.0-Beta2
  */
 public final class SessionManagerI extends Glacier2._SessionManagerDisp
-        implements ApplicationContextAware, ApplicationListener {
+        implements ApplicationContextAware, ApplicationListener<InternalMessage> {
 
     /**
      * "ome.security.basic.BasicSecurityWiring" <em>may</em> be replaced by
@@ -286,7 +286,7 @@ public final class SessionManagerI extends Glacier2._SessionManagerDisp
     // Listener
     // =========================================================================
 
-    public void onApplicationEvent(ApplicationEvent event) {
+    public void onApplicationEvent(InternalMessage event) {
         try {
             if (event instanceof UnregisterServantMessage) {
                 UnregisterServantMessage msg = (UnregisterServantMessage) event;

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -21,11 +21,15 @@ import java.util.Map;
 import java.util.List;
 import java.util.HashMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.Advised;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import Ice.Current;
 
@@ -126,8 +130,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
      * invoked with the integer lookup to this map, in which case the instance
      * will be purged.
      */
-    private ConcurrentHashMap<Integer, UploadState> uploaders
-        = new ConcurrentHashMap<Integer, UploadState>();
+    private final Cache<Integer, UploadState> uploaders = CacheBuilder.newBuilder().build();
 
     /**
      * Handle which is the initial first step of import.
@@ -202,7 +205,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
     // ICE INTERFACE METHODS
     //
 
-    public RawFileStorePrx getUploader(int i, Current current)
+    public RawFileStorePrx getUploader(final int i, Current current)
             throws ServerError {
 
         String mode = null;
@@ -213,35 +216,34 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
             }
         }
 
-        UploadState state = uploaders.get(i);
-        if (state != null) {
-            return state.prx; // EARLY EXIT!
-        }
-
-        final String path = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
-
-        boolean success = false;
-        RawFileStorePrx prx = repo.file(path, mode, this.current);
-        registerCallback(prx, i);
+        final String applicableMode = mode;
+        final Callable<UploadState> rfsOpener = new Callable<UploadState>() {
+            @Override
+            public UploadState call() throws ServerError {
+                final String path = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
+                final RawFileStorePrx prx = repo.file(path, applicableMode, ManagedImportProcessI.this.current);
+                try {
+                    registerCallback(prx, i);
+                } catch (RuntimeException re) {
+                    try {
+                        prx.close();  // close if anything happens
+                    } catch (Exception e) {
+                        log.error("Failed to close RawFileStorePrx", e);
+                    }
+                    throw re;
+                }
+                return new UploadState(prx);
+            }
+        };
 
         try {
-            state = new UploadState(prx); // Overwrite
-            if (uploaders.putIfAbsent(i, state) != null) {
-                // The new object wasn't used.
-                // Close it.
-                prx.close();
-                prx = null;
+            return uploaders.get(i, rfsOpener).prx;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
             } else {
-                success = true;
-            }
-            return prx;
-        } finally {
-            if (!success && prx != null) {
-                try {
-                    prx.close(); // Close if anything happens.
-                } catch (Exception e) {
-                    log.error("Failed to close RawFileStorePrx", e);
-                }
+                /* there are no checked exceptions to worry about, so this cannot happen */
+                return null;
             }
         }
     }
@@ -339,8 +341,8 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
     // GETTERS
     //
 
-    public long getUploadOffset(int i, Current ignore) throws ServerError {
-        UploadState state = uploaders.get(i);
+    public long getUploadOffset(int idx, Current ignore) throws ServerError {
+        final UploadState state = uploaders.getIfPresent(idx);
         if (state == null) {
             return 0;
         }
@@ -356,7 +358,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
     //
 
     public void setOffset(int idx, long offset) {
-        UploadState state = uploaders.get(idx);
+        final UploadState state = uploaders.getIfPresent(idx);
         if (state == null) {
             log.warn(String.format("setOffset(%s, %s) - no such object", idx, offset));
         } else {
@@ -366,10 +368,11 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
     }
 
     public void closeCalled(int idx) {
-        UploadState state = uploaders.remove(idx);
+        final UploadState state = uploaders.getIfPresent(idx);
         if (state == null) {
             log.warn(String.format("closeCalled(%s) - no such object", idx));
         } else {
+            uploaders.invalidate(idx);
             log.debug(String.format("closeCalled(%s) successfully", idx));
         }
     }

--- a/components/blitz/src/omero/cmd/HandleI.java
+++ b/components/blitz/src/omero/cmd/HandleI.java
@@ -14,10 +14,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import ome.api.local.LocalAdmin;
 import ome.conditions.InternalException;
 import ome.services.util.Executor;
-import ome.system.EventContext;
 import ome.system.Principal;
 import ome.system.ServiceFactory;
 import ome.util.SqlAction;

--- a/components/blitz/src/omero/cmd/HandleI.java
+++ b/components/blitz/src/omero/cmd/HandleI.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,6 +28,8 @@ import org.hibernate.Session;
 import org.perf4j.StopWatch;
 import org.perf4j.slf4j.Slf4JStopWatch;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.collect.MapMaker;
 
 import Ice.Current;
 import Ice.Identity;
@@ -62,6 +63,8 @@ public class HandleI implements _HandleOperations, IHandle,
 
     private static final long serialVersionUID = 15920349984928755L;
 
+    private static final MapMaker mapMaker = new MapMaker();
+
     /**
      * Timeout in seconds that cancellation should wait.
      */
@@ -70,8 +73,7 @@ public class HandleI implements _HandleOperations, IHandle,
     /**
      * Callbacks that have been added by clients.
      */
-    private final ConcurrentHashMap<String, CmdCallbackPrx> callbacks =
-        new ConcurrentHashMap<String, CmdCallbackPrx>();
+    private final Map<String, CmdCallbackPrx> callbacks = mapMaker.makeMap();
 
     /**
      * State-diagram location. This instance is also used as a lock around

--- a/components/common/src/ome/system/PreferenceContext.java
+++ b/components/common/src/ome/system/PreferenceContext.java
@@ -51,8 +51,6 @@ public class PreferenceContext extends PropertyPlaceholderConfigurer {
     private final Map<String, Preference> preferences = new MapMaker().makeMap();
 
     private PropertyPlaceholderHelper helper;
-    
-    private String path;
 
     /**
      * By default, configures this instance for

--- a/components/common/src/ome/system/PreferenceContext.java
+++ b/components/common/src/ome/system/PreferenceContext.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +22,8 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
+
+import com.google.common.collect.MapMaker;
 
 /**
  * Central configuration for OMERO properties from (in order):
@@ -47,7 +48,7 @@ public class PreferenceContext extends PropertyPlaceholderConfigurer {
 
     private final static Logger log = LoggerFactory.getLogger(PreferenceContext.class);
 
-    final private Map<String, Preference> preferences = new ConcurrentHashMap<String, Preference>();
+    private final Map<String, Preference> preferences = new MapMaker().makeMap();
 
     private PropertyPlaceholderHelper helper;
     

--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -284,7 +284,7 @@ implements java.io.Serializable, IObject
 #if(!${type.immutable} && !${type.superclass})
     public final static String VERSION = "${type.id}_version";
 
-    protected Integer version = new Integer(0);
+    protected Integer version = 0;
 
    /**
     * This version number is controlled by the database for optimisitic

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/UnitBarSizeDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/UnitBarSizeDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.util.UnitBarSizeDialog
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -74,10 +74,10 @@ public class UnitBarSizeDialog
     private void handleSelection()
     {
         try {
-            double val = Double.parseDouble(label.getText());
+            final Double val = Double.valueOf(label.getText());
             if (val > 0) {
-                firePropertyChange(UNIT_BAR_VALUE_PROPERTY, new Double(0), 
-                                    new Double(val));
+                firePropertyChange(UNIT_BAR_VALUE_PROPERTY, Double.valueOf(0), 
+                                   val);
                 setVisible(false);
                 dispose();
             } else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.view.IntensityView 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -576,7 +576,7 @@ class IntensityView
 			if (x >= sizeX || y >= sizeY) continue;
 			
 			if (pixels.containsKey(point)) value = entry.getValue();
-			else value = new Double(0);
+			else value = 0.0;
 			data[x][y] = value;
 		}
 		tableModel = new IntensityModel(data);
@@ -795,7 +795,7 @@ class IntensityView
 			if (x >= sizeX || y >= sizeY) continue;
 			
 			if (pixels.containsKey(point)) value = entry.getValue();
-			else value = new Double(0);
+			else value = 0.0;
 			data[x][y] = value;
 		}
 		tableModel = new IntensityModel(data);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1582,10 +1582,10 @@ public class EditorUtil
         LinkedHashMap<String, Object>
         details = new LinkedHashMap<String, Object>(4);
         List<String> notSet = new ArrayList<String>();
-        details.put(TEMPERATURE, new Double(0));
-        details.put(AIR_PRESSURE, new Double(0));
-        details.put(HUMIDITY, new Double(0));
-        details.put(CO2_PERCENT, new Double(0));
+        details.put(TEMPERATURE, Double.valueOf(0));
+        details.put(AIR_PRESSURE, Double.valueOf(0));
+        details.put(HUMIDITY, Double.valueOf(0));
+        details.put(CO2_PERCENT, Double.valueOf(0));
 
         if (data == null) {
             notSet.add(TEMPERATURE);
@@ -1654,9 +1654,9 @@ public class EditorUtil
         details = new LinkedHashMap<String, Object>(4);
         List<String> notSet = new ArrayList<String>();
         details.put(NAME, "");
-        details.put(POSITION_X, new Double(0));
-        details.put(POSITION_Y, new Double(0));
-        details.put(POSITION_Z, new Double(0));
+        details.put(POSITION_X, Double.valueOf(0));
+        details.put(POSITION_Y, Double.valueOf(0));
+        details.put(POSITION_Z, Double.valueOf(0));
 
         if (data == null) {
             notSet.add(NAME);
@@ -1899,7 +1899,7 @@ public class EditorUtil
         List<String> notSet = (List) m.get(NOT_SET);
         m.remove(NOT_SET);
         details.putAll(m);
-        details.put(ATTENUATION, new Double(0));
+        details.put(ATTENUATION, Double.valueOf(0));
         if (data == null) {
             details.put(WAVELENGTH, Float.valueOf(0));
             notSet.add(ATTENUATION);
@@ -1955,7 +1955,7 @@ public class EditorUtil
         details.put(SERIAL_NUMBER, "");
         details.put(LOT_NUMBER, "");
         details.put(LIGHT_TYPE, "");
-        details.put(POWER, new Double(0));
+        details.put(POWER, Double.valueOf(0));
         details.put(TYPE, "");
         if (data == null) {
             notSet.add(MODEL);
@@ -2101,10 +2101,10 @@ public class EditorUtil
         details.put(SERIAL_NUMBER, "");
         details.put(LOT_NUMBER, "");
         details.put(TYPE, "");
-        details.put(GAIN, new Double(0));
-        details.put(VOLTAGE, new Double(0));
-        details.put(OFFSET, new Double(0));
-        details.put(ZOOM, new Double(0));
+        details.put(GAIN, Double.valueOf(0));
+        details.put(VOLTAGE, Double.valueOf(0));
+        details.put(OFFSET, Double.valueOf(0));
+        details.put(ZOOM, Double.valueOf(0));
         details.put(AMPLIFICATION, "");
         List<String> notSet = new ArrayList<String>();
         if (data == null) {
@@ -2207,7 +2207,7 @@ public class EditorUtil
         List<String> notSet = (List) m.get(NOT_SET);
         m.remove(NOT_SET);
         details.putAll(m);
-        details.put(READ_OUT_RATE, new Double(0));
+        details.put(READ_OUT_RATE, Double.valueOf(0));
         details.put(BINNING, "");
         if (data == null) {
             notSet.add(READ_OUT_RATE);
@@ -2284,12 +2284,12 @@ public class EditorUtil
     {
         LinkedHashMap<String, Object>
         details = new LinkedHashMap<String, Object>(4);
-        details.put(DELTA_T, new Double(0));
-        details.put(EXPOSURE_TIME, new Double(0));
-        details.put(POSITION_X, new Double(0));
-        details.put(POSITION_Y, new Double(0));
-        details.put(POSITION_Z, new Double(0));
-        List<String> notSet = new ArrayList<String>();
+        details.put(DELTA_T, Double.valueOf(0));
+        details.put(EXPOSURE_TIME, Double.valueOf(0));
+        details.put(POSITION_X, Double.valueOf(0));
+        details.put(POSITION_Y, Double.valueOf(0));
+        details.put(POSITION_Z, Double.valueOf(0));
+        final List<String> notSet = new ArrayList<String>(5);
         notSet.add(DELTA_T);
         notSet.add(EXPOSURE_TIME);
         notSet.add(POSITION_X);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/config/RegistryImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/config/RegistryImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.config.RegistryImpl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -25,7 +25,6 @@ package org.openmicroscopy.shoola.env.config;
 
 //Java imports
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 //Third-party libraries
 
@@ -42,6 +41,8 @@ import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.log.Logger;
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+
+import com.google.common.collect.MapMaker;
 
 /** 
  * Implements the <code>Registry</code> interface. 
@@ -69,7 +70,7 @@ class RegistryImpl
 {
     
     /** The name-value map. */
-    private Map<String, Object>	entriesMap;
+    private final Map<String, Object> entriesMap = new MapMaker().makeMap();
     
     /** Reference to container's service. */
     private EventBus                eb;
@@ -98,11 +99,8 @@ class RegistryImpl
     /** Reference to the Cache service. */
     private CacheService			cache;
     
-    /** Creates an empty map. */
-    RegistryImpl()
-    {
-        entriesMap = new ConcurrentHashMap<String, Object>();
-    }
+    /* may be constructed only by classes in this package */
+    RegistryImpl() { }
     
 	/** 
      * Implemented as specified by {@link Registry}. 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/Connector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/Connector.java
@@ -33,12 +33,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.MapMaker;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
@@ -162,7 +166,7 @@ class Connector
      * TODO: this should be reviewed, since if getConnector(String) is used
      * outside of the import process there could be a race condition.
      */
-    private final ConcurrentHashMap<String, Connector> derived;
+    private final Cache<String, Connector> derived;
 
     /** The name of the group. To be removed when we can use groupId.*/
     private String groupName;
@@ -190,12 +194,12 @@ class Connector
      * @param encrypted The entry point to access the various services.
      * @param logger Reference to the logger.
      * @param elapseTime The time between network check.
-     * @throws Throwable Thrown if entry points cannot be initialized.
+     * @throws Exception Thrown if entry points cannot be initialized.
      */
     Connector(SecurityContext context, client secureClient,
             ServiceFactoryPrx entryEncrypted, boolean encrypted, Logger logger,
             Integer elapseTime)
-                    throws Throwable
+                    throws Exception
     {
         if (context == null)
             throw new IllegalArgumentException("No Security context.");
@@ -217,15 +221,16 @@ class Connector
         this.secureClient = secureClient;
         this.entryEncrypted = entryEncrypted;
         this.context = context;
-        statelessServices = new ConcurrentHashMap<String, ServiceInterfacePrx>();
-        importStores = new ConcurrentHashMap<OMEROMetadataStoreClient, String>();
+        final MapMaker mapMaker = new MapMaker();
+        statelessServices = mapMaker.makeMap();
+        importStores = mapMaker.makeMap();
         statefulServices = Multimaps.<String, StatefulServiceInterfacePrx>
         synchronizedMultimap(
                 HashMultimap.<String, StatefulServiceInterfacePrx>create());
         reServices = Multimaps.<Long, RenderingEnginePrx>
         synchronizedMultimap(
                 HashMultimap.<Long, RenderingEnginePrx>create());
-        derived = new ConcurrentHashMap<String, Connector>();
+        derived = CacheBuilder.newBuilder().build();
     }
 
     //
@@ -628,19 +633,15 @@ class Connector
     void closeDerived(boolean networkup)
             throws Throwable
     {
-        Collection<Connector> list = derived.values();
-        Iterator<Connector> i = list.iterator();
-        while (i.hasNext()) {
-            Connector c = null;
+        for (final Connector c : derived.asMap().values()) {
             try {
-                c = i.next();
                 c.close(networkup);
             } catch (Throwable e) {
                 log(String.format("Failed to close(%s) service: %s",
                         networkup, c));
             }
         }
-        derived.clear();
+        derived.invalidateAll();
     }
 
     /** 
@@ -840,43 +841,35 @@ class Connector
      * @param userName The name of the user. To be replaced by user's id.
      * @return See above.
      */
-    Connector getConnector(String userName)
+    Connector getConnector(final String userName)
             throws Throwable
     {
         if (CommonsLangUtils.isBlank(userName)) return this;
-        Connector c = derived.get(userName);
-        if (c != null) return c;
-        if (groupName == null) {
-            ExperimenterGroup g = getAdminService().getGroup(
-                    context.getGroupID());
-            groupName = g.getName().getValue();
-        }
-        //Create a connector.
-        Principal p = new Principal();
-        p.group = groupName;
-        p.name = userName;
-        p.eventType = "Sessions";
-        ISessionPrx prx = entryEncrypted.getSessionService();
-        Session session = prx.createSessionWithTimeout(p, 0L);
-        //Create the userSession
-        omero.client client = new omero.client(context.getHostName(),
-                context.getPort());
-        ServiceFactoryPrx userSession = client.createSession(
-                session.getUuid().getValue(), session.getUuid().getValue());
-        c = new Connector(context.copy(), client, userSession,
-                unsecureClient == null, logger, elapseTime);
-        log("Created derived connector: " + userName);
-
-        Connector otherThread = derived.putIfAbsent(userName, c);
-        if (null != otherThread) {
-            // This means that in the mean time someone else has created
-            // another derived connector for this userName. We need to clean
-            // up our instance and return the one from the other thread.
-            c.close(true); // Assuming network up, otherwise create fails
-            c = otherThread;
-            log("Return derived connector from other thread: " + userName);
-        }
-        return c;
+        return derived.get(userName, new Callable<Connector>() {
+            @Override
+            public Connector call() throws Exception {
+                if (groupName == null) {
+                    ExperimenterGroup g = getAdminService().getGroup(
+                            context.getGroupID());
+                    groupName = g.getName().getValue();
+                }
+                //Create a connector.
+                Principal p = new Principal();
+                p.group = groupName;
+                p.name = userName;
+                p.eventType = "Sessions";
+                ISessionPrx prx = entryEncrypted.getSessionService();
+                Session session = prx.createSessionWithTimeout(p, 0L);
+                //Create the userSession
+                omero.client client = new omero.client(context.getHostName(),
+                        context.getPort());
+                ServiceFactoryPrx userSession = client.createSession(
+                        session.getUuid().getValue(), session.getUuid().getValue());
+                final Connector c = new Connector(context.copy(), client, userSession,
+                        unsecureClient == null, logger, elapseTime);
+                log("Created derived connector: " + userName);
+                return c;
+            }});
     }
     //
     // HELPERS

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1,6 +1,6 @@
 /*
  *   $Id$
- *  Copyright 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -768,7 +768,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             
             channelBinding = channelBindings.get(i);
             channelBinding.setFamily(family);
-            channelBinding.setCoefficient(new Double(1));
+            channelBinding.setCoefficient(1.0);
     
             // If we have more than one channel set each of the first three
             // active, otherwise only activate the first.

--- a/components/server/src/ome/security/basic/BasicMethodSecurity.java
+++ b/components/server/src/ome/security/basic/BasicMethodSecurity.java
@@ -11,8 +11,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import ome.annotations.PermitAll;
 import ome.annotations.RolesAllowed;
@@ -42,8 +40,6 @@ public class BasicMethodSecurity implements MethodSecurity {
         boolean permitAll;
     }
 
-    private final Map<Class<?>, Map<Method, Info>> info;
-
     private SessionManager sessionManager;
 
     public BasicMethodSecurity() {
@@ -52,7 +48,6 @@ public class BasicMethodSecurity implements MethodSecurity {
 
     public BasicMethodSecurity(boolean active) {
         this.active = active;
-        info = new ConcurrentHashMap<Class<?>, Map<Method, Info>>();
     }
 
     public void setSessionManager(SessionManager sessionManager) {
@@ -75,7 +70,7 @@ public class BasicMethodSecurity implements MethodSecurity {
         //
         // Map<Method, Info> map = info.get(o.getClass());
         // if (map == null) {
-        // map = new ConcurrentHashMap<Method, Info>();
+        // map = new MapMaker().makeMap();
         // map.put(o.getClass(), map);
         // }
         // Info i = map.get(m);

--- a/components/server/src/ome/security/basic/BasicMethodSecurity.java
+++ b/components/server/src/ome/security/basic/BasicMethodSecurity.java
@@ -79,7 +79,7 @@ public class BasicMethodSecurity implements MethodSecurity {
         // }
         //        
         try {
-            Class c = o.getClass(); // Getting runtime class
+            Class<?> c = o.getClass(); // Getting runtime class
             while (Advised.class.isAssignableFrom(c)) {
                 Advised advised = (Advised) o;
                 o = advised.getTargetSource().getTarget();

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -1,7 +1,7 @@
 /*
  *   $Id$
  *
- *   Copyright 2006-2013 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -16,7 +16,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import ome.annotations.RolesAllowed;
 import ome.api.IPixels;
@@ -41,6 +40,8 @@ import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.collect.MapMaker;
 
 /**
  * Implementation of the RawPixelsStore stateful service.
@@ -298,7 +299,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
     @RolesAllowed("user")
     public synchronized void prepare(Set<Long> pixelsIds)
     {
-	pixelsCache = new ConcurrentHashMap<Long, Pixels>(pixelsIds.size());
+    	pixelsCache = new MapMaker().makeMap();
     	List<Pixels> pixelsList = iQuery.findAllByQuery(
     			"select p from Pixels as p join fetch p.pixelsType " +
         		"where p.id in (:ids)", new Parameters().addIds(pixelsIds));

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
 import net.sf.ehcache.Ehcache;
@@ -70,6 +69,8 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.collect.MapMaker;
 
 /**
  * Is for ISession a cache and will be kept there in sync? OR Factors out the
@@ -717,7 +718,7 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
         Element elt = cache.get(env);
         Map<String, Object> map;
         if (elt == null) {
-            map = new ConcurrentHashMap<String, Object>();
+            map = new MapMaker().makeMap();
             elt = new Element(env, map);
             cache.put(elt);
         } else {


### PR DESCRIPTION
ConcurrentHashMap undergoes API changes among Java 6, 7, 8, so to keep code nicely portable it's generally easier to simply avoid using it given that we already have Guava available and that offers a suitable substitute.

Testing: No tests or builds should break, and the OMERO source should no longer contain direct usage of ConcurrentHashMap. (It has already been removed from Bio-Formats.) Import should still work, and management of Insight sessions / connectors should still be fine; @jburel may have specific testing ideas there. (I guess, try logging in and out and switching user and whatnot.)

To avoid regressions, the less-trivial code changes should be reviewed by eye.

--no-rebase