### PR TITLE
Only show useful search errors

### DIFF
--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -48,9 +48,9 @@ ${FailureMessage}       Search should Not Contain an Alert Window.
 
 ${SEARCH URL}           ${WELCOME URL}search/
 
-@{SearchKeyWords}       *  \  *:  :
+@{SearchKeyWords}       *  \  *:  :  :abc
 
-@{SearchKeyWords1}      ?  *.dv  Â¡  â¬  Â¢  â  Â§  Ê  â¢  Âª  Ê  â  â   Â±  !  @  Â£  $  %  ^  &  (  )  +  __  â  Â´  Â®  â   Â¥  Â¨  ã  Ï  ^ã  â  â  ã  ã  â  Æ  Â©  Ë  â  Ë  Â¬  â¦  ã  Â«  `  Î©  â  ã  â  â«  ~  Âµ  â¤  â¥  ã  Â±  !  @  Â£  $  %  ^  &  (  )  _  +  Q  W  E  R  T  Y  U  I  O  P  {  }  A  S  D  F  G  H  J  K  L  |  ~  Z  X  C  V  B  N  M  <  >  ?  Â§  1  2  3  4  5  6  7  8  9  0  =  q  w  e  r  t  y  u  i  o  [  ]  a  s  d  f  g  h  j  k  l  ;  '  `  z  x  c  v  b  n  m  ,  .  /  (a)  (*)  (?)  *.svs  *.ome.tiff  *.*  a, b  a-b  a_b  a/b  */  ?/  *_  *-  *=  *{}  *[]  *^  **  *a*  *1*  *,*  *-*  ?.*  ?*  *?  a?  1?  123  a1n23;(-)*j.-t  GFP-ABC  GFP-abc  GFP_ABC.svs  "GFP ABC"  "GFP_ABC"  "GFP-ABC"  "GFP.ABC.ome.tiff"  GFP AND ABC  GFP and ABC  "#"  -  "
+@{SearchKeyWords1}      ?  *.dv  Â¡  â¬  Â¢  â  Â§  Ê  â¢  Âª  Ê  â  â   Â±  !  @  Â£  $  %  ^  &  (  )  +  __  â  Â´  Â®  â   Â¥  Â¨  ã  Ï  ^ã  â  â  ã  ã  â  Æ  Â©  Ë  â  Ë  Â¬  â¦  ã  Â«  `  Î©  â  ã  â  â«  ~  Âµ  â¤  â¥  ã  Â±  !  @  Â£  $  %  ^  &  (  )  _  +  Q  W  E  R  T  Y  U  I  O  P  {  }  A  S  D  F  G  H  J  K  L  |  ~  Z  X  C  V  B  N  M  <  >  ?  Â§  1  2  3  4  5  6  7  8  9  0  =  q  w  e  r  t  y  u  i  o  [  ]  a  s  d  f  g  h  j  k  l  ;  '  `  z  x  c  v  b  n  m  ,  .  /  (a)  (*)  (?)  *.svs  *.ome.tiff  *.*  a, b  a-b  a_b  a/b  */  ?/  *_  *-  *=  *{}  *[]  *^  **  *a*  *1*  *,*  *-*  ?.*  ?*  *?  a?  1?  123  a1n23;(-)*j.-t  GFP-ABC  GFP-abc  GFP_ABC.svs  "GFP ABC"  "GFP_ABC"  "GFP-ABC"  "GFP.ABC.ome.tiff"  GFP AND ABC  GFP and ABC  "#"  -  "  GFP:ABC
 
 *** Keywords ***
 

--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -131,11 +131,12 @@ For-Loop-In-Range-Search-Keywords-Error-Or-Alert-Expected
     \   ${status}   Run Keyword And Return Status  Click Element   ${AlertWindow}
     \   Run Keyword If    '${status}' == 'False'     Wait Until Keyword Succeeds     10     0.2    Page Should Not Contain Element   ${SearchInProgress} 
 
