### PR TITLE
Replace deprecated Delete/Chgrp methods in gateway

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3841,7 +3841,6 @@ class _BlitzGateway (object):
                                 * 'Well'
                                 * 'Annotation'
                                 * 'OriginalFile'
-                                * 'Image+Only'
                                 * 'Image/Pixels/Channel'
 
                                 As of OMERO 4.4.0 the correct case is now
@@ -3856,6 +3855,10 @@ class _BlitzGateway (object):
         :rtype:                 :class:`omero.api.delete.DeleteHandle`
         """
 
+        if '+' in graph_spec:
+            raise AttributeError(
+                "Graph specs containing '+'' no longer supported: '%s'"
+                % graph_spec)
         if not isinstance(obj_ids, list) and len(obj_ids) < 1:
             raise AttributeError('Must be a list of object IDs')
 
@@ -3940,6 +3943,11 @@ class _BlitzGateway (object):
         :param obj_ids:         IDs for the objects to move.
         :param group_id:        The group to move the data to.
         """
+
+        if '+' in graph_spec:
+            raise AttributeError(
+                "Graph specs containing '+'' no longer supported: '%s'"
+                % graph_spec)
 
         graph = graph_spec.lstrip('/').split('/')
         obj_ids = map(long, obj_ids)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -902,7 +902,7 @@ class BlitzObjectWrapper (object):
             a = al.child
             ids.append(a.id.val)
         if len(ids):
-            handle = self._conn.deleteObjects('/Annotation', ids)
+            handle = self._conn.deleteObjects('Annotation', ids)
             try:
                 self._conn._waitOnCmd(handle)
             finally:
@@ -8191,7 +8191,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         for chunk in ofw.getFileInChunks():
             outfile.write(chunk)
         outfile.close()
-        handle = self._conn.deleteObjects('/OriginalFile', todel)
+        handle = self._conn.deleteObjects('OriginalFile', todel)
         try:
             self._conn._waitOnCmd(handle)
         finally:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3809,8 +3809,9 @@ class _BlitzGateway (object):
         :param obj:     Object to delete
         :type obj:      IObject"""
 
-        u = self.getUpdateService()
-        u.deleteObject(obj, self.SERVICE_OPTS)
+        type = obj.__class__.__name__.rstrip('I')
+        delete = Delete2(targetObjects={type: [obj.getId().val]})
+        self.c.submit(delete, self.SERVICE_OPTS)
 
     def getAvailableDeleteCommands(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3859,7 +3859,7 @@ class _BlitzGateway (object):
             raise AttributeError(
                 "Graph specs containing '+'' no longer supported: '%s'"
                 % graph_spec)
-        if not isinstance(obj_ids, list) and len(obj_ids) < 1:
+        if not isinstance(obj_ids, list) or len(obj_ids) < 1:
             raise AttributeError('Must be a list of object IDs')
 
         graph = graph_spec.lstrip('/').split('/')
@@ -3948,6 +3948,8 @@ class _BlitzGateway (object):
             raise AttributeError(
                 "Graph specs containing '+'' no longer supported: '%s'"
                 % graph_spec)
+        if not isinstance(obj_ids, list) or len(obj_ids) < 1:
+            raise AttributeError('Must be a list of object IDs')
 
         graph = graph_spec.lstrip('/').split('/')
         obj_ids = map(long, obj_ids)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8634,8 +8634,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return True
 
     def _deleteSettings(self):
-        handle = self._conn.deleteObjects(
-            "/Image/Pixels/RenderingDef", [self.getId()])
+        handle = self._conn.deleteObjects("Image/RenderingDef", [self.getId()])
         try:
             self._conn._waitOnCmd(handle)
         finally:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3859,9 +3859,8 @@ class _BlitzGateway (object):
         if not isinstance(obj_ids, list) and len(obj_ids) < 1:
             raise AttributeError('Must be a list of object IDs')
 
-        graph_spec = graph_spec.lstrip('/')
-        graph = graph_spec.split("/")
-
+        graph = graph_spec.lstrip('/').split('/')
+        obj_ids = map(long, obj_ids)
         delete = Delete2(targetObjects={graph[0]: obj_ids})
 
         exc = list()
@@ -3940,9 +3939,8 @@ class _BlitzGateway (object):
         :param group_id:        The group to move the data to.
         """
 
