### PR TITLE
Unicode scripts 12571

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -874,8 +874,8 @@ class BaseContainer(BaseController):
             pass
         if ann is None:
             ann = omero.model.TagAnnotationI()
-            ann.textValue = rstring(str(tag))
-            ann.setDescription(rstring(str(desc)))
+            ann.textValue = rstring(tag.encode('utf8'))
+            ann.setDescription(rstring(desc.encode('utf8')))
             ann = self.conn.saveAndReturnObject(ann)
             if tag_group_id:  # Put new tag in given tag set
                 tag_group = None

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3926,7 +3926,8 @@ def script_run(request, scriptId, conn=None, **kwargs):
 
     try:
         # Try/except in case inputs are not serializable, e.g. unicode
-        logger.debug("Running script %s with params %s" % (scriptName, inputMap))
+        logger.debug("Running script %s with "
+                     "params %s" % (scriptName, inputMap))
     except:
         pass
     rsp = run_script(request, conn, sId, inputMap, scriptName)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -863,11 +863,13 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
         # don't seem to need to do this for tiff
         elif format == 'tif':
             rsp = HttpResponse(jpeg_data, content_type='image/tif')
+        fileName = img.getName().decode('utf8').replace(" ", "_")
+        fileName = fileName.replace(",", ".")
         rsp['Content-Type'] = 'application/force-download'
         rsp['Content-Length'] = len(jpeg_data)
         rsp['Content-Disposition'] = (
             'attachment; filename=%s.%s'
-            % (img.getName().replace(" ", "_"), format))
+            % (fileName, format))
     return rsp
 
 


### PR DESCRIPTION
This handles unicode script param values when running scripts.

To test, need to check that all parameters passed to scripts can handle unicode strings and different scripts handle these values correctly.
E.g String parameters, Lists with unicode values and Maps with unicode values.

Set up:
 - Rename a Dataset, Image and Channels with strings containing unicode characters. Also Tag the image with a unicode tag.

Scripts:
 - Split view Figure, with unicode in channels and figure name.
 - Thumbnail Figure, sorting by Tag with unicode.
 - Combine Images, naming new channels (map) with unicode names.

Corresponding scripts PR: https://github.com/ome/scripts/issues/101 has unicode handling to Split_View_Figure and Thumbnail_Figure as well as other small fixes.