### PR TITLE
5.1.2: session api additions

### DIFF
--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -350,6 +350,8 @@
       <constructor-arg ref="securitySystem"/>
       <constructor-arg ref="passwordProvider"/>
       <constructor-arg ref="graphRequestFactory"/>
+      <constructor-arg ref="currentDetails"/>
+      <constructor-arg ref="sessionManager"/>
       <property name="iceCommunicator" ref="Ice.Communicator"/>
   </bean>
 

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -38,7 +38,7 @@
         <bean class="ome.services.blitz.impl.RoiI">
             <constructor-arg ref="throttlingStrategy"/>
             <constructor-arg ref="geomTool"/>
-		<constructor-arg ref="simpleSqlAction"/>
+            <constructor-arg ref="simpleSqlAction"/>
         </bean>
     </constructor-arg>
   </bean>
@@ -350,8 +350,6 @@
       <constructor-arg ref="securitySystem"/>
       <constructor-arg ref="passwordProvider"/>
       <constructor-arg ref="graphRequestFactory"/>
-      <constructor-arg ref="currentDetails"/>
-      <constructor-arg ref="sessionManager"/>
       <property name="iceCommunicator" ref="Ice.Communicator"/>
   </bean>
 
@@ -396,6 +394,21 @@
      <constructor-arg ref="repositoryDao"/>
      <constructor-arg ref="ring"/>
      <constructor-arg ref="/OMERO/Pixels"/>
+     <property name="iceCommunicator" ref="Ice.Communicator"/>
+  </bean>
+
+  <!-- "Self"-factories -->
+
+  <bean class="omero.cmd.admin.UpdateSessionTimeoutRequestI$Factory" lazy-init="false">
+      <constructor-arg ref="currentDetails"/>
+      <constructor-arg ref="sessionManager"/>
+      <constructor-arg ref="securitySystem"/>
+     <property name="iceCommunicator" ref="Ice.Communicator"/>
+  </bean>
+
+  <bean class="omero.cmd.admin.CurrentSessionsRequestI$Factory" lazy-init="false">
+      <constructor-arg ref="currentDetails"/>
+      <constructor-arg ref="sessionManager"/>
      <property name="iceCommunicator" ref="Ice.Communicator"/>
   </bean>
 

