### PR TITLE
Read write

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.GroupProfile 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -114,7 +114,7 @@ class GroupProfile
     	//permission level
 
     	permissionsPane = new PermissionsPane(ref.getPermissions(),
-    			UIUtilities.BACKGROUND_COLOR);
+    			UIUtilities.BACKGROUND_COLOR, model.isAdministrator());
     	level = permissionsPane.getPermissions();
     	permissionsPane.allowDowngrade(!mayChangePermissions);
     	permissionsPane.setBorder(

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
@@ -383,7 +383,7 @@ class UserProfile
 			}
 		});
         permissionsPane = new PermissionsPane(defaultGroup.getPermissions(),
-                UIUtilities.BACKGROUND_COLOR);
+                UIUtilities.BACKGROUND_COLOR, model.isAdministrator());
         permissionsPane.disablePermissions();
 
         ExperimenterData logUser = model.getCurrentUser();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.util.AdminDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -347,7 +347,7 @@ implements ActionListener, PropertyChangeListener
             }
             body = new ExperimenterPane(true, groups, selected);
         } else if (GroupData.class.equals(type)) {
-            body = new GroupPane();
+            body = new GroupPane(TreeViewerAgent.isAdministrator());
         }
         body.addPropertyChangeListener(this);
         initComponents();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupPane.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.admin.util.GroupPane 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -74,10 +74,13 @@ class GroupPane
     /** The component displaying the permissions options. */
     private PermissionsPane permissions;
 
-    /** Initializes the components. */
-    private void initComponents()
+    /** Initializes the components.
+     * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
+     */
+    private void initComponents(boolean admin)
     {
-    	permissions = new PermissionsPane();
+    	permissions = new PermissionsPane(admin);
     	permissions.setBorder(
 				BorderFactory.createTitledBorder("Permissions"));
     	descriptionArea = new JTextField();
@@ -162,10 +165,15 @@ class GroupPane
         add(expPane, c);
     }
     
-	/** Creates a new instance. */
-	GroupPane()
+    /**
+     * Creates a new instance
+     * 
+     * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
+     */
+	GroupPane(boolean admin)
 	{
-		initComponents();
+		initComponents(admin);
 		buildGUI();
 	}
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/DeleteBox.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/DeleteBox.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.view.DeleteBox
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -82,7 +82,7 @@ public class DeleteBox
 	private static final String		TITLE = "Confirm delete";
 	
 	/** The default delete text. */
-	private static final String		DEFAULT_TEXT = "Are you sure you want to " +
+	private static final String		DEFAULT_TEXT = "<html>Are you sure you want to " +
 			"delete the selected ";
 
 	/** The text displayed in the tool tip for annotations. */
@@ -94,6 +94,11 @@ public class DeleteBox
 			"might be used by other users,\nthey will no longer be able to " +
 			"use or see them.";
 	
+    /**
+     * Text display if other user's data is going to be deleted 
+     */
+    private static final String NOT_OWNER_WARNING = "Warning: Some objects you selected are owned by other users!";
+
 	/** The button to display the tool tip. */
 	private JButton					infoButton;
 	
@@ -290,10 +295,12 @@ public class DeleteBox
 	 * @param nameSpace		Name space related to the data object if any.
 	 * @param annotation	Pass <code>true</code> if the objects have been 
 	 * 						annotated, <code>false</code> otherwise.
+	 * @param notOwner     Flag indicating that objects belonging to other users
+     *  are going to be deleted
 	 * @return See above. 
 	 */
 	private static String getMessage(Class type, int number, String nameSpace,
-						boolean annotation)
+						boolean annotation, boolean notOwner)
 	{
 		StringBuffer buffer = new StringBuffer(); 
 		String value = getTypeAsString(type, number, nameSpace);
@@ -312,6 +319,11 @@ public class DeleteBox
 				if (annotation) buffer.append("If yes, ");
 			}
 		}
+		if(notOwner) {
+		    buffer.append("<br/><br/>");
+		    buffer.append("<p style=\"font-weight: bold; color: red;\">"+NOT_OWNER_WARNING+"</p>");
+		}
+		buffer.append("</html>");
 		return buffer.toString();
 	}
 	
@@ -327,12 +339,14 @@ public class DeleteBox
 	 * @param groupLeader Pass <code>true</code> to indicate that the user
 	 * currently logged in is the owner of one of the groups the objects 
 	 * belong to, <code>false</code> otherwise.
+	 * @param notOwner Flag indicating that objects belonging to other users
+	 *  are going to be deleted
 	 */
 	public DeleteBox(JFrame parent, Class type, boolean annotation, int number,
-			String nameSpace, boolean groupLeader)
+			String nameSpace, boolean groupLeader, boolean notOwner)
 	{
 		super(parent, TITLE, 
-				DeleteBox.getMessage(type, number, nameSpace, annotation));
+				DeleteBox.getMessage(type, number, nameSpace, annotation, notOwner));
 		this.nameSpace = nameSpace;
 		this.type = type;
 		this.annotation = annotation;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -260,16 +260,21 @@ class TreeViewerComponent
 		String ns = null;
 		GroupData group;
 		long userID = model.getExperimenter().getId();
