### PR TITLE
Optimize plate grid metadata

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5604,11 +5604,10 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         if self._gridSize is None:
             q = self._conn.getQueryService()
-            params = omero.sys.Parameters()
-            params.map = {}
-            params.map['pid'] = omero_type(self.getId())
+            params = omero.sys.ParametersI()
+            params.addId(self.getId())
             query = "select max(row), max(column) from Well "\
-                    "where plate.id = :pid"
+                    "where plate.id = :id"
             res = q.projection(query, params, self._conn.SERVICE_OPTS)
             (row, col) = res[0]
             self._gridSize = {'rows': row.val+1, 'columns': col.val+1}

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5607,7 +5607,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             params = omero.sys.Parameters()
             params.map = {}
             params.map['pid'] = omero_type(self.getId())
-            query = "select max(row), max(column) from Well"\
+            query = "select max(row), max(column) from Well "\
                     "where plate.id = :pid"
             res = q.projection(query, params, self._conn.SERVICE_OPTS)
             (row, col) = res[0]

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5603,10 +5603,15 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     dict of {'rows': rSize, 'columns':cSize}
         """
         if self._gridSize is None:
-            r, c = 0, 0
-            for child in self._listChildren():
-                r, c = max(child.row.val, r), max(child.column.val, c)
-            self._gridSize = {'rows': r+1, 'columns': c+1}
+            q = self._conn.getQueryService()
+            params = omero.sys.Parameters()
+            params.map = {}
+            params.map['pid'] = omero_type(self.getId())
+            query = "select max(row), max(column) from Well"\
+                    "where plate.id = :pid"
+            res = q.projection(query, params, self._conn.SERVICE_OPTS)
+            (row, col) = res[0]
+            self._gridSize = {'rows': row.val+1, 'columns': col.val+1}
         return self._gridSize
 
     def getWellGrid(self, index=0):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   gateway tests - Testing the gateway image wrapper
+
+   pytest fixtures used as defined in conftest.py:
+   - gatewaywrapper
+
+"""
+
+import pytest
+
+from omero.model import ImageI
+from omero.rtypes import rstring, rint, rtime
+from datetime import datetime
+from uuid import uuid4
+
+
+@pytest.fixture()
+def image(request, gatewaywrapper):
+    """Creates an Image."""
+    gatewaywrapper.loginAsAuthor()
+    gw = gatewaywrapper.gateway
+    update_service = gw.getUpdateService()
+    image = ImageI()
+    image.name = rstring('an image')
+    # 2015-04-21 01:15:00
+    image.acquisitionDate = rtime(1429578900000L)
+    image_id, = update_service.saveAndReturnIds([image])
+    return gw.getObject('Image', image_id)
+
+
+@pytest.fixture()
+def image_no_acquisition_date(request, gatewaywrapper):
+    """Creates an Image."""
+    gatewaywrapper.loginAsAuthor()
+    gw = gatewaywrapper.gateway
+    update_service = gw.getUpdateService()
+    image = ImageI()
+    image.name = rstring('an image')
+    image.acquisitionDate = rtime(0L)
+    image_id, = update_service.saveAndReturnIds([image])
+    return gw.getObject('Image', image_id)
+
+
+class TestImageWrapper(object):
+
+    def testGetDate(self, gatewaywrapper, image):
+        date = image.getDate()
+        assert date == datetime.fromtimestamp(1429578900L)
+
+    def testGetDateNoAcquisitionDate(
+            self, gatewaywrapper, image_no_acquisition_date):
+        date = image_no_acquisition_date.getDate()
+        creation_event_date = image_no_acquisition_date.creationEventDate()
+        assert date == creation_event_date
+
+
+    def testSimpleMarshal(self, gatewaywrapper, image):
+        marshalled = image.simpleMarshal()
+        assert marshalled == {
+            'description': '',
+            'author': 'Author ',
+            'date': 1429578900.0,
+            'type': 'Image',
+            'id': image.getId(),
+            'name': 'an image'
+        }

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -16,9 +16,8 @@
 import pytest
 
 from omero.model import ImageI
-from omero.rtypes import rstring, rint, rtime
+from omero.rtypes import rstring, rtime
 from datetime import datetime
-from uuid import uuid4
 
 
 @pytest.fixture()
@@ -59,7 +58,6 @@ class TestImageWrapper(object):
         date = image_no_acquisition_date.getDate()
         creation_event_date = image_no_acquisition_date.creationEventDate()
         assert date == creation_event_date
