### PR TITLE
Set var permissions to 755 when starting OMERO.web

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -351,6 +351,11 @@ class WebControl(BaseControl):
                 return 1
         deploy = getattr(settings, 'APPLICATION_SERVER')
 
+        # Set permissions var folder to be readable/executable
+        var = self.ctx.dir / "var"
+        if os.path.exists(var):
+            os.chmod(var, 0755)
+
         # 3216
         if deploy in (settings.FASTCGI_TYPES):
             if "Windows" == platform.system():


### PR DESCRIPTION
See https://github.com/openmicroscopy/ome-documentation/pull/1203#issuecomment-97220838 and the corresponding community threads linked in the documentation PR.

Default Apache stanza uses the var folder of the OMERO.server as the root directory. However this folder is created by default with 700 permissions, meaning it is not readable/accessible to another user than the owner of the OMERO.server, e.g. the Apache agent.
This commit tries to improve the OMERO.web deployment workflow by teaching bin/omero web start/restart to set the permissions of this folder to 755.

To test this PR, deploy OMERO.server + OMERO.web on a LInux system with Apache using the default stanza created by `bin/omero web config apache`:
- check `bin/omero admin start` creates a `var` folder with 700
- check `bin/omero web start` sets the permissions to 755
- check Apache serves OMERO.web without any `Permissions denied` in the error logs

Note this permissions operation may also expose other files in the `var` folder or subfolders (`log`, `registry`) so this PR should be also be reviewed with regard to security. A first conservative approach as suggested by @manics might be to `os.listdir()` and chmod all `var` subfolders back to 700 - or would that affect server functionalities?

/cc @joshmoore @aleksandra-tarkowska @manics @kennethgillen @chris-allan @knabar 