### PR TITLE
10661 dynamic params

### DIFF
--- a/components/blitz/build.xml
+++ b/components/blitz/build.xml
@@ -15,54 +15,25 @@
             <delete file="${basedir}/.sconsign.dblite"/>
         </target>
 
-	<target name="compile" depends="generate,_compile" unless="skip.compile"/>
-	<target name="_compile" description="Internal develop target which doesn't run codegen">
-            <if>
-                <uptodate targetfile="${target.dir}/blitz.jar">
-                    <srcfiles dir="${basedir}" includes="**/*.java,**/*.ice,**/*.vm"/>
-                </uptodate>
-            <then>
-                <echo>Up to date</echo>
-            </then>
-            <else>
-                <antcall target="icegen" inheritRefs="true" inheritAll="true"/>
-		<hard-wire file="ome/services/blitz/fire/SessionManagerI.java"
-		    token="&quot;ome.security.basic.BasicSecurityWiring&quot;"/>
-
-                <!-- WORKAROUND: Attempting to compile mutually dependent directories
-                     via javac is quite complicated. Moving the difficult file out of the way -->
-                <property name="file.real.sessionmanager" value="${src.dest}/ome/services/blitz/fire/SessionManagerI.java"/>
-                <property name="file.fake.sessionmanager" value="${src.dest}/ome/services/blitz/fire/SessionManagerI.fake"/>
-                <move file="${file.real.sessionmanager}" tofile="${file.fake.sessionmanager}"/>
-		<myjavac>
-		    <src path="${src.dir}"/>
-		    <src path="${src.dest}"/>
-		    <src path="${basedir}/generated"/>
-		    <include name="pojos/**"/>
-		    <include name="omero/**"/>
-		    <include name="omero/model/**"/>
-		    <include name="ome/services/blitz/impl/CloseableServant.java"/>
-		    <include name="ome/services/blitz/util/ConvertToBlitzExceptionMessage.java"/>
-		    <include name="ome/services/blitz/util/ObjectFactoryRegistry.java"/>
-		    <include name="ome/formats/model/UnitsFactory.java"/>
-		</myjavac>
-		<myjavac>
-		    <src path="${src.dir}"/>
-		    <src path="${src.dest}"/>
-		    <src path="${basedir}/generated"/>
-                    <exclude name="omero/**"/>
-                    <exclude name="omero/model/**"/>
-		</myjavac>
-                <move file="${file.fake.sessionmanager}" tofile="${file.real.sessionmanager}"/>
-		<myjavac>
-		    <include name="**/SessionManagerI.java"/>
-		    <src path="${src.dest}"/>
-		</myjavac>
-                <delete file="${file.real.sessionmanager}"/>
-                <delete file="${file.fake.sessionmanager}"/><!-- Just in case -->
-            </else>
-            </if>
-	</target>
+    <target name="compile" depends="generate,_compile" unless="skip.compile"/>
+    <target name="_compile" description="Internal develop target which doesn't run codegen">
+        <if>
+            <uptodate targetfile="${target.dir}/blitz.jar">
+                <srcfiles dir="${basedir}" includes="**/*.java,**/*.ice,**/*.vm"/>
+            </uptodate>
+        <then>
+            <echo>Up to date</echo>
+        </then>
+        <else>
+            <antcall target="icegen" inheritRefs="true" inheritAll="true"/>
+            <myjavac>
+                <src path="${src.dir}"/>
+                <src path="${src.dest}"/>
+                <src path="${basedir}/generated"/>
+            </myjavac>
+        </else>
+        </if>
+    </target>
 
     <!-- = = = = = = = = = = = = = = = = =
           generate model

--- a/components/blitz/resources/beanRefContext.xml
+++ b/components/blitz/resources/beanRefContext.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" 
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
   "http://www.springframework.org/dtd/spring-beans.dtd">
 <beans>
   <description>
   Defines the contexts for the OMERO.blitz server. Other beanRefFactory.xmls may define
   other contexts.
   </description>
-  
+
   <bean    id="OMERO.blitz"
-    	  class="ome.system.OmeroContext"
-    	  lazy-init="true">
-	<constructor-arg index="0">
+           class="ome.system.OmeroContext"
+           lazy-init="true">
+    <constructor-arg index="0">
       <list>
         <value>classpath:ome/config.xml</value>
         <value>classpath:ome/services/messaging.xml</value>
         <value>classpath:ome/services/objectfactories.xml</value>
         <value>classpath:ome/services/throttling/throttling.xml</value>
-        <value>classpath*:ome/services/blitz-*.xml</value>   
+        <value>classpath*:ome/services/blitz-*.xml</value>
       </list>
     </constructor-arg>
     <constructor-arg index="1" value="true"/>
@@ -24,9 +24,9 @@
   </bean>
 
   <bean   id="OMERO.blitz.test"
-    	  class="ome.system.OmeroContext"
-    	  lazy-init="true">
-	<constructor-arg index="0">
+          class="ome.system.OmeroContext"
+          lazy-init="true">
+    <constructor-arg index="0">
       <list>
         <value>classpath:ome/config.xml</value>
         <value>classpath:ome/services/messaging.xml</value>
@@ -40,7 +40,7 @@
     </constructor-arg>
     <constructor-arg index="1" value="true"/>
   </bean>
-  
+
   <bean   id="OMERO.repository"
           class="ome.system.OmeroContext"
           lazy-init="true">
