### PR TITLE
Library object helpers (part 2)

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -861,7 +861,7 @@ class ITest(object):
         If no name has been provided, a UUID string shall be used.
 
         :param name: the name of the project
-        :param client: user context
+        :param client: The client to use to create the object
         """
 
         if client is None:
@@ -896,15 +896,17 @@ class ITest(object):
 
     def link(self, obj1, obj2, client=None):
         """
-        Links two linkable model entities together by creating an instance
-        of the correct link entity (e.g. ProjectDatasetLinkI) and persisting
-        it in the DB. Accepts client instance to allow calls to happen
-        in correct user contexts. Limited to ProjectI-DatasetI
-        and DatasetI-ImageI links.
+        Links two linkable model entities together by creating an instance of
+        the correct link entity (e.g. ProjectDatasetLinkI) and persisting it
+        in the DB. Accepts client instance to allow calls to happen in correct
+        user contexts. Currently support links are:
+          * project/dataset
+          * dataset/image
+          * image/annotation
 
         :param obj1: parent object
         :param obj2: child object
-        :param client: user context
+        :param client: The client to use to create the link
         """
         if client is None:
             client = self.client

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -995,6 +995,24 @@ class ITest(object):
 
         self.doSubmit(command, client)
 
+    def create_share(self, description="", timeout=None,
+                     objects=[], experimenters=[], guests=[],
+                     enabled=True, client=None):
+        """
+        Create share object
+
+        :param objects: a list of objects to include in the share
+        :param description: a string containing the description of the share
+        :param timeout: the timeout of the share
+        :param experimenters: a list of users associated with the share
+        :param client: The client to use to create the share
+        """
+        if client is None:
+            client = self.client
+        share = client.sf.getShareService()
+        return share.createShare(description, timeout, objects,
+                                 experimenters, guests, enabled)
+
 
 class ProjectionFixture(object):
     """

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -770,14 +770,16 @@ class ITest(object):
         obj.setDescription(rstring(description))
         return obj
 
-    def new_image(self, name=None, description=None):
+    def new_image(self, name=None, description=None, date=0):
         """
         Creates a new image object.
         If no name has been provided, a UUID string shall be used.
         :param name: The image name. If None, a UUID string will be used
+        :param description: The image description
+        :param date: The image acquisition date
         """
         img = self.new_object(ImageI, name=name, description=description)
-        img.acquisitionDate = rtime(0)
+        img.acquisitionDate = rtime(date)
         return img
 
     def new_project(self, name=None, description=None):
@@ -796,16 +798,17 @@ class ITest(object):
         """
         return self.new_object(DatasetI, name=name, description=description)
 
-    def make_image(self, name=None, description=None, client=None):
+    def make_image(self, name=None, description=None, date=0, client=None):
         """
         Creates a new image instance and returns the persisted object.
-        :param name: The project name. If None, a UUID string will be used
+        :param name: The image name. If None, a UUID string will be used
         :param description: The image description
+        :param date: The image acquisition date
         :param client: The client to use to create the object
         """
         if client is None:
             client = self.client
-        image = self.new_image(name=name, description=description)
+        image = self.new_image(name=name, description=description, date=date)
         return client.sf.getUpdateService().saveAndReturnObject(image)
 
     def make_project(self, name=None, description=None, client=None):
@@ -824,7 +827,7 @@ class ITest(object):
         """
         Creates a new dataset instance and returns the persisted object.
         :param name: The dataset name. If None, a UUID string will be used
