### PR TITLE
Order: 'Model',  'Manufacturer'

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/forms.py
@@ -882,7 +882,7 @@ class MetadataDichroicForm(forms.Form):
             set_widget_attrs(self.fields['lotNumber'])
 
         self.fields.keyOrder = [
-            'manufacturer', 'model', 'serialNumber', 'lotNumber']
+            'model', 'manufacturer', 'serialNumber', 'lotNumber']
 
 
 class MetadataMicroscopeForm(forms.Form):
@@ -1878,7 +1878,7 @@ class MetadataFilterForm(forms.Form):
             set_widget_attrs(self.fields['transmittance'])
 
         self.fields.keyOrder = [
-            'manufacturer', 'model', 'serialNumber', 'lotNumber', 'type',
+            'model', 'manufacturer', 'serialNumber', 'lotNumber', 'type',
             'filterWheel', 'cutIn', 'cutOut', 'cutInTolerance',
             'cutOutTolerance', 'transmittance']
 
@@ -2256,7 +2256,7 @@ class MetadataDetectorForm(forms.Form):
             set_widget_attrs(self.fields['binning'])
 
         self.fields.keyOrder = [
-            'manufacturer', 'model', 'serialNumber', 'lotNumber', 'type',
+            'model', 'manufacturer', 'serialNumber', 'lotNumber', 'type',
             'gain', 'voltage', 'offsetValue', 'zoom', 'amplificationGain',
             'readOutRate', 'binning']
 
@@ -2713,7 +2713,7 @@ class MetadataLightSourceForm(forms.Form):
         set_widget_attrs(self.fields['attenuation'])
 
         self.fields.keyOrder = [
-            'manufacturer', 'model', 'serialNumber', 'lotNumber', 'power',
+            'model', 'manufacturer', 'serialNumber', 'lotNumber', 'power',
             'lstype', 'pump', 'lmedium', 'wavelength',
             'frequencyMultiplication', 'tuneable', 'pulse', 'repetitionRate',
             'pockelCell', 'attenuation']


### PR DESCRIPTION
From https://trello.com/c/ScEErwT9/222-5-1-2-follow-up

Web does same as Insight and displays "Model" then "Manufacturer" in that order for all acquisition metadata objects.
This fixes it in Dichroic, Microscope, Detector and LightSource.
To test:
 - View metadata and check 1 or more of the above objects.
 - May need to "Show Unset Fields"
 - Should see Model, then Manufacturer (as in Insight)

Screenshot is 1h.oib.

![screen shot 2015-05-06 at 14 47 29](https://cloud.githubusercontent.com/assets/900055/7494354/0a0e149a-f3ff-11e4-9ce4-a4f0a30e68d3.png)
