### PR TITLE
Show tags of the selected objects only

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -910,12 +910,14 @@ class EditorComponent
 						return;
 					}
 						
-					Collection tags = model.getExistingTags();
+					Collection tags = model.isMultiSelection() ? model.getAllTags() : model.getTags();
 					dialog = controller.createFigureDialog(name, 
 							pixels, FigureDialog.THUMBNAILS);
 					dialog.setParentRef(model.getParentRootObject());
-					if (tags != null) dialog.setTags(tags);
-					else model.loadExistingTags();
+					if (tags != null) 
+					    dialog.setTags(tags);
+					else 
+					    model.loadExistingTags();
 					dialog.centerDialog();
 					break;
 				case FigureDialog.MOVIE:


### PR DESCRIPTION
Tiny fix for [Ticket 12679](http://trac.openmicroscopy.org.uk/ome/ticket/12679)

I couldn't reproduce the missing tag issue, but I fixed the problem, that the dialog showed all tags available. Now just the ones which are attached to the selected images are shown.

Test:
Select a few images with different tags attached to them. Open the ThumbnailFigure dialog and make sure only the tags which are attached to the selected images are shown.
