### PR TITLE
Disable delete key in jsTree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/hotkeys.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/hotkeys.js
@@ -139,5 +139,9 @@
             this.select_node(new_select, true, e); // tree handles shift events for multi-select
         }
         return false;
+    },
+    // Disable delete key
+    "del" : function (e) {
+        return false;
     }
 }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12831 and http://trac.openmicroscopy.org.uk/ome/ticket/12840 (also see https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7785).

To test, use a keyboard with a "Delete" key:
 - Check that Delete doesn't do anything to the tree main webclient page, shares or tags page.