-    \   ${status1}  Run Keyword And Return Status   Element Should Be Visible   ${QueryError}
-    \   Run Keyword If    '${status1}' == 'True'    Sleep           ${ImplicitDelay}
-    \   Run Keyword If   '${status}' == 'False'       Should Be True     ${status1}
-    \   Run Keyword If   '${status1}' == 'False'       Should Be True     ${status}
-    \   Run Keyword If    '${status1}' == 'True'    Omero Default Search   
+    \   ${status1}  Run Keyword And Return Status       Element Should Be Visible   ${QueryError}
+    \   Run Keyword If    '${status1}' == 'True'        Sleep               ${ImplicitDelay}
+    \   Run Keyword If   '${status}' == 'False'         Should Be True      ${status1}
+    \   Run Keyword If   '${status}' == 'False'         Element Text Should Be   id=searchResultCount   0 results
+    \   Run Keyword If   '${status1}' == 'False'        Should Be True      ${status}
+    \   Run Keyword If    '${status1}' == 'True'        Omero Default Search
 
 
 For-Loop-In-Range-Search-Keywords-No-Error-Or-Alert-Expected
@@ -153,6 +154,7 @@ For-Loop-In-Range-Search-Keywords-No-Error-Or-Alert-Expected
     \   ${status3}   Run Keyword And Return status   Element Should Be Visible  ${NoResultsFound}   10
     \   Run Keyword If   '${status2}' == 'False'       Should Be True     ${status3}
     \   Run Keyword If   '${status3}' == 'False'       Should Be True     ${status2}
+    \   Run Keyword If   '${status3}' == 'True'        Element Text Should Be   id=searchResultCount   0 results
 
 
 Condition Check Imported Date

--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -48,9 +48,9 @@ ${FailureMessage}       Search should Not Contain an Alert Window.
 
 ${SEARCH URL}           ${WELCOME URL}search/
 
-@{SearchKeyWords}       *  \  *:  "  -  :  
+@{SearchKeyWords}       *  \  *:  :
 
-@{SearchKeyWords1}      ?  *.dv  Â¡  â¬  Â¢  â  Â§  Ê  â¢  Âª  Ê  â  â   Â±  !  @  Â£  $  %  ^  &  (  )  +  __  â  Â´  Â®  â   Â¥  Â¨  ã  Ï  ^ã  â  â  ã  ã  â  Æ  Â©  Ë  â  Ë  Â¬  â¦  ã  Â«  `  Î©  â  ã  â  â«  ~  Âµ  â¤  â¥  ã  Â±  !  @  Â£  $  %  ^  &  (  )  _  +  Q  W  E  R  T  Y  U  I  O  P  {  }  A  S  D  F  G  H  J  K  L  |  ~  Z  X  C  V  B  N  M  <  >  ?  Â§  1  2  3  4  5  6  7  8  9  0  =  q  w  e  r  t  y  u  i  o  [  ]  a  s  d  f  g  h  j  k  l  ;  '  `  z  x  c  v  b  n  m  ,  .  /  (a)  (*)  (?)  *.svs  *.ome.tiff  *.*  a, b  a-b  a_b  a/b  */  ?/  *_  *-  *=  *{}  *[]  *^  **  *a*  *1*  *,*  *-*  ?.*  ?*  *?  a?  1?  123  a1n23;(-)*j.-t  GFP-ABC  GFP-abc  GFP_ABC.svs  "GFP ABC"  "GFP_ABC"  "GFP-ABC"  "GFP.ABC.ome.tiff"  GFP AND ABC  GFP and ABC  "#"         
+@{SearchKeyWords1}      ?  *.dv  Â¡  â¬  Â¢  â  Â§  Ê  â¢  Âª  Ê  â  â   Â±  !  @  Â£  $  %  ^  &  (  )  +  __  â  Â´  Â®  â   Â¥  Â¨  ã  Ï  ^ã  â  â  ã  ã  â  Æ  Â©  Ë  â  Ë  Â¬  â¦  ã  Â«  `  Î©  â  ã  â  â«  ~  Âµ  â¤  â¥  ã  Â±  !  @  Â£  $  %  ^  &  (  )  _  +  Q  W  E  R  T  Y  U  I  O  P  {  }  A  S  D  F  G  H  J  K  L  |  ~  Z  X  C  V  B  N  M  <  >  ?  Â§  1  2  3  4  5  6  7  8  9  0  =  q  w  e  r  t  y  u  i  o  [  ]  a  s  d  f  g  h  j  k  l  ;  '  `  z  x  c  v  b  n  m  ,  .  /  (a)  (*)  (?)  *.svs  *.ome.tiff  *.*  a, b  a-b  a_b  a/b  */  ?/  *_  *-  *=  *{}  *[]  *^  **  *a*  *1*  *,*  *-*  ?.*  ?*  *?  a?  1?  123  a1n23;(-)*j.-t  GFP-ABC  GFP-abc  GFP_ABC.svs  "GFP ABC"  "GFP_ABC"  "GFP-ABC"  "GFP.ABC.ome.tiff"  GFP AND ABC  GFP and ABC  "#"  -  "
 
 *** Keywords ***
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -26,9 +26,12 @@
 import datetime
 import time
 import omero
