### PR TITLE
Revive foreground_poll logic for callbacks.py

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3028,7 +3028,8 @@ def activities(request, conn=None, **kwargs):
                 try:
                     prx = omero.cmd.HandlePrx.checkedCast(
                         conn.c.ic.stringToProxy(cbString))
-                    callback = omero.callbacks.CmdCallbackI(conn.c, prx)
+                    callback = omero.callbacks.CmdCallbackI(
+                        conn.c, prx, foreground_poll=True)
                     rsp = callback.getResponse()
                     close_handle = False
                     try:
@@ -3085,10 +3086,12 @@ def activities(request, conn=None, **kwargs):
                 try:
                     handle = omero.cmd.HandlePrx.checkedCast(
                         conn.c.ic.stringToProxy(cbString))
-                    cb = omero.callbacks.CmdCallbackI(conn.c, handle)
+                    cb = omero.callbacks.CmdCallbackI(
+                        conn.c, handle, foreground_poll=True)
+                    rsp = cb.getResponse()
                     close_handle = False
                     try:
-                        if not cb.block(0):  # Response not available
+                        if not rsp:  # Response not available
                             update_callback(
                                 request, cbString,
                                 error=0,


### PR DESCRIPTION
In 5.1.0 and before, the CmdCallbackI constructor
in Python (unlike Java and C++) was performing its
initial polling invocation in the calling thread.
Due to its statelessness, OMERO.web was making use
of this fact. Now by passing foreground_poll=True,
the previous, deprecated behavior can be revived.

More complicated behavior should be achieved by
subclassing CmdCallbackI and overriding initialPoll.