### PR TITLE
Right panel MissingPyramidException

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7748,16 +7748,19 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         return self.getRenderingModel().value.lower() == 'greyscale'
 
-    @assert_re()
+    @assert_re(ignoreExceptions=(omero.ConcurrencyException))
     def getRenderingDefId(self):
         """
         Returns the ID of the current rendering def on the image.
-        Loads and initialises the rendering engine if needed
+        Loads and initialises the rendering engine if needed.
+        If rendering engine fails (E.g. MissingPyramidException)
+        then returns None.
 
         :return:    current rendering def ID
         :rtype:     Long
         """
-        return self._re.getRenderingDefId()
+        if self._re is not None:
+            return self._re.getRenderingDefId()
 
     def getAllRenderingDefs(self, eid=-1):
         """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
@@ -54,6 +54,12 @@ class TestPyramid (object):
         for c in channels:
             print c.getLabel()
 
+    def testGetRdefId(self):
+        """ getRenderingDefId() silently returns None with Missing Pyramid """
+        self.image._conn.createRenderingEngine = lambda: MockRenderingEngine()
+
+        assert self.image.getRenderingDefId() is None
+
 
 class MockRenderingEngine(object):
     """ Should throw on re.load() """

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -150,27 +150,30 @@
             {% if image %}
               <li>
                   {% if share and not share.share.isOwned %}
-                      <a href="{% url 'web_render_image_download' share.share.id image.id image.getDefaultZ image.getDefaultT %}" title="Download as JPEG">
+                      <a href="{% url 'web_render_image_download' share_id=share.share.id iid=image.id %}"
+                        title="Download as JPEG">
                   {% else %}
-                      <a href="{% url 'web_render_image_download' image.id image.getDefaultZ image.getDefaultT %}" title="Download as JPEG">
+                      <a href="{% url 'web_render_image_download' image.id %}" title="Download as JPEG">
                   {% endif %}
                   Export as JPEG
                 </a>
               </li>
               <li>
                   {% if share and not share.share.isOwned %}
-                      <a href="{% url 'web_render_image_download' share.share.id image.id image.getDefaultZ image.getDefaultT %}?format=png" title="Download as PNG">
+                      <a href="{% url 'web_render_image_download' share_id=share.share.id iid=image.id %}?format=png"
+                        title="Download as PNG">
                   {% else %}
-                      <a href="{% url 'web_render_image_download' image.id image.getDefaultZ image.getDefaultT %}?format=png" title="Download as PNG">
+                      <a href="{% url 'web_render_image_download' image.id %}?format=png" title="Download as PNG">
                   {% endif %}
                   Export as PNG
                 </a>
               </li>
               <li>
                   {% if share and not share.share.isOwned %}
-                      <a href="{% url 'web_render_image_download' share.share.id image.id image.getDefaultZ image.getDefaultT %}?format=tif" title="Download as TIFF">
+                      <a href="{% url 'web_render_image_download' share_id=share.share.id iid=image.id %}?format=tif"
+                        title="Download as TIFF">
                   {% else %}
-                      <a href="{% url 'web_render_image_download' image.id image.getDefaultZ image.getDefaultT %}?format=tif" title="Download as TIFF">
+                      <a href="{% url 'web_render_image_download' image.id %}?format=tif" title="Download as TIFF">
                   {% endif %}
                   Export as TIFF
                 </a>


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12835

The "Download" drop-down menu for an image no-longer calls getDefaultZ/T to generate download urls.
Urls are generated without Z/T, which will also result in the default Z and T indices being used anyway.

To test, try loading the right "General" panel after importing a Big 'png' or 'jpeg', during Pyramid Generation. Should see no exception (although Download > png/jpeg won't work).

Also test that the Download > PNG / JPEG / TIFF functionality is working for non-big images using normal permissions AND in a share (when you don't otherwise have permission to access the image).