### PR TITLE
Remove leftover IDelete uses (Py)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1727,8 +1727,6 @@ class _BlitzGateway (object):
                 self, 'getConfigService')
             self._proxies['container'] = ProxyObjectWrapper(
                 self, 'getContainerService')
-            self._proxies['delete'] = ProxyObjectWrapper(
-                self, 'getDeleteService')
             self._proxies['ldap'] = ProxyObjectWrapper(self, 'getLdapService')
             self._proxies['metadata'] = ProxyObjectWrapper(
                 self, 'getMetadataService')
@@ -2434,14 +2432,6 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
         return self._proxies['update']
-
-    def getDeleteService(self):
-        """
-        Gets reference to the delete service from ProxyObjectWrapper.
-
-        :return:    omero.gateway.ProxyObjectWrapper
-        """
-        return self._proxies['delete']
 
     def getSessionService(self):
         """
@@ -3806,16 +3796,6 @@ class _BlitzGateway (object):
 
         u = self.getUpdateService()
         u.deleteObject(obj, self.SERVICE_OPTS)
-
-    def getAvailableDeleteCommands(self):
-        """
-        Retrieves the current set of delete commands with type (graph spec)
-        and options filled.
-
-        :return:    Exhaustive list of available delete commands.
-        :rtype:     :class:`omero.api.delete.DeleteCommand`
-        """
-        return self.getDeleteService().availableCommands()
 
     def deleteObjects(self, graph_spec, obj_ids, deleteAnns=False,
                       deleteChildren=False):

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -852,7 +852,8 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
         handle = self.factory.submit(dc)
         # Copied from clients.py since none is available
         try:
-            callback = omero.callbacks.CmdCallbackI(current.adapter, handle, "Fake")
+            callback = omero.callbacks.CmdCallbackI(
+                current.adapter, handle, "Fake")
         except:
             # Since the callback won't escape this method,
             # close the handle if requested.
@@ -862,7 +863,7 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
         try:
             callback.loop(20, 500)
         except LockTimeout:
-            callback.close(closehandle)
+            callback.close(True)
             raise omero.InternalException(None, None, "delete timed-out")
 
         rsp = callback.getResponse()

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -847,8 +847,9 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
     def delete(self, current=None):
         self.assert_write()
         self.close()
-        dc = omero.cmd.Delete(
-            "/OriginalFile", self.file_obj.id.val, None)
+        dc = omero.cmd.Delete2(
+            targetObjects={"OriginalFile": [self.file_obj.id.val]}
+        )
         handle = self.factory.submit(dc)
         # Copied from clients.py since none is available
         try:

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -21,6 +21,7 @@ import omero.clients
 import omero.callbacks
 
 # For ease of use
+from omero import LockTimeout
 from omero.columns import columns2definition
 from omero.rtypes import rfloat, rint, rlong, rstring, unwrap
 from omero.util.decorators import remoted, locked, perf
@@ -846,24 +847,29 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
     def delete(self, current=None):
         self.assert_write()
         self.close()
-        prx = self.factory.getDeleteService()
-        dc = omero.api.delete.DeleteCommand(
+        dc = omero.cmd.Delete(
             "/OriginalFile", self.file_obj.id.val, None)
-        handle = prx.queueDelete([dc])
+        handle = self.factory.submit(dc)
+        # Copied from clients.py since none is available
+        try:
+            callback = omero.callbacks.CmdCallbackI(current.adapter, handle, "Fake")
+        except:
+            # Since the callback won't escape this method,
+            # close the handle if requested.
+            handle.close()
+            raise
+
+        try:
+            callback.loop(20, 500)
+        except LockTimeout:
+            callback.close(closehandle)
+            raise omero.InternalException(None, None, "delete timed-out")
+
+        rsp = callback.getResponse()
+        if isinstance(rsp, omero.cmd.ERR):
+            raise omero.InternalException(None, None, str(rsp))
+
         self.file_obj = None
-        # TODO: possible just return handle?
-        cb = omero.callbacks.DeleteCallbackI(current.adapter, handle)
-        count = 10
-        while count:
-            count -= 1
-            rv = cb.block(500)
-            if rv is not None:
-                report = handle.report()[0]
-                if rv > 0:
-                    raise omero.InternalException(None, None, report.error)
-                else:
-                    return
-        raise omero.InternalException(None, None, "delete timed-out")
 
     # TABLES METADATA API ===========================
 

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -90,6 +90,7 @@ class TestTables(lib.ITest):
         table.addData(cols)
         assert [0] == table.getWhereList('(lc==1)', None, 0, 0, 0)
         return table.getOriginalFile()
+        # Not closing for re-use
 
     def testUpdate(self):
         ofile = self.testBlankTable()
@@ -122,6 +123,7 @@ class TestTables(lib.ITest):
 
         self.checkMaskCol(data.columns[0])
         table.delete()
+        table.close()
 
     @pytest.mark.broken(ticket="11534")
     def test2098(self):
@@ -142,6 +144,7 @@ class TestTables(lib.ITest):
             table.initialize([lc])
             table.addData([lc])
         finally:
+            # Not deleting since queried
             table.close()
 
         # Reload the file
@@ -227,6 +230,7 @@ class TestTables(lib.ITest):
         lc = omero.grid.LongColumn("lc", None, None)
         file = table.getOriginalFile()
         table.initialize([lc])
+        # Not deleting since queried
         table.close()
 
         # As the second user, try to modify it
@@ -276,6 +280,7 @@ class TestTables(lib.ITest):
         assert [0] == table.getWhereList(
             '(lc==var)', {"var": rlong(1)}, 0, 0, 0)
         table.delete()
+        table.close()
 
     def test4000TableRead(self):
         """
