### PR TITLE
fix OriginalFile ordering for deletion

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -34,6 +34,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.model.internal.Permissions;
@@ -165,7 +166,9 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                         targetObjectCount++;
                     }
                 }
-                return graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
+                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
                 graphTraversal.unlinkTargets();
                 return null;

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -34,6 +34,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.api.IAdmin;
@@ -162,7 +163,9 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                         targetObjectCount++;
                     }
                 }
-                return graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
+                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
                 graphTraversal.unlinkTargets();
                 return null;

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -31,6 +31,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
@@ -147,7 +148,9 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                         targetObjectCount++;
                     }
                 }
-                return graphTraversal.planOperation(helper.getSession(), targetMultimap, false);
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, false);
+                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
                 graphTraversal.unlinkTargets();
                 return null;

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -50,6 +50,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
 import ome.model.IObject;
+import ome.model.core.OriginalFile;
 import ome.model.internal.Permissions;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
@@ -1410,8 +1411,18 @@ public class GraphTraversal {
                     final String className = oneClassToDelete.getKey();
                     final Collection<Long> allIds = oneClassToDelete.getValue();
                     assertMayBeDeleted(className, allIds);
-                    for (final List<Long> ids : Iterables.partition(allIds, BATCH_SIZE)) {
-                        processor.deleteInstances(className, ids);
+                    final Collection<List<Long>> idGroups;
+                    if (OriginalFile.class.getName().equals(className)) {
+                        idGroups = ModelObjectSequencer.sortOriginalFileIds(session, allIds);
+                        for (final List<Long> idGroup : idGroups) {
+                            for (final List<Long> ids : Iterables.partition(idGroup, BATCH_SIZE)) {
+                                processor.deleteInstances(className, ids);
+                            }
+                        }
+                    } else {
+                        for (final List<Long> ids : Iterables.partition(allIds, BATCH_SIZE)) {
+                            processor.deleteInstances(className, ids);
+                        }
                     }
                 }
             }

--- a/components/server/src/ome/services/graphs/ModelObjectSequencer.java
+++ b/components/server/src/ome/services/graphs/ModelObjectSequencer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.graphs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.hibernate.Session;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+
+/**
+ * OMERO model objects sometimes must be processed in a specific order.
+ * This class groups the utility methods for performing such ordering.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.1
+ */
+public class ModelObjectSequencer {
+    /**
+     * Sort a list of original file IDs such that files precede containing directories.
+     * @param session the Hibernate session
+     * @param unorderedIds the IDs of original files
+     * @return a batching of the given IDs such that a batch containing a file precedes a batch containing a containing directory
+     */
+    public static Collection<List<Long>> sortOriginalFileIds(Session session, Collection<Long> unorderedIds) {
+        if (unorderedIds.size() < 2) {
+            /* no need to rearrange anything, as there are not multiple original files */
+            return Collections.<List<Long>>singletonList(new ArrayList<Long>(unorderedIds));
+        }
+        final String hql = "SELECT id, length(path) FROM OriginalFile WHERE id IN (:ids)";
+        final SortedMap<Integer, List<Long>> filesByPathLength = new TreeMap<Integer, List<Long>>(Ordering.natural().reverse());
+        for (final Collection<Long> idBatch : Iterables.partition(unorderedIds, 256)) {
+            for (final Object[] result : (List<Object[]>) session.createQuery(hql).setParameterList("ids", idBatch).list()) {
+                final Long id = (Long) result[0];
+                final Integer length = (Integer) result[1];
+                List<Long> idList = filesByPathLength.get(length);
+                if (idList == null) {
+                    idList = new ArrayList<Long>();
+                    filesByPathLength.put(length, idList);
+                }
+                idList.add(id);
+            }
+        }
+        final Collection<List<Long>> orderedIds = new ArrayList<List<Long>>();
+        for (final List<Long> ids : filesByPathLength.values()) {
+            orderedIds.add(ids);
+        }
+        return orderedIds;
+    }
+}

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -56,6 +56,8 @@ import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.State;
 import omero.cmd.Status;
+import omero.grid.RepositoryMap;
+import omero.grid.RepositoryPrx;
 import omero.model.Arc;
 import omero.model.BooleanAnnotation;
 import omero.model.BooleanAnnotationI;
@@ -881,6 +883,21 @@ public class AbstractServerTest extends AbstractTest {
         Experiment e = (Experiment) results.get(0);
         assertNotNull(e);
         return e;
+    }
+
+    /**
+     * @return a repository rooted at a directory named <q>ManagedRepository</q>
+     * @throws ServerError if the repository map could not be retrieved
+     */
+    protected RepositoryPrx getManagedRepository() throws ServerError {
+        final RepositoryMap repos = factory.sharedResources().repositories();
+        int index = repos.descriptions.size();
+        while (--index >= 0) {
+            if ("ManagedRepository".equals(repos.descriptions.get(index).getName().getValue())) {
+                return repos.proxies.get(index);
+            }
+        }
+        throw new RuntimeException("no managed repository");
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -1060,9 +1060,9 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         int fileCount = 0;
 
         /* import a small image to discover a suitable location in the repository for further testing */
-        final File imageFile = ResourceUtils.getFile("classpath:red.png");
-        final long filesetId = importFile(imageFile, "png").get(0).getImage().getFileset().getId().getValue();
-        fileCount += 2;  /* for PNG file and import log */
+        final File imageFile = ResourceUtils.getFile("classpath:tinyTest.d3d.dv");
+        final long filesetId = importFile(imageFile, "dv").get(0).getImage().getFileset().getId().getValue();
+        fileCount += 2;  /* for image file and import log */
 
         /* find the managed repository directory for the imported image file */
         query = "SELECT originalFile.path FROM FilesetEntry WHERE fileset.id = :id";


### PR DESCRIPTION
As suggested by https://trello.com/c/gglTLzkS/480-have-delete2-order-file-deletions, improves the new graph requests such that original file deletions may be combined within the same request regardless of if they must be deleted in a certain order.

Integration tests ought still pass, including the new `DeleteServiceFilesTest.testRecursiveDelete` at https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration/DeleteServiceFilesTest/testRecursiveDelete/.

Manual testing may be most easily effected with the help of @ximenesuk's CLI PRs as you need a hierarchy of original files that are not linked to anything else, and there is the extra complication that regular users appear not to be able to delete directories. Still, to give it a try from a simple Python client:

1. Arrange a file hierarchy in a repository. What I do is import an image and then, say, for image 12345, submit a `Delete2(targetObjects={'Image' : [12345]}, childOptions=[ChildOption(excludeType=['OriginalFile'])])` to delete all of it except for its files.
1. Find the IDs of the files and directories. You can't just use a dry-run `Delete2` on the image to find them as that doesn't mention directories, so for a fresh import I just look for the latest entries in the `originalfile` table.
1. Submit a single `Delete2` request to delete all those files and directories, listing their IDs in any crazy order you like regardless of which contain which. Do this as the root user, so that directories may be deleted.
1. Observe that they are all listed in the `Delete2Response` and deleted from the database and the filesystem. (They are probably listed in deletion order, from "deep" to "shallow".)

Alternatively, instead of unlinking the original files from everything else before deleting them, you may of course simply include whatever links them (e.g., an image) in the actual delete request you submit; just note that specifying the image will imply the files but not the directories (which are also original files) and you need to include the directories in the same delete request to properly test this PR.

--no-rebase