### PR TITLE
ResetDefaults cant annotate

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8680,10 +8680,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     @assert_re()
     def resetDefaults(self, save=True):
-        if not self.canAnnotate():
-            return False
         ns = self._conn.CONFIG.IMG_ROPTSNS
-        if ns:
+        if ns and self.canAnnotate():
             opts = self._collectRenderOptions()
             self.removeAnnotations(ns)
             ann = omero.gateway.CommentAnnotationWrapper()
@@ -8693,6 +8691,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             self.linkAnnotation(ann)
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
+        if not self.canAnnotate():
+            save = False
         self._re.resetDefaultSettings(save, ctx)
         return True
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -292,22 +292,53 @@ class TestRDefs (object):
         """
         Test we can resetDefaultSettings with or without saving.
         """
-        # Author saves Rdef (greyscale)
         gatewaywrapper.loginAsAuthor()
-        self.image = gatewaywrapper.getTestImage()
-        self.image.setGreyscaleRenderingModel()
-        self.image.saveDefaults()
+        userId = gatewaywrapper.gateway.getUser().getId()
+        # Admin creates a new group with user
+        gatewaywrapper.loginAsAdmin()
+        uuid = gatewaywrapper.gateway.getEventContext().sessionUuid
+        gid = gatewaywrapper.gateway.createGroup(
+            "testResetDefaults-%s" % uuid, member_Ids=[userId], perms='rw----')
 
-        # resetDefaults without saving - shouldn't be greyscale
-        self.image.resetDefaults(save=False)
-        assert not self.image.isGreyscaleRenderingModel()
+        # login as Author again (into 'default' group)
+        gatewaywrapper.loginAsAuthor()
+        conn = gatewaywrapper.gateway
+        # Try to create image in another group
+        conn.SERVICE_OPTS.setOmeroGroup(gid)
 
-        # retrieve the image again... Should still be greyscale
-        self.image = gatewaywrapper.getTestImage()
-        assert self.image.isGreyscaleRenderingModel()
+        # Author saves Rdef (greyscale)
+        image = gatewaywrapper.createTestImage()
+        # test image is greyscale initially
+        assert image.isGreyscaleRenderingModel()
+        image.setColorRenderingModel()
+        image.saveDefaults()
+        iid = image.getId()
+
+        # resetDefaults without saving - should be greyscale
+        image.resetDefaults(save=False)
+        assert image.isGreyscaleRenderingModel()
+
+        # retrieve the image again... Should still be color
+        image = gatewaywrapper.gateway.getObject("Image", iid)
+        assert not image.isGreyscaleRenderingModel()
         # Then reset and Save
-        self.image.resetDefaults()
+        image.resetDefaults()
 
-        # retrieve the image again... Should not be greyscale
-        self.image = gatewaywrapper.getTestImage()
-        assert not self.image.isGreyscaleRenderingModel()
+        # retrieve the image again... Should be greyscale
+        image = gatewaywrapper.gateway.getObject("Image", iid)
+        assert image.isGreyscaleRenderingModel()
+        # Finally save as Color again, so Admin can test reset
+        image.setColorRenderingModel()
+        image.saveDefaults()
+
+        # Login as Admin and try resetting...
+        gatewaywrapper.loginAsAdmin()
+        gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
+        i = gatewaywrapper.gateway.getObject("Image", iid)
+        # will be color (owner's settings by default)
+        assert not i.isGreyscaleRenderingModel()
+        # Shouldn't be able to annotate image in Private group
+        assert not i.canAnnotate()
+        # Try resetting (save=True will be ignored, but reset will work)
+        i.resetDefaults(save=True)
+        assert i.isGreyscaleRenderingModel()


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12796

Even if you can't annotate an image, you should be able to call resetDefaults() to get the "Imported" rendering settings.

To test:
 - view an image that you can't annotate
 - Try to reset to "Imported settings"
 - Check you get the same as the owner of the image.

Also added a gateway test.