### PR TITLE
Tweak the CLI delete report

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -49,18 +49,23 @@ class DeleteControl(GraphControl):
     def print_delete_response(self, rsp):
         self.ctx.out("Deleted objects")
         objIds = self._get_object_ids(rsp)
-        for k in sorted(objIds):
+        for k in objIds:
             self.ctx.out("%s:%s" % (k, objIds[k]))
 
     def _get_object_ids(self, rsp):
+        import collections
         objIds = {}
         for k in rsp.deletedObjects.keys():
             if rsp.deletedObjects[k]:
                 for excl in EXCLUDED_PACKAGES:
                     if not k.startswith(excl):
                         ids = ','.join(map(str, rsp.deletedObjects[k]))
-                        k = k[k.rfind('.')+1:]
                         objIds[k] = ids
+        newIds = collections.OrderedDict(sorted(objIds.items()))
+        objIds = collections.OrderedDict()
+        for k in newIds:
+            key = k[k.rfind('.')+1:]
+            objIds[key] = newIds[k]
         return objIds
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -48,12 +48,20 @@ class DeleteControl(GraphControl):
 
     def print_delete_response(self, rsp):
         self.ctx.out("Deleted objects")
+        objIds = self._get_object_ids(rsp)
+        for k in sorted(objIds):
+            self.ctx.out("%s:%s" % (k, objIds[k]))
+
+    def _get_object_ids(self, rsp):
+        objIds = {}
         for k in rsp.deletedObjects.keys():
             if rsp.deletedObjects[k]:
                 for excl in EXCLUDED_PACKAGES:
                     if not k.startswith(excl):
                         ids = ','.join(map(str, rsp.deletedObjects[k]))
-                        self.ctx.out("%s:%s" % (k, ids))
+                        k = k[k.rfind('.')+1:]
+                        objIds[k] = ids
+        return objIds
 
 try:
     register("delete", DeleteControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -27,6 +27,8 @@ Examples:
 
 """
 
+EXCLUDED_PACKAGES = ["ome.model.display"]
+
 
 class DeleteControl(GraphControl):
 
@@ -45,11 +47,13 @@ class DeleteControl(GraphControl):
             self.print_delete_response(rsp)
 
     def print_delete_response(self, rsp):
+        self.ctx.out("Deleted objects")
         for k in rsp.deletedObjects.keys():
             if rsp.deletedObjects[k]:
-                self.ctx.out("Deleted %s objects" % k)
-                for i in rsp.deletedObjects[k]:
-                    self.ctx.out("%s:%s" % (k, i))
+                for excl in EXCLUDED_PACKAGES:
+                    if not k.startswith(excl):
+                        ids = ','.join(map(str, rsp.deletedObjects[k]))
+                        self.ctx.out("%s:%s" % (k, ids))
 
 try:
     register("delete", DeleteControl, HELP)


### PR DESCRIPTION
This PR alters the output of the `--report` option of the `omero delete` command in line with https://github.com/openmicroscopy/openmicroscopy/pull/3725#issuecomment-96042925

The deleted objects list should use comma-separated ID lists rather than one object per line as before. Deleted `ome.model.display.*` objects should be excluded from the output:

```
$ omero delete Image:101 --dry-run --report
omero.cmd.Delete2 Image 101... ok
Steps: 1
Elapsed time: 0.451 secs.
Flags: []
Deleted objects
ome.model.fs.FilesetEntry:101
ome.model.core.Image:101
ome.model.core.OriginalFile:156,155
ome.model.core.LogicalChannel:51
ome.model.core.Channel:51
ome.model.jobs.PixelDataJob:53
ome.model.jobs.IndexingJob:55
ome.model.fs.Fileset:51
ome.model.jobs.ThumbnailGenerationJob:54
ome.model.jobs.MetadataImportJob:52
ome.model.jobs.UploadJob:51
ome.model.core.Pixels:101
ome.model.fs.FilesetJobLink:51,55,54,53,52
ome.model.stats.StatsInfo:65
ome.model.jobs.JobOriginalFileLink:51
```

--no-rebase