### PR TITLE
File name

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -42,9 +42,12 @@ import java.util.Map.Entry;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JTree;
+import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 
 //Third-party libraries
+
+
 
 
 import org.apache.commons.collections.CollectionUtils;
@@ -58,6 +61,7 @@ import org.openmicroscopy.shoola.agents.treeviewer.cmd.EditVisitor;
 import org.openmicroscopy.shoola.agents.treeviewer.cmd.ExperimenterVisitor;
 import org.openmicroscopy.shoola.agents.treeviewer.cmd.ParentVisitor;
 import org.openmicroscopy.shoola.agents.treeviewer.cmd.RefreshVisitor;
+import org.openmicroscopy.shoola.agents.treeviewer.cmd.UpdateVisitor;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.agents.util.browser.ContainerFinder;
@@ -715,6 +719,19 @@ class BrowserComponent
         view.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         view.getTreeRoot().accept(visitor, algoType);
         view.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+        if (visitor instanceof UpdateVisitor) {
+            UpdateVisitor us = (UpdateVisitor) visitor;
+            Collection<TreeImageDisplay> updated = us.getUpdated();
+            if (CollectionUtils.isEmpty(updated)) return;
+            Iterator<TreeImageDisplay> i = updated.iterator();
+            TreeImageDisplay n;
+            TreeModel tm = view.getTreeDisplay().getModel();
+            while (i.hasNext()) {
+                n = i.next();
+                tm.valueForPathChanged(new TreePath(n.getPath()),
+                        n.getUserObject());
+            }
+        }
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -325,7 +325,7 @@ class BrowserUI
         partialButton = new JToggleButton(
         				controller.getAction(BrowserControl.PARTIAL_NAME));
         partialButton.setBorderPainted(true);
