### PR TITLE
Image J

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -928,7 +928,13 @@ public class FileImportComponent
 		} else if (image instanceof List) {
 			List<ThumbnailData> list = new ArrayList<ThumbnailData>((List) image);
 			int m = list.size();
-			imageLabel.setData(list.get(0));
+			ThumbnailData data = list.get(0);
+			long iid = data.getImageID();
+			if (data.getImage() != null) {
+			    iid = data.getImage().getId();
+			}
+			getFile().setImageID(iid);
+			imageLabel.setData(data);
 			list.remove(0);
 			if (list.size() > 0) {
 				ThumbnailLabel label = imageLabels.get(0);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -83,6 +83,18 @@ public class FileObject
     }
 
     /**
+     * Sets the omero image Id after saving the image.
+     *
+     * @param id The value to set.
+     */
+    public void setImageID(long id)
+    {
+        if (!isImagePlus()) return;
+        ImagePlus image = (ImagePlus) file;
+        image.setProperty(OMERO_GROUP, id);
+    }
+
+    /**
      * Add the associated file if any.
      * 
      * @param file The file to add.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -91,7 +91,7 @@ public class FileObject
     {
         if (!isImagePlus()) return;
         ImagePlus image = (ImagePlus) file;
-        image.setProperty(OMERO_GROUP, id);
+        image.setProperty(OMERO_ID, id);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
@@ -20,6 +20,7 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
+import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
@@ -121,7 +122,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     rois = reader.readImageJROIFromSources(id, img);
                     //create a tmp file.
@@ -145,6 +148,7 @@ public class ResultsSaver
                                             imageID, fa);
                                 }
                             } catch (Exception e) {
+                                IJ.log("error:"+e.toString());
                                 context.getLogger().error(this,
                                         "Cannot Save the ROIs results: "
                                                 +e.getMessage());
@@ -172,7 +176,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     //create a tmp file.
                     File f = createFile(img);
@@ -221,7 +227,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     rois = reader.readImageJROIFromSources(id, img);
                     if (CollectionUtils.isNotEmpty(rois)) {


### PR DESCRIPTION
Fix workflow issue noticed while reviewing 5.1.2
To test:
 * Open an image from disk in imageJ
 * Import the image in omero
 * Draw roi on the image.
 * Click Save ROIs.
 * The dialog indicating that the image is not imported should not pop up. The roi should be added to the image previously imported

cc @pwalczysko 