### PR TITLE
Group owner form read write

### DIFF
--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -100,10 +100,7 @@ Test Delete Images in Share
     Click Element                               create_share
     Wait Until Page Contains Element            id_message
     Input Text                                  id_message      Robot Test Delete Images in Share
-    # Select first user with Chosen plugin
-    Click Element                               xpath=//div[@id='id_members_chosen']/ul[@class='chosen-choices']
-    Page Should Contain Element                 xpath=//div[@id='id_members_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']
-    Click Element                               xpath=//div[@id='id_members_chosen']/div[@class='chosen-drop']/ul[@class='chosen-results']/li[@data-option-array-index='1']
+    Select From List                            id_members      1
     Submit Form                                 create_share_form
     Wait Until Page Contains Element            id=Public
     # Wait Until Page Contains Element          xpath=//div[@id='dataTree']//li[@rel='share']/a

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -71,8 +71,11 @@
                         null, "WARNING", ['OK'], null, 180);
                 });
 
-                // Disable the "Read-Write" permissions option for group owners.
-                $('#id_permissions_3').prop('disabled', 'disabled');
+                // Disable the "Read-Write" permissions option for group owners (if it's not checked)
+                var $readWriteCheckbox = $('#id_permissions_3');
+                if (!$readWriteCheckbox.is(':checked')) {
+                    $readWriteCheckbox.prop('disabled', 'disabled');
+                }
                 $('label[for="id_permissions_3"]')
                     .css('opacity',0.5)
                     .prop('title', 'Group owners cannot upgrade to Read-Write permissions. Please contact your sysadmin.');

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -840,6 +840,8 @@ def manage_group_owner(request, action, gid, conn=None, **kwargs):
                                 " their only group" % (url, e.getFullName()))
                 # refresh the form and add messages
                 context = getEditFormContext()
+            else:
+                context = {'gid': gid, 'form': form}
     else:
         return HttpResponseRedirect(reverse("wamyaccount"))
 


### PR DESCRIPTION
This fixes https://trac.openmicroscopy.org.uk/ome/ticket/12901 and also fixes failing Robot tests.

To test:
 - Owner of a Read-Write group should be able to make changes to the group and the form should be submitted without errors.
 - If owner is editing a Read-Write group, they should be able to click on other permission options, and will still be able to click on "Read-Write" again so as to make no permissions changes on Save.
 - However, if they save with other permissions, they won't then be able to choose "Read-Write" permissions when they edit again.

 - Check https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-robotframework/lastBuild/robot/ for failure in Test Delete Images in Share.