### PR TITLE
Handle deleted images in shares

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1652,7 +1652,12 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         sh = self.getShareService()
         for e in sh.getContents(long(share_id)):
             if isinstance(e, omero.model.ImageI):
-                obj = omero.gateway.ImageWrapper(self, e)
+                try:
+                    obj = omero.gateway.ImageWrapper(self, e)
+                except omero.ValidationException:
+                    # If Object deleted, simply return placeholder
+                    # ID used to generate placeholder thumbnail
+                    obj = {'id': e.id.val}
                 yield obj
 
     def getComments(self, share_id):


### PR DESCRIPTION
See: https://trac.openmicroscopy.org.uk/ome/ticket/12842
Handle deleted images in shares.

To test:
 - Put some images in a share
 - Delete one of them
 - Browse the share
 - Share should load and display all other images OK
 - Should see "Object deleted" in tree and placeholder thumbnail.