-        :param description: The project description
+        :param description: The dataset description
         :param client: The client to use to create the object
         """
         if client is None:

--- a/components/tools/OmeroPy/test/integration/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/test_annotation.py
@@ -41,9 +41,7 @@ class TestFigureExportScripts(lib.ITest):
         queryService = session.getQueryService()
 
         # create project
-        parent = omero.model.ProjectI()
-        parent.name = rstring("Annotations Test")
-        parent = updateService.saveAndReturnObject(parent)
+        parent = self.make_project(name="Annotations Test", client=self.root)
 
         xml = "<testXml><testElement><annotation>\
             Text</annotation></testElement></testXml>"

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -86,9 +86,7 @@ class TestChgrp(lib.ITest):
         first_gid = admin.getEventContext().groupId
 
         # Create a dataset in the 'first group'
-        ds = DatasetI()
-        ds.name = rstring("testChgrpImage_target")
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(name="testChgrpImage_target", client=client)
         ds_id = ds.id.val
 
         # Change our context to new group and create image
@@ -137,27 +135,13 @@ class TestChgrp(lib.ITest):
         grp = self.new_group([exp])
         gid = grp.id.val
         client.sf.getAdminService().getEventContext()  # Reset session
-        update = client.sf.getUpdateService()
 
         # Data Setup (image in the P/D hierarchy)
-        img = self.new_image()
-        img = update.saveAndReturnObject(img)
-        project = ProjectI()
-        project.setName(rstring("chgrp-test"))
-        project = update.saveAndReturnObject(project)
-        dataset = DatasetI()
-        dataset.setName(rstring("chgrp-test"))
-        dataset = update.saveAndReturnObject(dataset)
-        links = []
-        link = DatasetImageLinkI()
-        link.setChild(img)
-        link.setParent(dataset)
-        links.append(link)
-        l = ProjectDatasetLinkI()
-        l.setChild(dataset.proxy())
-        l.setParent(project.proxy())
-        links.append(l)
-        update.saveAndReturnArray(links)
+        img = self.make_image(client=client)
+        project = self.make_project(name="chgrp-test", client=client)
+        dataset = self.make_dataset(name="chgrp-test", client=client)
+        self.link(dataset, img, client=client)
+        self.link(project, dataset, client=client)
 
         # Move Project to new group
         chgrp = Chgrp2(
@@ -272,15 +256,11 @@ class TestChgrp(lib.ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        update = client.sf.getUpdateService()
         datasets = self.createDatasets(
             2, "testChgrpOneDatasetFilesetErr", client=client)
         images = self.importMIF(2, client=client)
         for i in range(2):
-            link = DatasetImageLinkI()
-            link.setParent(datasets[i].proxy())
-            link.setChild(images[i].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(datasets[i], images[i], client=client)
 
         # chgrp should succeed with the first Dataset only
         chgrp = Chgrp2(
@@ -319,15 +299,11 @@ class TestChgrp(lib.ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        update = client.sf.getUpdateService()
         datasets = self.createDatasets(
             2, "testChgrpAllDatasetsFilesetOK", client=client)
         images = self.importMIF(2, client=client)
         for i in range(2):
-            link = DatasetImageLinkI()
-            link.setParent(datasets[i].proxy())
-            link.setChild(images[i].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(datasets[i], images[i], client=client)
 
         # Now chgrp, should succeed
         ids = [datasets[0].id.val, datasets[1].id.val]
@@ -356,16 +332,11 @@ class TestChgrp(lib.ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring("testChgrpOneDatasetFilesetOK")
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(name="testChgrpOneDatasetFilesetOK",
+                               client=client)
         images = self.importMIF(2, client=client)
         for i in range(2):
-            link = DatasetImageLinkI()
-            link.setParent(ds.proxy())
-            link.setChild(images[i].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(ds, images[i], client=client)
 
         # Now chgrp, should succeed
         chgrp = Chgrp2(
@@ -415,16 +386,11 @@ class TestChgrp(lib.ITest):
         imagesFsOne = self.importMIF(2, client=client)
         imagesFsTwo = self.importMIF(2, client=client)
 
-        update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring("testChgrpDatasetTwoFilesetsErr")
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(name="testChgrpDatasetTwoFilesetsErr",
+                               client=client)
         self.importMIF(2, client=client)
         for i in (imagesFsOne, imagesFsTwo):
-            link = DatasetImageLinkI()
-            link.setParent(ds.proxy())
-            link.setChild(i[0].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(ds, i[0], client=client)
 
         # chgrp should succeed with the Dataset only
         chgrp = Chgrp2(
@@ -458,16 +424,11 @@ class TestChgrp(lib.ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring("testChgrpDatasetCheckFsGroup")
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(name="testChgrpDatasetCheckFsGroup",
+                               client=client)
         images = self.importMIF(2, client=client)
         for i in range(2):
-            link = DatasetImageLinkI()
-            link.setParent(ds.proxy())
-            link.setChild(images[i].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(ds, images[i], client=client)
 
         # Now chgrp, should succeed
         chgrp = Chgrp2(
@@ -523,17 +484,11 @@ class TestChgrp(lib.ITest):
         """
         # One user in two groups
         client, user = self.new_client_and_user(perms=PRIVATE)