--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -107,6 +107,9 @@ module omero {
         ["java:type:java.util.ArrayList<omero.model.NamedValue>:java.util.List<omero.model.NamedValue>"]
         sequence<omero::model::NamedValue> NamedValueList;
 
+        ["java:type:java.util.ArrayList<omero.sys.EventContext>:java.util.List<omero.sys.EventContext>"]
+        sequence<omero::sys::EventContext> EventContextList;
+
         // Arrays
 
         sequence<bool> BoolArray;

--- a/components/blitz/resources/omero/cmd/Admin.ice
+++ b/components/blitz/resources/omero/cmd/Admin.ice
@@ -77,8 +77,25 @@ module omero {
          * those belonging to that user will be nulled.
          **/
         class CurrentSessionsResponse extends Response {
+
+            /**
+             * [omero::model::Session] objects loaded from
+             * the database.
+             **/
             omero::api::SessionList sessions;
+
+            /**
+             * [omero::sys::EventContext] objects stored in
+             * memory by the server.
+             **/
             omero::api::EventContextList contexts;
+
+            /**
+             * Other session state which may vary based on
+             * usage. This may include "hitCount", "lastAccess",
+             * and similar metrics.
+             **/
+            omero::api::RTypeDictArray data;
         };
 
     };

--- a/components/blitz/resources/omero/cmd/Admin.ice
+++ b/components/blitz/resources/omero/cmd/Admin.ice
@@ -22,22 +22,22 @@ module omero {
     module cmd {
 
          /**
-         * Requests a reset password for the given user.
-         * 
-         * examples:
-         *  - omero.cmd.ResetPasswordRequest(omename, email)
-         *      sends new password to the given user
-         **/
+          * Requests a reset password for the given user.
+          *
+          * examples:
+          *  - omero.cmd.ResetPasswordRequest(omename, email)
+          *      sends new password to the given user
+          **/
          class ResetPasswordRequest extends Request {
              string omename;
              string email;
          };
 
          /**
-         * Successful response for [ResetPasswordRequest].
-         * If no valid user with matching email is found,
-         * an [ERR] will be returned.
-         **/
+          * Successful response for [ResetPasswordRequest].
+          * If no valid user with matching email is found,
+          * an [ERR] will be returned.
+          **/
          class ResetPasswordResponse extends Response {
          };
 

--- a/components/blitz/resources/omero/cmd/Admin.ice
+++ b/components/blitz/resources/omero/cmd/Admin.ice
@@ -42,7 +42,14 @@ module omero {
          };
 
         /**
-         *
+         * Proposes a change to one or both of the timeToLive
+         * and timeToIdle properties of a live session. The session
+         * uuid cannot be null. If either other argument is null,
+         * it will be ignored. Otherwise, the long value will be
+         * interpreted as the the millisecond value which should
+         * be set. Non-administrators will not be able to reduce
+         * current values. No special response is returned, but
+         * an [omero::cmd::OK] counts as success.
          **/
         class UpdateSessionTimeoutRequest extends Request {
             string session;
@@ -50,9 +57,25 @@ module omero {
             omero::RLong timeToIdle;
         };
 
+        /**
+         * Argument-less request that will produce a
+         * [CurrentSessionsResponse] if no [omero::cmd::ERR] occurs.
+         **/
         class CurrentSessionsRequest extends Request {
         };
 
+        /**
+         * Return value from [omero::cmd::CurrentSessionsRequest] consisting of
+         * two ordered lists of matching length. The sessions field
+         * contains a list of the OMERO [omero::model::Session] objects
+         * that are currently active *after* all timeouts have been applied.
+         * This is the value that would be returned by
+         * [omero::api::ISession::getSession] when joined to that session.
+         * Similarly, the contexts field contains the value that would be
+         * returned by a call to [omero::api::IAdmin::getEventContext].
+         * For non-administrators, most values for all sessions other than
+         * those belonging to that user will be nulled.
+         **/
         class CurrentSessionsResponse extends Response {
             omero::api::SessionList sessions;
             omero::api::EventContextList contexts;

--- a/components/blitz/resources/omero/cmd/Admin.ice
+++ b/components/blitz/resources/omero/cmd/Admin.ice
@@ -41,6 +41,23 @@ module omero {
          class ResetPasswordResponse extends Response {
          };
 
+        /**
+         *
+         **/
+        class UpdateSessionTimeoutRequest extends Request {
+            string session;
+            omero::RLong timeToLive;
+            omero::RLong timeToIdle;
+        };
+
+        class CurrentSessionsRequest extends Request {
+        };
+
+        class CurrentSessionsResponse extends Response {
+            omero::api::SessionList sessions;
+            omero::api::EventContextList contexts;
+        };
+
     };
 };
 

--- a/components/blitz/src/omero/cmd/IRequest.java
+++ b/components/blitz/src/omero/cmd/IRequest.java
@@ -19,11 +19,6 @@ package omero.cmd;
 
 import java.util.Map;
 
-import org.hibernate.Session;
-
-import ome.system.ServiceFactory;
-import ome.util.SqlAction;
-
 import omero.cmd.HandleI.Cancel;
 
 /**
@@ -71,7 +66,7 @@ public interface IRequest {
     Object step(int step) throws Cancel;
 
     /**
-     * Method within the transaction boudnaries after all processing has
+     * Method within the transaction boundaries after all processing has
      * occurred. A thrown {@link Cancel} will still rollback the current
      * transaction.
      *

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -9,11 +9,6 @@ package omero.cmd;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
-
 import ome.io.nio.PixelsService;
 import ome.io.nio.ThumbnailService;
 import ome.security.ACLVoter;
@@ -21,13 +16,16 @@ import ome.security.ChmodStrategy;
 import ome.security.SecuritySystem;
 import ome.security.auth.PasswordProvider;
 import ome.security.auth.PasswordUtil;
+import ome.security.basic.CurrentDetails;
 import ome.services.chgrp.ChgrpStepFactory;
 import ome.services.chown.ChownStepFactory;
 import ome.services.delete.Deletion;
 import ome.services.mail.MailUtil;
+import ome.services.sessions.SessionManager;
 import ome.system.OmeroContext;
 import ome.system.Roles;
 import ome.tools.hibernate.ExtendedMetadata;
+import omero.cmd.admin.CurrentSessionsRequestI;
 import omero.cmd.admin.ResetPasswordRequestI;
 import omero.cmd.basic.DoAllI;
 import omero.cmd.basic.ListRequestsI;
@@ -35,22 +33,27 @@ import omero.cmd.basic.TimingI;
 import omero.cmd.fs.ManageImageBinariesI;
 import omero.cmd.fs.OriginalMetadataRequestI;
 import omero.cmd.fs.UsedFilesRequestI;
-import omero.cmd.graphs.ChgrpI;
 import omero.cmd.graphs.Chgrp2I;
 import omero.cmd.graphs.ChgrpFacadeI;
+import omero.cmd.graphs.ChgrpI;
 import omero.cmd.graphs.ChildOptionI;
 import omero.cmd.graphs.ChmodI;
-import omero.cmd.graphs.ChownI;
 import omero.cmd.graphs.Chown2I;
 import omero.cmd.graphs.ChownFacadeI;
-import omero.cmd.graphs.DeleteI;
+import omero.cmd.graphs.ChownI;
 import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
+import omero.cmd.graphs.DeleteI;
 import omero.cmd.graphs.DiskUsageI;
 import omero.cmd.graphs.GraphRequestFactory;
 import omero.cmd.graphs.GraphSpecListI;
 import omero.cmd.graphs.SkipHeadI;
 import omero.cmd.mail.SendEmailRequestI;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * SPI type picked up from the Spring configuration and given a chance to
@@ -59,6 +62,7 @@ import omero.cmd.mail.SendEmailRequestI;
  *
  * @see ticket:6340
  */
+@SuppressWarnings("deprecation")
 public class RequestObjectFactoryRegistry extends
         omero.util.ObjectFactoryRegistry implements ApplicationContextAware {
 
@@ -82,6 +86,10 @@ public class RequestObjectFactoryRegistry extends
     
     private final GraphRequestFactory graphRequestFactory;
 
+    private final CurrentDetails current;
+
+    private final SessionManager sessionManager;
+
     private/* final */OmeroContext ctx;
 
     public RequestObjectFactoryRegistry(ExtendedMetadata em,
@@ -93,7 +101,9 @@ public class RequestObjectFactoryRegistry extends
             PasswordUtil passwordUtil,
             SecuritySystem sec,
             PasswordProvider passwordProvider,
-            GraphRequestFactory graphRequestFactory) {
+            GraphRequestFactory graphRequestFactory,
+            CurrentDetails current,
+            SessionManager sessionManager) {
 
         this.em = em;
         this.voter = voter;
@@ -105,6 +115,8 @@ public class RequestObjectFactoryRegistry extends
         this.sec = sec;
         this.passwordProvider = passwordProvider;
         this.graphRequestFactory = graphRequestFactory;
+        this.current = current;
+        this.sessionManager = sessionManager;
     }
 
     public void setApplicationContext(ApplicationContext ctx)
@@ -271,7 +283,14 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(ResetPasswordRequestI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                    	return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
+                        return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
+                    }
+                });
+        factories.put(CurrentSessionsRequestI.ice_staticId(),
+                new ObjectFactory(CurrentSessionsRequestI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return new CurrentSessionsRequestI(current, sessionManager);
                     }
                 });
         /* request parameters */

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -9,6 +9,11 @@ package omero.cmd;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
 import ome.io.nio.PixelsService;
 import ome.io.nio.ThumbnailService;
 import ome.security.ACLVoter;
@@ -16,45 +21,36 @@ import ome.security.ChmodStrategy;
 import ome.security.SecuritySystem;
 import ome.security.auth.PasswordProvider;
 import ome.security.auth.PasswordUtil;
-import ome.security.basic.CurrentDetails;
 import ome.services.chgrp.ChgrpStepFactory;
 import ome.services.chown.ChownStepFactory;
 import ome.services.delete.Deletion;
 import ome.services.mail.MailUtil;
-import ome.services.sessions.SessionManager;
 import ome.system.OmeroContext;
 import ome.system.Roles;
 import ome.tools.hibernate.ExtendedMetadata;
-import omero.cmd.admin.CurrentSessionsRequestI;
 import omero.cmd.admin.ResetPasswordRequestI;
-import omero.cmd.admin.UpdateSessionTimeoutRequestI;
 import omero.cmd.basic.DoAllI;
 import omero.cmd.basic.ListRequestsI;
 import omero.cmd.basic.TimingI;
 import omero.cmd.fs.ManageImageBinariesI;
 import omero.cmd.fs.OriginalMetadataRequestI;
 import omero.cmd.fs.UsedFilesRequestI;
+import omero.cmd.graphs.ChgrpI;
 import omero.cmd.graphs.Chgrp2I;
 import omero.cmd.graphs.ChgrpFacadeI;
-import omero.cmd.graphs.ChgrpI;
 import omero.cmd.graphs.ChildOptionI;
 import omero.cmd.graphs.ChmodI;
+import omero.cmd.graphs.ChownI;
 import omero.cmd.graphs.Chown2I;
 import omero.cmd.graphs.ChownFacadeI;
-import omero.cmd.graphs.ChownI;
+import omero.cmd.graphs.DeleteI;
 import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
-import omero.cmd.graphs.DeleteI;
 import omero.cmd.graphs.DiskUsageI;
 import omero.cmd.graphs.GraphRequestFactory;
 import omero.cmd.graphs.GraphSpecListI;
 import omero.cmd.graphs.SkipHeadI;
 import omero.cmd.mail.SendEmailRequestI;
-
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * SPI type picked up from the Spring configuration and given a chance to
@@ -63,7 +59,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  *
  * @see ticket:6340
  */
-@SuppressWarnings("deprecation")
 public class RequestObjectFactoryRegistry extends
         omero.util.ObjectFactoryRegistry implements ApplicationContextAware {
 
@@ -87,10 +82,6 @@ public class RequestObjectFactoryRegistry extends
     
     private final GraphRequestFactory graphRequestFactory;
 
-    private final CurrentDetails current;
-
-    private final SessionManager sessionManager;
-
     private/* final */OmeroContext ctx;
 
     public RequestObjectFactoryRegistry(ExtendedMetadata em,
@@ -102,9 +93,7 @@ public class RequestObjectFactoryRegistry extends
             PasswordUtil passwordUtil,
             SecuritySystem sec,
             PasswordProvider passwordProvider,
-            GraphRequestFactory graphRequestFactory,
-            CurrentDetails current,
-            SessionManager sessionManager) {
+            GraphRequestFactory graphRequestFactory) {
 
         this.em = em;
         this.voter = voter;
@@ -116,8 +105,6 @@ public class RequestObjectFactoryRegistry extends
         this.sec = sec;
         this.passwordProvider = passwordProvider;
         this.graphRequestFactory = graphRequestFactory;
-        this.current = current;
-        this.sessionManager = sessionManager;
     }
 
     public void setApplicationContext(ApplicationContext ctx)
@@ -277,28 +264,14 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(SendEmailRequestI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        return new SendEmailRequestI(mailUtil);
+                    	return new SendEmailRequestI(mailUtil);
                     }
                 });
         factories.put(ResetPasswordRequestI.ice_staticId(),
                 new ObjectFactory(ResetPasswordRequestI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
-                    }
-                });
-        factories.put(UpdateSessionTimeoutRequestI.ice_staticId(),
-                new ObjectFactory(UpdateSessionTimeoutRequestI.ice_staticId()) {
-                    @Override
-                    public Ice.Object create(String name) {
-                        return new UpdateSessionTimeoutRequestI(current, sessionManager, sec);
-                    }
-                });
-        factories.put(CurrentSessionsRequestI.ice_staticId(),
-                new ObjectFactory(CurrentSessionsRequestI.ice_staticId()) {
-                    @Override
-                    public Ice.Object create(String name) {
-                        return new CurrentSessionsRequestI(current, sessionManager);
+                    	return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
                     }
                 });
         /* request parameters */

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -276,7 +276,7 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(SendEmailRequestI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                    	return new SendEmailRequestI(mailUtil);
+                        return new SendEmailRequestI(mailUtil);
                     }
                 });
         factories.put(ResetPasswordRequestI.ice_staticId(),

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -27,6 +27,7 @@ import ome.system.Roles;
 import ome.tools.hibernate.ExtendedMetadata;
 import omero.cmd.admin.CurrentSessionsRequestI;
 import omero.cmd.admin.ResetPasswordRequestI;
+import omero.cmd.admin.UpdateSessionTimeoutRequestI;
 import omero.cmd.basic.DoAllI;
 import omero.cmd.basic.ListRequestsI;
 import omero.cmd.basic.TimingI;
@@ -284,6 +285,13 @@ public class RequestObjectFactoryRegistry extends
                     @Override
                     public Ice.Object create(String name) {
                         return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
+                    }
+                });
+        factories.put(UpdateSessionTimeoutRequestI.ice_staticId(),
+                new ObjectFactory(UpdateSessionTimeoutRequestI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return new UpdateSessionTimeoutRequestI(current, sessionManager, sec);
                     }
                 });
         factories.put(CurrentSessionsRequestI.ice_staticId(),

--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -20,6 +20,7 @@
 package omero.cmd.admin;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,18 +31,39 @@ import ome.services.sessions.SessionManager;
 import ome.system.EventContext;
 import omero.cmd.CurrentSessionsRequest;
 import omero.cmd.CurrentSessionsResponse;
-import omero.cmd.ERR;
 import omero.cmd.HandleI.Cancel;
 import omero.cmd.Helper;
 import omero.cmd.IRequest;
 import omero.cmd.Response;
 import omero.model.Session;
 import omero.util.IceMapper;
-import edu.emory.mathcs.backport.java.util.Collections;
+import omero.util.ObjectFactoryRegistry;
+import Ice.Communicator;
+
+import com.google.common.collect.ImmutableMap;
 
 @SuppressWarnings("serial")
 public class CurrentSessionsRequestI extends CurrentSessionsRequest
     implements IRequest {
+
+    public static class Factory extends ObjectFactoryRegistry {
+        private final ObjectFactory factory;
+        public Factory(final CurrentDetails current,
+                final SessionManager sessionManager) {
+            factory = new ObjectFactory(ice_staticId()) {
+                @Override
+                public Ice.Object create(String name) {
+                    return new CurrentSessionsRequestI(
+                            current, sessionManager);
+                }};
+            }
+
+        @Override
+        public Map<String, ObjectFactory> createFactories(Communicator ic) {
+            return new ImmutableMap.Builder<String, ObjectFactory>()
+                    .put(ice_staticId(), factory).build();
+        }
+    }
 
     protected Helper helper;
 

--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -75,7 +75,7 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
         helper.assertStep(step);
 
         contexts = manager.getAll();
-        if (contexts.size() == 0) {
+        if (contexts.isEmpty()) {
             return Collections.emptyList();
         }
         return helper.getServiceFactory().getQueryService().

--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -153,6 +153,7 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
                     ec.groupId = orig.getCurrentGroupId();
                     ec.groupName = orig.getCurrentGroupName();
                     ec.isAdmin = orig.isCurrentUserAdmin();
+                    rsp.data[count++] = new HashMap<String, RType>();
                 } else {
                     rsp.contexts.add(IceMapper.convert(orig));
                     rsp.data[count++] = parseData(rsp, data);

--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.admin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import ome.parameters.Parameters;
+import ome.security.basic.CurrentDetails;
+import ome.services.sessions.SessionManager;
+import ome.system.EventContext;
+import omero.cmd.CurrentSessionsRequest;
+import omero.cmd.CurrentSessionsResponse;
+import omero.cmd.ERR;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+import omero.model.Session;
+import omero.util.IceMapper;
+import edu.emory.mathcs.backport.java.util.Collections;
+
+@SuppressWarnings("serial")
+public class CurrentSessionsRequestI extends CurrentSessionsRequest
+    implements IRequest {
+
+    protected Helper helper;
+
+    protected final CurrentDetails current;
+
+    protected final SessionManager manager;
+
+    protected Map<String, EventContext> contexts;
+
+    public CurrentSessionsRequestI(CurrentDetails current,
+            SessionManager manager) {
+        this.current = current;
+        this.manager = manager;
+    }
+
+    //
+    // CMD API
+    //
+
+    @Override
+    public Map<String, String> getCallContext() {
+        return null;
+    }
+
+    public void init(Helper helper) {
+        this.helper = helper;
+        this.helper.setSteps(1);
+    }
+
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+
+        contexts = manager.getAll();
+        if (contexts.size() == 0) {
+            return Collections.emptyList();
+        }
+        return helper.getServiceFactory().getQueryService().
+                findAllByQuery("select s from Session s where s.uuid in (:uuid)",
+                        new Parameters().addList("uuid", new ArrayList<String>(
+                                contexts.keySet())));
+    }
+
+    @Override
+    public void finish() throws Cancel {
+        // no-op
+    }
+
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+
+        @SuppressWarnings("unchecked")
+        List<ome.model.meta.Session> rv = (List<ome.model.meta.Session>) object;
+        Map<String, Session> objects = new HashMap<String, Session>();
+        IceMapper mapper = new IceMapper();
+        for (ome.model.meta.Session obj : rv) {
+            objects.put(obj.getUuid(), (Session) mapper.map(obj));
+        }
+
+        if (helper.isLast(step)) {
+            CurrentSessionsResponse rsp = new CurrentSessionsResponse();
+            rsp.sessions = new ArrayList<Session>(contexts.size());
+            rsp.contexts = new ArrayList<omero.sys.EventContext>(contexts.size());
+            for (Map.Entry<String, EventContext> entry : contexts.entrySet()) {
+                String uuid = entry.getKey();
+                Session s = objects.get(uuid);
+                rsp.sessions.add(s);
+                if (s == null) {
+                    // Non-admin
+                    EventContext orig = entry.getValue();
+                    omero.sys.EventContext ec = new omero.sys.EventContext();
+                    rsp.contexts.add(ec);
+                    ec.userId = orig.getCurrentUserId();
+                    ec.userName = orig.getCurrentUserName();
+                    ec.groupId = orig.getCurrentGroupId();
+                    ec.groupName = orig.getCurrentGroupName();
+                    ec.isAdmin = orig.isCurrentUserAdmin();
+                } else {
+                    rsp.contexts.add(IceMapper.convert(entry.getValue()));
+                }
+            }
+            helper.setResponseIfNull(rsp);
+        }
+    }
+
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+
+}

--- a/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
@@ -21,6 +21,9 @@ package omero.cmd.admin;
 
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+
+import Ice.Communicator;
 import ome.api.local.LocalQuery;
 import ome.api.local.LocalUpdate;
 import ome.model.meta.Session;
@@ -38,10 +41,31 @@ import omero.cmd.IRequest;
 import omero.cmd.OK;
 import omero.cmd.Response;
 import omero.cmd.UpdateSessionTimeoutRequest;
+import omero.util.ObjectFactoryRegistry;
 
 @SuppressWarnings("serial")
 public class UpdateSessionTimeoutRequestI extends UpdateSessionTimeoutRequest
     implements IRequest {
+
+    public static class Factory extends ObjectFactoryRegistry {
+        private final ObjectFactory factory;
+        public Factory(final CurrentDetails current,
+                final SessionManager sessionManager,
+                final SecuritySystem securitySystem) {
+            factory = new ObjectFactory(ice_staticId()) {
+                @Override
+                public Ice.Object create(String name) {
+                    return new UpdateSessionTimeoutRequestI(
+                            current, sessionManager, securitySystem);
+                }};
+            }
+
+        @Override
+        public Map<String, ObjectFactory> createFactories(Communicator ic) {
+            return new ImmutableMap.Builder<String, ObjectFactory>()
+                    .put(ice_staticId(), factory).build();
+        }
+    }
 
     protected Helper helper;
 

--- a/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.admin;
+
+import java.util.Map;
+
+import ome.api.local.LocalQuery;
+import ome.api.local.LocalUpdate;
+import ome.model.meta.Session;
+import ome.parameters.Parameters;
+import ome.security.AdminAction;
+import ome.security.SecuritySystem;
+import ome.security.basic.CurrentDetails;
+import ome.services.sessions.SessionManager;
+import ome.system.ServiceFactory;
+import omero.RLong;
+import omero.cmd.ERR;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.OK;
+import omero.cmd.Response;
+import omero.cmd.UpdateSessionTimeoutRequest;
+
+@SuppressWarnings("serial")
+public class UpdateSessionTimeoutRequestI extends UpdateSessionTimeoutRequest
+    implements IRequest {
+
+    protected Helper helper;
+
+    protected LocalQuery query;
+
+    protected LocalUpdate update;
+
+    protected final CurrentDetails current;
+
+    protected final SessionManager manager;
+
+    protected final SecuritySystem security;
+
+    protected boolean updated = false;
+
+    public UpdateSessionTimeoutRequestI(CurrentDetails current,
+            SessionManager manager, SecuritySystem security) {
+        this.current = current;
+        this.manager = manager;
+        this.security = security;
+    }
+
+    //
+    // CMD API
+    //
+
+    @Override
+    public Map<String, String> getCallContext() {
+        return null;
+    }
+
+    public void init(Helper helper) {
+        this.helper = helper;
+        this.helper.setSteps(1);
+        ServiceFactory sf = this.helper.getServiceFactory();
+        query = (LocalQuery) sf.getQueryService();
+        update = (LocalUpdate) sf.getUpdateService();
+    }
+
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+        return updateSession();
+    }
+
+    @Override
+    public void finish() throws Cancel {
+        // no-op
+    }
+
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (helper.isLast(step)) {
+            manager.reload(session);
+            helper.setResponseIfNull(new OK());
+        }
+    }
+
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+
+    //
+    // IMPLEMENTATION
+    //
+
+    protected Session updateSession() {
+        Session s = helper.getServiceFactory().getQueryService()
+                .findByQuery("select s from Session s where s.uuid = :uuid",
+                new Parameters().addString("uuid", session));
+
+        if (s == null) {
+            // we assume that if the session is visible, then
+            // the current user should be able to edit it.
+            throw helper.cancel(new ERR(), null, "no-session");
+        }
+
+        boolean isAdmin = current.getCurrentEventContext().isCurrentUserAdmin();
+        updated |= updateField(s, Session.TIMETOLIVE, timeToLive, isAdmin);
+        updated |= updateField(s, Session.TIMETOIDLE, timeToIdle, isAdmin);
+        if (updated) {
+            security.runAsAdmin(new AdminAction(){
+                @Override
+                public void runAsAdmin() {
+                    update.flush();
+                }});
+            return s;
+        } else {
+            throw helper.cancel(new ERR(), null, "no-update-performed",
+                    "session", session);
+        }
+    }
+
+    protected boolean updateField(Session s, String field, RLong value,
+            boolean isAdmin) {
+
+        if (value == null) {
+            return false;
+        }
+
+        long target = value.getValue();
+        long current = ((Long) s.retrieve(field)).longValue();
+        long diff = target - current;
+        if (!isAdmin && diff > 0) {
+            throw helper.cancel(new ERR(), null, "non-admin-increase",
+                    "target", ""+target,
+                    "current", ""+current);
+        }
+
+        helper.info("Modifying %s from %s to %s for %s",
+                field, current, target, session);
+        s.putAt(field, target);
+        return true;
+    }
+}

