### PR TITLE
rewrite the policy rules for Chmod2 and make it often fast

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -41,56 +41,190 @@
 
         <!-- see blitz-graph-rules.xml for rule syntax -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = X:[E]/!d, L.child = T:TagAnnotation[D]"
-                                       p:error="may not delete {T} because {X} is tagged with it"/>
-        <bean parent="graphPolicyRule" p:matches="G:IGlobal[E]" p:changes="G:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="X:[E].details.group = ExperimenterGroup[I]" p:changes="X:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent =/!o [E], L.child = C:[E]" p:changes="L:[D]/n, C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child =/!o C:[E]" p:changes="L:[D]/n, C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:BooleanAnnotation[E]{o}" p:changes="C:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:CommentAnnotation[E]{o}" p:changes="C:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:NumericAnnotation[E]{o}" p:changes="C:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:TimestampAnnotation[E]{o}" p:changes="C:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[D].child = C:XmlAnnotation[E]{o}" p:changes="C:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="R:Roi[E].image =/!o [E]" p:changes="R:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].pixels =/!o [E]" p:changes="RD:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[E].pixels =/!o [E]" p:changes="T:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="R:Roi[D]/!no.image = [!O]/o" p:changes="R:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[D]/!no.pixels = [!O]/o" p:changes="RD:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[D]/!no.pixels = [!O]/o" p:changes="T:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="[D] =? X:!ILink[E]{o}/d" p:changes="X:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="[D] =?/o X:!ILink[E]{o}" p:changes="X:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!DO].parent = [D], L.child = C:!Job[E]/!d" p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:[E]{o}/d" p:changes="C:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:Job[E]{o}" p:changes="C:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = C:[D]" p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [D], L.child = [D]" p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [D], L.child = [E]{a}" p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.rois = [D]" p:changes="I:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.stageLabel = [D]" p:changes="I:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.channels = [D]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.settings = [D]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.relatedTo = [D]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[D] == X:!IGlobal[E]{o}/d" p:changes="X:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[D] = X:[E]{i}" p:changes="X:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[E]{r} = X:[E]{i}" p:changes="X:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [D], L.child = C:[E]{i}" p:changes="C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="DS:DetectorSettings[E]{i}.detector = [E]{r}" p:changes="DS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="LS:LightSettings[E]{i}.lightSource = [E]{r}" p:changes="LS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="OS:ObjectiveSettings[E]{i}.objective = [E]{r}" p:changes="OS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/d == [D]" p:changes="X:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/!d == [D]" p:changes="X:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E].file = [D]" p:changes="FA:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].child = C:!Job[E]{r}/!d" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:TagAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:TermAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!D].parent = [E], L.child = C:!Pixels[E]{r}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[E]{ia} = X:!ILink[E]{r}" p:changes="X:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="X:[E]{r} == [E]{a}" p:changes="X:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E]{a}.parent = [D]" p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="C:Channel[E]{r}.pixels = Pixels[E]{i}" p:changes="C:{a}"/>
+        <!-- Note that these rules apply only for downgrading a group to private. -->
+
+        <!-- ACQUISITION -->
+
+        <!-- Delete cross-owner links regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = FS:[E], L.child = EF:[E], FS =/!o EF"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = FS:[E], L.child = EF:[E], FS =/!o EF"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = LP:[E], L.child = EF:[E], LP =/!o EF"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = LP:[E], L.child = EF:[E], LP =/!o EF"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- Delete cross-owner settings regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[E].detectorSettings =/!o S:[E]" p:changes="S:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[E].lightSourceSettings =/!o S:[E]" p:changes="S:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E].objectiveSettings =/!o S:[E]" p:changes="S:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector =/!o [E]" p:changes="S:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource =/!o [E]" p:changes="S:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective =/!o [E]" p:changes="S:[D]/n"/>
+
+        <!-- Cannot downgrade if images have cross-owner subgraphs. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].imagingEnvironment =/!o IE:[E]"
+                                       p:error="cannot downgrade to private as {I} uses differently owned {IE}"/>
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].instrument =/!o IN:[E]"
+                                       p:error="cannot downgrade to private as {I} uses differently owned {IN}"/>
+
+        <!-- ANNOTATIONS -->
+
+        <!-- Delete cross-owner links regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = X:[E], L.child = A:[E], X =/!o A"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- If a basic or comment annotation is unlinked then consider it for deletion regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:BasicAnnotation[E]{i}" p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:CommentAnnotation[E]{i}" p:changes="A:{r}"/>
+
+        <!-- If a list, map, or XML annotation is unlinked then consider it for deletion. -->
+
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:ListAnnotation[E]{i}/d" p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:MapAnnotation[E]{i}/d" p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:XmlAnnotation[E]{i}/d"  p:changes="A:{r}"/>
+
+        <!-- In considering deleting an annotation then do not delete the annotation if it remains linked. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [E]{ia}, L.child = A:Annotation[E]{r}"
+                                       p:changes="A:{a}"/>
+
+        <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
+
+        <bean parent="graphPolicyRule" p:matches="A:BasicAnnotation[E]{o}" p:changes="A:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="A:CommentAnnotation[E]{o}" p:changes="A:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
+
+        <!-- If an annotation link's parent or child is deleted then delete the link regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = [D]" p:changes="L:[D]/n"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
+
+        <!-- CONTAINERS -->
+
+        <!-- Delete cross-owner links regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[E], L.child = D:[E], P =/!o D"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[E], L.child = I:[E], D =/!o I"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- CORE -->
+
+        <!-- Do not delete an original file that is being used by an object. -->
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation.file = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry.originalFile = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[E].source = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [E], L.child = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [E], L.parent = OF:[E]{r}" p:changes="OF:{a}"/>
+
+        <!-- If an original file is orphaned then delete it. -->
+
+        <bean parent="graphPolicyRule" p:matches="OF:OriginalFile[E]{o}" p:changes="OF:[D]"/>
+
+        <!-- Cannot downgrade to a private group if the image has a differently owned stage label. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E].stageLabel =/!o SL:[E]"
+                                       p:error="cannot downgrade to private as {E} uses differently owned {SL}"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
+
+        <!-- DISPLAY -->
+
+        <!-- Regardless of permissions delete others' rendering settings and thumbnails. -->
+
+        <bean parent="graphPolicyRule" p:matches="Pixels[E].settings =/!o RD:[E]" p:changes="RD:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[E].thumbnails =/!o T:[E]" p:changes="T:[D]/n"/>
+
+        <!-- If rendering settings are deleted then delete the subgraph below. -->
+
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+
+        <!-- EXPERIMENT -->
+
+        <!-- Cannot downgrade if image is associated with differently owned experiment. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].experiment =/!o E:[E]"
+                                       p:error="cannot downgrade to private as {E} uses differently owned {I}"/>
+
+        <!-- JOB -->
+
+        <!-- Cannot downgrade to a private group if jobs have differently owned original files. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E], L.child = OF:[E], J =/!o OF"
+                                       p:error="cannot downgrade to private as {J} has differently owned {OF}"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
+
+        <!-- META -->
+
+        <!-- If an object is deleted then also delete or move its external info regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="[D].details.externalInfo = EI:[E]" p:changes="EI:[D]/n"/>
+
+        <!-- Consider every model object in the group. -->
+
+        <bean parent="graphPolicyRule" p:matches="X:[E].details.group = [I]" p:changes="X:[-]"/>
+
+        <!-- ROI -->
+
+        <!-- Regardless of permissions delete others' ROIs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E].rois =/!o ROI:[E]" p:changes="ROI:[D]/n"/>
+
+        <!-- Consider deleting an original file if it is unlinked from a ROI. -->
+
+        <bean parent="graphPolicyRule" p:matches="Roi[D].source = OF:[E]{i}" p:changes="OF:{r}"/>
+
+        <!-- Delete the shapes of deleted ROIs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
+
+        <!-- SCREEN -->
+
+        <!-- Cannot downgrade to a private group if the image has a differently owned field. -->
+
+        <bean parent="graphPolicyRule" p:matches="WS:WellSample.image =/!o I:[E]"
+                                       p:error="cannot downgrade to private as {WS} uses differently owned {I}"/>
+
+        <!-- Cannot downgrade to a private group if wells have differently owned reagents. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = W:[E], L.child = R:[E], W =/!o R"
+                                       p:error="cannot downgrade to private as {W} has differently owned {R}"/>
+
+        <!-- Cannot downgrade to a private group if screen has differently owned reagents. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents =/!o R:Reagent"
+                                       p:error="cannot downgrade to private as {S} has differently owned {R}"/>
+
+        <!-- Delete cross-owner links regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = S:[E], L.child = P:[E], S =/!o P" p:changes="L:[D]/n"/>
+
+        <!-- STATS -->
+
+        <!-- Delete cross-owner statistics. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[E].statsInfo =/!o SI:[E]" p:changes="SI:[D]"/>
+
     </util:list>
 
 </beans>

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -176,10 +176,9 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(ChmodI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        // TODO: Chmod2 too slow to be automatically substituted for Chmod
-                        /* if (graphRequestFactory.isGraphsWrap()) {
+                        if (graphRequestFactory.isGraphsWrap()) {
                             return new ChmodFacadeI(graphRequestFactory);
-                        } else */ {
+                        } else {
                             return new ChmodI(ic,
                                     ctx.getBean("chmodStrategy", ChmodStrategy.class));
                         }

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,6 @@
 package omero.cmd.graphs;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -67,15 +66,6 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
         return false;
     }
 