-
         update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring("testChgrp11000")
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(name="testChgrp11000", client=client)
         images = self.importMIF(2, client=client)
         for i in range(2):
-            link = DatasetImageLinkI()
-            link.setParent(ds.proxy())
-            link.setChild(images[i].proxy())
-            link = update.saveAndReturnObject(link)
+            self.link(ds, images[i], client=client)
 
         # Perform the extra companion file logic
         fs = client.sf.getQueryService().findByQuery("""
@@ -596,12 +551,10 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         d = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(d, i, client)
+        i = self.make_image(client=client)
+        self.link(d, i, client=client)
         self.change_group([d], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -624,15 +577,13 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(p, d, client)
-        self.link(d, i, client)
-        self.change_group([p], target_gid, client)
+        i = self.make_image(client=client)
+        self.link(p, d, client=client)
+        self.link(d, i, client=client)
+        self.change_group([p], target_gid, client=client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Project",
@@ -657,15 +608,13 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         d1 = self.make_dataset(client=client)
         d2 = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(d1, i, client)
-        self.link(d2, i, client)
-        self.change_group([d1], target_gid, client)
+        i = self.make_image(client=client)
+        self.link(d1, i, client=client)
+        self.link(d2, i, client=client)
+        self.change_group([d1], target_gid, client=client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Dataset",
@@ -690,14 +639,12 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         d1 = self.make_dataset(client=client)
         d2 = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(d1, i, client)
-        self.link(d2, i, client)
+        i = self.make_image(client=client)
+        self.link(d1, i, client=client)
+        self.link(d2, i, client=client)
 
         hard = ChildOption(includeType=["Image"])
         chgrp = Chgrp2(
@@ -728,16 +675,14 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p = self.make_project(client=client)
         d1 = self.make_dataset(client=client)
         d2 = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(d1, i, client)
-        self.link(d2, i, client)
-        self.link(p, d1, client)
+        i = self.make_image(client=client)
+        self.link(d1, i, client=client)
+        self.link(d2, i, client=client)
+        self.link(p, d1, client=client)
         self.change_group([p], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -763,16 +708,14 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p = self.make_project(client=client)
         d1 = self.make_dataset(client=client)
         d2 = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(d1, i, client)
-        self.link(d2, i, client)
-        self.link(p, d1, client)
+        i = self.make_image(client=client)
+        self.link(d1, i, client=client)
+        self.link(d2, i, client=client)
+        self.link(p, d1, client=client)
 
         hard = ChildOption(includeType=["Image"])
         chgrp = Chgrp2(
@@ -805,16 +748,14 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p1 = self.make_project(client=client)
         p2 = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(p1, d, client)
-        self.link(p2, d, client)
-        self.link(d, i, client)
+        i = self.make_image(client=client)
+        self.link(p1, d, client=client)
+        self.link(p2, d, client=client)
+        self.link(d, i, client=client)
         self.change_group([d], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -843,16 +784,14 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p1 = self.make_project(client=client)
         p2 = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(p1, d, client)
-        self.link(p2, d, client)
-        self.link(d, i, client)
+        i = self.make_image(client=client)
+        self.link(p1, d, client=client)
+        self.link(p2, d, client=client)
+        self.link(d, i, client=client)
         self.change_group([p1], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -878,16 +817,14 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p1 = self.make_project(client=client)
         p2 = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(p1, d, client)
-        self.link(p2, d, client)
-        self.link(d, i, client)
+        i = self.make_image(client=client)
+        self.link(p1, d, client=client)
+        self.link(p2, d, client=client)
+        self.link(d, i, client=client)
 
         hard = ChildOption(includeType=["Dataset"])
         chgrp = Chgrp2(
@@ -924,8 +861,8 @@ class TestChgrp(lib.ITest):
         p1 = self.make_project(client=client)
         p2 = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        self.link(p1, d, client)
-        self.link(p2, d, client)
+        self.link(p1, d, client=client)
+        self.link(p2, d, client=client)
         self.change_group([p1], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -953,8 +890,8 @@ class TestChgrp(lib.ITest):
         p1 = self.make_project(client=client)
         p2 = self.make_project(client=client)
         d = self.make_dataset(client=client)
-        self.link(p1, d, client)
-        self.link(p2, d, client)
+        self.link(p1, d, client=client)
+        self.link(p2, d, client=client)
 
         hard = ChildOption(includeType=["Dataset"])
         chgrp = Chgrp2(
@@ -985,17 +922,15 @@ class TestChgrp(lib.ITest):
         admin.getEventContext()  # Refresh
 
         query = client.sf.getQueryService()
-        update = client.sf.getUpdateService()
 
         p = self.make_project(client=client)
         d1 = self.make_dataset(client=client)
         d2 = self.make_dataset(client=client)
-        i = self.new_image()
-        i = update.saveAndReturnObject(i)
-        self.link(p, d1, client)
-        self.link(p, d2, client)
-        self.link(d1, i, client)
-        self.link(d2, i, client)
+        i = self.make_image(client=client)
+        self.link(p, d1, client=client)
+        self.link(p, d2, client=client)
+        self.link(d1, i, client=client)
+        self.link(d2, i, client=client)
         self.change_group([p], target_gid, client)
 
         ctx = {'omero.group': '-1'}
@@ -1088,8 +1023,7 @@ class TestChgrpTarget(lib.ITest):
             client = self.client
         ctx = {'omero.group': str(gid)}
         update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring(name)
+        ds = self.new_dataset(name)
         return update.saveAndReturnObject(ds, ctx)
 
     def chgrpImagesToTargetDataset(self, imgCount):
@@ -1201,13 +1135,10 @@ class TestChgrpTarget(lib.ITest):
 
         # User creates Dataset in current group...
         update = client.sf.getUpdateService()
-        ds = DatasetI()
-        ds.name = rstring(self.uuid())
-        ds = update.saveAndReturnObject(ds)
+        ds = self.make_dataset(client=client)
         # ...and Project in target group
         ctx = {'omero.group': str(target_gid)}
-        pr = ProjectI()
-        pr.name = rstring(self.uuid())
+        pr = self.new_project()
         pr = update.saveAndReturnObject(pr, ctx)
 
         requests = []

--- a/components/tools/OmeroPy/test/integration/test_counts.py
+++ b/components/tools/OmeroPy/test/integration/test_counts.py
@@ -25,21 +25,15 @@
 """
 
 import library as lib
-from omero_model_ImageI import ImageI
 from omero_model_TagAnnotationI import TagAnnotationI
-from omero.rtypes import rstring, rtime
 
 
 class TestCounts(lib.ITest):
 
     def testBasicUsage(self):
 
-        img = ImageI()
-        img.name = rstring("name")
-        img.acquisitionDate = rtime(0)
-        tag = TagAnnotationI()
-        img.linkAnnotation(tag)
-
+        img = self.new_image(name="name")
+        img.linkAnnotation(TagAnnotationI())
         img = self.update.saveAndReturnObject(img)
 
         img = self.query.findByQuery(

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -221,11 +221,8 @@ class TestDelete(lib.ITest):
             fa = omero.model.FileAnnotationI()
             fa.setNs(rstring(omero.constants.namespaces.NSCOMPANIONFILE))
             fa.setFile(of)
-            l_ia = omero.model.ImageAnnotationLinkI()
-            l_ia.setParent(img)
-            l_ia.setChild(fa)
-            l_ia = self.update.saveAndReturnObject(l_ia)
 
+            self.link(img, fa)
             images.append(iid)
 
         command = Delete2(targetObjects={"Image": images})

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -35,15 +35,13 @@ import os
 from time import time
 from omero.cmd import Delete2
 from omero.cmd.graphs import ChildOption
-from omero.rtypes import rstring, rtime, rlist, rlong
+from omero.rtypes import rstring, rlist, rlong
 
 
 class TestDelete(lib.ITest):
 
     def testBasicUsage(self):
-        img = omero.model.ImageI()
-        img.name = rstring("delete test")
-        img.acquisitionDate = rtime(0)
+        img = self.new_image(name="delete test")
         tag = omero.model.TagAnnotationI()
         img.linkAnnotation(tag)
 
@@ -56,9 +54,7 @@ class TestDelete(lib.ITest):
     def testDeleteMany(self):
         images = list()
         for i in range(0, 5):
-            img = omero.model.ImageI()
-            img.name = rstring("delete test")
-            img.acquisitionDate = rtime(0)
+            img = self.new_image(name="delete test")
             tag = omero.model.TagAnnotationI()
             img.linkAnnotation(tag)
 

--- a/components/tools/OmeroPy/test/integration/test_figureExportScripts.py
+++ b/components/tools/OmeroPy/test/integration/test_figureExportScripts.py
@@ -74,10 +74,8 @@ class TestFigureExportScripts(lib.ITest):
 
             # add tag
             tIndex = i % 5
-            tlink = omero.model.ImageAnnotationLinkI()
-            tlink.child = omero.model.TagAnnotationI(tagIds[tIndex].val, False)
-            tlink.parent = omero.model.ImageI(image.id.val, False)
-            self.root.sf.getUpdateService().saveObject(tlink)
+            tag = omero.model.TagAnnotationI(tagIds[tIndex].val, False)
+            self.link(image, tag, client=self.root)
 
         # run the script twice. First with all args...
         datasetIds = [omero.rtypes.rlong(dataset.id.val), ]

--- a/components/tools/OmeroPy/test/integration/test_icontainer.py
+++ b/components/tools/OmeroPy/test/integration/test_icontainer.py
@@ -26,7 +26,6 @@
 
 import library as lib
 import omero
-from omero_model_ImageAnnotationLinkI import ImageAnnotationLinkI
 from omero_model_CommentAnnotationI import CommentAnnotationI
 from omero.rtypes import rstring
 from uuid import uuid4
@@ -47,18 +46,12 @@ class TestIContainer(lib.ITest):
         group = self.new_group(perms="rwra--")
         client1, user1 = self.new_client_and_user(group=group)
 
-        # create image
+        # create image with comment annotation
         img = self.make_image(name='test1154-img-%s' % self.uuid(),
                               client=client1)
-        img.unload()
-
-        update1 = client1.sf.getUpdateService()
-        ann1 = CommentAnnotationI()
-        ann1.textValue = rstring("user comment - %s" % self.uuid())
-        l_ann1 = ImageAnnotationLinkI()
-        l_ann1.setParent(img)
-        l_ann1.setChild(ann1)
-        update1.saveObject(l_ann1)
+        ann1 = self.new_object(
+            CommentAnnotationI, name="user comment - %s" % self.uuid())
+        self.link(img, ann1, client=client1)
 
         # user retrives the annotations for image
         ipojo1 = client1.sf.getContainerService()
@@ -69,14 +62,9 @@ class TestIContainer(lib.ITest):
 
         # login as user2
         client2, user2 = self.new_client_and_user(group=group)
-        update2 = client2.sf.getUpdateService()
-
-        ann = CommentAnnotationI()
-        ann.textValue = rstring("user2 comment - %s" % self.uuid())
-        l_ann = ImageAnnotationLinkI()
-        l_ann.setParent(img)
-        l_ann.setChild(ann)
-        update2.saveObject(l_ann)
+        ann2 = self.new_object(
+            CommentAnnotationI, name="user2 comment - %s" % self.uuid())
+        self.link(img, ann2, client=client2)
 
         # do they see the same vals?
         coll_count = ipojo1.getCollectionCount(

--- a/components/tools/OmeroPy/test/integration/test_icontainer.py
+++ b/components/tools/OmeroPy/test/integration/test_icontainer.py
@@ -28,7 +28,7 @@ import library as lib
 import omero
 from omero_model_ImageAnnotationLinkI import ImageAnnotationLinkI
 from omero_model_CommentAnnotationI import CommentAnnotationI
-from omero.rtypes import rstring, rtime
+from omero.rtypes import rstring
 from uuid import uuid4
 
 
@@ -352,20 +352,14 @@ class TestSplitFilesets(lib.ITest):
                                + children(dataset_image_hierarchy)
                                + children(well_image_hierarchy)
                                + children(fileset_image_hierarchy)):
-            image = omero.model.ImageI()
-            image.name = rstring('Image #%i' % image_index)
-            image.acquisitionDate = rtime(0L)
-            image.id = update.saveAndReturnObject(image).id
+            image = self.make_image('Image #%i' % image_index)
             images.append(query.get('Image', image.id.val))
 
         # associate test entities
 
         for project_index, dataset_indices in project_dataset_hierarchy:
             for dataset_index in dataset_indices:
-                project_dataset = omero.model.ProjectDatasetLinkI()
-                project_dataset.parent = projects[project_index]
-                project_dataset.child = datasets[dataset_index]
-                update.saveAndReturnObject(project_dataset)
+                self.link(projects[project_index], datasets[dataset_index])
 
         for dataset_index, image_indices in dataset_image_hierarchy:
             for image_index in image_indices:

--- a/components/tools/OmeroPy/test/integration/test_itimeline.py
+++ b/components/tools/OmeroPy/test/integration/test_itimeline.py
@@ -29,14 +29,7 @@ class TestITimeline(lib.ITest):
         for i in range(0, 10):
             # create image
             acquired = long(time.time() * 1000)
-            img = omero.model.ImageI()
-            img.setName(rstring('test-img-%s' % (uuid)))
-            img.setAcquisitionDate(rtime(acquired))
-
-            # default permission 'rw----':
-            img = self.update.saveAndReturnObject(img)
-            img.unload()
-
+            img = self.make_image(name='test-img-%s' % uuid, date=acquired)
             im_ids[i] = [img.id.val, acquired]
 
         # Here we assume that this test is not run within the last 1 second
@@ -103,14 +96,8 @@ class TestITimeline(lib.ITest):
         for i in range(0, 10):
             # create image
             acquired = long(time.time() * 1000)
-            img = omero.model.ImageI()
-            img.setName(rstring('test-img-%s' % client2.sf))
-            img.setAcquisitionDate(rtime(acquired))
-
-            # default permission 'rw----':
-            img = client2.sf.getUpdateService().saveAndReturnObject(img)
-            img.unload()
-
+            img = self.make_image(name='test-img-%s' % client2.sf,
+                                  date=acquired, client=client2)
             im_ids[i] = [img.id.val, acquired]
 
         # Here we assume that this test is not run within the last 1 second

--- a/components/tools/OmeroPy/test/integration/test_mail.py
+++ b/components/tools/OmeroPy/test/integration/test_mail.py
@@ -87,7 +87,6 @@ class TestMail(lib.ITest):
 
         group = self.new_group(perms="rwra--")  # TODO: fixture
         user = self.new_client(group=group)
-        update = user.sf.getUpdateService()
         admin = user.sf.getAdminService()
 
         image = self.make_image(name="testOwnComments", client=user)
@@ -100,11 +99,8 @@ class TestMail(lib.ITest):
 
         commenter = self.new_client(group=group,
                                     email="commenter@localhost")
-        link = omero.model.ImageAnnotationLinkI()
         comment = omero.model.CommentAnnotationI()
-        link.parent = image.proxy()
-        link.child = comment
-        update = commenter.sf.getUpdateService()
-        comment = update.saveAndReturnObject(link).child
+        link = self.link(image, comment, client=commenter)
+        comment = link.child
 
         self.assertMail("CommentAnnotation:%s -" % comment.id.val)

--- a/components/tools/OmeroPy/test/integration/test_mail.py
+++ b/components/tools/OmeroPy/test/integration/test_mail.py
@@ -90,9 +90,7 @@ class TestMail(lib.ITest):
         update = user.sf.getUpdateService()
         admin = user.sf.getAdminService()
 
-        image = omero.model.ImageI()
-        image.name = omero.rtypes.rstring("testOwnComments")
-        image = update.saveAndReturnObject(image)
+        image = self.make_image(name="testOwnComments", client=user)
         ctx = admin.getEventContext()
 
         # Set own email

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -278,11 +278,9 @@ class TestSearch(lib.ITest):
         ofile.path = _(os.path.dirname(path))
         ofile.name = _(os.path.basename(path))
         ofile = client.upload(path, ofile=ofile)
-        link = omero.model.ImageAnnotationLinkI()
-        link.parent = image
-        link.child = omero.model.FileAnnotationI()
-        link.child.file = ofile.proxy()
-        link = client.sf.getUpdateService().saveObject(link)
+        fa = omero.model.FileAnnotationI()
+        fa.file = ofile.proxy()
+        self.link(image, fa, client=client)
         self.root.sf.getUpdateService().indexObject(image)
         return image
 

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -117,9 +117,7 @@ class TestSearch(lib.ITest):
 
         images = list()
         for i in range(0, 5):
-            img = omero.model.ImageI()
-            img.name = omero.rtypes.rstring("search_test_%i.tif" % i)
-            img.acquisitionDate = omero.rtypes.rtime(0)
+            img = self.new_image(name="search_test_%i.tif" % i)
             tag = omero.model.TagAnnotationI()
             tag.textValue = omero.rtypes.rstring("tag %i" % i)
             img.linkAnnotation(tag)
@@ -373,9 +371,7 @@ class TestSearch(lib.ITest):
     ))
     def test_hyphen_underscore(self, name, test):
         client = self.new_client()
