### PR TITLE
Jnlp parameters

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
@@ -43,7 +43,6 @@ import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.init.Initializer;
 import org.openmicroscopy.shoola.env.init.StartupException;
-
 import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
@@ -23,8 +23,6 @@
 
 package org.openmicroscopy.shoola.env;
 
-import ij.IJ;
-
 import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,7 +43,7 @@ import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.init.Initializer;
 import org.openmicroscopy.shoola.env.init.StartupException;
-import org.openmicroscopy.shoola.env.ui.UserNotifier;
+
 import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
@@ -132,6 +132,7 @@ public final class Container
                     jnlpHost, UserCredentials.HIGH);
             uc.setPort(Integer.parseInt(jnlpPort));
             svc.login(uc);
+            reg.getEventBus().post(new ActivateAgents());
         } catch (Exception e) {
             AbnormalExitHandler.terminate(e);
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/Container.java
@@ -107,35 +107,6 @@ public final class Container
 	 */
 	private static Container singleton;
 
-    /**
-     * Starts up the application w/o login screen and connect.
-     *
-     * @param home Path to the installation directory. If <code>null<code> or
-     *              empty, then the user directory is assumed.
-     * @param configFile The configuration file.
-     * @param sessionId The session to join.
-     */
-    private static void runStartupProcedureHeadlessAndLogin(String home,
-                String configFile, String sessionId)
-    {
-        //read jnlp parameters
-        String jnlpHost = System.getProperty("jnlp.omero.host");
-        String jnlpPort = System.getProperty("jnlp.omero.port");
-        AbnormalExitHandler.configure();
-        try {
-            Container c = startupInHeadlessMode(home, configFile);
-            Registry reg = c.getRegistry();
-            LoginService svc = (LoginService) reg.lookup(LookupNames.LOGIN);
-            UserCredentials uc = new UserCredentials(sessionId, sessionId,
-                    jnlpHost, UserCredentials.HIGH);
-            uc.setPort(Integer.parseInt(jnlpPort));
-            svc.login(uc);
-            reg.getEventBus().post(new ActivateAgents());
-        } catch (Exception e) {
-            AbnormalExitHandler.terminate(e);
-        }
-    }
-
 	/**
 	 * Performs the start up procedure.
 	 * 
@@ -147,18 +118,13 @@ public final class Container
 	{
 		AbnormalExitHandler.configure();
 		Initializer initManager = null;
-		String jnlpSession = System.getProperty("jnlp.omero.sessionid");
-		if (CommonsLangUtils.isNotBlank(jnlpSession)) {
-		    runStartupProcedureHeadlessAndLogin(home, configFile, jnlpSession);
-		    return;
-		}
 		try {
 			singleton = new Container(home, configFile);
 			initManager = new Initializer(singleton);
 			initManager.configure();
 			initManager.doInit();
 			initManager.notifyEnd();
-			
+
 			//startService() called by Initializer at end of doInit().
 		} catch (StartupException se) {
 			if (initManager != null) initManager.rollback();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -36,6 +36,7 @@ import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.env.ui.SplashScreen;
 import org.openmicroscopy.shoola.env.ui.UIFactory;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 /** 
  * Does some configuration required for the initialization process to run.
@@ -155,7 +156,6 @@ public final class SplashScreenInit
         	splashScreen.close();
         	return;
         }
-        
         LoginConfig cfg = new LoginConfig(reg);
         int max = cfg.getMaxRetry();
         LoginService loginSvc = (LoginService) reg.lookup(LookupNames.LOGIN);
@@ -164,8 +164,18 @@ public final class SplashScreenInit
         UserCredentials uc;
         UserNotifier un = UIFactory.makeUserNotifier(container);
 
+        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
+        String jnlpHost = System.getProperty("jnlp.omero.host");
+        String jnlpPort = System.getProperty("jnlp.omero.port");
+        
         while (0 < max--) {
-            uc = splashScreen.getUserCredentials((max == index-1));
+            if (CommonsLangUtils.isNotBlank(jnlpSession)) {
+                uc = new UserCredentials(jnlpSession,
+                        jnlpSession, jnlpHost, UserCredentials.HIGH);
+                uc.setPort(Integer.parseInt(jnlpPort));
+            } else {
+                uc = splashScreen.getUserCredentials((max == index-1));
+            }
             //needed b/c need to retrieve user's details later.
             reg.bind(LookupNames.USER_CREDENTIALS, uc);
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -152,6 +152,7 @@ public final class SplashScreenInit
 		    b = v.intValue() == LookupNames.INSIGHT_ENTRY ||
 	                    v.intValue() == LookupNames.IMPORTER_ENTRY;
 		}
+		
         if (!b) {
         	splashScreen.close();
         	return;
@@ -163,13 +164,13 @@ public final class SplashScreenInit
         int index = max;
         UserCredentials uc;
         UserNotifier un = UIFactory.makeUserNotifier(container);
-
-        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
         String jnlpHost = System.getProperty("jnlp.omero.host");
         String jnlpPort = System.getProperty("jnlp.omero.port");
-        
+        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
+        boolean jnlp = false;
         while (0 < max--) {
             if (CommonsLangUtils.isNotBlank(jnlpSession)) {
+                jnlp = true;
                 uc = new UserCredentials(jnlpSession,
                         jnlpSession, jnlpHost, UserCredentials.HIGH);
                 try {
@@ -193,6 +194,7 @@ public final class SplashScreenInit
 					if (max != 0) {
 						loginSvc.notifyLoginFailure();
 						splashScreen.onLoginFailure();
+						jnlpSession = null;
 		        	} else if (max == 0) {
 		        		//Exit if we couldn't manage to log in.
 		        		 un.notifyError("Login Failure", 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -86,8 +86,6 @@ public final class SplashScreenInit
 	void configure()
 	{
         initializer.register(this);
-		//splashScreen = UIFactory.makeSplashScreen(container);
-		//splashScreen.open();
 	}
 
 	/** 
@@ -116,7 +114,6 @@ public final class SplashScreenInit
 	 */
 	public void onStart(int totalTasks)
 	{
-		//splashScreen.setTotalTasks(totalTasks);
 		this.totalTasks = totalTasks;
 	}
 
@@ -167,10 +164,8 @@ public final class SplashScreenInit
         String jnlpHost = System.getProperty("jnlp.omero.host");
         String jnlpPort = System.getProperty("jnlp.omero.port");
         String jnlpSession = System.getProperty("jnlp.omero.sessionid");
-        boolean jnlp = false;
         while (0 < max--) {
             if (CommonsLangUtils.isNotBlank(jnlpSession)) {
-                jnlp = true;
                 uc = new UserCredentials(jnlpSession,
                         jnlpSession, jnlpHost, UserCredentials.HIGH);
                 try {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -172,7 +172,9 @@ public final class SplashScreenInit
             if (CommonsLangUtils.isNotBlank(jnlpSession)) {
                 uc = new UserCredentials(jnlpSession,
                         jnlpSession, jnlpHost, UserCredentials.HIGH);
-                uc.setPort(Integer.parseInt(jnlpPort));
+                try {
+                    uc.setPort(Integer.parseInt(jnlpPort));
+                } catch (Exception e) {}//use the default port.
             } else {
                 uc = splashScreen.getUserCredentials((max == index-1));
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -186,7 +186,6 @@ class SplashScreenManager
     	    configurable = false;
     	}
         String jnlpPort = System.getProperty("jnlp.omero.port");
-        
         if (CommonsLangUtils.isNotBlank(jnlpPort)) {
             port = jnlpPort;
             p = Integer.parseInt(port);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -32,10 +32,13 @@ import java.awt.event.WindowFocusListener;
 import java.awt.event.WindowStateListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+
 import javax.swing.Icon;
 import javax.swing.JFrame;
 
 //Third-party libraries
+
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
@@ -43,6 +46,7 @@ import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.ui.login.LoginCredentials;
 import org.openmicroscopy.shoola.util.ui.login.ScreenLogin;
@@ -172,9 +176,18 @@ class SplashScreenManager
     		(OMEROInfo) container.getRegistry().lookup(LookupNames.OMERODS);
         
     	String port = ""+info.getPortSSL();
-    	
-    	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port, 
-    			info.getHostName(), connectToServer());
+    	String host = info.getHostName();
+    	//check if we have jnlp option
+    	String jnlpHost = System.getProperty("jnlp.omero.host");
+    	if (CommonsLangUtils.isNotBlank(jnlpHost)) {
+    	    host = jnlpHost;
+    	}
+        String jnlpPort = System.getProperty("jnlp.omero.port");
+        if (CommonsLangUtils.isNotBlank(jnlpPort)) {
+            port = jnlpPort;
+        }
+    	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port,
+    			host, connectToServer());
     	view.setEncryptionConfiguration(info.isEncrypted(),
     			info.isEncryptedConfigurable());
     	view.setHostNameConfiguration(info.getHostName(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -178,20 +178,27 @@ class SplashScreenManager
     	int p = -1;
     	String port = ""+ info.getPortSSL();
     	String host = info.getHostName();
+    	boolean configurable = info.isHostNameConfigurable();
     	//check if we have jnlp option
     	String jnlpHost = System.getProperty("jnlp.omero.host");
     	if (CommonsLangUtils.isNotBlank(jnlpHost)) {
     	    host = jnlpHost;
+    	    configurable = false;
     	}
         String jnlpPort = System.getProperty("jnlp.omero.port");
-        boolean configurable = info.isHostNameConfigurable();
+        
         if (CommonsLangUtils.isNotBlank(jnlpPort)) {
             port = jnlpPort;
             p = Integer.parseInt(port);
             configurable = false;
         }
+        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
+        boolean serverAvailable = connectToServer();
+        if (CommonsLangUtils.isNotBlank(jnlpSession)) {
+            serverAvailable = false;
+        }
     	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port,
-    			host, connectToServer());
+    			host, serverAvailable);
     	view.setEncryptionConfiguration(info.isEncrypted(),
     			info.isEncryptedConfigurable());
     	view.setHostNameConfiguration(host, configurable, p);
@@ -214,10 +221,6 @@ class SplashScreenManager
      */
     private boolean connectToServer()
     {
-        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
-        if (CommonsLangUtils.isNotBlank(jnlpSession)) {
-            return false;
-        }
     	Integer v = (Integer) container.getRegistry().lookup(
 				LookupNames.ENTRY_POINT);
 		if (v != null) {
@@ -328,7 +331,9 @@ class SplashScreenManager
 		if (doneTasks == totalTasks) {
 			view.setStatusVisible(false, lc == null);
 			if (lc == null) view.requestFocusOnField();
-			if (!connectToServer()) view.setVisible(false);
+			if (!connectToServer()) {
+			    view.setVisible(false);
+			}
 		}
 	}
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -40,6 +40,7 @@ import javax.swing.JFrame;
 
 
 
+
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -213,6 +214,10 @@ class SplashScreenManager
      */
     private boolean connectToServer()
     {
+        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
+        if (CommonsLangUtils.isNotBlank(jnlpSession)) {
+            return false;
+        }
     	Integer v = (Integer) container.getRegistry().lookup(
 				LookupNames.ENTRY_POINT);
 		if (v != null) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -174,8 +174,8 @@ class SplashScreenManager
     		v = (String) version;
     	OMEROInfo info = 
     		(OMEROInfo) container.getRegistry().lookup(LookupNames.OMERODS);
-        
-    	String port = ""+info.getPortSSL();
+    	int p = -1;
+    	String port = ""+ info.getPortSSL();
     	String host = info.getHostName();
     	//check if we have jnlp option
     	String jnlpHost = System.getProperty("jnlp.omero.host");
@@ -183,15 +183,17 @@ class SplashScreenManager
     	    host = jnlpHost;
     	}
         String jnlpPort = System.getProperty("jnlp.omero.port");
+        boolean configurable = info.isHostNameConfigurable();
         if (CommonsLangUtils.isNotBlank(jnlpPort)) {
             port = jnlpPort;
+            p = Integer.parseInt(port);
+            configurable = false;
         }
     	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port,
     			host, connectToServer());
     	view.setEncryptionConfiguration(info.isEncrypted(),
     			info.isEncryptedConfigurable());
-    	view.setHostNameConfiguration(info.getHostName(),
-    			info.isHostNameConfigurable());
+    	view.setHostNameConfiguration(host, configurable, p);
 		view.showConnectionSpeed(true);
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 		Dimension d = view.getPreferredSize();

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -263,7 +263,10 @@ public class ScreenLogin
     
     /** The default server name from the configuration file.*/
     private String configureServerName;
-    
+
+    /** List of components to show or hide depending on connection status.*/
+    private List<JComponent> components;
+
 	/** Quits the application. */
 	private void quit()
 	{
@@ -495,6 +498,7 @@ public class ScreenLogin
 	 */
 	private void initialize(String userName, String hostName)
 	{
+	    components = new ArrayList<JComponent>();
 		//status update.
 		currentTask = new JLabel();
 		Font newFont = currentTask.getFont().deriveFont(8);
@@ -683,7 +687,7 @@ public class ScreenLogin
 		row.add(bar);
 		
 		mainPanel.add(row);
-		
+		components.add(row);
 		//user name
 		JPanel group = new JPanel();
 		group.setOpaque(false);
@@ -706,20 +710,20 @@ public class ScreenLogin
 		group.add(row);
 		
 		mainPanel.add(group);
+		components.add(group);
 		//controls
 		JPanel controls = new JPanel();
 		controls.setOpaque(false);
 		controls.add(Box.createHorizontalGlue());
 		controls.add(login);
 		controls.add(cancel);
-		mainPanel.add(UIUtilities.buildComponentPanelCenter(controls, 0, 0,
-				false));
-		
+		p = UIUtilities.buildComponentPanelCenter(controls, 0, 0, false);
+		mainPanel.add(p);
+		components.add(p);
 
-		
 		return mainPanel;
 	}
-	
+
 	/** 
 	 * Lays out the widgets and positions the window in the middle of
 	 * the screen.
@@ -759,16 +763,30 @@ public class ScreenLogin
 		versionInfo.setOpaque(false);
 		//Add login details.
 		int y = height-bottom-10;
-		if (serverAvailable) {
-			y = top+2*h;
-			buildLogin();
-		}
-		
+		y = top+2*h;
+        buildLogin();
+        displayComponents(serverAvailable);
 		mainPanel.add(UIUtilities.buildComponentPanelCenter(
 				versionInfo, 0, 0, false));
 		mainPanel.setBounds(0, y, width, height-top-bottom);
 		addToLayer(mainPanel);
 	}
+
+    /**
+     * Shows or hides the components.
+     *
+     * @param visible Pass <code>true</code> to show,
+     *                <code>false</code> to hide.
+     */
+    private void displayComponents(boolean visible)
+    {
+        Iterator<JComponent> i = components.iterator();
+        while (i.hasNext()) {
+            i.next().setVisible(visible);
+        }
+        repaint();
+    }
+
 	/** 
 	 * Returns the server's name.
 	 * 
@@ -1148,6 +1166,7 @@ public class ScreenLogin
 	{
 		loginAttempt = false;
 		setControlsEnabled(true);
+		displayComponents(true);
 	}
 	
 	/** Sets the text of all textFields to <code>null</code>. */
@@ -1176,7 +1195,7 @@ public class ScreenLogin
 				pass.setText("");
 				break;
 			default:
-				cleanFields();	
+				cleanFields();
 		}
 	}
 	
@@ -1348,7 +1367,6 @@ public class ScreenLogin
                 } else {
                     selectedPort = port;
                 }
-                
                 setNewServer(originalServerName);
             }
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -516,7 +516,7 @@ public class ScreenLogin
 		pass.setToolTipText("Enter your password.");
 		pass.setColumns(TEXT_COLUMN);
 		Map<String, String> servers = editor.getServers();
