### PR TITLE
CLI sessions list

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -33,6 +33,7 @@ import glob
 import platform
 import time
 import shlex
+import errno
 from threading import Lock
 from path import path
 
@@ -459,6 +460,9 @@ class Context:
                 stream.write("\n")
             else:
                 stream.flush()
+        except IOError, e:
+            if e.errno != errno.EPIPE:
+                raise
         except:
             print >>sys.stderr, "Error printing text"
             print >>sys.stdout, text

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -105,6 +105,12 @@ Other commands:
     $ bin/omero sessions clear
 """
 
+LISTHELP = """
+By default, inactive sessions are purged from the local sessions store and
+removed from the listing. To list all sessions stored locally independently of
+their status, use the --no-purge argument.
+"""
+
 
 class SessionsControl(BaseControl):
 
@@ -137,11 +143,7 @@ class SessionsControl(BaseControl):
             help="Id or name of the group to switch this session to")
 
         list = parser.add(sub, self.list, (
-            "List all available sessions stored locally\n\n"
-            "By default, inactive sessions are purged from the local"
-            " sessions store and removed from the listing. To list all"
-            " sessions stored locally independently of their status, use the"
-            " --no-purge argument."))
+            "List all available sessions stored locally\n\n" + LISTHELP))
         list.add_argument(
             "--no-purge", dest="purge", action="store_false",
             help="Do not remove inactive sessions")

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -137,11 +137,7 @@ class SessionsControl(BaseControl):
             help="Id or name of the group to switch this session to")
 
         list = parser.add(sub, self.list, "List all locally stored sessions")
-        purge = list.add_mutually_exclusive_group()
-        purge.add_argument(
-            "--purge", action="store_true", default=True,
-            help="Remove inactive sessions")
-        purge.add_argument(
+        list.add_argument(
             "--no-purge", dest="purge", action="store_false",
             help="Do not remove inactive sessions")
 

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -550,6 +550,7 @@ class SessionsControl(BaseControl):
                             self.ctx.dbg("Purging %s / %s / %s"
                                          % (server, name, uuid))
                             store.remove(server, name, uuid)
+                            continue
                         except IOError, ioe:
                             self.ctx.dbg("Aborting session purging. %s" % ioe)
                             break

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -136,7 +136,12 @@ class SessionsControl(BaseControl):
             "target",
             help="Id or name of the group to switch this session to")
 
-        list = parser.add(sub, self.list, "List all locally stored sessions")
+        list = parser.add(sub, self.list, (
+            "List all available sessions stored locally\n\n"
+            "By default, inactive sessions are purged from the local"
+            " sessions store and removed from the listing. To list all"
+            " sessions stored locally independently of their status, use the"
+            " --no-purge argument."))
         list.add_argument(
             "--no-purge", dest="purge", action="store_false",
             help="Do not remove inactive sessions")

--- a/components/tools/OmeroPy/src/omero/util/temp_files.py
+++ b/components/tools/OmeroPy/src/omero/util/temp_files.py
@@ -176,7 +176,7 @@ class TempFileManager(object):
                     locktest.close()
                     locktest = None
                     choice = target
-                    self.logger.debug("Chose gloabl tmpdir: %s", choice)
+                    self.logger.debug("Chose global tmpdir: %s", choice)
                 finally:
                     if locktest is not None:
                         try:

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -738,14 +738,13 @@ class TestSessions(object):
         """
         cli = MyCLI()
         cli.STORE.add("srv", "usr", "uuid", {})
-
+        cli.creates_client(new=False)
         cli.invoke(["s", "list"])
         o, e = capsys.readouterr()
-        o = o.splitlines()
-        assert o[-1] == "(1 row)"
-        assert "srv" in str(o[-2])
-        assert "usr" in str(o[-2])
-        assert "uuid" in str(o[-2])
+        assert o.endswith("(1 row)\n")
+        assert "srv" in o
+        assert "usr" in o
+        assert "uuid" in o
 
     @pytest.mark.parametrize("purge", [True, False])
     def testListOptions(self, capsys, purge):
@@ -753,24 +752,32 @@ class TestSessions(object):
         Test purge options of bin/omero sessions list
         """
         cli = MyCLI()
+        # Create 2 sessions in store
         cli.STORE.add("srv", "usr", "uuid", {})
         cli.STORE.add("srv", "usr2", "uuid2", {})
-        cli.creates_client(new=False)
 
         if purge:
             cmd = ["s", "list"]
         else:
             cmd = ["s", "list", "--no-purge"]
 
+        # Keep one session active
+        cli.creates_client(new=False)
         cli.invoke(cmd)
         o, e = capsys.readouterr()
-        assert o.splitlines()[-1] == "(2 rows)"
+        if purge:
+            assert o.endswith("(1 row)\n")
+        else:
+            assert o.endswith("(2 rows)\n")
+
+        # Keep one session active
+        cli.creates_client(new=False)
         cli.invoke(cmd)
         o2, e2 = capsys.readouterr()
         if purge:
-            assert o2.splitlines()[-1] == "(1 row)"
+            assert o2.endswith("(1 row)\n")
         else:
-            assert o2.splitlines()[-1] == "(2 rows)"
+            assert o2.endswith("(2 rows)\n")
 
 
 class TestParseConn(object):

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -732,6 +732,46 @@ class TestSessions(object):
         current = cli.STORE.get_current()
         assert key != current[1]
 
+    def testList(self, capsys):
+        """
+        Test the output of sessions list
+        """
+        cli = MyCLI()
+        cli.STORE.add("srv", "usr", "uuid", {})
+
+        cli.invoke(["s", "list"])
+        o, e = capsys.readouterr()
+        o = o.splitlines()
+        assert o[-1] == "(1 row)"
+        assert "srv" in str(o[-2])
+        assert "usr" in str(o[-2])
+        assert "uuid" in str(o[-2])
+
+    @pytest.mark.parametrize("purge", [True, False])
+    def testListOptions(self, capsys, purge):
+        """
+        Test purge options of bin/omero sessions list
+        """
+        cli = MyCLI()
+        cli.STORE.add("srv", "usr", "uuid", {})
+        cli.STORE.add("srv", "usr2", "uuid2", {})
+        cli.creates_client(new=False)
+
+        if purge:
+            cmd = ["s", "list"]
+        else:
+            cmd = ["s", "list", "--no-purge"]
+
+        cli.invoke(cmd)
+        o, e = capsys.readouterr()
+        assert o.splitlines()[-1] == "(2 rows)"
+        cli.invoke(cmd)
+        o2, e2 = capsys.readouterr()
+        if purge:
+            assert o2.splitlines()[-1] == "(1 row)"
+        else:
+            assert o2.splitlines()[-1] == "(2 rows)"
+
 
 class TestParseConn(object):
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12392 and https://trac.openmicroscopy.org.uk/ome/ticket/12834

To test this PR, check Travis is green and reproduce the scenarios described in both tickets.

For 12392, the main change is that inactive sessions purged by default by the `sessions list` subcommand are not listed anymore by the command output, i.e. the command lists all local non-expired sessions. To list all local sessions independently of their status, `bin/omero sessions list --no-purge` should be used. Listing differences between the output of two consecutive calls to `bin/omero sessions list` should be only caused by either newly created sessions or sessions which expired in-between the two calls.

/cc @kennethgillen @pwalczysko 

