### PR TITLE
Remove locked

### DIFF
--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -111,8 +111,8 @@ Test Discussion
     Select From List                            css=#create_discussion_form select      1
     Submit Form                                 create_discussion_form
     # Click Element                               css=div.ui-dialog-buttonset:visible button:first
-    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='discussion-locked']/a    60
-    Click Element                               xpath=//div[@id='dataTree']//li[@rel='discussion-locked']/a
+    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='discussion']/a    60
+    Click Element                               xpath=//div[@id='dataTree']//li[@rel='discussion']/a
     # Test Editing of Discussion. NB: Adding a Comment to Share is currently broken.
     Wait Until Page Contains Element            id=edit_share
     Click Element                               id=edit_share
@@ -121,8 +121,8 @@ Test Discussion
     Submit Form                                 edit_share_form
     # Bug - right panel does not refresh on it's own. Need to click the discussion in tree again
     Go To                                       ${WELCOME URL}public/
-    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='discussion-locked']/a    60
-    Click Element                               xpath=//div[@id='dataTree']//li[@rel='discussion-locked']/a
+    Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='discussion']/a    60
+    Click Element                               xpath=//div[@id='dataTree']//li[@rel='discussion']/a
     Wait Until Page Contains                    Edited Discussion Message       60
     # Add Comment
     Input Text                                  id_comment      New Discussion Comment

--- a/components/tests/ui/testcases/web/tree_test.txt
+++ b/components/tests/ui/testcases/web/tree_test.txt
@@ -32,17 +32,17 @@ Test Container Creation Enabled
     Create Button Should Be Enabled             project
     Create Button Should Be Enabled             dataset
     Create Button Should Be Enabled             screen
-    Node Popup Menu Item Should Be Enabled      Project
+    Node Popup Menu Item Should Be Disabled     Project
     Node Popup Menu Item Should Be Enabled      Dataset
-    Node Popup Menu Item Should Be Enabled      Screen
+    Node Popup Menu Item Should Be Disabled     Screen
     Node Popup Menu Item Should Be Enabled      Delete
     Select And Expand Dataset
     Create Button Should Be Enabled             project
     Create Button Should Be Enabled             dataset
     Create Button Should Be Enabled             screen