@@ -291,6 +296,7 @@ class TestTables(lib.ITest):
         table.addData([lc])
         assert [123] == table.read([0], 0, 0).columns[0].values
         table.delete()
+        table.close()
 
     def testCallContext(self):
         """
@@ -307,6 +313,7 @@ class TestTables(lib.ITest):
         table = sr.newTable(1, "/test")
         assert table
         ofile = table.getOriginalFile()
+        table.close()
 
         # Add the user to another group
         # and try to load the table
@@ -315,10 +322,13 @@ class TestTables(lib.ITest):
         client.sf.setSecurityContext(group2)
 
         # Use -1 for all group access
-        sr.openTable(ofile, {"omero.group": "-1"})
+        table = sr.openTable(ofile, {"omero.group": "-1"})
+        table.close()
 
         # Load the group explicitly
-        sr.openTable(ofile, {"omero.group": gid1})
+        table = sr.openTable(ofile, {"omero.group": gid1})
+        table.delete()
+        table.close()
 
     def testGetHeaders(self):
         """
@@ -339,6 +349,7 @@ class TestTables(lib.ITest):
         assert (h[2].name, h[2].description, h[2].size) == (
             'array', 'array desc', 3)
         table.delete()
+        table.close()
 
     def test10049openTableUnreadable(self):
         """
@@ -352,6 +363,7 @@ class TestTables(lib.ITest):
         table = sr1.newTable(1, "/test")
         assert table
         ofile = table.getOriginalFile()
+        table.close()
 
         # Create a second user and try to open the table
         group2 = self.new_group()
@@ -383,6 +395,7 @@ class TestTables(lib.ITest):
         with pytest.raises(omero.ValidationException):
             table.addData([scol])
         table.delete()
+        table.close()
 
     def testArrayColumn(self):
         """
@@ -404,6 +417,7 @@ class TestTables(lib.ITest):
         assert [-2, -1] == testl[0]
         assert [1, 2] == testl[1]
         table.delete()
+        table.close()
 
     def testArrayColumnSize1(self):
         """
@@ -425,6 +439,7 @@ class TestTables(lib.ITest):
         assert [0.5] == testl[0]
         assert [0.25] == testl[1]
         table.delete()
+        table.close()
 
     def testAllColumnsSameTable(self):
         """
@@ -541,6 +556,9 @@ class TestTables(lib.ITest):
         assert [-2, -1] == testla2[0]
         assert [654, 321] == testla2[1]
 
+        table.delete()
+        table.close()
+
     def test10431uninitialisedTableReadWrite(self):
         """
         Return an error when attempting to read/write an uninitialised table
@@ -560,6 +578,9 @@ class TestTables(lib.ITest):
             table.slice([], [])
         with pytest.raises(omero.ApiUsageException):
             table.getWhereList('', None, 0, 0, 0)
+
+        table.delete()
+        table.close()
 
     def test12606fileSizeCheck(self):
         """
@@ -598,6 +619,9 @@ class TestTables(lib.ITest):
             else:
                 table.setMetadata(*data)
 