-        rightMenuBar.add(partialButton);
+        //rightMenuBar.add(partialButton);
         rightMenuBar.add(new JSeparator(JSeparator.VERTICAL));
         button = new JButton(controller.getAction(BrowserControl.COLLAPSE));
         button.setBorderPainted(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/cmd/UpdateVisitor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/cmd/UpdateVisitor.java
@@ -29,11 +29,16 @@ package org.openmicroscopy.shoola.agents.treeviewer.cmd;
 //Third-party libraries
 
 //Application-internal dependencies
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageNode;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageSet;
 import org.openmicroscopy.shoola.agents.util.browser.TreeViewerTranslator;
+
 import pojos.DataObject;
 import pojos.ImageData;
 
@@ -56,6 +61,9 @@ public class UpdateVisitor
 
 	/** The update object.*/
 	private DataObject object;
+
+	/** The collection of updated nodes.*/
+	private Set<TreeImageDisplay> updated;
 	
 	/**
 	 * Updates the specified node.
@@ -72,6 +80,7 @@ public class UpdateVisitor
 			object.getId() == data.getId()) {
 			node.setUserObject(object);
 			TreeViewerTranslator.formatToolTipFor(node);
+			updated.add(node);
 		}
 	}
 	
@@ -87,8 +96,16 @@ public class UpdateVisitor
         if (object == null)
         	throw new IllegalArgumentException("No object to update.");
         this.object = object;
+        updated = new HashSet<TreeImageDisplay>();
     }
-    
+
+    /**
+     * Returns the collection of updated nodes
+     *
+     * @return See above.
+     */
+    public Collection<TreeImageDisplay> getUpdated() { return updated; }
+
     /**
      * Updates the nodes.
      * @see BrowserVisitor#visit(TreeImageSet)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -34,6 +34,7 @@ import java.awt.Rectangle;
 import javax.swing.Icon;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
+import javax.swing.JViewport;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
@@ -770,7 +771,8 @@ public class TreeCellRenderer
 			g.fillRect(xText, 0, getSize().width, getSize().height);
 		}
     	if (ref != null) {
-    	    int w = ref.getViewport().getSize().width;
+    	    JViewport vp = ref.getViewport();
+    	    int w = vp.getSize().width;
             FontMetrics fm = getFontMetrics(getFont());
             String text = node.getNodeName();
             if (numberChildrenVisible) text = node.getNodeText();
@@ -786,7 +788,12 @@ public class TreeCellRenderer
                 String value = UIUtilities.formatPartialName(text, vv);
                 setText(value);
                 w = getPreferredWidth();
-                setPreferredSize(new Dimension(w, fm.getHeight()+4));//4 b/c GTK L&F
+                Dimension d = new Dimension(w, fm.getHeight()+4);
+                if (vp.getComponentCount() > 0) {
+                    vp.getComponent(0).setPreferredSize(d);
+                }
+                setSize(d);//4 b/c GTK L&F
+                setPreferredSize(d);//4 b/c GTK L&F
             }
     	}
     	selected = false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -722,6 +722,11 @@ public class TreeCellRenderer
         return this;
     }
 
+    /**
+     * Determines the preferred width of the component.
+     *
+     * @return See above.
+     */
     private int getPreferredWidth()
     {
         FontMetrics fm = getFontMetrics(getFont());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -716,19 +716,26 @@ public class TreeCellRenderer
         else setTextColor(getBackgroundSelectionColor());
         if (getIcon() != null) w += getIcon().getIconWidth();
         else w += SIZE.width;
-        w += getIconTextGap();
-        xText = w;
-        if (ho instanceof ImageData)
-        	w += fm.stringWidth(getText());
-        else if (node instanceof TreeFileSet)
-        	w +=  fm.stringWidth(getText())+40;
-        else w += fm.stringWidth(getText());
-        
+        w = getPreferredWidth();
         setPreferredSize(new Dimension(w, fm.getHeight()+4));//4 b/c GTK L&F
         setEnabled(node.isSelectable());
         return this;
     }
-    
+
+    private int getPreferredWidth()
+    {
+        FontMetrics fm = getFontMetrics(getFont());
+        int w = 0;
+        if (getIcon() != null) w += getIcon().getIconWidth();
+        else w += SIZE.width;
+        w += getIconTextGap();
+        xText = w;
+        if (node instanceof TreeFileSet)
+            w +=  fm.stringWidth(getText())+40;
+        else w += fm.stringWidth(getText());
+        return w;
+    }
+
     /**
      * Overridden to highlight the destination of the target.
      * @see paintComponent(Graphics)
@@ -744,11 +751,7 @@ public class TreeCellRenderer
 				else g.setColor(backgroundNonSelectionColor);
 				
 			} else g.setColor(draggedColor);
-			if (ref != null ) {
-			    g.fillRect(xText, 0, ref.getSize().width, ref.getSize().height);
-			} else {
-			    g.fillRect(xText, 0, getSize().width, getSize().height);
-			}
+			g.fillRect(xText, 0, getSize().width, getSize().height);
 		}
     	if (ref != null) {
     	    int w = ref.getSize().width;
@@ -762,6 +765,8 @@ public class TreeCellRenderer
                 String value = UIUtilities.formatPartialName(text,
                         (int) (w/charWidth));
                 setText(value);
+                w = getPreferredWidth();
+                setPreferredSize(new Dimension(w, fm.getHeight()+4));
             }
     	}
     	selected = false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -31,7 +31,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 
 import javax.swing.Icon;
-import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -397,7 +396,7 @@ public class TreeCellRenderer
     private long userId;
 
     /** The component of reference.*/
-    private JComponent ref;
+    private JScrollPane ref;
 
     /** The node to display.*/
     private TreeImageDisplay node;
@@ -748,7 +747,7 @@ public class TreeCellRenderer
     public void paintComponent(Graphics g)
     {
         if (ref == null) {
-            ref = (JComponent) UIUtilities.findParent(this, JScrollPane.class);
+            ref = (JScrollPane) UIUtilities.findParent(this, JScrollPane.class);
         }
     	if (isTargetNode) {
 			if (!droppedAllowed) {
@@ -759,7 +758,7 @@ public class TreeCellRenderer
 			g.fillRect(xText, 0, getSize().width, getSize().height);
 		}
     	if (ref != null) {
-    	    int w = ref.getSize().width;
+    	    int w = ref.getViewport().getSize().width;
             FontMetrics fm = getFontMetrics(getFont());
             String text = node.getNodeName();
             int v = fm.stringWidth(text+UIUtilities.DOTS);
@@ -771,7 +770,7 @@ public class TreeCellRenderer
                         (int) (w/charWidth));
                 setText(value);
                 w = getPreferredWidth();
-                setPreferredSize(new Dimension(w, fm.getHeight()+4));
+                setSize(new Dimension(w, fm.getHeight()+4));
             }
     	}
     	selected = false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -29,6 +29,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
+import java.awt.Rectangle;
 
 import javax.swing.Icon;
 import javax.swing.JScrollPane;
@@ -740,6 +741,16 @@ public class TreeCellRenderer
         return w;
     }
 
