### PR TITLE
Delete refresh centre

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -1,5 +1,10 @@
 *** Keywords ***
 
+Click Dialog Button
+    [Arguments]     ${buttonText}
+    # Confirm dialog (make sure we pick the currently visible dialog)
+    Click Element                           xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//button/span[contains(text(), '${buttonText}')]
+
 Xpath Should Have Class
     [Arguments]         ${identifier}   ${className}
     Page Should Contain Element    ${identifier}

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -47,6 +47,13 @@ do
   done
 done
 
+# Create Dataset with images for deleting
+delDs=$(bin/omero obj new Dataset name='Delete')
+for (( k=1; k<=5; k++ ))
+do
+  bin/omero import -d $delDs test.fake --debug ERROR
+done
+
 # Logout
 bin/omero logout
 

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -1,0 +1,82 @@
+*** Settings ***
+Documentation     Tests delete of Projects, Datasets, Images
+
+Resource          ../../resources/config.txt
+Resource          ../../resources/web/login.txt
+Resource          ../../resources/web/tree.txt
+
+Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Teardown      Close all browsers
+
+
+*** Variables ***
+
+${thumbnailsXpath}      //ul[@id='dataIcons']//div[contains(@class, 'image')]
+
+
+*** Test Cases ***
+
+Test Delete Project
+    [Documentation]     Create and Delete a Project
+
+    Select Experimenter
+    ${pid}=                                 Create project      robot test delete
+    Click Element                           refreshButton
+    Wait Until Page Contains Element        id=project-${pid}
+    Click Element                           id=deleteButton
+    Wait Until Element Is Visible           id=delete-dialog-form
+    Click Dialog Button                     Yes
+    # On POST success, Experimenter should be selected and project removed from tree
+    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
+    Page Should Not Contain Element         id=project-${pid}
+
+
+Test Delete Project Dataset
+    [Documentation]     Create and Delete a Project containing a Dataset
+
+    # Clear any activities from earlier tests etc.
+    Click Element                           id=launch_activities
+    Click Element                           id=clear_activities
+    Select Experimenter
+    ${pid}=                                 Create project      robot test delete
+    ${did}=                                 Create Dataset      robot test deleteChildren
+    Click Element                           refreshButton
+    Wait Until Page Contains Element        id=project-${pid}
+    Click Element                           css=#project-${pid}>a
+    Click Element                           id=deleteButton
+    Wait Until Element Is Visible          id=delete-dialog-form
+    Click Dialog Button                     Yes
+    # Wait for activities to show job done, then refresh tree...
+    Wait Until Page Contains Element        xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
+    Click Element                           refreshButton
+    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
+    Page Should Not Contain Element         id=project-${pid}
+    # Dataset should be Deleted too
+    Page Should Not Contain Element         id=dataset-${did}
+
+
+Test Delete Images in Dataset
+    [Documentation]     Deletes images pre-imported into a dataset named "Delete"
+
+    Select Experimenter
+    # Click on Dataset, wait for thumbnails and count them
+    Click Element                           xpath=//div[@id='dataTree']//li[contains(@rel, 'dataset')]/a[contains(text(), 'Delete')]
+    Wait Until Page Contains Element        id=dataIcons
+    ${thumbCount}=                          Get Matching Xpath Count     ${thumbnailsXpath}
+    # Click first image in Tree
+    Click Element                           xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]/a
+    Click Element                           id=deleteButton
+    Wait Until Element Is Visible           id=delete-dialog-form
+    Click Dialog Button                     Yes
+    # Should see almost instant removal of 1 thumbnail...
+    ${delThumbCount}=                       Evaluate   ${thumbCount} - 1
+    Wait Until Keyword Succeeds             1   0.1   Xpath Should Match X Times   ${thumbnailsXpath}   ${delThumbCount}
+    # ...Need to check that centre panel doesn't reload and show image during delete: #12866
+    Sleep                                   5
+    Xpath Should Match X Times   ${thumbnailsXpath}   ${delThumbCount}
+
+
+
+
+
+

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -10,45 +10,6 @@ Suite Teardown      Close all browsers
 
 *** Test Cases ***
 