-        graph_spec = graph_spec.lstrip('/')
-        graph = graph_spec.split("/")
-
+        graph = graph_spec.lstrip('/').split('/')
+        obj_ids = map(long, obj_ids)
         chgrp = Chgrp2(targetObjects={graph[0]: obj_ids}, groupId=group_id)
 
         if len(graph) > 1:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3898,6 +3898,8 @@ class _BlitzGateway (object):
         logger.debug('Deleting %s [%s]. Options: %s' %
                      (graph_spec, str(obj_ids), exc))
 
+        logger.debug('Delete2: \n%s' % str(delete))
+
         handle = self.c.sf.submit(delete, self.SERVICE_OPTS)
         return handle
 
@@ -3986,6 +3988,8 @@ class _BlitzGateway (object):
 
         logger.debug('DoAll Chgrp2: type: %s, ids: %s, grp: %s' %
                      (graph_spec, obj_ids, group_id))
+
+        logger.debug('Chgrp2: \n%s' % str(da))
 
         ctx = self.SERVICE_OPTS.copy()
         # NB: For Save to work, we need to be in target group

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -303,10 +303,8 @@ def testFileAnnotation(author_testimg_generated, gatewaywrapper):
 
     # delete what we created
     assert gateway.getObject("Annotation", annId) is not None
-    link = ann.link
-    gateway.deleteObjectDirect(link._obj)        # delete link
-    gateway.deleteObjectDirect(ann._obj)         # then the annotation
-    gateway.deleteObjectDirect(ann._obj.file)    # then the file
+    handle = gateway.deleteObjects("Annotation", [annId])
+    gateway._waitOnCmd(handle)
     assert gateway.getObject("Annotation", annId) is None
 
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_services.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_services.py
@@ -4,7 +4,7 @@
 """
    gateway tests - Wrapped service methods
 
-   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
    pytest fixtures used as defined in conftest.py:
@@ -72,9 +72,10 @@ class TestServices (object):
         try:
             # Make the group writable so Author can delete the annotation
             g = img.details.group
-            admin = gatewaywrapper.gateway.getAdminService()
             perms = str(img.details.permissions)
-            admin.changePermissions(g, omero.model.PermissionsI('rwrw--'))
+            chmod = omero.cmd.Chmod(
+                type="/ExperimenterGroup", id=g.id.val, permissions='rwrw--')
+            gatewaywrapper.gateway.c.submit(chmod)
             img = gatewaywrapper.gateway.getObject('image', imgid)
             g = img.details.group
             assert g.details.permissions.isGroupWrite()
@@ -96,8 +97,9 @@ class TestServices (object):
             img = gatewaywrapper.gateway.getObject('image', imgid)
             img.removeAnnotations(self.TESTANN_NS)
             # Revert group permissions and remove user from group
-            admin = gatewaywrapper.gateway.getAdminService()
-            admin.changePermissions(g, omero.model.PermissionsI(perms))
+            chmod = omero.cmd.Chmod(
+                type="/ExperimenterGroup", id=g.id.val, permissions=perms)
+            gatewaywrapper.gateway.c.submit(chmod)
 
 
 class TestTables (object):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -4,7 +4,7 @@
 """
    gateway tests - Object Wrappers
 
-   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
    pytest fixtures used as defined in conftest.py:
@@ -91,22 +91,23 @@ class TestWrapper(object):
         assert m['child_count'] == p.countChildren_cached()
         # Verify canOwnerWrite
         gatewaywrapper.loginAsAdmin()
-        admin = gatewaywrapper.gateway.getAdminService()
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
         p = gatewaywrapper.gateway.getObject('project', pid)
