### PR TITLE
Original file download

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -124,7 +124,7 @@ Download files
         {% for f in fs %}
         <tr>
             <td>
-                <a href="{% url 'get_original_file' f.id %}">
+                <a href="{% url 'download_original_file' f.id %}">
                     <div>
                         {{ f.name }}
                         <span style="margin-left:20px; text-decoration:none"> {{ f.size|filesizeformat }}</span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -287,6 +287,10 @@ urlpatterns = patterns(
     url(r'^get_original_file/(?:(?P<fileId>[0-9]+)/)?$',
         views.get_original_file,
         name="get_original_file"),  # for stderr, stdout etc
+    url(r'^download_original_file/(?:(?P<fileId>[0-9]+)/)?$',
+        views.get_original_file,
+        {'download': True},
+        name="download_original_file"),  # for stderr, stdout etc
     url(r'^figure_script/(?P<scriptName>'
         r'((?i)SplitView|RoiSplit|Thumbnail|MakeMovie))/$',
         views.figure_script,

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2470,7 +2470,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
 
 
 @login_required(doConnectionCleanup=False)
-def get_original_file(request, fileId, conn=None, **kwargs):
+def get_original_file(request, fileId, download=False, conn=None, **kwargs):
     """
     Returns the specified original file as an http response. Used for
     displaying text or png/jpeg etc files in browser
@@ -2491,9 +2491,11 @@ def get_original_file(request, fileId, conn=None, **kwargs):
         mimetype = "text/plain"  # allows display in browser
     rsp['Content-Type'] = mimetype
     rsp['Content-Length'] = orig_file.getSize()
-    downloadName = orig_file.name.replace(" ", "_")
-    downloadName = downloadName.replace(",", ".")
-    rsp['Content-Disposition'] = 'attachment; filename=%s' % downloadName
+
+    if download:
+        downloadName = orig_file.name.replace(" ", "_")
+        downloadName = downloadName.replace(",", ".")
+        rsp['Content-Disposition'] = 'attachment; filename=%s' % downloadName
     return rsp
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1284,10 +1284,8 @@ def load_metadata_acquisition(request, c_type, c_id, conn=None, share_id=None,
                                 lstypes = filamenttypes
                             channel['form_light_source'] = \
                                 MetadataLightSourceForm(initial={
-                                    'lightSource':
-                                        lightSrc,
-                                    'lightSourceSettings':
-                                        lightSourceSettings,
+                                    'lightSource': lightSrc,
+                                    'lightSourceSettings': lightSourceSettings,
                                     'lstypes': lstypes,
                                     'mediums': list(
                                         conn.getEnumerationEntries(


### PR DESCRIPTION
Fixes the download vv viewing of files in browser.

To test:
 - Run a script, E.g. split view figure and inspect the resulting image and stdout (i) from the Activities dialog. These should open in the browser instead of downloading.
 - Check that downloading still works - Select image(s) with more than 1 original file > Download. In the downloader dialog, click on individual files to download. These should download directly.