### PR TITLE
Delete not owned warning

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -68,14 +68,22 @@
             var q = false;
             var dtypes = {};
             var first_parent;   // select this when we're done deleting
+            var notOwned = false;
             selected.each(function (i) {
                 if (!first_parent) first_parent = datatree._get_parent(this);
-                ajax_data[i] = $(this).attr('id').replace("-","=");
-                var dtype = $(this).attr('rel');
+                var $this = $(this);
+                ajax_data[i] = $this.attr('id').replace("-","=");
+                var dtype = $this.attr('rel');
                 if (dtype in dtypes) dtypes[dtype] += 1;
                 else dtypes[dtype] = 1;
-                if (!q && $(this).attr('rel').indexOf('image')<0) q = true;
+                if (!q && $this.attr('rel').indexOf('image')<0) q = true;
+                if (!$this.hasClass('isOwned')) notOwned = true;
             });
+            if (notOwned) {
+                $("#deleteOthersWarning").show();
+            } else {
+                $("#deleteOthersWarning").hide();
+            }
             var type_strings = [];
             for (var key in dtypes) {
                 key = key.replace("-locked", "");
@@ -1146,6 +1154,9 @@
 
         <!-- hidden form for delete dialogs -->
         <div id="delete-dialog-form" title="Delete" style="display:none">
+            <p id="deleteOthersWarning" class='error' style="font-size: 120%; font-weight: bold">
+                Warning: Some objects you selected are owned by other users.
+            </p>
             <p>Are you sure you want to delete the selected <span id="delete_type">Images</span>?</p>
             <p>If yes:</p>
             <form>

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -55,6 +55,8 @@ def get_perms(conn, object_type, object_id, object_owner_id, object_group_id,
         for r in restrictions:
             if getattr(perms_obj, r)():
                 perms[r] = True
+        if (obj.details.owner.id.val == conn.getUserId()):
+            perms['isOwned'] = True
 
         # Cache the result
         cache[(object_group_id.val, object_owner_id.val)] = perms
@@ -73,7 +75,7 @@ def parse_permissions_css(permissions, ownerid, conn):
         @param conn OMERO gateway.
         @type conn L{omero.gateway.BlitzGateway}
     '''
-    restrictions = ('canEdit', 'canAnnotate', 'canLink', 'canDelete')
+    restrictions = ('canEdit', 'canAnnotate', 'canLink', 'canDelete', 'isOwned')
     permissionsCss = [r for r in restrictions if permissions.get(r)]
     if ownerid == conn.getUserId() or conn.isAdmin():
         permissionsCss.append("canChgrp")

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -75,7 +75,11 @@ def parse_permissions_css(permissions, ownerid, conn):
         @param conn OMERO gateway.
         @type conn L{omero.gateway.BlitzGateway}
     '''
-    restrictions = ('canEdit', 'canAnnotate', 'canLink', 'canDelete', 'isOwned')
+    restrictions = ('canEdit',
+                    'canAnnotate',
+                    'canLink',
+                    'canDelete',
+                    'isOwned')
     permissionsCss = [r for r in restrictions if permissions.get(r)]
     if ownerid == conn.getUserId() or conn.isAdmin():
         permissionsCss.append("canChgrp")

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2157,6 +2157,8 @@ class OmeroWebObjectWrapper (object):
             flags.append("canLink")
         if self.canDelete():
             flags.append("canDelete")
+        if self.isOwned():
+            flags.append("isOwned")
         if self.canChgrp():
             flags.append("canChgrp")
         return " ".join(flags)

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -359,7 +359,7 @@ class TestTree(lib.ITest):
     def test_marshal_project_dataset(self, project_dataset):
         project_id = project_dataset.id.val
         dataset, = project_dataset.linkedDatasetList()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': project_id,
             'childCount': 1L,
@@ -381,7 +381,7 @@ class TestTree(lib.ITest):
     def test_marshal_projects_datasets(self, projects_datasets):
         project_a, project_b, project_c, project_d = projects_datasets
         expected = list()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         # The underlying query explicitly orders the Projects list by
         # case-insensitive name.
         for project in sorted(projects_datasets, cmp_name_insensitive):
@@ -448,7 +448,7 @@ class TestTree(lib.ITest):
 
     def test_marshal_datasets(self, datasets):
         dataset_a, dataset_b, dataset_c, dataset_d = datasets
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': dataset_a.id.val,
@@ -506,7 +506,7 @@ class TestTree(lib.ITest):
         screen_id = screen_plate_run.id.val
         plate, = screen_plate_run.linkedPlateList()
         plate_acquisition, = plate.copyPlateAcquisitions()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': screen_id,
             'childCount': 1,
@@ -522,7 +522,7 @@ class TestTree(lib.ITest):
                     'name': 'Run %d' % plate_acquisition.id.val,
                     'isOwned': True,
                     'permsCss': perms_css
-                }],
+                    }],
                 'plateAcquisitionCount': 1,
                 'permsCss': perms_css
             }],
