### PR TITLE
Add WARNING on group-write graph operation

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1722,12 +1722,47 @@ class GraphControl(CmdControl):
         if not args.ordered and len(commands) > 1:
             commands = self.combine_commands(commands)
 
+        for command_check in commands:
+            self._check_command(command_check)
+
         if len(commands) == 1:
             cmd = args.obj[0]
         else:
             cmd = omero.cmd.DoAll(commands)
 
         self._process_request(cmd, args, client)
+
+    def _check_command(self, command_check):
+        query = self.ctx.get_client().sf.getQueryService()
+        ec = self.ctx.get_event_context()
+        own_id = ec.userId
+        if not command_check or not command_check.targetObjects:
+            return
+        for k, v in command_check.targetObjects.items():
+            query_str = (
+                "select "
+                "x.details.owner.id, "
+                "x.details.group.details.permissions "
+                "from %s x "
+                "where x.id = :id") % k
+            if not v:
+                return
+            for w in v:
+                try:
+                    uid, perms = omero.rtypes.unwrap(
+                        query.projection(
+                            query_str,
+                            omero.sys.ParametersI().addId(w),
+                            {"omero.group": "-1"})[0])
+                    perms = perms["perm"]
+                    perms = omero.model.PermissionsI(perms)
+                    if perms.isGroupWrite() and uid != own_id:
+                        self.ctx.err(
+                            "WARNING: %s:%s belongs to user %s" % (
+                                k, w, uid))
+                except:
+                    self.ctx.dbg(traceback.format_exc())
+                    # Doing nothing since this is a best effort
 
     def combine_commands(self, commands):
         """


### PR DESCRIPTION
When a user is in a new writeable-group (a new
feature for 5.1.2) *AND* is trying to perform
an operation on an object they don't own, then
print a "WARNING" message before acting. With
the hope that users will first issue a --dry-run,
this will hopefully suffice to prevent false
deletions, etc. The only other option would be
to require confirmation, which would be quite a
new CLI introduction at this point.


#### Testing ####
Create an image as a user in a rwrw group and then try to delete (`--dry-run`) it as another user. A warning of the form: `WARNING: Image:51 belongs to user 2` should be printed. E.g.

```
  612  dist/bin/omero login root@localhost
  613  dist/bin/omero import /tmp/a.fake
  614  dist/bin/omero group add rw --perms=rwrw--
  615  dist/bin/omero user add writer Writer User rw
  616  dist/bin/omero login writer@localhost
  617  dist/bin/omero import /tmp/a.fake
  618  dist/bin/omero login root@localhost
  619  dist/bin/omero hql "from Image" --all
  620  dist/bin/omero delete --dry-run Image:2    # Root's image
  621  dist/bin/omero delete --dry-run Image:51   # Writer's image
```