-
 
     def testSimpleMarshal(self, gatewaywrapper, image):
         marshalled = image.simpleMarshal()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -1,23 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#
-# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015 Glencoe Software, Inc.
 # All rights reserved.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Use is subject to license terms supplied in LICENSE.txt
 
 """
    gateway tests - Testing the gateway image wrapper

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -1,23 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#
-# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015 Glencoe Software, Inc.
 # All rights reserved.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Use is subject to license terms supplied in LICENSE.txt
 
 """
    gateway tests - Testing the gateway plate wrapper

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   gateway tests - Testing the gateway plate wrapper
+
+   pytest fixtures used as defined in conftest.py:
+   - gatewaywrapper
+
+"""
+
+import pytest
+
+from omero.model import PlateI, WellI, WellSampleI, ImageI
+from omero.rtypes import rstring, rint, rtime
+from uuid import uuid4
+
+
+def uuid():
+    return str(uuid4())
+
+
+@pytest.fixture()
+def plate(request, gatewaywrapper):
+    """Creates a Plate."""
+    gatewaywrapper.loginAsAuthor()
+    gw = gatewaywrapper.gateway
+    update_service = gw.getUpdateService()
+    plate = PlateI()
+    plate.name = rstring(uuid())
+    for well_index in range(3):
+        well = WellI()
+        well.row = rint(well_index**2)
+        well.column = rint(well_index**3)
+        for well_sample_index in range(2):
+            well_sample = WellSampleI()
+            image = ImageI()
+            image.name = rstring('%s_%d' % (uuid(), well_sample_index))
+            image.acquisitionDate = rtime(0)
+            well_sample.image = image
+            well.addWellSample(well_sample)
+        plate.addWell(well)
+    plate_id, = update_service.saveAndReturnIds([plate])
+    return gw.getObject('Plate', plate_id)
+
+
+class TestPlateWrapper(object):
+
+    def testGetGridSize(self, gatewaywrapper, plate):
+        assert plate.getGridSize() == {'rows': 5L, 'columns': 9L}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -58,7 +58,7 @@ class PlateGrid(object):
                 row, col, img_id, img_name, author, well_id, acq_date, \
                     create_date, description = res
 
-                if acq_date.val is not None and acq_date.val > 0:
+                if acq_date is not None and acq_date.val > 0:
                     date = acq_date.val / 1000
                 else:
                     date = create_date.val / 1000

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -54,25 +54,22 @@ class PlateGrid(object):
                     "where well.plate.id = :id "\
                     "and index(ws) = :wsidx"
 
-            wellGrid = q.projection(query, params, self._conn.SERVICE_OPTS)
-            for w in wellGrid:
-                gridRow = w[0].val
-                gridCol = w[1].val
+            for res in q.projection(query, params, self._conn.SERVICE_OPTS):
+                row, col, img_id, img_name, author, well_id, time = res
                 wellmeta = {'type': 'Image',
-                            'id': w[2].val,
-                            'name': w[3].val,
-                            'author': w[4].val,
-                            'wellId': w[5].val,
+                            'id': img_id.val,
+                            'name': img_name.val,
+                            'author': author.val,
+                            'date': time.val / 1000,
+                            'wellId': well_id.val,
                             'field': self.field}
 
-                date = dt.fromtimestamp(w[6].val / 1000)
-                wellmeta['date'] = time.mktime(date.timetuple())
                 if callable(self._thumbprefix):
-                    wellmeta['thumb_url'] = self._thumbprefix(str(w[2].val))
+                    wellmeta['thumb_url'] = self._thumbprefix(str(img_id.val))
                 else:
-                    wellmeta['thumb_url'] = self._thumbprefix + str(w[2].val)
+                    wellmeta['thumb_url'] = self._thumbprefix + str(img_id.val)
 
-                grid[gridRow][gridCol] = wellmeta
+                grid[row.val][col.val] = wellmeta
 
             self._metadata = {'grid': grid,
                               'collabels': self.plate.getColumnLabels(),

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -15,7 +15,7 @@ from datetime import datetime as dt
 import time
 
 import omero.sys
-from omero.rtypes import rint, rlong
+from omero.rtypes import rint
 
 logger = logging.getLogger(__name__)
 
@@ -41,9 +41,9 @@ class PlateGrid(object):
             grid = [[None] * size['columns'] for _ in range(size['rows'])]
 
             q = self._conn.getQueryService()
-            params = omero.sys.Parameters()
-            params.map = {'pid': rlong(self.plate.id),
-                          'wsidx': rint(self.field)}
+            params = omero.sys.ParametersI()
+            params.addId(self.plate.id)
+            params.add('wsidx', rint(self.field))
             query = "select well.row, well.column, img.id, img.name, "\
                     "author.firstName||' '||author.lastName, "\
                     "well.id, img.acquisitionDate "\

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -44,20 +44,15 @@ class PlateGrid(object):
             params = omero.sys.Parameters()
             params.map = {'pid': rlong(self.plate.id),
                           'wsidx': rint(self.field)}
-            query = ' '.join([
-                    "select well.row, well.column,",  # Grid index
-                    "img.id,",                        # 'id'
-                    "img.name,",                      # 'name'
-                    "img.details.owner.firstName||' '",
-                    "||img.details.owner.lastName,",  # 'author'
-                    "well.id,",                       # 'wellId'
-                    "img.acquisitionDate",            # 'date'
-                    "from Well well",
-                    "join well.wellSamples ws",
-                    "join ws.image img",
-                    "where well.plate.id = :pid",     # plate ID
-                    "and index(ws) = :wsidx"          # field
-                ])
+            query = "select well.row, well.column, img.id, img.name, "\
+                    "author.firstName||' '||author.lastName, "\
+                    "well.id, img.acquisitionDate "\
+                    "from Well well "\
+                    "join well.wellSamples ws "\
+                    "join ws.image img "\
+                    "join img.details.owner author "\
+                    "where well.plate.id = :id "\
+                    "and index(ws) = :wsidx"
 
             wellGrid = q.projection(query, params, self._conn.SERVICE_OPTS)
             for w in wellGrid:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -46,7 +46,8 @@ class PlateGrid(object):
             query = "select well.row, well.column, img.id, img.name, "\
                     "author.firstName||' '||author.lastName, "\
                     "well.id, img.acquisitionDate, "\
-                    "img.details.creationEvent.time "\
+                    "img.details.creationEvent.time, "\
+                    "img.description "\
                     "from Well well "\
                     "join well.wellSamples ws "\
                     "join ws.image img "\
@@ -56,16 +57,18 @@ class PlateGrid(object):
 
             for res in q.projection(query, params, self._conn.SERVICE_OPTS):
                 row, col, img_id, img_name, author, well_id, acq_date, \
-                    create_date = res
+                    create_date, description = res
 
                 if acq_date.val is not None and acq_date.val > 0:
                     date = acq_date.val / 1000
                 else:
                     date = create_date.val / 1000
+                description = (description and description.val) or ''
 
                 wellmeta = {'type': 'Image',
                             'id': img_id.val,
                             'name': img_name.val,
+                            'description': description,
                             'author': author.val,
                             'date': date,
                             'wellId': well_id.val,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -11,7 +11,6 @@
 """
 
 import logging
