### PR TITLE
Robot test delete image in share

### DIFF
--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -100,7 +100,10 @@ Test Delete Images in Share
     Click Element                               create_share
     Wait Until Page Contains Element            id_message
     Input Text                                  id_message      Robot Test Delete Images in Share
-    Select From List                            id_members      1
+    # Select first user with Chosen plugin
+    Click Element                               xpath=//div[@id='id_members_chosen']/ul[@class='chosen-choices']
+    Page Should Contain Element                 xpath=//div[@id='id_members_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']
+    Click Element                               xpath=//div[@id='id_members_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']/li[@data-option-array-index='1']
     Submit Form                                 create_share_form
     Wait Until Page Contains Element            id=Public
     # Wait Until Page Contains Element          xpath=//div[@id='dataTree']//li[@rel='share']/a

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -76,7 +76,44 @@ Test Delete Images in Dataset
     Xpath Should Match X Times   ${thumbnailsXpath}   ${delThumbCount}
 
 
+Test Delete Images in Share
+    [Documentation]     Deletes pre-imported images after putting them in Share
 
+    Select Experimenter
+    # Clear any activities from earlier tests etc.
+    Click Element                           id=launch_activities
+    Click Element                           id=clear_activities
+    # Add image in 'Delete' Dataset to Share
+    Click Element                               xpath=//div[@id='dataTree']//li[contains(@rel, 'dataset')]/a[contains(text(), 'Delete')]
+    Wait Until Page Contains Element            id=dataIcons
+    # Click first image in Tree
+    Click Element                               xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]/a
+    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]/a[contains(@class, 'jstree-clicked')]
+    ${imageId}=                                 Get Element Attribute    xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]@id
+    Click Element                               basketButton
+    Sleep                                       0.5
+    Go To                                       ${WELCOME URL}basket/
+    Wait Until Page Contains Element            xpath=//table[@id='dataTable']
+    Click Element                               xpath=//table[@id='dataTable']//tr/td
+    Click Element                               create_share
+    Wait Until Page Contains Element            id_message
+    Input Text                                  id_message      Robot Test Delete Images in Share
+    Select From List                            id_members      1
+    Submit Form                                 create_share_form
+    Wait Until Page Contains Element            id=Public
+    # Wait Until Page Contains Element          xpath=//div[@id='dataTree']//li[@rel='share']/a
+    # Click Element                             xpath=//div[@id='dataTree']//li[@rel='share']/a
+    Go To                                       ${WELCOME URL}?show=${imageId}
+    Wait Until Page Contains Element            id=dataIcons
+    Click Element                               id=deleteButton
+    Wait Until Element Is Visible               id=delete-dialog-form
+    Click Dialog Button                         Yes
+    Wait Until Page Contains Element            xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
+    Go To                                       ${WELCOME URL}public
+    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='share']/a
+    Click Element                               xpath=//div[@id='dataTree']//li[@rel='share']/a
+    # Should be image with id='image-123', with 'Object Deleted'
+    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@id='${imageId}'][contains(text(), 'Object deleted')]
 
 
 

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -112,8 +112,9 @@ Test Delete Images in Share
     Go To                                       ${WELCOME URL}public
     Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='share']/a
     Click Element                               xpath=//div[@id='dataTree']//li[@rel='share']/a
-    # Should be image with id='image-123', with 'Object Deleted'
+    # Should be image with id='image-123', with 'Object Deleted' in Tree and icons
     Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@id='${imageId}'][contains(text(), 'Object deleted')]
+    Wait Until Page Contains Element            xpath=//ul[@id='dataIcons']//li[@title='Object deleted']
 
 
 

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -43,8 +43,9 @@ Test Delete Project Dataset
     Click Element                           refreshButton
     Wait Until Page Contains Element        id=project-${pid}
     Click Element                           css=#project-${pid}>a
+    Sleep                                   0.5
     Click Element                           id=deleteButton
-    Wait Until Element Is Visible          id=delete-dialog-form
+    Wait Until Element Is Visible           id=delete-dialog-form
     Click Dialog Button                     Yes
     # Wait for activities to show job done, then refresh tree...
     Wait Until Page Contains Element        xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
@@ -90,6 +91,7 @@ Test Delete Images in Share
     Click Element                               xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]/a
     Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]/a[contains(@class, 'jstree-clicked')]
     ${imageId}=                                 Get Element Attribute    xpath=//div[@id='dataTree']//li[contains(@rel, 'image')]@id
+    Sleep                                       0.5
     Click Element                               basketButton
     Sleep                                       0.5
     Go To                                       ${WELCOME URL}basket/


### PR DESCRIPTION
From comment at https://github.com/openmicroscopy/openmicroscopy/pull/3757#issuecomment-95871006

This robot test creates a share with an image, deletes the image and looks for the "Object Deleted" text on the same in in the Public tree.
To test:
 - check https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-robotframework for failures of this test.