### PR TITLE
Scrollbar

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -789,9 +789,6 @@ public class TreeCellRenderer
                 setText(value);
                 w = getPreferredWidth();
                 Dimension d = new Dimension(w, fm.getHeight()+4);
-                if (vp.getComponentCount() > 0) {
-                    vp.getComponent(0).setPreferredSize(d);
-                }
                 setSize(d);//4 b/c GTK L&F
                 setPreferredSize(d);//4 b/c GTK L&F
             }


### PR DESCRIPTION
No longer set the preferred size.
The source of the problem is due to a reset of the component hosted by the viewport.
Instead of rolling back the truncated name, I only removed the code resetting the preferred size.
It means that the horizontal scrollbar is visible when dragging the splitpane to the left but at this stage I think it is a minor problem that we can address post 5.1.2

cc @pwalczysko @gusferguson 
I will close PR opened by @dominikl and @joshmoore 