-import time
 
 import omero.sys
 from omero.rtypes import rint

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -38,7 +38,7 @@ class PlateGrid(object):
         if self._metadata is None:
             self.plate.setGridSizeConstraints(8, 12)
             size = self.plate.getGridSize()
-            grid = [[None] * size['columns']] * size['rows']
+            grid = [[None] * size['columns'] for _ in range(size['rows'])]
 
             q = self._conn.getQueryService()
             params = omero.sys.Parameters()

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 Glencoe Software, Inc.
+# All rights reserved.
+#
+# Use is subject to license terms supplied in LICENSE.txt
+
+"""
+   Module to encapsulate operations concerned with displaying the contents of a
+   plate as a grid.
+"""
+
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class PlateGrid(object):
+    """
+    A PlateGrid object encapsulates a PlateI reference and provides a number of
+    methods useful for displaying the contents of the plate as a grid.
+    """
+
+    def __init__(self, conn, pid, fid, xtra):
+        t0 = datetime.now()
+        self.plate = conn.getObject('plate', long(pid))
+        t1 = datetime.now()
+        logger.debug('time to get plate: %s' % (t1 - t0))
+        self.field = fid
+        self.xtra = xtra
+        self._metadata = None
+
+    @property
+    def metadata(self):
+        if self._metadata is None:
+            t0 = datetime.now()
+            self.plate.setGridSizeConstraints(8, 12)
+            t1 = datetime.now()
+            logger.debug('time to set grid constraints: %s' % (t1 - t0))
+            t0 = t1
+
+            grid = []
+            wellGrid = self.plate.getWellGrid(self.field)
+            t1 = datetime.now()
+            logger.debug('time to get well grid: %s' % (t1 - t0))
+            t0 = t1
+            for row in wellGrid:
+                tr = []
+                for e in row:
+                    if e:
+                        i = e.getImage()
+                        t2 = datetime.now()
+                        logger.warn('time to get image: %s' % (t2 - t1))
+                        t1 = t2
+                        if i:
+                            t = i.simpleMarshal(xtra=self.xtra)
+                            t['wellId'] = e.getId()
+                            t['field'] = self.field
+                            tr.append(t)
+                            t2 = datetime.now()
+                            logger.debug(
+                                'time to marshal image: %s' % (t2 - t1))
+                            t1 = t2
+                            continue
+                    tr.append(None)
+                grid.append(tr)
+            t1 = datetime.now()
+            logger.debug('time to get wells in grid: %s' % (t1 - t0))
+            self._metadata = {'grid': grid,
+                              'collabels': self.plate.getColumnLabels(),
+                              'rowlabels': self.plate.getRowLabels()}
+        return self._metadata

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -27,10 +27,7 @@ class PlateGrid(object):
     """
 
     def __init__(self, conn, pid, fid, thumbprefix=''):
-        t0 = dt.now()
         self.plate = conn.getObject('plate', long(pid))
-        t1 = dt.now()
-        logger.debug('time to get plate: %s' % (t1 - t0))
         self._conn = conn
         self.field = fid
         self._thumbprefix = thumbprefix
@@ -39,12 +36,7 @@ class PlateGrid(object):
     @property
     def metadata(self):
         if self._metadata is None:
-            t0 = dt.now()
             self.plate.setGridSizeConstraints(8, 12)
-            t1 = dt.now()
-            logger.debug('time to set grid constraints: %s' % (t1 - t0))
-            t0 = t1
-
             size = self.plate.getGridSize()
             grid = [[None] * size['columns']] * size['rows']
 
@@ -68,11 +60,6 @@ class PlateGrid(object):
                 ])
 
             wellGrid = q.projection(query, params, self._conn.SERVICE_OPTS)
-            t1 = dt.now()
-            logger.debug('time to get well grid: %s' % (t1 - t0))
-            t0 = t1
-            maxplanesize = self._conn.getMaxPlaneSize()
-            tiledsize = maxplanesize[0] * maxplanesize[1]
             for w in wellGrid:
                 gridRow = w[0].val
                 gridCol = w[1].val
@@ -91,8 +78,7 @@ class PlateGrid(object):
                     wellmeta['thumb_url'] = self._thumbprefix + str(w[2].val)
 
                 grid[gridRow][gridCol] = wellmeta
-            t1 = dt.now()
-            logger.debug('time to get wells in grid: %s' % (t1 - t0))
+
             self._metadata = {'grid': grid,
                               'collabels': self.plate.getColumnLabels(),
                               'rowlabels': self.plate.getRowLabels()}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -29,7 +29,7 @@ from django.template import RequestContext as Context
 from django.core.servers.basehttp import FileWrapper
 from omero.rtypes import rlong, unwrap
 from omero.constants.namespaces import NSBULKANNOTATIONS
-from omeroweb.webgateway.plategrid import PlateGrid
+from plategrid import PlateGrid
 from omero_version import build_year
 from marshal import imageMarshal, shapeMarshal
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1341,9 +1341,8 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
 
     def urlprefix(iid):
         return reverse(prefix, args=(iid, thumbsize))
-    xtra = {'thumbUrlPrefix': kwargs.get('urlprefix', urlprefix)}
-
-    plateGrid = PlateGrid(conn, pid, field, xtra)
+    plateGrid = PlateGrid(conn, pid, field,
+                          kwargs.get('urlprefix', urlprefix))
     plate = plateGrid.plate
     if plate is None:
         return Http404

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -15,7 +15,6 @@
 
 import re
 import json
-from datetime import datetime
 import omero
 import omero.clients
 

--- a/components/tools/OmeroWeb/test/integration/test_plate_grid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plate_grid.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 Glencoe Software, Inc.
+# All rights reserved.
+#
+# Use is subject to license terms supplied in LICENSE.txt
+
+"""
+   Integration tests for the "plategrid" module.
+"""
+
+import pytest
+import test.integration.library as lib
+
+from omero.model import PlateI, WellI, WellSampleI
+from omero.rtypes import rint, rstring
+from omero.gateway import BlitzGateway
+
+from django.test import Client
+from django.core.urlresolvers import reverse
+import json
+
+
+@pytest.fixture(scope='function')
+def itest(request):
+    """
+    Returns a new L{test.integration.library.ITest} instance. With attached
+    finalizer so that pytest will clean it up.
+    """
+    o = lib.ITest()
+    o.setup_method(None)
+
+    def finalizer():
+        o.teardown_method(None)
+    request.addfinalizer(finalizer)
+    return o
+
+
+@pytest.fixture(scope='function')
+def client(request, itest):
+    """Returns a new user client."""
+    return itest.new_client()
+
+
+@pytest.fixture(scope='function')
+def conn(request, client):
+    """Returns a new OMERO gateway."""
+    return BlitzGateway(client_obj=client)
+
+
+@pytest.fixture(scope='function')
+def update_service(request, client):
+    """Returns a new OMERO update service."""
+    return client.getSession().getUpdateService()
+
+
+@pytest.fixture(scope='function')
+def plate_wells(request, itest, update_service):
+    """
+    Returns a new OMERO Plate, linked Wells, linked WellSamples, and linked
+    Images populated by an L{test.integration.library.ITest} instance.
+    """
+    plate = PlateI()
+    plate.name = rstring(itest.uuid())
+    # Well A10 (will have two WellSamples)
+    well_a = WellI()
+    well_a.row = rint(0)
+    well_a.column = rint(9)
+    # Well A11 (will not have a WellSample)
+    well_b = WellI()
+    well_b.row = rint(0)
+    well_b.column = rint(10)
+    # Well D3 (will have one WellSample)
+    well_c = WellI()
+    well_c.row = rint(3)
+    well_c.column = rint(2)
+    ws_a = WellSampleI()
+    image_a = itest.new_image(name=itest.uuid())
+    ws_a.image = image_a
+    ws_b = WellSampleI()
+    image_b = itest.new_image(name=itest.uuid())
+    ws_b.image = image_b
+    ws_c = WellSampleI()
+    image_c = itest.new_image(name=itest.uuid())
+    ws_c.image = image_c
+    well_a.addWellSample(ws_a)
+    well_a.addWellSample(ws_b)
+    well_c.addWellSample(ws_c)
+    plate.addWell(well_a)
+    plate.addWell(well_b)
+    plate.addWell(well_c)
+    return update_service.saveAndReturnObject(plate)
+
+
+@pytest.fixture(scope='function')
+def django_client(request, client):
+    """Returns a logged in Django test client."""
+    django_client = Client()
+    login_url = reverse('weblogin')
+
+    response = django_client.get(login_url)
+    assert response.status_code == 200
+
+    data = {
+        'server': 1,
+        'username': client.getProperty('omero.user'),
+        'password': client.getProperty('omero.pass'),
+    }
+    response = django_client.post(login_url, data)
+    assert response.status_code == 302
+
+    def finalizer():
+        logout_url = reverse('weblogout')
+        response = django_client.post(logout_url, data=data)
+        assert response.status_code == 302
+    request.addfinalizer(finalizer)
+    return django_client
+
+
+class TestPlateGrid(object):
+    """
+    Tests to ensure that the OMERO.web "plategrid" functionality works as
+    expected.
+    """
+
+    def test_get_plate_grid_metadata(self, django_client, plate_wells, conn):
+        """
+        Do a simple GET request to retrieve the metadata for a plate in JSON
+        form
+        """
+        for field in range(2):
+            request_url = reverse('webgateway_plategrid_json',
+                                  args=(plate_wells.id.val, field))
+
+            response = django_client.get(request_url)
+            assert response.status_code == 200
+
+            plate_metadata = json.loads(response.content)
+            assert len(plate_metadata['rowlabels']) == 8
+            assert len(plate_metadata['collabels']) == 12
+
+            grid = plate_metadata['grid']
+            for well in plate_wells.copyWells():
+                well_metadata = grid[well.row.val][well.column.val]
+                well_samples = well.copyWellSamples()
+                if len(well_samples) > field:
+                    assert well_metadata['name'] ==\
+                        well_samples[field].getImage().name.val

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -23,7 +23,7 @@ import json
 import time
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def itest(request):
     """
     Returns a new L{weblibrary.IWebTest} instance. With attached
