### PR TITLE
Disable scripts menu in share page

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -33,13 +33,17 @@
         $(document).ready(function() 
         {
 
-            // Disable the groups/users dropdown menu.
+            // Disable the groups/users dropdown menu and scripts menu.
             $("#groupsUsersButton")
                 .css('background-image', 'url()')
                 .attr('title', 'Use "Scope" in form below to search within specific Groups / Users');
+            $("#scriptButton")
+                .css('opacity', 0.5)
+                .attr('title', 'Scripts are disabled for data in shares');
             setTimeout(function(){
                 // make sure we remove click handler AFTER it's been added
                 $("#groupsUsersButton").off('click');
+                $("#scriptButton").off('click');
             },500);
         });
 


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/12832

Disables script menu for share page. Although the image owner *may* be able to run scripts on their own images in share, the majority of times it will be users who only have access to the images via share permissions, so the script won't be able to access the images.

To test:
 - Go to public share page.
 - The script menu button should look disabled and clicking on it won't launch script menu. Tooltip will tell you it's disabled in shares.