### PR TITLE
Refactor plugins using Delete2 & Chgrp2 requests

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -16,7 +16,7 @@ arguments, sys.argv, and finally from standard-in using the
 cmd.Cmd.cmdloop method.
 
 Josh Moore, josh at glencoesoftware.com
-Copyright (c) 2007-2014, Glencoe Software, Inc.
+Copyright (c) 2007-2015, Glencoe Software, Inc.
 See LICENSE for details.
 
 """

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1769,6 +1769,8 @@ class GraphControl(CmdControl):
         for req in doall.requests:
             for type in req.targetObjects.keys():
                 ids = ",".join(map(str, req.targetObjects[type]))
+                if isinstance(req, omero.cmd.SkipHead):
+                    type += ("/" + req.startFrom[0])
                 objects.append('%s %s' % (type, ids))
         return "%s %s... " % (cmd_type, ', '.join(objects))
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1461,6 +1461,7 @@ class GraphArg(object):
         try:
             parts = arg.split(":", 1)
             assert len(parts) == 2
+            assert '+' not in parts[0]
             parts[0] = parts[0].lstrip("/")
             graph = parts[0].split("/")
             ids = [long(id) for id in parts[1].split(",")]

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1697,7 +1697,11 @@ class GraphControl(CmdControl):
     def print_request_description(self, request):
         doall = self.as_doall(request)
         cmd_type = self.cmd_type().ice_staticId()[2:].replace("::", ".")
-        objects = ['%s %s' % (req.type, req.id) for req in doall.requests]
+        objects = []
+        for req in doall.requests:
+            for type in req.targetObjects.keys():
+                ids = ",".join(map(str, req.targetObjects[type]))
+                objects.append('%s %s' % (type, ids))
         return "%s %s... " % (cmd_type, ', '.join(objects))
 
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1608,12 +1608,11 @@ class GraphControl(CmdControl):
             help="Number of seconds to wait for the processing to complete "
             "(Indefinite < 0; No wait=0).", default=-1)
         parser.add_argument(
-            "--edit", action="store_true",
-            help="Configure options in a text editor")
+            "--include",
+            help="Modifies the given option by including a list of objects")
         parser.add_argument(
-            "--opt", action="append",
-            help="Modifies the given option (e.g. /Image:KEEP). Applied "
-            "*after* 'edit' ")
+            "--exclude",
+            help="Modifies the given option by excluding a list of objects")
         parser.add_argument(
             "--list", action="store_true",
             help="Print a list of all available graph specs")
@@ -1683,11 +1682,15 @@ class GraphControl(CmdControl):
             doall = omero.cmd.DoAll(args.obj)
 
         for req in doall.requests:
-            if args.edit:
-                req.options = self.edit_options(req, specmap)
-            if args.opt:
-                for opt in args.opt:
-                    self.line_to_opts(opt, req.options)
+            req.childOptions = list()
+            if args.include:
+                inc = args.include.split(",")
+                opt = omero.cmd.graphs.ChildOption(includeType=inc)
+                req.childOptions.append(opt)
+            if args.exclude:
+                exc = args.exclude.split(",")
+                opt = omero.cmd.graphs.ChildOption(excludeType=exc)
+                req.childOptions.append(opt)
 
         self._process_request(doall, args, client)
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1685,12 +1685,7 @@ class GraphControl(CmdControl):
                 self.ctx.out("\n".join(keys))
                 return  # Early exit.
 
-        if len(args.obj) == 1 and isinstance(args.obj[0], omero.cmd.DoAll):
-            doall = args.obj[0]
-        else:
-            doall = omero.cmd.DoAll(args.obj)
-
-        for req in doall.requests:
+        for req in args.obj:
             req.childOptions = list()
             req.dryRun = args.dry_run
             if args.include:
@@ -1705,7 +1700,12 @@ class GraphControl(CmdControl):
                 req.request.childOptions = req.childOptions
                 req.request.dryRun = req.dryRun
 
-        self._process_request(doall, args, client)
+        if len(args.obj) == 1:
+            cmd = args.obj[0]
+        else:
+            cmd = omero.cmd.DoAll(args.obj)
+
+        self._process_request(cmd, args, client)
 
     def print_request_description(self, request):
         doall = self.as_doall(request)

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1641,40 +1641,40 @@ class GraphControl(CmdControl):
 
     def main_method(self, args):
 
-        import omero
         client = self.ctx.conn(args)
-        cb = None
-        req = omero.cmd.GraphSpecList()
-        try:
+        if args.list_details or args.list:
+            cb = None
+            req = omero.cmd.GraphSpecList()
             try:
-                speclist, status, cb = self.response(client, req)
-            except omero.LockTimeout, lt:
-                self.ctx.die(446, "LockTimeout: %s" % lt.message)
-        finally:
-            if cb is not None:
-                cb.close(True)  # Close handle
+                try:
+                    speclist, status, cb = self.response(client, req)
+                except omero.LockTimeout, lt:
+                    self.ctx.die(446, "LockTimeout: %s" % lt.message)
+            finally:
+                if cb is not None:
+                    cb.close(True)  # Close handle
 
-        # Could be put in positive_response helper
-        err = self.get_error(speclist)
-        if err:
-            self.ctx.die(367, err)
+            # Could be put in positive_response helper
+            err = self.get_error(speclist)
+            if err:
+                self.ctx.die(367, err)
 
-        specs = speclist.list
-        specmap = dict()
-        for s in specs:
-            specmap[s.type] = s
-        keys = sorted(specmap)
+            specs = speclist.list
+            specmap = dict()
+            for s in specs:
+                specmap[s.type] = s
+            keys = sorted(specmap)
 
-        if args.list_details:
-            for key in keys:
-                spec = specmap[key]
-                self.ctx.out("=== %s ===" % key)
-                for k, v in spec.options.items():
-                    self.ctx.out("%s" % (k,))
-            return  # Early exit.
-        elif args.list:
-            self.ctx.out("\n".join(keys))
-            return  # Early exit.
+            if args.list_details:
+                for key in keys:
+                    spec = specmap[key]
+                    self.ctx.out("=== %s ===" % key)
+                    for k, v in spec.options.items():
+                        self.ctx.out("%s" % (k,))
+                return  # Early exit.
+            elif args.list:
+                self.ctx.out("\n".join(keys))
+                return  # Early exit.
 
         if len(args.obj) == 1 and isinstance(args.obj[0], omero.cmd.DoAll):
             doall = args.obj[0]

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1456,15 +1456,19 @@ class GraphArg(object):
         self.cmd_type = cmd_type
 
     def __call__(self, arg):
+        targetObjects = dict()
         try:
             parts = arg.split(":", 1)
             assert len(parts) == 2
-            type = parts[0]
-            id = long(parts[1])
-
-            return self.cmd_type(type=type,
-                                 id=id,
-                                 options={})
+            parts[0] = parts[0].lstrip("/")
+            graph = parts[0].split("/")
+            # Here we have something other than a simple object name
+            # graph probably needs to be used to form a SkipHead ?
+            if len(graph) > 1:
+                raise Exception
+            ids = [long(id) for id in parts[1].split(",")]
+            targetObjects[parts[0]] = ids
+            return self.cmd_type(targetObjects=targetObjects)
         except:
             raise ValueError("Bad object: %s", arg)
 
@@ -1623,7 +1627,7 @@ class GraphControl(CmdControl):
         self._pre_objects(parser)
         parser.add_argument(
             "obj", nargs="*", type=GraphArg(self.cmd_type()),
-            help="""Objects to be processedd in the form "<Class>:<Id>""")
+            help="Objects to be processed in the form <Class>:<Id>")
 
     def _pre_objects(self, parser):
         """

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1685,17 +1685,21 @@ class GraphControl(CmdControl):
                 self.ctx.out("\n".join(keys))
                 return  # Early exit.
 
-        for req in args.obj:
-            req.childOptions = list()
-            req.dryRun = args.dry_run
-            if args.include:
-                inc = args.include.split(",")
-                opt = omero.cmd.graphs.ChildOption(includeType=inc)
-                req.childOptions.append(opt)
-            if args.exclude:
-                exc = args.exclude.split(",")
+        opt = None
+        if args.include:
+            inc = args.include.split(",")
+            opt = omero.cmd.graphs.ChildOption(includeType=inc)
+        if args.exclude:
+            exc = args.exclude.split(",")
+            if opt is None:
                 opt = omero.cmd.graphs.ChildOption(excludeType=exc)
-                req.childOptions.append(opt)
+            else:
+                opt.excludeType = exc
+
+        for req in args.obj:
+            req.dryRun = args.dry_run
+            if args.include or args.exclude:
+                req.childOptions = [opt]
             if isinstance(req, omero.cmd.SkipHead):
                 req.request.childOptions = req.childOptions
                 req.request.dryRun = req.dryRun

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1694,40 +1694,6 @@ class GraphControl(CmdControl):
 
         self._process_request(doall, args, client)
 
-    def edit_options(self, req, specmap):
-
-        from omero.util import edit_path
-        from omero.util.temp_files import create_path
-
-        start_text = """# Edit options for your operation below.\n"""
-        start_text += ("# === %s ===\n" % req.type)
-        if req.type not in specmap:
-            self.ctx.die(162, "Unknown type: %s" % req.type)
-        start_text += self.append_options(req.type, dict(specmap))
-
-        temp_file = create_path()
-        try:
-            edit_path(temp_file, start_text)
-            txt = temp_file.text()
-            print txt
-            rv = dict()
-            for line in txt.split("\n"):
-                self.line_to_opts(line, rv)
-            return rv
-        except RuntimeError, re:
-            self.ctx.die(954, "%s: Failed to edit %s"
-                         % (getattr(re, "pid", "Unknown"), temp_file))
-
-    def append_options(self, key, specmap, indent=0):
-        spec = specmap.pop(key)
-        start_text = ""
-        for optkey in sorted(spec.options):
-            optval = spec.options[optkey]
-            start_text += ("%s%s=%s\n" % ("  " * indent, optkey, optval))
-            if optkey in specmap:
-                start_text += self.append_options(optkey, specmap, indent+1)
-        return start_text
-
     def print_request_description(self, request):
         doall = self.as_doall(request)
         cmd_type = self.cmd_type().ice_staticId()[2:].replace("::", ".")

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1627,6 +1627,10 @@ class GraphControl(CmdControl):
         parser.add_argument(
             "--report", action="store_true",
             help="Print more detailed report of each action")
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help=("Do a dry run of the command, providing a "
+                  "report of what would have been done"))
         self._pre_objects(parser)
         parser.add_argument(
             "obj", nargs="*", type=GraphArg(self.cmd_type()),
@@ -1687,6 +1691,7 @@ class GraphControl(CmdControl):
 
         for req in doall.requests:
             req.childOptions = list()
+            req.dryRun = args.dry_run
             if args.include:
                 inc = args.include.split(",")
                 opt = omero.cmd.graphs.ChildOption(includeType=inc)
@@ -1697,6 +1702,7 @@ class GraphControl(CmdControl):
                 req.childOptions.append(opt)
             if isinstance(req, omero.cmd.SkipHead):
                 req.request.childOptions = req.childOptions
+                req.request.dryRun = req.dryRun
 
         self._process_request(doall, args, client)
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -77,6 +77,27 @@ class ChgrpControl(GraphControl):
 
         super(ChgrpControl, self)._process_request(req, args, client)
 
+    def print_detailed_report(self, req, rsp, status):
+        import omero
+        if isinstance(rsp, omero.cmd.DoAllRsp):
+            for response in rsp.responses:
+                if isinstance(response, omero.cmd.Chgrp2Response):
+                    self.print_chgrp_response(response)
+        elif isinstance(rsp, omero.cmd.Chgrp2Response):
+            self.print_chgrp_response(rsp)
+
+    def print_chgrp_response(self, rsp):
+        for k in rsp.includedObjects.keys():
+            if rsp.includedObjects[k]:
+                self.ctx.out("Included %s objects" % k)
+                for i in rsp.includedObjects[k]:
+                    self.ctx.out("%s:%s" % (k, i))
+        for k in rsp.deletedObjects.keys():
+            if rsp.deletedObjects[k]:
+                self.ctx.out("Deleted %s objects" % k)
+                for i in rsp.deletedObjects[k]:
+                    self.ctx.out("%s:%s" % (k, i))
+
 try:
     register("chgrp", ChgrpControl, HELP)
 except NameError:

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -49,7 +49,7 @@ class ChgrpControl(GraphControl):
     def cmd_type(self):
         import omero
         import omero.all
-        return omero.cmd.Chgrp
+        return omero.cmd.Chgrp2
 
     def _pre_objects(self, parser):
         parser.add_argument(
@@ -78,7 +78,7 @@ class ChgrpControl(GraphControl):
 
         # Set requests group
         for request in req.requests:
-            request.grp = gid
+            request.groupId = gid
 
         super(ChgrpControl, self)._process_request(req, args, client)
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -20,26 +20,21 @@ HELP = """Move data between groups
 
 Example Usage:
 
-  omero chgrp 101 /Image:1                     # Move all of Image 1 to \
+  omero chgrp 101 Image:1                     # Move all of Image 1 to \
 group 101
-  omero chgrp Group:101 /Image:1               # Move all of Image 1 to \
+  omero chgrp Group:101 Image:1               # Move all of Image 1 to \
 group 101
-  omero chgrp ExperimenterGroup:101 /Image:1   # Move all of Image 1 to \
+  omero chgrp ExperimenterGroup:101 Image:1   # Move all of Image 1 to \
 group 101
-  omero chgrp "My Lab" /Image:1                # Move all of Image 1 to \
-group "myLab"
+  omero chgrp "My Lab" Image:1,2,3            # Move all of Images 1, 2 and 3 \
+to group "myLab"
 
-  omero chgrp --edit 101 /Image:1              # Open an editor with all \
-the chgrp
-                                               # options filled out with \
-defaults.
-
-  omero chgrp --opt /Image:KEEP /Plate:1       # Calls chgrp on Plate, \
+  omero chgrp --exclude Image Plate:1         # Calls chgrp on Plate, \
 leaving all
-                                               # images in the previous group.
+                                              # images in the previous group.
 
   What data is moved is the same as that which would be deleted by a similar
-  call to "omero delete /Image:1"
+  call to "omero delete Image:1"
 
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -72,8 +72,17 @@ class ChgrpControl(GraphControl):
                          group.id.val)
 
         # Set requests group
-        for request in req.requests:
-            request.groupId = gid
+        if isinstance(req, omero.cmd.DoAll):
+            for request in req.requests:
+                if isinstance(request, omero.cmd.SkipHead):
+                    request.request.groupId = gid
+                else:
+                    request.groupId = gid
+        else:
+            if isinstance(req, omero.cmd.SkipHead):
+                req.request.groupId = gid
+            else:
+                req.groupId = gid
 
         super(ChgrpControl, self)._process_request(req, args, client)
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2011 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2011-2015 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -3,7 +3,7 @@
 """
    Startup plugin for command-line deletes
 
-   Copyright 2009 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -37,18 +37,19 @@ class DeleteControl(GraphControl):
 
     def print_detailed_report(self, req, rsp, status):
         import omero
-        if isinstance(rsp, omero.cmd.DeleteRsp):
-            for k, v in rsp.undeletedFiles.items():
-                if v:
-                    self.ctx.out("Undeleted %s objects" % k)
-                    for i in v:
-                        self.ctx.out("%s:%s" % (k, i))
+        if isinstance(rsp, omero.cmd.DoAllRsp):
+            for response in rsp.responses:
+                if isinstance(response, omero.cmd.Delete2Response):
+                    self.print_delete_response(response)
+        elif isinstance(rsp, omero.cmd.Delete2Response):
+            self.print_delete_response(rsp)
 
-            self.ctx.out("Scheduled deletes: %s" % rsp.scheduledDeletes)
-            self.ctx.out("Actual deletes: %s" % rsp.actualDeletes)
-            if rsp.warning:
-                self.ctx.out("Warning message: %s" % rsp.warning)
-            self.ctx.out(" ")
+    def print_delete_response(self, rsp):
+        for k in rsp.deletedObjects.keys():
+            if rsp.deletedObjects[k]:
+                self.ctx.out("Deleted %s objects" % k)
+                for i in rsp.deletedObjects[k]:
+                    self.ctx.out("%s:%s" % (k, i))
 
 try:
     register("delete", DeleteControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -32,7 +32,7 @@ class DeleteControl(GraphControl):
     def cmd_type(self):
         import omero
         import omero.all
-        return omero.cmd.Delete
+        return omero.cmd.Delete2
 
     def print_detailed_report(self, req, rsp, status):
         import omero

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -20,9 +20,10 @@ Examples:
 
     bin/omero delete --list   # Print all of the graphs
 
-    bin/omero delete /Image:50
-    bin/omero delete /Plate:1
-    bin/omero delete /Image:51 /Image:52 /OriginalFile:101
+    bin/omero delete Image:50
+    bin/omero delete Plate:1
+    bin/omero delete Image:51,52 OriginalFile:101
+    bin/omero delete Project:101 --exclude Dataset,Image
 
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -73,8 +73,7 @@ def prep_directory(client, mrepo):
     then deleting the created fileset.
     """
 
-    from omero.cmd import Delete
-    from omero.cmd import DoAll
+    from omero.cmd import Delete2, DoAll
     from omero.grid import ImportSettings
 
     from omero.model import ChecksumAlgorithmI
@@ -115,12 +114,8 @@ def prep_directory(client, mrepo):
         oid = dir.items()[0][1].get("id")
         ofile = client.sf.getQueryService().get("OriginalFile", oid)
 
-        delete1 = Delete()
-        delete1.type = "/Fileset"
-        delete1.id = fs.id.val
-        delete2 = Delete()
-        delete2.type = "/OriginalFile"
-        delete2.id = ofile.id.val
+        delete1 = Delete2(targetObjects={'Fileset': [fs.id.val]})
+        delete2 = Delete2(targetObjects={'OriginalFile': [ofile.id.val]})
         doall = DoAll()
         doall.requests = [delete1, delete2]
         cb = client.submit(doall)

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -186,7 +186,9 @@ server-permissions.html
                          % (g.name.val, gid, perms))
         else:
             try:
-                a.changePermissions(Grp(gid, False), perms)
+                chmod = omero.cmd.Chmod(
+                    type="/ExperimenterGroup", id=gid, permissions=str(perms))
+                c.sf.submit(chmod)
                 self.ctx.out("Changed permissions for group %s (id=%s) to %s"
                              % (g.name.val, gid, perms))
             except omero.GroupSecurityViolation:

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -3,7 +3,7 @@
 """
    Group administration plugin
 
-   Copyright 2009-2014 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -187,7 +187,7 @@ server-permissions.html
             try:
                 chmod = omero.cmd.Chmod(
                     type="/ExperimenterGroup", id=gid, permissions=str(perms))
-                c.sf.submit(chmod)
+                c.submit(chmod)
                 self.ctx.out("Changed permissions for group %s (id=%s) to %s"
                              % (g.name.val, gid, perms))
             except omero.GroupSecurityViolation:

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -172,7 +172,6 @@ server-permissions.html
     def perms(self, args):
 
         import omero
-        from omero_model_ExperimenterGroupI import ExperimenterGroupI as Grp
 
         perms = self.parse_perms(args)
         c = self.ctx.conn(args)

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -163,8 +163,7 @@ class TestChgrp(CLITest):
         # try to move both the images to the new group
         target_group = self.target_groups['rw----']
         self.args += ['%s' % target_group.id.val,
-                      '/Image:%s' % images[0].id.val,
-                      '/Image:%s' % images[1].id.val]
+                      'Image:%s,%s' % (images[0].id.val, images[1].id.val)]
         self.cli.invoke(self.args, strict=True)
 
         # check the images have been moved
@@ -186,7 +185,7 @@ class TestChgrp(CLITest):
 
         # try to move the dataset to the new group
         target_group = self.target_groups['rw----']
-        self.args += ['%s' % target_group.id.val, '/Dataset:%s' % dataset_id]
+        self.args += ['%s' % target_group.id.val, 'Dataset:%s' % dataset_id]
         self.cli.invoke(self.args, strict=True)
 
         # query across groups

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -261,8 +261,8 @@ class TestDelete(CLITest):
             assert self.query.find('Dataset', d.id.val)
         for i in imgs:
             assert not self.query.find('Image', i.id.val)
-        for d in dsets:
-            assert self.query.find('Dataset', d.id.val)
+        for d in ds:
+            assert not self.query.find('Dataset', d.id.val)
 
     @pytest.mark.parametrize('number', [1, 2, 3])
     @pytest.mark.parametrize("ordered", ordered)

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -81,10 +81,10 @@ class TestDelete(CLITest):
 
         # Delete the fileset
         if arguments == 'fileset':
-            self.args += ['/Fileset:%s' % filesetId]
+            self.args += ['Fileset:%s' % filesetId]
         else:
-            for i in images:
-                self.args += ['/Image:%s' % i.id.val]
+            ids = [str(i.id.val) for i in images]
+            self.args += ['Image:' + ",".join(ids)]
         self.cli.invoke(self.args, strict=True)
 
         # Check the fileset and images have been deleted

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -260,12 +260,12 @@ class TestChgrp(lib.ITest):
             assert target_gid == img_gid,\
                 "Image should be in group: %s, NOT %s" % (target_gid,  img_gid)
 
-    @pytest.mark.xfail(reason="Two commands in a DoAll rather than one.")
-    def testChgrpAllImagesFilesetOKTwoCommands(self):
+    def testChgrpAllImagesFilesetTwoCommandsErr(self):
         """
-        Simple example of the MIF chgrp bad case:
-        A single fileset containing 2 images
-        can be moved to the same group together.
+        Simple example of the MIF chgrp bad case with Chgrp2:
+        A single fileset containing 2 images cannot be moved
+        to the same group together using two commands
+        See testChgrpAllImagesFilesetOK for the good.
         """
         # One user in two groups
         client, user = self.new_client_and_user(perms=PRIVATE)
@@ -279,16 +279,7 @@ class TestChgrp(lib.ITest):
             targetObjects={'Image': [images[0].id.val]}, groupId=target_gid)
         chgrp2 = Chgrp2(
             targetObjects={'Image': [images[1].id.val]}, groupId=target_gid)
-        self.doSubmit([chgrp1, chgrp2], client)
-
-        # Check both Images moved
-        queryService = client.sf.getQueryService()
-        ctx = {'omero.group': '-1'}      # query across groups
-        for i in images:
-            image = queryService.get('Image', i.id.val, ctx)
-            img_gid = image.details.group.id.val
-            assert target_gid == img_gid,\
-                "Image should be in group: %s, NOT %s" % (target_gid,  img_gid)
+        self.doSubmit([chgrp1, chgrp2], client, test_should_pass=False)
 
     def testChgrpOneDatasetFilesetErr(self):
         """


### PR DESCRIPTION
This PR refactors the CLI plugins `delete` and `chgrp` to use the new `Delete2` and `Chgrp2` requests respectively. In addition `fs rename` has been modified to use `Delete2`.

The `--edit` option has been removed as it was broken by the earlier changes

The `--opt` option have been removed and its usage replaced by two new options `--include` and `--exclude`. How the old option maps to the new ones is detailed in the testing section below.

A new option `--ordered` has been introduced to force the preservation of the order of the arguments.

Integration tests have been added but, as ever, more would be useful to test more complex functionality.

Testing
-------
Relevant cli unit and integration tests should pass.

A number of simple delete and chgrp should be checked, see `--help` for examples. Also see below for how the new usage maps to the old usage. In addition more complex "skiphead" requests should be tried, for examples see below.

Prior to this PR objects had to be listed separately. So to delete three images and two datasets.
```
$ omero delete /Image:51 /Image:52 /Image:53 /Dataset:101 /Dataset:201
```
While this form can still be used the following more concise version is now possible.
```
$ omero delete Image:51,52,53 Dataset:101,201
```
Note also that the preceding `/` is no longer used though the command should still work if it is.

Prior to this PR including or excluding objects from a delete used the `KEEP` and `HARD` syntax with `--opt`. So to delete and image but keep its annotations:
```
$ omero delete --opt /Annotation:KEEP /Image:51 
```
This form is no longer possible. Instead the `--exclude` option should be used.
```
$ omero delete Image:51 --exclude Annotation
```
ie the annotations are *excluded* from the delete. Multiple classes of object can be excluded:
```
$ omero delete Image:51,52,53 --exclude TagAnnotation,FileAnnotation
```
Similarly uses of `/Object:HARD` would be replaced by `--include Object`. 

All of this also applies to `chgrp` so to change the group of dataset but not its images.
```
$ omero chgrp 101 Dataset:201 --exclude Image
```
This may orphan the images if they are not also in another dataset.

To delete or change the group of all the objects under some other object a `SkipHead` command is used behind the scenes. CLI users don't need to worry about the details this but the CLI syntax is important.

Delete all images under a project an object hierarchy is used. 
```
$ omero delete Project/Dataset/Image:53
```
As only the first and last objects are important this hierarchy can be shortened
```
$ omero delete Project/Image:53
```
Both of these commands will delete **all** of the images under Project 53.

Links can also be deleted, so to effectively "orphan" all images under projects 51 and 52 and also those under dataset 53:
```
$ omero delete Project/Dataset/DatasetImageLink:51,52 Dataset/DatasetImageLink:53
```
With all of the above commands the option `--ordered` can be used. Without the option,
```
$ omero delete Image:51 Image:52 Image:53 Dataset:101 Dataset:201
```
will be rolled into one single delete command that is passed to the server while
```
$ omero delete Image:51 Image:52 Image:53 Dataset:101 Dataset:201 --ordered
```
will be processed as five separate commands in the order given on the command line. The effect here is that there should be no difference between the two calls but the `--ordered` option is added for any potential edge cases where the order may be important.

One very specific case to test is that of a MIF. A two image MIF with images 51 and 52 should have the following results according to several different calls:
```
$ omero delete Image:51                    # failure, one image cannot be deleted (no change to behaviour here)
$ omero delete Image:51,52                 # success
$ omero delete Image:51 Image:52           # success
$ omero delete Image:51 Image:52 --ordered # failure, as there are two commands they cannot succeed separately
```

Finally a couple of smaller changes need to be checked, the commands should work as before.

The subcommand `group perms` should be checked:
```
$ omero group perms --name pg-0 --perms "rwr---"
Changed permissions for group pg-0 (id=3) to rwr---
$ omero group perms --id 3 --perms "rw----"
Changed permissions for group pg-0 (id=3) to rw----
```

And `omero fs rename` should be checked. See https://github.com/openmicroscopy/openmicroscopy/pull/2805#issue-37880873


--no-rebase