@@ -532,7 +532,7 @@ class TestTree(lib.ITest):
         assert marshaled == expected
 
     def test_marshal_screens_plates_runs(self, screens_plates_runs):
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = []
         # The underlying query explicitly orders the Screens by name.
         for screen in sorted(screens_plates_runs, cmp_name):
@@ -575,7 +575,7 @@ class TestTree(lib.ITest):
 
     def test_marshal_screen_plate(self, screen_plate):
         plate, = screen_plate.linkedPlateList()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [
             {
                 'id': screen_plate.id.val,
@@ -600,7 +600,7 @@ class TestTree(lib.ITest):
     def test_marshal_plate_run(self, plate_run):
         plate_id = plate_run.id.val
         plate_acquisition, = plate_run.copyPlateAcquisitions()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': plate_id,
             'isOwned': True,
@@ -620,7 +620,7 @@ class TestTree(lib.ITest):
 
     def test_marshal_plates_runs(self, plates_runs):
         plate_a, plate_b, plate_c, plate_d = plates_runs
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = list()
         # The underlying query explicitly orders the Plates by name.
         for plate in sorted(plates_runs, cmp_name_insensitive):
@@ -674,7 +674,7 @@ class TestTree(lib.ITest):
 
     def test_marshal_plate(self, plate):
         plate_id = plate.id.val
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': plate_id,
             'isOwned': True,
@@ -690,7 +690,7 @@ class TestTree(lib.ITest):
     def test_marshal_project_dataset_image(self, project_dataset_image):
         project_id = project_dataset_image.id.val
         dataset, = project_dataset_image.linkedDatasetList()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': project_id,
             'isOwned': True,
@@ -711,7 +711,7 @@ class TestTree(lib.ITest):
 
     def test_marshal_projects(self, projects):
         project_a, project_b, project_c, project_d = projects
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': project_a.id.val,
@@ -744,11 +744,12 @@ class TestTree(lib.ITest):
         }]
 
         marshaled = marshal_projects(self.conn, self.conn.getUserId())
+        print marshaled
         assert marshaled == expected
 
     def test_marshal_screens(self, screens):
         screen_a, screen_b, screen_c, screen_d = screens
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': screen_a.id.val,
@@ -786,7 +787,7 @@ class TestTree(lib.ITest):
     def test_marshal_screens_plates(self, screens_plates):
         screen_a, screen_b, screen_c, screen_d = screens_plates
         expected = list()
-        perms_css = 'canEdit canAnnotate canLink canDelete canChgrp'
+        perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         # The underlying query explicitly orders the Screens list by
         # case-insensitive name.
         for screen in sorted(screens_plates, cmp_name_insensitive):


### PR DESCRIPTION
Equivalent to #3811 in Insight, we now show a warning if any of the objects selected for Delete are not owned by the user.

To test:
 - Try to delete your own object and another user's object (in Read-Write group or as group owner).
 - You should only see warning in Delete dialog if data doesn't belong to you.

NB: Noticed that the "-locked" flag is still shown to indicate non-ownership but this should be removed in 5.2.3 as discussed with @aleksandra-tarkowska since it is not longer needed and is buggy.