-		if (hostName != null && hostName.trim().length() > 0) {
+		if (CommonsLangUtils.isNotBlank(hostName)) {
 			serverName = hostName;
 			//if user did point to another server
 			if (servers != null && servers.size() > 0) {
@@ -803,7 +803,7 @@ public class ScreenLogin
 	 */
 	private void setNewServer(String s)
 	{
-		if (s == null || s.length() == 0) {
+		if (CommonsLangUtils.isBlank(s)) {
 			if (configureServerName != null)
 				s = configureServerName;
 			else s = DEFAULT_SERVER;
@@ -1309,7 +1309,51 @@ public class ScreenLogin
     	if (!configurable)
     		encryptedButton.removeActionListener(encryptionListener);
     }
-    
+    /**
+     * Indicates if the user can modify or not the host name from the UI.
+     * 
+     * @param hostName The hostname.
+     * @param configurable Pass <code>true</code> to allow to change the 
+     * host name, <code>false</code> otherwise.
+     * @param port The selected port.
+     */
+    public void setHostNameConfiguration(String hostName, boolean configurable,
+            int port)
+    {
+        hostConfigurable = configurable;
+        configureServerName = hostName;
+        if (CommonsLangUtils.isNotBlank(hostName)) {
+            if (configurable) {
+                Map<String, String> servers = editor.getServers();
+                if (servers == null || servers.size() == 0) 
+                    editor.addRow(hostName);
+                else {
+                    Iterator<String> i = servers.keySet().iterator();
+                    String value;
+                    boolean exist = false;
+                    while (i.hasNext()) {
+                        value = i.next();
+                        if (hostName.equals(value)) {
+                            exist = true;
+                            break;
+                        }
+                    }
+                    if (!exist) editor.addRow(hostName);
+                }
+            } else {
+                serverName = hostName;
+                originalServerName = serverName;
+                if (port < 0) {
+                    selectedPort = Integer.parseInt(editor.getDefaultPort());
+                } else {
+                    selectedPort = port;
+                }
+                
+                setNewServer(originalServerName);
+            }
+        }
+    }
+
     /**
      * Indicates if the user can modify or not the host name from the UI.
      * 
@@ -1319,33 +1363,7 @@ public class ScreenLogin
      */
     public void setHostNameConfiguration(String hostName, boolean configurable)
     {
-    	hostConfigurable = configurable;
-    	configureServerName = hostName;
-    	if (hostName != null && hostName.trim().length() > 0) {
-    		if (configurable) {
-        		Map<String, String> servers = editor.getServers();
-        		if (servers == null || servers.size() == 0) 
-    				editor.addRow(hostName);
-    			else {
-    				Iterator<String> i = servers.keySet().iterator();
-    				String value;
-    				boolean exist = false;
-    				while (i.hasNext()) {
-    					value = i.next();
-    					if (hostName.equals(value)) {
-    						exist = true;
-    						break;
-    					}
-    				}
-    				if (!exist) editor.addRow(hostName);
-    			}
-        	} else {
-        		serverName = hostName;
-        		originalServerName = serverName;
-        		selectedPort = Integer.parseInt(editor.getDefaultPort());
-        		setNewServer(originalServerName);
-        	}
-    	}
+        setHostNameConfiguration(hostName, configurable, -1);
     }
 
 	/**


### PR DESCRIPTION
Handle the parameters specified when using webstart
To test:
 * Log using the web client
 * Start insight from web
 * After the standard steps, insight splashscreen should only show the progress bar displayed when initializing the internal services. No username/password field
 * When completed, the application should automatically log in and the data manager should pop up.

cc @dominikl @aleksandra-tarkowska 
see gh-3810