### PR TITLE
Improve rendering of Image metadata details

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7512,7 +7512,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         q = self._conn.getQueryService()
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = "select lc.name, lc.emissionWave, lc.id "\
+        query = "select lc.name, lc.emissionWave, chan.id "\
                 "from LogicalChannel lc, Channel chan, Image img "\
                 "where chan.logicalChannel = lc "\
                 "and chan.pixels.image = img "\
@@ -7520,10 +7520,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         res = q.projection(query, params, self._conn.SERVICE_OPTS)
         ret = []
         for name, emissionWave, idx in res:
-            label = (name and name.val) or\
-                    (emissionWave and emissionWave.val) or\
-                    (idx and idx.val) or -1
-            ret.append(label)
+            if name is not None and len(name.val.strip()) > 0:
+                ret.append(name.val)
+            elif emissionWave is not None and\
+                    len(unicode(emissionWave.val).strip()) > 0:
+                ret.append(unicode(emissionWave.val))
+            else:
+                ret.append(unicode(idx.val))
         return ret
 
     @assert_re()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7517,7 +7517,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 "join p.image as img "\
                 "join p.channels as chan "\
                 "join chan.logicalChannel as lc "\
-                "where img.id = :id"
+                "where img.id = :id order by index(chan)"
         res = q.projection(query, params, self._conn.SERVICE_OPTS)
         ret = []
         for name, emissionWave, idx in res:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7512,11 +7512,12 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         q = self._conn.getQueryService()
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = "select lc.name, lc.emissionWave, chan.id "\
-                "from LogicalChannel lc, Channel chan, Image img "\
-                "where chan.logicalChannel = lc "\
-                "and chan.pixels.image = img "\
-                "and img.id = :id"
+        query = "select lc.name, lc.emissionWave, index(chan) "\
+                "from Pixels p "\
+                "join p.image as img "\
+                "join p.channels as chan "\
+                "join chan.logicalChannel as lc "\
+                "where img.id = :id"
         res = q.projection(query, params, self._conn.SERVICE_OPTS)
         ret = []
         for name, emissionWave, idx in res:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7512,7 +7512,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         q = self._conn.getQueryService()
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = "select lc.name, lc.emissionWave, index(chan) "\
+        query = "select lc.name, lc.emissionWave.value, index(chan) "\
                 "from Pixels p "\
                 "join p.image as img "\
                 "join p.channels as chan "\
@@ -7525,7 +7525,12 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 ret.append(name.val)
             elif emissionWave is not None and\
                     len(unicode(emissionWave.val).strip()) > 0:
-                ret.append(unicode(emissionWave.val))
+                # FIXME: units ignored for wavelength
+                rv = emissionWave.getValue()
+                # Don't show as double if it's really an int
+                if int(rv) == rv:
+                    rv = int(rv)
+                ret.append(unicode(rv))
             else:
                 ret.append(unicode(idx.val))
         return ret

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7505,6 +7505,27 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return [ChannelWrapper(self._conn, c, idx=n, re=self._re, img=self)
                 for n, c in enumerate(pixels.iterateChannels())]
 
+    def getChannelLabels(self):
+        """
+        Returns a list of the labels for the Channels for this image
+        """
+        q = self._conn.getQueryService()
+        params = omero.sys.ParametersI()
+        params.addId(self.getId())
+        query = "select lc.name, lc.emissionWave, lc.id "\
+                "from LogicalChannel lc, Channel chan, Image img "\
+                "where chan.logicalChannel = lc "\
+                "and chan.pixels.image = img "\
+                "and img.id = :id"
+        res = q.projection(query, params, self._conn.SERVICE_OPTS)
+        ret = []
+        for name, emissionWave, idx in res:
+            label = (name and name.val) or\
+                    (emissionWave and emissionWave.val) or\
+                    (idx and idx.val) or -1
+            ret.append(label)
+        return ret
+
     @assert_re()
     def getZoomLevelScaling(self):
         """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -14,10 +14,31 @@
 """
 
 import pytest
+from library import ITest
 
-from omero.model import ImageI
+from omero.model import ImageI, ChannelI, LogicalChannelI, LengthI
 from omero.rtypes import rstring, rtime
 from datetime import datetime
