### PR TITLE
Preserve Z/T changes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -1811,7 +1811,7 @@ class ImViewerModel
 	{
             RndProxyDef rndDef = null;
             Renderer rnd = metadataViewer.getRenderer();
-            if (rnd != null && rnd.isModified()) {
+            if (rnd != null && rnd.isModified(false)) {
                 rndDef = rnd.getRndSettingsCopy();
             }
             

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -55,6 +55,7 @@ import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.event.ReloadThumbsEvent;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import pojos.ChannelData;
 import pojos.ExperimenterData;
@@ -289,6 +290,25 @@ public class MetadataViewerAgent
     }
     
     /**
+     * Reload thumbnails
+     * 
+     * @param evt
+     *            The ReloadThumbsEvent containing information about the images
+     *            to reload the thumbnails for
+     */
+    private void handleReloadThumbs(ReloadThumbsEvent evt) {
+        Iterator<Long> i = evt.getImageIds().iterator();
+        MetadataViewer viewer;
+        while (i.hasNext()) {
+            viewer = MetadataViewerFactory.getViewerFromId(
+                    ImageData.class.getName(), i.next());
+            if (viewer != null) {
+                viewer.loadViewedBy();
+            }
+        }
+    }
+    
+    /**
      * Updates the view when the channels have been updated.
      * 
      * @param evt The event to handle.
@@ -393,6 +413,7 @@ public class MetadataViewerAgent
         bus.register(this, RndSettingsCopied.class);
         bus.register(this, CopyRndSettings.class);
         bus.register(this, RndSettingsPasted.class);
+        bus.register(this, ReloadThumbsEvent.class);
     }
 
     /**
@@ -441,6 +462,8 @@ public class MetadataViewerAgent
                    	 handleCopyRndSettings((CopyRndSettings) e);
 		else if (e instanceof RndSettingsPasted) 
                     	handleRndSettingsPasted((RndSettingsPasted) e);
+		else if (e instanceof ReloadThumbsEvent) 
+            handleReloadThumbs((ReloadThumbsEvent) e);
 	}
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ManageRndSettingsAction.java
@@ -303,7 +303,7 @@ public class ManageRndSettingsAction
     private void copyRndSettings() {
 
         CopyRndSettings evt;
-        if (model.isModified()) {
+        if (model.isModified(false)) {
             // copy the current 'pending' rendering settings
             evt = new CopyRndSettings(model.getRefImage(),
                     model.getRndSettingsCopy());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2718,7 +2718,7 @@ class EditorModel
                     }
                 } catch (Exception e) {
                     MetadataViewerAgent.getRegistry().getLogger()
-                            .warn(this, "Could not save renderign settings");
+                            .warn(this, "Could not save rendering settings");
                 }
                 renderer.discard();
                 renderer = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -96,6 +96,7 @@ import org.openmicroscopy.shoola.env.data.model.SaveAsParam;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
+import org.openmicroscopy.shoola.env.event.ReloadThumbsEvent;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
@@ -2701,10 +2702,27 @@ class EditorModel
 	    	} else if (refObject instanceof ExperimenterData) {
 	    		fireExperimenterPhotoLoading();
 	    	}
-	    	if (renderer != null) {
-	    		renderer.discard();
-	    		renderer = null;
-	    	}
+            if (renderer != null) {
+                try {
+                    // save Z/T changes (only Z/T, therefore call discardChanges
+                    // beforehand)
+                    if (renderer.isModified(false))
+                        renderer.discardChanges();
+                    if (renderer.isModified(true)) {
+                        renderer.saveCurrentSettings();
+                        MetadataViewerAgent
+                                .getRegistry()
+                                .getEventBus()
+                                .post(new ReloadThumbsEvent(renderer
+                                        .getRefImage().getId()));
+                    }
+                } catch (Exception e) {
+                    MetadataViewerAgent.getRegistry().getLogger()
+                            .warn(this, "Could not save renderign settings");
+                }
+                renderer.discard();
+                renderer = null;
+            }
 	    }
 	} 
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -526,6 +526,14 @@ public interface Renderer
     RndProxyDef saveCurrentSettings()
             throws RenderingServiceException, DSOutOfServiceException;
 
+    /**
+     * Discards the changes to the rendering settings
+     * (apart from Z/T changes)
+     * @throws DSOutOfServiceException 
+     * @throws RenderingServiceException 
+     */
+    void discardChanges() throws RenderingServiceException, DSOutOfServiceException;
+    
     /** Fires a property to indicate to save the settings. */
     void saveSettings();
 
@@ -794,10 +802,10 @@ public interface Renderer
     /**
      * Returns <code>true</code> if the rendering settings 
      * have been modified
-     *
+     * @param checkPlane Take Z/T changes into account
      * @return See above.
      */
-    boolean isModified();
+    boolean isModified(boolean checkPlane);
     
     /**
      * Enables/Disables the paste action

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.rnd.RendererControl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -451,7 +451,7 @@ class RendererControl
             actionsMap.get(SAVE).setEnabled(false);
         } 
         else {
-            boolean settingsModified = model.isModified();
+            boolean settingsModified = model.isModified(false);
             actionsMap.get(SAVE).setEnabled(settingsModified && model.canAnnotate());
         }
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -297,7 +297,9 @@ class RendererModel
 	/** Discards component. */
 	void discard() 
 	{
-		if (rndControl == null) return;
+		if (rndControl == null) 
+		    return;
+		
 		RenderingControlShutDown loader =
 			new RenderingControlShutDown(ctx, rndControl.getPixelsID());
 		loader.load();
@@ -1246,6 +1248,16 @@ class RendererModel
 		return def;
 	}
 	
+    /**
+     * Discard unsaved rendering settings, apart from Z/T changes
+     */
+    void discardChanges() throws RenderingServiceException,
+            DSOutOfServiceException {
+        if (rndControl != null && rndDef != null) {
+            rndControl.resetSettings(rndDef);
+        }
+    }
+	
 	/**
 	 * Undoes the last change to the rendering settings
 	 * @throws RenderingServiceException
@@ -1393,18 +1405,19 @@ class RendererModel
 		return rndControl.isSameSettings(def, checkPlane);
 	}
 	
-       /**
-        * Returns <code>true</code> if the rendering settings 
-        * have been modified
-        *
-        * @return See above.
-        */
-	boolean isModified() {
-	    if(rndControl!=null) {
-	        return !rndControl.isSameSettings(rndDef, false);
-	    }
-	    return false;
-	}
+    /**
+     * Returns <code>true</code> if the rendering settings have been modified
+     * 
+     * @param checkPlane
+     *            Pass <code>true</code> to take Z/T changes into account
+     * @return See above.
+     */
+    boolean isModified(boolean checkPlane) {
+        if (rndControl != null) {
+            return !rndControl.isSameSettings(rndDef, checkPlane);
+        }
+        return false;
+    }
 
     /**
      * Returns <code>true</code> if the image with the active channels

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -42,7 +42,6 @@ import org.openmicroscopy.shoola.agents.metadata.browser.TreeBrowserDisplay;
 import org.openmicroscopy.shoola.agents.metadata.editor.Editor;
 import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.agents.metadata.util.DataToSave;
-import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
@@ -133,9 +132,6 @@ public interface MetadataViewer
 	
 	/** Bound property indicating to render a plane. */
 	public static final String	RENDER_PLANE_PROPERTY = "renderPlane";
-	
-	/** Bound property indicating to generate a thumbnail. */
-	public static final String	RENDER_THUMBNAIL_PROPERTY = "renderThumbnail";
 	
 	/** Bound property name indicating that a new channel is selected. */
     public final static String  SELECTED_CHANNEL_PROPERTY = "selectedChannel";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -79,6 +79,7 @@ import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.event.ReloadThumbsEvent;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
@@ -1242,9 +1243,7 @@ class MetadataViewerComponent
 			}
 			
 			if (imageID >= 0 && model.canAnnotate()) {
-				firePropertyChange(RENDER_THUMBNAIL_PROPERTY, -1, imageID);
-				// reload the viewedby thumbnails after new rendering settings were applied
-				model.fireViewedByLoading();
+			    MetadataViewerAgent.getRegistry().getEventBus().post(new ReloadThumbsEvent(imageID));
 			}
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treemng.TreeViewerAgent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -78,6 +78,7 @@ import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.event.ReloadThumbsEvent;
 import org.openmicroscopy.shoola.env.event.SaveEvent;
 import org.openmicroscopy.shoola.env.ui.ActivityProcessEvent;
 import org.openmicroscopy.shoola.env.ui.ViewObjectEvent;