@@ -55,7 +55,7 @@
       </list>
     </constructor-arg>
   </bean>
-  
+
     <bean   id="OMERO.security.test"
           class="ome.system.OmeroContext"
           lazy-init="true">
@@ -66,5 +66,5 @@
       </list>
     </constructor-arg>
   </bean>
-  
+
 </beans>

--- a/components/blitz/resources/ome/services/blitz-repositories.xml
+++ b/components/blitz/resources/ome/services/blitz-repositories.xml
@@ -133,5 +133,15 @@
     <property name="cronExpression" value="${omero.scripts.cache.cron}"/>
     <property name="jobDetail" ref="paramsCacheRun"/>
   </bean>
+  <bean id="paramsCacheStartupRun" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="paramsCache" />
+    <property name="targetMethod" value="lookupAll" />
+  </bean>
+  <bean id="paramsCacheStartupTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    <property name="startDelay" value="15000"/>
+    <property name="repeatCount" value="0"/>
+    <property name="repeatInterval" value="86400000"/><!-- 1 day just in case -->
+    <property name="jobDetail" ref="paramsCacheStartupRun"/>
+  </bean>
 
 </beans>

--- a/components/blitz/resources/ome/services/blitz-repositories.xml
+++ b/components/blitz/resources/ome/services/blitz-repositories.xml
@@ -117,4 +117,21 @@
     <property name="repeatInterval" value="60000" />
   </bean>
 
+  <!-- Params caching logic, see trac:10661 -->
+
+  <bean id="paramsCache" class="ome.services.blitz.util.ParamsCache" lazy-init="false">
+      <constructor-arg ref="Registry"/>
+      <constructor-arg ref="roles"/>
+      <constructor-arg ref="scriptRepoHelper"/>
+      <constructor-arg value="${omero.scripts.cache.spec}"/>
+  </bean>
+  <bean id="paramsCacheRun" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="paramsCache" />
+    <property name="targetMethod" value="lookupAll" />
+  </bean>
+  <bean id="paramsCacheTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+    <property name="cronExpression" value="${omero.scripts.cache.cron}"/>
+    <property name="jobDetail" ref="paramsCacheRun"/>
+  </bean>
+
 </beans>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -119,6 +119,7 @@
             <constructor-arg ref="throttlingStrategy"/>
             <constructor-arg ref="TopicManager"/>
             <constructor-arg ref="Registry"/>
+            <constructor-arg ref="paramsCache"/>
             <constructor-arg ref="scriptRepoHelper"/>
             <constructor-arg value="${omero.grid.registry_timeout}"/>
             <constructor-arg value="${omero.scripts.timeout}"/>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -65,6 +65,7 @@
             <constructor-arg ref="throttlingStrategy"/>
             <constructor-arg ref="scriptRepoHelper"/>
             <constructor-arg ref="checksumProviderFactory"/>
+            <constructor-arg ref="paramsCache"/>
         </bean>
     </constructor-arg>
   </bean>

--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -183,6 +183,11 @@ module omero {
         const string NSVIEW = "openmicroscopy.org/omero/scripts/results/view";
 
         //
+        // omero.grid.JobParam.namespaces in Scripts.ice
+        //
+        const string NSDYNAMIC = "openmicroscopy.org/omero/scripts/job/dynamic";
+
+        //
         // modulo namespaces for <a href="http://www.openmicroscopy.org/site/support/ome-model/developers/6d-7d-and-8d-storage.html">6d-7d-and-8d-storage</a>
         //
         const string NSMODULO = "openmicroscopy.org/omero/dimension/modulo";

--- a/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
+++ b/components/blitz/src/ome/services/blitz/fire/SessionManagerI.java
@@ -297,8 +297,11 @@ public final class SessionManagerI extends Glacier2._SessionManagerDisp
                 SessionI.unregisterServant(curr.id, adapter, holder);
             } else if (event instanceof FindServiceFactoryMessage) {
                 FindServiceFactoryMessage msg = (FindServiceFactoryMessage) event;
-                Ice.Current curr = msg.getCurrent();
-                Ice.Identity id = getServiceFactoryIdentity(curr);
+                Ice.Identity id = msg.getIdentity();
+                if (id == null) {
+                    Ice.Current curr = msg.getCurrent();
+                    id = getServiceFactoryIdentity(curr);
+                }
                 ServiceFactoryI sf = getServiceFactory(id);
                 msg.setServiceFactory(id, sf);
             } else if (event instanceof DestroySessionMessage) {

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -411,7 +411,11 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
             final Current __current) throws ServerError {
         safeRunnableCall(__current, __cb, false, new Callable<Object>() {
             public Object call() throws Exception {
-                return cache.getParams(id);
+                final OriginalFile file = getOriginalFileOrNull(id, __current);
+                if (file == null) {
+                    return null;
+                }
+                return cache.getParams(id, file.getHash());
             }
         });
     }
@@ -710,7 +714,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
         try {
 
-            JobParams params = cache.getParams(file.getId());
+            JobParams params = cache.getParams(file.getId(), file.getHash());
 
             if (params == null) {
                 throw new ApiUsageException(null, null, "Script error: no params found.");

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -415,7 +415,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
                 if (file == null) {
                     return null;
                 }
-                return cache.getParams(id, file.getHash());
+                return cache.getParams(id, file.getHash(), __current);
             }
         });
     }
