### PR TITLE
Webadmin 'Read-Write' perms

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -201,6 +201,7 @@ PERMISSION_CHOICES = (
     ('0', 'Private'),
     ('1', 'Read-Only'),
     ('2', 'Read-Annotate'),
+    ('3', 'Read-Write'),
 )
 
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -85,6 +85,11 @@
                     OME.confirm_dialog("Changing group to Private may fail if links have been created under Read-Annotate permissions",
                         null, "WARNING", ['OK'], null, 180);
                 });
+                $('#id_permissions_3').click(function(){
+                    OME.confirm_dialog("Read-Write groups allow members to delete other members' data. " +
+                        "Follow the 'OMERO permissions' link below for full details.",
+                        null, "WARNING", ['OK'], null, 180);
+                });
 
         })
     </script>

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -71,6 +71,12 @@
                         null, "WARNING", ['OK'], null, 180);
                 });
 
+                // Disable the "Read-Write" permissions option for group owners.
+                $('#id_permissions_3').prop('disabled', 'disabled');
+                $('label[for="id_permissions_3"]')
+                    .css('opacity',0.5)
+                    .prop('title', 'Group owners cannot upgrade to Read-Write permissions. Please contact your sysadmin.');
+
         })
     </script>
 {% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
@@ -124,6 +124,8 @@
 
     <p>{% trans "<strong>Read-Annotate (rwra--)</strong>: Users in a Read-Annotate group can view and annotate the data belonging to other users. You can tag another user's images or use their tags to annotate your own images. You can add comments to their images and save your own rendering settings for each image. However, you cannot edit the names of their images, projects, datasets or tags etc." %}</p>
 
+    <p>{% trans "<strong>Read-Write (rwrw--)</strong>: Users in a Read-Write group have permission to edit and delete the data belonging to other users." %}</p>
+
 <div>
         
 {% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -158,6 +158,8 @@ def setActualPermissions(permissions):
         p = PermissionsI("rwr---")
     elif permissions == 2:
         p = PermissionsI("rwra--")
+    elif permissions == 3:
+        p = PermissionsI("rwrw--")
     else:
         p = PermissionsI()
     return p
@@ -171,7 +173,9 @@ def getActualPermissions(group):
         p = group.details.getPermissions()
 
     flag = None
-    if p.isGroupAnnotate():
+    if p.isGroupWrite():
+        flag = 3
+    elif p.isGroupAnnotate():
         flag = 2
     elif p.isGroupRead():
         flag = 1


### PR DESCRIPTION
This allows Admins to create 'Read-Write' groups in webadmin. See https://trac.openmicroscopy.org/ome/ticket/10751

To test:
 - Log in as Admin, go to webadmin, create a Group...
 - See that there is now a 4th "Read-Write" option for group perms.
 - Create a group with these perms.
 - Test new group behaves / appears as expected in web (or insight)
 - Edit the new group (check that perms are "Read-Write" before editing)
 - Edit permissions and check updated OK.