### PR TITLE
Fix usage of OMERO_SESSION_DIR

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -189,7 +189,8 @@ class Parser(ArgumentParser):
     def add_login_arguments(self):
         group = self.add_argument_group(
             'Login arguments', """Environment variables:
-    OMERO_SESSDIR - Set the sessions directory (Default: $HOME/omero/sessions)
+    OMERO_SESSIONDIR - Set the sessions directory (Default:
+ $HOME/omero/sessions)
 
 Optional session arguments:
 """)

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -189,8 +189,7 @@ class Parser(ArgumentParser):
     def add_login_arguments(self):
         group = self.add_argument_group(
             'Login arguments', """Environment variables:
-    OMERO_SESSION_DIR - Set the sessions directory \
-(Default: $HOME/omero/sessions)
+    OMERO_SESSDIR - Set the sessions directory (Default: $HOME/omero/sessions)
 
 Optional session arguments:
 """)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -97,12 +97,26 @@ Options for logging in:
     $ bin/omero sessions login --sudo=root example@localhost
     Password for root:
 
-Other commands:
+Other sessions commands:
 
-    $ bin/omero sessions list
-    $ OMERO_SESSIONDIR=/tmp bin/omero sessions list
+    # Logging out of the currently active sessions
     $ bin/omero sessions logout
-    $ bin/omero sessions clear
+
+    # List all locally available sessions (purging the expired ones)
+    $ bin/omero sessions list
+
+    # List all local sessions
+    $ bin/omero sessions list --no-purge
+
+
+Custom sessions directory:
+
+    # Specify a custom session directory using OMERO_SESSIONDIR
+    $ export OMERO_SESSIONDIR=/tmp/my_sessions
+    # Create a new session stored under OMERO_SESSIONDIR
+    $ bin/omero sessions login
+    $ bin/omero sessions file
+    $ bin/omero sessions list
 """
 
 

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -207,8 +207,7 @@ class SessionsControl(BaseControl):
         self._configure_dir(login)
 
     def _configure_dir(self, parser):
-        parser.add_argument("--session-dir", help=SUPPRESS,
-                            default=os.environ.get('OMERO_SESSIONDIR', None))
+        parser.add_argument("--session-dir", help=SUPPRESS)
 
     def help(self, args):
         self.ctx.err(LONGHELP % {"prog": args.prog})

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -100,7 +100,7 @@ Options for logging in:
 Other commands:
 
     $ bin/omero sessions list
-    $ OMERO_SESSDIR=/tmp bin/omero sessions list
+    $ OMERO_SESSIONDIR=/tmp bin/omero sessions list
     $ bin/omero sessions logout
     $ bin/omero sessions clear
 """
@@ -188,7 +188,7 @@ class SessionsControl(BaseControl):
 
     def _configure_dir(self, parser):
         parser.add_argument("--session-dir", help=SUPPRESS,
-                            default=os.environ.get('OMERO_SESSDIR', None))
+                            default=os.environ.get('OMERO_SESSIONDIR', None))
 
     def help(self, args):
         self.ctx.err(LONGHELP % {"prog": args.prog})

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -31,6 +31,7 @@ import Ice
 import IceImport
 import time
 import traceback
+import warnings
 import omero.java
 
 IceImport.load("Glacier2_Router_ice")
@@ -132,17 +133,22 @@ class SessionsControl(BaseControl):
                 # Read base directory from deprecated OMERO_SESSION_DIR envvar
                 base_dir = os.environ.get('OMERO_SESSION_DIR', None)
                 if base_dir:
-                    import warnings
                     warnings.warn(
                         "OMERO_SESSION_DIR is deprecated. Use OMERO_SESSIONDIR"
                         " instead.", DeprecationWarning)
+                else:
+                    base_dir = getattr(args, "session_dir", None)
+                    warnings.warn(
+                        "--session-dir is deprecated. Use OMERO_SESSIONDIR"
+                        " instead.", DeprecationWarning)
+
+                if base_dir:
                     from path import path
                     sessions_dir = path(base_dir) / "omero" / "sessions"
 
-            dirpath = getattr(args, "session_dir", sessions_dir)
-            return self.FACTORY(dirpath)
+            return self.FACTORY(sessions_dir)
         except OSError, ose:
-            filename = getattr(ose, "filename", dirpath)
+            filename = getattr(ose, "filename", sessions_dir)
             self.ctx.die(155, "Could not access session dir: %s" % filename)
 
     def _configure(self, parser):

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -112,16 +112,16 @@ class SessionsControl(BaseControl):
 
     def store(self, args):
         try:
-            # Read sessions directory from OMERO_SESS_DIR envvar
-            sessions_dir = os.environ.get('OMERO_SESSDIR', None)
+            # Read sessions directory from OMERO_SESSIONDIR envvar
+            sessions_dir = os.environ.get('OMERO_SESSIONDIR', None)
             if not sessions_dir:
                 # Read base directory from deprecated OMERO_SESSION_DIR envvar
                 base_dir = os.environ.get('OMERO_SESSION_DIR', None)
                 if base_dir:
                     import warnings
                     warnings.warn(
-                        "OMERO_SESSION_DIR is deprecated. Use OMERO_SESSDIR "
-                        "instead.", DeprecationWarning)
+                        "OMERO_SESSION_DIR is deprecated. Use OMERO_SESSIONDIR"
+                        " instead.", DeprecationWarning)
                     from path import path
                     sessions_dir = path(base_dir) / "omero" / "sessions"
 

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -138,9 +138,10 @@ class SessionsControl(BaseControl):
                         " instead.", DeprecationWarning)
                 else:
                     base_dir = getattr(args, "session_dir", None)