@@ -484,6 +485,18 @@ public class TreeViewerAgent
     }
     
     /**
+     * Passes ReloadThumbsEvent on to the Treeviewer 
+     */
+    private void handleReloadThumbsEvent(ReloadThumbsEvent evt) {
+        ExperimenterData exp = (ExperimenterData) registry.lookup(
+                LookupNames.CURRENT_USER_DETAILS);
+        if (exp == null) 
+            return;
+        TreeViewer viewer = TreeViewerFactory.getTreeViewer(exp);
+        viewer.reloadThumbs(evt.getImageIds());
+    }
+    
+    /**
      * Passes the SearchSelectionEvent on to the Treeviewer 
      */
     private void handleSearchSelectionEvent(SearchSelectionEvent evt) {
@@ -592,6 +605,7 @@ public class TreeViewerAgent
         bus.register(this, SearchSelectionEvent.class);
         bus.register(this, SaveEvent.class);
         bus.register(this, DownloadEvent.class);
+        bus.register(this, ReloadThumbsEvent.class);
     }
 
     /**
@@ -658,6 +672,8 @@ public class TreeViewerAgent
             handleSaveEvent((SaveEvent) e);
 		else if (e instanceof DownloadEvent)
             handleDownloadEvent((DownloadEvent) e);
+		else if (e instanceof ReloadThumbsEvent)
+            handleReloadThumbsEvent((ReloadThumbsEvent) e);
 	}
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -1189,4 +1189,11 @@ public interface TreeViewer
      */
     boolean isSystemGroup(long groupID, String key);
 
