### PR TITLE
prevent group owner from self removal

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -43,11 +43,10 @@
                 var highlightCurrent = function() {
                     var userId = {{ userId }};
                     var selected = $.grep($('#id_members').data('chosen').results_data, function(item){
-                        if (parseInt(item.value) === userId) {
-                            $("#id_owners_chzn_c_"+item.array_index).addClass('search-choice-current').find("a").first().unbind("click").remove();                            
-                            $("#id_members_chzn_c_"+item.array_index).addClass('search-choice-current').find("a").first().unbind("click").remove();                            
-                        }
+                        return item.value == userId;
                     });
+                    $("#id_owners_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
+                    $("#id_members_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
                 }
                 
                 $("#id_owners").chosen({placeholder_text:'Type owners names to add...'});


### PR DESCRIPTION
Group owner shouldn't be able to remove himself from the group he can manager users.

To test log in as group owner. Go to User Settings -> My Group and check if current user is highlited and there is no X allowing to delete from current group.

![firefoxscreensnapz051](https://cloud.githubusercontent.com/assets/1065155/7813323/db53e50e-03b1-11e5-95ab-a9fc2470e665.png)

cc: @will-moore 