--- a/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
@@ -170,6 +170,12 @@ public class UpdateSessionTimeoutRequestI extends UpdateSessionTimeoutRequest
         long diff = target - current;
         if (!isAdmin && diff > 0) {
             throw helper.cancel(new ERR(), null, "non-admin-increase",
+                    "field", field,
+                    "target", ""+target,
+                    "current", ""+current);
+        } else if (!isAdmin && target <= 0) {
+            throw helper.cancel(new ERR(), null, "non-admin-disabling",
+                    "field", field,
                     "target", ""+target,
                     "current", ""+current);
         }

--- a/components/blitz/test/ome/services/blitz/test/AbstractGraphTest.java
+++ b/components/blitz/test/ome/services/blitz/test/AbstractGraphTest.java
@@ -64,9 +64,7 @@ public class AbstractGraphTest extends AbstractServantTest {
                 user.ctx.getBean(PasswordUtil.class),
                 user.ctx.getBean(SecuritySystem.class),
                 user.ctx.getBean(PasswordProvider.class),
-                user.ctx.getBean("graphRequestFactory", GraphRequestFactory.class),
-                user.ctx.getBean("currentDetails", CurrentDetails.class),
-                user.sm
+                user.ctx.getBean("graphRequestFactory", GraphRequestFactory.class)
                 );
         rofr.setApplicationContext(ctx);
         rofr.setIceCommunicator(ic);

