### PR TITLE
LDAP-support for group-owners

### DIFF
--- a/components/server/resources/ome/services/service-ome.api.ILdap.xml
+++ b/components/server/resources/ome/services/service-ome.api.ILdap.xml
@@ -54,6 +54,7 @@
       <constructor-arg index="5" value="${omero.ldap.group_mapping}" />
       <constructor-arg index="6" value="${omero.ldap.sync_on_login}" />
       <constructor-arg index="7" value="${omero.ldap.base}"/>
+      <constructor-arg index="8" value="${omero.ldap.new_user_group_owner}"/>
     </bean>
 
 	<bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">

--- a/components/server/src/ome/logic/LdapImpl.java
+++ b/components/server/src/ome/logic/LdapImpl.java
@@ -660,7 +660,11 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
         for (Long id : ldapExperimenters) {
             Map<String, Object> values = Maps.newHashMap();
             // This will break whenever the mapping in AdminI changes
-            values.put("dn", lookupLdapAuthExperimenter(id));
+            try {
+                values.put("dn", lookupLdapAuthExperimenter(id));
+            } catch (ApiUsageException aue) {
+                values.put("dn", "ERROR");
+            }
             values.put("experimenter_id", id);
             rv.add(values);
         }

--- a/components/server/src/ome/logic/LdapImpl.java
+++ b/components/server/src/ome/logic/LdapImpl.java
@@ -507,7 +507,8 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
                     false);
             long uid = provider.createExperimenter(exp, grp1, grpOther);
             for (Long toBeOwned : ownerOfGroups) {
-                provider.setGroupOwner(exp,
+                provider.setGroupOwner(
+                        new Experimenter(uid, false),
                         new ExperimenterGroup(toBeOwned, false), true);
             }
             return iQuery.get(Experimenter.class, uid);

--- a/components/server/src/ome/logic/LdapImpl.java
+++ b/components/server/src/ome/logic/LdapImpl.java
@@ -42,6 +42,7 @@ import ome.security.auth.GroupAttributeMapper;
 import ome.security.auth.GroupContextMapper;
 import ome.security.auth.LdapConfig;
 import ome.security.auth.NewUserGroupBean;
+import ome.security.auth.NewUserGroupOwnerBean;
 import ome.security.auth.OrgUnitNewUserGroupBean;
 import ome.security.auth.PersonContextMapper;
 import ome.security.auth.QueryNewUserGroupBean;
@@ -295,7 +296,9 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
         Experimenter ldapExp = findExperimenter(username);
         String ldapDN = getPersonContextMapper().getDn(ldapExp);
         DistinguishedName dn = new DistinguishedName(ldapDN);
-        List<Long> ldapGroups = loadLdapGroups(username, dn);
+        GroupLoader loader = new GroupLoader(username, dn);
+        List<Long> ldapGroups = loader.getGroups();
+        List<Long> ownedGroups = loader.getOwnedGroups();
         List<Object[]> currentGroups = iQuery
                 .projection(
                         "select g.id, g.ldap from ExperimenterGroup g "
@@ -315,6 +318,13 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
         modifyGroups(omeExp, currentLdapGroups, ldapGroups, false);
         // All the ldapGroups not in currentLdapGroups should be added.
         modifyGroups(omeExp, ldapGroups, currentLdapGroups, true);
+        // Then for all remaining groups, set the ownership flag based
+        // on ownedGroups
+        for (Long ldapGroupId : ldapGroups) {
+            provider.setGroupOwner(omeExp,
+                    new ExperimenterGroup(ldapGroupId, false),
+                    ownedGroups.contains(ldapGroupId));
+        }
 
         List<String> fields = Arrays.asList(Experimenter.FIRSTNAME,
                 Experimenter.MIDDLENAME, Experimenter.LASTNAME,
@@ -474,7 +484,9 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
         }
 
         if (access) {
-            List<Long> groups = loadLdapGroups(username, dn);
+            GroupLoader loader = new GroupLoader(username, dn);
+            List<Long> groups = loader.getGroups();
+            List<Long> ownerOfGroups = loader.getOwnedGroups();
 
             if (groups.size() == 0) {
                 throw new ValidationException("No group found for: " + dn);
@@ -494,6 +506,10 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
             grpOther[count] = new ExperimenterGroup(roles.getUserGroupId(),
                     false);
             long uid = provider.createExperimenter(exp, grp1, grpOther);
+            for (Long toBeOwned : ownerOfGroups) {
+                provider.setGroupOwner(exp,
+                        new ExperimenterGroup(toBeOwned, false), true);
+            }
             return iQuery.get(Experimenter.class, uid);
         } else {
             return null;
@@ -506,54 +522,100 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
             "dn_attribute|filtered_dn_attribute|" +
             "query|bean):(.*)$");
 
+    @Deprecated // Use GroupLoader to handle ownership
     public List<Long> loadLdapGroups(String username, DistinguishedName dn) {
-        final String grpSpec = config.getNewUserGroup();
-        final List<Long> groups = new ArrayList<Long>();
+        return new GroupLoader(username, dn).getGroups();
+    }
 
-        if (!grpSpec.startsWith(":")) {
-            // The default case is the original logic: use the spec as name
-            groups.add(provider.createGroup(grpSpec, null, false, true));
-            return groups; // EARLY EXIT!
+    /**
+     * Data class which stores the state of the {@link NewUserGroupBean} and
+     * {@link NewUserGroupOwnerBean} operations.
+     */
+    public class GroupLoader {
+
+        final String username;
+        final DistinguishedName dn;
+        final String grpSpec;
+        final List<Long> groups;
+        final List<Long> ownedGroups;
+        final NewUserGroupBean bean;
+        final AttributeSet attrSet;
+
+        /**
+         * Return the found groups for the given username.
+         * @return Never null.
+         */
+        List<Long> getGroups() {
+            return groups;
         }
 
-        final Matcher m = p.matcher(grpSpec);
-        if (!m.matches()) {
-            throw new ValidationException(grpSpec
-                    + " spec currently not supported.");
+        /**
+         * Return the found owned groups for the given username.
+         * @return Never null.
+         */
+        public List<Long> getOwnedGroups() {
+            return ownedGroups;
         }
 
-        final String type = m.group(1);
-        final String data = m.group(2);
-        NewUserGroupBean bean = null;
-        AttributeSet attrSet = null;
+        GroupLoader(String username, DistinguishedName dn) {
+            this.username = username;
+            this.dn = dn;
 
-        if ("ou".equals(type)) {
-            bean = new OrgUnitNewUserGroupBean(dn);
-            attrSet = getAttributeSet(username, getPersonContextMapper());
-        } else if ("filtered_attribute".equals(type)) {
-            bean = new AttributeNewUserGroupBean(data, true, false);
-            attrSet = getAttributeSet(username, getPersonContextMapper(data));
-        } else if ("attribute".equals(type)) {
-            bean = new AttributeNewUserGroupBean(data, false, false);
-            attrSet = getAttributeSet(username, getPersonContextMapper(data));
-        } else if ("filtered_dn_attribute".equals(type)) {
-            bean = new AttributeNewUserGroupBean(data, true, true);
-            attrSet = getAttributeSet(username, getPersonContextMapper(data));
-        } else if ("dn_attribute".equals(type)) {
-            bean = new AttributeNewUserGroupBean(data, false, true);
-            attrSet = getAttributeSet(username, getPersonContextMapper(data));
-        } else if ("query".equals(type)) {
-            bean = new QueryNewUserGroupBean(data);
-            attrSet = getAttributeSet(username, getPersonContextMapper());
-        } else if ("bean".equals(type)) {
-            bean = appContext.getBean(data, NewUserGroupBean.class);
-            // Likely, this should be added to the API in order to allow bean
-            // implementations to provide an attribute set.
-            attrSet = getAttributeSet(username, getPersonContextMapper());
+            grpSpec = config.getNewUserGroup();
+            groups = new ArrayList<Long>();
+            ownedGroups = new ArrayList<Long>();
+
+            if (!grpSpec.startsWith(":")) {
+                // The default case is the original logic: use the spec as name
+                // No support for group ownership.
+                groups.add(provider.createGroup(grpSpec, null, false, true));
+                bean = null;
+                attrSet = null;
+                return; // EARLY EXIT!
+            }
+
+            final Matcher m = p.matcher(grpSpec);
+            if (!m.matches()) {
+                throw new ValidationException(grpSpec
+                        + " spec currently not supported.");
+            }
+
+            final String type = m.group(1);
+            final String data = m.group(2);
+
+            if ("ou".equals(type)) {
+                bean = new OrgUnitNewUserGroupBean(dn);
+                attrSet = getAttributeSet(username, getPersonContextMapper());
+            } else if ("filtered_attribute".equals(type)) {
+                bean = new AttributeNewUserGroupBean(data, true, false);
+                attrSet = getAttributeSet(username, getPersonContextMapper(data));
+            } else if ("attribute".equals(type)) {
+                bean = new AttributeNewUserGroupBean(data, false, false);
+                attrSet = getAttributeSet(username, getPersonContextMapper(data));
+            } else if ("filtered_dn_attribute".equals(type)) {
+                bean = new AttributeNewUserGroupBean(data, true, true);
+                attrSet = getAttributeSet(username, getPersonContextMapper(data));
+            } else if ("dn_attribute".equals(type)) {
+                bean = new AttributeNewUserGroupBean(data, false, true);
+                attrSet = getAttributeSet(username, getPersonContextMapper(data));
+            } else if ("query".equals(type)) {
+                bean = new QueryNewUserGroupBean(data);
+                attrSet = getAttributeSet(username, getPersonContextMapper());
+            } else if ("bean".equals(type)) {
+                bean = appContext.getBean(data, NewUserGroupBean.class);
+                // Likely, this should be added to the API in order to allow bean
+                // implementations to provide an attribute set.
+                attrSet = getAttributeSet(username, getPersonContextMapper());
+            } else {
+                throw new RuntimeException("Unknown spec: " + grpSpec);
+            }
+
+            groups.addAll(bean.groups(username, config, ldap, provider, attrSet));
+            if (bean instanceof NewUserGroupOwnerBean) {
+                ownedGroups.addAll(((NewUserGroupOwnerBean) bean).ownerOfGroups(
+                        username, config, ldap, provider, attrSet));
+            }
         }
-
-        groups.addAll(bean.groups(username, config, ldap, provider, attrSet));
-        return groups;
     }
 
     private AttributeSet getAttributeSet(String username,

--- a/components/server/src/ome/security/auth/LdapConfig.java
+++ b/components/server/src/ome/security/auth/LdapConfig.java
@@ -42,6 +42,8 @@ public class LdapConfig {
 
     private final String newUserGroup;
 
+    private final String newUserGroupOwner;
+
     private final boolean enabled;
 
     private final boolean syncOnLogin;
@@ -66,6 +68,16 @@ public class LdapConfig {
     }
 
     /**
+     * Sets {@link #newUserGroupOwner} to null.
+     */
+    public LdapConfig(boolean enabled, String newUserGroup, String userFilter,
+        String groupFilter, String userMapping, String groupMapping, boolean syncOnLogin,
+        String base) {
+        this(enabled, newUserGroup, userFilter, groupFilter, userMapping,
+            groupMapping, syncOnLogin, base, null);
+    }
+
+    /**
      * Base constructor which stores all {@link #parse(String)} and stores all
      * values for later lookup.
      */
@@ -73,7 +85,8 @@ public class LdapConfig {
             String newUserGroup,
             String userFilter, String groupFilter,
             String userMapping, String groupMapping,
-            boolean syncOnLogin, String base) {
+            boolean syncOnLogin, String base,
+            String newUserGroupOwner) {
         this.enabled = enabled;
         this.newUserGroup = newUserGroup;
         this.userFilter = new HardcodedFilter(userFilter);
@@ -82,6 +95,7 @@ public class LdapConfig {
         this.groupMapping = parse(groupMapping);
         this.syncOnLogin = syncOnLogin;
         this.base = base;
+        this.newUserGroupOwner = newUserGroupOwner;
     }
 
     // Helpers
@@ -142,6 +156,10 @@ public class LdapConfig {
 
     public String getNewUserGroup() {
         return newUserGroup;
+    }
+
+    public String getNewUserGroupOwner() {
+        return newUserGroupOwner;
     }
 
     public Filter getUserFilter() {

--- a/components/server/src/ome/security/auth/NewUserGroupOwnerBean.java
+++ b/components/server/src/ome/security/auth/NewUserGroupOwnerBean.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.security.auth;
+
+import java.util.List;
+
+import org.springframework.ldap.core.LdapOperations;
+
+/**
+ * Strategy for finding the appropriate group owners for a given user in LDAP.
+ *
+ * @see NewUserGroupBean
+ * @since 5.1.2
+ */
+public interface NewUserGroupOwnerBean {
+
+    List<Long> ownerOfGroups(String username,
+            LdapConfig config, LdapOperations ldap, RoleProvider provider,
+            AttributeSet attrSet);
+
+}

--- a/components/server/src/ome/security/auth/QueryNewUserGroupBean.java
+++ b/components/server/src/ome/security/auth/QueryNewUserGroupBean.java
@@ -8,16 +8,20 @@
 package ome.security.auth;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import ome.conditions.ValidationException;
 import ome.security.SecuritySystem;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.filter.AndFilter;
 import org.springframework.ldap.filter.HardcodedFilter;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the ":query:" specifier from etc/omero.properties.
@@ -30,7 +34,9 @@ import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
  * @see SecuritySystem
  * @since Beta4.2
  */
-public class QueryNewUserGroupBean implements NewUserGroupBean {
+public class QueryNewUserGroupBean implements NewUserGroupBean, NewUserGroupOwnerBean {
+
+    private final static Logger log = LoggerFactory.getLogger(QueryNewUserGroupBean.class);
 
     private final String grpQuery;
 
@@ -38,29 +44,46 @@ public class QueryNewUserGroupBean implements NewUserGroupBean {
         this.grpQuery = grpQuery;
     }
 
-    @SuppressWarnings("unchecked")
-    public List<Long> groups(String username, LdapConfig config,
-            LdapOperations ldap, RoleProvider provider,
-            final AttributeSet attrSet) {
-
+    private String parseQuery(final AttributeSet attrSet, final String query) {
         PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("@{",
                 "}", null, false);
-        String query = helper.replacePlaceholders(grpQuery,
+        return helper.replacePlaceholders(query,
                 new PlaceholderResolver() {
                     public String resolvePlaceholder(String arg0) {
                         if (attrSet.size(arg0) > 1) {
                             throw new ValidationException(
                                     "Multivalued property used in @{} format:"
-                                            + grpQuery + "="
+                                            + query + "="
                                             + attrSet.getAll(arg0).toString());
                         }
                         return attrSet.getFirst(arg0);
                     }
                 });
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> _groups(boolean owner, String username, LdapConfig config,
+            LdapOperations ldap, RoleProvider provider, final AttributeSet attrSet) {
+
+        String query = parseQuery(attrSet, grpQuery);
+        String ownerQuery = null;
+        if (owner) {
+            ownerQuery = config.getNewUserGroupOwner();
+            if (StringUtils.isBlank(ownerQuery)) {
+                log.debug("Owner query disabled");
+                return Collections.emptyList(); // EARLY EXIT
+            }
+            ownerQuery = parseQuery(attrSet, ownerQuery);
+        }
+
         AndFilter and = new AndFilter();
         and.and(config.getGroupFilter());
-
         and.and(new HardcodedFilter(query));
+        if (owner) {
+            and.and(new HardcodedFilter(ownerQuery));
+        }
+
+        log.debug("Running query: {}", and.encode());
         List<String> groupNames = (List<String>) ldap.search("", and.encode(),
             new GroupAttributeMapper(config));
 
@@ -72,4 +95,16 @@ public class QueryNewUserGroupBean implements NewUserGroupBean {
 
     }
 
+    @Override
+    public List<Long> groups(String username, LdapConfig config,
+            LdapOperations ldap, RoleProvider provider,
+            AttributeSet attrSet) {
+        return _groups(false, username, config, ldap, provider, attrSet);
+    }
+
+    @Override
+    public List<Long> ownerOfGroups(String username, LdapConfig config,
+            LdapOperations ldap, RoleProvider provider, AttributeSet attrSet) {
+        return _groups(true, username, config, ldap, provider, attrSet);
+    }
 }

--- a/components/server/src/ome/security/auth/RoleProvider.java
+++ b/components/server/src/ome/security/auth/RoleProvider.java
@@ -39,6 +39,9 @@ public interface RoleProvider {
 
     void setDefaultGroup(final Experimenter user, final ExperimenterGroup group);
 
+    void setGroupOwner(final Experimenter user, final ExperimenterGroup group,
+            final boolean value);
+
     void addGroups(final Experimenter user, final ExperimenterGroup... groups);
 
     void removeGroups(final Experimenter user,

--- a/components/server/src/ome/security/auth/SimpleRoleProvider.java
+++ b/components/server/src/ome/security/auth/SimpleRoleProvider.java
@@ -157,6 +157,28 @@ public class SimpleRoleProvider implements RoleProvider {
 
     }
 
+    public void setGroupOwner(Experimenter user, ExperimenterGroup group, boolean value) {
+        Session session = sf.getSession();
+        Experimenter foundUser = userById(user.getId(), session);
+        ExperimenterGroup foundGroup = groupById(group.getId(), session);
+        Set<GroupExperimenterMap> foundMaps = foundUser
+                .findGroupExperimenterMap(foundGroup);
+        if (foundMaps.size() < 1) {
+            throw new ApiUsageException("Group " + group.getId() + " was not "
+                    + "found for user " + user.getId());
+        } else if (foundMaps.size() > 1) {
+            log.warn(foundMaps.size() + " copies of " + foundGroup
+                    + " found for " + foundUser);
+        } else {
+            // May throw an exception
+            GroupExperimenterMap newDef = foundMaps.iterator().next();
+            log.info(String.format("Seeting ownership flag on user %s to %s for %s",
+                    foundUser.getId(), value, group.getId()));
+            newDef.setOwner(value);
+            sec.doAction(new SecureMerge(session), newDef);
+        }
+    }
+
     public void addGroups(final Experimenter user,
             final ExperimenterGroup... groups) {
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -659,6 +659,7 @@ omero.ldap.user_filter=(objectClass=person)
 omero.ldap.user_mapping=omeName=cn,firstName=givenName,lastName=sn,email=mail
 
 omero.ldap.group_filter=(objectClass=groupOfNames)
+
 omero.ldap.group_mapping=name=cn
 
 ## Without a prefix the "new_user_group" property
@@ -704,6 +705,17 @@ omero.ldap.new_user_group=default
 ## :bean: looks in the server's context for a
 ## bean with the given name which implements ome.security.auth.NewUserGroupBean
 ## omero.ldap.new_user_group=:bean:myNewUserGroupMapperBean
+
+# A query element to check if user who is being created
+# via the new_user_group setting should be made a
+# "manager", i.e. owner, of the queried group. E.g.
+# `omero.ldap.new_user_group_owner=(owner=@{dn})`
+# will use the 'manager' attribute to set the 'owner'
+# flag in the database.
+#
+# This property is not used by new_user_group type
+# 'default' and only potentially by ':bean:'.
+omero.ldap.new_user_group_owner=
 
 #############################################
 ## OMERO client properties:


### PR DESCRIPTION
A new property `new_user_group_owner` has been
added which is used by `NewUserGroupOwnerBean`
implementations to query for groups that some
user should be considered an owner of. If the
sync_on_login property is set and the user is
loses the *owner* attribute, then the flag in
OMERO will also be removed.

Currently, only supported for `:query:` based
groups.

#### Testing ####

This began largely as a test of https://github.com/joshmoore/apacheds-docker to set up general LDAP testing. Turns out adding support was easy enough in that context that I figured I'd open a PR.

* **0. Test that the LDAP connection works for you and get a feel for what data (users & groups) is present:**
```
$ ldapsearch -h $SERVER -p 10389 -x -D uid=admin,ou=system -W -b dc=example,dc=com
Enter LDAP Password:
```
To explain the values:
 * `-x` is the type of authentication being used
 * `-D`is the "bind DN", i.e. the identity that you are using to login.
 * `-W` says to ask for a password. A password can be passed on the command-line with `-w`.
 * `-b` is the base of the search (like `omero.ldap.base`). It prevents the query from showing information unrelated to the mythical company "example.com".


* **1. Connect to such an apacheds instance with a configuration of the form:**
```
omero.ldap.config=true
omero.ldap.base=dc=example,dc=com
omero.ldap.group_filter=(objectClass=groupOfUniqueNames)
omero.ldap.group_mapping=name=cn
omero.ldap.new_user_group=:query:(uniquemember=@{dn})
omero.ldap.new_user_group_owner=(owner=@{dn})
omero.ldap.password=$PASSWORD
omero.ldap.sync_on_login=true
omero.ldap.urls=ldap://$SERVER:10389
omero.ldap.user_filter=(objectClass=person)
omero.ldap.user_mapping=omeName=uid,firstName=givenName,lastName=sn,email=mail
omero.ldap.username=uid=admin,ou=system
```


* **2. Using the [./user](https://github.com/joshmoore/apacheds-docker/blob/0cf5e7eeb15a298f784d22c59576fcdf16641e94/user) script which you must download from apacheds-docker, set up users:**
```
$ export LDAPHOST=$SERVERHERE
$ export LDAPPORT=10389
./user ldapuser1 group   # Boot straps the group "test"
./user ldapuser1 add     # Adds the user
./user ldapuser2 add     # Another user
./user ldapuser2 owner # Make an owner
```


* **3. Login as the above users and check their group membership. E.g.:**
```
$ bin/omero -C login ldapuser1@localhost -w ldapuser1
$ bin/omero user info
```


* **4. Change the state of a user and then re-test. E.g.:**
```
$ ./user ldapuser2 member  # Make a non-owner (regular member)
$ bin/omero -C login ldapuser2@localhost -w ldapuser2
$ bin/omero user info
```


* **5. Repeat 3 & 4 as desired, including removing a user from the `test` group and showing that they can no longer log in.**
```
$ ./user ldapuser1 out
$ bin/omero -C login ldapuser1@localhost -w ldapuser1 # Fails
$ ./user ldapuser1 in
$ bin/omero -C login ldapuser1@localhost -w ldapuser1 # Passes
```