@@ -38,30 +38,30 @@ def itest(request):
     PlateGridIWebTest.setup_class()
 
     def finalizer():
-        IWebTest.teardown_class()
+        PlateGridIWebTest.teardown_class()
     request.addfinalizer(finalizer)
-    return IWebTest()
+    return PlateGridIWebTest()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def client(itest):
     """Returns a new user client."""
     return itest.new_client()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def conn(client):
     """Returns a new OMERO gateway."""
     return BlitzGateway(client_obj=client)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def update_service(client):
     """Returns a new OMERO update service."""
     return client.getSession().getUpdateService()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def well_sample_factory(itest):
 
     def make_well_sample():
@@ -72,7 +72,7 @@ def well_sample_factory(itest):
     return make_well_sample
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def well_factory(well_sample_factory):
 
     def make_well(ws_count=0):
@@ -83,7 +83,7 @@ def well_factory(well_sample_factory):
     return make_well
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def well_grid_factory(well_factory):
 
     def make_well_grid(grid_layout={}):
@@ -98,7 +98,7 @@ def well_grid_factory(well_factory):
     return make_well_grid
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def plate_wells(itest, well_grid_factory, update_service):
     """
     Returns a new OMERO Plate, linked Wells, linked WellSamples, and linked
@@ -115,7 +115,7 @@ def plate_wells(itest, well_grid_factory, update_service):
     return update_service.saveAndReturnObject(plate)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def full_plate_wells(itest, update_service):
     """
     Returns a full OMERO Plate, linked Wells, linked WellSamples, and linked