+
+
+@pytest.fixture(scope='module')
+def itest(request):
+    """
+    Returns a new L{library.ITest} instance. With attached
+    finalizer so that pytest will clean it up.
+    """
+    class ImageWrapperITest(ITest):
+        """
+        This class emulates py.test scoping semantics when the xunit style
+        is in use.
+        """
+        pass
+    ImageWrapperITest.setup_class()
+
+    def finalizer():
+        ImageWrapperITest.teardown_class()
+    request.addfinalizer(finalizer)
+    return ImageWrapperITest()
 
 
 @pytest.fixture()
@@ -47,6 +68,47 @@ def image_no_acquisition_date(request, gatewaywrapper):
     return gw.getObject('Image', image_id)
 
 
+@pytest.fixture()
+def image_channel_factory(itest, gatewaywrapper):
+
+    def make_image_channel(channel):
+        gatewaywrapper.loginAsAuthor()
+        gw = gatewaywrapper.gateway
+        update_service = gw.getUpdateService()
+        pixels = itest.pix(client=gw.c)
+        pixels.addChannel(channel)
+        pixels = update_service.saveAndReturnObject(pixels)
+        return gw.getObject('Image', pixels.image.id)
+    return make_image_channel
+
+
+
+@pytest.fixture()
+def labeled_channel(image_channel_factory):
+    channel = ChannelI()
+    lchannel = LogicalChannelI()
+    lchannel.name = rstring('a channel')
+    channel.logicalChannel = lchannel
+    return image_channel_factory(channel)
+
+
+@pytest.fixture()
+def emissionWave_channel(image_channel_factory):
+    channel = ChannelI()
+    lchannel = LogicalChannelI()
+    lchannel.emissionWave = LengthI(123.0, 'NANOMETER')
+    channel.logicalChannel = lchannel
+    return image_channel_factory(channel)
+
+
+@pytest.fixture()
+def unlabeled_channel(image_channel_factory):
+    channel = ChannelI()
+    lchannel = LogicalChannelI()
+    channel.logicalChannel = lchannel
+    return image_channel_factory(channel)
+
+
 class TestImageWrapper(object):
 
     def testGetDate(self, gatewaywrapper, image):
@@ -69,3 +131,33 @@ class TestImageWrapper(object):
             'id': image.getId(),
             'name': 'an image'
         }
+
+    def testChannelLabel(self, labeled_channel):
+        labels = labeled_channel.getChannelLabels()
+        channels = labeled_channel.getChannels()
+        assert labels
+        assert channels
+        assert len(labels) == len(channels)
+
+        for channel in channels:
+            assert channel.getLabel() in labels
+
+    def testChannelEmissionWaveLabel(self, emissionWave_channel):
+        labels = emissionWave_channel.getChannelLabels()
+        channels = emissionWave_channel.getChannels()
+        assert labels
+        assert channels
+        assert len(labels) == len(channels)
+
+        for channel in channels:
+            assert channel.getLabel() in labels
+
+    def testChannelNoLabel(self, unlabeled_channel):
+        labels = unlabeled_channel.getChannelLabels()
+        channels = unlabeled_channel.getChannels()
+        assert labels
+        assert channels
+        assert len(labels) == len(channels)
+
+        for channel in channels:
+            assert channel.getLabel() in labels

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -82,7 +82,6 @@ def image_channel_factory(itest, gatewaywrapper):
     return make_image_channel
 
 
-
 @pytest.fixture()
 def labeled_channel(image_channel_factory):
     channel = ChannelI()

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -58,14 +58,14 @@
         <th>Channels:</th>
         <td id='channel_names'>
             <div>
-                {% with channels=manager.channel_metadata %}
-                {% if channels %}
+                {% with channelLabels=image.getChannelLabels %}
+                {% if channelLabels %}
                     <div id="channel_names_display">
-                    {% for label in image.getChannelLabels %}{% if not forloop.first %}, {% endif %}<span>{{ label|escape }}</span>{% endfor %}
+                    {% for label in channelLabels %}{% if not forloop.first %}, {% endif %}<span>{{ label|escape }}</span>{% endfor %}
                     </div>
                     <!-- form for editing channel names (initially hidden)-->
                     <form action="{% url 'edit_channel_names' image.id %}" method="POST" id="channel_names_edit" style="display:none">
