### PR TITLE
Download single files

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -58,6 +58,20 @@ Download files
 <h1 class="downloading">Please <a href="#" onClick="window.close()">close this window</a> once the download is complete.</h1>
 </div>
 
+{% if fileLists %}
+<table>
+    {% for fs in fileLists %}
+    <tbody>
+        {% for f in fs %}
+        <tr>
+            <td><a href="{% url 'get_original_file' f.id %}">{{ f.name }}</a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    {% endfor %}
+</table>
+{% endif %}
+
 <script>
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -53,7 +53,7 @@ Download files
             padding: 5px;
         }
         td:hover {
-            background-color: #ccccff;
+            background-color: hsl(215,20%,75%);
         }
         td .download {
             visibility: hidden;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -85,8 +85,9 @@ Download files
     <p>You have 2 options:</p>
     {% endif %}
 
+    <div style="clear:both"></div>
     <hr>
-    <p>Create a zip file which will contain these files:</p>
+    <p>Create and download a zip file which will contain these files:</p>
 
     <div style="padding: 15px; float: right">
         <input type="submit" value="Create Zip"/>
@@ -127,7 +128,7 @@ Download files
 
 </form>
 
-<h1 class="downloading">Download will be available in a moment...</h1>
+<h1 class="downloading">Preparing zip for download...</h1>
 <h1 class="downloading">Please <a href="#" onClick="window.close()">close this window</a> once the download is complete.</h1>
 </div>
     

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -70,7 +70,11 @@ Download files
 {% block body %}
 
 <div class="center">
-<h1 style="font-size: 24px;">Download Files</h1>
+<h1 style="font-size: 24px;">
+    {% if fileLists %} Download Original Files
+    {% else %} Download Files
+    {% endif %}
+</h1>
 
 <form id="downloadForm">
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -115,6 +115,7 @@ Download files
                 <a href="{% url 'get_original_file' f.id %}">
                     <div>
                         {{ f.name }}
+                        <span style="margin-left:20px; text-decoration:none"> {{ f.size|filesizeformat }}</span>
                         <span class="download">Download</span>
                     </div>
                 </a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -19,20 +19,49 @@ Download files
             margin-right: auto;
             margin-left: auto;
             position: relative;
-            top: 100px;
-            width: 350px;
+            top: 50px;
+            width: 550px;
             background-color: #fafafa;
-            text-align: center;
+            /*text-align: center;*/
             padding: 15px;
         }
         h1 {
-            text-align: center;
+            /*text-align: center;*/
+        }
+        p {
+            font-size: 14px;
         }
         a {
             text-decoration: underline;
         }
         .downloading {
             display: none;
+        }
+        table {
+            width: 90%;
+            margin-left: 20px
+        }
+        tbody:hover tr {
+            background-color: #ededff;
+        }
+        td {
+            padding: 0;
+            font-size: 12px;
+        }
+        td div {
+            width:100%;
+            padding: 5px;
+        }
+        td:hover {
+            background-color: #ccccff;
+        }
+        td .download {
+            visibility: hidden;
+            float:right;
+            margin-right: 20px;
+        }
+        td:hover .download {
+            visibility: visible;
         }
     </style>
 {% endblock %}
@@ -41,36 +70,67 @@ Download files
 {% block body %}
 
 <div class="center">
-<h1 style="font-size: 20px;">Download Files</h1>
+<h1 style="font-size: 24px;">Download Files</h1>
 
 <form id="downloadForm">
-    <h1>Please choose a name for the downloaded zip file:</h1>
-    <span>Zip file name: </span>
-    <input id="zipName" value="{{ defaultName }}.zip"/><br/>
 
-    <div style="padding: 15px">
+    <div style="padding: 15px; float: right">
         <button id="reset" type="reset" value="Reset">Cancel</button>
-        <input type="submit" value="OK"/>
     </div>
-</form>
 
-<h1 class="downloading">Download will be available in a moment...</h1>
-<h1 class="downloading">Please <a href="#" onClick="window.close()">close this window</a> once the download is complete.</h1>
-</div>
+    <h2>You have chosen to download {{ fileCount }} files.</h2>
 
-{% if fileLists %}
-<table>
+    <!-- If we have a list of original files, allow option of downloading 1 at a time -->
+    {% if fileLists %}
+    <p>You have 2 options:</p>
+    {% endif %}
+
+    <hr>
+    <p>Create a zip file which will contain these files:</p>
+
+    <div style="padding: 15px; float: right">
+        <input type="submit" value="Create Zip"/>
+    </div>
+
+    <p>
+        Zip file name:
+        <input id="zipName" value="{{ defaultName }}.zip"/>
+    </p>
+
+    <div style="clear:both"></div>
+
+    {% if fileLists %}
+    <hr>
+
+    <p>Download individual files:</p>
+    <p>Click on files below to download</p>
+
+    <table>
     {% for fs in fileLists %}
     <tbody>
         {% for f in fs %}
         <tr>