-    Node Popup Menu Item Should Be Enabled      Project
-    Node Popup Menu Item Should Be Enabled      Dataset
-    Node Popup Menu Item Should Be Enabled      Screen
+    Node Popup Menu Item Should Be Disabled     Project
+    Node Popup Menu Item Should Be Disabled     Dataset
+    Node Popup Menu Item Should Be Disabled     Screen
     Node Popup Menu Item Should Be Enabled      Delete
     ${imageId}=                                 Select And Expand Image
     Create Button Should Be Enabled             project

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -72,7 +72,7 @@ OME.handle_tree_selection = function(data) {
         var share_id = null;
         if (selected.length == 1) {
             var pr = selected.parent().parent();
-            if (pr.length>0 && pr.attr('rel') && pr.attr('rel').replace("-locked", "")==="share") {
+            if (pr.length>0 && pr.attr('rel') && pr.attr('rel')==="share") {
                 share_id = pr.attr("id").split("-")[1];
             }
         }
@@ -484,7 +484,7 @@ OME.handleDelete = function() {
         if (!first_parent) first_parent = datatree._get_parent(this);
         var $this = $(this);
         ajax_data[i] = $this.attr('id').replace("-","=");
-        var dtype = $this.attr('rel').replace("-locked", "");
+        var dtype = $this.attr('rel');
         if (dtype in dtypes) dtypes[dtype] += 1;
         else dtypes[dtype] = 1;
         if (!q && $this.attr('rel').indexOf('image')<0) q = true;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_subtree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_subtree.html
@@ -24,7 +24,7 @@
 {% if manager.containers.orphaned %}
     {% if manager.containers.images %}
     {% for d in manager.containers.images %}
-        <li id='image-{{ d.id }}' rel="image{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}">
+        <li id='image-{{ d.id }}' rel="image" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}">
           <a href="#" data-name="{{ d.name|escape }}" >
             {{ d.name|default:"Image"|escape }}
           </a>
@@ -34,7 +34,7 @@
 {% else %}
     {% if manager.containers.images %}
     {% for d in manager.containers.images %}
-        <li id='image-{{ d.id }}' rel="image{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}" {% if share and not share.share.isOwned %}data-share="{{ share.obj_id }}"{% endif %}>
+        <li id='image-{{ d.id }}' rel="image" class="{{ d.getPermsCss }}" data-fileset="{{ d.fileset.id.val }}" {% if share and not share.share.isOwned %}data-share="{{ share.obj_id }}"{% endif %}>
           {% if d.loaded %}
               <a href="#" data-name="{{ d.name|escape }}" >
                 {{ d.name|default:"Image"|escape }}
@@ -48,7 +48,7 @@
 {% if manager.plate %}
     {% if manager.plate.countPlateAcquisitions %}
         {% for e in manager.plate.listPlateAcquisitions %}
-            <li id='acquisition-{{ e.id }}' rel="acquisition{% if not e.isOwned %}-locked{% endif %}" class="{{ e.getPermsCss }}">
+            <li id='acquisition-{{ e.id }}' rel="acquisition" class="{{ e.getPermsCss }}">
                 <a href="#">{{ e.name|default:"Run"|escape|truncatebefor:"35" }}</a>
             </li>
         {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -99,12 +99,12 @@
                                     var url;
                                     if (n.attr) {
                                         var parent = this._get_parent(n);
-                                        if ($.inArray($(parent).attr("rel").replace("-locked", ""), ["project", "screen"]) > -1) {
-                                            url = "{% url 'load_data' %}"+$(parent).attr("rel").replace("-locked", "")+"/"+$(parent).attr("id").split("-")[1]+"/"+n.attr("rel").replace("-locked", "")+"/"+n.attr("id").split("-")[1]+"/";
-                                        } else if ($.inArray($(parent).attr("rel").replace("-locked", ""), ["image"]) > -1){
-                                            url = "{% url 'load_data' %}"+n.attr("rel").replace("-locked", "")+"/"+n.attr("id").split("-")[1]+"/";
+                                        if ($.inArray($(parent).attr("rel"), ["project", "screen"]) > -1) {
+                                            url = "{% url 'load_data' %}"+$(parent).attr("rel")+"/"+$(parent).attr("id").split("-")[1]+"/"+n.attr("rel")+"/"+n.attr("id").split("-")[1]+"/";
+                                        } else if ($.inArray($(parent).attr("rel"), ["image"]) > -1){
+                                            url = "{% url 'load_data' %}"+n.attr("rel")+"/"+n.attr("id").split("-")[1]+"/";
                                         } else {
-                                            url = "{% url 'load_data_by_tag' %}"+n.attr("rel").replace("-locked", "")+"/"+n.attr("id").split("-")[1]+"/";
+                                            url = "{% url 'load_data_by_tag' %}"+n.attr("rel")+"/"+n.attr("id").split("-")[1]+"/";
                                         }
                                     } else {
                                         url = "{% url 'load_data_by_tag' %}";
@@ -115,7 +115,7 @@
                                 // the parameter is the node being loaded (may be -1, 0, or undefined when loading the root nodes)
                                 "data" : function (n) {
                                     var r = { "view" : "tree" };
-                                    if (n.attr && $.inArray(n.attr("rel").replace("-locked", ""), ["dataset"]) > -1) {
+                                    if (n.attr && $.inArray(n.attr("rel"), ["dataset"]) > -1) {
                                         if($("div#content_details").has("#page").length > 0) {
                                             r["page"] = parseInt($("div#content_details").find("#page").attr("rel"));
                                         }
@@ -134,94 +134,58 @@
                             "valid_children" : [ "experimenter" ],
                             "types" : {
                                 "experimenter" : {
-                                    "valid_children" : [ "tagset", "tagset-locked", "tag", "tag-locked" ],
+                                    "valid_children" : [ "tagset", "tag" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/icon_user.png" %}'
                                     },
-                                    "create_node" : true,
+                                    "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "tagset" : {
-                                    "valid_children" : [ "tag", "tag-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_tags.png" %}'
-                                    },
-                                    "create_node" : true,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : true
-                                },
-                                "tagset-locked" : {
-                                    "valid_children" : [ "tag", "tag-locked" ],
+                                    "valid_children" : [ "tag" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/left_sidebar_icon_tags.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
-                                },                                
-                                "tag" : {
-                                    "valid_children" : [ "project", "project-locked", "dataset", "dataset-locked", "image", "image-locked", "screen", "screen-locked", "plate", "plate-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_tag.png" %}'
-                                    },
-                                    "create_node" : true,
-                                    "start_drag" : true,
-                                    "move_node" : true,
-                                    "delete_node" : true,
-                                    "remove" : true
                                 },
-                                "tag-locked" : {
-                                    "valid_children" : [ "project", "project-locked", "dataset", "dataset-locked", "image", "image-locked", "screen", "screen-locked", "plate", "plate-locked" ],
+                                "tag" : {
+                                    "valid_children" : [ "project", "dataset", "image", "screen", "plate" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/left_sidebar_icon_tag.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "project" : {
-                                    "valid_children" : [ "dataset", "dataset-locked" ],
+                                    "valid_children" : [ "dataset" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/folder16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : false
-                                },
-                                "project-locked" : {
-                                    "valid_children" : [ "dataset", "dataset-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/folder16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "dataset" : {
-                                    "valid_children" : [ "image", "image-locked" ],
+                                    "valid_children" : [ "image" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/folder_image16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : false
-                                },
-                                "dataset-locked" : {
-                                    "valid_children" : [ "image", "image-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/folder_image16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "image" : {
@@ -232,36 +196,18 @@
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : false
-                                },
-                                "image-locked" : {
-                                    "valid_children" : "none",
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/image16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "screen" : {
-                                    "valid_children" : [ "plate", "plate-locked" ],
+                                    "valid_children" : [ "plate" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/folder_screen16.png" %}'
                                     },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : false
-                                },
-                                "screen-locked" : {
-                                    "valid_children" : [ "plate", "plate-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/folder_screen16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "plate" : {
@@ -272,16 +218,7 @@
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : false
-                                },
-                                "plate-locked" : {
-                                    "valid_children" : "none",
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/folder_plate16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
+                                    "delete_node" : false,
                                     "remove" : false
                                 },
                                 "acquisition" : {
@@ -289,14 +226,11 @@
                                     "icon" : {
                                         "image" : '{% static "webclient/image/image16.png" %}'
                                     },
-                                    "create_node" : false
-                                },
-                                "acquisition-locked" : {
-                                    "valid_children" : "none",
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/image16.png" %}'
-                                    },
-                                    "create_node" : false
+                                    "create_node" : false,
+                                    "start_drag" : false,
+                                    "move_node" : false,
+                                    "delete_node" : false,
+                                    "remove" : false
                                 }
                             }
                         },
@@ -338,7 +272,7 @@
                         obj_rel = $this.parent().attr('rel'),
                         ob_id = $this.parent().attr('id'),
                         iid;
-                    if ((obj_rel=='image') || (obj_rel=='image-locked')) {
+                    if (obj_rel=='image') {
                         iid = ob_id.split("-")[1];
                         OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/" + iid + "/"));
                     }
@@ -350,7 +284,7 @@
                 })
                 .bind("remove.jstree", function (e, data) {
                     data.args[0].each(function (i) {
-                        var url = '{% url 'manage_action_containers' "delete" %}'+$(this).attr("rel").replace("-locked","")+'/'+$(this).attr("id").split("-")[1]+'/'
+                        var url = '{% url 'manage_action_containers' "delete" %}'+$(this).attr("rel")+'/'+$(this).attr("id").split("-")[1]+'/'
 
                         $.ajax({
                             async : false,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_containers.html
@@ -26,7 +26,7 @@
     {% if manager.c_size > 0 %}
     
     {% for i in manager.containers.images %}
-        <li id='image-{{ i.id }}' rel="image{% if not i.isOwned %}-locked{% endif %}" class="{{ i.getPermsCss }}">
+        <li id='image-{{ i.id }}' rel="image" class="{{ i.getPermsCss }}">
             <a href="#" data-name="{{ i.name|escape }}" >
             {{ i.name|default:"Image"|escape }}
           </a>
@@ -34,12 +34,12 @@
     {% endfor %}
     
     {% for c in manager.containers.projects %}
-    <li id='project-{{ c.id }}' rel="project{% if not c.isOwned %}-locked{% endif %}" class="{{ c.getPermsCss }}">
+    <li id='project-{{ c.id }}' rel="project" class="{{ c.getPermsCss }}">
         <a href="#">{{ c.name|escape|truncatebefor:"35" }}</a>
         <ul>
             {% if c.countChildren %}
             {% for d in c.listChildren %}
-                <li id='dataset-{{ d.id }}' rel="dataset{% if not d.isOwned %}-locked{% endif %}" class="{{ c.getPermsCss }}{% if d.countChildren %} jstree-closed{% endif %}">
+                <li id='dataset-{{ d.id }}' rel="dataset" class="{{ c.getPermsCss }}{% if d.countChildren %} jstree-closed{% endif %}">
                     <a href="#">{{ d.name|escape|truncatebefor:"35" }}</a>
                 </li>
             {% endfor %}
@@ -49,18 +49,18 @@
     {% endfor %}
 
     {% for d in manager.containers.datasets %}
-        <li id='dataset-{{ d.id }}' rel="dataset{% if not d.isOwned %}-locked{% endif %}" class="{{ c.getPermsCss }}{% if d.countChildren %} jstree-closed{% endif %}">
+        <li id='dataset-{{ d.id }}' rel="dataset" class="{{ c.getPermsCss }}{% if d.countChildren %} jstree-closed{% endif %}">
             <a href="#">{{ d.name|escape|truncatebefor:"35" }}</a>
         </li>
     {% endfor %}
 
     {% for c in manager.containers.screens %}
-    <li id='screen-{{ c.id }}' rel="screen{% if not c.isOwned %}-locked{% endif %}" class="{{ c.getPermsCss }}">
+    <li id='screen-{{ c.id }}' rel="screen" class="{{ c.getPermsCss }}">
         <a href="#">{{ c.name|escape|truncatebefor:"35" }}</a>
         <ul>
             {% if c.countChildren %}
             {% for d in c.listChildren %}
-                <li id='plate-{{ d.id }}' rel="plate{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}">
+                <li id='plate-{{ d.id }}' rel="plate" class="{{ d.getPermsCss }}">
                     <a href="#">{{ d.name|escape|truncatebefor:"35" }}</a>
                 </li>
             {% endfor %}
@@ -70,12 +70,12 @@
     {% endfor %}
     
     {% for d in manager.containers.plates %}
-        <li id='plate-{{ d.id }}' rel="plate{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}">
+        <li id='plate-{{ d.id }}' rel="plate" class="{{ d.getPermsCss }}">
             <a href="#">{{ d.name|escape|truncatebefor:"35" }}</a>
             {% if d.countPlateAcquisitions %}
             <ul>
                 {% for e in d.listPlateAcquisitions %}
-                    <li id='acquisition-{{ e.id }}' rel="acquisition{% if not e.isOwned %}-locked{% endif %}" class="{{ e.getPermsCss }}">
+                    <li id='acquisition-{{ e.id }}' rel="acquisition" class="{{ e.getPermsCss }}">
                         <a href="#">{{ e.name|escape|truncatebefor:"35" }}</a>
                     </li>
                 {% endfor %}
@@ -85,7 +85,7 @@
     {% endfor %}
 
     {% for a in manager.containers.aquisitions %}
-        <li id='acquisition-{{ a.id }}' rel="acquisition{% if not a.isOwned %}-locked{% endif %}" class="{{ a.getPermsCss }}">
+        <li id='acquisition-{{ a.id }}' rel="acquisition" class="{{ a.getPermsCss }}">
             <a href="#">{{ a.name|escape|truncatebefor:"35" }}</a>
         </li>
     {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_subtree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_subtree.html
@@ -24,7 +24,7 @@
 
 {% if manager.containers.images %}
 {% for d in manager.containers.images %}
-    <li id='image-{{ d.id }}' rel="image{% if not d.isOwned %}-locked{% endif %}" class="{{ d.getPermsCss }}">
+    <li id='image-{{ d.id }}' rel="image" class="{{ d.getPermsCss }}">
         <a href="#" data-name="{{ d.name|escape }}" >
           {{ d.name|default:"Image"|escape }}
         </a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags_tree.html
@@ -28,19 +28,19 @@
         <ul>
             {% for t in manager.tags %}
             {% ifequal t.ns insight_ns %}
-            <li id='tagset-{{ t.id }}' rel="tagset{% if not t.isOwned %}-locked{% endif %}"
+            <li id='tagset-{{ t.id }}' rel="tagset"
                 class="{{ t.getPermsCss }}{% if t.countTagsInTagset %} jstree-closed{% endif %}">
                     <a href="#">{{ t.textValue|escape|truncatebefor:"35" }}</a>
                 {% if t.countTagsInTagset %}
                 <ul>    
                     {% for d in t.listTagsInTagset %}
-                        <li id='tag-{{ d.id }}' rel="tag{% if not d.isOwned %}-locked{% endif %}" class="jstree-closed"><a href="#">{{ d.textValue|escape|truncatebefor:"35" }}</a></li>
+                        <li id='tag-{{ d.id }}' rel="tag" class="jstree-closed"><a href="#">{{ d.textValue|escape|truncatebefor:"35" }}</a></li>
                     {% endfor %}
                 </ul>
                 {% endif %}
             </li>
             {% else %}
-            <li id='tag-{{ t.id }}' rel="tag{% if not t.isOwned %}-locked{% endif %}" class="{{ t.getPermsCss }} jstree-closed">
+            <li id='tag-{{ t.id }}' rel="tag" class="{{ t.getPermsCss }} jstree-closed">
                 <a href="#">{{ t.textValue|escape|truncatebefor:"35" }}</a>
             </li>
             {% endifequal %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -89,7 +89,7 @@
             var c = tree._get_children('#experimenter-0');
             c.each(function(){
                 var $node = $(this),
-                    rel = $node.attr('rel').replace("-locked",""),
+                    rel = $node.attr('rel'),
                     nodeTxt = OME.jsTreeNodeText($node);
                 if (topNodes.hasOwnProperty(rel)) {
                     topNodes[rel].push(nodeTxt.toLowerCase());
@@ -140,7 +140,7 @@
                 var pasteRenderingSettings = function(selected, owner, reset) {
                     var ids = [],
                         rdef_url = copy_paste_rdef_url,
-                        rel = selected.attr('rel').replace('-locked','');
+                        rel = selected.attr('rel');
                     if (owner) {
                         rdef_url = apply_owners_rdef_url;
                     } else if (reset) {
@@ -314,13 +314,13 @@
                                 if (to_paste && to_paste[0].id.indexOf("image")>=0) {
                                     toolbar_config['paste'] = true;
                                 }
-                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').replace("-locked", "").indexOf("experimenter") < 0) {
+                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').indexOf("experimenter") < 0) {
                                     toolbar_config["copy"] = true;
                                 }
                             } else if(selected.attr("id").indexOf("image")>=0) {
                                 toolbar_config['basket'] = true;
                                 toolbar_config['cut'] = true;
-                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').replace("-locked", "").indexOf("orphaned") < 0) {
+                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').indexOf("orphaned") < 0) {
                                     toolbar_config["copy"] = true;
                                 }
                             } else if(selected.attr("id").indexOf("screen")>=0) {
@@ -329,11 +329,11 @@
                                 }
                             } else if(selected.attr("id").indexOf("plate")>=0) {
                                 toolbar_config['copy'] = true;
-                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').replace("-locked", "").indexOf("experimenter") < 0) {
+                                if (selected.parent().parent().length > 0 && selected.parent().parent().attr('rel').indexOf("experimenter") < 0) {
                                     toolbar_config["cut"] = true;
                                 }
                             }
-                            if ((inst.data.crrm.cp_nodes || inst.data.crrm.ct_nodes) && ($.inArray(selected.attr('rel').replace("-locked", ""), ["project", "dataset", "screen"]) > -1)) {
+                            if ((inst.data.crrm.cp_nodes || inst.data.crrm.ct_nodes) && ($.inArray(selected.attr('rel'), ["project", "dataset", "screen"]) > -1)) {
                                 toolbar_config['paste'] = true;
                             }
                         }
@@ -393,10 +393,10 @@
                                 var url;
                                 if (n.attr) {
                                     var parent = this._get_parent(n);
-                                    if ($.inArray($(parent).attr("rel").replace("-locked", ""), ["project", "screen"]) > -1) {
-                                        url = "{% url 'load_data' %}"+$(parent).attr("rel").replace("-locked", "")+"/"+$(parent).attr("id").split("-")[1]+"/"+n.attr("rel").replace("-locked", "")+"/"+n.attr("id").split("-")[1]+"/";
+                                    if ($.inArray($(parent).attr("rel"), ["project", "screen"]) > -1) {
+                                        url = "{% url 'load_data' %}"+$(parent).attr("rel")+"/"+$(parent).attr("id").split("-")[1]+"/"+n.attr("rel")+"/"+n.attr("id").split("-")[1]+"/";
                                     } else {
-                                        url = "{% url 'load_data' %}"+n.attr("rel").replace("-locked", "")+"/"+n.attr("id").split("-")[1]+"/";
+                                        url = "{% url 'load_data' %}"+n.attr("rel")+"/"+n.attr("id").split("-")[1]+"/";
                                     }
                                 } else {
                                     url = "{% url 'load_data' %}";
@@ -407,7 +407,7 @@
                             // the parameter is the node being loaded (may be -1, 0, or undefined when loading the root nodes)
                             "data" : function (n) {
                                 var r = { "view" : "tree" };
-                                if (n.attr && $.inArray(n.attr("rel").replace("-locked", ""), ["dataset", "orphaned"]) > -1) {
+                                if (n.attr && $.inArray(n.attr("rel"), ["dataset", "orphaned"]) > -1) {
                                     // pagination supported for 'dataset' and 'orphaned'...
                                     var page = n.data("page") || null;      // this data is added by OME.doPagination()
                                     if (page) r["page"] = page;
@@ -423,10 +423,10 @@
                         // This will prevent moving or creating any other type as a root node
                         "max_depth" : -1,
                         "max_children" : -1,
-                        "valid_children" : [ "experimenter", "experimenter-locked" ],
+                        "valid_children" : [ "experimenter" ],
                         "types" : {
                             "experimenter" : {
-                                "valid_children" : [ "project", "project-locked", "dataset", "dataset-locked", "screen", "screen-locked", "plate", "plate-locked" ],
+                                "valid_children" : [ "project", "dataset", "screen", "plate" ],
                                 "icon" : {
                                     "image" : '{% static "webclient/image/icon_user.png" %}'
                                 },
@@ -436,36 +436,15 @@
                                 "delete_node" : false,
                                 "remove" : false
                             },
-                            "experimenter-locked" : {
-                                "valid_children" : [ "project", "project-locked", "dataset", "dataset-locked", "screen", "screen-locked", "plate", "plate-locked" ],
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/icon_user.png" %}'
-                                },
-                                "start_drag" : false
-                            },
                             "project" : {
-                                "valid_children" : [ "dataset", "dataset-locked" ],
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/folder16.png" %}'
-                                },
-                                "start_drag" : false
-                            },
-                            "project-locked" : {
-                                "valid_children" : [ "dataset", "dataset-locked" ],
+                                "valid_children" : [ "dataset" ],
                                 "icon" : {
                                     "image" : '{% static "webclient/image/folder16.png" %}'
                                 },
                                 "start_drag" : false
                             },
                             "dataset" : {
-                                "valid_children" : [ "image", "image-locked" ],
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/folder_image16.png" %}'
-                                },
-                                "start_drag" : function(obj){return obj.hasClass('canLink');}
-                            },
-                            "dataset-locked" : {
-                                "valid_children" : [ "image", "image-locked" ],
+                                "valid_children" : [ "image" ],
                                 "icon" : {
                                     "image" : '{% static "webclient/image/folder_image16.png" %}'
                                 },
@@ -478,22 +457,8 @@
                                 },
                                 "start_drag" : function(obj){return obj.hasClass('canLink');}
                             },
-                            "image-locked" : {
-                                "valid_children" : "none",
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/image16.png" %}'
-                                },
-                                "start_drag" : function(obj){return obj.hasClass('canLink');}
-                            },
                             "screen" : {
-                                "valid_children" : [ "plate", "plate-locked" ],
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/folder_screen16.png" %}'
-                                },
-                                "start_drag" : false
-                            },
-                            "screen-locked" : {
-                                "valid_children" : [ "plate", "plate-locked" ],
+                                "valid_children" : [ "plate" ],
                                 "icon" : {
                                     "image" : '{% static "webclient/image/folder_screen16.png" %}'
                                 },
@@ -506,26 +471,12 @@
                                 },
                                 "start_drag" : function(obj){return obj.hasClass('canLink');}
                             },
-                            "plate-locked" : {
-                                "valid_children" : "acquisition",
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/folder_plate16.png" %}'
-                                },
-                                "start_drag" : function(obj){return obj.hasClass('canLink');}
-                            },
                             "acquisition" : {
                                 "valid_children" : "none",
                                 "icon" : {
                                     "image" : '{% static "webclient/image/image16.png" %}'
                                 },
                                 "create_node" : false
-                            },
-                            "acquisition-locked" : {
-                                "valid_children" : "none",
-                                "icon" : {
-                                    "image" : '{% static "webclient/image/image16.png" %}'
-                                },
-                                "start_drag" : false
                             },
                             "orphaned" : {
                                 "valid_children" : [ "image", "image_locked" ],
@@ -542,9 +493,9 @@
                                 var p = this._get_parent(m.r);
                                 if(!p) return false;
                                 if (p == -1) return true;
-                                if ($.inArray(m.r.attr("rel").replace("-locked", ""), ["orphaned"]) > -1)
+                                if ($.inArray(m.r.attr("rel"), ["orphaned"]) > -1)
                                     return false;
-                                if ($.inArray(p.attr("rel").replace("-locked", ""), ["orphaned"]) > -1)
+                                if ($.inArray(p.attr("rel"), ["orphaned"]) > -1)
                                     return false;
                                 if (!m.cr.hasClass("canLink"))
                                     return false;
@@ -643,7 +594,7 @@
                             
                             config["basket"] = {
                                 "label" : "Add to Basket",
-                                "icon"  : '{% static "webclient/image/icon_basic_basket_16.png" %}',                                    
+                                "icon"  : '{% static "webclient/image/icon_basic_basket_16.png" %}',
                                 "action": function(){
                                     OME.addToBasket(this.get_selected(), '{% url 'update_basket' %}');
                                 }
@@ -778,7 +729,7 @@
                                 config["renderingsettings"]["_disabled"] = false;
                                 config["renderingsettings"]["submenu"]["copy_rdef"]["_disabled"] = false;
                             }
-                            if($.inArray(obj.attr("rel").replace('-locked',''), ["image", "dataset", "plate", "acquisition"])>=0) {
+                            if($.inArray(obj.attr("rel"), ["image", "dataset", "plate", "acquisition"])>=0) {
                                 // if 'canAnnotate' then we can paste settings to image/dataset/plate
                                 if(obj.hasClass('canAnnotate')) {
                                     config["renderingsettings"]["_disabled"] = false;
@@ -808,7 +759,7 @@
                         obj_rel = $this.parent().attr('rel'),
                         ob_id = $this.parent().attr('id'),
                         iid;
-                    if ((obj_rel=='image') || (obj_rel=='image-locked')) {
+                    if (obj_rel=='image') {
                         iid = ob_id.split("-")[1];
                         OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/" + iid + "/"));
                     }
@@ -829,28 +780,28 @@
                         var remove = false;
                         var url;
                         if (data.inst.data.crrm.cp_nodes) {
-                            url = '{% url 'manage_action_containers' "paste" %}'+$(this).attr("rel").replace("-locked","")+'/'+$(this).attr("id").split("-")[1]+'/'
+                            url = '{% url 'manage_action_containers' "paste" %}'+$(this).attr("rel")+'/'+$(this).attr("id").split("-")[1]+'/'
                             d = {
-                                "destination" : data.rslt.np.attr("rel").replace("-locked","") +'-'+data.rslt.np.attr("id").split("-")[1]
+                                "destination" : data.rslt.np.attr("rel") +'-'+data.rslt.np.attr("id").split("-")[1]
                             }
                         } else  {
                             // 'cr' is destination, 'op' is current parent
                             if (data.rslt.cr.attr('rel')!="orphaned") {
-                                url = '{% url 'manage_action_containers' "move" %}'+$(this).attr("rel").replace("-locked","")+'/'+$(this).attr("id").split("-")[1]+'/';
+                                url = '{% url 'manage_action_containers' "move" %}'+$(this).attr("rel")+'/'+$(this).attr("id").split("-")[1]+'/';
                                 var p = "orphaned-0";
                                 // ...but parent may be project if we are orphaning a dataset or drag'n'drop image
                                 if (data.rslt.op.attr("rel")) {
-                                    p = data.rslt.op.attr("rel").replace("-locked","")+'-'+data.rslt.op.attr("id").split("-")[1];
+                                    p = data.rslt.op.attr("rel")+'-'+data.rslt.op.attr("id").split("-")[1];
                                 }
                                 var d = {
                                     "parent" : p,
-                                    "destination" : data.rslt.np.attr("rel").replace("-locked","") +'-'+data.rslt.np.attr("id").split("-")[1]
+                                    "destination" : data.rslt.np.attr("rel") +'-'+data.rslt.np.attr("id").split("-")[1]
                                 };
                                 if (data.inst.get_container().find('#'+this.id).length > 1 ) data.inst.delete_node(this);
                             } else {
-                                url = '{% url 'manage_action_containers' "remove" %}'+$(this).attr("rel").replace("-locked","")+'/'+$(this).attr("id").split("-")[1]+'/'
+                                url = '{% url 'manage_action_containers' "remove" %}'+$(this).attr("rel")+'/'+$(this).attr("id").split("-")[1]+'/'
                                 d = {
-                                    "parent" : data.rslt.op.attr("rel").replace("-locked","")+'-'+data.rslt.op.attr("id").split("-")[1]
+                                    "parent" : data.rslt.op.attr("rel")+'-'+data.rslt.op.attr("id").split("-")[1]
                                 };
                             }
                         }
@@ -888,11 +839,11 @@
                             data.inst.refresh(data.inst._get_node('#orphaned-0'));
                         }
                         //refresh destination (will already be expanded, even if orphaned)
-                        if (!data.inst.is_leaf(data.rslt.cr) && $.inArray(data.rslt.cr.attr("rel").replace("-locked", ""), ["dataset", "orphaned"]) > -1) {
+                        if (!data.inst.is_leaf(data.rslt.cr) && $.inArray(data.rslt.cr.attr("rel"), ["dataset", "orphaned"]) > -1) {
                             data.inst.refresh(data.inst._get_node('#'+data.rslt.cr.attr('id')));
                         }
                         // select the destination (select source if destination is orphaned)
-                        if (data.rslt.cr.attr("rel").replace("-locked", "") === "orphaned") {
+                        if (data.rslt.cr.attr("rel") === "orphaned") {
                             data.inst.select_node(data.rslt.op);
                         } else {
                             data.inst.select_node(data.rslt.cr);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -479,7 +479,7 @@
                                 "create_node" : false
                             },
                             "orphaned" : {
-                                "valid_children" : [ "image", "image_locked" ],
+                                "valid_children" : [ "image" ],
                                 "icon" : {
                                     "image" : '{% static "webclient/image/folder_yellow16.png" %}'
                                 },
@@ -642,14 +642,16 @@
                             }
                             // if experimenter or orphaned is selected, use 'locked' flag to decide permissions
                             if(obj.attr("id").indexOf("experimenter")>=0 || obj.attr("rel") == 'orphaned') {
-                                var canCreate = $("#experimenter-0").attr("rel").indexOf("locked")>=0;
+                                var userId = {{ ome.user_id }},
+                                canCreate = (userId === {{ ome.user.id }} || userId === -1);
                                 // see #8879 config["ccp"]["_disabled"] = true;
                                 config["ccp"]["submenu"]["copy"]["_disabled"] = true;
                                 config["ccp"]["submenu"]["paste"]["_disabled"] = true;
                                 config["ccp"]["submenu"]["cut"]["_disabled"] = true;
                                 config["basket"]["_disabled"] = true;
-                                if(canCreate) {
+                                if(!canCreate) {
                                     // see #8879 config["create"]["_disabled"] = true;
+                                    config["create"]["_disabled"] = true;
                                     config["create"]["submenu"]["project"]["_disabled"] = true;
                                     config["create"]["submenu"]["dataset"]["_disabled"] = true;
                                     config["create"]["submenu"]["screen"]["_disabled"] = true;
@@ -669,6 +671,8 @@
                                 // see #8879 otherwise the options depend on type of node...
                                 var to_paste = this.data.crrm.cp_nodes || this.data.crrm.ct_nodes || false;
                                 if(obj.attr("id").indexOf("project")>=0) {
+                                    config["create"]["submenu"]["project"]["_disabled"] = true;
+                                    config["create"]["submenu"]["screen"]["_disabled"] = true;
                                     config["ccp"]["submenu"]["cut"]["_disabled"] = true;
                                     config["ccp"]["submenu"]["copy"]["_disabled"] = true;
                                     config["basket"]["_disabled"] = true;
@@ -679,6 +683,10 @@
                                     if (obj.parent().parent().attr('rel').indexOf('experimenter')>=0) {
                                         config["ccp"]["submenu"]["copy"]["_disabled"] = true;
                                     }
+                                    config["create"]["_disabled"] = true;
+                                    config["create"]["submenu"]["project"]["_disabled"] = true;
+                                    config["create"]["submenu"]["dataset"]["_disabled"] = true;
+                                    config["create"]["submenu"]["screen"]["_disabled"] = true;
                                     if (!(to_paste && to_paste[0].id.indexOf("image")>=0)) {
                                         config["ccp"]["submenu"]["paste"]["_disabled"] = true;
                                     }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_icon.html
@@ -205,7 +205,7 @@
                 var sel_obj, imgId;
                 for (var _s=0; _s<sel_objs.length; _s++) {
                     sel_obj = sel_objs[_s];
-                    if (sel_obj.rel.replace("-locked","") == "image") {
+                    if (sel_obj.rel == "image") {
                         imgId = sel_obj.id.split("-")[1];
                         $("#image_icon-"+imgId).addClass('ui-selected');
                         fsIds[sel_obj.fileset] = true;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -117,15 +117,15 @@
         {% if share.shSize %}
             {% for s in share.shares %}
             {% if s.isEmpty %}
-            <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
+            <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>
             {% else %}
                 {% if s.isOwned %}
-                <li id='share-{{ s.id }}' rel="share" class="jstree-closed"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
+                <li id='share-{{ s.id }}' rel="share" class="jstree-closed"><a href="#">{{ s.id }}</a></li>
                 {% else %}
                     {% if s.active %}
-                    <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
+                    <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>
                     {% else %}
-                    <li id='share-{{ s.id }}' rel="share" class="disabled"><a href="#">{{ s.id }} {{ s.uuid }} DISABLED</a></li>
+                    <li id='share-{{ s.id }}' rel="share" class="disabled"><a href="#">{{ s.id }} DISABLED</a></li>
                     {% endif %}
                 {% endif %}
             {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -117,13 +117,13 @@
         {% if share.shSize %}
             {% for s in share.shares %}
             {% if s.isEmpty %}
-            <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>
+            <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.isOwned %}isOwned{% endif %}"><a href="#">{{ s.id }}</a></li>
             {% else %}
                 {% if s.isOwned %}
-                <li id='share-{{ s.id }}' rel="share" class="{% if s.canEdit %}canEdit{% endif %} jstree-closed"><a href="#">{{ s.id }}</a></li>
+                <li id='share-{{ s.id }}' rel="share" class="{% if s.isOwned %}isOwned{% endif %} jstree-closed"><a href="#">{{ s.id }}</a></li>
                 {% else %}
                     {% if s.active %}
-                    <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>
+                    <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.isOwned %}isOwned{% endif %}"><a href="#">{{ s.id }}</a></li>
                     {% else %}
                     <li id='share-{{ s.id }}' rel="share" class="disabled"><a href="#">{{ s.id }} DISABLED</a></li>
                     {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -25,18 +25,18 @@
 
 
 <ul>
-    <li id="experimenter-0" rel="experimenter{% ifnotequal manager.experimenter.id ome.eventContext.userId %}-locked{% endifnotequal %}">
+    <li id="experimenter-0" rel="experimenter">
         <a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{{ ui.dropdown_menu.everyone }}{% endif %}</a>
         <ul>
             {% for c in projects %}
-            <li id='project-{{ c.id }}' rel="project{% if not c.isOwned %}-locked{% endif %}" class="{{ c.permsCss }}">
+            <li id='project-{{ c.id }}' rel="project" class="{{ c.permsCss }}">
 				<a href="#">{{ c.name|default:"Project"|escape|truncatebefor:"35" }} {% if c.childCount %}
 					<span class="children_count" id="counter-project-{{ c.id }}">{{ c.childCount }}</span>{% endif %}
 				</a>
                 {% if c.childCount %}
                 <ul>
                     {% for d in c.datasets %}
-                        <li id='dataset-{{ d.id }}' rel="dataset{% if not d.isOwned %}-locked{% endif %}" 
+                        <li id='dataset-{{ d.id }}' rel="dataset" 
                                 class="{{ d.permsCss }}{% if d.childCount %} jstree-closed{% endif %}">
 							<a href="#">{{ d.name|default:"Dataset"|escape|truncatebefor:"35" }} {% if d.childCount %}
 								<span class="children_count" id="counter-dataset-{{ d.id }}">{{ d.childCount }}
@@ -54,7 +54,7 @@
 		
 		
             {% for d in datasets %}
-                <li id='dataset-{{ d.id }}' rel="dataset{% if not d.isOwned %}-locked{% endif %}" 
+                <li id='dataset-{{ d.id }}' rel="dataset" 
                         class="{{ d.permsCss }}{% if d.childCount %} jstree-closed{% endif %}">
 					<a href="#">{{ d.name|default:"Dataset"|escape|truncatebefor:"35" }} {% if d.childCount %}
 						<span class="children_count" id="counter-dataset-{{ d.id }}">{{ d.childCount}}
@@ -67,18 +67,18 @@
 			
 			
             {% for c in screens %}
-            <li id='screen-{{ c.id }}' rel="screen{% if not c.isOwned %}-locked{% endif %}" class="{{ c.permsCss }}">
+            <li id='screen-{{ c.id }}' rel="screen" class="{{ c.permsCss }}">
 				<a href="#">{{ c.name|default:"Screen"|escape|truncatebefor:"35" }} {% if c.childCount %}
 					<span class="children_count" id="counter-screen-{{ c.id }}">{{ c.childCount }}</span>{% endif %}</a>
                 {% if c.childCount %}
                 <ul>
                     {% for p in c.plates %}
-                        <li id='plate-{{ p.id }}' rel="plate{% if not p.isOwned %}-locked{% endif %}" class="{{ p.permsCss }}">
+                        <li id='plate-{{ p.id }}' rel="plate" class="{{ p.permsCss }}">
                             <a href="#">{{ p.name|default:"Plate"|escape|truncatebefor:"35" }}</a>
                             {% if p.plateAcquisitionCount %}
                             <ul>
                                 {% for a in p.plateAcquisitions %}
-                                    <li id='acquisition-{{ a.id }}' rel="acquisition{% if not a.isOwned %}-locked{% endif %}" class="{{ a.permsCss }}">
+                                    <li id='acquisition-{{ a.id }}' rel="acquisition" class="{{ a.permsCss }}">
                                         <a href="#">{{ a.name|default:"Run"|escape|truncatebefor:"35" }}</a>
                                     </li>
                                 {% endfor %}
@@ -95,12 +95,12 @@
 			
 			
             {% for d in plates %}
-            <li id='plate-{{ d.id }}' rel="plate{% if not d.isOwned %}-locked{% endif %}" class="{{ d.permsCss }}">
+            <li id='plate-{{ d.id }}' rel="plate" class="{{ d.permsCss }}">
                 <a href="#">{{ d.name|default:"Plate"|escape|truncatebefor:"35" }}</a>
                 {% if d.plateAcquisitionCount %}
                 <ul>
                     {% for e in d.plateAcquisitions %}
-                        <li id='acquisition-{{ e.id }}' rel="acquisition{% if not e.isOwned %}-locked{% endif %}" class="{{ e.permsCss }}">
+                        <li id='acquisition-{{ e.id }}' rel="acquisition" class="{{ e.permsCss }}">
                             <a href="#">{{ e.name|default:"Run"|escape|truncatebefor:"35" }}</a>
                         </li>
                     {% endfor %}
@@ -117,15 +117,15 @@
         {% if share.shSize %}
             {% for s in share.shares %}
             {% if s.isEmpty %}
-            <li id='discussion-{{ s.id }}' rel="discussion{% if not s.canEdit %}-locked{% endif %}"><a href="#">{{ s.id }}</a></li>
+            <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
             {% else %}
                 {% if s.isOwned %}
-                <li id='share-{{ s.id }}' rel="share" class="jstree-closed"><a href="#">{{ s.id }}</a></li>
+                <li id='share-{{ s.id }}' rel="share" class="jstree-closed"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
                 {% else %}
                     {% if s.active %}
-                    <li id='share-{{ s.id }}' rel="share-locked" class="jstree-closed"><a href="#">{{ s.id }}</a></li>
+                    <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }} {{ s.uuid }}</a></li>
                     {% else %}
-                    <li id='share-{{ s.id }}' rel="share-disabled"><a href="#">{{ s.id }} DISABLED</a></li>
+                    <li id='share-{{ s.id }}' rel="share" class="disabled"><a href="#">{{ s.id }} {{ s.uuid }} DISABLED</a></li>
                     {% endif %}
                 {% endif %}
             {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers_tree.html
@@ -26,7 +26,7 @@
 
 <ul>
     <li id="experimenter-0" rel="experimenter">
-        <a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{{ ui.dropdown_menu.everyone }}{% endif %}</a>
+        <a href="#">{% if manager.experimenter %}{{ manager.experimenter.getFullName }}{% else %}{% if share.shSize %}Public{% else %}{{ ui.dropdown_menu.everyone }}{% endif %}{% endif %}</a>
         <ul>
             {% for c in projects %}
             <li id='project-{{ c.id }}' rel="project" class="{{ c.permsCss }}">
@@ -120,7 +120,7 @@
             <li id='discussion-{{ s.id }}' rel="discussion" class="{% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>
             {% else %}
                 {% if s.isOwned %}
-                <li id='share-{{ s.id }}' rel="share" class="jstree-closed"><a href="#">{{ s.id }}</a></li>
+                <li id='share-{{ s.id }}' rel="share" class="{% if s.canEdit %}canEdit{% endif %} jstree-closed"><a href="#">{{ s.id }}</a></li>
                 {% else %}
                     {% if s.active %}
                     <li id='share-{{ s.id }}' rel="share" class="jstree-closed {% if s.canEdit %}canEdit{% endif %}"><a href="#">{{ s.id }}</a></li>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -77,7 +77,7 @@ $(document).ready(function() {
         }
         // handle single object (or multi-image) selection...
         var oid = selected.attr('id');                              // E.g. 'dataset-501'
-        var orel = selected.attr('rel').replace("-locked", "");     // E.g. 'dataset'
+        var orel = selected.attr('rel');     // E.g. 'dataset'
         var page = selected.data("page") || null;                   // Check for pagination
         var well_index = selected.data("well_index") || 0;       // and well index
 
@@ -132,18 +132,18 @@ $(document).ready(function() {
                 page = pr.data("page") || null;
             }
             if (pr.length>0 && pr.attr('id')!==crel) {
-                if(pr.attr('rel').replace("-locked", "")==="share" && pr.attr('id')!==crel) {
+                if(pr.attr('rel')==="share" && pr.attr('id')!==crel) {
                     update['rel'] = pr.attr('id');
                     update['url'] = prefix+'load_public/'+pr.attr('id').split("-")[1]+'/?view=icon';
-                } else if (pr.attr('rel').replace("-locked", "")=="tag") {
+                } else if (pr.attr('rel')=="tag") {
                     update['rel'] = pr.attr('id');
-                    update['url'] = prefix+'load_tags/'+pr.attr('rel').replace("-locked", "")+'/'+pr.attr("id").split("-")[1]+'/?view=icon';
-                } else if (pr.attr('rel').replace("-locked", "")!=="orphaned") {
+                    update['url'] = prefix+'load_tags/'+pr.attr('rel')+'/'+pr.attr("id").split("-")[1]+'/?view=icon';
+                } else if (pr.attr('rel')!=="orphaned") {
                     update['rel'] = pr.attr('id');
-                    update['url'] = prefix+'load_data/'+pr.attr('rel').replace("-locked", "")+'/'+pr.attr("id").split("-")[1]+'/?view=icon';
+                    update['url'] = prefix+'load_data/'+pr.attr('rel')+'/'+pr.attr("id").split("-")[1]+'/?view=icon';
                 } else {
                     update['rel'] = pr.attr("id");
-                    update['url'] = prefix+'load_data/'+pr.attr('rel').replace("-locked", "")+'/?view=icon';
+                    update['url'] = prefix+'load_data/'+pr.attr('rel')+'/?view=icon';
                 }
             }
         } else {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -84,7 +84,7 @@ $(function () {
             $("#annotation_tabs").tabs("enable", general_tab_index);    // always want metadata_general enabled
             var url = null;
             //var oid = selected.attr('id');
-            //var orel = selected[0].attr('rel').replace("-locked", "");
+            //var orel = selected[0].attr('rel');
             var oid = selected[0]["id"];
             var orel = oid.split("-")[0];
             if (typeof oid =="undefined" || oid==false) return;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -66,7 +66,7 @@
                     var toolbar_config = new Object();
                     if(selected.length > 0) {
                         if((typeof selected.attr("rel") === 'undefined') ||
-                            !selected.parent().parent().hasClass("canEdit")) {
+                            !selected.parent().parent().hasClass("isOwned")) {
                             toolbar_config = {"adddiscussion":false, 'removecontent':false};
                         } else {
                             if(selected.attr("id").indexOf("experimenter")>=0) {
@@ -163,7 +163,7 @@
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : function(obj){return obj.hasClass('canEdit');}
+                                    "remove" : function(obj){return obj.hasClass('isOwned');}
                                 }
                             }
                         },

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -124,71 +124,32 @@
                             "valid_children" : [ "experimenter" ],
                             "types" : {
                                 "experimenter" : {
-                                    "valid_children" : [ "share", "share-locked", "discussion", "discussion-locked" ],
+                                    "valid_children" : [ "share", "discussion" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/icon_user.png" %}'
                                     },
                                     "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : false
-                                },
-                                "experimenter-locked" : {
-                                    "valid_children" : [ "share", "share-locked", "discussion", "discussion-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/icon_user.png" %}'
-                                    },
-                                       "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
                                     "remove" : false
                                 },
                                 "share" : {
-                                    "valid_children" : [ "image", "image-locked" ],
+                                    "valid_children" : [ "image" ],
                                     "icon" : {
                                         "image" : '{% static "webclient/image/left_sidebar_icon_public.png" %}'
                                     },
+                                    "select_node" : function(obj){return !obj.hasClass('disabled');},
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
                                     "remove" : false
                                 },
-                                "share-locked" : {
-                                    "valid_children" : [ "image", "image-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_public.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : false
-                                },
-                                "share-disabled" : {
-                                    "valid_children" : [ "image", "image-locked" ],
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/left_sidebar_icon_public.png" %}'
-                                    },
-                                    "select_node" : false,
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : false
-                                },                                
                                 "discussion" : {
                                     "valid_children" : "none",
                                     "icon" : {
                                         "image" : '{% static "webclient/image/wp_protocol16.png" %}'
                                     },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : false
-                                },
-                                "discussion-locked" : {
-                                    "valid_children" :  "none",
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/wp_protocol16.png" %}'
-                                    },
+                                    "select_node" : function(obj){return !obj.hasClass('disabled');},
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
@@ -202,17 +163,7 @@
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,
-                                    "remove" : true
-                                },
-                                "image-locked" : {
-                                    "valid_children" : "none",
-                                    "icon" : {
-                                        "image" : '{% static "webclient/image/image16.png" %}'
-                                    },
-                                    "create_node" : false,
-                                    "start_drag" : false,
-                                    "move_node" : false,
-                                    "remove" : false
+                                    "remove" : function(obj){return obj.hasClass('canEdit');}
                                 }
                             }
                         },
@@ -256,7 +207,7 @@
                         share_id = $this.parent().attr('data-share'),
                         popup_url = "{% url 'webindex' %}",
                         iid;
-                    if ((obj_rel=='image') || (obj_rel=='image-locked')) {
+                    if (obj_rel=='image') {
                         iid = ob_id.split("-")[1];
                         // Share-id will only be there if share is not owned.
                         if (share_id) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -66,7 +66,7 @@
                     var toolbar_config = new Object();
                     if(selected.length > 0) {
                         if((typeof selected.attr("rel") === 'undefined') ||
-                                (selected.attr("rel").indexOf("locked")>=0)) {
+                            !selected.parent().parent().hasClass("canEdit")) {
                             toolbar_config = {"adddiscussion":false, 'removecontent':false};
                         } else {
                             if(selected.attr("id").indexOf("experimenter")>=0) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -78,9 +78,10 @@ def parse_permissions_css(permissions, ownerid, conn):
     restrictions = ('canEdit',
                     'canAnnotate',
                     'canLink',
-                    'canDelete',
-                    'isOwned')
+                    'canDelete')
     permissionsCss = [r for r in restrictions if permissions.get(r)]
+    if ownerid == conn.getUserId():
+        permissionsCss.append("isOwned")
     if ownerid == conn.getUserId() or conn.isAdmin():
         permissionsCss.append("canChgrp")
     return ' '.join(permissionsCss)

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -104,7 +104,6 @@ def marshal_plate(conn, row):
     plate['id'] = plate_id.val
     plate['name'] = name.val
     plate['permsCss'] = parse_permissions_css(permissions, owner_id.val, conn)
-    plate['isOwned'] = owner_id.val == conn.getUserId()
     plate['plateAcquisitions'] = list()
     return plate
 
@@ -137,7 +136,6 @@ def marshal_plate_acquisition(conn, row):
         plate_acquisition['name'] = 'Run %d' % pa_id.val
     plate_acquisition['permsCss'] = \
         parse_permissions_css(permissions, owner_id.val, conn)
-    plate_acquisition['isOwned'] = owner_id.val == conn.getUserId()
     return plate_acquisition
 
 
@@ -159,7 +157,6 @@ def marshal_dataset(conn, row):
     dataset = dict()
     dataset['id'] = dataset_id.val
     dataset['name'] = name.val
-    dataset['isOwned'] = owner_id.val == conn.getUserId()
     dataset['childCount'] = child_count.val
     dataset['permsCss'] = \
         parse_permissions_css(permissions, owner_id.val, conn)
@@ -227,7 +224,7 @@ def marshal_projects(conn, experimenter_id):
             )
             project = {
                 'id': project_id.val, 'name': project_name.val,
-                'isOwned': is_owned, 'permsCss': perms_css, 'datasets': list()
+                'permsCss': perms_css, 'datasets': list()
             }
             projects.append(project)
 
@@ -372,8 +369,7 @@ def marshal_screens(conn, experimenter_id=None):
             )
             screen = {
                 'id': screen_id.val, 'name': screen_name.val,
-                'isOwned': is_owned, 'permsCss': perms_css,
-                'plates': list()
+                'permsCss': perms_css, 'plates': list()
             }
             screens.append(screen)
         screen = screens[-1]

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -218,7 +218,6 @@ def marshal_projects(conn, experimenter_id):
                                         project_group_id, cache)
 
         if len(projects) == 0 or projects[-1]['id'] != project_id.val:
-            is_owned = experimenter_id == conn.getUserId()
             perms_css = parse_permissions_css(
                 project_permissions, experimenter_id, conn
             )
@@ -363,7 +362,6 @@ def marshal_screens(conn, experimenter_id=None):
                                        screen_owner_id, screen_group_id, cache)
 
         if len(screens) == 0 or screen_id.val != screens[-1]['id']:
-            is_owned = screen_owner_id.val == conn.getUserId()
             perms_css = parse_permissions_css(
                 screen_permissions, screen_owner_id.val, conn
             )

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -364,11 +364,9 @@ class TestTree(lib.ITest):
             'id': project_id,
             'childCount': 1L,
             'name': project_dataset.name.val,
-            'isOwned': True,
             'datasets': [{
                 'childCount': 0L,
                 'id': dataset.id.val,
-                'isOwned': True,
                 'name': dataset.name.val,
                 'permsCss': perms_css
             }],
@@ -387,7 +385,6 @@ class TestTree(lib.ITest):
         for project in sorted(projects_datasets, cmp_name_insensitive):
             expected.append({
                 'id': project.id.val,
-                'isOwned': True,
                 'name': project.name.val,
                 'childCount': 4,
                 'permsCss': perms_css
@@ -401,7 +398,6 @@ class TestTree(lib.ITest):
                 datasets.append({
                     'childCount': 0L,
                     'id': dataset.id.val,
-                    'isOwned': True,
                     'name': dataset.name.val,
                     'permsCss': perms_css
                 })
@@ -432,7 +428,6 @@ class TestTree(lib.ITest):
         for project in sorted(projects_different_users, cmp_name_insensitive):
             expected.append({
                 'id': project.id.val,
-                'isOwned': False,
                 'name': project.name.val,
                 'childCount': 0,
                 'permsCss': perms_css,
@@ -452,25 +447,21 @@ class TestTree(lib.ITest):
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': dataset_a.id.val,
-            'isOwned': True,
             'name': 'Apple',
             'childCount': 0L,
             'permsCss': perms_css
         }, {
             'id': dataset_c.id.val,
-            'isOwned': True,
             'name': 'atom',
             'childCount': 0L,
             'permsCss': perms_css
         }, {
             'id': dataset_b.id.val,
-            'isOwned': True,
             'name': 'bat',
             'childCount': 0L,
             'permsCss': perms_css
         }, {
             'id': dataset_d.id.val,
-            'isOwned': True,
             'name': 'Butter',
             'childCount': 0L,
             'permsCss': perms_css
@@ -489,7 +480,6 @@ class TestTree(lib.ITest):
         for dataset in sorted(datasets_different_users, cmp_name_insensitive):
             expected.append({
                 'id': dataset.id.val,
-                'isOwned': False,
                 'name': dataset.name.val,
                 'childCount': 0L,
                 'permsCss': perms_css,
@@ -510,17 +500,14 @@ class TestTree(lib.ITest):
         expected = [{
             'id': screen_id,
             'childCount': 1,
-            'isOwned': True,
             'name': screen_plate_run.name.val,
             'permsCss': perms_css,
             'plates': [{
                 'id': plate.id.val,
-                'isOwned': True,
                 'name': plate.name.val,
                 'plateAcquisitions': [{
                     'id': plate_acquisition.id.val,
                     'name': 'Run %d' % plate_acquisition.id.val,
-                    'isOwned': True,
                     'permsCss': perms_css
                     }],
                 'plateAcquisitionCount': 1,
@@ -539,7 +526,6 @@ class TestTree(lib.ITest):
             expected_screen = {
                 'id': screen.id.val,
                 'name': screen.name.val,
-                'isOwned': True,
                 'permsCss': perms_css,
                 'childCount': 2,
                 'plates': list()
@@ -549,7 +535,6 @@ class TestTree(lib.ITest):
                 expected_plates = expected_screen['plates']
                 expected_plates.append({
                     'id': plate.id.val,
-                    'isOwned': True,
                     'name': plate.name.val,
                     'plateAcquisitions': list(),
                     'plateAcquisitionCount': 2,
@@ -563,7 +548,6 @@ class TestTree(lib.ITest):
                     expected_plates[-1]['plateAcquisitions'].append({
                         'id': plate_acquisition.id.val,
                         'name': 'Run %d' % plate_acquisition.id.val,
-                        'isOwned': True,
                         'permsCss': perms_css
                     })
             expected.append(expected_screen)
@@ -580,12 +564,10 @@ class TestTree(lib.ITest):
             {
                 'id': screen_plate.id.val,
                 'name': screen_plate.name.val,
-                'isOwned': True,
                 'permsCss': perms_css,
                 'childCount': 1,
                 'plates': [{
                     'id': plate.id.val,
-                    'isOwned': True,
                     'name': plate.name.val,
                     'plateAcquisitions': list(),
                     'plateAcquisitionCount': 0,
@@ -603,12 +585,10 @@ class TestTree(lib.ITest):
         perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': plate_id,
-            'isOwned': True,
             'name': plate_run.name.val,
             'plateAcquisitions': [{
                 'id': plate_acquisition.id.val,
                 'name': 'Run %d' % plate_acquisition.id.val,
-                'isOwned': True,
                 'permsCss': perms_css
             }],
             'plateAcquisitionCount': 1,
@@ -627,7 +607,6 @@ class TestTree(lib.ITest):
             plate_id = plate.id.val
             expected.append({
                 'id': plate_id,
-                'isOwned': True,
                 'name': plate.name.val,
                 'plateAcquisitions': list(),
                 'plateAcquisitionCount': 2,
@@ -641,7 +620,6 @@ class TestTree(lib.ITest):
                 expected[-1]['plateAcquisitions'].append({
                     'id': plate_acquisition.id.val,
                     'name': 'Run %d' % plate_acquisition.id.val,
-                    'isOwned': True,
                     'permsCss': perms_css
                 })
 
@@ -658,7 +636,6 @@ class TestTree(lib.ITest):
         for plate in sorted(plates_different_users, cmp_name_insensitive):
             expected.append({
                 'id': plate.id.val,
-                'isOwned': False,
                 'name': plate.name.val,
                 'plateAcquisitions': list(),
                 'plateAcquisitionCount': 0,
@@ -677,7 +654,6 @@ class TestTree(lib.ITest):
         perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': plate_id,
-            'isOwned': True,
             'name': plate.name.val,
             'plateAcquisitions': list(),
             'plateAcquisitionCount': 0,
@@ -693,12 +669,10 @@ class TestTree(lib.ITest):
         perms_css = 'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         expected = [{
             'id': project_id,
-            'isOwned': True,
             'name': project_dataset_image.name.val,
             'datasets': [{
                 'childCount': 1L,
                 'id': dataset.id.val,
-                'isOwned': True,
                 'name': dataset.name.val,
                 'permsCss': perms_css
             }],
@@ -715,28 +689,24 @@ class TestTree(lib.ITest):
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': project_a.id.val,
-            'isOwned': True,
             'name': 'Apple',
             'datasets': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': project_c.id.val,
-            'isOwned': True,
             'name': 'atom',
             'datasets': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': project_b.id.val,
-            'isOwned': True,
             'name': 'bat',
             'datasets': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': project_d.id.val,
-            'isOwned': True,
             'name': 'Butter',
             'datasets': list(),
             'childCount': 0,
@@ -753,28 +723,24 @@ class TestTree(lib.ITest):
         # Order is important to test desired HQL sorting semantics.
         expected = [{
             'id': screen_a.id.val,
-            'isOwned': True,
             'name': 'Apple',
             'plates': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': screen_c.id.val,
-            'isOwned': True,
             'name': 'atom',
             'plates': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': screen_b.id.val,
-            'isOwned': True,
             'name': 'bat',
             'plates': list(),
             'childCount': 0,
             'permsCss': perms_css
         }, {
             'id': screen_d.id.val,
-            'isOwned': True,
             'name': 'Butter',
             'plates': list(),
             'childCount': 0,
@@ -793,7 +759,6 @@ class TestTree(lib.ITest):
         for screen in sorted(screens_plates, cmp_name_insensitive):
             expected.append({
                 'id': screen.id.val,
-                'isOwned': True,
                 'name': screen.name.val,
                 'childCount': 4,
                 'permsCss': perms_css
@@ -806,7 +771,6 @@ class TestTree(lib.ITest):
             for plate in source:
                 plates.append({
                     'id': plate.id.val,
-                    'isOwned': True,
                     'name': plate.name.val,
                     'permsCss': perms_css,
                     'plateAcquisitions': list(),
@@ -827,7 +791,6 @@ class TestTree(lib.ITest):
         for screen in sorted(screens_different_users, cmp_name_insensitive):
             expected.append({
                 'id': screen.id.val,
-                'isOwned': False,
                 'name': screen.name.val,
                 'childCount': 0,
                 'permsCss': perms_css,

--- a/components/tools/OmeroWeb/test/unit/test_tree.py
+++ b/components/tools/OmeroWeb/test/unit/test_tree.py
@@ -88,9 +88,9 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': True,
             'name': 'Run 1',
-            'permsCss': 'canEdit canAnnotate canLink canDelete canChgrp'
+            'permsCss':
+                'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         }
 
         marshaled = marshal_plate_acquisition(mock_conn, row)
@@ -108,9 +108,9 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': True,
             'name': 'name',
-            'permsCss': 'canEdit canAnnotate canLink canDelete canChgrp'
+            'permsCss':
+                'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         }
 
         marshaled = marshal_plate_acquisition(mock_conn, row)
@@ -128,9 +128,9 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': True,
             'name': '2014-05-08 10:37:02 - 2014-05-08 10:38:30',
-            'permsCss': 'canEdit canAnnotate canLink canDelete canChgrp'
+            'permsCss':
+                'canEdit canAnnotate canLink canDelete isOwned canChgrp'
         }
 
         marshaled = marshal_plate_acquisition(mock_conn, row)
@@ -148,7 +148,6 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': False,
             'name': 'Run 1',
             'permsCss': 'canEdit canAnnotate canLink canDelete'
         }
@@ -179,7 +178,9 @@ class TestTree(object):
             received = filter(None, received.split(' '))
             received.sort()
             assert expected == received
-            # Test with matching owner_ids, which means canChgrp is True
+            # Test with matching owner_ids, which means
+            # isOwned and canChgrp is True
+            expected.append('isOwned')
             expected.append('canChgrp')
             expected.sort()
             received = parse_permissions_css(permissions_dict,
@@ -199,9 +200,9 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': True,
             'name': 'name',
-            'permsCss': 'canEdit canAnnotate canLink canDelete canChgrp',
+            'permsCss':
+                'canEdit canAnnotate canLink canDelete isOwned canChgrp',
             'childCount': 1
         }
 
@@ -218,7 +219,6 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': False,
             'name': 'name',
             'permsCss': 'canEdit canAnnotate canLink canDelete',
             'childCount': 1
@@ -236,9 +236,9 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': True,
             'name': 'name',
-            'permsCss': 'canEdit canAnnotate canLink canDelete canChgrp',
+            'permsCss':
+                'canEdit canAnnotate canLink canDelete isOwned canChgrp',
             'plateAcquisitions': list()
         }
 
@@ -254,7 +254,6 @@ class TestTree(object):
         ]
         expected = {
             'id': 1L,
-            'isOwned': False,
             'name': 'name',
             'permsCss': 'canEdit canAnnotate canLink canDelete',
             'plateAcquisitions': list()


### PR DESCRIPTION
This PR clean up templates and removes ``-locked``. It also fixes issues in the tags tree (disables all actions as they are not supported).

*Note: there is ``jstree-locked `` in jstree lib that is unrelated.*

To test: I am not sure how to test is easily as this affects navigation in a tree in Explore, Tags and Public.
 - Test Explore if you can navigate the tree and drag and drop entities.
 - Test Tags tree if actions including drag and drop are disabled on each type fo entities. Make sure you test entire hierarchy TagSet/Tag and Tag only linked to Project/Dataset/Image/Screen/Plate...
 - Test Public if drag and drop is disabled.

If there is any unexpected behavior please test first with latest to see if it was introduced here.

cc: @will-moore  @pwalczysko 