### PR TITLE
Avoid update event race condition by saving only once

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -169,9 +169,9 @@ def plate_wells_with_no_acq_date(itest, well_grid_factory, update_service,
     [well] = well_grid_factory({(0, 0): 1})
     plate.addWell(well)
     well.copyWellSamples()[0].image.acquisitionDate = None
-    well = update_service.saveAndReturnObject(well)
-    creation_date = well.copyWellSamples()[0].image.details.creationEvent.time
     plate = update_service.saveAndReturnObject(plate)
+    image = plate.copyWells()[0].copyWellSamples()[0].image
+    creation_date = image.details.creationEvent.time
     return {'plate': plate,
             'creation_date': creation_date.val / 1000}
 


### PR DESCRIPTION
It is possible to get off-by-one errors due to updates happening on
second boundaries with multiple save actions.  This PR removes that
possibility by saving only once and only picking up the creation event
time after that singular save.

Reference test failure:

* https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-web/326/testReport/test.integration.test_plategrid/TestPlateGrid/test_creation_date/

```
self = <test_plategrid.TestPlateGrid object at 0x615a750>
plate_wells_with_no_acq_date = {'creation_date': 1431059881L, 'plate': object #0 (::omero::model::Plate)
{
    _id = object #1 (::omero::RLong)
    {...   _val = 803ddbc5-7a55-4c54-aef4-3aaec0726596
    }
    _description = <nil>
}}
conn = <omero.gateway._BlitzGateway object at 0x615aad0>

    def test_creation_date(self, plate_wells_with_no_acq_date, conn):
        """
            Check that plate grid metadata falls back to using creation event time
            if an image has no (or an invalid) acquistion date
            """
        plate = plate_wells_with_no_acq_date['plate']
        creation_date = plate_wells_with_no_acq_date['creation_date']
        plate_grid = PlateGrid(conn, plate.id.val, 0)
        metadata = plate_grid.metadata
>       assert metadata['grid'][0][0]['date'] == creation_date
E       assert 1431059882L == 1431059881L

test/integration/test_plategrid.py:315: AssertionError
```

/cc @jballanc 