-        proj = omero.model.ProjectI()
-        proj.name = omero.rtypes.rstring(name)
-        proj = client.sf.getUpdateService().saveAndReturnObject(proj)
+        proj = self.make_project(name, client=client)
         self.root.sf.getUpdateService().indexObject(proj)
 
         search = client.sf.createSearchService()
@@ -398,8 +394,7 @@ class TestSearch(lib.ITest):
         ann.setMapValue([
             omero.model.NamedValue(key, val)
         ])
-        proj = omero.model.ProjectI()
-        proj.name = omero.rtypes.rstring("test_map_annotations")
+        proj = self.new_project(name="test_map_annotations")
         proj.linkAnnotation(ann)
         proj = client.sf.getUpdateService().saveAndReturnObject(proj)
         self.root.sf.getUpdateService().indexObject(proj)

--- a/components/tools/OmeroPy/test/integration/test_tickets2000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets2000.py
@@ -338,11 +338,6 @@ class TestTickets2000(lib.ITest):
 
         for i in range(1, 2001):
             img = self.new_image(name='img1184-%s' % (uuid))
-            # Saving in one go
-            # dil = DatasetImageLinkI()
-            # dil.setParent(ds)
-            # dil.setChild(img)
-            # update.saveObject(dil)
             ds.linkImage(img)
         ds = update.saveAndReturnObject(ds)
 