@@ -714,7 +714,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
         try {
 
-            JobParams params = cache.getParams(file.getId(), file.getHash());
+            JobParams params = cache.getParams(file.getId(), file.getHash(), __current);
 
             if (params == null) {
                 throw new ApiUsageException(null, null, "Script error: no params found.");

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -13,34 +13,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.apache.commons.io.FilenameUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.hibernate.Session;
-import org.springframework.transaction.annotation.Transactional;
-
-import Ice.Current;
-
 import ome.api.IUpdate;
 import ome.api.RawFileStore;
-import ome.api.local.LocalAdmin;
 import ome.model.core.OriginalFile;
 import ome.model.enums.ChecksumAlgorithm;
 import ome.services.blitz.util.BlitzExecutor;
 import ome.services.blitz.util.BlitzOnly;
+import ome.services.blitz.util.ParamsCache;
 import ome.services.blitz.util.ServiceFactoryAware;
-import ome.services.delete.Deletion;
-import ome.services.graphs.GraphException;
 import ome.services.scripts.RepoFile;
 import ome.services.scripts.ScriptRepoHelper;
 import ome.services.util.Executor;
 import ome.system.EventContext;
 import ome.system.ServiceFactory;
 import ome.tools.hibernate.QueryBuilder;
-import ome.util.Utils;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumType;
-
 import omero.ApiUsageException;
 import omero.RInt;
 import omero.RType;
@@ -63,7 +51,6 @@ import omero.api.AMD_IScript_validateScript;
 import omero.api._IScriptOperations;
 import omero.grid.InteractiveProcessorPrx;
 import omero.grid.JobParams;
-import omero.grid.ParamsHelper;
 import omero.grid.ParamsHelper.Acquirer;
 import omero.grid.ProcessPrx;
 import omero.grid.ProcessorPrx;
@@ -77,6 +64,14 @@ import omero.model.OriginalFileI;
 import omero.model.ScriptJob;
 import omero.model.ScriptJobI;
 import omero.util.IceMapper;
+
+import org.apache.commons.io.FilenameUtils;
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import Ice.Current;
 
 /**
  * implementation of the IScript service interface.
@@ -93,22 +88,22 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
     protected ServiceFactoryI factory;
 
-    protected ParamsHelper helper;
+    protected ParamsCache cache;
 
     protected final ScriptRepoHelper scripts;
 
     protected final ChecksumProviderFactory cpf;
 
     public ScriptI(BlitzExecutor be, ScriptRepoHelper scripts,
-            ChecksumProviderFactory cpf) {
+            ChecksumProviderFactory cpf, ParamsCache cache) {
         super(null, be);
         this.scripts = scripts;
         this.cpf = cpf;
+        this.cache = cache;
     }
 
     public void setServiceFactory(ServiceFactoryI sf) throws ServerError {
         this.factory = sf;
-        helper = new ParamsHelper(acquirer(), sf.getExecutor(), sf.getPrincipal());
     }
 
     protected Acquirer acquirer() throws ServerError {
@@ -414,7 +409,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
             final Current __current) throws ServerError {
         safeRunnableCall(__current, __cb, false, new Callable<Object>() {
             public Object call() throws Exception {
-                return helper.getOrCreateParams(id, __current);
+                return cache.getParams(id);
             }
         });
     }
@@ -713,7 +708,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
         try {
 
-            JobParams params = helper.getOrCreateParams(file.getId(), __current);
+            JobParams params = cache.getParams(file.getId());
 
             if (params == null) {
                 throw new ApiUsageException(null, null, "Script error: no params found.");

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -236,6 +236,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
                                 "Use editScript to modify existing official scripts.");
                     } else if (fileID != null) {
                         log.info("Overwriting existing non-script: " + fileID);
+                        cache.removeParams(fileID);
                     }
                     RepoFile f = scripts.write(path, scriptText);
                     OriginalFile file = scripts.addOrReplace(f, fileID);
@@ -288,6 +289,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
                 } else {
                     file = writeContent(file, scriptText, __current);
                 }
+                cache.removeParams(file.getId());
                 validateParams(__current, file);
                 return null; // void
             }

--- a/components/blitz/src/ome/services/blitz/impl/SharedResourcesI.java
+++ b/components/blitz/src/ome/services/blitz/impl/SharedResourcesI.java
@@ -20,6 +20,7 @@ import ome.services.blitz.fire.Registry;
 import ome.services.blitz.fire.TopicManager;
 import ome.services.blitz.util.BlitzExecutor;
 import ome.services.blitz.util.BlitzOnly;
+import ome.services.blitz.util.ParamsCache;
 import ome.services.blitz.util.ResultHolder;
 import ome.services.blitz.util.ServiceFactoryAware;
 import ome.services.scripts.ScriptRepoHelper;
@@ -95,6 +96,8 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
 
     private final ScriptRepoHelper helper;
 
+    private final ParamsCache paramsCache;
+
     /**
      * How long to wait for shared resources (e.g. TablesPrx) to respond to
      * requests.
@@ -112,23 +115,25 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
     private ServiceFactoryI sf;
 
     public SharedResourcesI(BlitzExecutor be, TopicManager topicManager,
-            Registry registry, ScriptRepoHelper helper) {
-        this(be, topicManager, registry, helper, 5000);
+            Registry registry, ScriptRepoHelper helper, ParamsCache cache) {
+        this(be, topicManager, registry, helper, cache, 5000);
     }
 
     public SharedResourcesI(BlitzExecutor be, TopicManager topicManager,
-                Registry registry, ScriptRepoHelper helper, long waitMillis) {
-        this( be, topicManager, registry, helper, waitMillis, DEFAULT_TIMEOUT);
+                Registry registry, ScriptRepoHelper helper, ParamsCache cache,
+                long waitMillis) {
+        this( be, topicManager, registry, helper, cache, waitMillis, DEFAULT_TIMEOUT);
     }
 
     public SharedResourcesI(BlitzExecutor be, TopicManager topicManager,
-                Registry registry, ScriptRepoHelper helper, long waitMillis,
-                long timeout) {
+                Registry registry, ScriptRepoHelper helper, ParamsCache cache,
+                long waitMillis, long timeout) {
         super(null, be);
         this.waitMillis = waitMillis;
         this.topicManager = topicManager;
         this.registry = registry;
         this.helper = helper;
+        this.paramsCache = cache;
         this.timeout = timeout;
         // In order to prevent overflow of currentTimeMillis+timeout and more
         // generally to prevent nonsensical timeouts, we limit to 1 year.
@@ -445,7 +450,7 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
 
         InteractiveProcessorI ip = new InteractiveProcessorI(sf.principal,
                 sf.sessionManager, sf.executor, server, job, timeout,
-                sf.control,
+                sf.control, paramsCache,
                 new ParamsHelper(this, sf.getExecutor(), sf.getPrincipal()),
                 helper, current);
         Ice.Identity procId = sessionedID("InteractiveProcessor");

--- a/components/blitz/src/ome/services/blitz/impl/SharedResourcesI.java
+++ b/components/blitz/src/ome/services/blitz/impl/SharedResourcesI.java
@@ -198,7 +198,6 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
                 throws ServerError;
     }
 
-    @SuppressWarnings("unchecked")
     private <U extends Ice.ObjectPrx> U lookup(long millis, List<Ice.ObjectPrx> objectPrxs,
             RepeatTask<U> task) throws ServerError {
 

--- a/components/blitz/src/ome/services/blitz/util/FindServiceFactoryMessage.java
+++ b/components/blitz/src/ome/services/blitz/util/FindServiceFactoryMessage.java
@@ -37,12 +37,26 @@ public class FindServiceFactoryMessage extends InternalMessage {
 
     protected transient ServiceFactoryI sf;
 
+    public FindServiceFactoryMessage(Object source, Ice.Identity id) {
+        super(source);
+        this.id = id;
+        this.curr = null;
+    }
+
     public FindServiceFactoryMessage(Object source, Ice.Current current) {
         super(source);
         this.curr = current;
     }
 
+    public Ice.Identity getIdentity() {
+        return this.id;
+    }
+
     public Ice.Current getCurrent() {
+        if (this.curr == null) {
+            throw new RuntimeException(
+                    "This instance was initialized with an Identity");
+        }
         return this.curr;
     }
 

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.blitz.util;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import ome.model.core.OriginalFile;
+import ome.services.blitz.fire.Registry;
+import ome.services.blitz.impl.ServiceFactoryI;
+import ome.services.scripts.ScriptRepoHelper;
+import ome.system.OmeroContext;
+import ome.system.Roles;
+import ome.tools.spring.OnContextRefreshedEventListener;
+import omero.ServerError;
+import omero.api.ServiceFactoryPrx;
+import omero.grid.JobParams;
+import omero.grid.ParamsHelper;
+import omero.grid.ParamsHelper.Acquirer;
+import omero.util.IceMapper;
+
+import org.perf4j.slf4j.Slf4JStopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import Ice.UserException;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+/**
+ * Caching replacement of {@link omero.grid.ParamsHelper} which maintains an
+ * {@link OriginalFile} ID-to-{@link JobParams} mapping in memory rather than
+ * storing ParseJob instances in the database. All scripts are read once on
+ * start and them subsequently based on the omero.scripts.cache.cron setting.
+ * {@link JobParams} instances may be removed from the cache based on the
+ * omero.scripts.cache.spec setting. If a key is not present in the cache on
+ * {@link #getParams(long)} then an attempt will be made to load it. Any
+ * exceptions thrown will be propagated to the callter.
+ *
+ * @since 5.1.2
+ */
+public class ParamsCache extends OnContextRefreshedEventListener implements
+        ApplicationContextAware {
+
+    private final static Logger log = LoggerFactory
+            .getLogger(ParamsCache.class);
+
+    private final LoadingCache<Long, JobParams> cache;
+
+    private final Registry reg;
+
+    private final Roles roles;
+
+    private final ScriptRepoHelper scripts;
+
+    private/* final */OmeroContext ctx;
+
+    public ParamsCache(Registry reg, Roles roles, ScriptRepoHelper scripts,
+            String spec) {
+        this.reg = reg;
+        this.roles = roles;
+        this.scripts = scripts;
+        this.cache = CacheBuilder.from(spec).build(
+                new CacheLoader<Long, JobParams>() {
+                    public JobParams load(Long key) throws Exception {
+                        return lookup(key);
+                    }
+                });
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext ctx)
+            throws BeansException {
+        this.ctx = (OmeroContext) ctx;
+    }
+
+    /**
+     * Called once on startup. This can typically take many minutes before
+     * being called, and usually takes a few seconds per script to be loaded.
+     */
+    @Override
+    public void handleContextRefreshedEvent(ContextRefreshedEvent event) {
+        new Thread() {
+            public void run() {
+                Slf4JStopWatch startup = sw("startup");
+                log.info("in handle");
+                try {
+                    lookupAll();
+                } catch (Throwable t) {
+                    throw new FatalBeanException("Failed to initially load", t);
+                } finally {
+                    startup.stop();
+                }
+            }
+        }.run();
+    }
+
+    //
+    // Public API
+    //
+
+    /**
+     * Lookup a cached {@link JobParams} instance for the given key. If none
+     * is present, then an attempt will be made to load one, possibly throwing
+     * a {@link UserException}.
+     *
+     * @param key
+     * @return
+     * @throws UserException
+     */
+    public JobParams getParams(long key) throws UserException {
+        Slf4JStopWatch get = sw("get." + Long.toString(key));
+        try {
+            return cache.get(key);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            UserException ue = new IceMapper().handleException(cause, ctx);
+            log.warn("Error on scripts cache lookup", ue);
+            throw ue;
+        } finally {
+            get.stop();
+        }
+    }
+
+    /**
+     * Called by the {@link LoadingCache} when a cache-miss occurs.
+     */
+    public JobParams lookup(Long key) throws Exception {
+        return _load(key);
+    }
+
+    /**
+     * Called from a Quartz cron trigger for periodically reloading all scripts.
+     */
+    public void lookupAll() throws Exception {
+        _load(null);
+    }
+
+    //
+    // HELPERS
+    //
+
+    private Slf4JStopWatch sw(String suffix) {
+        return new Slf4JStopWatch("omero.scripts.cache." + suffix);
+    }
+
+    /**
+     * Internal loading method which uses a {@link Loader} to create
+     * a session as root and perform the necessary script invocation.
+     */
+    private JobParams _load(Long key) throws Exception {
+        Slf4JStopWatch load = sw(key == null ? "all" : Long.toString(key));
+        Loader loader = null;
+        try {
+            Slf4JStopWatch login = sw("login");
+            try {
+                loader = new Loader();
+            } finally {
+                login.stop();
+            }
+
+            if (key != null) {
+                return loader.createParams(key);
+            } else {
+                Slf4JStopWatch list = sw("list");
+                List<OriginalFile> files = scripts.loadAll(true);
+                list.stop();
+                for (OriginalFile file : files) {
+                    Slf4JStopWatch single = sw(file.getId().toString());
+                    cache.put(file.getId(),
+                            loader.createParams(file.getId()));
+                    single.stop();
+                }
+                log.info("New size of scripts cache: {} ({} ms.)",
+                        cache.size(), load.getElapsedTime());
+                return null;
+            }
+        } finally {
+            load.stop();
+            if (loader != null) {
+                loader.close();
+            }
+        }
+    }
+
+    /** Simple state class for holding the various instances needed for
+     * logging in and creating a {@link JobParams} instance.
+     */
+    private class Loader {
+
+        ParamsHelper helper = null;
+        ServiceFactoryI sf = null;
+        Ice.Current curr = null;
+
+        Loader() throws Exception {
+            ServiceFactoryPrx prx = reg.getInternalServiceFactory(roles
+                .getRootName(), "unused", 3, 1, UUID.randomUUID()
+                .toString());
+            Ice.Identity id = prx.ice_getIdentity();
+            FindServiceFactoryMessage msg = new FindServiceFactoryMessage(
+                    this, id);
+            try {
+                ctx.publishMessage(msg);
+            } catch (Throwable t) {
+                throw new IceMapper().handleException(t, ctx);
+            }
+            sf = msg.getServiceFactory();
+            curr = sf.newCurrent(id, "loadScripts");
+
+            // From ScriptI.java
+            Acquirer acq = (Acquirer) sf.getServant(sf
+                    .sharedResources(null).ice_getIdentity());
+            helper = new ParamsHelper(acq, sf.getExecutor(),
+                    sf.getPrincipal());
+        }
+
+        JobParams createParams(Long key) throws ServerError {
+            return helper.generateScriptParams(key, false, curr);
+        }
+
+        void close() {
+            if (sf != null) {
+                sf.destroy(curr);
+            }
+        }
+
+    }
+
+}

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -176,6 +176,13 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
     }
 
     /**
+     * Remove a cached {@link JobParams} instance.
+     */
+    public void removeParams(Long id) {
+        cache.invalidate(id);
+    }
+
+    /**
      * Called by the {@link LoadingCache} when a cache-miss occurs.
      */
     public JobParams lookup(Long key) throws Exception {

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -338,6 +338,10 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
 
     }
 
+    /**
+     * Subclass for when no {@link Ice.Current} is available. Uses "root" as
+     * the login and creates a new session which <em>must</em> be closed.
+     */
     private static class RootLoader extends Loader {
 
         final String root;
@@ -382,6 +386,10 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
         }
     }
 