+import logging
 
 from omero.rtypes import rtime
 from webclient.controller import BaseController
+
+logger = logging.getLogger(__name__)
 
 
 class BaseSearch(BaseController):
@@ -110,17 +113,17 @@ class BaseSearch(BaseController):
                         self.moreResults = True
                     resultCount += len(self.containers[dt])
         except Exception, x:
+            logger.info("Search Exception: %s" % x.message)
             if isinstance(x, omero.ServerError):
+                # Only show message to user if we can be helpful
                 if "TooManyClauses" in x.message:
                     self.searchError = (
                         "Please try to narrow down your query. The wildcard"
                         " matched too many terms.")
-                else:
+                elif ":" in query:
                     self.searchError = (
-                        "Your query for '%s' caused an error: %s."
-                        % (query, x.message))
-            else:
-                self.searchError = (
-                    "Your query for '%s' caused an error: %s."
-                    % (query, str(x)))
+                        "There was an error parsing your query."
+                        " Colons ':' are reserved for searches of"
+                        " Key Value annotations in the form: 'key:value'.")
+
         self.c_size = resultCount

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -124,6 +124,6 @@ class BaseSearch(BaseController):
                     self.searchError = (
                         "There was an error parsing your query."
                         " Colons ':' are reserved for searches of"
-                        " Key Value annotations in the form: 'key:value'.")
+                        " key-value annotations in the form: 'key:value'.")
 
         self.c_size = resultCount

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -177,9 +177,10 @@
                     success: function(html) {
                         $("div#content_details").html(html);
                         $("#filtersearch").show();
-                        var resultCount = parseInt($("#dataTable").attr('data-result-count')),
-                            result = (resultCount > 1) ? "results":"result",
-                            resultMessage = resultCount + " " + result;
+                        var rTable = $("#dataTable"),
+                            rCount = rTable.length > 0 ? parseInt(rTable.attr('data-result-count')): 0,
+                            result = (rCount === 0 || rCount > 1) ? "results":"result",
+                            resultMessage = rCount + " " + result;
                         if ($("#dataTable").attr('data-more-results')) {
                             resultMessage = "More than " + resultMessage;
                         }


### PR DESCRIPTION
Better handling of search errors, particularly those caused by parsing of invalid queries with a colon.

To test, try searching with valid and invalid key:value queries.
Invalid searches should give a useful error message.

Screenshots below are BEFORE and AFTER this change:

![screen shot 2015-04-16 at 14 37 53](https://cloud.githubusercontent.com/assets/900055/7182614/77c36fb8-e44a-11e4-8a07-fa423666b1ef.png)

![screen shot 2015-04-16 at 15 00 18](https://cloud.githubusercontent.com/assets/900055/7182619/7cc5a670-e44a-11e4-9e55-17cc23f2719a.png)
