### PR TITLE
Save enabled on z/t change

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -14,6 +14,8 @@ GROUP_NAME_2=${GROUP_NAME_2:-robot_group_2}
 USER_NAME=${USER_NAME:-robot_user}
 USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-robot_ice.config}
+IMAGE_NAME=${IMAGE_NAME:-test&sizeZ=3&sizeT=10.fake}
+TINY_IMAGE_NAME=${TINY_IMAGE_NAME:-test.fake}
 
 # Create robot user and group
 bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
@@ -24,7 +26,8 @@ bin/omero user joingroup --name $USER_NAME --group-name $GROUP_NAME --as-owner
 bin/omero logout
 
 # Create fake file
-touch test.fake
+touch $IMAGE_NAME
+touch $TINY_IMAGE_NAME
 
 # Create robot setup
 bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD
@@ -42,7 +45,7 @@ do
     echo "Importing images into dataset"
     for (( k=1; k<=$nImages; k++ ))
     do
-      bin/omero import -d $dataset test.fake --debug ERROR
+      bin/omero import -d $dataset $IMAGE_NAME --debug ERROR
     done
   done
 done
@@ -51,7 +54,7 @@ done
 delDs=$(bin/omero obj new Dataset name='Delete')
 for (( k=1; k<=5; k++ ))
 do
-  bin/omero import -d $delDs test.fake --debug ERROR
+  bin/omero import -d $delDs $TINY_IMAGE_NAME --debug ERROR
 done
 
 # Logout

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -12,6 +12,9 @@ Suite Teardown      Close all browsers
 
 ${importedChColor}                  rgb(128, 128, 128)
 ${importedMax}                      255
+${sizeZ}                            3
+${defaultZ}                         2
+${currZ}                            3
 
 *** Keywords ***
 
@@ -72,6 +75,19 @@ Test Rdef Copy Paste Save
     Element Should Be Disabled              id=rdef-undo-btn
     Element Should Be Disabled              id=rdef-redo-btn
     Element Should Be Disabled              id=rdef-setdef-btn
+
+    # Change Z-index: on callback, Save is enabled but not Undo/Redo
+    Element Text Should Be                  id=wblitz-z-count       ${sizeZ}
+    Element Text Should Be                  id=wblitz-z-curr        ${defaultZ}
+    Click Element                           id=viewport-zsl-bup
+    Wait Until Page Contains Element        xpath=//button[@id='rdef-setdef-btn'][not(@disabled="disabled")]
+    Element Text Should Be                  id=wblitz-z-curr        ${currZ}
+    Element Should Be Disabled              id=rdef-undo-btn
+    Element Should Be Disabled              id=rdef-redo-btn
+    # change back again...
+    Click Element                           id=viewport-zsl-bdn
+    Wait Until Page Contains Element        xpath=//button[@id='rdef-setdef-btn'][@disabled="disabled"]
+    Element Text Should Be                  id=wblitz-z-curr        ${defaultZ}
 
     # Color-picker, Yellow then Blue.
     Pick Color          ff0       FFFF00        rgb(255, 255, 0)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -55,7 +55,9 @@ var Metadata = function () {
         this[i][j] = cached[i][j];
       }
     }
+    this.defaultZ = this.rdefs.defaultZ;
     this.current.z = this.rdefs.defaultZ;
+    this.defaultT = this.rdefs.defaultT;
     this.current.t = this.rdefs.defaultT;
       if (this.rdefs.invertAxis) {
         var t = this.size.t;
@@ -942,10 +944,14 @@ jQuery._WeblitzViewport = function (container, server, options) {
   // When we Save settings to the server, we can remember the point we saved.
   this.setSaved = function() {
     saved_undo_stack_ptr = channels_undo_stack_ptr;
+    _this.loadedImg.defaultZ = this.getZPos()-1;
+    _this.loadedImg.defaultT = this.getTPos()-1;
   };
   // Do we have any unsaved changes? (undo/redo since we last saved)
   this.getSaved = function() {
-    return saved_undo_stack_ptr === channels_undo_stack_ptr;
+    var zSaved = _this.loadedImg.defaultZ === this.getZPos()-1;
+    var tSaved = _this.loadedImg.defaultT === this.getTPos()-1;
+    return (zSaved && tSaved && saved_undo_stack_ptr === channels_undo_stack_ptr);
   };
 
   this.doload = function(){

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -975,6 +975,8 @@ jQuery._WeblitzViewport = function (container, server, options) {
     }
   };
 
+  // bookmarks were previously set and used when rdef dialog
+  // was hidden and show. Not used currently.
   this.bookmark_channels = function () {
     channels_bookmark = channels_undo_stack_ptr+1;
   };

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -100,10 +100,6 @@
                 if (callback) {
                     callback();
                 }
-                // update 'default' values of Z & T so we know of unsaved changes
-                $('#wblitz-z-curr').attr('data-defaultZ',viewport.getZPos());
-                $('#wblitz-t-curr').attr('data-defaultT',viewport.getTPos());
-
                 viewport.setSaved();
                 updateUndoRedo(viewport);
             });
