### PR TITLE
updating icon

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -354,7 +354,7 @@
             <ul id="buttons">
 				
                 <li>
-					<input id="removecontentButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_delete.png" %}" alt="Remove content" title="Remove content" /> 
+					<input id="removecontentButton" class="button button-disabled" type="image" src="{% static "webclient/image/icon_toolbar_cut.png" %}" alt="Remove content" title="Remove content" /> 
 				</li>
 				
 				<li class=seperator></li>


### PR DESCRIPTION
The icon for Remove Content in Public tab in Web (share) was the same as the Delete icon under Data tab. Now it uses *scissors* to make clear the Delete action from Share is not possible
![firefoxscreensnapz035](https://cloud.githubusercontent.com/assets/1065155/7470652/b6f551f8-f316-11e4-832e-d759cb474aab.png)
