### PR TITLE
Viewer interpolate for big images

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -201,10 +201,14 @@ jQuery.fn.viewportImage = function(options) {
     };
 
     this.setPixelated = function (pixelated) {
+      // Handle images for regular viewer and big image viewer
+      var $tiledViewer = $(".viewer", wrapdiv);
       if (pixelated) {
         image.addClass("pixelated");
+        $tiledViewer.addClass("pixelated");
       } else {
         image.removeClass("pixelated");
+        $tiledViewer.removeClass("pixelated");
       }
     };
 


### PR DESCRIPTION
This extends the Interpolate / pixelate effect to the big image viewer which was missed in #3772.

To test, zoom in to max (400%) in the big image viewer, then toggle the ```Interpolate``` checkbox and see if the image becomes pixelated when Interpolate is off.
This is kinda subtle since the max zoom is only 400%.