-                    warnings.warn(
-                        "--session-dir is deprecated. Use OMERO_SESSIONDIR"
-                        " instead.", DeprecationWarning)
+                    if base_dir:
+                        warnings.warn(
+                            "--session-dir is deprecated. Use OMERO_SESSIONDIR"
+                            " instead.", DeprecationWarning)
 
                 if base_dir:
                     from path import path

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -62,8 +62,9 @@ class SessionsStore(object):
         """
         self.logger = logging.getLogger(make_logname(self))
         if dir is None:
-            dir = get_user_dir()
-        self.dir = path(dir) / "omero" / "sessions"
+            self.dir = path(get_user_dir()) / "omero" / "sessions"
+        else:
+            self.dir = path(dir)
         if not self.dir.exists():
             self.dir.makedirs()
         try:

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -180,7 +180,7 @@ class TestStore(object):
             props["omero.port"] = port
         s.add("srv", "usr", "uuid", props, sudo=sudo)
         assert 1 == len(s.available("srv", "usr"))
-        session_dir = tmpdir / "omero" / "sessions"
+        session_dir = tmpdir
         session_file = session_dir / "srv" / "usr" / "uuid"
         session_file_content = session_file.read()
         assert "omero.sess=uuid\n" in session_file_content
@@ -205,7 +205,7 @@ class TestStore(object):
         if port:
             props["omero.port"] = port
         s.set_current("srv", name=name, uuid=key, props=props)
-        session_dir = tmpdir / "omero" / "sessions"
+        session_dir = tmpdir
 
         # Using last_* methods
         assert (session_dir / "._LASTHOST_").exists()

--- a/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
@@ -57,9 +57,14 @@ class TestSessions(object):
         assert store.dir == path(args.session_dir)
 
         # OMERO_SESSION_DIR with no args.session_dir sets the sessions dir
-        monkeypatch.setenv("OMERO_SESSION_DIR", tmpdir / 'envvar')
+        monkeypatch.setenv("OMERO_SESSION_DIR", tmpdir / 'basedir')
         store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(tmpdir) / 'envvar'
+        assert store.dir == path(tmpdir) / 'basedir' / 'omero' / 'sessions'
+
+        # OMERO_SESSDIR takes precedence over OMERO_SESSION_DIR
+        monkeypatch.setenv("OMERO_SESSDIR", tmpdir / 'sessionsdir')
+        store = self.cli.controls['sessions'].store(None)
+        assert store.dir == path(tmpdir) / 'sessionsdir'
 
         # args.session_dir overrides OMERO_SESSION_DIR
         store = self.cli.controls['sessions'].store(args)

--- a/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
@@ -50,10 +50,10 @@ class TestSessions(object):
         assert store.dir == path(get_user_dir()) / 'omero' / 'sessions'
 
     @pytest.mark.parametrize('OMERO_SESSION_DIR', [True, False])
-    @pytest.mark.parametrize('OMERO_SESSDIR', [True, False])
+    @pytest.mark.parametrize('OMERO_SESSIONDIR', [True, False])
     @pytest.mark.parametrize('session_dir', [True, False])
     def testCustomSessionsDir(
-            self, tmpdir, monkeypatch, OMERO_SESSION_DIR, OMERO_SESSDIR,
+            self, tmpdir, monkeypatch, OMERO_SESSION_DIR, OMERO_SESSIONDIR,
             session_dir):
         from argparse import Namespace
         from omero.util import get_user_dir
@@ -62,8 +62,8 @@ class TestSessions(object):
         if OMERO_SESSION_DIR:
             monkeypatch.setenv("OMERO_SESSION_DIR", tmpdir / 'basedir')
 
-        if OMERO_SESSDIR:
-            monkeypatch.setenv("OMERO_SESSDIR", tmpdir / 'sessionsdir')
+        if OMERO_SESSIONDIR:
+            monkeypatch.setenv("OMERO_SESSIONDIR", tmpdir / 'sessiondir')
 
         # args.session_dir sets the sessions dir
         args = Namespace()
@@ -74,8 +74,8 @@ class TestSessions(object):
         # IN order of precedence
         if session_dir:
             assert store.dir == path(args.session_dir)
-        elif OMERO_SESSDIR:
-            assert store.dir == path(tmpdir) / 'sessionsdir'
+        elif OMERO_SESSIONDIR:
+            assert store.dir == path(tmpdir) / 'sessiondir'
         elif OMERO_SESSION_DIR:
             assert store.dir == path(tmpdir) / 'basedir' / 'omero' / 'sessions'
         else:

--- a/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
@@ -54,13 +54,13 @@ class TestSessions(object):
         args = Namespace()
         args.session_dir = tmpdir / 'session_dir'
         store = self.cli.controls['sessions'].store(args)
-        assert store.dir == path(args.session_dir) / 'omero' / 'sessions'
+        assert store.dir == path(args.session_dir)
 
         # OMERO_SESSION_DIR with no args.session_dir sets the sessions dir
         monkeypatch.setenv("OMERO_SESSION_DIR", tmpdir / 'envvar')
         store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(tmpdir) / 'envvar' / 'omero' / 'sessions'
+        assert store.dir == path(tmpdir) / 'envvar'
 
         # args.session_dir overrides OMERO_SESSION_DIR
         store = self.cli.controls['sessions'].store(args)
-        assert store.dir == path(args.session_dir) / 'omero' / 'sessions'
+        assert store.dir == path(args.session_dir)


### PR DESCRIPTION
Initial implementation of OMERO_SESSION_DIR led to the creation of a omero/sessions subfolders. This behavior is counter-intuitive and does not match the CLI documentation. This commit fixes this behavior by deprecating `OMERO_SESSION_DIR` in favor of `OMERO_SESSIONDIR` which allows to set the equivalent of `$HOME/omero/sessions` by environment variable.

To test this PR, check the sessions storage mechanism under various environments:

```
# Should store under ~/omero/sessions
bin/omero login -s localhost -u user -w pass -C
bin/omero sessions file
# Should store under ~/xxx/omero/sessions
OMERO_SESSION_DIR=~/xxx bin/omero login -s localhost -u user -w pass -C
OMERO_SESSION_DIR=~/xxx bin/omero sessions file
# Should store under ~/xxx2
OMERO_SESSIONDIR=~/xxx2 bin/omero login -s localhost -u user -w pass -C
OMERO_SESSIONDIR=~/xxx2 bin/omero sessions file
# Should store under ~/xxx2
OMERO_SESSIONDIR=~/xxx2 OMERO_SESSION_DIR=~/xxx bin/omero login -s localhost -u user -w pass -C
OMERO_SESSIONDIR=~/xxx2 OMERO_SESSION_DIR=~/xxx bin/omero sessions file
```
