### PR TITLE
Fix image simple marshal

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6982,7 +6982,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     rv['tiled'] = ((rv['size']['height'] * rv['size']['width'])
                                    > (maxplanesize[0] * maxplanesize[1]))
                 else:
-                    rv['tiles'] = False
+                    rv['tiled'] = False
 
         return rv
 

--- a/components/tools/OmeroPy/test/unit/test_gateway.py
+++ b/components/tools/OmeroPy/test/unit/test_gateway.py
@@ -27,7 +27,43 @@ Test of various things under omero.gateway
 import Ice
 import pytest
 
-from omero.gateway import BlitzGateway
+from omero.gateway import BlitzGateway, ImageWrapper
+from omero.model import ImageI, PixelsI, ExperimenterI, EventI
+from omero.rtypes import rstring, rtime, rlong, rint
+
+
+class MockQueryService(object):
+
+    def findByQuery(self, query, params, _ctx=None):
+        experimenter = ExperimenterI()
+        experimenter.firstName = rstring('first_name')
+        experimenter.lastName = rstring('last_name')
+        return experimenter
+
+
+class MockConnection(object):
+
+    SERVICE_OPTS = dict()
+
+    def getQueryService(self):
+        return MockQueryService()
+
+    def getMaxPlaneSize(self):
+        return (64, 64)
+
+
+@pytest.fixture(scope='function')
+def wrapped_image():
+    image = ImageI()
+    image.id = rlong(1L)
+    image.description = rstring('description')
+    image.name = rstring('name')
+    image.acquisitionDate = rtime(1000)  # In milliseconds
+    image.details.owner = ExperimenterI(1L, False)
+    creation_event = EventI()
+    creation_event.time = rtime(2000)  # In milliseconds
+    image.details.creationEvent = creation_event
+    return ImageWrapper(conn=MockConnection(), obj=image)
 
 
 class TestBlitzGatewayUnicode(object):
@@ -52,3 +88,33 @@ class TestBlitzGatewayUnicode(object):
                 host='localhost', port=65535
             )
             gateway.connect()
+
+
+class TestBlitzGatewayImageWrapper(object):
+    """Tests for various methods associated with the `ImageWrapper`."""
+
+    def assert_data(self, data):
+        assert data['description'] == 'description'
+        assert data['author'] == 'first_name last_name'
+        assert data['date'] == 1.0  # In seconds
+        assert data['type'] == 'Image'
+        assert data['id'] == 1L
+        assert data['name'] == 'name'
+
+    def test_simple_marshal(self, wrapped_image):
+        self.assert_data(wrapped_image.simpleMarshal())
+
+    def test_simple_marshal_tiled(self, wrapped_image):
+        image = wrapped_image._obj
+        pixels = PixelsI()
+        pixels.sizeX = rint(65)
+        pixels.sizeY = rint(65)
+        image.addPixels(pixels)
+        data = wrapped_image.simpleMarshal(xtra={'tiled': True})
+        self.assert_data(data)
+        assert data['tiled'] is True
+
+    def test_simple_marshal_not_tiled(self, wrapped_image):
+        data = wrapped_image.simpleMarshal(xtra={'tiled': True})
+        self.assert_data(data)
+        assert data['tiled'] is False


### PR DESCRIPTION
Fix a typo bug found in `ImageWrapper.simpleMarshal()` during performance testing and improvement. Unit tests included.

/cc @jballanc 