### PR TITLE
Dropbox permissions on Linux

### DIFF
--- a/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
+++ b/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
@@ -277,41 +277,50 @@ class ProcessEvent(pyinotify.ProcessEvent):
                         self.wm.addWatch(
                             name, self.wm.watchParams[
                                 pathModule.path(name).parent].getMask())
-                        if self.wm.watchParams[
-                                pathModule.path(name).parent].getRec():
-                            for d in pathModule.path(name).walkdirs():
-                                self.log.info(
-                                    'NON-INOTIFY event: New directory at: %s',
-                                    str(d))
-                                if not self.ignoreDirEvents:
+                        if self.wm.isPathWatched(name):
+                            if self.wm.watchParams[
+                                    pathModule.path(name).parent].getRec():
+                                for d in pathModule.path(name).walkdirs(
+                                        errors='warn'):
+                                    self.log.info(
+                                        ('NON-INOTIFY event: '
+                                         'New directory at: %s'),
+                                        str(d))
+                                    if not self.ignoreDirEvents:
+                                        el.append((
+                                            str(d),
+                                            monitors.EventType.Create))
+                                    else:
+                                        self.log.info('Not propagated.')
+                                    self.wm.addWatch(
+                                        str(d), self.wm.watchParams[
+                                            pathModule.path(
+                                                name).parent].getMask())
+                                for f in pathModule.path(name).walkfiles(
+                                        errors='warn'):
+                                    self.log.info(
+                                        'NON-INOTIFY event: New file at: %s',
+                                        str(f))
                                     el.append(
-                                        (str(d), monitors.EventType.Create))
-                                else:
-                                    self.log.info('Not propagated.')
-                                self.wm.addWatch(
-                                    str(d), self.wm.watchParams[
-                                        pathModule.path(
-                                            name).parent].getMask())
-                            for f in pathModule.path(name).walkfiles():
-                                self.log.info(
-                                    'NON-INOTIFY event: New file at: %s',
-                                    str(f))
-                                el.append((str(f), monitors.EventType.Create))
-                        else:
-                            for d in pathModule.path(name).dirs():
-                                self.log.info(
-                                    'NON-INOTIFY event: New directory at: %s',
-                                    str(d))
-                                if not self.ignoreDirEvents:
+                                        (str(f), monitors.EventType.Create))
+                            else:
+                                for d in pathModule.path(name).dirs():
+                                    self.log.info(
+                                        ('NON-INOTIFY event: '
+                                         'New directory at: %s'),
+                                        str(d))
+                                    if not self.ignoreDirEvents:
+                                        el.append((
+                                            str(d),
+                                            monitors.EventType.Create))
+                                    else:
+                                        self.log.info('Not propagated.')
+                                for f in pathModule.path(name).files():
+                                    self.log.info(
+                                        'NON-INOTIFY event: New file at: %s',
+                                        str(f))
                                     el.append(
-                                        (str(d), monitors.EventType.Create))
-                                else:
-                                    self.log.info('Not propagated.')
-                            for f in pathModule.path(name).files():
-                                self.log.info(
-                                    'NON-INOTIFY event: New file at: %s',
-                                    str(f))
-                                el.append((str(f), monitors.EventType.Create))
+                                        (str(f), monitors.EventType.Create))
                 else:
                     self.log.info('Created "untitled folder" ignored.')
             else:

--- a/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
+++ b/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
@@ -251,9 +251,11 @@ class ProcessEvent(pyinotify.ProcessEvent):
                 'Event with "-unknown-path" of type %s : %s', maskname, name)
             name = name.replace('-unknown-path', '')
 
-        # New directory within watch area, either created or moved into.
-        if event.mask == (pyinotify.IN_CREATE | pyinotify.IN_ISDIR) \
-                or event.mask == (pyinotify.IN_MOVED_TO | pyinotify.IN_ISDIR):
+        # New directory within watch area,
+        # either created, moved in or modfied attributes, ie now readable.
+        if (event.mask == (pyinotify.IN_CREATE | pyinotify.IN_ISDIR)
+                or event.mask == (pyinotify.IN_MOVED_TO | pyinotify.IN_ISDIR)
+                or event.mask == (pyinotify.IN_ATTRIB | pyinotify.IN_ISDIR)):
             self.log.info(
                 'New directory event of type %s at: %s', maskname, name)
             if "Creation" in self.et:
@@ -386,7 +388,7 @@ class ProcessEvent(pyinotify.ProcessEvent):
 
         # These are all the currently ignored events.
         elif event.mask == pyinotify.IN_ATTRIB:
-            # Attributes have changed? Useful?
+            # File attributes have changed? Useful?
             self.log.debug('Ignored event of type %s at: %s', maskname, name)
         elif (event.mask == pyinotify.IN_DELETE_SELF
                 or event.mask == pyinotify.IN_IGNORED):

--- a/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
+++ b/components/tools/OmeroFS/src/fsPyinotifyMonitor.py
@@ -88,11 +88,14 @@ class PlatformMonitor(AbstractPlatformMonitor):
             self.wm, ProcessEvent(
                 wm=self.wm, cb=self.propagateEvents, et=self.eTypes,
                 ignoreDirEvents=self.ignoreDirEvents))
-        self.wm.addBaseWatch(
-            self.pathsToMonitor, (pyinotify.ALL_EVENTS), rec=recurse,
-            auto_add=follow)
-        self.log.info('Monitor set-up on %s', str(self.pathsToMonitor))
-        self.log.info('Monitoring %s events', str(self.eTypes))
+        try:
+            self.wm.addBaseWatch(
+                self.pathsToMonitor, (pyinotify.ALL_EVENTS), rec=recurse,
+                auto_add=follow)
+            self.log.info('Monitor set-up on %s', str(self.pathsToMonitor))
+            self.log.info('Monitoring %s events', str(self.eTypes))
+        except:
+            self.log.error('Monitor failed on: %s', str(self.pathsToMonitor))
 
     def start(self):
         """


### PR DESCRIPTION
This PR attempts to fix the problem reported in https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7814

Creating a DropBox user directory with permissions that don't allow omero to read it should not cause DropBox to fail. Changing the permissions later should cause the directory to be watched. More specifically:
```
mkdir -m 300 /path/to/omero.data.dir/DropBox/username
```
should log an error in `MonitorServer.log` indicating that the directory isn't being watched. Then:
```
chmod 770 /path/to/omero.data.dir/DropBox/username
```
should log that the directory is now being watched.

--no-rebase