### PR TITLE
Handle projections of unit types

### DIFF
--- a/components/blitz/src/omero/model/ElectricPotentialI.java
+++ b/components/blitz/src/omero/model/ElectricPotentialI.java
@@ -777,7 +777,7 @@ public class ElectricPotentialI extends ElectricPotential implements ModelBased 
            setUnit(value.getUnit());
         } else {
             UnitsElectricPotential targetUnit = UnitsElectricPotential.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/FrequencyI.java
+++ b/components/blitz/src/omero/model/FrequencyI.java
@@ -777,7 +777,7 @@ public class FrequencyI extends Frequency implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsFrequency targetUnit = UnitsFrequency.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/LengthI.java
+++ b/components/blitz/src/omero/model/LengthI.java
@@ -1439,7 +1439,7 @@ public class LengthI extends Length implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsLength targetUnit = UnitsLength.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/PowerI.java
+++ b/components/blitz/src/omero/model/PowerI.java
@@ -777,7 +777,7 @@ public class PowerI extends Power implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsPower targetUnit = UnitsPower.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/PressureI.java
+++ b/components/blitz/src/omero/model/PressureI.java
@@ -1437,7 +1437,7 @@ public class PressureI extends Pressure implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsPressure targetUnit = UnitsPressure.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/TemperatureI.java
+++ b/components/blitz/src/omero/model/TemperatureI.java
@@ -233,7 +233,7 @@ public class TemperatureI extends Temperature implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsTemperature targetUnit = UnitsTemperature.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/model/TimeI.java
+++ b/components/blitz/src/omero/model/TimeI.java
@@ -933,7 +933,7 @@ public class TimeI extends Time implements ModelBased {
            setUnit(value.getUnit());
         } else {
             UnitsTime targetUnit = UnitsTime.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(target);
+            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
             if (conversion == null) {
                 throw new RuntimeException(String.format(
                     "%f %s cannot be converted to %s",

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -468,6 +468,15 @@ public class IceMapper extends ome.util.ModelMapper implements
             return rmap(mOut);
         } else if (o instanceof omero.Internal) {
             return rinternal((omero.Internal) o);
+        } else if (o instanceof ome.model.internal.Permissions) {
+            ome.model.internal.Permissions p = (ome.model.internal.Permissions) o;
+            Map<String, RType> rv = new HashMap<String, RType>();
+            rv.put("perm", rstring(p.toString()));
+            rv.put("canAnnotate", rbool(!p.isDisallowAnnotate()));
+            rv.put("canDelete", rbool(!p.isDisallowDelete()));
+            rv.put("canEdit", rbool(!p.isDisallowEdit()));
+            rv.put("canLink", rbool(!p.isDisallowLink()));
+            return rmap(rv);
         } else if (o instanceof ome.model.units.Unit) {
             ome.model.units.Unit u = (ome.model.units.Unit) o;
             Map<String, RType> rv = new HashMap<String, RType>();

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -480,7 +480,6 @@ public class IceMapper extends ome.util.ModelMapper implements
         } else if (o instanceof ome.model.units.Unit) {
             ome.model.units.Unit u = (ome.model.units.Unit) o;
             Map<String, RType> rv = new HashMap<String, RType>();
-            rv.put("string", rstring(u.toString()));
             rv.put("value", rdouble(u.getValue()));
             rv.put("unit", rstring(u.getUnit().toString()));
             rv.put("symbol", rstring(u.getUnit().getSymbol()));

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -468,15 +468,16 @@ public class IceMapper extends ome.util.ModelMapper implements
             return rmap(mOut);
         } else if (o instanceof omero.Internal) {
             return rinternal((omero.Internal) o);
-        } else if (o instanceof ome.model.internal.Permissions) {
-            ome.model.internal.Permissions p = (ome.model.internal.Permissions) o;
+        } else if (o instanceof ome.model.units.Unit) {
+            ome.model.units.Unit u = (ome.model.units.Unit) o;
             Map<String, RType> rv = new HashMap<String, RType>();
-            rv.put("perm", rstring(p.toString()));
-            rv.put("canAnnotate", rbool(!p.isDisallowAnnotate()));
-            rv.put("canDelete", rbool(!p.isDisallowDelete()));
-            rv.put("canEdit", rbool(!p.isDisallowEdit()));
-            rv.put("canLink", rbool(!p.isDisallowLink()));
+            rv.put("string", rstring(u.toString()));
+            rv.put("value", rdouble(u.getValue()));
+            rv.put("unit", rstring(u.getUnit().toString()));
+            rv.put("symbol", rstring(u.getUnit().getSymbol()));
             return rmap(rv);
+        } else if (o instanceof ome.model.units.UnitEnum) {
+            return rstring(((ome.model.units.UnitEnum) o).toString());
         } else {
             throw new ApiUsageException(null, null,
                     "Unsupported conversion to rtype from " + o.getClass().getName() + ":" + o);

--- a/components/blitz/test/ome/formats/utests/UnitsTest.java
+++ b/components/blitz/test/ome/formats/utests/UnitsTest.java
@@ -18,17 +18,36 @@
 
 package ome.formats.utests;
 
+import junit.framework.TestCase;
 import ome.model.units.BigResult;
 import ome.units.UNITS;
 import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 
 import org.testng.annotations.Test;
 
-public class UnitsTest {
+public class UnitsTest extends TestCase {
 
+    /**
+     * Creates a new length instance of the default units.
+     *
+     * @param d The value.
+     * @return See above.
+     */
     protected omero.model.Length mm(double d) {
+        return mm(d, UnitsLength.MILLIMETER);
+    }
+
+    /**
+     * Creates a new length instance of the specified units.
+     *
+     * @param d The value.
+     * @param units The units.
+     * @return See above.
+     */
+    protected omero.model.Length mm(double d, UnitsLength units) {
         omero.model.Length l = new omero.model.LengthI();
-        l.setUnit(omero.model.enums.UnitsLength.MILLIMETER);
+        l.setUnit(units);
         l.setValue(d);
         return l;
     }
@@ -48,4 +67,28 @@ public class UnitsTest {
         new LengthI(mm(1), UNITS.MM);
     }
 
+    @Test
+    public void testLengthMappingFromCentimeterToMicrometer() throws BigResult {
+        new LengthI(mm(1, UnitsLength.CENTIMETER), UnitsLength.MICROMETER);
+    }
+
+    @Test
+    public void testLengthMappingFromMeterToMicrometer() throws BigResult {
+        new LengthI(mm(1, UnitsLength.METER), UnitsLength.MICROMETER);
+    }
+
+    @Test
+    public void testLengthMappingFromMicrometerToMicrometer() throws BigResult {
+        new LengthI(mm(1, UnitsLength.MICROMETER), UnitsLength.MICROMETER);
+    }
+
+    @Test
+    public void testLengthMappingFromMeterToCentimeter() throws BigResult {
+        new LengthI(mm(1, UnitsLength.METER), UnitsLength.CENTIMETER);
+    }
+
+    @Test
+    public void testLengthMappingFromCentimeterToMeter() throws BigResult {
+        new LengthI(mm(1, UnitsLength.CENTIMETER), UnitsLength.METER);
+    }
 }

--- a/components/blitz/test/omero/util/test/TempFileManagerTest.java
+++ b/components/blitz/test/omero/util/test/TempFileManagerTest.java
@@ -15,7 +15,20 @@ import omero.util.TempFileManager;
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Test;
 
-@Test(groups = "unit")
+//
+// Upping timeout since travis can fail with the following:
+// [nomemorytestng] FAILED: testBasicUsage on null(omero.util.test.TempFileManagerTest)
+// [nomemorytestng] org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testBasicUsage() didn't finish within the time-out 1000
+// [nomemorytestng]    at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
+// [nomemorytestng]    at java.net.InetAddress$1.lookupAllHostAddr(InetAddress.java:901)
+// [nomemorytestng]    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1293)
+// [nomemorytestng]    at java.net.InetAddress.getLocalHost(InetAddress.java:1469)
+// [nomemorytestng]    at sun.management.VMManagementImpl.getVmId(VMManagementImpl.java:135)
+// [nomemorytestng]    at sun.management.RuntimeImpl.getName(RuntimeImpl.java:59)
+// [nomemorytestng]    at omero.util.TempFileManager.pid(TempFileManager.java:279)
+// [nomemorytestng]    at omero.util.TempFileManager.<init>(TempFileManager.java:118)
+//
+@Test(groups = "unit", timeOut = 30000)
 public class TempFileManagerTest extends TestCase {
 
     @Test

--- a/components/model/src/ome/model/enums/UnitsElectricPotential.java
+++ b/components/model/src/ome/model/enums/UnitsElectricPotential.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsElectricPotential {
+public enum UnitsElectricPotential implements UnitEnum {
 
     YOTTAVOLT("YV"),
     ZETTAVOLT("ZV"),

--- a/components/model/src/ome/model/enums/UnitsFrequency.java
+++ b/components/model/src/ome/model/enums/UnitsFrequency.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsFrequency {
+public enum UnitsFrequency implements UnitEnum {
 
     YOTTAHERTZ("YHz"),
     ZETTAHERTZ("ZHz"),

--- a/components/model/src/ome/model/enums/UnitsLength.java
+++ b/components/model/src/ome/model/enums/UnitsLength.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsLength {
+public enum UnitsLength implements UnitEnum {
 
     YOTTAMETER("Ym"),
     ZETTAMETER("Zm"),

--- a/components/model/src/ome/model/enums/UnitsPower.java
+++ b/components/model/src/ome/model/enums/UnitsPower.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsPower {
+public enum UnitsPower implements UnitEnum {
 
     YOTTAWATT("YW"),
     ZETTAWATT("ZW"),

--- a/components/model/src/ome/model/enums/UnitsPressure.java
+++ b/components/model/src/ome/model/enums/UnitsPressure.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsPressure {
+public enum UnitsPressure implements UnitEnum {
 
     YOTTAPASCAL("YPa"),
     ZETTAPASCAL("ZPa"),

--- a/components/model/src/ome/model/enums/UnitsTemperature.java
+++ b/components/model/src/ome/model/enums/UnitsTemperature.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsTemperature {
+public enum UnitsTemperature implements UnitEnum {
 
     KELVIN("K"),
     CELSIUS("°C"),

--- a/components/model/src/ome/model/enums/UnitsTime.java
+++ b/components/model/src/ome/model/enums/UnitsTime.java
@@ -20,10 +20,12 @@
 
 package ome.model.enums;
 
+import ome.model.units.UnitEnum;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public enum UnitsTime {
+public enum UnitsTime implements UnitEnum {
 
     YOTTASECOND("Ys"),
     ZETTASECOND("Zs"),

--- a/components/model/src/ome/model/units/UnitEnum.java
+++ b/components/model/src/ome/model/units/UnitEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -22,12 +22,11 @@ package ome.model.units;
 import ome.model.internal.Primitive;
 
 /**
- * marker interface for all of ome.model.unit types.
+ * marker interface for all of ome.model.unit enums.
+ * @since 5.1.2
  */
-public interface Unit extends Primitive {
+public interface UnitEnum {
 
-    public double getValue();
-    public void setValue(double d);
-    public UnitEnum getUnit();
+    public String getSymbol();
 
 }

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -201,7 +201,8 @@ class TestModel51(lib.ITest):
         as_map = self.query.projection((
             "select pi.exposureTime from PlaneInfo pi "
             "join pi.pixels as pix join pix.image as img "
-            "where img.id = :id"), omero.sys.ParametersI().addId(img.id.val))[0][0]
+            "where img.id = :id"),
+            omero.sys.ParametersI().addId(img.id.val))[0][0]
         as_map = unwrap(as_map)
         pytest.assertAlmostEqual(1.2, as_map.get("value"))
         assert "SECOND" == as_map.get("unit")
@@ -215,7 +216,8 @@ class TestModel51(lib.ITest):
             "pi.exposureTime.unit, "
             "cast(pi.exposureTime.unit as text) from PlaneInfo pi "
             "join pi.pixels as pix join pix.image as img "
-            "where img.id = :id"), omero.sys.ParametersI().addId(img.id.val))[0]
+            "where img.id = :id"),
+            omero.sys.ParametersI().addId(img.id.val))[0]
         as_objs = unwrap(as_objs)
         pytest.assertAlmostEqual(1.2, as_objs[0])
         assert "SECOND" == as_objs[1]

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -29,6 +29,7 @@ import omero
 import omero.model
 
 from omero.model import NamedValue as NV
+from omero.rtypes import unwrap
 
 
 class TestModel51(lib.ITest):
@@ -193,3 +194,29 @@ class TestModel51(lib.ITest):
             [NV("foo", "WRONG")])
         with pytest.raises(omero.SecurityViolation):
             u2.saveAndReturnObject(m2)
+
+    def testUnitProjections(self):
+        img = self.importMIF(name="testUnitProjections", exposureTime=1.2)[0]
+
+        as_map = self.query.projection((
+            "select pi.exposureTime from PlaneInfo pi "
+            "join pi.pixels as pix join pix.image as img "
+            "where img.id = :id"), omero.sys.ParametersI().addId(img.id.val))[0][0]
+        as_map = unwrap(as_map)
+        pytest.assertAlmostEqual(1.2, as_map.get("value"))
+        assert "SECOND" == as_map.get("unit")
+        assert "s" == as_map.get("symbol")
+        as_str = as_map.get("string", "")
+        assert as_str.startswith("Time(1.2")
+        assert as_str.endswith("SECOND)")
+
+        as_objs = self.query.projection((
+            "select pi.exposureTime.value, "
+            "pi.exposureTime.unit, "
+            "cast(pi.exposureTime.unit as text) from PlaneInfo pi "
+            "join pi.pixels as pix join pix.image as img "
+            "where img.id = :id"), omero.sys.ParametersI().addId(img.id.val))[0]
+        as_objs = unwrap(as_objs)
+        pytest.assertAlmostEqual(1.2, as_objs[0])
+        assert "SECOND" == as_objs[1]
+        assert "s" == as_objs[2]

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -207,9 +207,6 @@ class TestModel51(lib.ITest):
         pytest.assertAlmostEqual(1.2, as_map.get("value"))
         assert "SECOND" == as_map.get("unit")
         assert "s" == as_map.get("symbol")
-        as_str = as_map.get("string", "")
-        assert as_str.startswith("Time(1.2")
-        assert as_str.endswith("SECOND)")
 
         as_objs = self.query.projection((
             "select pi.exposureTime.value, "

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -33,7 +33,7 @@ java_build()
 java_test()
 {
     NAME=java_test
-    for dir in dsl model common rendering romio server
+    for dir in dsl model common rendering romio server blitz
     do
         fold start $dir
         ant -f components/$dir/build.xml test -Dtest.with.fail=true -Dtestng.useDefaultListeners=true


### PR DESCRIPTION
`projection("select x.unit"...)`-style queries were failing in
IceMapper because no RType was defined to store the return value.
Rather than define multiple RTypes for each of the quantities and
their enums, the same strategy has been applied as for Permissions.
Returning a quantity object like omero.model.LengthI results in a
dictionary of values including the keys: value, unit, symbol, string.
Returning an enum produces the uppercase code enum value (as opposed
to the database/SI symbol).


#### Testing ####

In addition to the integration tests, `bin/omero hql` can be used to test the return values.
 * `select planeInfo.exposureTime.value` will return just the value (**as previously**)
 * `select cast(planeInfo.exposureTime.unit as text)` will return just the symbol, e.g. `s` (**as previously**)
 * `select planeInfo.exposureTime` will return a map of the form `{'symbol': 's', 'unit': 'SECOND', 'string': 'Time(1.2000000476837158 SECOND)', 'value': 1.2000000476837158}` (**failed before this PR**)
 * `select planeInfo.exposureTime.unit` will return just the enum as a string, i.e. 'SECOND' (**failed before this PR**)