-        perms = str(p.getDetails().getGroup().getDetails().permissions)
-        admin.changePermissions(
-            p.getDetails().getGroup()._obj,
-            omero.model.PermissionsI('rw' + perms[2:]))
+        g = p.getDetails().getGroup()
+        perms = str(g.getDetails().permissions)
+        chmod = omero.cmd.Chmod(
+            type="/ExperimenterGroup", id=g.id, permissions='rw' + perms[2:])
+        gatewaywrapper.gateway.c.submit(chmod)
         p = gatewaywrapper.gateway.getObject('project', pid)
         assert p.canOwnerWrite() is True
-        admin.changePermissions(
-            p.getDetails().getGroup()._obj,
-            omero.model.PermissionsI('r-' + perms[2:]))
+        chmod = omero.cmd.Chmod(
+            type="/ExperimenterGroup", id=g.id, permissions='r-' + perms[2:])
+        gatewaywrapper.gateway.c.submit(chmod)
         p = gatewaywrapper.gateway.getObject('project', pid)
         assert p.canOwnerWrite() is False
-        admin.changePermissions(
-            p.getDetails().getGroup()._obj, omero.model.PermissionsI(perms))
+        chmod = omero.cmd.Chmod(
+            type="/ExperimenterGroup", id=g.id, permissions=perms)
+        gatewaywrapper.gateway.c.submit(chmod)
 
     def testDatasetWrapper(self, gatewaywrapper, author_testimg):
         # author_testimg above is only included to populate the dataset

--- a/components/tools/OmeroPy/test/unit/gatewaytest/test_argument_errors.py
+++ b/components/tools/OmeroPy/test/unit/gatewaytest/test_argument_errors.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   gateway tests - argument errors in gateway methods
+
+"""
+
+from omero.gateway import _BlitzGateway
+import pytest
+
+
+class TestArgumentErrors(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.g = _BlitzGateway()
+
+    def test_graphspec_with_plus(self):
+        """
+        The graph_spec Name+Qualifier is no longer supported.
+        """
+        with pytest.raises(AttributeError):
+            self.g.deleteObjects("Image+Only", ["1"])
+        with pytest.raises(AttributeError):
+            self.g.chgrpObjects("Image+Only", ["1"], 1L)
+
+    @pytest.mark.parametrize("object_ids", ["1", [], None])
+    def test_bad_object_ids(self, object_ids):
+        """
+        object_ids must be a non-zero length list
+        """
+        with pytest.raises(AttributeError):
+            self.g.deleteObjects("Image", object_ids)
+        with pytest.raises(AttributeError):
+            self.g.chgrpObjects("Image", object_ids, 1L)

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_utils.py
@@ -48,10 +48,7 @@ def _formatReport(callback):
         warn = rsp.parameters.get("Warning", "")
         logger.error('Format report: %r' % {'error': err, 'warning': warn})
         return "Operation could not be completed successfully"
-    else:
-        for rsp in rsp.responses:
-            if rsp.warning:
-                logger.warning("Delete warning: %s" % rsp.warning)
+    # Delete2Response, etc include no warnings
     # Might want to take advantage of other feedback here
 
 


### PR DESCRIPTION
This PR replaces deprecated delete and chgrp methods in the gateway and the gateway tests.

With the PR as it stands the tests pass. However, not all functionality may be fully tested and so this PR is probably best tested on a breaking build. In particular methods such as `deleteSettings` and calls to `deleteObjects` with extended graph specs that will exploit `SkipHead` need through checking.

The one method of concern is is `deleteObjectDirect`:

https://github.com/ximenesuk/openmicroscopy/blob/deprecated-gateway/components/tools/OmeroPy/src/omero/gateway/__init__.py#L3803

This is used extensively by the web but a couple of basic patterns, using `Delete2` commands or using `deleteObjects` did cause at least one test to fail. The tests now pass through re-ordering the deletes. It may be that `deleteObjectDirect` should now be deprecated in favour of `deleteObjects` but I'll leave that as a point for discussion.

I have not yet dealt with the `ObjectOne+ObjectTwo` deprecated graphspec. It may be that the webclient simply doesn't use this form and the comment in the docstrings has just been copied in. If it is used then it would need to be re-written and the deprecated form trapped.

Testing
-------
To test this as many aspects as possible of delete and change group with in the web need to be tested.

--no-rebase