### PR TITLE
Delete Plate Run

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -106,9 +106,12 @@
                                   $.jstree.rollback(data.rlbk);
                                   alert(r.errs);
                               } else {
-                                  OME.tree_selection_changed();   // clear center and right panels etc
+                                  OME.clear_selected(true);   // clear center and right panels etc
                                   datatree.delete_node(selected);
-                                  first_parent.children("a").click();
+                                  if (type_str.indexOf('Plate Run') === -1) {
+                                    // If not 'Run', then select parent. See ticket #12860
+                                    first_parent.children("a").click();
+                                  }
                                   OME.refreshActivities();
                               }
                         },

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -78,6 +78,8 @@
             });
             var type_strings = [];
             for (var key in dtypes) {
+                key = key.replace("-locked", "");
+                if (key === "acquisition") key = "Plate Run";
                 type_strings.push(key.capitalize() + (dtypes[key]>1 && "s" || ""));
             }
             var type_str = type_strings.join(" & ");    // For delete dialog: E.g. 'Project & Datasets'

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2438,6 +2438,8 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
             for key, ids in object_ids.iteritems():
                 if ids is not None and len(ids) > 0:
                     handle = manager.deleteObjects(key, ids, child, anns)
+                    if key == "PlateAcquisition":
+                        key = "Plate Run"      # for nicer user message
                     dMap = {
                         'job_type': 'delete',
                         'start_time': datetime.datetime.now(),


### PR DESCRIPTION
See http://trac.openmicroscopy.org.uk/ome/ticket/12860

This is a small fix to the delete dialog message, to use 'Plate Run' instead of 'Acquisition' and remove '-locked' from the message (if you were not the owner). Also fixes refresh of Plate during Run deletion:

To test:
 - Login as Admin and try to delete data belonging to another user.
 - Project etc should simply be "Project" in the delete confirm dialog (not 'Project-locked').
 - Acquisition should be "Plate Run" (see first screenshot).
 - On delete, centre panel should be cleared and nothing should be selected in tree (fixes bug shown in second screenshot).

![screen shot 2015-05-01 at 14 25 07](https://cloud.githubusercontent.com/assets/900055/7430753/226906e2-f00f-11e4-94f6-8f100c83cce6.png)

Before this PR, centre panel reloaded Plate while Run was deleting.
![screen shot 2015-05-01 at 14 25 28](https://cloud.githubusercontent.com/assets/900055/7430767/3fb361fc-f00f-11e4-9b8c-bea15e6cd8f1.png)

NB: Empty plate is not well handled in Web:
![screen shot 2015-05-01 at 14 25 59](https://cloud.githubusercontent.com/assets/900055/7430776/60f6cf8e-f00f-11e4-9f62-5b2ead2a1511.png)

And worse in Insight:
![screen shot 2015-05-01 at 14 03 03](https://cloud.githubusercontent.com/assets/900055/7430792/814ad51e-f00f-11e4-86fd-ca9a27061c5b.png)