### PR TITLE
Apache stanza fcgi

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi-withoptions.conf
@@ -54,11 +54,6 @@
 
 RewriteEngine on
 
-<Directory "/home/omero/OMERO.server/var">
-    Options -Indexes +FollowSymLinks
-    Require all granted
-</Directory>
-
 <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes +FollowSymLinks
     Require all granted

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-fcgi.conf
@@ -54,11 +54,6 @@
 
 RewriteEngine on
 
-<Directory "/home/omero/OMERO.server/var">
-    Options -Indexes +FollowSymLinks
-    Require all granted
-</Directory>
-
 <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes +FollowSymLinks
     Require all granted

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
@@ -54,13 +54,7 @@
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:12345 -idle-timeout 60
-
-<Directory "/home/omero/OMERO.server/var">
-    Options -Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
-</Directory>
+FastCGIExternalServer "/var/run/omero.fcgi" -host 0.0.0.0:12345 -idle-timeout 60
 
 <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes FollowSymLinks
@@ -80,6 +74,6 @@ FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 0.0.0.0:12
 
 Alias /test/error /home/omero/OMERO.server/etc/templates/error
 Alias /test-static /home/omero/OMERO.server/lib/python/omeroweb/static
-Alias /test "/home/omero/OMERO.server/var/omero.fcgi/"
+Alias /test "/var/run/omero.fcgi/"
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
@@ -54,13 +54,7 @@
 ### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
 ###
 
-FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 127.0.0.1:4080 -idle-timeout 60
-
-<Directory "/home/omero/OMERO.server/var">
-    Options -Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
-</Directory>
+FastCGIExternalServer "/var/run/omero.fcgi" -host 127.0.0.1:4080 -idle-timeout 60
 
 <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
     Options -Indexes FollowSymLinks
@@ -80,6 +74,6 @@ FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 127.0.0.1:
 
 Alias /error /home/omero/OMERO.server/etc/templates/error
 Alias /static /home/omero/OMERO.server/lib/python/omeroweb/static