+    /**
+     * Reload the thumbnails of the specified images
+     * 
+     * @param imageIds
+     *            The ids of the images which thumbnails should be reloaded
+     */
+    void reloadThumbs(List<Long> imageIds);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4874,4 +4874,12 @@ class TreeViewerComponent
     {
         return model.isSystemGroup(groupID, key);
     }
+    
+    /** 
+     * Implemented as specified by the {@link TreeViewer} interface.
+     * @see TreeViewer#reloadThumbs(List)
+     */
+    public void reloadThumbs(List<Long> imageIds) {
+        view.reloadThumbnails(imageIds);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -1299,11 +1299,6 @@ class TreeViewerControl
 			model.showTagWizard();
 		} else if (DataBrowser.FIELD_SELECTED_PROPERTY.equals(name)) {
 			model.setSelectedField(pce.getNewValue());
-		} else if (MetadataViewer.RENDER_THUMBNAIL_PROPERTY.equals(name)) {
-			long imageID = ((Long) pce.getNewValue()).longValue();
-			List<Long> ids = new ArrayList<Long>(1);
-			ids.add(imageID);
-			view.reloadThumbnails(ids);
 		} else if (MetadataViewer.APPLY_SETTINGS_PROPERTY.equals(name)) {
 			Object object = pce.getNewValue();
 			if (object instanceof ImageData) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/event/ReloadThumbsEvent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/event/ReloadThumbsEvent.java
@@ -1,0 +1,74 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.event;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Notification that the thumbnails of the specified images have to
+ * be reloaded.
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @since 5.1
+ */
+
+public class ReloadThumbsEvent extends RequestEvent {
+
+    /** The list of images ids */
+    private List<Long> imageIds = new ArrayList<Long>();
+
+    /**
+     * Create a new instance for a single image id
+     * @param imageId The image id
+     */
+    public ReloadThumbsEvent(long imageId) {
+        this(Arrays.asList(imageId));
+    }
+    
+    /**
+     * Creates a new instance for a list of images ids
+     * @param imageIds The image ids
+     */
+    public ReloadThumbsEvent(List<Long> imageIds) {
+        super();
+        this.imageIds = imageIds;
+    }
+
+    /**
+     * Get the image ids to reload the thumbnails for
+     * @return See above.
+     */
+    public List<Long> getImageIds() {
+        return imageIds;
+    }
+
+    /**
+     * Set the image ids to reload the thumbnails for
+     * @param imageIds The image ids
+     */
+    public void setImageIds(List<Long> imageIds) {
+        this.imageIds = imageIds;
+    }
+    
+}


### PR DESCRIPTION
Fixes [Ticket 12709](http://trac.openmicroscopy.org.uk/ome/ticket/12709) and also some occasionally appearing problems that thumbnails are not in sync with the rendering settings (unfortunately mixed that altogether in one commit).

Note: With this PR **Z/T changes are silently stored**, i. e. the user's last selected Z/T frame will be stored in the rendering settings automatically as soon as he moves away from the image (selects a different image, close the image viewer, or just switch from the preview pane to the general pane). Whereas 'real' rendering setting changes (to the channels) are discarded, when moving away from the preview panel.
Is this an acceptable behaviour? Can't treat Z/T changes as 'real' rendering setting changes, because this leads to whole lot of inconsistencies with respect to undo/redo, save, copy/paste, etc.

**Test:**
For the scope of the ticket:
- Select an image with multiple Z frames. Change the currently viewed Z frame in the preview pane, switch to the general pane (at this point the current Z frame should be stored and also the thumbnail updating), open the SplitViewFigure dialog (make sure your selected Z frame is shown), create the figure (make sure the figure also shows your selected Z frame).
- Do the same again but now modifiy the Z frame in the full image viewer.

General:
- Ideally some more rendering settings workflows (copy/paste, undo/redo, etc.) should be tested as well.
