### PR TITLE
allow non-admin users to delete many related original files (and directories) in one request

### DIFF
--- a/components/blitz/resources/omero/Repositories.ice
+++ b/components/blitz/resources/omero/Repositories.ice
@@ -173,8 +173,8 @@ module omero {
 
             /**
              * Delete several individual paths. Internally, this converts
-             * each of the paths into an [omero::cmd::Delete] command and
-             * submits all of them via [omero::cmd::DoAll].
+             * all of the paths into a single [omero::cmd::Delete2] command
+             * and submits it.
              *
              * If a "recursively" is true, then directories will be searched
              * and all of their contained files will be placed before them in

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -261,9 +261,7 @@ public class GraphUtil {
      */
     private static boolean isCombined(DeleteFacadeI delete1, DeleteFacadeI delete2) {
         /* in deleting original files, order is significant */
-        if (!delete1.type.endsWith("/OriginalFile") &&
-            !delete2.type.endsWith("/OriginalFile") &&
-            isEqualMaps(delete1.options, delete2.options)) {
+        if (isEqualMaps(delete1.options, delete2.options)) {
             delete1.addToTargets(delete2.type, delete2.id);
             return true;
         } else {

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -7,9 +7,6 @@
 
 package ome.security.basic;
 
-// Java imports
-
-// Third-party libraries
 import static ome.model.internal.Permissions.Role.GROUP;
 import static ome.model.internal.Permissions.Role.USER;
 import static ome.model.internal.Permissions.Role.WORLD;

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -621,14 +621,14 @@ public class GraphTraversal {
     private void noteDetails(CI object, ome.model.internal.Details objectDetails) throws GraphException {
         final IObject objectInstance = object.toIObject();
 
-        if (planning.detailsNoted.isEmpty()) {
-            /* allowLoad ensures that BasicEventContext.groupPermissionsMap is populated */
-            aclVoter.allowLoad(session, objectInstance.getClass(), objectDetails, object.id);
-        }
         if (planning.detailsNoted.put(object, objectDetails) != null) {
             return;
         }
+
         if (!eventContext.isCurrentUserAdmin()) {
+            /* allowLoad ensures that BasicEventContext.groupPermissionsMap is populated */
+            aclVoter.allowLoad(session, objectInstance.getClass(), objectDetails, object.id);
+
             if (aclVoter.allowUpdate(objectInstance, objectDetails)) {
                 planning.mayUpdate.add(object);
             }

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -1075,7 +1075,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         String pathName = ((RString) results.get(0).get(0)).getValue();
 
         /* create a deeply nested directory hierarchy with files at every level */
-        final int count = 32;
+        final int count = 12;
         final RepositoryPrx mrepo = getManagedRepository();
         final String directoryName = "bar";
         final String fileName = "baz";

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -1109,7 +1109,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         request.targetObjects.put("OriginalFile", fileIds);
 
         /* perform the deletion and confirm that it successfully deletes all the files */
-        final Delete2Response deletions = (Delete2Response) doChange(root, root.getSession(), request, true);
+        final Delete2Response deletions = (Delete2Response) doChange(request);
         assertEquals(fileCount, deletions.deletedObjects.get(ome.model.core.OriginalFile.class.getName()).size());
     }
 }

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -305,16 +305,19 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
             throw new Exception("Unknown class: " + klass);
         }
 
+        final Formatter formatter = new Formatter();
+
         while (remaining > 999) {
             remaining /= 1000;
 
             if (remaining > 0) {
-                Formatter formatter = new Formatter();
                 dirno = remaining % 1000;
                 suffix = formatter.format("Dir-%03d", dirno).out().toString()
                         + File.separator + suffix;
             }
         }
+
+        formatter.close();
 
         String path = FilenameUtils.concat(prefix, suffix + id);
         return path;


### PR DESCRIPTION
Fixes https://trello.com/c/dWphbVIw/486-deletion-of-repository-hierarchies-by-normal-users and largely tested by integration tests. The keen may wish to:

1. reproduce @ximenesuk's problem in https://github.com/openmicroscopy/openmicroscopy/pull/3751#issuecomment-95619415 when he wasn't root
1. try out recursive delete with http://downloads.openmicroscopy.org/omero/5.1.1/api/slice2html/omero/grid/Repository.html#deletePaths.

--no-rebase