### PR TITLE
check for Unicode units on startup

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-header.vm
+++ b/components/dsl/resources/ome/dsl/psql-header.vm
@@ -35,7 +35,9 @@ BEGIN
     END IF;
 
     IF char_encoding != 'UTF8' THEN
-       RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+        RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+    ELSE
+        SET client_encoding = 'UTF8';
     END IF;
 
 END;$$ LANGUAGE plpgsql;

--- a/components/model/resources/ome/util/actions/psql.properties
+++ b/components/model/resources/ome/util/actions/psql.properties
@@ -1,4 +1,5 @@
 sql_action.active_session=select count(id) from session s where s.closed is null and s.uuid = ?
+sql_action.check_units=SELECT CAST('Å' AS UnitsLength)
 sql_action.curr_val=select next_val from seq_table where sequence_name = ?
 sql_action.db_version=select currentversion, currentpatch from dbpatch order by id desc limit 1
 sql_action.get_pixels_name_path_repo=select name, path, repo from pixels where id = ?

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -31,6 +31,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -519,6 +520,11 @@ public interface SqlAction {
     int changeGroupPermissions(Long id, Long internal);
 
     int changeTablePermissionsForGroup(String table, Long id, Long internal);
+
+    /**
+     * @return if the database's type system contains correctly encoded units of measure
+     */
+    boolean hasUnicodeUnits();
 
     /**
      * Add a unique message to the DB patch table within the current patch.
@@ -1118,6 +1124,20 @@ public interface SqlAction {
                 public Object mapRow(ResultSet arg0, int arg1) {
                     return null;
                 }});
+        }
+
+        @Override
+        public boolean hasUnicodeUnits() {
+            try {
+                _jdbc().query(_lookup("check_units"), new RowMapper<Object>() {
+                    @Override
+                    public Object mapRow(ResultSet rs, int rowNum) {
+                        return null;
+                    }});
+            } catch (DataAccessException dae) {
+                return false;
+            }
+            return true;
         }
 
         @Override

--- a/components/server/resources/ome/services/startup.xml
+++ b/components/server/resources/ome/services/startup.xml
@@ -56,6 +56,13 @@
      <constructor-arg ref="preferenceContext"/>
   </bean>
 
+  <bean id="dbUnicodeUnitsCheck" depends-on="dbPatchCheck"
+     class="ome.services.util.DBUnicodeUnitsCheck"
+     init-method="start" lazy-init="false">
+     <constructor-arg ref="executor"/>
+     <constructor-arg ref="preferenceContext"/>
+  </bean>
+
   <bean id="serverDirectoryCheck"
      class="ome.services.util.ServerDirectoryCheck"
      init-method="run" lazy-init="false">

--- a/components/server/src/ome/services/util/DBUnicodeUnitsCheck.java
+++ b/components/server/src/ome/services/util/DBUnicodeUnitsCheck.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import ome.conditions.InternalException;
+import ome.system.PreferenceContext;
+import ome.util.SqlAction;
+
+/**
+ * Checks that the database contains correctly encoded enumerations for units of measure.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.2
+ *
+ */
+public class DBUnicodeUnitsCheck extends BaseDBCheck {
+
+    public final static Logger LOGGER = LoggerFactory.getLogger(DBUnicodeUnitsCheck.class);
+
+    protected DBUnicodeUnitsCheck(Executor executor, PreferenceContext preferences) {
+        super(executor, preferences);
+    }
+
+    @Override
+    protected void doCheck() {
+        final boolean hasUnicodeUnits;
+        try {
+            hasUnicodeUnits = (Boolean) executor.executeSql(new Executor.SimpleSqlWork(this, "DBUnicodeUnitsCheck") {
+                @Transactional(readOnly = true)
+                public Boolean doWork(SqlAction sql) {
+                    return sql.hasUnicodeUnits();
+                }
+            });
+        } catch (Exception e) {
+            final String message = "Error while checking the encoding of units of measure.";
+            LOGGER.error(message, e);
+            throw new InternalException(message);
+        }
+        if (hasUnicodeUnits) {
+            LOGGER.info("Database has the correctly encoded units of measure.");
+        } else {
+            final String message = "Database does not contain correctly encoded units of measure.";
+            LOGGER.error(message);
+            throw new InternalException(message);
+        }
+    }
+}

--- a/sql/psql/OMERO5.1DEV__11/OMERO5.1DEV__10.sql
+++ b/sql/psql/OMERO5.1DEV__11/OMERO5.1DEV__10.sql
@@ -70,6 +70,8 @@ END;$$ LANGUAGE plpgsql;
 SELECT assert_db_server_prerequisites(84000);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
 
+SET client_encoding = 'UTF8';
+
 
 INSERT INTO dbpatch (currentVersion, currentPatch,   previousVersion,     previousPatch)
              VALUES ('OMERO5.1DEV',    11,              'OMERO5.1DEV',    10);

--- a/sql/psql/OMERO5.1DEV__13/OMERO5.1DEV__12.sql
+++ b/sql/psql/OMERO5.1DEV__13/OMERO5.1DEV__12.sql
@@ -42,6 +42,8 @@ END;' LANGUAGE plpgsql;
 SELECT omero_assert_db_version('OMERO5.1DEV', 12);
 DROP FUNCTION omero_assert_db_version(varchar, int);
 
+SET client_encoding = 'UTF8';
+
 
 INSERT INTO dbpatch (currentVersion, currentPatch,   previousVersion,     previousPatch)
              VALUES ('OMERO5.1DEV',  13,                'OMERO5.1DEV',    12);

--- a/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
+++ b/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
@@ -62,7 +62,9 @@ BEGIN
     END IF;
 
     IF char_encoding != 'UTF8' THEN
-       RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %', char_encoding;
+        RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+    ELSE
+        SET client_encoding = 'UTF8';
     END IF;
 
 END;$$ LANGUAGE plpgsql;

--- a/sql/psql/OMERO5.1__1/psql-header.sql
+++ b/sql/psql/OMERO5.1__1/psql-header.sql
@@ -35,7 +35,9 @@ BEGIN
     END IF;
 
     IF char_encoding != 'UTF8' THEN
-       RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+        RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+    ELSE
+        SET client_encoding = 'UTF8';
     END IF;
 
 END;$$ LANGUAGE plpgsql;


### PR DESCRIPTION
See https://trello.com/c/CVUflk8g/490-encoding-for-db-init-upgrade-script. Adds a startup check to the server to prevent the server being used if the wrong character encoding was used to set up its database. Also tweaks SQL scripts to ensure that those with Unicode symbol literals are read with the correct encoding.

--no-rebase

***

To test, start out with a local OMERO.server and SQL scripts that do not have this PR merged. Partway through testing you will switch to a local OMERO.server and SQL scripts that do have this PR merged.

1. Start out without this PR.
1. Use `export PGCLIENTENCODING=WIN1252` in your shell to mess up the reading of Unicode SQL scripts.
1. Empty your binary repository and use `bin/omero db script` and `psql` to create a 5.0 or 5.1 database. If you used a 5.0 database, use `psql` to upgrade it to 5.1.
1. Start the server and try to import some metadata-rich images. You will quickly run into problems.
1. Stop the server, include this PR, then start it again.
1. Observe that the server doesn't quite manage to start up usably. Stop the server and observe the helpful errors in `Blitz-0.log`.
1. Empty your binary repository and use `bin/omero db script` and `psql` to create a 5.0 or 5.1 database. If you used a 5.0 database, use `psql` to upgrade it to 5.1.
1. Observe that the server starts up just fine and all manner of metadata-rich images may be imported with units preserved.