### PR TITLE
script_ui isinstance

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3413,12 +3413,12 @@ def script_ui(request, scriptId, conn=None, **kwargs):
             i["list"] = True
             if "default" in i:
                 i["default"] = i["default"][0]
-        elif isinstance(pt.__class__, bool):
+        elif isinstance(pt, bool):
             i["boolean"] = True
-        elif isinstance(pt.__class__, int) or isinstance(pt.__class__, long):
+        elif isinstance(pt, int) or isinstance(pt, long):
             # will stop the user entering anything other than numbers.
             i["number"] = "number"
-        elif isinstance(pt.__class__, float):
+        elif isinstance(pt, float):
             i["number"] = "float"
 
         # if we got a value for this key in the page request, use this as


### PR DESCRIPTION
This fixes a bug in display of script UI, introduced by the flake8 of webclient views.py https://github.com/openmicroscopy/openmicroscopy/pull/3674
which causes Boolean parameters not to be recognised (no checkbox displayed):

![screen shot 2015-05-11 at 14 12 21](https://cloud.githubusercontent.com/assets/900055/7565516/78bd61b0-f7e8-11e4-9438-f0c7416dd6d6.png)

To test, check script UI to see if there's checkboxes for Boolean (E.g. Channel offsets script).