+		boolean notOwner = false;
 		while (i.hasNext()) {
 			node = (TreeImageDisplay) i.next();
 			if (node.isAnnotated() && ann == null) ann = true;
 			Object uo = node.getUserObject();
 			type = uo.getClass();
-			if (uo instanceof DataObject && leader == null) {
-				group = model.getGroup(((DataObject) uo).getGroupId());
-				if (EditorUtil.isUserGroupOwner(group, userID)) {
-					leader = true;
-				}
+			if (uo instanceof DataObject) {
+			    if( leader == null) {
+    				group = model.getGroup(((DataObject) uo).getGroupId());
+    				if (EditorUtil.isUserGroupOwner(group, userID)) {
+    					leader = true;
+    				}
+			    }
+			    if(((DataObject)uo).getOwner().getId()!=userID)
+			        notOwner = true;
 			}
 			if (uo instanceof TagAnnotationData) 
 				ns = ((TagAnnotationData) uo).getNameSpace();
@@ -278,7 +283,7 @@ class TreeViewerComponent
 		if (ann != null) b = ann.booleanValue();
 		boolean le = false;
 		if (leader != null) le = leader.booleanValue();
-		DeleteBox dialog = new DeleteBox(view, type, b, nodes.size(), ns, le);
+		DeleteBox dialog = new DeleteBox(view, type, b, nodes.size(), ns, le, notOwner);
 		if (dialog.centerMsgBox() == DeleteBox.YES_OPTION) {
 			boolean content = dialog.deleteContents();
 			List<Class> types = dialog.getAnnotationTypes();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.ui.PermissionsPane 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -216,11 +217,11 @@ public class PermissionsPane
      */
     private JPanel buildCollaborative()
     {
-    	JPanel p = new JPanel();
+    	JPanel p = new JPanel(new GridLayout(2, 2));
     	p.setBackground(getBackground());
     	p.add(readOnlyGroupBox);
     	p.add(readAnnotateGroupBox);
-    	//p.add(readWriteGroupBox);
+    	p.add(readWriteGroupBox);
     	return p;
     }
     
@@ -373,14 +374,17 @@ public class PermissionsPane
 	 */
 	public int getPermissions()
 	{
-		if (privateBox.isSelected()) return GroupData.PERMISSIONS_PRIVATE;
+		if (privateBox.isSelected())
+		    return GroupData.PERMISSIONS_PRIVATE;
 		if (readAnnotateGroupBox.isSelected())
 			return GroupData.PERMISSIONS_GROUP_READ_LINK;
 		if (readOnlyGroupBox.isSelected())
 			return GroupData.PERMISSIONS_GROUP_READ;
 		if (readOnlyPublicBox.isSelected())
 			return GroupData.PERMISSIONS_PUBLIC_READ;
-		return GroupData.PERMISSIONS_PUBLIC_READ_WRITE;
+		if (readWriteGroupBox.isSelected())
+            return GroupData.PERMISSIONS_GROUP_READ_WRITE;
+		return -1;
 	}
 
 	/** 
@@ -497,7 +501,7 @@ public class PermissionsPane
 		}
 		currentPermissions = getPermissions();
  		if (readOnlyGroupBox == src || readAnnotateGroupBox == src ||
-				privateBox == src) {
+				privateBox == src || readWriteGroupBox == src) {
 			firePropertyChange(PERMISSIONS_CHANGE_PROPERTY, -1,
 					getPermissions());
 			return;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
@@ -115,6 +115,9 @@ public class PermissionsPane
      */
     private boolean allowDowngrade;
     
+    /** Flag indicating if the current user is an admin */
+    private boolean admin;
+    
     /** The original permissions level.*/
     private int originalPermissions;
     
@@ -282,38 +285,49 @@ public class PermissionsPane
      * 
      * @param permissions The permissions level.
      * @param background The background color or <code>null</code>.
+     * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
      */
-    private void initialize(int permissions, Color background)
+    private void initialize(int permissions, Color background, boolean admin)
     {
-    	if (background != null) setBackground(background);
+    	if (background != null) 
+    	    setBackground(background);
+    	this.admin = admin;
 		initComponents(permissions);
 		buildGUI();
     }
     
-	/** Creates a new instance. */
-	public PermissionsPane()
+	/** Creates a new instance.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
+     */
+	public PermissionsPane(boolean admin)
 	{
-		this(GroupData.PERMISSIONS_PRIVATE);
+		this(GroupData.PERMISSIONS_PRIVATE, admin);
 	}
 	
 	/** 
 	 * Creates a new instance. 
 	 * 
 	 * @param background	The background color or <code>null</code>.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
 	 */
-	public PermissionsPane(Color background)
+	public PermissionsPane(Color background, boolean admin)
 	{
-		this(GroupData.PERMISSIONS_PRIVATE, background);
+		this(GroupData.PERMISSIONS_PRIVATE, background, admin);
 	}
 	
 	/** 
 	 * Creates a new instance. 
 	 * 
 	 * @param permissions The permissions level.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
 	 */
-	public PermissionsPane(int permissions)
+	public PermissionsPane(int permissions, boolean admin)
 	{
-		this(permissions, null);
+		this(permissions, null, admin);
 	}
 	
 	/** 
@@ -321,10 +335,12 @@ public class PermissionsPane
 	 * 
 	 * @param permissions 	The permissions level.
 	 * @param background	The background color or <code>null</code>.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
 	 */
-	public PermissionsPane(int permissions, Color background)
+	public PermissionsPane(int permissions, Color background, boolean admin)
 	{
-		initialize(permissions, background);
+		initialize(permissions, background, admin);
 	}
 
 	/** 
@@ -332,10 +348,12 @@ public class PermissionsPane
 	 * 
 	 * @param permissions 	The permissions level.
 	 * @param background	The background color or <code>null</code>.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
 	 */
-	public PermissionsPane(PermissionData permissions)
+	public PermissionsPane(PermissionData permissions, boolean admin)
 	{
-		this(permissions, null);
+		this(permissions, null, admin);
 	}
 	
 	/** 
@@ -343,13 +361,15 @@ public class PermissionsPane
 	 * 
 	 * @param permissions 	The permissions level.
 	 * @param background	The background color or <code>null</code>.
+	 * @param admin
+     *            Pass <code>true</code> to enable admin-only permission changes
 	 */
-	public PermissionsPane(PermissionData permissions, Color background)
+	public PermissionsPane(PermissionData permissions, Color background, boolean admin)
 	{
 		int level = GroupData.PERMISSIONS_PRIVATE;
 		if (permissions != null)
 			level = permissions.getPermissionsLevel();
-		initialize(level, background);
+		initialize(level, background, admin);
 	}
 	
 	/**
@@ -361,7 +381,7 @@ public class PermissionsPane
 	{
 	    if (permissions == null) return;
 	    removeAll();
-	    initialize(permissions.getPermissionsLevel(), getBackground());
+	    initialize(permissions.getPermissionsLevel(), getBackground(), admin);
 	    revalidate();
 	    repaint();
 	}
@@ -468,7 +488,7 @@ public class PermissionsPane
 		if (readOnlyGroupBox != null) readOnlyGroupBox.setEnabled(enabled);
 		if (readOnlyPublicBox != null) readOnlyPublicBox.setEnabled(enabled);
 		if (readWriteGroupBox != null)
-			readWriteGroupBox.setEnabled(enabled);
+			readWriteGroupBox.setEnabled(admin);
 		if (readAnnotateGroupBox != null)
 			readAnnotateGroupBox.setEnabled(enabled);
 		publicBox.addActionListener(this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
@@ -38,6 +38,7 @@ import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
@@ -47,6 +48,7 @@ import javax.swing.JRadioButton;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.ui.RefWindow;
+import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -82,6 +84,10 @@ public class PermissionsPane
 	private static final String WARNING = " Changing group to Private may fail if links"
 	        + " have been\n created under Read-Annotate permissions. Make the change?";
 	
+	/** ReadWrite warning message */
+    private static final String RW_WARNING = "Read-Write groups allow members to delete other"
+            + " members' data.\nSee documentation about 'OMERO permissions' for full details.";
+
 	/** Indicate that the group has <code>RWRA--</code>. */
     //private JRadioButton		collaborativeGroupBox;
     
@@ -123,6 +129,9 @@ public class PermissionsPane
     
     /** The current permissions level.*/
     private int currentPermissions;
+    
+    /** Internal flag making sure the RW warning message is only shown once */
+    private boolean warningMessageShown = false;
     
     /**
      * Sets the controls depending on the specified permissions.
@@ -179,6 +188,24 @@ public class PermissionsPane
     			GroupData.PERMISSIONS_GROUP_READ_WRITE_SHORT_TEXT);
     	readWriteGroupBox.setToolTipText(
     			GroupData.PERMISSIONS_GROUP_READ_WRITE_TEXT);
+    	
+        readWriteGroupBox.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (readWriteGroupBox.isSelected() && !warningMessageShown) {
+                    // for some reason can't use NotificationDialog here, just shows
+                    // a black panel instead of the text, using JOptionPane therefore
+                    JOptionPane.showMessageDialog(
+                            PermissionsPane.this,
+                            RW_WARNING,
+                            "Warning",
+                            JOptionPane.WARNING_MESSAGE,
+                            IconManager.getInstance().getIcon(
+                                    IconManager.INFO_32));
+                    warningMessageShown = true;
+                }
+            }
+        });
     	
     	readOnlyGroupBox.setSelected(true);//default
     	readOnlyPublicBox = new JCheckBox(


### PR DESCRIPTION
Enables ReadWrite group permission in Insight, [Trello](https://trello.com/c/RpdAOmKp/50-permissions-system-problems-chown)
Test:
- Create a new group with ReadWrite permission and add two users to it, make one owner of the group.
- Log in as one of the users and import some images.
- Switch to the other user and delete an image of the previous user. Make sure the confirmation dialog states that you're going to delete another user's data.
- Log in as the group owner. Change permission level of the group. Make sure you cannot change the permission back to ReadWrite.
- Log in as admin. Change permission level back to ReadWrite