--- a/components/tools/OmeroPy/test/integration/test_tickets2000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets2000.py
@@ -14,7 +14,6 @@ import library as lib
 import pytest
 import omero
 from omero.rtypes import rbool, rstring, rtime, rlong, rint
-from omero_model_ImageI import ImageI
 from omero_model_DatasetI import DatasetI
 from omero_model_ProjectI import ProjectI
 from omero_model_ExperimenterI import ExperimenterI
@@ -140,7 +139,6 @@ class TestTickets2000(lib.ITest):
 
         # images
         im2 = self.make_image(name='test1071-im2-%s' % (c2_uuid), client=c2)
-        im2.unload()
 
         # links
         # im2 owned by u2
@@ -311,14 +309,11 @@ class TestTickets2000(lib.ITest):
         uuid = self.uuid()
         new_gr1 = self.new_group(perms="rw----")
         client_share1, new_exp_obj = self.new_client_and_user(new_gr1)
-        update1 = client_share1.sf.getUpdateService()
         search1 = client_share1.sf.createSearchService()
 
         # create image and index
-        img = ImageI()
-        img.setName(rstring('test1154-img-%s' % (uuid)))
-        img = update1.saveAndReturnObject(img)
-        img.unload()
+        img = self.make_image(name='test1154-img-%s' % uuid,
+                              client=client_share1)
         self.index(img)
 
         # search

