### PR TITLE
do not substitute Chmod requests with Chmod2

### DIFF
--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -176,9 +176,10 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(ChmodI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        if (graphRequestFactory.isGraphsWrap()) {
+                        // TODO: Chmod2 too slow to be automatically substituted for Chmod
+                        /* if (graphRequestFactory.isGraphsWrap()) {
                             return new ChmodFacadeI(graphRequestFactory);
-                        } else {
+                        } else */ {
                             return new ChmodI(ic,
                                     ctx.getBean("chmodStrategy", ChmodStrategy.class));
                         }


### PR DESCRIPTION
Has the server use `ChmodI` instead of `Chmod2I` when given a `Chmod` request regardless of `omero.graphs.wrap`.