@@ -137,7 +137,7 @@ def full_plate_wells(itest, update_service):
     return update_service.saveAndReturnObject(plate)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def plate_wells_with_acq_date(itest, well_grid_factory, update_service):
     """
     Creates a plate with a single well containing an image with both an
@@ -156,7 +156,7 @@ def plate_wells_with_acq_date(itest, well_grid_factory, update_service):
             'acq_date': int(acq_date / 1000)}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def plate_wells_with_no_acq_date(itest, well_grid_factory, update_service,
                                  conn):
     """
@@ -176,7 +176,7 @@ def plate_wells_with_no_acq_date(itest, well_grid_factory, update_service,
             'creation_date': creation_date.val / 1000}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def plate_wells_with_description(itest, well_grid_factory, update_service):
     """
     Creates a plate with a single well containing an image with a description.
@@ -194,7 +194,7 @@ def plate_wells_with_description(itest, well_grid_factory, update_service):
             'description': description}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def django_client(request, client):
     """Returns a logged in Django test client."""
     django_client = Client()

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -162,6 +162,7 @@ def plate_wells_with_no_acq_date(itest, well_grid_factory, update_service,
     # Simple grid: one well with one image
     [well] = well_grid_factory({(0, 0): 1})
     plate.addWell(well)
+    well.copyWellSamples()[0].image.acquisitionDate = None
     well = update_service.saveAndReturnObject(well)
     creation_date = well.copyWellSamples()[0].image.details.creationEvent.time
     plate = update_service.saveAndReturnObject(plate)

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -10,7 +10,7 @@
 """
 
 import pytest
