### PR TITLE
Set pyramid thumb versions to -1 (Fix #12538)

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -982,7 +982,13 @@ public class ThumbnailBean extends AbstractLevel2Service
                 }
                 try
                 {
+                    // At this point, we're sure that we have a thumbnail obj
+                    // that we want to use, but retrieveThumbnail likes to
+                    // re-generate. For the moment, we're saving and restoring
+                    // that value to prevent creating a new one.
+                    Thumbnail copy = thumbnailMetadata;
                     byte[] thumbnail = retrieveThumbnail();
+                    thumbnailMetadata = copy;
                     toReturn.put(pixelsId, thumbnail);
                     if (dirtyMetadata)
                     {

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -75,6 +75,7 @@ class TestThumbs(lib.ITest):
 
     @pytest.mark.parametrize("meth", ("one", "set"))
     def testThumbnailVersion(self, meth):
+        assert meth in ("one", "set")
         i64 = rint(64)
         pix = self.missing_pyramid()
         q = ("select tb from Thumbnail tb "
@@ -98,10 +99,14 @@ class TestThumbs(lib.ITest):
 
         # As soon as it's requested, it should have a -1
         # version to mark pyramid creation as ongoing.
-        before = tb.getThumbnail(i64, i64)
+        if meth == "one":
+            before = tb.getThumbnail(i64, i64)
+            assert not tb.thumbnailExists(i64, i64)
+            assert tb.isInProgress()
+        elif meth == "set":
+            before = tb.getThumbnailSet(i64, i64, [long(pix)])
+            before = before[long(pix)]
         assert get().version.val == -1
-        assert not tb.thumbnailExists(i64, i64)
-        assert tb.isInProgress()
 
         # Now we wait until the pyramid has been created
         # and test that a proper version has been set.
@@ -126,7 +131,6 @@ class TestThumbs(lib.ITest):
             tb.resetDefaults()
             assert tb.setPixelsId(long(pix))
 
-        assert meth in ("one", "set")
         if meth == "one":
             after = tb.getThumbnail(i64, i64)
             assert before != after

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -73,10 +73,12 @@ class TestThumbs(lib.ITest):
         finally:
             tb.close()
 
-    @pytest.mark.parametrize("meth", ("one", "set"))
+    @pytest.mark.parametrize("meth", ("one", "set",))
     def testThumbnailVersion(self, meth):
+
         assert meth in ("one", "set")
         i64 = rint(64)
+
         pix = self.missing_pyramid()
         q = ("select tb from Thumbnail tb "
              "where tb.pixels.id = %s "
@@ -92,10 +94,11 @@ class TestThumbs(lib.ITest):
         # At this stage, there should still be no
         # thumbnail
         tb = self.client.sf.createThumbnailStore()
-        tb.setPixelsId(long(pix))
-        tb.resetDefaults()
-        assert not tb.thumbnailExists(i64, i64)
-        assert tb.isInProgress()
+        if meth == "one":
+            tb.setPixelsId(long(pix))
+            tb.resetDefaults()
+            assert not tb.thumbnailExists(i64, i64)
+            assert tb.isInProgress()
 
         # As soon as it's requested, it should have a -1
         # version to mark pyramid creation as ongoing.
@@ -125,11 +128,12 @@ class TestThumbs(lib.ITest):
 
         # Re-load the thumbnail store now that
         # the pyramid is generated.
-        tb.close()
-        tb = self.client.sf.createThumbnailStore()
-        if not tb.setPixelsId(long(pix)):
-            tb.resetDefaults()
-            assert tb.setPixelsId(long(pix))
+        if meth == "one":
+            tb.close()
+            tb = self.client.sf.createThumbnailStore()
+            if not tb.setPixelsId(long(pix)):
+                tb.resetDefaults()
+                assert tb.setPixelsId(long(pix))
 
         if meth == "one":
             after = tb.getThumbnail(i64, i64)

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -126,16 +126,16 @@ class TestThumbs(lib.ITest):
         if event:
             assert "Pyramid was not generated %ss" % secs
 
-        # Re-load the thumbnail store now that
-        # the pyramid is generated.
         if meth == "one":
+            # Re-load the thumbnail store now that
+            # the pyramid is generated.
             tb.close()
             tb = self.client.sf.createThumbnailStore()
             if not tb.setPixelsId(long(pix)):
                 tb.resetDefaults()
+                tb.close()
+                tb = self.client.sf.createThumbnailStore()
                 assert tb.setPixelsId(long(pix))
-
-        if meth == "one":
             after = tb.getThumbnail(i64, i64)
             assert before != after
             assert tb.thumbnailExists(i64, i64)

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -10,7 +10,11 @@
 """
 
 import library as lib
+import pytest
 
+from omero import MissingPyramidException
+from omero.sys import ParametersI
+from omero.util.concurrency import get_event
 from omero.rtypes import rint, unwrap
 
 
@@ -68,6 +72,69 @@ class TestThumbs(lib.ITest):
             assert not tb.thumbnailExists(rint(64), rint(64))
         finally:
             tb.close()
+
+    @pytest.mark.parametrize("meth", ("one", "set"))
+    def testThumbnailVersion(self, meth):
+        i64 = rint(64)
+        pix = self.missing_pyramid()
+        q = ("select tb from Thumbnail tb "
+             "where tb.pixels.id = %s "
+             "order by tb.id desc ")
+        q = q % pix
+        p = ParametersI().page(0, 1)
+        get = lambda: self.query.findByQuery(q, p)
+
+        # Before anything has been called, there
+        # should be no thumbnail
+        assert not get()
+
+        # At this stage, there should still be no
+        # thumbnail
+        tb = self.client.sf.createThumbnailStore()
+        tb.setPixelsId(long(pix))
+        tb.resetDefaults()
+        assert not tb.thumbnailExists(i64, i64)
+        assert tb.isInProgress()
+
+        # As soon as it's requested, it should have a -1
+        # version to mark pyramid creation as ongoing.
+        before = tb.getThumbnail(i64, i64)
+        assert get().version.val == -1
+        assert not tb.thumbnailExists(i64, i64)
+        assert tb.isInProgress()
+
+        # Now we wait until the pyramid has been created
+        # and test that a proper version has been set.
+        event = get_event("test_thumbs")
+        secs = 20
+        rps = self.client.sf.createRawPixelsStore()
+        for x in range(secs):
+            try:
+                rps.setPixelsId(long(pix), True)
+                event = None
+                break
+            except MissingPyramidException:
+                event.wait(1)
+        if event:
+            assert "Pyramid was not generated %ss" % secs
+
+        # Re-load the thumbnail store now that
+        # the pyramid is generated.
+        tb.close()
+        tb = self.client.sf.createThumbnailStore()
+        if not tb.setPixelsId(long(pix)):
+            tb.resetDefaults()
+            assert tb.setPixelsId(long(pix))
+
+        assert meth in ("one", "set")
+        if meth == "one":
+            after = tb.getThumbnail(i64, i64)
+            assert before != after
+            assert tb.thumbnailExists(i64, i64)
+            assert not tb.isInProgress()
+        elif meth == "set":
+            tb.getThumbnailSet(i64, i64, [long(pix)])
+        assert get().version.val >= 0
 
 
 def assign(f, method, *args):


### PR DESCRIPTION
Thumbnails that are generated while pyramids are being
created (i.e. the clock symbol) should have a version of
-1 so that clients know to refresh.

There is currently no case where `version == null` is
used or even possible.

cc: @will-moore