-            <td><a href="{% url 'get_original_file' f.id %}">{{ f.name }}</a></td>
+            <td>
+                <a href="{% url 'get_original_file' f.id %}">
+                    <div>
+                        {{ f.name }}
+                        <span class="download">Download</span>
+                    </div>
+                </a>
+            </td>
         </tr>
         {% endfor %}
     </tbody>
     {% endfor %}
 </table>
-{% endif %}
+    {% endif %}
+
+</form>
+
+<h1 class="downloading">Download will be available in a moment...</h1>
+<h1 class="downloading">Please <a href="#" onClick="window.close()">close this window</a> once the download is complete.</h1>
+</div>
+    
 
 <script>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -71,8 +71,9 @@ Download files
 
 <div class="center">
 <h1 style="font-size: 24px;">
+    <!-- This dialog is used for exporting original files OR 'export as jpeg/png' etc -->
     {% if fileLists %} Download Original Files
-    {% else %} Download Files
+    {% else %} Export Images
     {% endif %}
 </h1>
 
@@ -82,7 +83,13 @@ Download files
         <button id="reset" type="reset" value="Reset">Cancel</button>
     </div>
 
-    <h2>You have chosen to download {{ fileCount }} files.</h2>
+    <h2>
+    {% if fileLists %}
+        You have chosen to download {{ fileCount }} files.
+    {% else %}
+        You have chosen to export {{ fileCount }} images.
+    {% endif %}
+    </h2>
 
     <!-- If we have a list of original files, allow option of downloading 1 at a time -->
     {% if fileLists %}
@@ -91,7 +98,8 @@ Download files
 
     <div style="clear:both"></div>
     <hr>
-    <p>Create and download a zip file which will contain these files:</p>
+    <p>Create and download a zip file which will contain these
+        {% if fileLists %} files{% else %} images{% endif %}:</p>
 
     <div style="padding: 15px; float: right">
         <input type="submit" value="Create Zip"/>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -90,7 +90,7 @@
                     href="#"
                     onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids=image-{{ image.id }}&fileCount={{ fileCount }}&name={{ image.name }}');"
                   {% endifequal %}
-                title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s as zip'}} ({{ filesetInfo.size|filesizeformat }})"
+                title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s'}} ({{ filesetInfo.size|filesizeformat }})"
                 >
                 Download...</a>
             </li>
@@ -115,7 +115,7 @@
                     onClick="return OME.openPopup('{% url 'download_placeholder' %}?ids={{ link_string }}&fileCount={{ filesetInfo.count }}&index={{ index }}');"
                   {% endifequal %}
                 {% endifequal %}
-                title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s as zip'}} ({{ filesetInfo.size|filesizeformat }})"
+                title="Download {{ filesetInfo.count }} original imported file{{ filesetInfo.count|pluralize:'s'}} ({{ filesetInfo.size|filesizeformat }})"
                 >
                 Download...</a>
             </li>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2718,7 +2718,7 @@ def download_placeholder(request, conn=None, **kwargs):
         'url': download_url,
         'defaultName': defaultName,
         'fileLists': fileLists,
-        'fileCount': fileCount 
+        'fileCount': fileCount
         }
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2487,8 +2487,9 @@ def get_original_file(request, fileId, conn=None, **kwargs):
         mimetype = "text/plain"  # allows display in browser
     rsp['Content-Type'] = mimetype
     rsp['Content-Length'] = orig_file.getSize()
-    # rsp['Content-Disposition'] = ('attachment; filename=%s'
-    #                               % (orig_file.name.replace(" ", "_")))
+    downloadName = orig_file.name.replace(" ", "_")
+    downloadName = downloadName.replace(",", ".")
+    rsp['Content-Disposition'] = 'attachment; filename=%s' % downloadName
     return rsp
 
 
@@ -2623,8 +2624,9 @@ def download_orig_metadata(request, imageId, conn=None, **kwargs):
     return rsp
 
 
+@login_required()
 @render_response()
