### PR TITLE
share_preview_panel_12805

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7761,10 +7761,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     Dict
         """
 
+        rv = []
+        pixelsId = self.getPixelsId()
+        if pixelsId is None:
+            return rv
         pixelsService = self._conn.getPixelsService()
         rdefs = pixelsService.retrieveAllRndSettings(
-            self.getPixelsId(), eid, self._conn.SERVICE_OPTS)
-        rv = []
+            pixelsId, eid, self._conn.SERVICE_OPTS)
         for rdef in rdefs:
             d = {}
             owner = rdef.getDetails().owner


### PR DESCRIPTION
Fixes exception when browsing share image preview panel for incomplete images, see: https://trac.openmicroscopy.org/ome/ticket/12805

To test:
 - log in to trout as 'root' and browse to public shares.
 - Browse share '1401', select image and open Preview panel.
 - Image will be incomplete (viewer won't work) but you shouldn't see any exception/crash