-Alias / "/home/omero/OMERO.server/var/omero.fcgi/"
+Alias / "/var/run/omero.fcgi/"
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_cli.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_cli.py
@@ -9,16 +9,10 @@
 
 """
 
-import os
 import pytest
 
-from path import path
-from omero.cli import CLI
-from omero.cli import NonZeroReturnCode
+from omero.cli import CLI, NonZeroReturnCode
 from omero.plugins.basics import LoadControl
-from omero.util.temp_files import create_path
-
-omeroDir = path(os.getcwd()) / "build"
 
 
 class TestCli(object):
@@ -56,14 +50,14 @@ class TestCli(object):
         assert len(threads) == len(set([t.con for t in threads]))
         assert len(threads) == len(set([t.cmp for t in threads]))
 
-    def testLoad(self):
-        tmp = create_path()
-        tmp.write_text("foo")
+    def testLoad(self, tmpdir):
+        tmpfile = tmpdir.join('test')
+        tmpfile.write("foo")
         self.cli = CLI()
         self.cli.register("load", LoadControl, "help")
 
         with pytest.raises(NonZeroReturnCode):
-            self.cli.invoke("load %s" % tmp, strict=True)
+            self.cli.invoke("load %s" % tmpfile, strict=True)
 
-        self.cli.invoke("load -k %s" % tmp, strict=True)
-        self.cli.invoke("load --keep-going %s" % tmp, strict=True)
+        self.cli.invoke("load -k %s" % tmpfile, strict=True)
+        self.cli.invoke("load --keep-going %s" % tmpfile, strict=True)

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -174,22 +174,20 @@ class TestWeb(object):
 
         if prefix:
             missing = self.required_lines_in([
-                ('FastCGIExternalServer ',
-                 '/var/run/omero.fcgi" -host %s -idle-timeout 60'
-                 % expected_cgi),
+                ('FastCGIExternalServer "/var/run/omero.fcgi" -host %s'
+                 ' -idle-timeout 60' % expected_cgi),
                 ('Alias %s/error ' % prefix, 'etc/templates/error'),
                 ('Alias %s ' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
-                ('Alias %s "' % prefix, '/var/run/omero.fcgi/"'),
+                ('Alias %s "/var/run/omero.fcgi/"' % prefix),
                 ], lines)
         else:
             missing = self.required_lines_in([
-                ('FastCGIExternalServer ',
-                 '/var/run/omero.fcgi" -host %s -idle-timeout 60'
-                 % expected_cgi),
+                ('FastCGIExternalServer "/var/run/omero.fcgi" -host %s'
+                 ' -idle-timeout 60' % expected_cgi),
                 ('Alias /error ', 'etc/templates/error'),
                 ('Alias /static ', 'lib/python/omeroweb/static'),
-                ('Alias / "', '/var/run/omero.fcgi/"'),
+                ('Alias / "/var/run/omero.fcgi/"'),
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -175,19 +175,19 @@ class TestWeb(object):
         if prefix:
             missing = self.required_lines_in([
                 ('FastCGIExternalServer ',
-                 'var/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
+                 '/var/run/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
                 ('Alias %s/error ' % prefix, 'etc/templates/error'),
                 ('Alias %s ' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
-                ('Alias %s "' % prefix, 'var/omero.fcgi/"'),
+                ('Alias %s "' % prefix, '/var/run/omero.fcgi/"'),
                 ], lines)
         else:
             missing = self.required_lines_in([
                 ('FastCGIExternalServer ',
-                 'var/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
+                 '/var/run/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
                 ('Alias /error ', 'etc/templates/error'),
                 ('Alias /static ', 'lib/python/omeroweb/static'),
-                ('Alias / "', 'var/omero.fcgi/"'),
+                ('Alias / "', '/var/run/omero.fcgi/"'),
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -175,7 +175,8 @@ class TestWeb(object):
         if prefix:
             missing = self.required_lines_in([
                 ('FastCGIExternalServer ',
-                 '/var/run/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
+                 '/var/run/omero.fcgi" -host %s -idle-timeout 60'
+                 % expected_cgi),
                 ('Alias %s/error ' % prefix, 'etc/templates/error'),
                 ('Alias %s ' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
@@ -184,7 +185,8 @@ class TestWeb(object):
         else:
             missing = self.required_lines_in([
                 ('FastCGIExternalServer ',
-                 '/var/run/omero.fcgi" -host %s -idle-timeout 60' % expected_cgi),
+                 '/var/run/omero.fcgi" -host %s -idle-timeout 60'
+                 % expected_cgi),
                 ('Alias /error ', 'etc/templates/error'),
                 ('Alias /static ', 'lib/python/omeroweb/static'),
                 ('Alias / "', '/var/run/omero.fcgi/"'),

--- a/etc/templates/apache-fcgi.conf.template
+++ b/etc/templates/apache-fcgi.conf.template
@@ -54,11 +54,6 @@
 
 RewriteEngine on
 
-<Directory "%(ROOT)s/var">
-    Options -Indexes +FollowSymLinks
-    Require all granted
-</Directory>
-
 <Directory "%(OMEROWEBROOT)s/static">
     Options -Indexes +FollowSymLinks
     Require all granted

--- a/etc/templates/apache.conf.template
+++ b/etc/templates/apache.conf.template
@@ -54,13 +54,7 @@
 ### Stanza for OMERO.web created %(NOW)s
 ###
 
-FastCGIExternalServer "%(ROOT)s/var/omero.fcgi" -host %(FASTCGI_EXTERNAL)s -idle-timeout 60
-
-<Directory "%(ROOT)s/var">
-    Options -Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
-</Directory>
+FastCGIExternalServer "/var/run/omero.fcgi" -host %(FASTCGI_EXTERNAL)s -idle-timeout 60
 
 <Directory "%(OMEROWEBROOT)s/static">
     Options -Indexes FollowSymLinks
@@ -80,4 +74,4 @@ FastCGIExternalServer "%(ROOT)s/var/omero.fcgi" -host %(FASTCGI_EXTERNAL)s -idle
 
 Alias %(WEB_PREFIX)s/error %(ROOT)s/etc/templates/error
 Alias %(STATIC_URL)s %(OMEROWEBROOT)s/static
-Alias %(FORCE_SCRIPT_NAME)s "%(ROOT)s/var/omero.fcgi/"
+Alias %(FORCE_SCRIPT_NAME)s "/var/run/omero.fcgi/"


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/3769#issuecomment-97706639

This PR users `/var/run/omero.fcgi` as the default filename for the `FastCGIExternalServer` directive in the Apache stanza. This change is expected to reduce the number of  `Permission Denied` issues encountered when upgrading a server and starting OMERO.web in production as highlighted byhttps://github.com/openmicroscopy/ome-documentation/pull/1203. Since `/var/run` exists on all UNIX-like platforms and should be readable/executable by the Apache agents, this filename was chosen as the lowest common denominator for all platforms. 

This PR should be tested both under Apache 2.2 and 2.4 by downloading the server, generating the Apache stanza via `bin/omero web config` and starting OMERO.server and OMERO.web. With this PR included, the expectation is that the Web client will be able to start without any need to modify permissions/ownerships under the server directory.