### PR TITLE
Python lib fixes

### DIFF
--- a/components/tools/OmeroCpp/src/omero/callbacks.cpp
+++ b/components/tools/OmeroCpp/src/omero/callbacks.cpp
@@ -121,6 +121,10 @@ namespace omero {
             Ice::ObjectPrx prx = adapter->add(this, id);
             omero::cmd::CmdCallbackPrx cb = omero::cmd::CmdCallbackPrx::uncheckedCast(prx);
             handle->addCallback(cb);
+            initialPoll();
+        }
+
+        void CmdCallbackI::initialPoll() {
             // Now check just in case the process exited VERY quickly
             pollThread = new PollThread(this);
             pollThread->start();

--- a/components/tools/OmeroCpp/src/omero/callbacks.h
+++ b/components/tools/OmeroCpp/src/omero/callbacks.h
@@ -176,10 +176,14 @@ namespace omero {
                     } catch (...) {
                         // don't throw any exceptions, e.g. if the
                         // handle has already been closed.
-                        callback->onFinished(
+                        try {
+                            callback->onFinished(
                                 omero::cmd::ResponsePtr(),
                                 omero::cmd::StatusPtr(),
                                 Ice::Current());
+                        } catch (...) {
+                            // ditto
+                        }
                     }
                 }
             private:
@@ -240,7 +244,7 @@ namespace omero {
              * receive a call to finished, leading to perceived hangs.
              *
              * By default, this method starts a background thread and
-             * calls poll(). An Ice.ObjectNotExistException
+             * calls poll(). An Ice::ObjectNotExistException
              * implies that another caller has already closed the
              * HandlePrx.
              */

--- a/components/tools/OmeroCpp/src/omero/callbacks.h
+++ b/components/tools/OmeroCpp/src/omero/callbacks.h
@@ -171,7 +171,16 @@ namespace omero {
                 {}
 
                 virtual void run() {
-                    callback->poll();
+                    try {
+                        callback->poll();
+                    } catch (...) {
+                        // don't throw any exceptions, e.g. if the
+                        // handle has already been closed.
+                        callback->onFinished(
+                                omero::cmd::ResponsePtr(),
+                                omero::cmd::StatusPtr(),
+                                Ice::Current());
+                    }
                 }
             private:
                 CmdCallbackIPtr callback;
@@ -221,6 +230,21 @@ namespace omero {
                     omero::cmd::State s);
 
             void doinit(std::string category);
+
+            /**
+             * Called at the end of construction to check a race condition.
+             *
+             * If HandlePrx finishes its execution before the
+             * CmdCallbackPrx has been sent set via addCallback,
+             * then there's a chance that this implementation will never
+             * receive a call to finished, leading to perceived hangs.
+             *
+             * By default, this method starts a background thread and
+             * calls poll(). An Ice.ObjectNotExistException
+             * implies that another caller has already closed the
+             * HandlePrx.
+             */
+            void initialPoll();
 
         public:
 

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -14,6 +14,7 @@
 """
 
 import sys
+import traceback
 
 from path import path
 from omero.cli import CLI
@@ -426,6 +427,7 @@ class PrefsControl(WriteableConfigControl):
         try:
             edit_path(temp_file, start_text)
         except RuntimeError, re:
+            self.ctx.dbg(traceback.format_exc())
             self.ctx.die(954, "%s: Failed to edit %s"
                          % (getattr(re, "pid", "Unknown"), temp_file))
         args.NAME = config.default()

--- a/components/tools/OmeroPy/src/omero/util/__init__.py
+++ b/components/tools/OmeroPy/src/omero/util/__init__.py
@@ -11,6 +11,7 @@ import os
 import sys
 import Ice
 import path
+import shlex
 import omero
 import IcePy
 import IceGrid
@@ -854,16 +855,20 @@ def edit_path(path_or_obj, start_text):
     # If absolute, then use the path
     # as is (ticket:4246). Otherwise,
     # use which.py to find it.
+    editor_parts = shlex.split(editor)
+    editor = editor_parts[0]
     editor_obj = path.path(editor)
     if editor_obj.isabs():
-        editor_path = editor
+        editor_parts[0] = editor
     else:
         from omero_ext.which import which
-        editor_path = which(editor)
+        editor_parts[0] = which(editor)
+    editor_parts.append(f)
 
-    pid = os.spawnl(os.P_WAIT, editor_path, editor_path, f)
+    pid = os.spawnl(os.P_WAIT, editor_parts[0], *tuple(editor_parts))
     if pid:
-        re = RuntimeError("Couldn't spawn editor: %s" % editor)
+        re = RuntimeError(
+            "Couldn't spawn editor: %s" % editor_parts[0])
         re.pid = pid
         raise re
 


### PR DESCRIPTION
Few minor fixes to the Python library (and C++ where necessary to keep symmetry):

 * [x] Translate @dominikl's recent fix to `CmdCallback` to Python and C++.
 * [x] Fix use of `bin/omero config edit` with `EDITOR=mate -w`. cc: @pwalczysko 
 * [ ] ~~Change the behavior of `client.submit` and close handles automatically where possible. See https://github.com/openmicroscopy/openmicroscopy/pull/3791#issuecomment-100892988~~