### PR TITLE
CLI: review debug help

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -360,26 +360,31 @@ class ExceptionHandler(object):
 DEBUG_HELP = """
 Set debug options for developers
 
-The value to the debug argument is a comma-separated list of commands:
+The value to the debug argument is a comma-separated list of commands.
 
- * 'debug' prints at the "debug" level. Similar to setting DEBUG=1 in
-   the environment.
- * 'trace' runs the command with tracing enabled.
- * 'profile' runs the command with profiling enabled.
+Available debugging choices:
 
-Only one of "trace" and "profile" can be chosen.
+    '0'         Disable debugging
+    'debug'     Enable debugging at the first debug level
+    '1'-'9'     Enable debugging at the specified debug level
+    'trace'     Run the command with tracing enabled
+    'profile'   Run the command with profiling enabled
 
-Example:
+Note "trace" and "profile" can not be used simultaneously
 
-    # Debugs at level 1 and prints tracing
+Examples:
+
+    # Enabled debugging at level 1 and prints tracing
     bin/omero --debug=debug,trace admin start
-    # Debugs at level 1
+    # Enabled debugging at level 1
     bin/omero -d1 admin start
-    # Prints profiling
+    # Enabled debugging at level 3
+    bin/omero -d3 admin start
+    # Enable profiling
     bin/omero -dp admin start
-    # Fails!; can't print tracing and profiling together
+    # Fails - can not print tracing and profiling together
     bin/omero -dt,p admin start
-    # Disables debugging
+    # Disable debugging
     bin/omero -d0 admin start
 """
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -370,7 +370,7 @@ Available debugging choices:
     'trace'     Run the command with tracing enabled
     'profile'   Run the command with profiling enabled
 
-Note "trace" and "profile" can not be used simultaneously
+Note "trace" and "profile" cannot be used simultaneously
 
 Examples:
 
@@ -382,7 +382,7 @@ Examples:
     bin/omero -d3 admin start
     # Enable profiling
     bin/omero -dp admin start
-    # Fails - can not print tracing and profiling together
+    # Fails - cannot print tracing and profiling together
     bin/omero -dt,p admin start
     # Disable debugging
     bin/omero -d0 admin start

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -357,6 +357,32 @@ class ExceptionHandler(object):
         else:
             return "Unknown Ice.RequestFailedException"
 
+DEBUG_HELP = """
+Set debug options for developers
+
+The value to the debug argument is a comma-separated list of commands:
+
+ * 'debug' prints at the "debug" level. Similar to setting DEBUG=1 in
+   the environment.
+ * 'trace' runs the command with tracing enabled.
+ * 'profile' runs the command with profiling enabled.
+
+Only one of "trace" and "profile" can be chosen.
+
+Example:
+
+    # Debugs at level 1 and prints tracing
+    bin/omero --debug=debug,trace admin start
+    # Debugs at level 1
+    bin/omero -d1 admin start
+    # Prints profiling
+    bin/omero -dp admin start
+    # Fails!; can't print tracing and profiling together
+    bin/omero -dt,p admin start
+    # Disables debugging
+    bin/omero -d0 admin start
+"""
+
 
 class Context:
     """Simple context used for default logic. The CLI registry which registers
@@ -382,32 +408,7 @@ class Context:
         self.isquiet = False
         # This usage will go away and default will be False
         self.isdebug = DEBUG
-        self.topics = {"debug": """
-
-        debug options for developers:
-
-        The value to the debug argument is a comma-separated list of commands:
-
-         * 'debug' prints at the "debug" level. Similar to setting DEBUG=1 in
-           the environment.
-         * 'trace' runs the command with tracing enabled.
-         * 'profile' runs the command with profiling enabled.
-
-        Only one of "trace" and "profile" can be chosen.
-
-        Example:
-
-            # Debugs at level 1 and prints tracing
-            bin/omero --debug=debug,trace admin start
-            # Debugs at level 1
-            bin/omero -d1 admin start
-            # Prints profiling
-            bin/omero -dp admin start
-            # Fails!; can't print tracing and profiling together
-            bin/omero -dt,p admin start
-            # Disables debugging
-            bin/omero -d0 admin start
-        """}
+        self.topics = {"debug": DEBUG_HELP}
         self.parser = Parser(prog=prog, description=OMERODOC)
         self.subparsers = self.parser_init(self.parser)
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/1293

This PR reviews the help for the debug topic of the CLI, bringing it in line with the subcommands help. It also removes the reference to the deprecated `DEBUG` environment variable.

To test this PR, review the output of

```
bin/omero help debug
```