### PR TITLE
Viewer Interpolate checkbox

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.viewport.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.viewport.css
@@ -157,3 +157,15 @@ div.weblitz-viewport-tiles img {
   color: white;
 }
 
+/* from http://phrogz.net/tmp/canvas_image_zoom.html */
+.pixelated {
+  image-rendering:optimizeSpeed;             /* Legal fallback */
+  image-rendering:-moz-crisp-edges;          /* Firefox        */
+  image-rendering:-o-crisp-edges;            /* Opera          */
+  image-rendering:-webkit-optimize-contrast; /* Safari         */
+  image-rendering:optimize-contrast;         /* CSS3 Proposed  */
+  image-rendering:crisp-edges;               /* CSS4 Proposed  */
+  image-rendering:pixelated;                 /* CSS4 Proposed  */
+  -ms-interpolation-mode:nearest-neighbor;   /* IE8+           */
+}
+

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -847,6 +847,10 @@ jQuery._WeblitzViewport = function (container, server, options) {
     return _this.getPos().z + 1;
   };
 
+  this.setPixelated = function (pixelated) {
+    _this.viewportimg.get(0).setPixelated(pixelated);
+  };
+
   this.setZoom = function (z) {
     var size = getSizeDict();
     _this.viewportimg.get(0).setZoom(z, size.width, size.height);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -200,6 +200,14 @@ jQuery.fn.viewportImage = function(options) {
       return overlay.is(':visible') || overlay.is('.loading');
     };
 
+    this.setPixelated = function (pixelated) {
+      if (pixelated) {
+        image.addClass("pixelated");
+      } else {
+        image.removeClass("pixelated");
+      }
+    };
+
     /**
      * Pan the image within the viewport
      */

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -901,6 +901,10 @@
                 <span>Paste</span>
             </button>
           </div>
+          <div class="odd row">
+            <label for="wblitz-interpolate">Interpolate</label>
+            <input id="wblitz-interpolate" type="checkbox" checked/>
+          </div>
             <h1>Current Image</h1>
           <div class="even row">
             <span style="font-size: 0.9em">
@@ -1146,6 +1150,13 @@
 
     $(".paste_rdef").click(function() {
         pasteRdefs(viewport);
+    });
+
+    $("#wblitz-interpolate").click(function(event){
+      var interpolate = $(this).is(":checked");
+      if (viewport) {
+        viewport.setPixelated(!interpolate);
+      }
     });
 
     // Reset defaults without saving


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12828 (see https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7786).

 To test:
 - Zoom in a lot in web image viewer
 - Toggle the "Interpolate" checkbox (checked by default).
 - When unchecked, image should appear pixelated.
 - Compare with same image in Insight, to check this pixelation is valid.

![screen shot 2015-04-29 at 14 08 45](https://cloud.githubusercontent.com/assets/900055/7391635/798996da-ee7a-11e4-906c-a3986255fcfa.png)
