### PR TITLE
introduce Chmod2 request

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -185,6 +185,58 @@
         <bean parent="graphPolicyRule" p:matches="ILink[D].child = C:TimestampAnnotation[E]{o}" p:changes="C:[D]/n"/>
     </util:list>
 
+    <util:list id="chmodRules" value-type="ome.services.graphs.GraphPolicyRule">
+        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = X:[E]/!d, L.child = T:TagAnnotation[D]"
+                                       p:error="may not delete {T} because {X} is tagged with it"/>
+        <bean parent="graphPolicyRule" p:matches="G:IGlobal[E]" p:changes="G:[O]"/>
+        <bean parent="graphPolicyRule" p:matches="X:[E].details.group = ExperimenterGroup[I]" p:changes="X:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent =/!o [E], L.child = C:[E]" p:changes="L:[D]/n, C:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child =/!o C:[E]" p:changes="L:[D]/n, C:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:BooleanAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:CommentAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:NumericAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:TimestampAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:XmlAnnotation[E]{o}" p:changes="C:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="R:Roi[E].image =/!o [E]" p:changes="R:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].pixels =/!o [E]" p:changes="RD:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[E].pixels =/!o [E]" p:changes="T:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="R:Roi[D]/!no.image = [!O]/o" p:changes="R:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[D]/!no.pixels = [!O]/o" p:changes="RD:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[D]/!no.pixels = [!O]/o" p:changes="T:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="[D] =? X:!ILink[E]{o}/d" p:changes="X:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="[D] =?/o X:!ILink[E]{o}" p:changes="X:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!DO].parent = [D], L.child = C:!Job[E]/!d" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:[E]{o}/d" p:changes="C:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:Job[E]{o}" p:changes="C:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = C:[D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [D], L.child = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.rois = [D]" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.stageLabel = [D]" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.channels = [D]" p:changes="P:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.settings = [D]" p:changes="P:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.relatedTo = [D]" p:changes="P:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="!ILink[D] == X:!IGlobal[E]{o}/d" p:changes="X:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="!ILink[D] = X:[E]{i}" p:changes="X:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!ILink[E]{r} = X:[E]{i}" p:changes="X:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:[E]{i}" p:changes="C:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="DS:DetectorSettings[E]{i}.detector = [E]{r}" p:changes="DS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="LS:LightSettings[E]{i}.lightSource = [E]{r}" p:changes="LS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="OS:ObjectiveSettings[E]{i}.objective = [E]{r}" p:changes="OS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/d == [D]" p:changes="X:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/!d == [D]" p:changes="X:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E].file = [D]" p:changes="FA:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:!Job[E]{r}/!d" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:FileAnnotation[E]{r}/!o" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:TagAnnotation[E]{r}/!o" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:TermAnnotation[E]{r}/!o" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [E], L.child = C:!Pixels[E]{r}" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="!ILink[E]{ia} = X:!ILink[E]{r}" p:changes="X:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="X:[E]{r} == [E]{a}" p:changes="X:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[E]{a}.parent = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="C:Channel[E]{r}.pixels = Pixels[E]{i}" p:changes="C:{a}"/>
+    </util:list>
+
     <util:list id="chownRules" value-type="ome.services.graphs.GraphPolicyRule">
         <bean parent="graphPolicyRule" p:matches="F:Fileset[!I].images = [I], F.images = [!I]" p:error="may not split {F}"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:Instrument, Image[!I].instrument = IN"

--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -228,9 +228,9 @@
         <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/!d == [D]" p:changes="X:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E].file = [D]" p:changes="FA:[D]"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:!Job[E]{r}/!d" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:FileAnnotation[E]{r}/!o" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:TagAnnotation[E]{r}/!o" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:TermAnnotation[E]{r}/!o" p:changes="C:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E]{r}/!o" p:changes="A:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="A:TagAnnotation[E]{r}/!o" p:changes="A:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="A:TermAnnotation[E]{r}/!o" p:changes="A:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [E], L.child = C:!Pixels[E]{r}" p:changes="C:{a}"/>
         <bean parent="graphPolicyRule" p:matches="!ILink[E]{ia} = X:!ILink[E]{r}" p:changes="X:{a}"/>
         <bean parent="graphPolicyRule" p:matches="X:[E]{r} == [E]{a}" p:changes="X:{a}"/>

--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -210,6 +210,7 @@
         <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:Job[E]{o}" p:changes="C:[D]"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = C:[D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [D], L.child = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [D], L.child = [E]{a}" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!O]" p:changes="L:[-]"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.rois = [D]" p:changes="I:{a}"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.stageLabel = [D]" p:changes="I:{a}"/>

--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -43,7 +43,7 @@
             O = outside: do not operate on, do not even unlink from target objects
         In matches, starting these action letters with a ! negates the given set.
         For changes, in the square brackets an additional action is available:
-            * = process: apply rule set to the object and its relationships
+            - = process: apply rule set to the object and its relationships
 
         In curly braces, the orphan status of the object:
             i = irrelevant: don't care about orphan status

--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -247,6 +247,8 @@
         <bean parent="graphPolicyRule" p:matches="G:IGlobal[E]" p:changes="G:[O]"/>
         <bean parent="graphPolicyRule" p:matches="[I] =? X:!ILink[E]{o}/o" p:changes="X:[I]"/>
         <bean parent="graphPolicyRule" p:matches="[I] =?/o X:!ILink[E]{o}" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].parent =/!o [!O]" p:changes="L:[O]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].child =/!o [!O]" p:changes="L:[O]"/>
         <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap[!IO].parent = [E]/!d, POFM.child = Pixels[I]"
                                        p:changes="POFM:[O]"/>
         <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = [I], POFM.child = P:Pixels[E]{r}"
@@ -256,9 +258,9 @@
         <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = OF:[E]{o}/d, POFM.child = Pixels[I]"
                                        p:changes="OF:[O]"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].parent = [I], L.child = C:!Job[E]/!d" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:[E]{o}/o" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [I], L.child = C:[E]{o}/o" p:changes="C:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:[E]{o}" p:changes="C:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:Job[E]{o}" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [I], L.child = C:Job[E]{o}" p:changes="C:[I]"/>
         <bean parent="graphPolicyRule" p:matches="[I] == X:[E]{o}" p:changes="X:[I]"/>
         <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{r}.images = Image[E]{i}" p:changes="F:{a}"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.rois = [I]" p:changes="I:{a}"/>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -361,6 +361,7 @@
       <constructor-arg>
         <map>
           <entry key="omero.cmd.graphs.Chgrp2I" value-ref="chgrpRules"/>
+          <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodRules"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownRules"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteRules"/>
         </map>

--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -72,7 +72,7 @@ module omero {
                 ["deprecated:changeGroup() is deprecated. use omero::cmd::Chgrp2() instead."]
                 idempotent void changeGroup(omero::model::IObject obj, string omeName) throws ServerError;
 
-                ["deprecated:changePermissions() is deprecated. use omero::cmd::Chmod() instead."]
+                ["deprecated:changePermissions() is deprecated. use omero::cmd::Chmod2() instead."]
                 idempotent void changePermissions(omero::model::IObject obj, omero::model::Permissions perms) throws ServerError;
                 idempotent void moveToCommonSpace(IObjectList objects) throws ServerError;
 

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -75,6 +75,7 @@ module omero {
          * At the moment, the only supported type is "/ExperimenterGroup".
          *
          **/
+        ["deprecated:use omero::cmd::Chmod2 instead"]
         class Chmod extends GraphModify {
 
             /**
@@ -84,6 +85,7 @@ module omero {
             string permissions;
         };
 
+        ["deprecated:use omero::cmd::Chmod2Response instead"]
         class ChmodRsp extends Response {
         };
 
@@ -255,6 +257,36 @@ module omero {
 
             /**
              * The model objects that were moved.
+             **/
+            omero::api::StringLongListMap includedObjects;
+
+            /**
+             * The model objects that were deleted.
+             **/
+            omero::api::StringLongListMap deletedObjects;
+        };
+
+        /**
+         * Change the permissions on model objects.
+         * The user must be an administrator, the owner of the objects,
+         * or an owner of the objects' group.
+         * The only permitted target object type is ExperimenterGroup.
+         **/
+        class Chmod2 extends GraphModify2 {
+
+            /**
+             * The permissions to set on the model objects.
+             **/
+            string permissions;
+        };
+
+        /**
+         * Result of changing the permissions on model objects.
+         **/
+        class Chmod2Response extends OK {
+
+            /**
+             * The model objects with changed permissions.
              **/
             omero::api::StringLongListMap includedObjects;
 

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -40,6 +40,8 @@ import omero.cmd.graphs.Chgrp2I;
 import omero.cmd.graphs.ChgrpFacadeI;
 import omero.cmd.graphs.ChildOptionI;
 import omero.cmd.graphs.ChmodI;
+import omero.cmd.graphs.Chmod2I;
+import omero.cmd.graphs.ChmodFacadeI;
 import omero.cmd.graphs.ChownI;
 import omero.cmd.graphs.Chown2I;
 import omero.cmd.graphs.ChownFacadeI;
@@ -174,8 +176,20 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(ChmodI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        return new ChmodI(ic,
-                                ctx.getBean("chmodStrategy", ChmodStrategy.class));
+                        if (graphRequestFactory.isGraphsWrap()) {
+                            return new ChmodFacadeI(graphRequestFactory);
+                        } else {
+                            return new ChmodI(ic,
+                                    ctx.getBean("chmodStrategy", ChmodStrategy.class));
+                        }
+                    }
+
+                });
+        factories.put(Chmod2I.ice_staticId(),
+                new ObjectFactory(Chmod2I.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return graphRequestFactory.getRequest(Chmod2I.class);
                     }
 
                 });

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,7 @@
 package omero.cmd.graphs;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -65,6 +66,15 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
         return false;
     }
 