+    /**
+     * Simpler subclass which uses the {@link Ice.Current} stored within a
+     * {@link Key} instance.
+     */
     private static class UserLoader extends Loader {
 
         final Key key;
@@ -403,6 +411,12 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
         }
     }
 
+    /**
+     * Simple Set/Map-compatible class for storing instances based on a
+     * (Long, String) tuple. An additional possibly null {@link Ice.Current}
+     * instance can also be stored but will not effect {@link #equals(Object)}
+     * or {@link #hashCode()} calculation.
+     */
     private static class Key {
 
         final Long id;

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -316,7 +316,7 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
 
             // From ScriptI.java
             Acquirer acq = (Acquirer) sf.getServant(sf
-                    .sharedResources(null).ice_getIdentity());
+                    .sharedResources(getCurrent()).ice_getIdentity());
             helper = new ParamsHelper(acq, sf.getExecutor(),
                     sf.getPrincipal());
             return helper;

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -328,8 +328,9 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
          * a temporary loader with just that context.
          */
         JobParams createParams(Key key) throws Exception {
+            ParamsHelper helper = getHelper();
             Ice.Current curr = getCurrent();
-            return getHelper().generateScriptParams(key.id, false, curr);
+            return helper.generateScriptParams(key.id, false, curr);
         }
 
         abstract Ice.Current getCurrent();