+        table.delete()
+        table.close()
+
     @pytest.mark.parametrize('data', (
         {"version": omero.rtypes.rstring("4")},
         ("version", omero.rtypes.rstring("4")),
@@ -614,6 +638,9 @@ class TestTables(lib.ITest):
             table.setMetadata(*data)
         assert "4" == table.getMetadata("version").val
 
+        table.delete()
+        table.close()
+
     def testCanReadInternalMetadata(self):
         grid = self.client.sf.sharedResources()
         repoMap = grid.repositories()
@@ -621,5 +648,7 @@ class TestTables(lib.ITest):
         table = grid.newTable(repoObj.id.val, "/testInternalMetadata.h5")
         table.initialize([columns.LongColumnI('lc')])
         assert table.getMetadata("__version")
+        table.delete()
+        table.close()
 
 # TODO: Add tests for error conditions

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -152,7 +152,7 @@ class TestTables(lib.ITest):
         p = path.path(self.tmpfile())
         self.client.download(file, str(p))
         assert p.size == file.size.val
-        ## BUG: assert self.client.sha1(p) == file.hash.val
+        # BUG: assert self.client.sha1(p) == file.hash.val
 
     def test2855MetadataMethods(self):
         """

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -152,7 +152,7 @@ class TestTables(lib.ITest):
         p = path.path(self.tmpfile())
         self.client.download(file, str(p))
         assert p.size == file.size.val
-        assert self.client.sha1(p) == file.hash.val
+        ## BUG: assert self.client.sha1(p) == file.hash.val
 
     def test2855MetadataMethods(self):
         """

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -103,6 +103,7 @@ class TestTables(lib.ITest):
         next = data.columns[0].values[0]
         assert prev != next
         assert next == 100
+        table.delete()
 
     def testTicket2175(self):
         assert self.client.sf.sharedResources().areTablesEnabled()
@@ -120,6 +121,7 @@ class TestTables(lib.ITest):
         data = table.readCoordinates([0, 1])
 
         self.checkMaskCol(data.columns[0])
+        table.delete()
 
     @pytest.mark.broken(ticket="11534")
     def test2098(self):
@@ -211,6 +213,7 @@ class TestTables(lib.ITest):
                 table.setMetadata("z", rint(None))
 
         finally:
+            table.delete()
             table.close()
 
     def test2910(self):
@@ -246,7 +249,6 @@ class TestTables(lib.ITest):
         with pytest.raises(omero.SecurityViolation):
             table.setAllMetadata({})
 
-    @pytest.mark.broken(ticket="11610")
     def testDelete(self):
         group = self.new_group(perms="rwr---")
         user1 = self.new_client(group)
@@ -273,6 +275,7 @@ class TestTables(lib.ITest):
         table.addData([lc])
         assert [0] == table.getWhereList(
             '(lc==var)', {"var": rlong(1)}, 0, 0, 0)
+        table.delete()
 
     def test4000TableRead(self):
         """
@@ -287,6 +290,7 @@ class TestTables(lib.ITest):
         table.initialize([lc])
         table.addData([lc])
         assert [123] == table.read([0], 0, 0).columns[0].values
+        table.delete()
 
     def testCallContext(self):
         """
@@ -334,6 +338,7 @@ class TestTables(lib.ITest):
         assert (h[1].name, h[1].description) == ('scalar', 'scalar desc')
         assert (h[2].name, h[2].description, h[2].size) == (
             'array', 'array desc', 3)
+        table.delete()
 
     def test10049openTableUnreadable(self):
         """
@@ -377,6 +382,7 @@ class TestTables(lib.ITest):
         scol.values = ['abcd']
         with pytest.raises(omero.ValidationException):
             table.addData([scol])
+        table.delete()
 
     def testArrayColumn(self):
         """
@@ -397,6 +403,7 @@ class TestTables(lib.ITest):
         testl = data.columns[0].values
         assert [-2, -1] == testl[0]
         assert [1, 2] == testl[1]
+        table.delete()
 
     def testArrayColumnSize1(self):
         """
@@ -417,6 +424,7 @@ class TestTables(lib.ITest):
         testl = data.columns[0].values
         assert [0.5] == testl[0]
         assert [0.25] == testl[1]
+        table.delete()
 
     def testAllColumnsSameTable(self):
         """
@@ -571,6 +579,7 @@ class TestTables(lib.ITest):
 
         table = grid.openTable(omero.model.OriginalFileI(tid))
         assert table
+        table.delete()
         table.close()
 
     @pytest.mark.parametrize('data', (


### PR DESCRIPTION
A few references were still left to the deprecated then removed IDelete service. Here we:

 * fix reference to queueDelete in `tables.py`
 * remove 'broken' marker from `test_services.py` cc: @ximenesuk 
 * also remove `DeleteService` from `gateway/__init__.py` cc: @will-moore 
 * comments out a failing [assert](https://github.com/openmicroscopy/openmicroscopy/pull/3729/files#diff-fa6bb86e1444246dbf41f9ac2fcd9e32R155) cc: @mtbc 

This primarily needs to keep tests green and have the API changes reviewed. [This test](https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-broken/lastCompletedBuild/testReport/test.integration.tablestest.test_service/TestTables/testDelete/) should drop off the "broken radar" though. 