### PR TITLE
Fix in-place server-side file leak

### DIFF
--- a/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -60,7 +60,8 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
             final long length = state.getLength();
             final ChecksumProvider cp = state.getChecksumProvider();
             state.uploadStarted();
-            checkLocation(location, rawFileStore);
+            checkLocation(location, rawFileStore); // closes rawFileStore
+            state.closeUploader();
             exec(file, location);
             checkTarget(location, state);
             cp.putFile(file.getAbsolutePath());
@@ -68,7 +69,7 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
             state.uploadBytes(length);
             return finish(state, length);
         } finally {
-            cleanupUpload(rawFileStore, null);
+            state.closeUploader();
         }
     }
 


### PR DESCRIPTION
In-place import (e.g. `--transfer=ln`) was leading
to dangling file handles on the server since multiple
calls to `TransferState.getUploader` were being made
without the return values being properly closed. This
commit is slightly uglier than it should be in order
to not break the `FileTransfer` API. Later refactorings
should pass `TransferState` everywhere rather than the
`RawFileStorePrx`.

#### TESTING ###

 * Record the open file handles for your server: `lsof -p $(bin/omero admin ice server pid Blitz-0) > before.txt`
 * Choose a dataset with a number of files (see make.sh below)
 * Import with `--transfer=ln` or `--transfer=ln_s`
 * Record the open file handles after the import: `lsof -p $(bin/omero admin ice server pid Blitz-0) > after.txt`
 * Look at the `diff` of the two files. At most, only the single `.setId` file should be present, not the additional members of the fileset.

#### make.sh ####
```
echo "test_Z<00-09>.fake" > fake.pattern
for x in $(seq 0 9); do uuid >> $(printf "test_Z%02d.fake\n" $x); done
```