--- a/components/blitz/src/ome/services/blitz/util/ParamsCache.java
+++ b/components/blitz/src/ome/services/blitz/util/ParamsCache.java
@@ -19,28 +19,20 @@
 
 package ome.services.blitz.util;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import ome.conditions.SecurityViolation;
 import ome.model.core.OriginalFile;
 import ome.services.blitz.fire.Registry;
 import ome.services.blitz.impl.ServiceFactoryI;
 import ome.services.scripts.ScriptRepoHelper;
-import ome.services.util.Executor;
 import ome.system.OmeroContext;
 import ome.system.Roles;
-import ome.system.ServiceFactory;
-import ome.tools.spring.OnContextRefreshedEventListener;
-import omero.ServerError;
 import omero.api.ServiceFactoryPrx;
-import omero.constants.GROUP;
 import omero.constants.namespaces.NSDYNAMIC;
 import omero.grid.JobParams;
 import omero.grid.ParamsHelper;
@@ -48,16 +40,12 @@ import omero.grid.ParamsHelper.Acquirer;
 import omero.model.ExperimenterGroupI;
 import omero.util.IceMapper;
 
-import org.hibernate.Session;
 import org.perf4j.slf4j.Slf4JStopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.FatalBeanException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.transaction.annotation.Transactional;
 
 import Ice.UserException;
 