+    private int getIconGap()
+    {
+        FontMetrics fm = getFontMetrics(getFont());
+        int w = 0;
+        if (getIcon() != null) w += getIcon().getIconWidth();
+        else w += SIZE.width;
+        w += getIconTextGap();
+        return w;
+    }
+    
     /**
      * Overridden to highlight the destination of the target.
      * @see paintComponent(Graphics)
@@ -761,16 +772,19 @@ public class TreeCellRenderer
     	    int w = ref.getViewport().getSize().width;
             FontMetrics fm = getFontMetrics(getFont());
             String text = node.getNodeName();
-            int v = fm.stringWidth(text+UIUtilities.DOTS);
+            int v = getPreferredSize().width;
+            Rectangle r = getBounds();
+            w = w-r.x;
             if (v > w) {
                 //truncate the text
                 v = fm.stringWidth(text);
-                double charWidth = v/text.length();
-                String value = UIUtilities.formatPartialName(text,
-                        (int) (w/charWidth));
+                int charWidth = fm.charWidth('A');
+                int vv = (w-getIconGap()-5)/charWidth;
+                if (vv < 0) vv = 0;
+                String value = UIUtilities.formatPartialName(text, vv);
                 setText(value);
                 w = getPreferredWidth();
-                setSize(new Dimension(w, fm.getHeight()+4));
+                setPreferredSize(new Dimension(w, fm.getHeight()+4));//4 b/c GTK L&F
             }
     	}
     	selected = false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -773,6 +773,7 @@ public class TreeCellRenderer
     	    int w = ref.getViewport().getSize().width;
             FontMetrics fm = getFontMetrics(getFont());
             String text = node.getNodeName();
+            if (numberChildrenVisible) text = node.getNodeText();
             int v = getPreferredSize().width;
             Rectangle r = getBounds();
             w = w-r.x;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -744,7 +744,11 @@ public class TreeCellRenderer
 				else g.setColor(backgroundNonSelectionColor);
 				
 			} else g.setColor(draggedColor);
-			g.fillRect(xText, 0, getSize().width, getSize().height);
+			if (ref != null ) {
+			    g.fillRect(xText, 0, ref.getSize().width, ref.getSize().height);
+			} else {
+			    g.fillRect(xText, 0, getSize().width, getSize().height);
+			}
 		}
     	if (ref != null) {
     	    int w = ref.getSize().width;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -730,10 +730,7 @@ public class TreeCellRenderer
     private int getPreferredWidth()
     {
         FontMetrics fm = getFontMetrics(getFont());
-        int w = 0;
-        if (getIcon() != null) w += getIcon().getIconWidth();
-        else w += SIZE.width;
-        w += getIconTextGap();
+        int w = getIconGap();
         xText = w;
         if (node instanceof TreeFileSet)
             w +=  fm.stringWidth(getText())+40;
@@ -741,9 +738,13 @@ public class TreeCellRenderer
         return w;
     }
 
+    /**
+     * Returns the gap between icon and text.
+     *
+     * @return See above
+     */
     private int getIconGap()
     {
-        FontMetrics fm = getFontMetrics(getFont());
         int w = 0;
         if (getIcon() != null) w += getIcon().getIconWidth();
         else w += SIZE.width;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
@@ -487,7 +487,7 @@ public abstract class TreeImageDisplay
         String name = getNodeName();
         Object uo = getUserObject();
         if (uo instanceof ImageData) {
-        	if (partialName) return UIUtilities.formatPartialName(name);
+        	//if (partialName) return UIUtilities.formatPartialName(name);
         	return name;
         } else if (uo instanceof ExperimenterData) return name;
         else if (uo instanceof FileAnnotationData) return name;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
@@ -486,9 +486,7 @@ public abstract class TreeImageDisplay
     {
         String name = getNodeName();
         Object uo = getUserObject();
-        if (uo instanceof ImageData) {
-        	//if (partialName) return UIUtilities.formatPartialName(name);
-        	return name;
+        if (uo instanceof ImageData) { return name;
         } else if (uo instanceof ExperimenterData) return name;
         else if (uo instanceof FileAnnotationData) return name;
         else if (uo instanceof File) return name; 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2774,5 +2774,29 @@ public class UIUtilities
         else
             c.gridx++;
     }
-    
+
+    /**
+     * Finds the parent of the component identified by the specified class.
+     * Returns the found component or <code>null</code> if 
+     * none found.
+     * 
+     * @param comp The component to visit. Mustn't be <code>null</code>.
+     * @param c The class identifying the component to find.
+     * @return See above.
+     */
+    public static Component findParent(Component comp, Class c)
+    {
+        if (c == null || comp == null)
+            throw new IllegalArgumentException("The parameters cannot be " +
+                    "null");
+        if (c.isAssignableFrom(comp.getClass())) return comp;
+        
+        if (comp instanceof Container) {
+            Component parent = ((Container) comp).getParent();
+            if (parent == null) return null;
+            if (parent.getClass().equals(c)) return parent;
+            return findParent(parent, c);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Fix the display of the file name when dragging the divider of the split pane

To test:
 * Log in as user-1
 * Expand the "archived dv " dataset
 * Dragging the divider of the split pane. Check that the name displayed is adjusted.

This might require some screenshots update since I have removed the "nebulous" full name icon (abc)
cc @gusferguson 

ref https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7596&p=14469#p14469