@@ -154,44 +150,16 @@
 
 
     window.imageChange = function (viewport) {
-        var newZ = viewport.getZPos(),
-            oldZ = $('#wblitz-z-curr').attr('data-defaultZ'),
-            newT = viewport.getTPos(),
-            oldT = $('#wblitz-t-curr').attr('data-defaultT');
-            // zChanged = (oldZ && oldZ != newZ),
-            // tChanged = (oldT && oldT != newT);
-        $('#wblitz-t-curr').html(newT);
-        $('#wblitz-z-curr').html(newZ);
-        // if default Z and T not set yet, we are just loading image for first time...
-        if (!oldZ) {
-            $('#wblitz-z-curr').attr('data-defaultZ',newZ);
-        }
-        if (!oldT) {
-            $('#wblitz-t-curr').attr('data-defaultT',newT);
-        }
+        $('#wblitz-t-curr').html(viewport.getTPos());
+        $('#wblitz-z-curr').html(viewport.getZPos());
         $('#wblitz-t-count').html(viewport.getTCount());
         $('#wblitz-z-count').html(viewport.getZCount());
-
-        // Z/T change enables Save button
-        // var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
-        // if ((zChanged || tChanged) && canSaveRdef) {
-        //     $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
-        // }
-        updateUndoRedo(viewport);
 
         if (viewport.hasLinePlot() || $('#wblitz-lp-enable').prop('checked')) {
             viewport.refreshPlot();
         }
-    };
-
-    window.isZandTsaved = function(viewport) {
-        var savedZ = $('#wblitz-z-curr').attr('data-defaultZ'),
-            currZ = viewport.getZPos(),
-            savedT = $('#wblitz-t-curr').attr('data-defaultT'),
-            currT = viewport.getTPos();
-        var zSaved = (!savedZ || savedZ == currZ);
-        var tSaved = (!savedT || savedT == currT);
-        return (zSaved && tSaved);
+        // Z/T change update Save button
+        updateUndoRedo(viewport);
     };
 
     window.syncChannelsActive = function(viewport) {
@@ -238,7 +206,7 @@
             $('#rdef-redo-btn').attr("disabled", "disabled").addClass("button-disabled");
         }
         var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
-        if ((viewport.getSaved() && isZandTsaved(viewport)) || !canSaveRdef) {
+        if (viewport.getSaved() || !canSaveRdef) {
             $("#rdef-setdef-btn").attr("disabled", "disabled").addClass("button-disabled");
         } else {
             $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -100,6 +100,10 @@
                 if (callback) {
                     callback();
                 }
+                // update 'default' values of Z & T so we know of unsaved changes
+                $('#wblitz-z-curr').attr('data-defaultZ',viewport.getZPos());
+                $('#wblitz-t-curr').attr('data-defaultT',viewport.getTPos());
+
                 viewport.setSaved();
                 updateUndoRedo(viewport);
             });
