### PR TITLE
Exclude annotations in CLI delete

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -39,7 +39,8 @@ import omero.gateway
 from omero.cmd import DoAll, State, ERR, OK, Chmod2, Chgrp2, Delete2
 from omero.callbacks import CmdCallbackI
 from omero.model import DatasetI, DatasetImageLinkI, ImageI, ProjectI
-from omero.model import Annotation, FileAnnotationI, OriginalFileI
+from omero.model import Annotation, FileAnnotationI, TagAnnotationI
+from omero.model import OriginalFileI
 from omero.model import DimensionOrderI, PixelsI, PixelsTypeI
 from omero.model import Experimenter, ExperimenterI
 from omero.model import ExperimenterGroup, ExperimenterGroupI
@@ -798,6 +799,13 @@ class ITest(object):
         """
         return self.new_object(DatasetI, name=name, description=description)
 
+    def new_tag(self, name=None):
+        """
+        Creates a new tag object.
+        :param name: The tag name. If None, a UUID string will be used
+        """
+        return self.new_object(TagAnnotationI, name=name)
+
     def make_image(self, name=None, description=None, date=0, client=None):
         """
         Creates a new image instance and returns the persisted object.
@@ -834,6 +842,17 @@ class ITest(object):
             client = self.client
         dataset = self.new_dataset(name=name, description=description)
         return client.sf.getUpdateService().saveAndReturnObject(dataset)
+
+    def make_tag(self, name=None, client=None):
+        """
+        Creates a new tag instance and returns the persisted object.
+        :param name: The tag name. If None, a UUID string will be used
+        :param client: The client to use to create the object
+        """
+        if client is None:
+            client = self.client
+        tag = self.new_tag(name=name)
+        return client.sf.getUpdateService().saveAndReturnObject(tag)
 
     def createDatasets(self, count, baseName, client=None):
         """

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1662,6 +1662,12 @@ class GraphControl(CmdControl):
             req_or_doall = omero.cmd.DoAll([req_or_doall])
         return req_or_doall
 
+    def default_exclude(self):
+        """
+        Return a list of types to exclude by default.
+        """
+        return []
+
     def main_method(self, args):
 
         client = self.ctx.conn(args)
@@ -1699,21 +1705,24 @@ class GraphControl(CmdControl):
                 self.ctx.out("\n".join(keys))
                 return  # Early exit.
 
-        opt = None
+        inc = []
         if args.include:
             inc = args.include.split(",")
-            opt = omero.cmd.graphs.ChildOption(includeType=inc)
+        exc = self.default_exclude()
         if args.exclude:
-            exc = args.exclude.split(",")
-            if opt is None:
-                opt = omero.cmd.graphs.ChildOption(excludeType=exc)
-            else:
+            exc = exc.extend(args.exclude.split(","))
+
+        if len(inc) > 0 or len(exc) > 0:
+            opt = omero.cmd.graphs.ChildOption()
+            if len(inc) > 0:
+                opt.includeType = inc
+            if len(exc) > 0:
                 opt.excludeType = exc
 
         commands = args.obj
         for req in commands:
             req.dryRun = args.dry_run
-            if args.include or args.exclude:
+            if len(inc) > 0 or len(exc) > 0:
                 req.childOptions = [opt]
             if isinstance(req, omero.cmd.SkipHead):
                 req.request.childOptions = req.childOptions

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -16,6 +16,9 @@ HELP = """Delete OMERO data.
 
 Remove entire graphs of data based on the ID of the top-node.
 
+By default linked tag, file and term annotations are not deleted.
+To delete linked annoations they must be explicitly included.
+
 Examples:
 
     bin/omero delete --list   # Print all of the graphs
@@ -24,6 +27,9 @@ Examples:
     bin/omero delete Plate:1
     bin/omero delete Image:51,52 OriginalFile:101
     bin/omero delete Project:101 --exclude Dataset,Image
+
+    # Force delete of linked annotations
+    bin/omero delete Image:51 --include Annotation
 
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -51,6 +51,13 @@ class DeleteControl(GraphControl):
                 for i in rsp.deletedObjects[k]:
                     self.ctx.out("%s:%s" % (k, i))
 
+    def default_exclude(self):
+        """
+        Don't delete these three types of Annotation by default
+        """
+        return ["TagAnnotation", "TermAnnotation", "FileAnnotation"]
+
+
 try:
     register("delete", DeleteControl, HELP)
 except NameError:

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -102,7 +102,7 @@ class TestDelete(CLITest):
         for i in images:
             assert self.query.get('Image', i.id.val) is not None
 
-    def testFilesetAllImagesMoveDataset(self):
+    def testFilesetAllImagesDeleteDataset(self):
         images = self.importMIF(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -381,3 +381,39 @@ class TestDelete(CLITest):
         assert self.query.find('FileAnnotation', fa.id.val)
         assert self.query.find('TagAnnotation', tag.id.val)
         assert not self.query.find('FileAnnotation', fa2.id.val)
+
+    def testLinkedAnnotationDelete(self):
+        img = self.update.saveAndReturnObject(self.new_image())
+        fa = self.make_file_annotation()
+        fa2 = self.make_file_annotation()
+
+        self.link(img, fa)
+        self.link(img, fa2)
+
+        self.args += ['Image:%s' % img.id.val]
+        self.args += ['Annotation:%s' % fa.id.val]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that the image has been deleted and annotation, fa,
+        # but that the other annotation has not been deleted.
+        assert not self.query.find('Image', img.id.val)
+        assert not self.query.find('FileAnnotation', fa.id.val)
+        assert self.query.find('FileAnnotation', fa2.id.val)
+
+    def testLinkedAnnotationDeleteWithOverride(self):
+        img = self.update.saveAndReturnObject(self.new_image())
+        fa = self.make_file_annotation()
+        fa2 = self.make_file_annotation()
+
+        self.link(img, fa)
+        self.link(img, fa2)
+
+        self.args += ['Image:%s' % img.id.val]
+        self.args += ['Annotation:%s' % fa.id.val]
+        self.args += ['--include', 'FileAnnotation']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that the image and both annotations have been deleted.
+        assert not self.query.find('Image', img.id.val)
+        assert not self.query.find('FileAnnotation', fa.id.val)
+        assert not self.query.find('FileAnnotation', fa2.id.val)

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -295,6 +295,17 @@ class TestDelete(CLITest):
         for d in ds:
             assert not self.query.find('Dataset', d.id.val)
 
+    # Test dry-run option
+    def testDryRun(self):
+        img = self.update.saveAndReturnObject(self.new_image())
+
+        self.args += ['Image:%s' % img.id.val]
+        self.args += ['--dry-run']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that the image has not been deleted,
+        assert self.query.find('Image', img.id.val)
+
     # These tests check the default exclusion of the annotations:
     # FileAnnotation, TagAnnotation and TermAnnotation
 


### PR DESCRIPTION
This PR mirrors the default action in the other clients and does not delete linked annotations (File, Tag and Term) without confirmation.
```
omero delete Image:51
``` 
will delete the image but not its annotations. Whereas
```
omero delete Image:51 --include Annotation
``` 
will also delete the images annotations. Individual annotation types can be selected,
```
omero delete Image:51 --include FileAnnotation
``` 
will delete any linked FileAnnotation objects but not other types. Other annotations can be deleted in the same command,
```
omero delete Image:51 Annotation:101
``` 
will not delete linked annotations but it will delete the separate specified annotation. Individual linked annotations can be deleted by explicitly using their IDs,
```
omero delete Image:51 Annotation:51
```
will delete the linked annotation with the given id but exclude other linked annotations.


--no-rebase