-import test.integration.library as lib
+from weblibrary import IWebTest
 
 from omero.model import PlateI, WellI, WellSampleI
 from omero.rtypes import rint, rstring, rtime
@@ -26,16 +26,15 @@ import time
 @pytest.fixture(scope='function')
 def itest(request):
     """
-    Returns a new L{test.integration.library.ITest} instance. With attached
+    Returns a new L{weblibrary.IWebTest} instance. With attached
     finalizer so that pytest will clean it up.
     """
-    o = lib.ITest()
-    o.setup_method(None)
+    IWebTest.setup_class()
 
     def finalizer():
-        o.teardown_method(None)
+        IWebTest.teardown_class()
     request.addfinalizer(finalizer)
-    return o
+    return IWebTest()
 
 
 @pytest.fixture(scope='function')
@@ -97,7 +96,7 @@ def well_grid_factory(well_factory):
 def plate_wells(itest, well_grid_factory, update_service):
     """
     Returns a new OMERO Plate, linked Wells, linked WellSamples, and linked
-    Images populated by an L{test.integration.library.ITest} instance.
+    Images populated by an L{weblibrary.IWebTest} instance.
     """
     plate = PlateI()
     plate.name = rstring(itest.uuid())
@@ -114,7 +113,7 @@ def plate_wells(itest, well_grid_factory, update_service):
 def full_plate_wells(itest, update_service):
     """
     Returns a full OMERO Plate, linked Wells, linked WellSamples, and linked
-    Images populated by an L{test.integration.library.ITest} instance.
+    Images populated by an L{weblibrary.IWebTest} instance.
     """
     lett = map(chr, range(ord('A'), ord('Z')+1))
     plate = PlateI()

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -152,18 +152,16 @@ class TestPlateGrid(object):
         """
         Check that the helper object can be created
         """
