### PR TITLE
adding login params for autologin

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -214,6 +214,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.web.host">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1535,6 +1535,12 @@ class _BlitzGateway (object):
         return (self.getConfigService().getConfigValue(
                 "omero.client.viewer.initial_zoom_level") or 0)
 
+    def getWebclientHost(self):
+        """
+        Returns default initial zoom level set on the server.
+        """
+        return self.getConfigService().getConfigValue("omero.client.web.host")
+
     def isAnonymous(self):
         """
         Returns the anonymous flag

--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
@@ -32,7 +32,8 @@
     <j2se version="1.6+" max-heap-size="{{heap}}"/>{% for jar in jarlist %}
     <jar href="{{jar}}"/>{% endfor %}
     <property name="jnlp.omero.host" value="{{host}}"/>
-    <property name="jnlp.omero.port" value="{{port}}"/>
+    <property name="jnlp.omero.port" value="{{port}}"/>{% if sessionid %}
+    <property name="jnlp.omero.sessionid" value="{{sessionid}}"/>{% endif %}
   </resources>
   <application-desc main-class="{{class}}"/>
 </jnlp>

--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
@@ -32,7 +32,8 @@
     <j2se version="1.6+" max-heap-size="{{heap}}"/>{% for jar in jarlist %}
     <jar href="{{jar}}"/>{% endfor %}
     <property name="jnlp.omero.host" value="{{host}}"/>
-    <property name="jnlp.omero.port" value="{{port}}"/>{% if sessionid %}
+    <property name="jnlp.omero.port" value="{{port}}"/>
+    <property name="jnlp.omero.web.host" value="{{web_host}}"/>{% if sessionid %}
     <property name="jnlp.omero.sessionid" value="{{sessionid}}"/>{% endif %}
   </resources>
   <application-desc main-class="{{class}}"/>

--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -80,7 +80,8 @@ def index(request, conn=None, **kwargs):
 
 
 @never_cache
-def insight(request):
+@login_required()
+def insight(request, conn=None, **kwargs):
     t = template_loader.get_template('webstart/insight.xml')
 
     codebase = request.build_absolute_uri(settings.STATIC_URL+'webstart/jars/')
@@ -103,13 +104,18 @@ def insight(request):
         'codebase': codebase, 'href': href, 'jarlist': jarlist,
         'icon': settings.WEBSTART_ICON,
         'heap': settings.WEBSTART_HEAP,
-        'host': settings.WEBSTART_HOST,
-        'port': settings.WEBSTART_PORT,
         'class': settings.WEBSTART_CLASS,
         'title': settings.WEBSTART_TITLE,
         'vendor': settings.WEBSTART_VENDOR,
         'homepage': settings.WEBSTART_HOMEPAGE,
     }
+    if conn is None:
+        context['host'] = settings.WEBSTART_HOST
+        context['port'] = settings.WEBSTART_PORT
+    else:
+        context['host'] = conn.host
+        context['port'] = conn.port
+        context['sessionid'] = conn.c.getSessionId()
 
     c = Context(request, context)
     return HttpJNLPResponse(t.render(c))

--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -29,6 +29,7 @@ import traceback
 from glob import glob
 
 from django.conf import settings
+from django.http.request import split_domain_port
 from django.template import loader as template_loader
 from django.template import RequestContext as Context
 from django.core.urlresolvers import reverse
@@ -39,6 +40,7 @@ from omero_version import build_year
 from omero_version import omero_version
 
 from decorators import login_required, render_response
+
 
 @never_cache
 @login_required()
@@ -76,7 +78,6 @@ def index(request, conn=None, **kwargs):
         context['template'] = 'webstart/index.html'
 
     return context
-
 
 
 @never_cache
@@ -130,7 +131,7 @@ def buildWebhost(request, web_host=None):
         web_host = request.build_absolute_uri(prefix)
     return web_host
 
-from django.http.request import split_domain_port
+
 def getOmeroHost(request, host=None):
     if host is None or host in ("localhost", "127.0.0.1"):
         hostport = request.get_host()

--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -127,14 +127,14 @@ def insight(request, conn=None, **kwargs):
 
 
 def buildWebhost(request, web_host=None):
-    if web_host is None or "localhost" in web_host:
+    if not web_host or "localhost" in web_host:
         prefix = settings.FORCE_SCRIPT_NAME or "/"
         web_host = request.build_absolute_uri(prefix)
     return str_slash(web_host)
 
 
 def getOmeroHost(request, host=None):
-    if host is None or host in ("localhost", "127.0.0.1"):
+    if not host or host in ("localhost", "127.0.0.1"):
         hostport = request.get_host()
         host, port = split_domain_port(hostport)
     return host

--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -36,6 +36,7 @@ from django.core.urlresolvers import reverse
 from django.views.decorators.cache import never_cache
 
 from omeroweb.http import HttpJNLPResponse
+from omeroweb.settings import str_slash
 from omero_version import build_year
 from omero_version import omero_version
 
@@ -129,7 +130,7 @@ def buildWebhost(request, web_host=None):
     if web_host is None or "localhost" in web_host:
         prefix = settings.FORCE_SCRIPT_NAME or "/"
         web_host = request.build_absolute_uri(prefix)
-    return web_host
+    return str_slash(web_host)
 
 
 def getOmeroHost(request, host=None):

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -709,6 +709,9 @@ omero.ldap.new_user_group=default
 ## OMERO client properties:
 #############################################
 
+# Absolute omeroweb host http(s)://your_domain/prefix/
+omero.client.web.host=
+
 # Server-side scripts used in IScript service Clients shouldn't display.
 omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/Split_View_Figure.py,\


### PR DESCRIPTION
This PR should allow passing login parameters to auto login into Insight.

JNLP file now gets host port and session ID that is minimum to log in

```
<property name="jnlp.omero.host" value="trout...org"/>
<property name="jnlp.omero.port" value="4064"/>
<property name="jnlp.omero.sessionid" value="79e4596a-bb8c-470f-8e6a-47b91ed0c5ab"/>
<property name="jnlp.omero.web.host" value="http://omero.testdomain.com:4080/"/>
```

Note: Webstat page is also available when user is **not logged in**. In this case there will be default server host and port set and no sessionid provided. These parameters should be used as a helper to choose the right server from the list.

cc: @jburel @dominikl 