### PR TITLE
Micromanager

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -219,9 +219,17 @@ public class FileObject
             ImagePlus img = (ImagePlus) file;
             if (img.changes) return true;
             FileInfo info = img.getOriginalFileInfo();
+            IJ.log("info:"+info);
+            String name;
             if (info == null) {
                 info = img.getFileInfo();
-                String name = info.fileName;
+                name = info.fileName;
+                IJ.log("name:"+name);
+                if (CommonsLangUtils.isBlank(name) || "Untitled".equals(name))
+                    return true;
+            } else {
+                name = info.fileName;
+                IJ.log("name:"+name);
                 if (CommonsLangUtils.isBlank(name) || "Untitled".equals(name))
                     return true;
             }
@@ -260,7 +268,9 @@ public class FileObject
                         }
                         return trueFile;
                     }
-                    if (info.directory != null && info.fileName != null) {
+                    if (isNewImage()) return null;
+                    if (info.directory != null && info.fileName != null &&
+                            !"Untitled".equals(info.fileName)) {
                         trueFile = new File(info.directory, info.fileName);
                         return trueFile;
                     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -125,7 +125,16 @@ public class FileObject
             return ((File) file).getName();
         } else if (file instanceof ImagePlus) {
             ImagePlus img = (ImagePlus) file;
-            return img.getTitle();
+            String name = img.getTitle();
+            if (CommonsLangUtils.isNotBlank(name))
+                return name;
+            FileInfo info = img.getOriginalFileInfo();
+            if (info != null) {
+                if (CommonsLangUtils.isNotBlank(name)) {
+                    return name;
+                }
+                return "No Name Set";
+            }
         }
         return null;
     }
@@ -142,7 +151,7 @@ public class FileObject
         } else if (file instanceof ImagePlus) {
             File f = getTrueFile();
             if (f != null) return f.getAbsolutePath();
-            return ((ImagePlus) file).getTitle();
+            return getName();
         }
         return "";
     }
@@ -162,10 +171,10 @@ public class FileObject
             try {
                 //name w/o extension
                 String baseName = FilenameUtils.getBaseName(
-                        FilenameUtils.removeExtension(img.getTitle()));
+                        FilenameUtils.removeExtension(getName()));
                 baseName = CommonsLangUtils.deleteWhitespace(baseName);
                 String n = baseName+".ome.tif";
-                f = File.createTempFile(img.getTitle(), ".ome.tif");
+                f = File.createTempFile(getName(), ".ome.tif");
                 File p = f.getParentFile();
                 File[] list = p.listFiles();
                 if (list != null) {
@@ -183,6 +192,8 @@ public class FileObject
                 f = new File(p, n);
                 f.deleteOnExit();
             } catch (Exception e) {
+                if (f != null) f.delete();
+                IJ.log(e.toString());
                 return null;
             }
             StringBuffer buffer = new StringBuffer();
@@ -219,17 +230,14 @@ public class FileObject
             ImagePlus img = (ImagePlus) file;
             if (img.changes) return true;
             FileInfo info = img.getOriginalFileInfo();
-            IJ.log("info:"+info);
             String name;
             if (info == null) {
                 info = img.getFileInfo();
                 name = info.fileName;
-                IJ.log("name:"+name);
                 if (CommonsLangUtils.isBlank(name) || "Untitled".equals(name))
                     return true;
             } else {
                 name = info.fileName;
-                IJ.log("name:"+name);
                 if (CommonsLangUtils.isBlank(name) || "Untitled".equals(name))
                     return true;
             }


### PR DESCRIPTION
This PR fixes a problem noticed by @bramalingam when importing a non saved "snap" image or album to OMERO.
To test:
 * Install Micromanager see https://www.micro-manager.org/wiki/Download_Micro-Manager_Latest_Release
 * Add bioformats_package and omero-ij in the plugins folder of MicroManager
 * Start micromanager in demo mode. An instance of imageJ will be launched
 * Click on Snap
 * Go to Plugins>OMERO>Save Image(s) to OMERO
 * Import the image
 * Check that the image is imported

Note that you might have to increase the memory allocated to micromanager.
