### PR TITLE
Group summery isLeader

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5393,7 +5393,7 @@ class _ExperimenterGroupWrapper (BlitzObjectWrapper):
                 else:
                     colleagues.append(ExperimenterWrapper(self._conn, d.child))
         else:
-            if self._conn.isLeader():
+            if self._conn.isLeader(self.id):
                 leaders = [self._conn.getUser()]
             else:
                 colleagues = [self._conn.getUser()]


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12879

To test:
 - A user needs to be owner of their Default group and a regular member of another group.
 - Check that they are listed correctly under the Group / User menu as Owner and Member of the correct groups (not owner of both).