### PR TITLE
Server configuration: autogenerated docs improvement

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -143,8 +143,11 @@ and :doc:`Windows <windows/server-installation>` pages, as well as the
 
 .. _core_configuration:
 
-Core
-----
+Mandatory properties
+--------------------
+
+The following properties need to be correctly set for all installations of the
+OMERO.server. Depending on your set-up, default values may be sufficient.
 
 - :property:`omero.data.dir`
 - :property:`omero.db.host`

--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -25,8 +25,8 @@ mark up.
 """
 
 HEADER_MAPPING = {
-    "omero.data": "Core",
-    "omero.db": "Core",
+    "omero.data": "FS",
+    "omero.db": "Database",
     "omero.cluster": "Grid",
     "omero.grid": "Grid",
     "omero.checksum": "FS",
@@ -114,6 +114,18 @@ editor.
 Examples of doing this are on the main :doc:`Unix <unix/server-installation>`
 and :doc:`Windows <windows/server-installation>` pages, as well as the
 :doc:`LDAP installation <server-ldap>` page.
+
+.. _core_configuration:
+
+Core
+----
+
+- :property:`omero.data.dir`
+- :property:`omero.db.host`
+- :property:`omero.db.name`
+- :property:`omero.db.pass`
+- :property:`omero.db.version`
+- :property:`omero.db.patch`
 
 """
 

--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -124,8 +124,6 @@ Core
 - :property:`omero.db.host`
 - :property:`omero.db.name`
 - :property:`omero.db.pass`
-- :property:`omero.db.version`
-- :property:`omero.db.patch`
 
 """
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -67,8 +67,8 @@ omero.db.prepared_statement_cache_size=10
 # you can modify the defaults.
 #
 # Note: some other properties are defined in
-# the file etc/profiles/${omero.db.profile}
-# Especially of importance is omero.db.port
+# the file :file:`etc/profiles/${omero.db.profile}`
+# Especially of importance is :property:`omero.db.port`
 omero.db.profile=psql
 
 # Whether JMX statistics are collected
@@ -531,7 +531,7 @@ omero.search.ram_buffer_size=64
 # At least one user-owned directory must be included in the path.
 #
 # The template path is created below :property:`omero.managed.dir`,
-# e.g. /OMERO/ManagedRepository/<omero.fs.repo.path>/
+# e.g. :file:`/OMERO/ManagedRepository/${omero.fs.repo.path}/`
 omero.fs.repo.path=%user%_%userId%//%year%-%month%/%day%/%time%
 
 # Rules to apply to judge the acceptability of FS paths for writing into


### PR DESCRIPTION
This PR follows up on https://github.com/openmicroscopy/openmicroscopy/pull/3825 which was adding DB properties parsing to the documentation page. Main changes are described as  follows:

- a new configuration section is introduced listing the `Database` server properties
- the `FS` section is renamed as `Binary repository` in the docs to unify with the existing semantics
- a new top-level `Core` section is created with hyperlinks to the fundamental server properties (any better name?)
- in terms of underlying logic, a `Header` object is added allowing to define for each configuration section a display name, a reference (to prevent breakage of `fs_configuration` refs) and a stub for a description (which could be displayed under the title).

To test this PR, check the output of the rST file generated by

```
bin/omero config parse --rst
```

Also check

```
bin/omero config parse --keys
bin/omero config parse --defaults
bin/omero config parse --headers
```
work as expected.


/cc @joshmoore @hflynn @mtbc @ximenesuk 