### PR TITLE
Fixed DnD mif move

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4515,9 +4515,16 @@ class TreeViewerComponent
 	    if (ot instanceof ExperimenterData) {
 	        Object po = p.getUserObject();
 	        if (po instanceof GroupData) group = (GroupData) po;
-	    } else {
-	        group = new GroupData();
-	        group.setId(otData.getGroupId());
+	    } else if (ot instanceof GroupData) {
+	        group = (GroupData)ot;
+	    }
+	    else { 
+            for (Object gd : TreeViewerAgent.getAvailableUserGroups()) {
+                if (((GroupData) gd).getId() == otData.getGroupId()) {
+                    group = (GroupData) gd;
+                    break;
+                }
+            }
 	    }
 	    //to review
 	    if (browser.getBrowserType() == Browser.ADMIN_EXPLORER)


### PR DESCRIPTION
While checking [Ticket 12171](https://trac.openmicroscopy.org.uk/ome/ticket/12171) I noticed that moving a single image which is part of a MIF via drag&drop into another group crashed Insight with an IllegalStateException being thrown. This PR fixes the issue.

**Test:** 
Select a subset of images of a MIF and move them via Drag&Drop into another group; expected: All images of the MIF should be moved (but you should get asked for confirmation beforehand).