-    /**
-     * An opportunity to reverse any change to each model object after the graph policy reviews it.
-     * @param object the model object after review
-     * @return if this object should <em>not</em> be adjusted
-     */
-    protected boolean isBlockedFromAdjustment(Details object) {
-        return false;
-    }
-
     @Override
     public void registerPredicate(GraphPolicyRulePredicate predicate) {
         graphPolicy.registerPredicate(predicate);
@@ -105,7 +95,14 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
     public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject, Map<String, Set<Details>> linkedTo,
             Set<String> notNullable, boolean isErrorRules) throws GraphException {
         /* note all the model objects that may be adjusted in review */
-        final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
+        final Set<Details> allTerms = new HashSet<Details>();
+        allTerms.add(rootObject);
+        for (final Set<Details> terms : linkedFrom.values()) {
+            allTerms.addAll(terms);
+        }
+        for (final Set<Details> terms : linkedTo.values()) {
+            allTerms.addAll(terms);
+        }
         /* allow isAdjustedBeforeReview to adjust objects before review */
         final Set<Details> changedTerms = new HashSet<Details>();
         for (final Details object : allTerms) {
@@ -119,13 +116,6 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
         for (final Details object : allTerms) {
             if (isAdjustedAfterReview(object)) {
                 changedTerms.add(object);
-            }
-        }
-        /* allow isBlockedFromAdjustment to block any adjustments */
-        final Iterator<Details> changedTermIterator = changedTerms.iterator();
-        while (changedTermIterator.hasNext()) {
-            if (isBlockedFromAdjustment(changedTermIterator.next())) {
-                changedTermIterator.remove();
             }
         }
         return changedTerms;

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -95,14 +95,7 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
     public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject, Map<String, Set<Details>> linkedTo,
             Set<String> notNullable, boolean isErrorRules) throws GraphException {
         /* note all the model objects that may be adjusted in review */
-        final Set<Details> allTerms = new HashSet<Details>();
-        allTerms.add(rootObject);
-        for (final Set<Details> terms : linkedFrom.values()) {
-            allTerms.addAll(terms);
-        }
-        for (final Set<Details> terms : linkedTo.values()) {
-            allTerms.addAll(terms);
-        }
+        final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
         /* allow isAdjustedBeforeReview to adjust objects before review */
         final Set<Details> changedTerms = new HashSet<Details>();
         for (final Details object : allTerms) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -15,6 +15,7 @@ import static org.testng.AssertJUnit.fail;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,6 +38,8 @@ import ome.formats.importer.util.ErrorHandler;
 import ome.io.nio.SimpleBackOff;
 import ome.services.blitz.repo.path.FsFile;
 import omero.ApiUsageException;
+import omero.RLong;
+import omero.RType;
 import omero.ServerError;
 import omero.rtypes;
 import omero.api.IAdminPrx;
@@ -128,6 +131,7 @@ import omero.model.WellSample;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -924,6 +928,23 @@ public class AbstractServerTest extends AbstractTest {
         }
     }
 
+    protected void assertAllExist(Iterable<? extends IObject> obj) throws Exception {
+        for (IObject iObject : obj) {
+            assertExists(iObject);
+        }
+    }
+
+    protected void assertExists(String className, Long id) throws ServerError {
+        assertAllExist(className, Collections.singletonList(id));
+    }
+
+    protected void assertAllExist(String className, Collection<Long> ids) throws ServerError {
+        final String hql = "SELECT COUNT(*) FROM " + className + " WHERE id IN (:ids)";
+        final List<List<RType>> results = iQuery.projection(hql, new ParametersI().addIds(ids));
+        final long count = ((RLong) results.get(0).get(0)).getValue();
+        Assert.assertEquals(count, ids.size());
+    }
+
     /**
      * Makes sure that the passed object does not exist.
      *
@@ -945,6 +966,23 @@ public class AbstractServerTest extends AbstractTest {
         for (IObject iObject : obj) {
             assertDoesNotExist(iObject);
         }
+    }
+
+    protected void assertNoneExist(Iterable<? extends IObject> obj) throws Exception {
+        for (IObject iObject : obj) {
+            assertDoesNotExist(iObject);
+        }
+    }
+
+    protected void assertDoesNotExist(String className, Long id) throws ServerError {
+        assertNoneExist(className, Collections.singletonList(id));
+    }
+
+    protected void assertNoneExist(String className, Collection<Long> ids) throws ServerError {
+        final String hql = "SELECT COUNT(*) FROM " + className + " WHERE id IN (:ids)";
+        final List<List<RType>> results = iQuery.projection(hql, new ParametersI().addIds(ids));
+        final long count = ((RLong) results.get(0).get(0)).getValue();
+        Assert.assertEquals(count, 0);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -20,8 +20,12 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
 import ome.formats.model.UnitsFactory;
 import ome.units.UNITS;
+import omero.ServerError;
 import omero.api.IPixelsPrx;
 import omero.model.*;
 import omero.model.enums.UnitsLength;
@@ -98,6 +102,9 @@ public class ModelMockFactory {
     /** Helper reference to the <code>IPixels</code> service. */
     private IPixelsPrx pixelsService;
 
+    /** all {@link ExperimentType}s */
+    private ImmutableList<ExperimentType> experimentTypes;
+
     private static Frequency hz(double d) {
         return new FrequencyI(d, UNITS.HZ);
     }
@@ -114,9 +121,23 @@ public class ModelMockFactory {
      * Creates a new instance.
      *
      * @param pixelsService
+     * @throws ServerError unexpected
      */
-    ModelMockFactory(IPixelsPrx pixelsService) {
+    ModelMockFactory(IPixelsPrx pixelsService) throws ServerError {
         this.pixelsService = pixelsService;
+        getExperimentTypes();
+    }
+
+    /**
+     * Note the experiment types from the pixels service.
+     * @throws ServerError unexpected
+     */
+    public void getExperimentTypes() throws ServerError {
+        final Builder<ExperimentType> builder = ImmutableList.builder();
+        for (final IObject experimentType : pixelsService.getAllEnumerations(ExperimentType.class.getName())) {
+            builder.add((ExperimentType) experimentType);
+        }
+        experimentTypes = builder.build();
     }
 
     // POJO
@@ -210,6 +231,37 @@ public class ModelMockFactory {
         Fileset fs = new FilesetI();
         fs.setTemplatePrefix(omero.rtypes.rstring("fileset-" + System.nanoTime() + "/"));
         return fs;
+    }
+
+    /**
+     * Creates a default dataset and returns it.
+     *
+     * @return See above.
+     */
+    public Dataset simpleDataset() {
+        // prepare data
+        final Dataset dataset = new DatasetI();
+        String uuidAsString = UUID.randomUUID().toString();
+        String uniqueName = String.format("test-dataset:%s", uuidAsString);
+        String uniqueDesc = String.format("test-desc:%s", uuidAsString);
+        dataset.setName(rstring(uniqueName));
+        dataset.setDescription(rstring(uniqueDesc));
+        return dataset;
+    }
+
+    /**
+     * Creates a default experiment and returns it.
+     *
+     * @return See above.
+     */
+    public Experiment simpleExperiment() throws ServerError {
+        // prepare data
+        final Experiment experiment = new ExperimentI();
+        String uuidAsString = UUID.randomUUID().toString();
+        String uniqueDesc = String.format("test-exp:%s", uuidAsString);
+        experiment.setDescription(rstring(uniqueDesc));
+        experiment.setType(experimentTypes.get(0));
+        return experiment;
     }
 
     /**
@@ -479,11 +531,7 @@ public class ModelMockFactory {
         settings.setAttenuation(omero.rtypes.rdouble(1));
         MicrobeamManipulation mm = new MicrobeamManipulationI();
         mm.setType((MicrobeamManipulationType) types.get(0));
-        Experiment exp = new ExperimentI();
-        types = pixelsService
-                .getAllEnumerations(ExperimentType.class.getName());
-        exp.setType((ExperimentType) types.get(0));
-        mm.setExperiment(exp);
+        mm.setExperiment(simpleExperiment());
         // settings.setMicrobeamManipulation(mm);
         settings.setWavelength(new LengthI(500.1, UnitsFactory.LightSourceSettings_Wavelength));
         return settings;

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -20,25 +20,34 @@
 package integration.chmod;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import ome.model.internal.Permissions;
 import ome.util.Utils;
+import omero.RLong;
+import omero.RType;
 import omero.ServerError;
 import omero.cmd.Chmod2;
 import omero.cmd.Delete2;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
+import omero.model.Dataset;
+import omero.model.DatasetImageLink;
+import omero.model.DatasetImageLinkI;
+import omero.model.Experiment;
+import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
+import omero.model.ExperimenterI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
+import omero.model.Instrument;
 import omero.model.Pixels;
+import omero.model.Plate;
 import omero.model.RectI;
 import omero.model.Roi;
 import omero.model.RoiI;
@@ -46,6 +55,7 @@ import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.model.Thumbnail;
 import omero.sys.EventContext;
+import omero.sys.Parameters;
 import omero.sys.ParametersI;
 
 import org.testng.Assert;
@@ -140,35 +150,7 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Assert that the given object still exists or not.
-     * @param object a model object
-     * @param isExists if the object should now exist
-     * @throws ServerError unexpected
-     */
-    private void assertExistence(IObject object, boolean isExists) throws ServerError {
-        assertExistence(Collections.singleton(object), isExists);
-    }
-
-    /**
-     * Assert that the given objects still exist or not.
-     * @param objects some model objects
-     * @param isExists if the objects should now exist
-     * @throws ServerError unexpected
-     */
-    private void assertExistence(Collection<IObject> objects, boolean isExists) throws ServerError {
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final IObject retrieved = iQuery.find(object.getClass().getName(), object.getId().getValue());
-            if (isExists) {
-                Assert.assertNotNull(retrieved, objectName);
-            } else {
-                Assert.assertNull(retrieved, objectName);
-            }
-        }
-    }
-
-    /**
-     * Test that a specific case of using {@link Chmod2} behaves as expected.
+     * Test that a specific case of using {@link Chmod2} on an annotated image behaves as expected.
      * @param isGroupOwner if the user submitting the {@link Chmod2} request is an owner of the target group
      * @param isGroupMember if the user submitting the {@link Chmod2} request is a member of the target group
      * @param isDataOwner if the user submitting the {@link Chmod2} request owns the data in the group
@@ -179,8 +161,8 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isExpectDeleteOther if the chmod is expected to cause another user's annotations to be removed from a user's image
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "chmod test cases")
-    public void testChmod(boolean isGroupOwner, boolean isGroupMember, boolean isDataOwner, boolean isAdmin,
+    @Test(dataProvider = "chmod annotation test cases")
+    public void testChmodAnnotation(boolean isGroupOwner, boolean isGroupMember, boolean isDataOwner, boolean isAdmin,
             String fromPerms, String toPerms, boolean isExpectSuccess, boolean isExpectDeleteOther) throws Exception {
 
         /* set up the users and group for this test case */
@@ -279,20 +261,24 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* check that exactly the expected object deletions have occurred */
 
-        assertExistence(image, true);
+        assertExists(image);
         if (tag != null) {
-            assertExistence(tag, true);
+            assertExists(tag);
         }
-        assertExistence(ownerAnnotations, true);
-        assertExistence(otherAnnotations, !isExpectDeleteOther);
+        assertAllExist(ownerAnnotations);
+        if (isExpectDeleteOther) {
+            assertNoneExist(otherAnnotations);
+        } else {
+            assertAllExist(otherAnnotations);
+        }
         disconnect();
     }
 
     /**
-     * @return a specific test case for chmod
+     * @return a specific test case for annotation chmod
      */
-    @DataProvider(name = "chmod test cases (debug)")
-    public Object[][] provideChmodCaseDebug() {
+    @DataProvider(name = "chmod annotation test cases (debug)")
+    public Object[][] provideChmodAnnotationCaseDebug() {
         int index = 0;
         final int IS_GROUP_OWNER = index++;
         final int IS_GROUP_MEMBER = index++;
@@ -320,10 +306,10 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a variety of test cases for chmod
+     * @return a variety of test cases for annotation chmod
      */
-    @DataProvider(name = "chmod test cases")
-    public Object[][] provideChmodCases() {
+    @DataProvider(name = "chmod annotation test cases")
+    public Object[][] provideChmodAnnotationCases() {
         int index = 0;
         final int IS_GROUP_OWNER = index++;
         final int IS_GROUP_MEMBER = index++;
@@ -369,6 +355,398 @@ public class PermissionsTest extends AbstractServerTest {
                     }
                 }
             }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * Test a specific case of using {@link Chmod2} on an image that is in a dataset.
+     * @param isImageOwner if the user who owns the dataset also owns the image
+     * @param isLinkOwner if the user who owns the dataset also linked the image to the dataset
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chmod container test cases")
+    public void testChmodContainerReadWriteToPrivate(boolean isImageOwner, boolean isLinkOwner) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext datasetOwner, imageOwner, linkOwner, chmodder;
+        final ExperimenterGroup dataGroup;
+
+        datasetOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = datasetOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        if (isImageOwner) {
+            imageOwner = datasetOwner;
+            linkOwner = isLinkOwner ? datasetOwner : newUserInGroup(dataGroup, false);
+        } else {
+            imageOwner = newUserInGroup(dataGroup, false);
+            linkOwner = isLinkOwner ? datasetOwner : imageOwner;
+        }
+
+        chmodder = newUserInGroup(dataGroup, true);
+
+        /* create a dataset */
+
+        init(datasetOwner);
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        disconnect();
+
+        /* create an image */
+
+        init(imageOwner);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        disconnect();
+
+        /* move the image into the dataset */
+
+        init(linkOwner);
+        DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        link = (DatasetImageLink) iUpdate.saveAndReturnObject(link);
+        disconnect();
+
+        /* perform the chmod */
+
+        init(chmodder);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = "rw----";
+        doChange(client, factory, chmod, true);
+        disconnect();
+
+        /* check that exactly the expected object deletions have occurred */
+
+        logRootIntoGroup(dataGroupId);
+        assertExists(dataset);
+        assertExists(image);
+        if (datasetOwner == imageOwner) {
+            assertExists(link);
+        } else {
+            assertDoesNotExist(link);
+        }
+        disconnect();
+    }
+
+    /**
+     * @return a specific test case for container chmod
+     */
+    @DataProvider(name = "chmod container test cases (debug)")
+    public Object[][] provideChmodContainerCaseDebug() {
+        int index = 0;
+        final int IS_IMAGE_OWNER = index++;
+        final int IS_LINK_OWNER = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[IS_IMAGE_OWNER] = true;
+        testCase[IS_LINK_OWNER] = true;
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for container chmod
+     */
+    @DataProvider(name = "chmod container test cases")
+    public Object[][] provideChmodContainerCases() {
+        int index = 0;
+        final int IS_IMAGE_OWNER = index++;
+        final int IS_LINK_OWNER = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isImageOwner : booleanCases) {
+            for (final boolean isLinkOwner : booleanCases) {
+                final Object[] testCase = new Object[index];
+                testCase[IS_IMAGE_OWNER] = isImageOwner;
+                testCase[IS_LINK_OWNER] = isLinkOwner;
+                testCases.add(testCase);
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * Test chmod on a group wherein an image's instrument is shared with another's image.
+     * @param toPerms the permissions on the group after the chmod
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "private-group failure test cases")
+    public void testSharedInstrument(String toPerms) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext imageOwner, projectionOwner, chmodder;
+        final ExperimenterGroup dataGroup;
+
+        imageOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = imageOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        projectionOwner = newUserInGroup(dataGroup, false);
+        chmodder = newUserInGroup(dataGroup, true);
+
+        /* create an image with an instrument */
+
+        init(imageOwner);
+        Image image = mmFactory.createImage();
+        image.setInstrument(mmFactory.createInstrument());
+        image = (Image) iUpdate.saveAndReturnObject(image);
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        final Instrument instrument = (Instrument) image.getInstrument().proxy();
+        image = (Image) image.proxy();
+        disconnect();
+
+        /* another user projects the image */
+
+        init(projectionOwner);
+        Image projection = mmFactory.createImage();
+        projection.setInstrument(instrument);
+        projection = (Image) iUpdate.saveAndReturnObject(projection);
+        final long projectionId = projection.getId().getValue();
+        testImages.add(projectionId);
+        projection = (Image) projection.proxy();
+        disconnect();
+
+        /* perform the chmod */
+
+        final boolean isExpectSuccess = !"rw----".equals(toPerms);
+
+        init(chmodder);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = toPerms;
+        doChange(client, factory, chmod, isExpectSuccess);
+        disconnect();
+
+        if (!isExpectSuccess) {
+            return;
+        }
+
+        /* check that all the objects still exist */
+
+        logRootIntoGroup(dataGroupId);
+        assertExists(image);
+        assertExists(projection);
+        assertExists(instrument);
+        disconnect();
+    }
+
+
+    /**
+     * Test chmod on a group wherein an image is used in the same experiment as another's image.
+     * @param toPerms the permissions on the group after the chmod
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "private-group failure test cases")
+    public void testSharedExperiment(String toPerms) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext imageOwner, otherImageOwner, chmodder;
+        final ExperimenterGroup dataGroup;
+
+        imageOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = imageOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        otherImageOwner = newUserInGroup(dataGroup, false);
+        chmodder = newUserInGroup(dataGroup, true);
+
+        /* create an image with an experiment */
+
+        init(imageOwner);
+        Image image = mmFactory.createImage();
+        image.setExperiment(mmFactory.simpleExperiment());
+        image = (Image) iUpdate.saveAndReturnObject(image);
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        final Experiment experiment = (Experiment) image.getExperiment().proxy();
+        image = (Image) image.proxy();
+        disconnect();
+
+        /* another user's image is part of the same experiment */
+
+        init(otherImageOwner);
+        Image otherImage = mmFactory.createImage();
+        otherImage.setExperiment(experiment);
+        otherImage = (Image) iUpdate.saveAndReturnObject(otherImage);
+        final long otherImageId = otherImage.getId().getValue();
+        testImages.add(otherImageId);
+        otherImage = (Image) otherImage.proxy();
+        disconnect();
+
+        /* perform the chmod */
+
+        final boolean isExpectSuccess = !"rw----".equals(toPerms);
+
+        init(chmodder);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = toPerms;
+        doChange(client, factory, chmod, isExpectSuccess);
+        disconnect();
+
+        if (!isExpectSuccess) {
+            return;
+        }
+
+        /* check that all the objects still exist */
+
+        logRootIntoGroup(dataGroupId);
+        assertExists(image);
+        assertExists(otherImage);
+        assertExists(experiment);
+        disconnect();
+    }
+
+    /**
+     * Test chmod on a group wherein a plate's images are owned by a different user who has them in their dataset.
+     * @param toPerms the permissions on the group after the chmod
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "private-group failure test cases")
+    public void testDatasetToPlate(String toPerms) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext datasetOwner, plateOwner, chmodder;
+        final ExperimenterGroup dataGroup;
+
+        datasetOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = datasetOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        plateOwner = newUserInGroup(dataGroup, false);
+        chmodder = newUserInGroup(dataGroup, true);
+
+        /* create a plate */
+
+        init(plateOwner);
+        Plate plate = mmFactory.createPlate(2, 2, 1, 1, false);
+        plate = (Plate) iUpdate.saveAndReturnObject(plate).proxy();
+        final long plateId = plate.getId().getValue();
+
+        /* find the plate's images */
+
+        final List<Long> imageIds = new ArrayList<Long>();
+        final String hql = "SELECT image.id FROM WellSample where well.id IN (SELECT id FROM Well WHERE plate.id = :id)";
+        final Parameters params = new ParametersI().addId(plateId);
+        for (final List<RType> result : iQuery.projection(hql, params)) {
+            final Long imageId = ((RLong) result.get(0)).getValue();
+            imageIds.add(imageId);
+        }
+        disconnect();
+
+        /* the images should be owned by the dataset owner */
+
+        logRootIntoGroup(dataGroupId);
+        final Experimenter datasetOwnerActual = new ExperimenterI(datasetOwner.userId, false);
+        final List<IObject> images = iQuery.findAllByQuery("FROM Image WHERE id IN (:ids)", new ParametersI().addIds(imageIds));
+        Assert.assertEquals(images.size(), imageIds.size());
+        for (final IObject image : images) {
+            image.getDetails().setOwner(datasetOwnerActual);
+        }
+        iUpdate.saveCollection(images);
+        disconnect();
+
+        /* create the dataset and link the images to it */
+
+        init(datasetOwner);
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        final long datasetId = dataset.getId().getValue();
+
+        final List<DatasetImageLink> links = new ArrayList<DatasetImageLink>(images.size());
+        for (final IObject image : images) {
+            DatasetImageLink link = new DatasetImageLinkI();
+            link.setParent(dataset);
+            link.setChild((Image) image.proxy());
+            links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
+        }
+        disconnect();
+
+        /* perform the chmod */
+
+        final boolean isExpectSuccess = !"rw----".equals(toPerms);
+
+        init(chmodder);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = toPerms;
+        doChange(client, factory, chmod, isExpectSuccess);
+        disconnect();
+
+        logRootIntoGroup(dataGroupId);
+
+        if (isExpectSuccess) {
+
+            /* check that all the objects still exist */
+
+            assertExists(dataset);
+            assertAllExist(images);
+            assertAllExist(links);
+            assertExists(plate);
+        }
+
+        /* delete the objects as clean-up */
+
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = ImmutableMap.of(
+                "Dataset", Collections.singletonList(datasetId),
+                "Plate", Collections.singletonList(plateId));
+        doChange(client, factory, delete, true);
+        disconnect();
+    }
+
+    /**
+     * @return group permissions for a specific private-group failure test case
+     */
+    @DataProvider(name = "private-group failure test cases (debug)")
+    public Object[][] providePrivateGroupFailureCaseDebug() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[GROUP_PERMS] = "rw----";
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return group permissions for private-group failure test cases
+     */
+    @DataProvider(name = "private-group failure test cases")
+    public Object[][] providePrivateGroupFailureCases() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    testCase[GROUP_PERMS] = groupPerms;
+                    testCases.add(testCase);
         }
 
         return testCases.toArray(new Object[testCases.size()][]);

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -340,6 +340,10 @@ public class PermissionsTest extends AbstractServerTest {
 
                         for (final String fromPerms : permsCases) {
                             for (final String toPerms : permsCases) {
+                                if (fromPerms.equals(toPerms)) {
+                                    /* not a permissions change */
+                                    continue;
+                                }
                                 final Object[] testCase = new Object[index];
                                 testCase[IS_GROUP_OWNER] = isGroupOwner;
                                 testCase[IS_GROUP_MEMBER] = isGroupOwner;

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -29,17 +29,26 @@ import java.util.Set;
 import omero.RLong;
 import omero.RType;
 import omero.ServerError;
+import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
+import omero.model.Dataset;
+import omero.model.DatasetImageLink;
+import omero.model.DatasetImageLinkI;
+import omero.model.Experiment;
+import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
+import omero.model.ExperimenterI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
+import omero.model.Instrument;
 import omero.model.Pixels;
+import omero.model.Plate;
 import omero.model.RectI;
 import omero.model.Roi;
 import omero.model.RoiI;
@@ -47,6 +56,7 @@ import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.model.Thumbnail;
 import omero.sys.EventContext;
+import omero.sys.Parameters;
 import omero.sys.ParametersI;
 
 import org.testng.Assert;
@@ -200,9 +210,9 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isExpectSuccess if the chown is expected to succeed
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "chown test cases")
-    public void testChownPrivate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
-            throws Exception {
+    @Test(dataProvider = "chown annotation test cases")
+    public void testChownAnnotationPrivate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup,
+            boolean isExpectSuccess) throws Exception {
 
         /* set up the users and group for this test case */
 
@@ -299,9 +309,9 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isExpectSuccess if the chown is expected to succeed
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "chown test cases")
-    public void testChownReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
-            throws Exception {
+    @Test(dataProvider = "chown annotation test cases")
+    public void testChownAnnotationReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup,
+            boolean isExpectSuccess) throws Exception {
 
         /* set up the users and group for this test case */
 
@@ -375,10 +385,10 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for chown
+     * @return a specific test case for annotation chown
      */
-    @DataProvider(name = "chown test cases (debug)")
-    public Object[][] provideChownCaseDebug() {
+    @DataProvider(name = "chown annotation test cases (debug)")
+    public Object[][] provideChownAnnotationCaseDebug() {
         int index = 0;
         final int IS_DATA_OWNER = index++;
         final int IS_ADMIN = index++;
@@ -398,10 +408,10 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a variety of test cases for chown
+     * @return a variety of test cases for annotation chown
      */
-    @DataProvider(name = "chown test cases")
-    public Object[][] provideChownCases() {
+    @DataProvider(name = "chown annotation test cases")
+    public Object[][] provideChownAnnotationCases() {
         int index = 0;
         final int IS_DATA_OWNER = index++;
         final int IS_ADMIN = index++;
@@ -422,6 +432,572 @@ public class PermissionsTest extends AbstractServerTest {
                     testCase[IS_EXPECT_SUCCESS] = isAdmin || isDataOwner && isRecipientInGroup;
                     testCases.add(testCase);
                 }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * Test a specific case of using {@link Chown2} on an image that is in a dataset.
+     * @param isImageOwner if the user who owns the dataset also owns the image
+     * @param isLinkOwner if the user who owns the dataset also linked the image to the dataset
+     * @param groupPerms the permissions on the group in which the data exists
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chown container test cases")
+    public void testChownImageInDataset(boolean isImageOwner, boolean isLinkOwner, String groupPermissions) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext datasetOwner, imageOwner, linkOwner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        datasetOwner = newUserAndGroup(groupPermissions);
+
+        final long dataGroupId = datasetOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        recipient = newUserInGroup(dataGroup, false);
+
+        if (isImageOwner) {
+            imageOwner = datasetOwner;
+            linkOwner = isLinkOwner ? datasetOwner : newUserInGroup(dataGroup, false);
+        } else {
+            imageOwner = newUserInGroup(dataGroup, false);
+            linkOwner = isLinkOwner ? datasetOwner : imageOwner;
+        }
+
+        /* create a dataset */
+
+        init(datasetOwner);
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        disconnect();
+
+        /* create an image */
+
+        init(imageOwner);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        disconnect();
+
+        /* move the image into the dataset */
+
+        init(linkOwner);
+        DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        link = (DatasetImageLink) iUpdate.saveAndReturnObject(link);
+        disconnect();
+
+        /* perform the chown */
+
+        init(imageOwner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, true);
+        disconnect();
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(dataset, datasetOwner);
+        assertOwnedBy(image, recipient);
+        final boolean isExpectLink = "rwrw--".equals(groupPermissions);
+        if (isExpectLink) {
+            assertExists(link);
+            assertOwnedBy(link, linkOwner);
+        } else {
+            assertDoesNotExist(link);
+        }
+        disconnect();
+    }
+
+    /**
+     * Test a specific case of using {@link Chown2} on a dataset that contains an image.
+     * @param isImageOwner if the user who owns the dataset also owns the image
+     * @param isLinkOwner if the user who owns the dataset also linked the image to the dataset
+     * @param groupPerms the permissions on the group in which the data exists
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chown container test cases")
+    public void testChownDatasetWithImage(boolean isImageOwner, boolean isLinkOwner, String groupPermissions) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext datasetOwner, imageOwner, linkOwner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        datasetOwner = newUserAndGroup(groupPermissions);
+
+        final long dataGroupId = datasetOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        recipient = newUserInGroup(dataGroup, false);
+
+        if (isImageOwner) {
+            imageOwner = datasetOwner;
+            linkOwner = isLinkOwner ? datasetOwner : newUserInGroup(dataGroup, false);
+        } else {
+            imageOwner = newUserInGroup(dataGroup, false);
+            linkOwner = isLinkOwner ? datasetOwner : imageOwner;
+        }
+
+        /* create a dataset */
+
+        init(datasetOwner);
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        final long datasetId = dataset.getId().getValue();
+        disconnect();
+
+        /* create an image */
+
+        init(imageOwner);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        disconnect();
+
+        /* move the image into the dataset */
+
+        init(linkOwner);
+        DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        link = (DatasetImageLink) iUpdate.saveAndReturnObject(link);
+        disconnect();
+
+        /* perform the chown */
+
+        init(datasetOwner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, true);
+        disconnect();
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(dataset, recipient);
+        assertOwnedBy(image, isImageOwner ? recipient : imageOwner);
+        assertOwnedBy(link, isImageOwner ? recipient : linkOwner);
+        disconnect();
+    }
+
+    /**
+     * @return a specific test case for container chown
+     */
+    @DataProvider(name = "chown container test cases (debug)")
+    public Object[][] provideChownContainerCaseDebug() {
+        int index = 0;
+        final int IS_IMAGE_OWNER = index++;
+        final int IS_LINK_OWNER = index++;
+        final int GROUP_PERMS = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[IS_IMAGE_OWNER] = true;
+        testCase[IS_LINK_OWNER] = true;
+        testCase[GROUP_PERMS] = "rw----";
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for container chown
+     */
+    @DataProvider(name = "chown container test cases")
+    public Object[][] provideChownContainerCases() {
+        int index = 0;
+        final int IS_IMAGE_OWNER = index++;
+        final int IS_LINK_OWNER = index++;
+        final int GROUP_PERMS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isImageOwner : booleanCases) {
+            for (final boolean isLinkOwner : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    if (!(isImageOwner && isLinkOwner || "rwrw--".equals(groupPerms))) {
+                        /* test case does not make sense */
+                        continue;
+                    }
+                    final Object[] testCase = new Object[index];
+                    testCase[IS_IMAGE_OWNER] = isImageOwner;
+                    testCase[IS_LINK_OWNER] = isLinkOwner;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    testCases.add(testCase);
+                }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * Test chown on an image whose instrument is shared with another's image.
+     * @param groupPermissions the permissions on the group in which the chown is to occur
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "image sharing test cases")
+    public void testSharedInstrument(String groupPermissions) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext imageOwner, projectionOwner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        imageOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = imageOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        projectionOwner = newUserInGroup(dataGroup, false);
+        recipient = newUserInGroup(dataGroup, false);
+
+        /* create an image with an instrument */
+
+        init(imageOwner);
+        Image image = mmFactory.createImage();
+        image.setInstrument(mmFactory.createInstrument());
+        image = (Image) iUpdate.saveAndReturnObject(image);
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        final Instrument instrument = (Instrument) image.getInstrument().proxy();
+        image = (Image) image.proxy();
+        disconnect();
+
+        /* another user projects the image */
+
+        init(projectionOwner);
+        Image projection = mmFactory.createImage();
+        projection.setInstrument(instrument);
+        projection = (Image) iUpdate.saveAndReturnObject(projection);
+        final long projectionId = projection.getId().getValue();
+        testImages.add(projectionId);
+        projection = (Image) projection.proxy();
+        disconnect();
+
+        /* chmod the group to the required permissions */
+
+        logRootIntoGroup(dataGroupId);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = groupPermissions;
+        doChange(client, factory, chmod, true);
+        disconnect();
+
+        /* perform the chown */
+
+        init(imageOwner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, true);
+        disconnect();
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(image, recipient);
+        assertOwnedBy(projection, projectionOwner);
+        assertOwnedBy(instrument, imageOwner);
+        disconnect();
+    }
+
+    /**
+     * Test chown on an image that is used in the same experiment as another's image.
+     * @param groupPermissions the permissions on the group in which the chown is to occur
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "image sharing test cases")
+    public void testSharedExperiment(String groupPermissions) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext imageOwner, otherImageOwner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        imageOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = imageOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        otherImageOwner = newUserInGroup(dataGroup, false);
+        recipient = newUserInGroup(dataGroup, false);
+
+        /* create an image with an experiment */
+
+        init(imageOwner);
+        Image image = mmFactory.createImage();
+        image.setExperiment(mmFactory.simpleExperiment());
+        image = (Image) iUpdate.saveAndReturnObject(image);
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        final Experiment experiment = (Experiment) image.getExperiment().proxy();
+        image = (Image) image.proxy();
+        disconnect();
+
+        /* another user's image is part of the same experiment */
+
+        init(otherImageOwner);
+        Image otherImage = mmFactory.createImage();
+        otherImage.setExperiment(experiment);
+        otherImage = (Image) iUpdate.saveAndReturnObject(otherImage);
+        final long otherImageId = otherImage.getId().getValue();
+        testImages.add(otherImageId);
+        otherImage = (Image) otherImage.proxy();
+        disconnect();
+
+        /* chmod the group to the required permissions */
+
+        logRootIntoGroup(dataGroupId);
+        final Chmod2 chmod = new Chmod2();
+        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
+        chmod.permissions = groupPermissions;
+        doChange(client, factory, chmod, true);
+        disconnect();
+
+        /* perform the chown */
+
+        init(imageOwner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, true);
+        disconnect();
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(image, recipient);
+        assertOwnedBy(otherImage, otherImageOwner);
+        assertOwnedBy(experiment, imageOwner);
+        disconnect();
+    }
+
+
+    /**
+     * @return group permissions for a specific image sharing test case
+     */
+    @DataProvider(name = "image sharing test cases (debug)")
+    public Object[][] provideImageSharingCaseDebug() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[GROUP_PERMS] = "rwr---";
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return group permissions for image sharing test cases
+     */
+    @DataProvider(name = "image sharing test cases")
+    public Object[][] provideImageSharingCases() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+
+        final String[] permsCases = new String[]{"rwr---", "rwra--", "rwrw--"};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final String groupPerms : permsCases) {
+            final Object[] testCase = new Object[index];
+            testCase[GROUP_PERMS] = groupPerms;
+            testCases.add(testCase);
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /* for dataset to plate test cases */
+    private enum Target { DATASET, IMAGES, PLATE };
+
+    /**
+     * Test chown on a dataset, plate, or images, where the plate's images are in the dataset.
+     * @param groupPermissions the permissions on the group in which the chown is to occur
+     * @param target the target of the chown operation
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "dataset to plate test cases")
+    public void testDatasetToPlate(String groupPermissions, Target target) throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext datasetOwner, plateOwner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        datasetOwner = newUserAndGroup("rwrw--");
+
+        final long dataGroupId = datasetOwner.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        plateOwner = newUserInGroup(dataGroup, false);
+        recipient = newUserInGroup(dataGroup, true);
+
+        /* create a plate */
+
+        init(plateOwner);
+        Plate plate = mmFactory.createPlate(2, 2, 1, 1, false);
+        plate = (Plate) iUpdate.saveAndReturnObject(plate).proxy();
+        final long plateId = plate.getId().getValue();
+
+        /* find the plate's images */
+
+        final List<Long> imageIds = new ArrayList<Long>();
+        final String hql = "SELECT image.id FROM WellSample where well.id IN (SELECT id FROM Well WHERE plate.id = :id)";
+        final Parameters params = new ParametersI().addId(plateId);
+        for (final List<RType> result : iQuery.projection(hql, params)) {
+            final Long imageId = ((RLong) result.get(0)).getValue();
+            imageIds.add(imageId);
+        }
+        disconnect();
+
+        /* the images should be owned by the dataset owner */
+
+        logRootIntoGroup(dataGroupId);
+        final Experimenter datasetOwnerActual = new ExperimenterI(datasetOwner.userId, false);
+        final List<IObject> images = iQuery.findAllByQuery("FROM Image WHERE id IN (:ids)", new ParametersI().addIds(imageIds));
+        Assert.assertEquals(images.size(), imageIds.size());
+        for (final IObject image : images) {
+            image.getDetails().setOwner(datasetOwnerActual);
+        }
+        iUpdate.saveCollection(images);
+        disconnect();
+
+        /* create the dataset and link the images to it */
+
+        init(datasetOwner);
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        final long datasetId = dataset.getId().getValue();
+
+        final List<DatasetImageLink> links = new ArrayList<DatasetImageLink>(images.size());
+        for (final IObject image : images) {
+            DatasetImageLink link = new DatasetImageLinkI();
+            link.setParent(dataset);
+            link.setChild((Image) image.proxy());
+            links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
+        }
+        disconnect();
+
+        /* check that the objects' ownership is all as expected */
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(dataset, datasetOwner);
+        assertOwnedBy(images, datasetOwner);
+        assertOwnedBy(links, datasetOwner);
+        assertOwnedBy(plate, plateOwner);
+        disconnect();
+
+        /* perform the chown */
+
+        final boolean isExpectSuccess = target != Target.PLATE;
+
+        init(datasetOwner);
+        final Chown2 chown = new Chown2();
+
+        switch (target) {
+        case DATASET:
+            chown.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+            break;
+        case IMAGES:
+            chown.targetObjects = ImmutableMap.of("Image", imageIds);
+            break;
+        case PLATE:
+            chown.targetObjects = ImmutableMap.of("Plate", Collections.singletonList(plateId));
+            break;
+        }
+
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, isExpectSuccess);
+        disconnect();
+
+        logRootIntoGroup(dataGroupId);
+
+        if (isExpectSuccess) {
+
+            /* check that the objects' ownership is all as expected */
+
+            switch (target) {
+            case DATASET:
+                assertOwnedBy(dataset, recipient);
+                assertOwnedBy(images, datasetOwner);
+                assertOwnedBy(links, datasetOwner);
+                assertOwnedBy(plate, plateOwner);
+                break;
+            case IMAGES:
+                assertOwnedBy(dataset, datasetOwner);
+                assertOwnedBy(images, recipient);
+                assertOwnedBy(links, datasetOwner);
+                assertOwnedBy(plate, plateOwner);
+                break;
+            case PLATE:
+                Assert.fail("cannot change plate ownership without changing that of its images");
+            }
+        }
+
+        /* delete the objects as clean-up */
+
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = ImmutableMap.of(
+                "Dataset", Collections.singletonList(datasetId),
+                "Plate", Collections.singletonList(plateId));
+        doChange(client, factory, delete, true);
+
+        disconnect();
+}
+
+    /**
+     * @return a specific test case for dataset to plate
+     */
+    @DataProvider(name = "dataset to plate test cases (debug)")
+    public Object[][] provideDatasetToPlateCaseDebug() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+        final int TARGET = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[GROUP_PERMS] = "rwr---";
+        testCase[TARGET] = Target.IMAGES;
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for dataset to plate
+     */
+    @DataProvider(name = "dataset to plate test cases")
+    public Object[][] provideDatasetToPlateCases() {
+        int index = 0;
+        final int GROUP_PERMS = index++;
+        final int TARGET = index++;
+
+        final String[] permsCases = new String[]{"rwr---", "rwra--", "rwrw--"};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final String groupPerms : permsCases) {
+            for (final Target target : Target.values()) {
+                final Object[] testCase = new Object[index];
+                testCase[GROUP_PERMS] = groupPerms;
+                testCase[TARGET] = target;
+                testCases.add(testCase);
             }
         }
 

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -9,7 +9,6 @@ package integration.delete;
 import static omero.rtypes.rbool;
 import static omero.rtypes.rstring;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,6 +43,7 @@ import omero.model.ExperimenterGroupI;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
+import omero.model.ImageI;
 import omero.model.Instrument;
 import omero.model.Pixels;
 import omero.model.Plate;
@@ -63,6 +63,7 @@ import omero.sys.ParametersI;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.HashMultimap;
@@ -572,5 +573,150 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         assertDoesNotExist(dataset);
         assertDoesNotExist(original);
         assertExists(projection);
+    }
+
+    /* for dataset to plate test cases */
+    private enum Target { DATASET, IMAGES, PLATE };
+
+    /**
+     * Test deletion on a dataset, plate, or images, where the plate's images are in the dataset.
+     * @param target the target of the delete operation
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "dataset to plate test cases")
+    public void testDeletingDatasetToPlate(Target target) throws Exception {
+        newUserAndGroup("rw----");
+
+        /* create a plate */
+
+        Plate plate = mmFactory.createPlate(2, 2, 1, 1, false);
+        plate = (Plate) iUpdate.saveAndReturnObject(plate).proxy();
+        final long plateId = plate.getId().getValue();
+
+        /* find the plate's images */
+
+        final List<Long> imageIds = new ArrayList<Long>();
+        final String hql = "SELECT image.id FROM WellSample where well.id IN (SELECT id FROM Well WHERE plate.id = :id)";
+        final omero.sys.Parameters params = new ParametersI().addId(plateId);
+        for (final List<RType> result : iQuery.projection(hql, params)) {
+            final Long imageId = ((RLong) result.get(0)).getValue();
+            imageIds.add(imageId);
+        }
+
+        /* create the dataset and link the images to it */
+
+        final Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        final long datasetId = dataset.getId().getValue();
+
+        final List<Long> linkIds = new ArrayList<Long>(imageIds.size());
+        for (final long imageId : imageIds) {
+            DatasetImageLink link = new DatasetImageLinkI();
+            link.setParent(dataset);
+            link.setChild(new ImageI(imageId, false));
+            linkIds.add(iUpdate.saveAndReturnObject(link).getId().getValue());
+        }
+
+        /* perform the deletion */
+
+        final boolean isExpectSuccess = target != Target.IMAGES;
+
+        final Delete2 delete = new Delete2();
+
+        switch (target) {
+        case DATASET:
+            delete.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+            break;
+        case IMAGES:
+            delete.targetObjects = ImmutableMap.of("Image", imageIds);
+            break;
+        case PLATE:
+            delete.targetObjects = ImmutableMap.of("Plate", Collections.singletonList(plateId));
+            break;
+        }
+
+        doChange(client, factory, delete, isExpectSuccess);
+
+        if (isExpectSuccess) {
+
+            /* check that exactly the expected objects were deleted */
+
+            switch (target) {
+            case DATASET:
+                assertDoesNotExist("Dataset", datasetId);
+                assertAllExist("Image", imageIds);
+                assertNoneExist("DatasetImageLink", linkIds);
+                assertExists("Plate", plateId);
+                break;
+            case IMAGES:
+                Assert.fail("cannot delete images while used by well samples");
+            case PLATE:
+                assertExists("Dataset", datasetId);
+                assertAllExist("Image", imageIds);
+                assertAllExist("DatasetImageLink", linkIds);
+                assertDoesNotExist("Plate", plateId);
+                break;
+            }
+        }
+
+        /* delete the remaining "containers" */
+
+        switch (target) {
+        case DATASET:
+            delete.targetObjects = ImmutableMap.of("Plate", Collections.singletonList(plateId));
+            break;
+        case IMAGES:
+            delete.targetObjects = ImmutableMap.of(
+                    "Dataset", Collections.singletonList(datasetId),
+                    "Plate", Collections.singletonList(plateId));
+            break;
+        case PLATE:
+            delete.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+            break;
+        }
+
+        doChange(client, factory, delete, true);
+
+        /* check that all the objects are now deleted */
+
+        assertDoesNotExist("Dataset", datasetId);
+        assertNoneExist("Image", imageIds);
+        assertNoneExist("DatasetImageLink", linkIds);
+        assertDoesNotExist("Plate", plateId);
+    }
+
+    /**
+     * @return a specific test case for dataset to plate
+     */
+    @DataProvider(name = "dataset to plate test cases (debug)")
+    public Object[][] provideDatasetToPlateCaseDebug() {
+        int index = 0;
+        final int TARGET = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        final Object[] testCase = new Object[index];
+        testCase[TARGET] = Target.IMAGES;
+        testCases.add(testCase);
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return a variety of test cases for dataset to plate
+     */
+    @DataProvider(name = "dataset to plate test cases")
+    public Object[][] provideDatasetToPlateCases() {
+        int index = 0;
+        final int TARGET = index++;
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Target target : Target.values()) {
+            final Object[] testCase = new Object[index];
+            testCase[TARGET] = target;
+            testCases.add(testCase);
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
     }
 }


### PR DESCRIPTION
This PR rewrites how the `Chmod2` requests work to make them easier to adjust in the future, and reintroduces default automatic substitution of legacy `Chmod`. Now in some cases it is possible to downgrade a group to private where previously it wasn't, but at the cost of those downgrades running slowly on large groups; for instance, see http://trac.openmicroscopy.org/ome/ticket/8566. Every other permissions change should remain fast.

This PR should not introduce any regressions. Integration tests should continue to pass.