### PR TITLE
Enable Dropbox on W2012-R2

### DIFF
--- a/components/tools/OmeroFS/src/fsUtil.py
+++ b/components/tools/OmeroFS/src/fsUtil.py
@@ -41,7 +41,7 @@ def monitorPackage(platformCheck):
 
     # Versions of Windows that have been tested.
     winTested = ['XP', '2003Server', '2008Server', '2008ServerR2', 'Vista',
-                 '7']
+                 '7', '2012Server']
 
     # Initial state
     current = 'UNKNOWN'


### PR DESCRIPTION
Can be tested using the server deployed by https://ci.openmicroscopy.org/job/OMERO-5.1-merge-deploy-win2012/

I've only looked at `2012-r2`, not `2012`.