### PR TITLE
CLI sessions: do not check group while rejoining session with key

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -260,10 +260,12 @@ class SessionsControl(BaseControl):
         pasw = args.password
         if args.key:
             if name and not self.ctx.isquiet:
-                self.ctx.err("Overriding name since session set")
+                self.ctx.err("Overriding name since session key set")
             name = args.key
+            if args.group and not self.ctx.isquiet:
+                self.ctx.err("Ignoring group since session key set")
             if args.password and not self.ctx.isquiet:
-                self.ctx.err("Ignoring password since key set")
+                self.ctx.err("Ignoring password since session key set")
             pasw = args.key
         #
         # If no key provided, then we check the last used connection

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -344,7 +344,7 @@ class SessionsControl(BaseControl):
                                  False, set_current=False)
             else:
                 rv = self.check_and_attach(store, server, stored_name,
-                                           args.key, props)
+                                           args.key, props, check_group=False)
             action = "Joined"
             if not rv:
                 if port:
@@ -355,7 +355,8 @@ class SessionsControl(BaseControl):
         elif not create:
             available = store.available(server, name)
             for uuid in available:
-                rv = self.check_and_attach(store, server, name, uuid, props)
+                rv = self.check_and_attach(store, server, name, uuid, props,
+                                           check_group=True)
                 action = "Reconnected to"
 
         if not rv:
@@ -401,7 +402,8 @@ class SessionsControl(BaseControl):
 
         return self.handle(rv, action)
 
-    def check_and_attach(self, store, server, name, uuid, props):
+    def check_and_attach(self, store, server, name, uuid, props,
+                         check_group=False):
         """
         Checks for conflicts in the settings for this session,
         and if there are none, then attempts an "attach()". If
@@ -411,7 +413,8 @@ class SessionsControl(BaseControl):
         exists = store.exists(server, name, uuid)
 
         if exists:
-            conflicts = store.conflicts(server, name, uuid, props)
+            conflicts = store.conflicts(server, name, uuid, props,
+                                        check_group=check_group)
             if conflicts:
                 self.ctx.err(
                     "Failed to join session %s due to property conflicts: %s"

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -418,9 +418,12 @@ class SessionsControl(BaseControl):
             conflicts = store.conflicts(server, name, uuid, props,
                                         check_group=check_group)
             if conflicts:
-                self.ctx.err(
-                    "Failed to join session %s due to property conflicts: %s"
-                    % (uuid, conflicts))
+                if "omero.port" in conflicts:
+                    self.ctx.dbg("Skipping session %s due to mismatching"
+                                 " ports: %s " % (uuid, conflicts))
+                elif not self.ctx.isquiet:
+                    self.ctx.err("Skipped session %s due to property"
+                                 " conflicts: %s" % (uuid, conflicts))
                 return None
 
         return self.attach(store, server, name, uuid, props, exists)

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -108,7 +108,8 @@ class SessionsStore(object):
 
         (dhn / id).write_lines(lines)
 
-    def conflicts(self, host, name, id, new_props, ignore_nulls=False):
+    def conflicts(self, host, name, id, new_props, ignore_nulls=False,
+                  check_group=True):
         """
         Compares if the passed properties are compatible with
         with those for the host, name, id tuple
@@ -119,8 +120,11 @@ class SessionsStore(object):
         conflicts = ""
         old_props = self.get(host, name, id)
         default_port = str(omero.constants.GLACIER2PORT)
+        keys = ["omero.port"]
+        if check_group:
+            keys.append("omero.group")
 
-        for key in ("omero.group", "omero.port"):
+        for key in keys:
             old = old_props.get(key, None)
             new = new_props.get(key, None)
             if ignore_nulls and new is None:

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -118,13 +118,15 @@ class SessionsStore(object):
         """
         conflicts = ""
         old_props = self.get(host, name, id)
+        default_port = str(omero.constants.GLACIER2PORT)
+
         for key in ("omero.group", "omero.port"):
             old = old_props.get(key, None)
             new = new_props.get(key, None)
             if ignore_nulls and new is None:
                 continue
-            elif (key == "omero.port" and old is None and
-                    new == str(omero.constants.GLACIER2PORT)):
+            elif (key == "omero.port" and
+                  set((old, new)) == set((None, default_port))):
                 continue
             elif old != new:
                 if conflicts != "":

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -295,9 +295,9 @@ class TestSessions(object):
     # The first element of each tuple correspond to the value stored in the
     # session file (where None means the property is not stored). The second
     # element corresponds to the value passed via the connection arguments.
-    NONCONFLICTING_PORTS = [(None, 4064)]
+    NONCONFLICTING_PORTS = [(None, 4064), (4064, None)]
     CONFLICTING_PORTS = [
-        (None, 14064), (14064, None), (4064, None), (4064, 14064)]
+        (None, 14064), (14064, None), (4064, 14064)]
     CONFLICTING_GROUPS = [
         (None, "mygroup"), ("mygroup", None), ("mygroup", "mygroup2")]
 


### PR DESCRIPTION
Follow up of https://github.com/openmicroscopy/openmicroscopy/pull/3702 and http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-April/005245.html.

This PR fixes a first bug where rejoining a stored session file using the session key was restricted to using the same connection arguments (including the initial connection group). Main changes of this PR are:
- fixing the port assymmetry (i.e. session file stored with the default port or without any omero.port can be rejoined without passing the port/by passing `-p 4064`)
- remove the group check restriction when joining an existing session stored on disk using the session key
- unit tests are modified to cover these bug fixes
- the unit tests when reusing session (i.e. without key) are also extended to cover all the group/port scenarios. In this case, the property check restriction (i.e. `omero.group` needs to match the content of the stored session file) is maintained for now.

/cc @PaulVanSchayck