+    /**
+     * An opportunity to reverse any change to each model object after the graph policy reviews it.
+     * @param object the model object after review
+     * @return if this object should <em>not</em> be adjusted
+     */
+    protected boolean isBlockedFromAdjustment(Details object) {
+        return false;
+    }
+
     @Override
     public void setCondition(String name) {
         graphPolicy.setCondition(name);
@@ -84,14 +94,7 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
     public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject, Map<String, Set<Details>> linkedTo,
             Set<String> notNullable, boolean isErrorRules) throws GraphException {
         /* note all the model objects that may be adjusted in review */
-        final Set<Details> allTerms = new HashSet<Details>();
-        allTerms.add(rootObject);
-        for (final Set<Details> terms : linkedFrom.values()) {
-            allTerms.addAll(terms);
-        }
-        for (final Set<Details> terms : linkedTo.values()) {
-            allTerms.addAll(terms);
-        }
+        final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
         /* allow isAdjustedBeforeReview to adjust objects before review */
         final Set<Details> changedTerms = new HashSet<Details>();
         for (final Details object : allTerms) {
@@ -105,6 +108,13 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
         for (final Details object : allTerms) {
             if (isAdjustedAfterReview(object)) {
                 changedTerms.add(object);
+            }
+        }
+        /* allow isBlockedFromAdjustment to block any adjustments */
+        final Iterator<Details> changedTermIterator = changedTerms.iterator();
+        while (changedTermIterator.hasNext()) {
+            if (isBlockedFromAdjustment(changedTermIterator.next())) {
+                changedTermIterator.remove();
             }
         }
         return changedTerms;

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphTraversalProcessor.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphTraversalProcessor.java
@@ -61,7 +61,7 @@ public abstract class BaseGraphTraversalProcessor implements GraphTraversal.Proc
     }
 
     @Override
-    public void assertMayProcess(Details details) throws GraphException {
+    public void assertMayProcess(String className, long id, Details details) throws GraphException {
         /* no check */
     }
 }

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -136,8 +136,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
 
         GraphPolicy graphPolicyWithOptions = graphPolicy;
 
-        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, graphPathBean, childOptions,
-                REQUIRED_ABILITIES);
+        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, childOptions, REQUIRED_ABILITIES);
 
         for (final Function<GraphPolicy, GraphPolicy> adjuster : graphPolicyAdjusters) {
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -169,7 +169,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                         graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
-                graphTraversal.unlinkTargets();
+                graphTraversal.unlinkTargets(true);
                 return null;
             case 2:
                 graphTraversal.processTargets();

--- a/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -50,9 +50,11 @@ public class ChildOptionsPolicy {
      * Adjust an existing graph traversal policy so that child objects may be included or excluded
      * regardless of if they are truly orphans.
      * @param graphPolicyToAdjust the graph policy to adjust
+     * @param childOptions the child options that the policy adjustments are to effect
+     * @param requiredPermissions the abilities that the user must have to operate upon an object for it to be included
      * @return the adjusted graph policy
      */
-    public static GraphPolicy getChildOptionsPolicy(final GraphPolicy graphPolicyToAdjust, final GraphPathBean graphPathBean,
+    public static GraphPolicy getChildOptionsPolicy(final GraphPolicy graphPolicyToAdjust,
             final Collection<ChildOptionI> childOptions, final Set<GraphPolicy.Ability> requiredPermissions) {
 
         if (CollectionUtils.isEmpty(childOptions)) {

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+
+import ome.api.IAdmin;
+import ome.model.IObject;
+import ome.model.internal.Details;
+import ome.model.internal.Permissions;
+import ome.model.meta.Experimenter;
+import ome.model.meta.ExperimenterGroup;
+import ome.security.ACLVoter;
+import ome.security.SystemTypes;
+import ome.services.delete.Deletion;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPathBean;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphTraversal;
+import ome.system.EventContext;
+import ome.system.Login;
+import ome.util.Utils;
+import omero.cmd.Chmod2;
+import omero.cmd.Chmod2Response;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+
+/**
+ * Request to change the permissions on model objects, reimplementing {@link ChmodI}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.1
+ */
+public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2> {
+
+    private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
+
+    private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.CHMOD);
+
+    private static final String PERMITTED_CLASS = ExperimenterGroup.class.getName();
+
+    private final ACLVoter aclVoter;
+    private final SystemTypes systemTypes;
+    private final GraphPathBean graphPathBean;
+    private final Deletion deletionInstance;
+    private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
+    private final SetMultimap<String, String> unnullable;
+
+    private long perm1;
+    private List<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters = new ArrayList<Function<GraphPolicy, GraphPolicy>>();
+    private Helper helper;
+    private GraphTraversal graphTraversal;
+    private Set<Long> acceptableGroups;
+
+    int targetObjectCount = 0;
+    int deletedObjectCount = 0;
+    int changedObjectCount = 0;
+
+    /**
+     * Construct a new <q>chmod</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
+     * @param aclVoter ACL voter for permissions checking
+     * @param systemTypes for identifying the system types
+     * @param graphPathBean the graph path bean to use
+     * @param deletionInstance a deletion instance for deleting files
+     * @param graphPolicy the graph policy to apply for chmod
+     * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
+     */
+    public Chmod2I(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
+            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable) {
+        this.aclVoter = aclVoter;
+        this.systemTypes = systemTypes;
+        this.graphPathBean = graphPathBean;
+        this.deletionInstance = deletionInstance;
+        this.graphPolicy = graphPolicy;
+        this.unnullable = unnullable;
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+        return new HashMap<String, String>(ALL_GROUPS_CONTEXT);
+    }
+
+    @Override
+    public void init(Helper helper) {
+        this.helper = helper;
+        helper.setSteps(dryRun ? 1 : 3);
+
+        try {
+            perm1 = (Long) Utils.internalForm(Permissions.parseString(permissions));
+        } catch (RuntimeException e) {
+            throw helper.cancel(new ERR(), e, "bad-permissions");
+        }
+
+        /* if the current user is not an administrator then find of which groups the target user is a owner */
+        final EventContext eventContext = helper.getEventContext();
+
+        if (eventContext.isCurrentUserAdmin()) {
+            acceptableGroups = null;
+        } else {
+            final Long userId = eventContext.getCurrentUserId();
+            final IAdmin iAdmin = helper.getServiceFactory().getAdminService();
+            acceptableGroups = ImmutableSet.copyOf(iAdmin.getLeaderOfGroupIds(new Experimenter(userId, false)));
+        }
+
+        final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
+
+        if (childOptions != null) {
+            for (final ChildOptionI childOption : childOptions) {
+                childOption.init();
+            }
+        }
+
+        GraphPolicy graphPolicyWithOptions = graphPolicy;
+
+        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, childOptions, REQUIRED_ABILITIES);
+
+        for (final Function<GraphPolicy, GraphPolicy> adjuster : graphPolicyAdjusters) {
+            graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);
+        }
+        graphPolicyAdjusters = null;
+
+        final boolean isToGroupReadable = Utils.toPermissions(perm1).isGranted(Permissions.Role.GROUP, Permissions.Right.READ);
+
+        if (isToGroupReadable) {
+            /* for permissions change to not-private, no changes are required based on policy rules */
+            graphPolicyWithOptions = new BaseGraphPolicyAdjuster(graphPolicyWithOptions) {
+                @Override
+                protected boolean isBlockedFromAdjustment(Details object) {
+                    return true;
+                }
+            };
+        } else {
+            /* for permissions change to private, objects not in private groups must have policy rule checks for deletion */
+            graphPolicyWithOptions = new BaseGraphPolicyAdjuster(graphPolicyWithOptions) {
+                private final Map<Long, Boolean> isGroupReadableById = new HashMap<Long, Boolean>();
+
+                @Override
+                public void noteDetails(Session session, IObject object, String realClass, long id) {
+                    /* note whether groups are private */
+                    if (object instanceof ExperimenterGroup && !isGroupReadableById.containsKey(id)) {
+                        final ExperimenterGroup group = (ExperimenterGroup) session.get(ExperimenterGroup.class, id);
+                        final Permissions permissions = group.getDetails().getPermissions();
+                        final boolean isGroupReadable = permissions.isGranted(Permissions.Role.GROUP, Permissions.Right.READ);
+                        isGroupReadableById.put(id, isGroupReadable);
+                    }
+                    super.noteDetails(session, object, realClass, id);
+                }
+
+                @Override
+                protected boolean isBlockedFromAdjustment(Details object) {
+                    /* for groups that are already private, no changes are required based on policy rules */
+                    final Long groupId = object.subject instanceof ExperimenterGroup ? object.subject.getId() : object.groupId;
+                    return Boolean.FALSE.equals(isGroupReadableById.get(groupId));
+                }
+            };
+        }
+
+        graphTraversal = new GraphTraversal(helper.getSession(), eventContext, aclVoter, systemTypes, graphPathBean, unnullable,
+                graphPolicyWithOptions, dryRun ? new NullGraphTraversalProcessor(REQUIRED_ABILITIES) : new InternalProcessor());
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+        try {
+            switch (step) {
+            case 0:
+                /* if targetObjects were an IObjectList then this would need IceMapper.reverse */
+                final SetMultimap<String, Long> targetMultimap = HashMultimap.create();
+                for (final Entry<String, List<Long>> oneClassToTarget : targetObjects.entrySet()) {
+                    String className = oneClassToTarget.getKey();
+                    if (className.lastIndexOf('.') < 0) {
+                        className = graphPathBean.getClassForSimpleName(className).getName();
+                    }
+                    for (final long id : oneClassToTarget.getValue()) {
+                        targetMultimap.put(className, id);
+                        targetObjectCount++;
+                    }
+                }
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
+                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
+            case 1:
+                graphTraversal.unlinkTargets(false);
+                return null;
+            case 2:
+                graphTraversal.processTargets();
+                return null;
+            default:
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
+            }
+        } catch (GraphException ge) {
+            final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
+            graphERR.message = ge.message;
+            throw helper.cancel(graphERR, ge, "graph-fail");
+        } catch (Throwable t) {
+            throw helper.cancel(new ERR(), t, "graph-fail");
+        }
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (step == 0) {
+            /* if the results object were in terms of IObjectList then this would need IceMapper.map */
+            final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> result =
+                    (Entry<SetMultimap<String, Long>, SetMultimap<String, Long>>) object;
+            if (!dryRun) {
+                try {
+                    deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
+                } catch (Exception e) {
+                    helper.cancel(new ERR(), e, "file-delete-fail");
+                }
+            }
+            final Map<String, List<Long>> changedObjects = new HashMap<String, List<Long>>();
+            final Map<String, List<Long>> deletedObjects = new HashMap<String, List<Long>>();
+            for (final Entry<String, Collection<Long>> oneChangedClass : result.getKey().asMap().entrySet()) {
+                final String className = oneChangedClass.getKey();
+                final Collection<Long> ids = oneChangedClass.getValue();
+                changedObjectCount += ids.size();
+                changedObjects.put(className, new ArrayList<Long>(ids));
+            }
+            for (final Entry<String, Collection<Long>> oneDeletedClass : result.getValue().asMap().entrySet()) {
+                final String className = oneDeletedClass.getKey();
+                final Collection<Long> ids = oneDeletedClass.getValue();
+                deletedObjectCount += ids.size();
+                deletedObjects.put(className, new ArrayList<Long>(ids));
+            }
+            final Chmod2Response response = new Chmod2Response(changedObjects, deletedObjects);
+            helper.setResponseIfNull(response);
+            helper.info("in " + (dryRun ? "mock " : "") + "chmod to " + permissions + " of " + targetObjectCount +
+                    ", changed " + changedObjectCount + " and deleted " + deletedObjectCount + " in total");
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+
+    @Override
+    public void copyFieldsTo(Chmod2 request) {
+        GraphUtil.copyFields(this, request);
+        request.permissions = permissions;
+    }
+
+    @Override
+    public void adjustGraphPolicy(Function<GraphPolicy, GraphPolicy> adjuster) {
+        if (graphPolicyAdjusters == null) {
+            throw new IllegalStateException("request is already initialized");
+        } else {
+            graphPolicyAdjusters.add(adjuster);
+        }
+    }
+
+    @Override
+    public GraphPolicy.Action getActionForStarting() {
+        return GraphPolicy.Action.INCLUDE;
+    }
+
+    @Override
+    public Map<String, List<Long>> getStartFrom(Response response) {
+        return ((Chmod2Response) response).includedObjects;
+    }
+
+    /**
+     * A <q>chmod</q> processor that updates model objects' permissions.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.1.1
+     */
+    private final class InternalProcessor extends BaseGraphTraversalProcessor {
+
+        private final Logger LOGGER = LoggerFactory.getLogger(InternalProcessor.class);
+
+        public InternalProcessor() {
+            super(helper.getSession());
+        }
+
+        @Override
+        public void processInstances(String className, Collection<Long> ids) throws GraphException {
+            final String update = "UPDATE " + className + " SET details.permissions.perm1 = :permissions WHERE id IN (:ids)";
+            final int count =
+                    session.createQuery(update).setParameter("permissions", perm1).setParameterList("ids", ids).executeUpdate();
+            if (count != ids.size()) {
+                LOGGER.warn("not all the objects of type " + className + " could be processed");
+            }
+        }
+
+        @Override
+        public Set<GraphPolicy.Ability> getRequiredPermissions() {
+            return REQUIRED_ABILITIES;
+        }
+
+        @Override
+        public void assertMayProcess(String className, long id, Details details) throws GraphException {
+            if (!PERMITTED_CLASS.equals(className)) {
+                /* chmod may be done only to groups */
+                throw new GraphException("may process objects only of type " + PERMITTED_CLASS);
+            }
+            if (!(acceptableGroups == null || acceptableGroups.contains(id))) {
+                throw new GraphException("user is not an owner of group " + id);
+            }
+        }
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -65,7 +65,7 @@ import omero.cmd.Response;
 /**
  * Request to change the permissions on model objects, reimplementing {@link ChmodI}.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.1.1
+ * @since 5.1.2
  */
 public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2> {
 
@@ -307,7 +307,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
     /**
      * A <q>chmod</q> processor that updates model objects' permissions.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since 5.1.1
+     * @since 5.1.2
      */
     private final class InternalProcessor extends BaseGraphTraversalProcessor {
 

--- a/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+import ome.services.graphs.GraphException;
+import omero.cmd.Chmod;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.OK;
+import omero.cmd.Response;
+import omero.cmd.HandleI.Cancel;
+
+/**
+ * Implements an approximation of {@link Chmod}'s API using {@link omero.cmd.Chmod2}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.1
+ * @deprecated will be removed in OMERO 5.3, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ */
+@Deprecated
+@SuppressWarnings("deprecation")
+public class ChmodFacadeI extends Chmod implements IRequest {
+
+    private final GraphRequestFactory graphRequestFactory;
+    private final SetMultimap<String, Long> targetObjects = HashMultimap.create();
+
+    private IRequest chmodRequest;
+
+    /**
+     * Construct a new <q>chmod</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
+     * @param graphRequestFactory a means of instantiating a sub-request for root-anchored subgraphs
+     */
+    public ChmodFacadeI(GraphRequestFactory graphRequestFactory) {
+        this.graphRequestFactory = graphRequestFactory;
+        this.chmodRequest = graphRequestFactory.getRequest(Chmod2I.class);
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+       return chmodRequest.getCallContext();
+    }
+
+    /**
+     * Add the given model object to the chmod request's target objects.
+     * To be called <em>before</em> {@link #init(Helper)}.
+     * @param type the model object's type
+     * @param id the model object's ID
+     */
+    public void addToTargets(String type, long id) {
+        targetObjects.put(GraphUtil.getFirstClassName(type), id);
+    }
+
+    @Override
+    public void init(Helper helper) {
+        /* find class name at start of type string */
+        if (type.charAt(0) == '/') {
+            type = type.substring(1);
+        }
+        final Chmod2I actualChmod = (Chmod2I) chmodRequest;
+        /* set target object and group then review options */
+        addToTargets(type, id);
+        actualChmod.targetObjects = new HashMap<String, List<Long>>();
+        for (final Map.Entry<String, Collection<Long>> oneClassToTarget : targetObjects.asMap().entrySet()) {
+            actualChmod.targetObjects.put(oneClassToTarget.getKey(), new ArrayList<Long>(oneClassToTarget.getValue()));
+        }
+        targetObjects.clear();
+        actualChmod.permissions = permissions;
+        try {
+            GraphUtil.translateOptions(graphRequestFactory, options, actualChmod, helper.getEventContext().isCurrentUserAdmin());
+        } catch (GraphException ge) {
+            final Exception e = new IllegalArgumentException("could not accept request options");
+            throw helper.cancel(new ERR(), e, "bad-options");
+        }
+        /* check for root-anchored subgraph */
+        final int lastSlash = type.lastIndexOf('/');
+        if (lastSlash > 0) {
+            /* wrap in skip-head request for operating on subgraphs */
+            final SkipHeadI wrapper = graphRequestFactory.getRequest(SkipHeadI.class);
+            GraphUtil.copyFields(actualChmod, wrapper);
+            wrapper.startFrom = Collections.singletonList(type.substring(lastSlash + 1));
+            wrapper.request = actualChmod;
+            chmodRequest = wrapper;
+        }
+
+        /* now the chmod request is configured, complete initialization */
+        chmodRequest.init(helper);
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        return chmodRequest.step(step);
+    }
+
+    @Override
+    public void finish() {
+        chmodRequest.finish();
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        chmodRequest.buildResponse(step, object);
+    }
+
+    @Override
+    public Response getResponse() {
+        final Response responseToWrap = chmodRequest.getResponse();
+
+        if (responseToWrap instanceof ERR) {
+            return responseToWrap;
+        }
+
+        /* no actual wrapping needed */
+        return new OK();
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
@@ -41,7 +41,7 @@ import omero.cmd.HandleI.Cancel;
 /**
  * Implements an approximation of {@link Chmod}'s API using {@link omero.cmd.Chmod2}.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.1.1
+ * @since 5.1.2
  * @deprecated will be removed in OMERO 5.3, so use the
  * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */

--- a/components/blitz/src/omero/cmd/graphs/ChmodI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodI.java
@@ -151,7 +151,7 @@ public class ChmodI extends Chmod implements IGraphModifyRequest {
                 IObject obj = (IObject)
                     helper.getSession().get(ExperimenterGroup.class, id);
                 if (obj == null) {
-                    helper.cancel(new ERR(), null, "unkown target", params());
+                    helper.cancel(new ERR(), null, "unknown target", params());
                 }
                 return obj;
             }

--- a/components/blitz/src/omero/cmd/graphs/ChmodI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodI.java
@@ -39,7 +39,11 @@ import omero.cmd.Response;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.4.0
+ * @deprecated will be removed in OMERO 5.2, so use the
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class ChmodI extends Chmod implements IGraphModifyRequest {
 
     private static final long serialVersionUID = -33294230498203989L;

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -166,7 +166,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                         graphTraversal.planOperation(helper.getSession(), targetMultimap, true);
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
-                graphTraversal.unlinkTargets();
+                graphTraversal.unlinkTargets(false);
                 return null;
             case 2:
                 graphTraversal.processTargets();

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -133,8 +133,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
 
         GraphPolicy graphPolicyWithOptions = graphPolicy;
 
-        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, graphPathBean, childOptions,
-                REQUIRED_ABILITIES);
+        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, childOptions, REQUIRED_ABILITIES);
 
         for (final Function<GraphPolicy, GraphPolicy> adjuster : graphPolicyAdjusters) {
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -285,7 +285,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
         }
 
         @Override
-        public void assertMayProcess(Details details) throws GraphException {
+        public void assertMayProcess(String className, long objectId, Details details) throws GraphException {
             final Long objectGroupId = details.getGroup().getId();
             if (!(acceptableGroups == null || acceptableGroups.contains(objectGroupId))) {
                 throw new GraphException("user " + userId + " is not a member of group " + objectGroupId);

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -151,7 +151,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                         graphTraversal.planOperation(helper.getSession(), targetMultimap, false);
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
-                graphTraversal.unlinkTargets();
+                graphTraversal.unlinkTargets(true);
                 return null;
             case 2:
                 graphTraversal.processTargets();

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -118,8 +118,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
 
         GraphPolicy graphPolicyWithOptions = graphPolicy;
 
-        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, graphPathBean, childOptions,
-                REQUIRED_ABILITIES);
+        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, childOptions, REQUIRED_ABILITIES);
 
         for (final Function<GraphPolicy, GraphPolicy> adjuster : graphPolicyAdjusters) {
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -99,8 +99,11 @@ public class GraphRequestFactory {
 
         this.defaultExcludeNs = ImmutableSet.copyOf(defaultExcludeNs);
 
+        final String logMessage = "substituting Chgrp, Chmod, Chown, Delete requests with Chgrp2, Chmod2, Chown2, Delete2 requests";
         if (isGraphsWrap) {
-            LOGGER.warn("substituting Chgrp, Delete requests with Chgrp2, Delete2 requests");
+            LOGGER.debug(logMessage);
+        } else {
+            LOGGER.warn("not " + logMessage);
         }
         this.isGraphsWrap = isGraphsWrap;
     }

--- a/components/blitz/src/omero/cmd/graphs/NullGraphTraversalProcessor.java
+++ b/components/blitz/src/omero/cmd/graphs/NullGraphTraversalProcessor.java
@@ -60,5 +60,5 @@ public class NullGraphTraversalProcessor implements GraphTraversal.Processor {
     }
 
     @Override
-    public void assertMayProcess(Details details) throws GraphException { }
+    public void assertMayProcess(String className, long id, Details details) throws GraphException { }
 }

--- a/components/blitz/test/ome/services/blitz/test/ChmodITest.java
+++ b/components/blitz/test/ome/services/blitz/test/ChmodITest.java
@@ -43,6 +43,7 @@ import omero.model.PermissionsI;
  * @see http://www.openmicroscopy.org/site/community/minutes/minigroup/2012.03.12-groupperms
  */
 @Test(groups = { "integration", "chmod" })
+@SuppressWarnings("deprecation")
 public class ChmodITest extends AbstractGraphTest {
 
     ManagedContextFixture user; // Overrides super class

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -19,7 +19,9 @@
 
 package ome.services.graphs;
 
+import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -206,6 +208,26 @@ public abstract class GraphPolicy {
      */
     public void noteDetails(Session session, IObject object, String realClass, long id) {
         /* This method is a no-op that subclasses may override. */
+    }
+
+    /**
+     * Utility method to return all the objects for review as a single set of objects.
+     * @param linkedFrom details of the objects linking to the root object
+     * @param rootObject details of the root objects
+     * @param linkedTo details of the objects linked by the root object
+     * @return details of all the objects passed as arguments
+     */
+    public static Set<Details> allObjects(Collection<Set<Details>> linkedFrom, Details rootObject,
+            Collection<Set<Details>> linkedTo) {
+        final Set<Details> allTerms = new HashSet<Details>();
+        allTerms.add(rootObject);
+        for (final Set<Details> terms : linkedFrom) {
+            allTerms.addAll(terms);
+        }
+        for (final Set<Details> terms : linkedTo) {
+            allTerms.addAll(terms);
+        }
+        return allTerms;
     }
 
     /**

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -190,7 +190,7 @@ public abstract class GraphPolicy {
      * {@link #review(Map, Details, Map, Set)}. Each object is passed only once.
      * Subclasses overriding this method probably ought also override {@link #getCleanInstance()}.
      * @param session the Hibernate session, for obtaining more information about the object
-     * @param object a model object about which policy may be asked
+     * @param object an unloaded model object about which policy may be asked
      * @param realClass the real class name of the object
      * @param id the ID of the object
      */

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -86,6 +86,12 @@ public abstract class GraphPolicy {
         DELETE,
 
         /**
+         * the user's ability to change permissions on the object, as judged by
+         * {@link ome.security.ACLVoter#allowChmod(IObject, ome.model.internal.Details)}
+         */
+        CHMOD,
+
+        /**
          * the user actually owns the object
          */
         OWN;
@@ -138,11 +144,12 @@ public abstract class GraphPolicy {
          * @param orphan the current <q>orphan</q> state of the object
          * @param mayUpdate if the object may be updated
          * @param mayDelete if the object may be deleted
+         * @param mayChmod if the object may have its permissions changed
          * @param isOwner if the user owns the object
          * @param isCheckPermissions if the user is expected to have the permissions required to process the object
          */
         Details(IObject subject, Long ownerId, Long groupId, Action action, Orphan orphan,
-                boolean mayUpdate, boolean mayDelete, boolean isOwner, boolean isCheckPermissions) {
+                boolean mayUpdate, boolean mayDelete, boolean mayChmod, boolean isOwner, boolean isCheckPermissions) {
             this.subject = subject;
             this.ownerId = ownerId;
             this.groupId = groupId;
@@ -155,6 +162,9 @@ public abstract class GraphPolicy {
             }
             if (mayDelete) {
                 permissions.add(Ability.DELETE);
+            }
+            if (mayChmod) {
+                permissions.add(Ability.CHMOD);
             }
             if (isOwner) {
                 permissions.add(Ability.OWN);

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -849,14 +849,7 @@ public class GraphPolicyRule {
         final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
         if (!policyRule.termMatchers.isEmpty()) {
             /* apply the term matchers */
-            final Set<Details> allTerms = new HashSet<Details>();
-            allTerms.add(rootObject);
-            for (final Set<Details> terms : linkedFrom.values()) {
-                allTerms.addAll(terms);
-            }
-            for (final Set<Details> terms : linkedTo.values()) {
-                allTerms.addAll(terms);
-            }
+            final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
             for (final TermMatch matcher : policyRule.termMatchers) {
                 for (final Details object : allTerms) {
                     if (matcher.isMatch(namedTerms, isCheckAllPermissions, object)) {
@@ -913,20 +906,11 @@ public class GraphPolicyRule {
             Details rootObject, Map<String, Set<Details>> linkedTo, Set<String> notNullable,
             ParsedPolicyRule policyRule, Set<Details> changedObjects) throws GraphException {
         final SortedMap<String, Details> namedTerms = new TreeMap<String, Details>();
-        final Set<Details> allTerms = new HashSet<Details>();
         final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
         final Set<TermMatch> unmatchedTerms = new HashSet<TermMatch>(policyRule.termMatchers);
+        final Set<Details> allTerms = unmatchedTerms.isEmpty() ? Collections.<Details>emptySet()
+                : GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
         final Set<RelationshipMatch> unmatchedRelationships = new HashSet<RelationshipMatch>(policyRule.relationshipMatchers);
-        if (!unmatchedTerms.isEmpty()) {
-            /* note all terms to which to apply term matchers */
-            allTerms.add(rootObject);
-            for (final Set<Details> terms : linkedFrom.values()) {
-                allTerms.addAll(terms);
-            }
-            for (final Set<Details> terms : linkedTo.values()) {
-                allTerms.addAll(terms);
-            }
-        }
         /* try all the matchers against all the terms */
         do {
             final int namedTermCount = namedTerms.size();

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1212,15 +1212,15 @@ public class GraphTraversal {
         if (!isSystemType(className)) {
             assertPermissions(objects, processor.getRequiredPermissions());
         }
-            if (!eventContext.isCurrentUserAdmin()) {
-                for (final CI object : Sets.difference(objects, planning.overrides)) {
-                    try {
-                        processor.assertMayProcess(object.className, object.id, planning.detailsNoted.get(object));
-                    } catch (GraphException e) {
-                        throw new GraphException("cannot process " + object + ": " + e.message);
-                    }
+        if (!eventContext.isCurrentUserAdmin()) {
+            for (final CI object : Sets.difference(objects, planning.overrides)) {
+                try {
+                    processor.assertMayProcess(object.className, object.id, planning.detailsNoted.get(object));
+                } catch (GraphException e) {
+                    throw new GraphException("cannot process " + object + ": " + e.message);
                 }
             }
+        }
     }
 
     /**

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1330,23 +1330,23 @@ public class GraphTraversal {
                     }
                 }
                 if (isUnlinkIncludeFromExclude) {
-                for (final Entry<String, String> backwardLink : model.getLinkedBy(superclassName)) {
-                    final CP linkProperty = new CP(backwardLink.getKey(), backwardLink.getValue());
-                    final boolean isCollection =
-                            model.getPropertyKind(linkProperty.className, linkProperty.propertyName) == PropertyKind.COLLECTION;
-                    final CPI linkTarget = linkProperty.toCPI(object.id);
-                    for (final CI linker : planning.backwardLinksCached.get(linkTarget)) {
-                        final Action linkerAction = getAction(linker);
-                        if (linkerAction == Action.EXCLUDE) {
-                            /* EXCLUDE is linked to INCLUDE, so unlink */
-                            if (isCollection) {
-                                addRemoval(linkerToIdToLinked, linkProperty.toCPI(linker.id), object);
-                            } else {
-                                toNullByCP.put(linkProperty, linker.id);
+                    for (final Entry<String, String> backwardLink : model.getLinkedBy(superclassName)) {
+                        final CP linkProperty = new CP(backwardLink.getKey(), backwardLink.getValue());
+                        final boolean isCollection =
+                                model.getPropertyKind(linkProperty.className, linkProperty.propertyName) == PropertyKind.COLLECTION;
+                        final CPI linkTarget = linkProperty.toCPI(object.id);
+                        for (final CI linker : planning.backwardLinksCached.get(linkTarget)) {
+                            final Action linkerAction = getAction(linker);
+                            if (linkerAction == Action.EXCLUDE) {
+                                /* EXCLUDE is linked to INCLUDE, so unlink */
+                                if (isCollection) {
+                                    addRemoval(linkerToIdToLinked, linkProperty.toCPI(linker.id), object);
+                                } else {
+                                    toNullByCP.put(linkProperty, linker.id);
+                                }
                             }
                         }
                     }
-                }
                 }
             }
         }

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1208,9 +1208,10 @@ public class GraphTraversal {
      * @throws GraphException if the user does not have the necessary permissions for all of the objects
      */
     private void assertMayBeProcessed(String className, Collection<Long> ids) throws GraphException {
+        final Set<CI> objects = idsToCIs(className, ids);
         if (!isSystemType(className)) {
-            final Set<CI> objects = idsToCIs(className, ids);
             assertPermissions(objects, processor.getRequiredPermissions());
+        }
             if (!eventContext.isCurrentUserAdmin()) {
                 for (final CI object : Sets.difference(objects, planning.overrides)) {
                     try {
@@ -1220,7 +1221,6 @@ public class GraphTraversal {
                     }
                 }
             }
-        }
     }
 
     /**

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -788,6 +788,7 @@ public class GraphTraversal {
      * @param linkProperty a class and property name
      * @return the linking class
      */
+    @SuppressWarnings("unused")
     private String getLinkerClass(CP linkProperty) {
         for (final Entry<String, String> backwardLink : model.getLinkedBy(linkProperty.className)) {
             if (linkProperty.propertyName.equals(backwardLink.getValue())) {

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -416,10 +416,12 @@ public class GraphTraversal {
 
         /**
          * Assert that an object with the given details may be processed. Called only if the user is not an administrator.
+         * @param className the name of the object's class
+         * @param id the ID of the object
          * @param details the object's details
          * @throws GraphException if the object may not be processed
          */
-        void assertMayProcess(ome.model.internal.Details details) throws GraphException;
+        void assertMayProcess(String className, long id, ome.model.internal.Details details) throws GraphException;
     }
 
     private final Session session;
@@ -1177,8 +1179,8 @@ public class GraphTraversal {
             }
 
             @Override
-            public void assertMayProcess(ome.model.internal.Details details) throws GraphException {
-                processor.assertMayProcess(details);
+            public void assertMayProcess(String className, long id, ome.model.internal.Details details) throws GraphException {
+                processor.assertMayProcess(className, id, details);
             }
         };
     }
@@ -1212,7 +1214,7 @@ public class GraphTraversal {
             if (!eventContext.isCurrentUserAdmin()) {
                 for (final CI object : Sets.difference(objects, planning.overrides)) {
                     try {
-                        processor.assertMayProcess(planning.detailsNoted.get(object));
+                        processor.assertMayProcess(object.className, object.id, planning.detailsNoted.get(object));
                     } catch (GraphException e) {
                         throw new GraphException("cannot process " + object + ": " + e.message);
                     }

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -36,7 +36,7 @@ import Ice
 import Glacier2
 import omero
 import omero.gateway
-from omero.cmd import DoAll, State, ERR, OK, Chmod, Chgrp2, Delete2
+from omero.cmd import DoAll, State, ERR, OK, Chmod2, Chgrp2, Delete2
 from omero.callbacks import CmdCallbackI
 from omero.model import DatasetI, DatasetImageLinkI, ImageI, ProjectI
 from omero.model import Annotation, FileAnnotationI, OriginalFileI
@@ -986,7 +986,7 @@ class ITest(object):
         """
         Changes the permissions of an ExperimenterGroup object.
         Accepts a client instance to guarantee calls in correct user contexts.
-        Creates Chmod commands and calls :func:`~test.ITest.doSubmit`.
+        Creates Chmod2 commands and calls :func:`~test.ITest.doSubmit`.
 
         :param gid: id of an ExperimenterGroup
         :param perms: permissions string
@@ -995,8 +995,8 @@ class ITest(object):
         if client is None:
             client = self.client
 
-        command = Chmod(
-            type="/ExperimenterGroup", id=gid, permissions=perms)
+        command = Chmod2(
+            targetObjects={'ExperimenterGroup': [gid]}, permissions=perms)
 
         self.doSubmit(command, client)
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -43,7 +43,7 @@ import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
-import omero.cmd.Chmod;
+import omero.cmd.Chmod2;
 import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
@@ -131,6 +131,7 @@ import omero.sys.ParametersI;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import spec.AbstractTest;
@@ -1139,8 +1140,11 @@ public class AbstractServerTest extends AbstractTest {
      * @param perms
      * @return
      */
-    Chmod createChmodCommand(String type, long id, String perms) {
-        return new Chmod(type, id, null, perms);
+    Chmod2 createChmodCommand(String type, long id, String perms) {
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of(type, Collections.singletonList(id));
+        chmod.permissions = perms;
+        return chmod;
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
- *   Copyright 2006-2013 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static omero.rtypes.rbool;
@@ -29,7 +28,7 @@ import omero.ServerError;
 import omero.ValidationException;
 import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
-import omero.cmd.Chmod;
+import omero.cmd.Request;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
@@ -61,8 +60,8 @@ import pojos.GroupData;
  */
 public class AdminServiceTest extends AbstractServerTest {
 
-    /** Identifies the image as root. */
-    public static final String REF_GROUP = "/ExperimenterGroup";
+    /** Identifies the model object class for groups. */
+    public static final String REF_GROUP = "ExperimenterGroup";
 
     /** The password of the user. */
     private String PASSWORD = "password";
@@ -1326,7 +1325,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1367,7 +1366,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwra--";
 
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1408,7 +1407,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1447,7 +1446,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwr---";
 
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1480,7 +1479,7 @@ public class AdminServiceTest extends AbstractServerTest {
         Permissions permissions = g.getDetails().getPermissions();
         // change permissions and promote the group
         representation = "rwrw--";
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
 
         doChange(root, root.getSession(), mod, true);
@@ -1516,7 +1515,7 @@ public class AdminServiceTest extends AbstractServerTest {
 
         // change permissions and promote the group
         representation = "rwr---";
-        Chmod mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
                 representation);
 
         doChange(root, root.getSession(), mod, true);

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -58,7 +58,7 @@ import integration.AbstractServerTest;
 /**
  * Tests that only appropriate users may use {@link Chmod2} and that others' data is then deleted only when appropriate.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.1.1
+ * @since 5.1.2
  */
 public class PermissionsTest extends AbstractServerTest {
 

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration.chmod;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import ome.model.internal.Permissions;
+import ome.util.Utils;
+import omero.ServerError;
+import omero.cmd.Chmod2;
+import omero.cmd.Delete2;
+import omero.model.Annotation;
+import omero.model.CommentAnnotationI;
+import omero.model.ExperimenterGroup;
+import omero.model.ExperimenterGroupI;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.ImageAnnotationLink;
+import omero.model.ImageAnnotationLinkI;
+import omero.model.RectI;
+import omero.model.Roi;
+import omero.model.RoiI;
+import omero.model.TagAnnotation;
+import omero.model.TagAnnotationI;
+import omero.sys.EventContext;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import integration.AbstractServerTest;
+
+/**
+ * Tests that only appropriate users may use {@link Chmod2} and that others' data is then deleted only when appropriate.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.1
+ */
+public class PermissionsTest extends AbstractServerTest {
+
+    private final List<Long> testImages = Collections.synchronizedList(new ArrayList<Long>());
+
+    private ExperimenterGroup systemGroup;
+    private EventContext userOtherGroup, adminOtherGroup;
+
+    /**
+     * Set up admin and non-admin users who are not a member of the groups created by tests.
+     * @throws Exception unexpected
+     */
+    @BeforeClass
+    public void setupOtherGroup() throws Exception {
+        systemGroup = new ExperimenterGroupI(iAdmin.getSecurityRoles().systemGroupId, false);
+        userOtherGroup = newUserAndGroup("rw----");
+        final ExperimenterGroup group = new ExperimenterGroupI(userOtherGroup.groupId, false);
+        adminOtherGroup = newUserInGroup(group, false);
+        addUsers(systemGroup, Collections.singletonList(adminOtherGroup.userId), false);
+    }
+
+    /**
+     * Clear the list of test images.
+     */
+    @BeforeClass
+    public void clearTestImages() {
+        testImages.clear();
+    }
+
+    /**
+     * Delete the test images then clear the list.
+     * @throws Exception unexpected
+     */
+    @AfterClass
+    public void deleteTestImages() throws Exception {
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = ImmutableMap.of("Image", testImages);
+        doChange(root, root.getSession(), delete, true);
+        clearTestImages();
+    }
+
+    /**
+     * Add a comment and a ROI to the given image.
+     * @param imageId an image ID
+     * @return the new model objects
+     * @throws ServerError unexpected
+     */
+    private List<IObject> annotateImage(long imageId) throws ServerError {
+        final List<IObject> annotationObjects = new ArrayList<IObject>();
+        final Image image = (Image) iQuery.get("Image", imageId);
+
+        for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(), new TagAnnotationI()}) {
+            ImageAnnotationLink link = new ImageAnnotationLinkI();
+            link.setParent((Image) image.proxy());
+            link.setChild(annotation);
+            link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
+            annotationObjects.add(link.proxy());
+            annotationObjects.add(link.getChild().proxy());
+        }
+
+        Roi roi = new RoiI();
+        roi.addShape(new RectI());
+        roi.setImage((Image) image.proxy());
+        roi = (Roi) iUpdate.saveAndReturnObject(roi);
+        annotationObjects.add(roi.proxy());
+        annotationObjects.add(roi.getShape(0).proxy());
+
+        return annotationObjects;
+    }
+
+    /**
+     * Assert that the given object still exists or not.
+     * @param object a model object
+     * @param isExists if the object should now exist
+     * @throws ServerError unexpected
+     */
+    private void assertExistence(IObject object, boolean isExists) throws ServerError {
+        assertExistence(Collections.singleton(object), isExists);
+    }
+
+    /**
+     * Assert that the given objects still exist or not.
+     * @param objects some model objects
+     * @param isExists if the objects should now exist
+     * @throws ServerError unexpected
+     */
+    private void assertExistence(Collection<IObject> objects, boolean isExists) throws ServerError {
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final IObject retrieved = iQuery.find(object.getClass().getName(), object.getId().getValue());
+            if (isExists) {
+                Assert.assertNotNull(retrieved, objectName);
+            } else {
+                Assert.assertNull(retrieved, objectName);
+            }
+        }
+    }
+
+    /**
+     * Test that a specific case of using {@link Chmod2} behaves as expected.
+     * @param isGroupOwner if the user submitting the {@link Chmod2} request is an owner of the target group
+     * @param isGroupMember if the user submitting the {@link Chmod2} request is a member of the target group
+     * @param isDataOwner if the user submitting the {@link Chmod2} request owns the data in the group
+     * @param isAdmin if the user submitting the {@link Chmod2} request is a member of the system group
+     * @param fromPerms the permissions on the group before the chmod
+     * @param toPerms the permissions on the group after the chmod
+     * @param isExpectSuccess if the chmod is expected to succeed
+     * @param isExpectDeleteOther if the chmod is expected to cause another user's annotations to be removed from a user's image
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chmod test cases")
+    public void testChmod(boolean isGroupOwner, boolean isGroupMember, boolean isDataOwner, boolean isAdmin,
+            String fromPerms, String toPerms, boolean isExpectSuccess, boolean isExpectDeleteOther) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext importer, annotator, chmodder;
+        final ExperimenterGroup dataGroup;
+
+        importer = newUserAndGroup(fromPerms, isGroupOwner && isDataOwner);
+
+        final long dataGroupId = importer.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        if (isDataOwner) {
+            chmodder = importer;
+        } else if (isGroupMember) {
+            chmodder = newUserInGroup(dataGroup, isGroupOwner);
+        } else {
+            chmodder = isAdmin ? adminOtherGroup : userOtherGroup;
+        }
+
+        if (isAdmin && chmodder != adminOtherGroup) {
+            addUsers(systemGroup, Collections.singletonList(chmodder.userId), false);
+        }
+
+        if ("rwra--".equals(fromPerms)) {
+            if (isGroupMember && !isDataOwner) {
+                annotator = chmodder;
+            } else {
+                annotator = newUserInGroup(dataGroup, false);
+            }
+        } else {
+            annotator = null;
+        }
+
+        /* note which objects were used to annotate an image */
+
+        final List<IObject> ownerAnnotations, otherAnnotations;
+
+        /* import and annotate an image */
+
+        init(importer);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        ownerAnnotations = annotateImage(imageId);
+        disconnect();
+
+        /* perhaps have another user annotate the image */
+
+        if (annotator == null) {
+            otherAnnotations = Collections.<IObject>emptyList();
+        } else {
+            init(annotator);
+            otherAnnotations = annotateImage(image.getId().getValue());
+            disconnect();
+        }
+
+        /* perform the chmod */
+
+        init(chmodder);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = toPerms;
+        doChange(client, factory, chmod, isExpectSuccess);
+        disconnect();
+
+        if (!isExpectSuccess) {
+            return;
+        }
+
+        /* check that the group's permissions are as requested */
+
+        logRootIntoGroup(dataGroupId);
+        final ExperimenterGroup changedGroup = (ExperimenterGroup) iQuery.get("ExperimenterGroup", dataGroupId);
+        final long actualPermissions = changedGroup.getDetails().getPermissions().getPerm1();
+        final long expectedPermissions = (Long) Utils.internalForm(Permissions.parseString(toPerms));
+        Assert.assertEquals(actualPermissions, expectedPermissions);
+
+        /* pluck the tag from the other user's annotations */
+
+        final TagAnnotation tag;
+
+        if (annotator == null) {
+            tag = null;
+        } else {
+            final Iterator<IObject> annotationIterator = otherAnnotations.iterator();
+            while (true) {
+                final IObject annotation = annotationIterator.next();
+                if (annotation instanceof TagAnnotation) {
+                    annotationIterator.remove();
+                    tag = (TagAnnotation) annotation;
+                    break;
+                }
+            }
+        }
+
+        /* check that exactly the expected object deletions have occurred */
+
+        assertExistence(image, true);
+        if (tag != null) {
+            assertExistence(tag, true);
+        }
+        assertExistence(ownerAnnotations, true);
+        assertExistence(otherAnnotations, !isExpectDeleteOther);
+        disconnect();
+    }
+
+    /**
+     * @return a specific test case for chmod
+     */
+    @DataProvider(name = "chmod test cases (debug)")
+    public Object[][] provideChmodCaseDebug() {
+        int index = 0;
+        final int IS_GROUP_OWNER = index++;
+        final int IS_GROUP_MEMBER = index++;
+        final int IS_DATA_OWNER = index++;
+        final int IS_ADMIN = index++;
+        final int FROM_PERMS = index++;
+        final int TO_PERMS = index++;
+        final int IS_EXPECT_SUCCESS = index++;
+        final int IS_EXPECT_DELETE_OTHER = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[IS_GROUP_OWNER] = true;
+        testCase[IS_GROUP_MEMBER] = true;
+        testCase[IS_DATA_OWNER] = true;
+        testCase[IS_ADMIN] = false;
+        testCase[FROM_PERMS] = "rwra--";
+        testCase[TO_PERMS] = "rw----";
+        testCase[IS_EXPECT_SUCCESS] = true;
+        testCase[IS_EXPECT_DELETE_OTHER] = true;
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for chmod
+     */
+    @DataProvider(name = "chmod test cases")
+    public Object[][] provideChmodCases() {
+        int index = 0;
+        final int IS_GROUP_OWNER = index++;
+        final int IS_GROUP_MEMBER = index++;
+        final int IS_DATA_OWNER = index++;
+        final int IS_ADMIN = index++;
+        final int FROM_PERMS = index++;
+        final int TO_PERMS = index++;
+        final int IS_EXPECT_SUCCESS = index++;
+        final int IS_EXPECT_DELETE_OTHER = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwra--"};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isGroupOwner : booleanCases) {
+            for (final boolean isGroupMember : booleanCases) {
+                for (final boolean isDataOwner : booleanCases) {
+                    for (final boolean isAdmin : booleanCases) {
+                        if (!isGroupMember && (isGroupOwner || isDataOwner)) {
+                            /* test case does not make sense */
+                            continue;
+                        }
+
+                        for (final String fromPerms : permsCases) {
+                            for (final String toPerms : permsCases) {
+                                final Object[] testCase = new Object[index];
+                                testCase[IS_GROUP_OWNER] = isGroupOwner;
+                                testCase[IS_GROUP_MEMBER] = isGroupOwner;
+                                testCase[IS_DATA_OWNER] = isDataOwner;
+                                testCase[IS_ADMIN] = isAdmin;
+                                testCase[FROM_PERMS] = fromPerms;
+                                testCase[TO_PERMS] = toPerms;
+                                testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner;
+                                testCase[IS_EXPECT_DELETE_OTHER] = "rwra--".equals(fromPerms) && "rw----".equals(toPerms);
+                                testCases.add(testCase);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+}

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -56,7 +56,7 @@ import integration.AbstractServerTest;
 /**
  * Tests that only appropriate users may use {@link Chown2} and that others' data is left unchanged.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.1.1
+ * @since 5.1.2
  */
 public class PermissionsTest extends AbstractServerTest {
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration.chown;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import omero.RLong;
+import omero.RType;
+import omero.ServerError;
+import omero.cmd.Chown2;
+import omero.cmd.Delete2;
+import omero.model.Annotation;
+import omero.model.CommentAnnotationI;
+import omero.model.ExperimenterGroup;
+import omero.model.ExperimenterGroupI;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.ImageAnnotationLink;
+import omero.model.ImageAnnotationLinkI;
+import omero.model.RectI;
+import omero.model.Roi;
+import omero.model.RoiI;
+import omero.model.TagAnnotationI;
+import omero.sys.EventContext;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import integration.AbstractServerTest;
+
+/**
+ * Tests that only appropriate users may use {@link Chown2} and that others' data is left unchanged.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.1
+ */
+public class PermissionsTest extends AbstractServerTest {
+
+    private final List<Long> testImages = Collections.synchronizedList(new ArrayList<Long>());
+
+    private ExperimenterGroup systemGroup;
+    private EventContext userOtherGroup, adminOtherGroup;
+
+    /**
+     * Set up admin and non-admin users who are not a member of the groups created by tests.
+     * @throws Exception unexpected
+     */
+    @BeforeClass
+    public void setupOtherGroup() throws Exception {
+        systemGroup = new ExperimenterGroupI(iAdmin.getSecurityRoles().systemGroupId, false);
+        userOtherGroup = newUserAndGroup("rw----");
+        final ExperimenterGroup group = new ExperimenterGroupI(userOtherGroup.groupId, false);
+        adminOtherGroup = newUserInGroup(group, false);
+        addUsers(systemGroup, Collections.singletonList(adminOtherGroup.userId), false);
+    }
+
+    /**
+     * Clear the list of test images.
+     */
+    @BeforeClass
+    public void clearTestImages() {
+        testImages.clear();
+    }
+
+    /**
+     * Delete the test images then clear the list.
+     * @throws Exception unexpected
+     */
+    @AfterClass
+    public void deleteTestImages() throws Exception {
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = ImmutableMap.of("Image", testImages);
+        doChange(root, root.getSession(), delete, true);
+        clearTestImages();
+    }
+
+    /**
+     * Add a comment and a ROI to the given image.
+     * @param imageId an image ID
+     * @return the new model objects
+     * @throws ServerError unexpected
+     */
+    private List<IObject> annotateImage(long imageId) throws ServerError {
+        final List<IObject> annotationObjects = new ArrayList<IObject>();
+        final Image image = (Image) iQuery.get("Image", imageId);
+
+        for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(), new TagAnnotationI()}) {
+            ImageAnnotationLink link = new ImageAnnotationLinkI();
+            link.setParent((Image) image.proxy());
+            link.setChild(annotation);
+            link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
+            annotationObjects.add(link.proxy());
+            annotationObjects.add(link.getChild().proxy());
+        }
+
+        Roi roi = new RoiI();
+        roi.addShape(new RectI());
+        roi.setImage((Image) image.proxy());
+        roi = (Roi) iUpdate.saveAndReturnObject(roi);
+        annotationObjects.add(roi.proxy());
+        annotationObjects.add(roi.getShape(0).proxy());
+
+        return annotationObjects;
+    }
+
+    /**
+     * Assert that the given object is owned by the given owner.
+     * @param object a model object
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    private void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
+        assertOwnedBy(Collections.singleton(object), expectedOwner);
+    }
+
+    /**
+     * Assert that the given objects are owned by the given owner.
+     * @param objects some model objects
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    private void assertOwnedBy(Collection<IObject> objects, EventContext expectedOwner) throws ServerError {
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
+                    " WHERE id = " + object.getId().getValue();
+            final List<List<RType>> results = iQuery.projection(query, null);
+            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
+            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
+        }
+    }
+
+    /**
+     * Test that a specific case of using {@link Chown2} behaves as expected.
+     * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
+     * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group
+     * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
+     * @param isExpectSuccess if the chown is expected to succeed
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chown test cases")
+    public void testChown(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
+            throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext importer, annotator, chowner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        importer = newUserAndGroup("rwra--");
+
+        final long dataGroupId = importer.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        recipient = isRecipientInGroup ? newUserInGroup(dataGroup, false) : userOtherGroup;
+
+        if (isDataOwner) {
+            chowner = importer;
+        } else {
+            chowner = isAdmin ? adminOtherGroup : recipient;
+        }
+
+        if (isAdmin && chowner != adminOtherGroup) {
+            addUsers(systemGroup, Collections.singletonList(chowner.userId), false);
+        }
+
+        annotator = newUserInGroup(dataGroup, false);
+
+        /* note which objects were used to annotate an image */
+
+        final List<IObject> ownerAnnotations, otherAnnotations;
+
+        /* import and annotate an image */
+
+        init(importer);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        ownerAnnotations = annotateImage(imageId);
+        disconnect();
+
+        /* have another user annotate the image */
+
+        init(annotator);
+        otherAnnotations = annotateImage(image.getId().getValue());
+        disconnect();
+
+        /* perform the chown */
+
+        init(chowner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, isExpectSuccess);
+        disconnect();
+
+        if (!isExpectSuccess) {
+            return;
+        }
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(image, recipient);
+        assertOwnedBy(ownerAnnotations, recipient);
+        assertOwnedBy(otherAnnotations, annotator);
+        disconnect();
+    }
+
+    /**
+     * @return a specific test case for chown
+     */
+    @DataProvider(name = "chown test cases (debug)")
+    public Object[][] provideChownCaseDebug() {
+        int index = 0;
+        final int IS_DATA_OWNER = index++;
+        final int IS_ADMIN = index++;
+        final int IS_RECIPIENT_IN_GROUP = index++;
+        final int IS_EXPECT_SUCCESS = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[IS_DATA_OWNER] = true;
+        testCase[IS_ADMIN] = true;
+        testCase[IS_RECIPIENT_IN_GROUP] = true;
+        testCase[IS_EXPECT_SUCCESS] = true;
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for chown
+     */
+    @DataProvider(name = "chown test cases")
+    public Object[][] provideChownCases() {
+        int index = 0;
+        final int IS_DATA_OWNER = index++;
+        final int IS_ADMIN = index++;
+        final int IS_RECIPIENT_IN_GROUP = index++;
+        final int IS_EXPECT_SUCCESS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isDataOwner : booleanCases) {
+            for (final boolean isAdmin : booleanCases) {
+                for (final boolean isRecipientInGroup : booleanCases) {
+                    final Object[] testCase = new Object[index];
+                    testCase[IS_DATA_OWNER] = isDataOwner;
+                    testCase[IS_ADMIN] = isAdmin;
+                    testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
+                    testCase[IS_EXPECT_SUCCESS] = isAdmin || isDataOwner && isRecipientInGroup;
+                    testCases.add(testCase);
+                }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+}

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -86,7 +86,7 @@ class AnnotationPermissions(lib.ITest):
         return project
 
     def getProjectAs(self, user, id):
-        """ Gets a Tag via its id. """
+        """ Gets a Project via its id. """
         return self.queryServices[user].find("Project", id)
 
     def makeTag(self):

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -373,13 +373,15 @@ class TestReadAnnotateGroup(AnnotationPermissions):
 
 class TestMovePrivatePermissions(AnnotationPermissions):
 
-    DEFAULT_PERMS = 'rwra--'
+    def setup_method(self, method):
+        super(TestMovePrivatePermissions, self).setup_method(method)
 
-    @pytest.mark.parametrize("admin_type", ("root", "admin"))
+        # Make the group read-annotate for every test run
+        self.chmodGroupAs("root", "rwra--")
+
+    @pytest.mark.parametrize("admin_type", ("root", "admin", "owner"))
     def testAddTagMakePrivate(self, admin_type):
         """ see ticket:11479 """
-        # Start with a read-annotate group
-        self.chmodGroupAs(admin_type, "rwra--")
 
         # Have member1 tag their project with member2's tag
         project = self.createProjectAs("member1")

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2013-2014 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 # All rights reserved. Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify
@@ -74,8 +74,8 @@ class AnnotationPermissions(lib.ITest):
 
     def chmodGroupAs(self, user, perms, succeed=True):
         client = self.clients[user]
-        chmod = omero.cmd.Chmod(
-            type="/ExperimenterGroup", id=self.group.id.val,
+        chmod = omero.cmd.Chmod2(
+            targetObjects={'ExperimenterGroup': [self.group.id.val]},
             permissions=perms)
         self.doSubmit(chmod, client, test_should_pass=succeed)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1423,10 +1423,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         admin_serv = self.getAdminService()
         admin_serv.updateSelf(up_exp)
-        defultGroup = self.getObject(
+        defaultGroup = self.getObject(
             "ExperimenterGroup", long(defaultGroupId))._obj
-        admin_serv.setDefaultGroup(up_exp, defultGroup)
-        self.changeActiveGroup(defultGroup.id)
+        admin_serv.setDefaultGroup(up_exp, defaultGroup)
+        self.changeActiveGroup(defaultGroup.id)
 
     def setDefaultGroup(self, group_id, exp_id=None):
         """

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -324,7 +324,7 @@ omero.pixeldata.tile_height=256
 omero.pixeldata.max_plane_width=3192
 omero.pixeldata.max_plane_height=3192
 
-# Whether to use the new Chgrp, Chown, Delete implementations.
+# Whether to use the new Chgrp, Chmod, Chown, Delete implementations.
 # Available only for OMERO 5.1:
 # from OMERO 5.2 the new implementations must be used.
 omero.graphs.wrap=true


### PR DESCRIPTION
Uses of `Chmod` requests are now actioned by the `Chmod2` implementation. Chmod-related integration tests should pass. Also try changing group permissions from the client to make sure it works correctly. (The admin service's `changePermissions` still uses the old `Chmod` but the clients don't much use that.)

This PR *should* be suitable for 5.1 so that a 5.1.1 (or trout-latest) client can work with a 5.1.2 (or trout-merge) server and vice versa: no commits with this PR switch clients to use `Chmod2` directly.

--no-rebase