### PR TITLE
CLI: implement timeout logic 

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -247,7 +247,7 @@ class SessionsControl(BaseControl):
     def _configure_login(self, login):
         login.add_login_arguments()
         login.add_argument(
-            "-t", "--timeout",
+            "-t", "--timeout", type=long,
             help="Timeout for session. After this many inactive seconds, the"
             " session will be closed")
         login.add_argument(
@@ -407,6 +407,8 @@ class SessionsControl(BaseControl):
         props["omero.user"] = name
         if port:
             props["omero.port"] = port
+        if "timeout" in args and args.timeout:
+            props["omero.timeout"] = args.timeout
 
         rv = None
         #

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -557,7 +557,7 @@ class SessionsControl(BaseControl):
         unit = "min."
         val = float(timeout) / 60 / 1000
         if val < 5:
-            unit = "sec."
+            unit = "s."
             val = val * 60
         return "%s%.f %s" % (msg, val, unit)
 

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -347,8 +347,13 @@ class SessionsStore(object):
             principal.name = name
             principal.group = props.get("omero.group", None)
             principal.eventType = "User"
+            try:
+                cs = sf.getConfigService()
+                idleTimeout = long(cs.getConfigValue('omero.sessions.timeout'))
+            except:
+                idleTimeout = 0L
             sess = sf.getSessionService().createSessionWithTimeouts(
-                principal, 0, 0)
+                principal, 0, idleTimeout)
             client.closeSession()
             sf = client.joinSession(sess.getUuid().getValue())
         else:

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -363,14 +363,17 @@ class SessionsStore(object):
 
         ec = sf.getAdminService().getEventContext()
         uuid = sf.ice_getIdentity().name
+        sf.detachOnDestroy()
         sess = sf.getSessionService().getSession(uuid)
         timeToIdle = sess.getTimeToIdle().getValue()
+        timeToLive = sess.getTimeToLive().getValue()
 
         # Retrieve timeout from properties
         timeout = None
         if props.get("omero.timeout", False):
             timeout = long(props.get("omero.timeout")) * 1000
 
+        # Update timeout
         if timeout and timeout != timeToIdle:
             req = omero.cmd.UpdateSessionTimeoutRequest()
             req.session = sf.getAdminService().getEventContext().sessionUuid
@@ -385,13 +388,10 @@ class SessionsStore(object):
                 import traceback
                 self.ctx.dbg(traceback.format_exc())
 
-            # Reload event context and session
-            ec = sf.getAdminService().getEventContext()
+            # Reload session
             sess = sf.getSessionService().getSession(uuid)
+            timeToIdle = sess.getTimeToIdle().getValue()
 
-        sf.detachOnDestroy()
-        timeToIdle = sess.getTimeToIdle().getValue()
-        timeToLive = sess.getTimeToLive().getValue()
         if new:
             self.add(host, ec.userName, uuid, props, sudo=sudo)
         if set_current:

--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -348,13 +348,14 @@ class SessionsStore(object):
             principal.name = name
             principal.group = props.get("omero.group", None)
             principal.eventType = "User"
-            try:
-                cs = sf.getConfigService()
-                idleTimeout = long(cs.getConfigValue('omero.sessions.timeout'))
-            except:
-                idleTimeout = 0L
+
+            # Retrieve the default time to idle value
+            uuid = sf.ice_getIdentity().name
+            sess = sf.getSessionService().getSession(uuid)
+            timeToIdle = sess.getTimeToIdle().getValue()
+
             sess = sf.getSessionService().createSessionWithTimeouts(
-                principal, 0, idleTimeout)
+                principal, 0, timeToIdle)
             client.closeSession()
             sf = client.joinSession(sess.getUuid().getValue())
         else:


### PR DESCRIPTION
Following https://github.com/openmicroscopy/openmicroscopy/pull/3786, this PR:

- implements the logic for the `--timeout` argument using a new property `omero.timeout` to minimize the API modification under `omero.util.sessions`
- add an integration test covering this implementation
- sets the default timeout for `--sudo` sessions using the `omero.sessions.timeout` configuration value
