### PR TITLE
Comment Delete2 dryRun

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -254,6 +254,7 @@ class TestDelete(lib.ITest):
         command = Delete2(targetObjects={"ImageAnnotationLink": linkIds})
         handle = self.client.sf.submit(command)
         self.waitOnCmd(self.client, handle)
+        handle.close()
 
         # Delete Dry Run...
         command = Delete2(targetObjects={"CommentAnnotation": [cid]},
@@ -279,6 +280,7 @@ class TestDelete(lib.ITest):
         command = Delete2(targetObjects={"CommentAnnotation": [cid]})
         handle = self.client.sf.submit(command)
         self.waitOnCmd(self.client, handle)
+        handle.close()
         assert not self.query.find("CommentAnnotation", cid)
 
     def test3639(self):

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -263,6 +263,7 @@ class TestDelete(lib.ITest):
 
         # ...Should tell us that remaining links will be deleted
         rsp = handle.getResponse()
+        handle.close()
         assert ('ome.model.annotations.ImageAnnotationLink'
                 in rsp.deletedObjects)
         links = rsp.deletedObjects['ome.model.annotations.ImageAnnotationLink']

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1263,10 +1263,9 @@ class BaseContainer(BaseController):
                 cid = self.comment.getId()
                 command = Delete2(targetObjects={"CommentAnnotation": [cid]},
                                   dryRun=True)
-                handle = self.conn.c.sf.submit(command)
-                self.conn._waitOnCmd(handle)
+                cb = self.conn.c.submit(command)
                 # ...to check for any remaining links
-                rsp = handle.getResponse()
+                rsp = cb.getResponse()
                 for parentType in ["Project", "Dataset", "Image", "Screen",
                                    "Plate", "PlateAcquisition", "Well"]:
                     key = 'ome.model.annotations.%sAnnotationLink' % parentType

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -28,6 +28,7 @@ from omero.rtypes import rstring, rlong, unwrap
 from django.conf import settings
 from django.utils.encoding import smart_str
 import logging
+from omero.cmd import Delete2
 
 from webclient.controller import BaseController
 
@@ -1257,11 +1258,19 @@ class BaseContainer(BaseController):
                         self.conn.deleteObjectDirect(al._obj)
                 # if comment is orphan, delete it directly
                 orphan = True
+
+                # Use delete Dry Run...
+                cid = self.comment.getId()
+                command = Delete2(targetObjects={"CommentAnnotation": [cid]},
+                                  dryRun=True)
+                handle = self.conn.c.sf.submit(command)
+                self.conn._waitOnCmd(handle)
+                # ...to check for any remaining links
+                rsp = handle.getResponse()
                 for parentType in ["Project", "Dataset", "Image", "Screen",
                                    "Plate", "PlateAcquisition", "Well"]:
-                    annLinks = list(self.conn.getAnnotationLinks(
-                        parentType, ann_ids=[self.comment.id]))
-                    if len(annLinks) > 0:
+                    key = 'ome.model.annotations.%sAnnotationLink' % parentType
+                    if key in rsp.deletedObjects:
                         orphan = False
                         break
                 if orphan:

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1266,6 +1266,7 @@ class BaseContainer(BaseController):
                 cb = self.conn.c.submit(command)
                 # ...to check for any remaining links
                 rsp = cb.getResponse()
+                cb.close(True)
                 for parentType in ["Project", "Dataset", "Image", "Screen",
                                    "Plate", "PlateAcquisition", "Well"]:
                     key = 'ome.model.annotations.%sAnnotationLink' % parentType

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -106,12 +106,16 @@
                                   $.jstree.rollback(data.rlbk);
                                   alert(r.errs);
                               } else {
-                                  OME.clear_selected(true);   // clear center and right panels etc
-                                  datatree.delete_node(selected);
-                                  if (type_str.indexOf('Plate Run') === -1) {
-                                    // If not 'Run', then select parent. See ticket #12860
+                                  // If deleting 'Plate Run', clear selection
+                                  if (type_str.indexOf('Plate Run') > -1) {
+                                    OME.clear_selected(true);
+                                  } else {
+                                    // otherwise, select parent
+                                    OME.tree_selection_changed();   // clear center and right panels etc
                                     first_parent.children("a").click();
                                   }
+                                  // remove node from tree
+                                  datatree.delete_node(selected);
                                   OME.refreshActivities();
                               }
                         },


### PR DESCRIPTION
This is a slight improvement to the way we handle Comment deletion.

When a Comment is removed from an object, we need to check whether it is linked to any other objects. If it isn't then we delete the Comment itself.

Previously, we simply looked up links to Projects, Datasets, Images etc in turn.
Now, we use a Delete2 with ```dryRun = True``` to see if the Comment delete would have deleted any links to P/D/I etc.

To test, select several objects, add a Comment.
Then remove the comment from each in turn, checking the DB to see that it is deleted only after being removed from last object.

Also added integration test for this behaviour. 