-                        {% for label in image.getChannelLabels %}
+                        {% for label in channelLabels %}
                             <input type="text" name="channel{{ forloop.counter0 }}" value="{{ label }}" size=20/><br/>
                         {% endfor %}
                         <!-- hidden input for 'apply to dataset' options -->

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -61,12 +61,12 @@
                 {% with channels=manager.channel_metadata %}
                 {% if channels %}
                     <div id="channel_names_display">
-                    {% for c in channels %}{% if not forloop.first %}, {% endif %}<span>{{ c.getLabel|escape }}</span>{% endfor %}
+                    {% for label in image.getChannelLabels %}{% if not forloop.first %}, {% endif %}<span>{{ label|escape }}</span>{% endfor %}
                     </div>
                     <!-- form for editing channel names (initially hidden)-->
                     <form action="{% url 'edit_channel_names' image.id %}" method="POST" id="channel_names_edit" style="display:none">
-                        {% for c in channels %}
-                            <input type="text" name="channel{{ forloop.counter0 }}" value="{{ c.getLabel }}" size=20/><br/>
+                        {% for label in image.getChannelLabels %}
+                            <input type="text" name="channel{{ forloop.counter0 }}" value="{{ label }}" size=20/><br/>
                         {% endfor %}
                         <!-- hidden input for 'apply to dataset' options -->
                         <input type="text" name="parentId" size=5 style="display:none" />

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -652,8 +652,9 @@
             {% endif %}
             
             {% if manager.well %}            
+            {% with image=manager.well.getWellSample.image %}
 
-            {% with image=manager.well.getWellSample.image canDownload=manager.well.canDownload omeTiffDisabled=True %}
+            {% with canDownload=manager.well.canDownload omeTiffDisabled=True %}
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 
@@ -669,21 +670,21 @@
             </div>
 
             <!-- Image (in WellSample) Name, ID, Owner -->
-            {% with obj=manager.well.getWellSample.image nameText=manager.well.getWellSample.image.name wellImageId=manager.well.getWellSample.image.id %}
+            {% with obj=image nameText=image.name wellImageId=image.id %}
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
 
             <hr/>
             
-                        <!-- Image (in WellSample) Description -->
-            {% with obj=manager.well.getWellSample.image %}
+            <!-- Image (in WellSample) Description -->
+            {% with obj=image %}
                 {% include "webclient/annotations/includes/description.html" %}
             {% endwith %}
 
             <!-- Include table of core metadata, Owner, SizeX,Y,Z, Channels etc -->
-            {% with image=manager.well.getWellSample.image %}
-                {% include "webclient/annotations/includes/core_metadata.html" %}
-            {% endwith %}
+            {% include "webclient/annotations/includes/core_metadata.html" %}
+
+            {% endwith %}{# "image=manager.well.getWellSample.image" #}
 
             {% else %}
                 {% if manager.acquisition %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1078,8 +1078,6 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
             manager.annotationList()
             figScripts = manager.listFigureScripts()
             form_comment = CommentAnnotationForm(initial=initial)
-        # Load channel metadata if appropriate
-        manager.channelMetadata(noRE=True)
     context['manager'] = manager
 
     if c_type in ("tag", "tagset"):


### PR DESCRIPTION
This is a fairly straight-forward change that should help improve the rendering
performance of the right-hand metadata panel for Images. Previously, in order
to get the list of Channel labels to display, the template would have to load
the image's pixels, the pixel's channels, and then each channel's logical
channel. With this change, the relevant labels are retrieved directly via HQL
query.

### Benchmarking

The following are times taken to render the complete template for the right-hand side panel. The first number in each set represents a plate with 3 wells, the last two a fully-populated plate.

* Before changes:
- 0:00:01.550193
- 0:00:02.114671
- 0:00:02.787666

* After switching to `getChannelLabels`:
- 0:00:00.118799
- 0:00:02.053346
- 0:00:02.155348

* `getChannelLabels` combined with `original_file_paths` optimizations from #3695 
- 0:00:00.085634
- 0:00:00.080752
- 0:00:00.080852