### PR TITLE
Pyramid generation thumbnails

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/basket/basket.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/basket/basket.html
@@ -272,7 +272,7 @@
 	                {% for c in basket.imageInBasket %}
 	                    <tr id="image-{{ c.id }}">
 	                        <td class="image">
-	                            <img src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_none }}"
+	                            <img src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_minus_one }}"
                                     id="{{ c.id }}" alt="image" alt="image" title="{{ c.name }}, owned by {{ c.getOwner.getNameWithInitial }}"/>
 	                            <input type="checkbox" name="image" id="{{ c.id }}" class="hide">
 	                        </td>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/basket/basketContent.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/basket/basketContent.html
@@ -36,7 +36,8 @@
             <li>
 				
 				<div class="basket_image">
-	                <img src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_none }}" alt="image" title="{{ c.name }}"/>
+	        <img src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_minus_one }}"
+            alt="image" title="{{ c.name }}"/>
 				</div>
 					
 	            <input type="checkbox" name="image" id="{{ c.id }}" class="hide">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
@@ -387,7 +387,9 @@
                         {% if share and not share.share.isOwned %}
                             <img id="{{ c.id }}" src="{% url 'render_thumbnail' c.id share.share.id %}" alt="image" title="{{ c.name|escape }}, owned by {{ c.getOwner.getNameWithInitial }}"/>
                         {% else %}
-                            <img id="{{ c.id }}" src="{% url 'render_thumbnail_resize' 96 c.id %}?version={{ c.getThumbVersion|random_if_none }}" alt="image" title="{{ c.name|escape }}{% if not c.isOwned %}, owned by {{ c.getOwner.getNameWithInitial }}{% endif %}"/>
+                            <img id="{{ c.id }}" alt="image"
+                                src="{% url 'render_thumbnail_resize' 96 c.id %}?version={{ c.getThumbVersion|random_if_minus_one }}"
+                                title="{{ c.name|escape }}{% if not c.isOwned %}, owned by {{ c.getOwner.getNameWithInitial }}{% endif %}"/>
                         {% endif %}
                     </div>
                     <!-- NB: '#image_icon-123 div.desc' etc is used to update name when changed in right panel via "editinplace" -->

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/history/history_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/history/history_details.html
@@ -133,7 +133,9 @@
             {% for c in i.image %}
                 <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
                     <td class="image">
-                        <img id="{{ c.id }}" src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_none }}" alt="image" title="{{ c.name }}"/>
+                        <img id="{{ c.id }}"
+                          src="{% url 'render_thumbnail_resize' 32 c.id  %}?version={{ c.getThumbVersion|random_if_minus_one }}"
+                          alt="image" title="{{ c.name }}"/>
                         <input type="checkbox" name="image" id="{{ c.id }}" class="hide">      
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -50,8 +50,9 @@ def hash(value, key):
 
 
 @register.filter
-def random_if_none(value):
-    if value is None:
+def random_if_minus_one(value):
+    """ Used for thumbnail versions """
+    if value == -1:
         value = str(random.random())[2:]
     return value
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -50,6 +50,13 @@ def hash(value, key):
 
 
 @register.filter
+def random_if_none(value):
+    if value is None:
+        value = str(random.random())[2:]
+    return value
+
+
+@register.filter
 def random_if_minus_one(value):
     """ Used for thumbnail versions """
     if value == -1:


### PR DESCRIPTION
This is part of #3713 after discussion with @joshmoore.

Now, if the thumbnail version is -1 (during Pyramid generation) then we use a random version number to prevent caching of the clock thumbnail in the browser.
Clock thumbnails will be retrieved each time a Dataset is refreshed until we get version 0.

To test, import a Big image (png/jpeg) load the Dataset then use only the tree toolbar refresh button to reload the dataset repeatedly during pyramid generation.
When pyramid generation finishes, the new thumbnail should be loaded.