### PR TITLE
roi_thumb shapes with no Z/T

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -373,8 +373,8 @@ def render_roi_thumbnail(request, roiId, w=None, h=None, conn=None, **kwargs):
         for s in roi.copyShapes():
             if s is None:   # seems possible in some situations
                 continue
-            t = s.getTheT().getValue()
-            z = s.getTheZ().getValue()
+            t = unwrap(s.getTheT())
+            z = unwrap(s.getTheZ())
             shapes[(z, t)] = s
             if minT is None:
                 minT = t


### PR DESCRIPTION
Noticed a very minor issue with roi thumbnails when shapes don't have Z or T set.

To test:
 - I don't think you need to find a shape that has Z/T unset, just check that the web image viewer ROI table displays ROI "preview" thumbs is still working OK.
 - Tested locally that this does work when Z is None.

![screen shot 2015-05-15 at 16 16 43](https://cloud.githubusercontent.com/assets/900055/7655766/dee1e92e-fb1d-11e4-80af-21f5f6e23321.png)
