### PR TITLE
Save z changes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -301,7 +301,7 @@ class ImViewerComponent
 		JPanel p = new JPanel();
 		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
 		JCheckBox rndBox = null;
-		if (!model.isOriginalSettings()) {
+		if (!model.isOriginalSettings(false)) {
 			rndBox = new JCheckBox(RND);
 			rndBox.setSelected(true);
 			p.add(rndBox);
@@ -805,6 +805,9 @@ class ImViewerComponent
 	 */
 	public void setSelectedXYPlane(int z, int t, int bin)
 	{
+	    boolean enableSave = z != model.getDefaultZ()
+                || t != model.getDefaultT();
+	    
 	    if (z < 0) z = model.getDefaultZ();
 	    if (t < 0) t = model.getRealSelectedT();
 	    switch (model.getState()) {
@@ -839,6 +842,9 @@ class ImViewerComponent
 	        newPlane = true;
 	    }
 	    model.setSelectedXYPlane(z, t, bin);
+	    
+	    if (enableSave)
+            controller.getAction(ImViewerControl.SAVE_RND_SETTINGS).setEnabled(true);
 	}
 	
 	/** 
@@ -2741,7 +2747,7 @@ class ImViewerComponent
 				throw new IllegalArgumentException("This method cannot be " +
 				"invoked in the DISCARDED state.");
 		}
-		return model.isOriginalSettings();
+		return model.isOriginalSettings(true);
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -343,7 +343,6 @@ class ImViewerComponent
 					ImViewerAgent.getRegistry().getLogger().error(this, logMsg);
 				}
 			}
-			savePlane();
 			return true;
 		}
 		MessageBox msg = new MessageBox(view, "Save Data", 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.iviewer.view.ImViewerControl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -708,7 +708,11 @@ class ImViewerControl
 	 */
 	void setSelectedXYPlane(int z, int t, int bin)
 	{ 
-		model.setSelectedXYPlane(z, t, bin); 
+        boolean enableSave = z != model.getDefaultZ()
+                || t != model.getDefaultT();
+        model.setSelectedXYPlane(z, t, bin);
+        if (enableSave)
+            actionsMap.get(SAVE_RND_SETTINGS).setEnabled(true);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2212,16 +2212,17 @@ class ImViewerModel
 	/**
 	 * Returns <code>true</code> if the rendering settings are original,
 	 * <code>false</code> otherwise.
-	 * 
+	 * @param checkPlane Pass <code>true</code> to take z/t changes into account, 
+	 *                     <code>false</code> to ignore them
 	 * @return See above.
 	 */
-	boolean isOriginalSettings()
+	boolean isOriginalSettings(boolean checkPlane)
 	{
 		if (originalDef == null) return true;
 		if (metadataViewer == null) return true;
 		Renderer rnd = metadataViewer.getRenderer();
 		if (rnd == null) return true;
-		return isSameSettings(originalDef, false);
+		return isSameSettings(originalDef, checkPlane);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -1401,7 +1401,7 @@ class RendererModel
         */
 	boolean isModified() {
 	    if(rndControl!=null) {
-	        return !rndControl.isSameSettings(rndDef, false);
+	        return !rndControl.isSameSettings(rndDef, true);
 	    }
 	    return false;
 	}


### PR DESCRIPTION
Enables the save button after Z or T has been changed. There are still some minor issues with the z/t sliders if both views (preview and full viewer) are open at the same time (z/t slider then shows the last selected z/t state, even if the z/t changes haven't been stored), not going to fix that in this PR.
