### PR TITLE
5.1.1 misc size fixes

### DIFF
--- a/components/server/src/ome/services/util/ServiceHandler.java
+++ b/components/server/src/ome/services/util/ServiceHandler.java
@@ -423,7 +423,9 @@ public class ServiceHandler implements MethodInterceptor, ApplicationListener {
             return sb.toString();
         } else {
             String s = o.toString();
-            if (s.length() > MAX_STRING_LEN) {
+            if (s == null) {
+                return null;
+            } else if (s.length() > MAX_STRING_LEN) {
                 s = s.substring(0, MAX_STRING_LEN);
             }
             return s;

--- a/components/server/src/ome/services/util/ServiceHandler.java
+++ b/components/server/src/ome/services/util/ServiceHandler.java
@@ -54,6 +54,11 @@ import org.springframework.transaction.CannotCreateTransactionException;
  */
 public class ServiceHandler implements MethodInterceptor, ApplicationListener {
 
+    /**
+     * Maxiumum length of a string that will be returned.
+     */
+    private final static int MAX_STRING_LEN = 100;
+
     private static Logger log = LoggerFactory.getLogger(ServiceHandler.class);
 
     private final CurrentDetails cd;
@@ -417,7 +422,11 @@ public class ServiceHandler implements MethodInterceptor, ApplicationListener {
             sb.append("]");
             return sb.toString();
         } else {
-            return o.toString();
+            String s = o.toString();
+            if (s.length() > MAX_STRING_LEN) {
+                s = s.substring(0, MAX_STRING_LEN);
+            }
+            return s;
         }
     }
 

--- a/components/server/test/ome/server/utests/ServiceHandlerUnitTest.java
+++ b/components/server/test/ome/server/utests/ServiceHandlerUnitTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import ome.security.basic.CurrentDetails;
 import ome.services.util.ServiceHandler;
 
 import org.jmock.MockObjectTestCase;
@@ -23,45 +22,43 @@ public class ServiceHandlerUnitTest extends MockObjectTestCase {
         
         String str;
         
-        ServiceHandler sh = new ServiceHandler(new CurrentDetails());
-
         // Plain
         
-        str = sh.getResultsString(null, null);
+        str = ServiceHandler.getResultsString(null, null);
         assertEquals("null", str);
         
-        str = sh.getResultsString(1L, null);
+        str = ServiceHandler.getResultsString(1L, null);
         assertEquals("1", str);
 
         // Arrays
         
-        str = sh.getResultsString(new Object[]{null}, null);
+        str = ServiceHandler.getResultsString(new Object[]{null}, null);
         assertEquals("[null]", str);
         
-        str = sh.getResultsString(new Long[]{1L}, null);
+        str = ServiceHandler.getResultsString(new Long[]{1L}, null);
         assertEquals("[1]", str);
 
-        str = sh.getResultsString(new Long[]{1L,1L,1L,1L}, null);
+        str = ServiceHandler.getResultsString(new Long[]{1L,1L,1L,1L}, null);
         assertEquals("[1, 1, 1, ... 1 more]", str);
         
         // Lists
 
-        str = sh.getResultsString(Arrays.asList(1L), null);
+        str = ServiceHandler.getResultsString(Arrays.asList(1L), null);
         assertEquals("(1)", str);
  
-        str = sh.getResultsString(Arrays.asList(new Object[]{null}), null);
+        str = ServiceHandler.getResultsString(Arrays.asList(new Object[]{null}), null);
         assertEquals("(null)", str);
  
         // Sets
         
-        str = sh.getResultsString(new HashSet(Arrays.asList(1L)), null);
+        str = ServiceHandler.getResultsString(new HashSet<Long>(Arrays.asList(1L)), null);
         assertEquals("(1)", str);
 
         // Maps
         
-        HashMap map = new HashMap();
+        HashMap<String, String> map = new HashMap<String, String>();
         map.put("a","b");
-        str = sh.getResultsString(map, null);
+        str = ServiceHandler.getResultsString(map, null);
         assertEquals("{a=b}", str);
 
         // Arrays of arrays
@@ -69,7 +66,21 @@ public class ServiceHandlerUnitTest extends MockObjectTestCase {
         objs[0] = new Object[]{1,2,3};
         objs[1] = new Object[]{4,5,6};
         objs[2] = new Object[]{7,8,9};
-        str = sh.getResultsString(objs, null);
+        str = ServiceHandler.getResultsString(objs, null);
         assertEquals("[[1, 2, 3], [4, 5, 6], [7, 8, 9]]", str);
+    }
+
+    @Test
+    public void testLongStringOutput() throws Exception {
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            sb.append("0123456789");
+        }
+
+        String rv = ServiceHandler.getResultsString(sb.toString(), null);
+        assertEquals(sb.toString().substring(0, 100), rv);
+        rv = ServiceHandler.getResultsString(Arrays.asList(sb.toString()), null);
+        assertEquals("(" + sb.toString().substring(0, 100) + ")", rv);
     }
 }


### PR DESCRIPTION
#### [ticket:12820](https://trac.openmicroscopy.org.uk/ome/ticket/12820#comment:7) - ServiceHandler logging ####

https://trac.openmicroscopy.org.uk/ome/ticket/12820 describes long figure json strings being printed in Blitz-0.log. This should limit those strings to a max. length of 1000 chars. cc @will-moore 

#### Large (50k+) directories  ####

`findRepoFiles` previously passed all the files (`basenames`)
in an entire directory into one query. This leads to strange
errors with PostgreSQL of the form:

```
IOException: Tried to send an out-of-range integer as a 2-byte value: 52671
```

Now, the list of basenames are grouped into batches, filling
up a single `Map<String, Long>` which is returned to the caller.

To test, generate a large directory and attempt to import:
```
/tmp/dont-look-here$ cat make.sh
echo "test_Z<00000-60000>.fake" > fake.pattern
for x in $(seq 0 60000); do touch $(printf "test_Z%05d.fake\n" $x); done
```
If the individual files start uploading, then the bug has been fixed. It is likely worth adding an import job, but the upload itself takes a significant amount of time. Until that can be fixed, this may need to be manual. Note: this will need https://github.com/melissalinkert/bioformats/tree/filestitcher-mem to be tested properly. @melissalinkert to open a PR.