-def download_placeholder(request):
+def download_placeholder(request, conn=None, **kwargs):
     """
     Page displays a simple "Preparing download..." message and redirects to
     the 'url'.
@@ -2642,7 +2644,61 @@ def download_placeholder(request):
     defaultName = request.REQUEST.get('name', zipName)  # default zip name
     defaultName = os.path.basename(defaultName)         # remove path
 
-    query = "&".join([i.replace("-", "=") for i in targetIds.split("|")])
+    if targetIds is None:
+        raise Http404("No IDs specified. E.g. ?ids=image-1|image-2")
+
+    ids = targetIds.split("|")
+
+    fileLists = []
+    # If we're downloading originals, list original files so user can
+    # download individual files.
+    if format is None:
+        imgIds = []
+        wellIds = []
+        for i in ids:
+            if i.split("-")[0] == "image":
+                imgIds.append(i.split("-")[1])
+            elif i.split("-")[0] == "image":
+                imgIds.append(i.split("-")[1])
+
+        images = []
+        # Get images...
+        if imgIds:
+            images = list(conn.getObjects("Image", imgIds))
+        elif wellIds:
+            try:
+                index = int(request.REQUEST.get("index", 0))
+            except ValueError:
+                index = 0
+            wells = conn.getObjects("Well", wellIds)
+            for w in wells:
+                images.append(w.getWellSample(index).image())
+
+        if len(images) == 0:
+            raise Http404("No images found.")
+
+        # Have a list of files per fileset (or per image without fileset)
+        fsIds = set()
+        fileIds = set()
+        for image in images:
+            fs = image.getFileset()
+            if fs is not None:
+                # Make sure we've not processed this fileset before.
+                if fs.id in fsIds:
+                    continue
+                fsIds.add(fs.id)
+            files = list(image.getImportedImageFiles())
+            fList = []
+            for f in files:
+                if f.id in fileIds:
+                    continue
+                fileIds.add(f.id)
+                fList.append({'id': f.id,
+                              'name': f.name})
+            if len(fList) > 0:
+                fileLists.append(fList)
+
+    query = "&".join([i.replace("-", "=") for i in ids])
     download_url = download_url + "?" + query
     if format is not None:
         download_url = (download_url + "&format=%s"
@@ -2654,7 +2710,8 @@ def download_placeholder(request):
     context = {
         'template': "webclient/annotations/download_placeholder.html",
         'url': download_url,
-        'defaultName': defaultName
+        'defaultName': defaultName,
+        'fileLists': fileLists
         }
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2650,6 +2650,7 @@ def download_placeholder(request, conn=None, **kwargs):
     ids = targetIds.split("|")
 
     fileLists = []
+    fileCount = 0
     # If we're downloading originals, list original files so user can
     # download individual files.
     if format is None:
@@ -2658,8 +2659,8 @@ def download_placeholder(request, conn=None, **kwargs):
         for i in ids:
             if i.split("-")[0] == "image":
                 imgIds.append(i.split("-")[1])
-            elif i.split("-")[0] == "image":
-                imgIds.append(i.split("-")[1])
+            elif i.split("-")[0] == "well":
+                wellIds.append(i.split("-")[1])
 
         images = []
         # Get images...
@@ -2697,6 +2698,10 @@ def download_placeholder(request, conn=None, **kwargs):
                               'name': f.name})
             if len(fList) > 0:
                 fileLists.append(fList)
+        fileCount = sum([len(l) for l in fileLists])
+    else:
+        # E.g. JPEG/PNG - 1 file per image
+        fileCount = len(ids)
 
     query = "&".join([i.replace("-", "=") for i in ids])
     download_url = download_url + "?" + query
@@ -2711,7 +2716,8 @@ def download_placeholder(request, conn=None, **kwargs):
         'template': "webclient/annotations/download_placeholder.html",
         'url': download_url,
         'defaultName': defaultName,
-        'fileLists': fileLists
+        'fileLists': fileLists,
+        'fileCount': fileCount 
         }
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2636,7 +2636,7 @@ def download_placeholder(request, conn=None, **kwargs):
     format = request.REQUEST.get('format', None)
     if format is not None:
         download_url = reverse('download_as')
-        zipName = 'SaveAs_%s' % format
+        zipName = 'Export_as_%s' % format
     else:
         download_url = reverse('archived_files')
         zipName = 'OriginalFileDownload'

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2695,7 +2695,8 @@ def download_placeholder(request, conn=None, **kwargs):
                     continue
                 fileIds.add(f.id)
                 fList.append({'id': f.id,
-                              'name': f.name})
+                              'name': f.name,
+                              'size': f.getSize()})
             if len(fList) > 0:
                 fileLists.append(fList)
         fileCount = sum([len(l) for l in fileLists])


### PR DESCRIPTION
This allows the downloading of individual files from a set of files selected for download.

To test:
 - Select 1 or more images, check the tooltip on "Download..." menu item for number of files that will download.
 - If more than 1, then clicking "Download" will open download placeholder dialog
 - You will see the option to download all files as zip (same as before)
 - Also should be a list of files, clicking on one will download it directly.
 - If multiple filesets are selected, files will be grouped in filesets and fileset indicated
   on hover (see screenshot).
 - Clicking on Zip, should show a "creating zip" message and hide everything else.

![screen shot 2015-05-02 at 23 22 53](https://cloud.githubusercontent.com/assets/900055/7442991/5c98050c-f122-11e4-8372-b2699900859e.png)


