### PR TITLE
Improving links in viewer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -994,7 +994,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
   /**
    * @return {String} The current query with state information.
    */
-  this.getQuery = function (include_slider_pos) {
+  this.getQuery = function (include_slider_pos, include_xy_pos, include_zoom) {
       
     var query = [];
     /* Channels (verbose as IE7 does not support Array.filter */
@@ -1018,29 +1018,33 @@ jQuery._WeblitzViewport = function (container, server, options) {
     if (this.loadedImg.current.quality) {
       query.push('q=' + this.loadedImg.current.quality);
     }
-    /* Zoom - getZoom() also handles big images */
-    query.push('zm=' + this.getZoom());
     /* Slider positions */
     if (include_slider_pos) {
       query.push('t=' + (this.loadedImg.current.t+1));
       query.push('z=' + (this.loadedImg.current.z+1));
     }
+    if (include_zoom) {
+        /* Zoom - getZoom() also handles big images */
+        query.push('zm=' + this.getZoom());
+    }
     /* Image offset */
-    if ((_this.loadedImg.tiles) && (_this.viewportimg.get(0).getBigImageContainer() )) {
-        // if this is a 'big image', calculate the current center of the viewport
-        var big_viewer = _this.viewportimg.get(0).getBigImageContainer();
-        var big_x = big_viewer.x * -1;
-        var big_y = big_viewer.y * -1;
-        var big_w = big_viewer.width / 2;
-        var big_h = big_viewer.height / 2;
-        var big_scale = big_viewer.currentScale();
-        var big_center_x = (big_x + big_w) / big_scale;
-        var big_center_y = (big_y + big_h) / big_scale;
-        query.push('x=' + big_center_x);
-        query.push('y=' + big_center_y);
-    } else {
-        query.push('x=' + this.viewportimg.get(0).getXOffset());
-        query.push('y=' + this.viewportimg.get(0).getYOffset());
+    if (include_xy_pos) {
+        if ((_this.loadedImg.tiles) && (_this.viewportimg.get(0).getBigImageContainer() )) {
+            // if this is a 'big image', calculate the current center of the viewport
+            var big_viewer = _this.viewportimg.get(0).getBigImageContainer();
+            var big_x = big_viewer.x * -1;
+            var big_y = big_viewer.y * -1;
+            var big_w = big_viewer.width / 2;
+            var big_h = big_viewer.height / 2;
+            var big_scale = big_viewer.currentScale();
+            var big_center_x = (big_x + big_w) / big_scale;
+            var big_center_y = (big_y + big_h) / big_scale;
+            query.push('x=' + big_center_x);
+            query.push('y=' + big_center_y);
+        } else {
+            query.push('x=' + this.viewportimg.get(0).getXOffset());
+            query.push('y=' + this.viewportimg.get(0).getYOffset());
+        }
     }
     /* Line plot */
     if (this.hasLinePlot()) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -616,7 +616,7 @@
       link = location.href.split(location.search)[0];   // handle trailing #
     }
     link = link.replace(/(.*?\/)\d+(?:\/\d+)?(?:\/)#?$/,'$1');
-    link = link + viewport.getCurrentImgUrlPath() +'?'+ viewport.getQuery(true);
+    link = link + viewport.getCurrentImgUrlPath() + '?' + viewport.getQuery(true, true, true);
     $('#curr-link input').attr('value', link);
     return false;
   }


### PR DESCRIPTION
This PR fixes issue reported by @emilroz regarding unnecessary parameters preventing caching. 

To test it:
 - open regular image and zoom in to see just a part of an image. Move the viewer. Copy image link and past into the new window. View of the image should be preserved including zoom level and position
 
inspect image element and checking if src doesn't contain z,x,y

```
<img width="1945" height="1945" id="weblitz-viewport-img" class="weblitz-viewport-img" style="overflow: hidden;" src="/webclient/render_image/1/14/0/?c=1|103:197$0000FF,2|96:124$FF0000&amp;m=c&amp;p=normal&amp;ia=0&amp;q=0.9">
```

 - open big image zoom in to 1:1. Move the viewer. Copy image link and past into the new window. View of the image should be preserved including zoom level and position

inspect image tile element and checking if src doesnt contain z,x,y

```
<img class="tile" src="/webclient/render_image_region/12/0/0/?c=1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF&m=c&p=normal&ia=0&q=0.9&tile=0,120,102,256,256" style="top: 873px; left: -278px; width: 256px; height: 256px;">
```

cc: @will-moore @emilroz 