### PR TITLE
selection when list

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
@@ -175,7 +175,7 @@
 
             // plugin to handle drag-select of images
             $("#dataIcons").selectable({
-                filter: 'li',
+                filter: 'li.row',
                 distance: 2,
                 stop: function(){  
                     syncTreeSelection();


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12791

To test:
 - browse to dataset
 - show centre panel in table layout
 - Try drag-selecting the table header. It shouldn't be selectable.
 - Drag-selecting table rows and sorting should work as normal.