### PR TITLE
Share tree open viewer 10578

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_subtree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_subtree.html
@@ -34,7 +34,7 @@
 {% else %}
     {% if manager.containers.images %}
     {% for d in manager.containers.images %}
-        <li id='image-{{ d.id }}' rel="image{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}">
+        <li id='image-{{ d.id }}' rel="image{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}" {% if share and not share.share.isOwned %}data-share="{{ share.obj_id }}"{% endif %}>
           {% if d.loaded %}
               <a href="#" data-name="{{ d.name|escape }}" >
                 {{ d.name|default:"Image"|escape }}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -246,8 +246,21 @@
                     }
                 })
                 .delegate("a", "dblclick", function(e) {
-                    if ($(this).parent().attr('rel')=='image') {
-                        OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/"+$(this).attr('id').split("-")[1]+"/" ));
+                    var $this = $(this),
+                        obj_rel = $this.parent().attr('rel'),
+                        ob_id = $this.parent().attr('id'),
+                        share_id = $this.parent().attr('data-share'),
+                        popup_url = "{% url 'webindex' %}",
+                        iid;
+                    if ((obj_rel=='image') || (obj_rel=='image-locked')) {
+                        iid = ob_id.split("-")[1];
+                        // Share-id will only be there if share is not owned.
+                        if (share_id) {
+                            popup_url += share_id + "/img_detail/" + iid;
+                        } else {
+                            popup_url += "img_detail/" + iid;
+                        }
+                        OME.openPopup(popup_url);
                     }
                 })
                 .bind("select_node.jstree deselect_node.jstree", function (e, data) {


### PR DESCRIPTION
This fixes https://trac.openmicroscopy.org/ome/ticket/10578

To test, create a share:
 - Browse the share as owner, double-click on image in tree. Should open image viewer *without* share permissions. E.g. url without share-id like  ``` .../webclient/img_detail/<imageId>/ ```
 - Browse the share as share member, double-click on image in tree. Should open image viewer *with* share permissions. E.g. url without share-id like  ``` .../webclient/<shareId>/img_detail/<imageId>/ ```