-Test Delete Project
-    [Documentation]     Create and Delete a Project
-
-    Select Experimenter
-    ${pid}=                                 Create project      robot test delete
-    Click Element                           refreshButton
-    Wait Until Page Contains Element        id=project-${pid}
-    Click Element                           id=deleteButton
-    Wait Until Page Contains Element        id=delete-dialog-form
-    Click Element                           xpath=//button/span[contains(text(),'Yes')]
-    # On POST success, Experimenter should be selected and project removed from tree
-    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
-    Page Should Not Contain Element         id=project-${pid}
-
-
-Test Delete Project Dataset
-    [Documentation]     Create and Delete a Project containing a Dataset
-
-    # Clear any activities from earlier tests etc.
-    Click Element                           id=launch_activities
-    Click Element                           id=clear_activities
-    Select Experimenter
-    ${pid}=                                 Create project      robot test delete
-    ${did}=                                 Create Dataset      robot test deleteChildren
-    Click Element                           refreshButton
-    Wait Until Page Contains Element        id=project-${pid}
-    Click Element                           css=#project-${pid}>a
-    Click Element                           id=deleteButton
-    Wait Until Page Contains Element        id=delete-dialog-form
-    Click Element                           xpath=//button/span[contains(text(),'Yes')]
-    # Wait for activities to show job done, then refresh tree...
-    Wait Until Page Contains Element        xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
-    Click Element                           refreshButton
-    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
-    Page Should Not Contain Element         id=project-${pid}
-    # Dataset should be Deleted too
-    Page Should Not Contain Element         id=dataset-${did}
-
-
 Test Edit Project
     [Documentation]     Create a Project and edit its name and description
 

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -50,16 +50,12 @@ Wait For Image Panel
     ${imageId}=                             Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
     [Return]                                ${imageId}
 
-Click Dialog OK
-    # Confirm dialog (make sure we pick the currently visible dialog)
-    Click Element                           xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//button/span[contains(text(), 'OK')]
-
 Right Click Rendering Settings
     [Arguments]            ${treeId}        ${optionText}
     Open Context Menu                       xpath=//li[@id='${treeId}']/a
     Mouse Over                              xpath=//div[@id='vakata-contextmenu']//a[@rel='renderingsettings']
     Click Element                           xpath=//div[@id='vakata-contextmenu']//a[contains(text(), "${optionText}")]
-    Click Dialog OK
+    Click Dialog Button                     OK
 
 *** Test Cases ***
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -106,12 +106,16 @@
                                   $.jstree.rollback(data.rlbk);
                                   alert(r.errs);
                               } else {
-                                  OME.clear_selected(true);   // clear center and right panels etc
-                                  datatree.delete_node(selected);
-                                  if (type_str.indexOf('Plate Run') === -1) {
-                                    // If not 'Run', then select parent. See ticket #12860
+                                  // If deleting 'Plate Run', clear selection
+                                  if (type_str.indexOf('Plate Run') > -1) {
+                                    OME.clear_selected(true);
+                                  } else {
+                                    // otherwise, select parent
+                                    OME.tree_selection_changed();   // clear center and right panels etc
                                     first_parent.children("a").click();
                                   }
+                                  // remove node from tree
+                                  datatree.delete_node(selected);
                                   OME.refreshActivities();
                               }
                         },


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12866

To test:
 - Delete an image in a Dataset
 - Dataset should become selected but centre panel should NOT reload (thumbnail should simply disappear).

NB: this bug was a result of recent PR https://github.com/openmicroscopy/openmicroscopy/pull/3784

Also added Robot tests which includes changes to the setup script to import a number of images for deletion.