### PR TITLE
Use default perms when creating var/

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -748,7 +748,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
     Top-level helpers (shared helpers are in components/antlib/resources)
     =====================================================================
     -->
-    <target name="build-dist" depends="init,copy-licenses,copy-history,copy-etc,copy-sql,copy-server,copy-client,update-version"
+    <target name="build-dist" depends="init,copy-licenses,copy-history,copy-etc,copy-sql,copy-server,copy-client,update-version,create-workdirs"
         description="Copy all components to dist/; called at the end of build-* targets"/>
 
     <target name="copy-licenses" depends="init">
@@ -793,6 +793,10 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
             <ivy:resolve file="ivy.xml" type="jar,egg" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
             <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
+    </target>
+
+    <target name="create-workdirs" depends="init">
+            <mkdir dir="${dist.dir}/var"/>
     </target>
 
     <macrodef name="jar_update_if">

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1408,7 +1408,7 @@ OMERO Diagnostics %s
         var = self.ctx.dir / 'var'
         if not os.path.exists(var):
             self.ctx.out("Creating directory %s" % var)
-            os.makedirs(var, 0700)
+            os.makedirs(var)
         else:
             self.can_access(var, mask)
 


### PR DESCRIPTION
- https://trello.com/c/xDMnFnPd/498-fix-omero-web-var-permissions
- https://github.com/openmicroscopy/ome-documentation/pull/1210

Testing: server.zip should include a `var` directory. If it's deleted then when a new `var/` is created it should always have the default umask, it shouldn't matter whether you run `omero admin` or `omero web` first.