--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -19,13 +19,8 @@ from omero.rtypes import rint, rlong, rstring
 class TestTickets3000(lib.ITest):
 
     def test2396(self):
-        uuid = self.uuid()
-
         # create image
-        img = self.new_image()
-        img.setName(rstring('test2396-img-%s' % (uuid)))
-        img = self.update.saveAndReturnObject(img)
-        img.unload()
+        img = self.make_image(name='test2396-img-%s' % self.uuid())
 
         format = "txt"
         binary = "12345678910"
@@ -46,10 +41,8 @@ class TestTickets3000(lib.ITest):
 
         fa = omero.model.FileAnnotationI()
         fa.setFile(of)
-        l_ia = omero.model.ImageAnnotationLinkI()
-        l_ia.setParent(img)
-        l_ia.setChild(fa)
-        self.update.saveObject(l_ia)
+
+        self.link(img, fa)
 
         # Alternatively, unload the file
         of = self.update.saveAndReturnObject(oFile)
@@ -63,10 +56,8 @@ class TestTickets3000(lib.ITest):
 
         fa = omero.model.FileAnnotationI()
         fa.setFile(of)
-        l_ia = omero.model.ImageAnnotationLinkI()
-        l_ia.setParent(img)
-        l_ia.setChild(fa)
-        self.update.saveObject(l_ia)
+
+        self.link(img, fa)
 
     def test2547(self):
         admin = self.root.sf.getAdminService()


### PR DESCRIPTION
Follow up of https://github.com/openmicroscopy/openmicroscopy/pull/3728

- more fixes across top-level integration tests to use `self.new_xxx`/`self.make_xxx()`/`self.link()` methods
- exposition of acquisition date in image creation helper methods
- migration of the BlitzGateway share test to OmeroPy (see https://github.com/openmicroscopy/openmicroscopy/pull/3715#issuecomment-93940978)
- migration of `create_share` helper method to `ITest` /cc @aleksandra-tarkowska 

Apart from checking that integration tests remain green and that changes are sensible, `test_icontainer.testFindAndCountAnnotationsForSharedData` should be reviewed more closely. The logic of the test has been modified as it didn't seem to include the second created client anywhere previously.