### PR TITLE
avi

### DIFF
--- a/components/server/src/ome/formats/OMEROMetadataStore.java
+++ b/components/server/src/ome/formats/OMEROMetadataStore.java
@@ -85,7 +85,7 @@ import org.perf4j.StopWatch;
 public class OMEROMetadataStore
 {
     /** List of graphics domains we are checking.*/
-    private static String[] DOMAINS = {"jpeg", "png", "bmp", "gif", "tiff"};
+    private static String[] DOMAINS = {"jpeg", "png", "bmp", "gif", "tiff", "avi"};
 
     /** Logger for this class. */
     private static Logger log = LoggerFactory.getLogger(OMEROMetadataStore.class);


### PR DESCRIPTION
Add avi to the list of format to check.

Check that the min/max for avi are set to 0-255
This will only be true if the pixels type is "uint8"