--- a/components/blitz/test/ome/services/blitz/test/AbstractGraphTest.java
+++ b/components/blitz/test/ome/services/blitz/test/AbstractGraphTest.java
@@ -19,6 +19,7 @@ import ome.security.ACLVoter;
 import ome.security.SecuritySystem;
 import ome.security.auth.PasswordProvider;
 import ome.security.auth.PasswordUtil;
+import ome.security.basic.CurrentDetails;
 import ome.services.mail.MailUtil;
 import ome.system.Roles;
 import ome.tools.hibernate.ExtendedMetadata;
@@ -63,7 +64,9 @@ public class AbstractGraphTest extends AbstractServantTest {
                 user.ctx.getBean(PasswordUtil.class),
                 user.ctx.getBean(SecuritySystem.class),
                 user.ctx.getBean(PasswordProvider.class),
-                user.ctx.getBean("graphRequestFactory", GraphRequestFactory.class)
+                user.ctx.getBean("graphRequestFactory", GraphRequestFactory.class),
+                user.ctx.getBean("currentDetails", CurrentDetails.class),
+                user.sm
                 );
         rofr.setApplicationContext(ctx);
         rofr.setIceCommunicator(ic);

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -378,6 +378,7 @@ public class BasicSecuritySystem implements SecuritySystem,
         long eventGroupId;
         Permissions callPerms;
 
