### PR TITLE
Use allow=0 for share post-processing (Fix #12562)

### DIFF
--- a/components/server/src/ome/security/sharing/SharingACLVoter.java
+++ b/components/server/src/ome/security/sharing/SharingACLVoter.java
@@ -13,15 +13,16 @@ import ome.api.IShare;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
 import ome.model.internal.Details;
+import ome.model.internal.Permissions;
 import ome.security.ACLVoter;
 import ome.security.SystemTypes;
 import ome.security.basic.CurrentDetails;
 import ome.security.basic.TokenHolder;
 import ome.services.sharing.ShareStore;
 
+import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.hibernate.Session;
 import org.springframework.util.Assert;
 
 /**
@@ -119,7 +120,13 @@ public class SharingACLVoter implements ACLVoter {
 
     @Override
     public void postProcess(IObject object) {
-        return;
+        if (object != null && object.isLoaded()) {
+            Details d = object.getDetails();
+            Permissions p = d.getPermissions();
+            Permissions copy = new Permissions(p);
+            copy.copyRestrictions(0, null);
+            d.setPermissions(copy);
+        }
     }
 
     // Helpers

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -189,8 +189,7 @@ class TestIShare(lib.ITest):
         for e in res:
             assert e.id.val == img.id.val
 
-    @pytest.mark.broken(ticket="12562")
-    def testCanAnntotate(self):
+    def testCanAnnotate(self):
 
         # Users in Private and Read-annotate groups
         private_g = self.new_group(perms="rw----")
@@ -202,7 +201,7 @@ class TestIShare(lib.ITest):
         # User2 is in read-ann group (default) AND private group
         user2 = self.new_user(group=readann_g)
         self.add_groups(user2, [private_g])
-        client2 = self.new_client(user=user2, password="ome")
+        client2 = self.new_client(user=user2)
 
         # User 1 creates image in Private group...
         update1 = client1.sf.getUpdateService()

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2387,37 +2387,6 @@ class ImageWrapper (OmeroWebObjectWrapper,
         if 'link' in kwargs:
             self.link = 'link' in kwargs and kwargs['link'] or None
 
-    def canEdit(self):
-        """
-        Determines if the current user can Edit (E.g. name, description) link
-        (E.g. Project, Dataset, Image etc) or Delete this object. The
-        canEdit() property is set on the permissions of every object as it is
-        read from the server, based on the current user, event context and
-        group permissions.
-
-        :rtype:     Boolean
-        :return:    True if user can Edit this object Delete, link etc.
-        """
-        if self._conn.SERVICE_OPTS.get('omero.share'):
-            if self.getDetails().getOwner().id != self._conn.getUserId():
-                return False
-        return self.getDetails().getPermissions().canEdit()
-
-    def canAnnotate(self):
-        """
-        Determines if the current user can annotate this object: ie create
-        annotation links. The canAnnotate() property is set on the permissions
-        of every object as it is read from the server, based on the current
-        user, event context and group permissions.
-
-        :rtype:     Boolean
-        :return:    True if user can Annotate this object
-        """
-        if self._conn.SERVICE_OPTS.get('omero.share'):
-            if self.getDetails().getOwner().id != self._conn.getUserId():
-                return False
-        return self.getDetails().getPermissions().canAnnotate()
-
     """
     This override standard omero.gateway.ImageWrapper.getChannels
     and catch exceptions.


### PR DESCRIPTION
The no-op method in SharingACLVoter was incorrect in
that by not calling copyRestrictions, there were *no*
restrictions on the object as opposed to nothing being
allowed. Now, all should return False in the context
of a share.

Testing: This should keep the same behavior as gh-3688
but without @aleksandra-tarkowska's workaround.