-        xtra = {'key': 'value'}
-        plateGrid = PlateGrid(conn, plate_wells.id.val, 0, xtra)
+        plateGrid = PlateGrid(conn, plate_wells.id.val, 0)
         assert plateGrid
         assert plateGrid.plate.id == plate_wells.id.val
         assert plateGrid.field == 0
-        assert plateGrid.xtra == xtra
 
     def test_metadata_grid_size(self, plate_wells, conn):
         """
         Check that the grid represented in the metadata is the correct size
         """
-        plateGrid = PlateGrid(conn, plate_wells.id.val, 0, {})
+        plateGrid = PlateGrid(conn, plate_wells.id.val, 0)
         assert len(plateGrid.metadata['grid']) == 8
         assert len(plateGrid.metadata['grid'][0]) == 12
 
@@ -172,8 +170,7 @@ class TestPlateGrid(object):
         Check that extra elements of the thumbnail URL passed in the `xtra`
         dictionary are properly prepended
         """
-        xtra = {'thumbUrlPrefix': 'foo/bar/'}
-        plateGrid = PlateGrid(conn, plate_wells.id.val, 0, xtra)
+        plateGrid = PlateGrid(conn, plate_wells.id.val, 0, 'foo/bar/')
         metadata = plateGrid.metadata
         for well in plate_wells.copyWells():
             well_metadata = metadata['grid'][well.row.val][well.column.val]

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -29,7 +29,13 @@ def itest(request):
     Returns a new L{weblibrary.IWebTest} instance. With attached
     finalizer so that pytest will clean it up.
     """
-    IWebTest.setup_class()
+    class PlateGridIWebTest(IWebTest):
+        """
+        This class emulates py.test scoping semantics when the xunit style
+        is in use.
+        """
+        pass
+    PlateGridIWebTest.setup_class()
 
     def finalizer():
         IWebTest.teardown_class()


### PR DESCRIPTION
## Summary

This change improves the performance of the `plateGrid_json` method called when displaying a plate in three main ways:

* getting the grid size
* retrieving wells in the plate
* generating the metadata for the plate grid

Various tests have been added to cover the expected behaviour and were used throughout development to attempt to ensure that no API deviation has taken place.

## Benchmarks

Based on some rough benchmarks, these changes represent an order of magnitude improvement in the overall request time. Bringing the overall request time down below the high watermark of 1 second for all OMERO.web calls.

The dataset used is the same as that outlined in #3695/#3753: 4608 Images (384 Wells, 12 Fields).

Before:

time to set grid constraints: 0:00:01.567579
time to get well grid: 0:00:00.012914
time to get wells in grid: 0:00:02.308659

After:

time to set grid constraints: 0:00:00.005936
time to get well grid: 0:00:00.086065
time to get wells in grid: 0:00:00.093965

## Details

### Grid Size
Previously, the grid size was calculated by first retrieving (via the query service) all wells in a plate, then iterating through the results to find the maximum row and column values. This change now uses HQL to find the maximum directly in the query. For the overall request, this represents a modest speed boost as all wells need to be retrieved eventually anyway, but combined with the other changes here the total number of Python objects created should still be reduced significantly.

### Retrieving Wells
With this change, instead of creating Python wrapper objects for every well in a plate, then using the wrapper to retrieve the necessary metadata, we now request the needed fields directly via HQL.

### Generating Grid Metadata
Combined with the change in how wells are retrieved, we now also avoid having to iterate every potential well in a plate. Instead, we iterate only the list of existing wells, and use the results of the Hibernate query to populate the relevant row/column in the 2D results array.

/cc @jballanc, @will-moore, @aleksandra-tarkowska, @knabar 