@@ -151,25 +155,43 @@
 
     window.imageChange = function (viewport) {
         var newZ = viewport.getZPos(),
-            oldZ = $('#wblitz-z-curr').html(),
+            oldZ = $('#wblitz-z-curr').attr('data-defaultZ'),
             newT = viewport.getTPos(),
-            oldT = $('#wblitz-t-curr').html(),
-            zChanged = (oldZ != '?' && oldZ != newZ),
-            tChanged = (oldT != '?' && oldT != newT);
-        $('#wblitz-t-curr').html(newZ);
+            oldT = $('#wblitz-t-curr').attr('data-defaultT');
+            // zChanged = (oldZ && oldZ != newZ),
+            // tChanged = (oldT && oldT != newT);
+        $('#wblitz-t-curr').html(newT);
         $('#wblitz-z-curr').html(newZ);
+        // if default Z and T not set yet, we are just loading image for first time...
+        if (!oldZ) {
+            $('#wblitz-z-curr').attr('data-defaultZ',newZ);
+        }
+        if (!oldT) {
+            $('#wblitz-t-curr').attr('data-defaultT',newT);
+        }
         $('#wblitz-t-count').html(viewport.getTCount());
         $('#wblitz-z-count').html(viewport.getZCount());
 
         // Z/T change enables Save button
-        var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
-        if ((zChanged || tChanged) && canSaveRdef) {
-            $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
-        }
+        // var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
+        // if ((zChanged || tChanged) && canSaveRdef) {
+        //     $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
+        // }
+        updateUndoRedo(viewport);
 
         if (viewport.hasLinePlot() || $('#wblitz-lp-enable').prop('checked')) {
             viewport.refreshPlot();
         }
+    };
+
+    window.isZandTsaved = function(viewport) {
+        var savedZ = $('#wblitz-z-curr').attr('data-defaultZ'),
+            currZ = viewport.getZPos(),
+            savedT = $('#wblitz-t-curr').attr('data-defaultT'),
+            currT = viewport.getTPos();
+        var zSaved = (!savedZ || savedZ == currZ);
+        var tSaved = (!savedT || savedT == currT);
+        return (zSaved && tSaved);
     };
 
     window.syncChannelsActive = function(viewport) {
@@ -216,7 +238,7 @@
             $('#rdef-redo-btn').attr("disabled", "disabled").addClass("button-disabled");
         }
         var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
-        if (viewport.getSaved() || !canSaveRdef) {
+        if ((viewport.getSaved() && isZandTsaved(viewport)) || !canSaveRdef) {
             $("#rdef-setdef-btn").attr("disabled", "disabled").addClass("button-disabled");
         } else {
             $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -150,10 +150,22 @@
 
 
     window.imageChange = function (viewport) {
-        $('#wblitz-t-curr').html(viewport.getTPos());
-        $('#wblitz-z-curr').html(viewport.getZPos());
+        var newZ = viewport.getZPos(),
+            oldZ = $('#wblitz-z-curr').html(),
+            newT = viewport.getTPos(),
+            oldT = $('#wblitz-t-curr').html(),
+            zChanged = (oldZ != '?' && oldZ != newZ),
+            tChanged = (oldT != '?' && oldT != newT);
+        $('#wblitz-t-curr').html(newZ);
+        $('#wblitz-z-curr').html(newZ);
         $('#wblitz-t-count').html(viewport.getTCount());
         $('#wblitz-z-count').html(viewport.getZCount());
+
+        // Z/T change enables Save button
+        var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
+        if ((zChanged || tChanged) && canSaveRdef) {
+            $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
+        }
 
         if (viewport.hasLinePlot() || $('#wblitz-lp-enable').prop('checked')) {
             viewport.refreshPlot();

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1105,10 +1105,7 @@
     $("#rdef-postit").bind('closed',
       function () {
                     hidePicker();
-                    /* viewport.back_to_bookmarked_channels();*/
-                    //syncRDCW(viewport);
-                  })
-      .bind('opening', function () { syncRDCW(viewport); viewport.bookmark_channels()});
+                  });
 
     $('.can-collapse').click(function () {
       $(this).toggleClass('closed').next().slideToggle();


### PR DESCRIPTION
This fixes http://trac.openmicroscopy.org.uk/ome/ticket/12709 in web.

To test:
 - Open Preview panel
 - Change Z or T index
 - Save button should become enabled and saving should update Thumbnail etc.
 - Test same behaviour in Image Viewer.

NB: we don't have a whole undo/redo queue for Z/T changes, so after Z/T change and "Save" is enabled, if you change rendering settings then click "Undo" the Save button will become disabled again.