### PR TITLE
Add IgnoreUnrecognizedVMOptions flag

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,7 +70,11 @@ def find_java():
 
 
 def calculate_memory_args():
-    return "-Xmx600M -XX:MaxPermSize=256m".split(" ")
+    return (
+        "-Xmx600M",
+        "-XX:MaxPermSize=256m",
+        "-XX:+IgnoreUnrecognizedVMOptions"
+    )
 
 
 def handle_tools(args):

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -202,6 +202,7 @@ omero.version=${omero.version}
                     <pathelement location="${test.dir}"/>
                 </classpath>
                 <jvmarg value="-XX:MaxPermSize=256m"/>
+                <jvmarg value="-XX:+IgnoreUnrecognizedVMOptions"/>
                 <jvmarg value="-Dlogback.configuration=logback-build.xml"/>
                 <jvmarg value="-Domero.db.name=${omero.db.name}"/>
                 <jvmarg value="-Domero.db.host=${omero.db.host}"/>

--- a/components/tools/OmeroPy/src/omero/install/jvmcfg.py
+++ b/components/tools/OmeroPy/src/omero/install/jvmcfg.py
@@ -279,6 +279,8 @@ class Strategy(object):
             self.get_heap_dump(),
             self.get_perm_gen(),
         ]
+        if any([x.startswith("-XX:MaxPermSize") for x in values]):
+            values.append("-XX:+IgnoreUnrecognizedVMOptions")
         values += self.get_append()
         return [x for x in values if x]
 

--- a/components/tools/OmeroPy/test/unit/old_templates.xml
+++ b/components/tools/OmeroPy/test/unit/old_templates.xml
@@ -199,6 +199,7 @@
              See #4670
         -->
         <option>-XX:MaxPermSize=128m</option>
+        <option>-XX:+IgnoreUnrecognizedVMOptions</option>
         <target name="memcfg">
             <option>${omero.blitz.maxmemory}</option>
             <option>${omero.blitz.permgen}</option>

--- a/components/tools/OmeroPy/test/unit/old_templates.xml
+++ b/components/tools/OmeroPy/test/unit/old_templates.xml
@@ -199,7 +199,6 @@
              See #4670
         -->
         <option>-XX:MaxPermSize=128m</option>
-        <option>-XX:+IgnoreUnrecognizedVMOptions</option>
         <target name="memcfg">
             <option>${omero.blitz.maxmemory}</option>
             <option>${omero.blitz.permgen}</option>

--- a/components/tools/OmeroPy/test/unit/test_jvmcfg.json
+++ b/components/tools/OmeroPy/test/unit/test_jvmcfg.json
@@ -9,6 +9,7 @@
             "blitz" : [
                 "-Xmx512m",
                 "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions",
                 "foo",
                 "bar"
             ]
@@ -22,7 +23,8 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:MaxPermSize=128m"
+                "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -35,7 +37,8 @@
         "output": {
             "blitz" : [
                 "-Xmx1G",
-                "-XX:MaxPermSize=128m"
+                "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -49,7 +52,8 @@
             "blitz" : [
                 "-Xmx512m",
                 "-XX:+HeapDumpOnOutOfMemoryError",
-                "-XX:MaxPermSize=128m"
+                "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -62,7 +66,8 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:MaxPermSize=1G"
+                "-XX:MaxPermSize=1G",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -75,7 +80,8 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:MaxPermSize=256m"
+                "-XX:MaxPermSize=256m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -89,7 +95,8 @@
         "output": {
             "blitz" : [
                 "-Xmx150m",
-                "-XX:MaxPermSize=128m"
+                "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -102,7 +109,8 @@
         "output": {
             "blitz" : [
                 "-Xmx600m",
-                "-XX:MaxPermSize=256m"
+                "-XX:MaxPermSize=256m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -115,7 +123,8 @@
         "output": {
             "blitz" : [
                 "-Xmx1200m",
-                "-XX:MaxPermSize=512m"
+                "-XX:MaxPermSize=512m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -128,7 +137,8 @@
         "output": {
             "blitz" : [
                 "-Xmx3600m",
-                "-XX:MaxPermSize=1g"
+                "-XX:MaxPermSize=1g",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -141,7 +151,8 @@
         "output": {
             "blitz" : [
                 "-Xmx7200m",
-                "-XX:MaxPermSize=1g"
+                "-XX:MaxPermSize=1g",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -154,7 +165,8 @@
         "output": {
             "blitz" : [
                 "-Xmx7200m",
-                "-XX:MaxPermSize=1g"
+                "-XX:MaxPermSize=1g",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -168,7 +180,8 @@
         "output": {
             "blitz" : [
                 "-Xmx9600m",
-                "-XX:MaxPermSize=1g"
+                "-XX:MaxPermSize=1g",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -182,6 +195,7 @@
             "blitz" : [
                 "-Xmx512m",
                 "-XX:MaxPermSize=128m",
+                "-XX:+IgnoreUnrecognizedVMOptions",
                 "foo"
             ]
         }
@@ -196,7 +210,8 @@
         "output": {
             "blitz" : [
                 "-Xmx4000m",
-                "-XX:MaxPermSize=512m"
+                "-XX:MaxPermSize=512m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -209,15 +224,18 @@
         "output": {
             "blitz" : [
                 "-Xmx1200m",
-                "-XX:MaxPermSize=512m"
+                "-XX:MaxPermSize=512m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ],
             "pixeldata" : [
                 "-Xmx1200m",
-                "-XX:MaxPermSize=512m"
+                "-XX:MaxPermSize=512m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ],
             "indexer" : [
                 "-Xmx800m",
-                "-XX:MaxPermSize=512m"
+                "-XX:MaxPermSize=512m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     },
@@ -230,7 +248,8 @@
         "output": {
             "blitz" : [
                 "-Xmx4g",
-                "-XX:MaxPermSize=256m"
+                "-XX:MaxPermSize=256m",
+                "-XX:+IgnoreUnrecognizedVMOptions"
             ]
         }
     }

--- a/components/tools/OmeroPy/test/unit/test_jvmcfg.py
+++ b/components/tools/OmeroPy/test/unit/test_jvmcfg.py
@@ -153,6 +153,7 @@ class TestStrategy(object):
         assert settings == [
             "-Xmx512m",
             "-XX:MaxPermSize=128m",
+            "-XX:+IgnoreUnrecognizedVMOptions",
         ]
 
     def test_percent_usage(self):

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -200,7 +200,7 @@ omero.jvmcfg.heap_size=
 
 ## (For documentation only)
 # Explicit value for the MaxPermSize argument
-# to the JVM, e.g. "500M"
+# to the JVM, e.g. "500M". Ignored for Java8+
 omero.jvmcfg.perm_gen=
 
 ## (For documentation only)


### PR DESCRIPTION
Our use of MaxPermSize has led to a number of warnings
in Java8 about the removal of that option. To prevent
these warnings, this adds another flag to ignore unknown
flags....

#### Testing ####

We're looking to remove this everywhere:
```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
```
 * `./build.py` should no longer print it.
 * It should no longer show up in `var/log/master.err`

At the same time, this should not break any Java version from 6-8, and the jvmcfg unit tests should remain green.