+        // Code copied in SessionManagerImpl
         if (groupId >= 0) { // negative groupId means all member groups
             eventGroupId = groupId;
             callGroup = admin.groupProxy(groupId);

--- a/components/server/src/ome/services/sessions/SessionManager.java
+++ b/components/server/src/ome/services/sessions/SessionManager.java
@@ -158,9 +158,10 @@ public interface SessionManager {
     List<Session> findByUserAndAgent(String user, String... agent);
 
     /**
-     * Return all sessions that are active.
+     * Return all sessions that are active with associated possibly varing
+     * session data information.
      */
-    Map<String, EventContext> getAll();
+    Map<String, Map<String, Object>> getSessionData();
 
     /**
      * If reference count for the session is less than 1, close the session.

--- a/components/server/src/ome/services/sessions/SessionManager.java
+++ b/components/server/src/ome/services/sessions/SessionManager.java
@@ -158,6 +158,11 @@ public interface SessionManager {
     List<Session> findByUserAndAgent(String user, String... agent);
 
     /**
+     * Return all sessions that are active.
+     */
+    Map<String, EventContext> getAll();
+
+    /**
      * If reference count for the session is less than 1, close the session.
      * Otherwise decrement the reference count. The current reference count is
      * returned. If -1, then no such session existed. If -2, then the session

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1266,7 +1266,8 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                         Session s = sc.getSession();
 
                         // Store old value for rollback
-                        if (!sc.getMemberOfGroupsList().contains(id)) {
+                        if (!sc.isCurrentUserAdmin() &&
+                                !sc.getMemberOfGroupsList().contains(id)) {
                             StringBuilder sb = new StringBuilder();
                             sb.append("User ");
                             sb.append(sc.getCurrentUserId());

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1359,13 +1359,15 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             final List<Long> memberOfGroupsIds = admin.getMemberOfGroupIds(exp);
             final List<Long> leaderOfGroupsIds = admin.getLeaderOfGroupIds(exp);
             final List<String> userRoles = admin.getUserRoles(exp);
+            final Session reloaded = (Session)
+                    sf.getQueryService().get(Session.class, session.getId());
             list.add(exp);
             list.add(grp);
             list.add(memberOfGroupsIds);
             list.add(leaderOfGroupsIds);
             list.add(userRoles);
             list.add(principal);
-            list.add(session);
+            list.add(reloaded);
             return list;
         } catch (Exception e) {
             log.info("No info for " + principal.getName(), e);

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1360,7 +1360,11 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             final List<Long> leaderOfGroupsIds = admin.getLeaderOfGroupIds(exp);
             final List<String> userRoles = admin.getUserRoles(exp);
             final Session reloaded = (Session)
-                    sf.getQueryService().get(Session.class, session.getId());
+                    sf.getQueryService().findByQuery(
+                            "select s from Session s "
+                            + "left outer join fetch s.annotationLinks l "
+                            + "left outer join fetch l.child a where s.id = :id",
+                            new Parameters().addId(session.getId()));
             list.add(exp);
             list.add(grp);
             list.add(memberOfGroupsIds);

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1268,6 +1268,7 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
 
                         // Store old value for rollback
                         if (!sc.isCurrentUserAdmin() &&
+                                id >= 0 &&
                                 !sc.getMemberOfGroupsList().contains(id)) {
                             StringBuilder sb = new StringBuilder();
                             sb.append("User ");

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -55,6 +55,7 @@ import ome.system.OmeroContext;
 import ome.system.Principal;
 import ome.system.Roles;
 import ome.system.ServiceFactory;
+import ome.system.SimpleEventContext;
 import ome.util.SqlAction;
 
 import org.apache.commons.lang.StringUtils;
@@ -601,6 +602,28 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                     + " more references: " + uuid);
             return refCount;
         }
+    }
+
+    public Map<String, EventContext> getAll() {
+        final Collection<String> ids = cache.getIds();
+        final Map<String, EventContext> rv = new HashMap<String, EventContext>();
+        for (String id : ids) {
+            if (asroot.getName().equals(id)) {
+                continue; // DON'T INCLUDE ROOT SESSION
+            }
+            try {
+                SessionContext ctx = cache.getSessionContext(id);
+                rv.put(id,  new SimpleEventContext(ctx));
+            } catch (RemovedSessionException rse) {
+                // Ok. Done for us
+            } catch (SessionTimeoutException ste) {
+                // Also ok
+            } catch (Exception e) {
+                log.warn(String.format("Exception thrown on getAll: %s:%s", e
+                        .getClass().getName(), e.getMessage()));
+            }
+        }
+        return rv;
     }
 
     public int closeAll() {

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1266,6 +1266,14 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                         Session s = sc.getSession();
 
                         // Store old value for rollback
+                        if (!sc.getMemberOfGroupsList().contains(id)) {
+                            StringBuilder sb = new StringBuilder();
+                            sb.append("User ");
+                            sb.append(sc.getCurrentUserId());
+                            sb.append(" is not a member of group ");
+                            sb.append(id);
+                            throw new SecurityViolation(sb.toString());
+                        }
                         group[0] = s.getDetails().getGroup();
                         s.getDetails().setGroup(sf.getAdminService().getGroup(id));
                         return s;

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -604,16 +604,17 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
         }
     }
 
-    public Map<String, EventContext> getAll() {
+    public Map<String, Map<String, Object>> getSessionData() {
         final Collection<String> ids = cache.getIds();
-        final Map<String, EventContext> rv = new HashMap<String, EventContext>();
+        final Map<String, Map<String, Object>> rv
+            = new HashMap<String, Map<String, Object>>();
+
         for (String id : ids) {
             if (asroot.getName().equals(id)) {
                 continue; // DON'T INCLUDE ROOT SESSION
             }
             try {
-                SessionContext ctx = cache.getSessionContext(id, true);
-                rv.put(id,  new SimpleEventContext(ctx));
+                rv.put(id,  cache.getSessionData(id, true));
             } catch (RemovedSessionException rse) {
                 // Ok. Done for us
             } catch (SessionTimeoutException ste) {

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -612,7 +612,7 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                 continue; // DON'T INCLUDE ROOT SESSION
             }
             try {
-                SessionContext ctx = cache.getSessionContext(id);
+                SessionContext ctx = cache.getSessionContext(id, true);
                 rv.put(id,  new SimpleEventContext(ctx));
             } catch (RemovedSessionException rse) {
                 // Ok. Done for us

--- a/components/server/src/ome/services/sessions/state/SessionCache.java
+++ b/components/server/src/ome/services/sessions/state/SessionCache.java
@@ -490,7 +490,6 @@ public class SessionCache implements ApplicationContextAware {
      * significantly effected.
      */
     public Set<String> getIds() {
-        // waitForUpdate();
         return sessions.keySet();
     }
 

--- a/components/server/src/ome/services/sessions/state/SessionCache.java
+++ b/components/server/src/ome/services/sessions/state/SessionCache.java
@@ -351,15 +351,27 @@ public class SessionCache implements ApplicationContextAware {
      * {@link RemovedSessionException} or {@link SessionTimeoutException}.
      */
     public SessionContext getSessionContext(String uuid) {
+        return getSessionContext(uuid, false);
+    }
 
+    /**
+     * Retrieve a session possibly raising either
+     * {@link RemovedSessionException} or {@link SessionTimeoutException}.
+     *
+     * @param quietly If true, then the access time for the given UUID
+     *                  will not be updated.
+     */
+    public SessionContext getSessionContext(String uuid, boolean quietly) {
         if (uuid == null) {
             throw new ApiUsageException("Uuid cannot be null.");
         }
 
         Data data = getDataNullOrThrowOnTimeout(uuid, true);
 
-        // Up'ing access time
-        this.sessions.put(uuid, new Data(data));
+        if (!quietly) {
+            // Up'ing access time
+            this.sessions.put(uuid, new Data(data));
+        }
         return data.sessionContext;
     }
 

--- a/components/server/src/ome/services/sessions/state/SessionCache.java
+++ b/components/server/src/ome/services/sessions/state/SessionCache.java
@@ -24,17 +24,19 @@ import ome.services.messages.DestroySessionMessage;
 import ome.services.sessions.SessionCallback;
 import ome.services.sessions.SessionContext;
 import ome.services.sessions.SessionManager;
+import ome.services.sessions.SessionManagerImpl;
 import ome.services.sessions.events.UserGroupUpdateEvent;
 import ome.system.OmeroContext;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.perf4j.StopWatch;
 import org.perf4j.slf4j.Slf4JStopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
 
 /**
@@ -373,6 +375,35 @@ public class SessionCache implements ApplicationContextAware {
             this.sessions.put(uuid, new Data(data));
         }
         return data.sessionContext;
+    }
+
+    /**
+     * Returns all the data contained in the internal implementation of
+     * this manger.
+     *
+     * @param quietly If true, then the access time for the given UUID
+     *                  will not be updated.
+     */
+    public Map<String, Object> getSessionData(String uuid, boolean quietly) {
+
+        if (uuid == null) {
+            throw new ApiUsageException("Uuid cannot be null.");
+        }
+
+        Data data = getDataNullOrThrowOnTimeout(uuid, true);
+
+        if (!quietly) {
+            // Up'ing access time
+            this.sessions.put(uuid, new Data(data));
+        }
+
+        return new ImmutableMap.Builder<String, Object>()
+            .put("class", getClass().getName())
+            .put("sessionContext", data.sessionContext)
+            .put("hitCount", data.hitCount)
+            .put("lastAccessTime", data.lastAccessTime)
+            // .put("error", data.error.get())
+            .build();
     }
 
     /**

--- a/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -9,8 +9,6 @@ package ome.server.utests.sessions;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
 
 import net.sf.ehcache.CacheManager;
 import ome.api.local.LocalAdmin;
@@ -35,9 +33,7 @@ import ome.server.utests.DummyExecutor;
 import ome.services.sessions.SessionContext;
 import ome.services.sessions.SessionContextImpl;
 import ome.services.sessions.SessionManagerImpl;
-import ome.services.sessions.events.UserGroupUpdateEvent;
 import ome.services.sessions.state.SessionCache;
-import ome.services.sessions.state.SessionCache.StaleCacheListener;
 import ome.services.sessions.stats.CounterFactory;
 import ome.services.sessions.stats.SessionStats;
 import ome.services.util.Executor;
@@ -51,6 +47,7 @@ import org.jmock.MockObjectTestCase;
 import org.jmock.core.Constraint;
 import org.jmock.core.Invocation;
 import org.jmock.core.Stub;
+import org.jmock.core.constraint.StringContains;
 import org.springframework.context.event.ApplicationEventMulticaster;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -355,8 +352,8 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         sf.mockAdmin.expects(once()).method("checkPassword").will(
                 returnValue(true));
         // execute lookup user
-        sf.mockQuery.expects(atLeastOnce()).method("get")
-            .with(eq(Session.class), ANYTHING)
+        sf.mockQuery.expects(atLeastOnce()).method("findByQuery")
+            .with(new StringContains("Session"), ANYTHING)
             .will(returnValue(session));
         sf.mockQuery.expects(once()).method("projection").will(
                 returnValue(Arrays.asList((Object)new Object[]{123L})));
@@ -368,6 +365,7 @@ public class SessMgrUnitTest extends MockObjectTestCase {
                 returnValue(test));
 
         sf.mockQuery.expects(atLeastOnce()).method("findByQuery")
+            .with(new StringContains("Node"), ANYTHING)
             .will(returnValue(new Node()));
 
         sf.mockUpdate.expects(atLeastOnce()).method("saveAndReturnObject")

--- a/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -355,6 +355,9 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         sf.mockAdmin.expects(once()).method("checkPassword").will(
                 returnValue(true));
         // execute lookup user
+        sf.mockQuery.expects(atLeastOnce()).method("get")
+            .with(eq(Session.class), ANYTHING)
+            .will(returnValue(session));
         sf.mockQuery.expects(once()).method("projection").will(
                 returnValue(Arrays.asList((Object)new Object[]{123L})));
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2171,12 +2171,6 @@ class _BlitzGateway (object):
             self._session = ss.getSession(self._sessionUuid)
         return self._session
 
-#    def setDefaultPermissionsForSession (self, permissions):
-#        self.getSession()
-#        self._session.setDefaultPermissions(rstring(permissions))
-#        self._session.setTimeToIdle(None)
-#        self.getSessionService().updateSession(self._session)
-
     def setGroupNameForSession(self, group):
         """
         Looks up the group by name, then delegates to
@@ -2207,36 +2201,12 @@ class _BlitzGateway (object):
             return False
         self._lastGroupId = self._ctx.groupId
         self._ctx = None
-        if hasattr(self.c.sf, 'setSecurityContext'):
-            # Beta4.2
-            for s in self.c.getStatefulServices():
-                s.close()
-            self.c.sf.setSecurityContext(
-                omero.model.ExperimenterGroupI(groupid, False))
-        else:
-            self.getSession()
-            self._session.getDetails().setGroup(
-                omero.model.ExperimenterGroupI(groupid, False))
-            self._session.setTimeToIdle(None)
-            self.getSessionService().updateSession(self._session)
+        for s in self.c.getStatefulServices():
+            s.close()
+        self.c.sf.setSecurityContext(
+            omero.model.ExperimenterGroupI(groupid, False))
         return True
 
-
-#    def setGroupForSession (self, group):
-#        self.getSession()
-#        if self._session.getDetails().getGroup().getId().val == group.getId():
-#            # Already correct
-#            return
-#        a = self.getAdminService()
-#        if (group.name not in
-#                [x.name.val for x in a.containedGroups(self._userid)]):
-#            # User not in this group
-#            return
-#        self._lastGroup = self._session.getDetails().getGroup()
-#        self._session.getDetails().setGroup(group._obj)
-#        self._session.setTimeToIdle(None)
-#        self.getSessionService().updateSession(self._session)
-#
     def revertGroupForSession(self):
         """ Switches the group to the previous group """
         if self._lastGroupId is not None:

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -184,7 +184,7 @@ class SessionsControl(BaseControl):
             "--no-purge", dest="purge", action="store_false",
             help="Do not remove inactive sessions")
 
-        who = parser.add(sub, self.who, (
+        parser.add(sub, self.who, (
             "List all active server sessions (admin-only)"))
 
         keepalive = parser.add(
@@ -620,14 +620,14 @@ class SessionsControl(BaseControl):
         req = omero.cmd.CurrentSessionsRequest()
         try:
             cb = client.submit(req)
-            rsp = cb.getResponse()
+            try:
+                rsp = cb.getResponse()
+            finally:
+                cb.close(True)
+
             headers = ("name", "group", "logged in", "agent")
-            results = {
-                        "name": [],
-                        "group": [],
-                        "logged in": [],
-                        "agent": []
-                      }
+            results = {"name": [], "group": [],
+                       "logged in": [], "agent": []}
             for idx, s in enumerate(rsp.sessions):
                 ec = rsp.contexts[idx]
                 results["name"].append(ec.userName)
@@ -659,8 +659,8 @@ class SessionsControl(BaseControl):
             else:
                 exc = traceback.format_exc()
                 self.ctx.dbg(exc)
-                self.ctx.die(562, "ClientError: %s" % e)
-        except omero.LockTimeout, lt:
+                self.ctx.die(562, "ClientError: %s" % ce.err.name)
+        except omero.LockTimeout:
             exc = traceback.format_exc()
             self.ctx.dbg(exc)
             self.ctx.die(563, "LockTimeout: operation took too long")

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -543,7 +543,7 @@ class SessionsControl(BaseControl):
 
         unit = "min."
         val = float(timeout) / 60 / 1000
-        if val < 1:
+        if val < 5:
             unit = "sec."
             val = val * 60
         return "%s%.f %s" % (msg, val, unit)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -695,6 +695,7 @@ class SessionsControl(BaseControl):
 
     def who(self, args):
         client = self.ctx.conn(args)
+        uuid = self.ctx.get_event_context().sessionUuid
         req = omero.cmd.CurrentSessionsRequest()
         try:
             cb = client.submit(req)
@@ -714,6 +715,8 @@ class SessionsControl(BaseControl):
                     t = s.started.val / 1000.0
                     t = time.localtime(t)
                     t = time.strftime("%Y-%m-%d %H:%M:%S", t)
+                    if uuid == ec.sessionUuid:
+                        t = t + " (*)"
                     results["logged in"].append(t)
                     results["agent"].append(unwrap(s.userAgent))
                 else:

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -584,11 +584,15 @@ class SessionsControl(BaseControl):
             self.ctx.err("Group '%s' (id=%s) is already active"
                          % (group_name, group_id))
         else:
-            sf.setSecurityContext(omero.model.ExperimenterGroupI(group_id,
-                                                                 False))
-            self.ctx.set_event_context(sf.getAdminService().getEventContext())
-            self.ctx.out("Group '%s' (id=%s) switched to '%s' (id=%s)"
-                         % (old_name, old_id, group_name, group_id))
+            try:
+                sf.setSecurityContext(omero.model.ExperimenterGroupI(
+                    group_id, False))
+                self.ctx.set_event_context(
+                    sf.getAdminService().getEventContext())
+                self.ctx.out("Group '%s' (id=%s) switched to '%s' (id=%s)" % (
+                    old_name, old_id, group_name, group_id))
+            except omero.SecurityViolation, sv:
+                    self.ctx.die(564, "SecurityViolation: %s" % sv.message)
 
     def timeout(self, args):
         client = self.ctx.conn(args)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -111,8 +111,18 @@ Other sessions commands:
     # List all local sessions
     $ bin/omero sessions list --no-purge
 
-    # List all active server sessions (admin-only)
+    # List all active server sessions
     $ bin/omero sessions who
+
+    # List or change the group for the session
+    $ bin/omero sessions group
+    $ bin/omero sessions group mygroup
+    $ bin/omero sessions group 123
+
+    # List or change the timeToLive for the session
+    $ bin/omero sessions timeout
+    $ bin/omero sessions timeout 300.0 # Seconds
+    $ bin/omero sessions timeout 300.0 --session=$UUID
 
 Custom sessions directory:
 
@@ -128,6 +138,10 @@ LISTHELP = """
 By default, inactive sessions are purged from the local sessions store and
 removed from the listing. To list all sessions stored locally independently of
 their status, use the --no-purge argument.
+"""
+
+GROUPHELP = """
+If any current services are open, the command will fail.
 """
 
 
@@ -174,7 +188,7 @@ class SessionsControl(BaseControl):
 
         group = parser.add(
             sub, self.group,
-            "Set the group of the current session by id or name")
+            "Set the group of the given session by id or name" + GROUPHELP)
         group.add_argument(
             "target",
             nargs="?",
@@ -233,7 +247,7 @@ class SessionsControl(BaseControl):
         parser.add_argument("--session-dir", help=SUPPRESS)
 
     def help(self, args):
-        self.ctx.err(LONGHELP % {"prog": args.prog})
+        self.ctx.out(LONGHELP % {"prog": args.prog})
 
     def login(self, args):
         ("Login to a given server, and store session key locally.\n\n"

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -717,8 +717,8 @@ class SessionsControl(BaseControl):
             self.ctx.dbg(str(ce.err))
             self.ctx.die(560, "CmdError: %s" % ce.err.name)
         except omero.ClientError, ce:
-            if ce.err == "Null handle":
-                v = client.getConfigService().getVersion()
+            if ce.message == "Null handle":
+                v = client.sf.getConfigService().getVersion()
                 self.ctx.die(561,
                              "Operation unsupported. Server version: %s" % v)
             else:

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -195,7 +195,8 @@ class SessionsControl(BaseControl):
             help="Id or name of the group to switch this session to")
 
         timeout = parser.add(
-            sub, self.timeout, "Query or set the timeToIdle for the given session")
+            sub, self.timeout,
+            "Query or set the timeToIdle for the given session")
         timeout.add_argument(
             "seconds",
             nargs="?",
@@ -603,8 +604,7 @@ class SessionsControl(BaseControl):
         req.session = uuid
         req.timeToIdle = rlong(args.seconds * 1000)
         try:
-            cb = client.submit(req)
-            rsp = cb.getResponse()
+            cb = client.submit(req)  # Response is "OK"
             cb.close(True)
         except omero.CmdError, ce:
             self.ctx.dbg(str(ce.err))
@@ -612,7 +612,6 @@ class SessionsControl(BaseControl):
         except:
             self.ctx.dbg(traceback.format_exc())
             self.ctx.die(559, "cannot update timeout for %s" % uuid)
-
 
     def list(self, args):
         store = self.store(args)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -144,6 +144,16 @@ GROUPHELP = """
 If any current services are open, the command will fail.
 """
 
+WHOHELP = """
+Administrators will receive a list of all active sessions
+along with critical information on last activity. This is
+useful for determining whether or not the server can be
+restarted.
+
+Other users will only see a list of names, i.e. users who
+can be considered "online".
+"""
+
 
 class SessionsControl(BaseControl):
 
@@ -213,7 +223,7 @@ class SessionsControl(BaseControl):
             help="Do not remove inactive sessions")
 
         parser.add(sub, self.who, (
-            "List all active server sessions (admin-only)"))
+            "List all active server sessions\n\n" + WHOHELP))
 
         keepalive = parser.add(
             sub, self.keepalive, "Keeps the current session alive")

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -528,15 +528,24 @@ class SessionsControl(BaseControl):
 
         msg = "%s session %s (%s@%s:%s)." \
             % (action, uuid, ec.userName, host, port)
-        if idle:
-            msg = msg + " Idle timeout: %s min." % (float(idle)/60/1000)
-        if live:
-            msg = msg + " Expires in %s min." % (float(live)/60/1000)
+        msg += self._parse_timeout(idle, "Idle timeout")
+        msg += self._parse_timeout(live, "Expires in ")
 
         msg += (" Current group: %s" % ec.groupName)
 
         if not self.ctx.isquiet:
             self.ctx.err(msg)
+
+    def _parse_timeout(self, timeout, msg):
+        if not timeout:
+            return ""
+
+        unit = "min."
+        val = float(timeout) / 60 / 1000
+        if val < 1:
+            unit = "sec."
+            val = val * 60
+        return " %s: %.f %s" % (msg, val, unit)
 
     def logout(self, args):
         store = self.store(args)

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -51,7 +51,7 @@ class TestSessions(CLITest):
 
     def get_connection_string(self):
         ec = self.cli.get_event_context()
-        return 'session %s (%s). Idle timeout: 10.0 min. ' \
+        return 'session %s (%s). Idle timeout: 10 min. ' \
             'Current group: %s\n' % (ec.sessionUuid, self.conn_string,
                                      ec.groupName)
 
@@ -140,7 +140,7 @@ class TestSessions(CLITest):
                     assert ec.userName == user.omeName.val
                     assert ec.groupName == target_group.name.val
                 else:
-                    with pytest.raises(SecurityViolation):
+                    with pytest.raises(NonZeroReturnCode):
                         self.cli.invoke(switch_cmd, strict=True)
             finally:
                 self.cli.invoke(["sessions", "logout"], strict=True)

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -22,7 +22,6 @@
 from test.integration.clitest.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.model import Experimenter
-from omero import SecurityViolation
 import pytest
 
 permissions = ["rw----", "rwr---", "rwra--", "rwrw--"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -185,7 +185,7 @@ class TestSessions(CLITest):
 
     # Group subcommand
     # ========================================================================
-    def testGroup(self):
+    def testGroup(self, capsys):
         group1 = self.new_group()
         client, user = self.new_client_and_user(group=group1)
         group2 = self.new_group([user])
@@ -200,6 +200,39 @@ class TestSessions(CLITest):
         self.cli.invoke(self.args, strict=True)
         ec = self.cli.get_event_context()
         assert ec.groupName == group2.name.val
+
+        # List current
+        capsys.readouterr()  # Clear
+        self.args = ["-q", "sessions", "group"]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+        assert o == "ExperimenterGroup:%s\n" % group2.id.val
+
+    # Timeout subcommand
+    # ========================================================================
+    def testTimeout(self, capsys):
+        client, user = self.new_client_and_user()
+
+        self.set_login_args(user)
+        self.args += ["-q", "-w", user.omeName.val]
+        self.cli.invoke(self.args, strict=True)
+
+        self.args = ["-q", "sessions", "timeout"]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+        assert o == "600.0\n"
+
+        self.args = ["-q", "sessions", "timeout", "300"]
+        self.cli.invoke(self.args, strict=True)
+
+        self.args = ["-q", "sessions", "timeout"]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+        assert o == "300.0\n"
+
+        self.args = ["-q", "sessions", "timeout", "1000000"]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
 
     # File subcommand
     # ========================================================================

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -49,8 +49,6 @@ class TestSessions(CLITest):
     def login_as(self, user):
         self.set_login_args(user)
 
-
-
     def get_connection_string(self):
         ec = self.cli.get_event_context()
         return 'session %s (%s). Idle timeout: 10.0 min. ' \
@@ -108,7 +106,7 @@ class TestSessions(CLITest):
         group2 = self.new_group(perms=perms)
         user = self.new_user(group1, owner=False)  # Member of two groups
         self.root.sf.getAdminService().addGroups(user, [group2])
-        member = self.new_user(group1, owner=False)  # Member of first gourp
+        member = self.new_user(group1, owner=False)  # Member of first group
         owner = self.new_user(group1, owner=True)  # Owner of first group
         admin = self.new_user(system=True)  # System administrator
 

--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -103,7 +103,7 @@ class TestISession(lib.ITest):
         ("root", -1, None),
         ("root", 1, None),
         ("user", -1, None),
-        ("baduser", 1, None)),
+        ("baduser", 1, None)))
     def testUpdateSessions(self, who):
         who, idlediff, livediff = who
         if who.startswith("root"):


### PR DESCRIPTION
In order to complete the CLI session workflow changes, a few API changes were needed.

 * `omero.cmd.UpdateSessionTimeoutRequest` can now be used to modify the `timeToLive` and `timeToIdle` values. cc: @sbesson 
 * `omero.cmd.CurrentSessionsRequest` can now be used to query the in-memory state of all sessions as opposed to the in-database state. Inactive sessions will be timed-out in the process of querying and will *not* be included in the list. cc: @kennethgillen 

#### Testing ####

Check the various CLI commands, their various arguments, and their associated help:
 * `bin/omero sessions group`
 * `bin/omero sessions timeout`
 * `bin/omero sessions who`

#### Caveat ####

Clients should take care when talking to pre-5.1.2 servers to handle the `null` return value from `session.submit`:

https://github.com/openmicroscopy/openmicroscopy/pull/3786/files#diff-e44a2f62042695e699c5c5a9725de6d4R655
```
+        except omero.ClientError, ce:
+            if ce.err == "Null handle":
+                v = client.getConfigService().getVersion()
+                self.ctx.die(561,
+                             "Operation unsupported. Server version: %s" % v)
```