### PR TITLE
Bugfix: Orphaned images selection

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -1834,7 +1834,12 @@ class BrowserComponent
 					model.addFoundNode(i.next());
 				view.setFoundNode(model.getSelectedDisplays());
 			}
-		}
+        } else if (selected instanceof String) {
+            // this is the case if the 'orphaned images' folder
+            // is selected
+            model.setSelectedDisplay(null, true);
+            view.setFoundNode(null);
+        }
 	}
 	
 	/**


### PR DESCRIPTION
Tiny fix for [Ticket 12814](http://trac.openmicroscopy.org.uk/ome/ticket/12814)

Test: Log in as a user who has some images in 'Orphaned Images' (e. g. user-3), select an orphaned image -> you should see it's metadata in the right panel; click on an empty space in the central panel -> metadata panel should be empty; select the **same** image again -> you should again see the metadata of the image.