@@ -77,8 +65,7 @@ import com.google.common.cache.LoadingCache;
  *
  * @since 5.1.2
  */
-public class ParamsCache extends OnContextRefreshedEventListener implements
-        ApplicationContextAware {
+public class ParamsCache implements ApplicationContextAware {
 
     /**
      * Thrown by {@link ParamsCache#_load(Long)} when a found
@@ -109,7 +96,8 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
 
     private/* final */OmeroContext ctx;
 
-    public ParamsCache(Registry reg, Roles roles, ScriptRepoHelper scripts,
+    public ParamsCache(Registry reg, Roles roles,
+            ScriptRepoHelper scripts,
             String spec) {
         this.reg = reg;
         this.roles = roles;
@@ -126,27 +114,6 @@ public class ParamsCache extends OnContextRefreshedEventListener implements
     public void setApplicationContext(ApplicationContext ctx)
             throws BeansException {
         this.ctx = (OmeroContext) ctx;
-    }
-
-    /**
-     * Called once on startup. This can typically take many minutes before
-     * being called, and usually takes a few seconds per script to be loaded.
-     */
-    @Override
-    public void handleContextRefreshedEvent(ContextRefreshedEvent event) {
-        new Thread() {
-            public void run() {
-                Slf4JStopWatch startup = sw("startup");
-                log.info("in handle");
-                try {
-                    lookupAll();
-                } catch (Throwable t) {
-                    throw new FatalBeanException("Failed to initially load", t);
-                } finally {
-                    startup.stop();
-                }
-            }
-        }.run();
     }
 
     //

--- a/components/blitz/src/omero/cmd/SessionI.java
+++ b/components/blitz/src/omero/cmd/SessionI.java
@@ -438,14 +438,8 @@ public class SessionI implements _SessionOperations {
                     // unregistered.
                     //
                     if (servant instanceof CloseableServant) {
-                        final Ice.Current __curr = new Ice.Current();
-                        __curr.id = id;
-                        __curr.adapter = adapter;
-                        __curr.operation = "close";
-                        __curr.ctx = new HashMap<String, String>();
-                        __curr.ctx.put(CLIENTUUID.value, clientId);
                         CloseableServant cs = (CloseableServant) servant;
-                        cs.close(__curr);
+                        cs.close(newCurrent(id, "close", adapter, clientId));
                     }
                     // Now ignoring all non-CloseableServants, since
                     // that is *the* interface that should be used
@@ -473,6 +467,21 @@ public class SessionI implements _SessionOperations {
         if (obj instanceof SessionAware) {
             ((SessionAware) obj).setSession(this);
         }
+    }
+
+    public static Ice.Current newCurrent(Ice.Identity id, String method,
+            Ice.ObjectAdapter adapter, String clientId) {
+        final Ice.Current __curr = new Ice.Current();
+        __curr.id = id;
+        __curr.adapter = adapter;
+        __curr.operation = method;
+        __curr.ctx = new HashMap<String, String>();
+        __curr.ctx.put(CLIENTUUID.value, clientId);
+        return __curr;
+    }
+
+    public Ice.Current newCurrent(Ice.Identity id, String method) {
+        return newCurrent(id, method, adapter, clientId);
     }
 
     public void allow(Ice.ObjectPrx prx) {

--- a/components/blitz/src/omero/grid/ParamsHelper.java
+++ b/components/blitz/src/omero/grid/ParamsHelper.java
@@ -191,6 +191,7 @@ public class ParamsHelper {
                 secSys.runAsAdmin(new AdminAction(){
                     public void runAsAdmin() {
                         session.delete(parseJob);
+                        session.flush();
                     }});
                 return null;
             }

--- a/components/blitz/src/omero/grid/ParamsHelper.java
+++ b/components/blitz/src/omero/grid/ParamsHelper.java
@@ -21,9 +21,9 @@ import omero.model.OriginalFileI;
 import omero.model.ParseJob;
 import omero.model.ParseJobI;
 
+import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.hibernate.Session;
 import org.springframework.transaction.annotation.Transactional;
 
 import Ice.Current;
@@ -54,6 +54,10 @@ public class ParamsHelper {
         this.secSys = // FIXME REFACTOR
             (SecuritySystem) ex.getContext().getBean("securitySystem");
     }
+
+    //
+    // HELPER
+    //
 
     /**
      * Build a job for the script with id.
@@ -128,6 +132,16 @@ public class ParamsHelper {
 
     JobParams generateScriptParams(long id, Ice.Current __current)
             throws ServerError {
+       return generateScriptParams(id, true, __current);
+    }
+
+    /**
+     * Acquires an {@link InteractiveProcessorPrx} and runs a {@link ParseJob}.
+     * If the "save" argument is true, then the {@link JobParams} instance will
+     * be saved to the database; otherwise, the {@link ParseJob} will be deleted.
+     */
+    public JobParams generateScriptParams(long id, boolean save, Ice.Current __current)
+            throws ServerError {
 
         ParseJob job = buildParseJob(id);
         InteractiveProcessorPrx proc = acq.acquireProcessor(job, 10, __current);
@@ -137,8 +151,12 @@ public class ParamsHelper {
 
         job = (ParseJob) proc.getJob(__current.ctx);
         final JobParams rv = proc.params(__current.ctx);
-        // Guaranteed non-null for a parse job
-        saveScriptParams(rv, job, __current);
+        if (save) {
+            // Guaranteed non-null for a parse job
+            saveScriptParams(rv, job, __current);
+        } else {
+            deleteScriptParams(job, __current);
+        }
         return rv;
     }
 
@@ -156,6 +174,23 @@ public class ParamsHelper {
                 secSys.runAsAdmin(new AdminAction(){
                     public void runAsAdmin() {
                         session.flush();
+                    }});
+                return null;
+            }
+        });
+    }
+
+    void deleteScriptParams(final ParseJob job, Ice.Current __current)
+            throws ServerError {
+
+        ex.execute(__current.ctx, p, new Executor.SimpleWork(this, "deleteScriptParams", job.getId().getValue()) {
+            @Transactional(readOnly = false)
+            public Object doWork(final Session session, final ServiceFactory sf) {
+                final ome.model.jobs.ParseJob parseJob = sf.getQueryService().get(
+                        ome.model.jobs.ParseJob.class, job.getId().getValue());
+                secSys.runAsAdmin(new AdminAction(){
+                    public void runAsAdmin() {
+                        session.delete(parseJob);
                     }});
                 return null;
             }

--- a/components/server/src/ome/services/scheduler/SchedulerFactoryBean.java
+++ b/components/server/src/ome/services/scheduler/SchedulerFactoryBean.java
@@ -12,15 +12,14 @@ import java.util.Map;
 
 import ome.tools.spring.OnContextRefreshedEventListener;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.scheduling.SchedulingException;

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -524,11 +524,12 @@ client.closeSession()
 
     def testDynamic(self):
         DYNAMIC = """if True:
-        import omero.constants as OC
+        import omero.all  # For constants
+        import omero.constants.namespaces as OCN
         import omero.grid as OG
         import omero.scripts as OS
         job = OG.JobParams(name="testDynamic",
-                           namespaces=[OC.namespaces.NSDYNAMIC])
+                           namespaces=[OCN.NSDYNAMIC])
         c = OS.client(job)
         """
         CACHED = """if True:

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -634,7 +634,8 @@ if __name__ == '__main__':
         svc = self.client.sf.getScriptService()
         rsvc = self.root.sf.getScriptService()
         script = rsvc.uploadOfficialScript(
-                "/test/dynamic/dyn%s.py" % self.uuid(), SCRIPT)
+            "/test/dynamic/dyn%s.py" % self.uuid(), SCRIPT)
+        update = self.client.sf.getUpdateService()
 
         def contains_uuids(u1, u2):
             params = svc.getParams(script)
@@ -643,7 +644,7 @@ if __name__ == '__main__':
             assert u2 == any([(uuid2 in x) for x in datasets])
 
         contains_uuids(False, False)
-        d1 = self.new_dataset(name=uuid1)
+        update.saveObject(self.new_dataset(name=uuid1))
         contains_uuids(True, False)
-        d2 = self.new_dataset(name=uuid2)
+        update.saveObject(self.new_dataset(name=uuid2))
         contains_uuids(True, True)

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -580,10 +580,9 @@ def get_params():
         client.createSession()
         conn = omero.gateway.BlitzGateway(client_obj=client)
         conn.SERVICE_OPTS.setOmeroGroup(-1)
-        objparams = [rstring('Dataset:%d %s' % (d.id, d.getName()))
-                     for d in conn.getObjects('Dataset')]
+        objparams = [rstring(d.getName()) for d in conn.getObjects('Dataset')]
         if not objparams:
-            objparams = [rstring('<No objects found> %s' % datetime.now())]
+            objparams = [rstring('<No objects found>')]
         return objparams
     except Exception as e:
         return ['Exception: %s' % e]
@@ -594,8 +593,6 @@ def get_params():
 def runScript():
     "The main entry point of the script"
 
-    startTime = datetime.now()
-    # objparams = [str(datetime.now()) for n in xrange(2)]
     objparams = get_params()
 
     client = scripts.client(
@@ -614,14 +611,7 @@ def runScript():
 
     try:
         scriptParams = client.getInputs(unwrap=True)
-        message = ''
-        message += 'Params: %s\\n' % scriptParams
-
-        stopTime = datetime.now()
-        message += 'Parameters time: %s\\n' % str(paramsTime - startTime)
-        message += 'Processing time: %s\\n' % str(stopTime - paramsTime)
-
-        print message
+        message = 'Params: %s\\n' % scriptParams
         client.setOutput('Message', rstring(str(message)))
 
     finally:
@@ -640,8 +630,8 @@ if __name__ == '__main__':
         def contains_uuids(u1, u2):
             params = svc.getParams(script)
             datasets = unwrap(params.inputs["Object"].values)
-            assert u1 == any([(uuid1 in x) for x in datasets])
-            assert u2 == any([(uuid2 in x) for x in datasets])
+            assert u1 == (uuid1 in datasets)
+            assert u2 == (uuid2 in datasets)
 
         contains_uuids(False, False)
         update.saveObject(self.new_dataset(name=uuid1))

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -633,8 +633,21 @@ if __name__ == '__main__':
             assert u1 == (uuid1 in datasets)
             assert u2 == (uuid2 in datasets)
 
+        def run_with_param(param):
+            process = svc.runScript(script, {'Object': wrap(param)}, None)
+            cb = omero.scripts.ProcessCallbackI(self.client, process)
+            while cb.block(500) is None:
+                pass
+            cb.close()
+
         contains_uuids(False, False)
+        with pytest.raises(omero.ValidationException):
+            run_with_param(uuid1)
+
         update.saveObject(self.new_dataset(name=uuid1))
         contains_uuids(True, False)
+        run_with_param(uuid1)
+
         update.saveObject(self.new_dataset(name=uuid2))
         contains_uuids(True, True)
+        run_with_param(uuid2)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -181,6 +181,20 @@ omero.process.python=omero.processor.ProcessI
 omero.process.jython=omero.processor.ProcessI
 omero.process.matlab=omero.processor.MATLABProcessI
 
+# Frequency to reload script params. By default,
+# once a day.
+#
+# |cron|
+omero.scripts.cache.cron=0 0 * * * ?
+
+# Guava LoadingCache spec for configuring how
+# many script JobParams will be kept in memory
+# for how long.
+#
+# For more information, see
+# http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html
+omero.scripts.cache.spec=maximumSize=1000
+
 #############################################
 ## JVM configuration
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -182,10 +182,10 @@ omero.process.jython=omero.processor.ProcessI
 omero.process.matlab=omero.processor.MATLABProcessI
 
 # Frequency to reload script params. By default,
-# once a day.
+# once a day at midnight.
 #
 # |cron|
-omero.scripts.cache.cron=0 0 * * * ?
+omero.scripts.cache.cron=0 0 0 * * ?
 
 # Guava LoadingCache spec for configuring how
 # many script JobParams will be kept in memory


### PR DESCRIPTION
See: http://trac.openmicroscopy.org.uk/ome/ticket/10661#comment:7

#### Background ####

An interesting recent bug lead to the review of the `JobParams` creation. The user-4 on merge/trout was receiving an exception when trying to run `Make_Movie.py` since the chosen color was not a member of a list of the form `["White", "Red", None, "Black", None, None, None]`. What seems to have happened is that some exception (`OutOfMemory`?) caused the params themselves to be corrupted. The reason that this was only happening for user-4 (and his/her group) was that `JobParams` were being created **per group**. This unnecessary overhead was a secondary bug.

#### Implementation ####

Rather than trying to fix the 2 underlying bugs caused by caching params for each group (and trying to clean up old params, etc.), ticket 10661 suggested reloading all scripts on server start-up. This is now possible along with 2 configuration options under the `omero.scripts.cache.` namespace:

 * `spec` determines the settings for the Guava cache, i.e. how quickly will the objects be freed from memory
 * `cron` how often will a full reloading of all the scripts be attempted. One run is always performed on startup so that the initial access by any user is not delayed.

#### Functional differences ####

 * The general user should notice no differences in behavior.
 * Developers will notice that `parsejob` instances are no longer being persisted. This could conceivably be viewed as a breaking change, but considering that the job itself consists of a byte array containing the serialized form of an Ice object, it's unlikely this was of use.
 * Any script with the namespace "dynamic" (TBD) will **not** be cached, and instead will be reprocessed on each invocation. This will include sizeable overhead.
 * (**Planned**) Disabling the new configuration options will rollback to using the previous `ParamsHelper` method of storing `parsejobs` in the database.

cc: @manics @pwalczysko @rleigh-dundee @ctrueden 