### PR TITLE
Modify delete and chgrp reporting

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1837,6 +1837,34 @@ class GraphControl(CmdControl):
                 objects.append('%s %s' % (type, ids))
         return "%s %s... " % (cmd_type, ', '.join(objects))
 
+    def _get_object_ids(self, objDict):
+        import collections
+        objIds = {}
+        for k in objDict.keys():
+            if objDict[k]:
+                objIds[k] = self._order_and_range_ids(objDict[k])
+        newIds = collections.OrderedDict(sorted(objIds.items()))
+        objIds = collections.OrderedDict()
+        for k in newIds:
+            key = k[k.rfind('.')+1:]
+            objIds[key] = newIds[k]
+        return objIds
+
+    def _order_and_range_ids(self, ids):
+        from itertools import groupby
+        from operator import itemgetter
+        out = ""
+        ids = sorted(ids)
+        for k, g in groupby(enumerate(ids), lambda (i, x): i-x):
+            g = map(str, map(itemgetter(1), g))
+            out += g[0]
+            if len(g) > 2:
+                out += "-" + g[-1]
+            elif len(g) == 2:
+                out += "," + g[1]
+            out += ","
+        return out.rstrip(",")
+
 
 class UserGroupControl(BaseControl):
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -96,16 +96,14 @@ class ChgrpControl(GraphControl):
             self.print_chgrp_response(rsp)
 
     def print_chgrp_response(self, rsp):
-        for k in rsp.includedObjects.keys():
-            if rsp.includedObjects[k]:
-                self.ctx.out("Included %s objects" % k)
-                for i in rsp.includedObjects[k]:
-                    self.ctx.out("%s:%s" % (k, i))
-        for k in rsp.deletedObjects.keys():
-            if rsp.deletedObjects[k]:
-                self.ctx.out("Deleted %s objects" % k)
-                for i in rsp.deletedObjects[k]:
-                    self.ctx.out("%s:%s" % (k, i))
+        self.ctx.out("Included objects")
+        objIds = self._get_object_ids(rsp.includedObjects)
+        for k in objIds:
+            self.ctx.out("%s:%s" % (k, objIds[k]))
+        self.ctx.out("Deleted objects")
+        objIds = self._get_object_ids(rsp.deletedObjects)
+        for k in objIds:
+            self.ctx.out("%s:%s" % (k, objIds[k]))
 
 try:
     register("chgrp", ChgrpControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -18,23 +18,30 @@ import sys
 
 HELP = """Move data between groups
 
-Example Usage:
+Move entire graphs of data based on the ID of the top-node.
 
-  omero chgrp 101 Image:1                     # Move all of Image 1 to \
-group 101
-  omero chgrp Group:101 Image:1               # Move all of Image 1 to \
-group 101
-  omero chgrp ExperimenterGroup:101 Image:1   # Move all of Image 1 to \
-group 101
-  omero chgrp "My Lab" Image:1,2,3            # Move all of Images 1, 2 and 3 \
-to group "myLab"
+Examples:
 
-  omero chgrp --exclude Image Plate:1         # Calls chgrp on Plate, \
-leaving all
-                                              # images in the previous group.
+    # Move an image to group 101
+    omero chgrp 101 Image:1
+    omero chgrp Group:101 Image:2
+    omero chgrp ExperimenterGroup:101 Image:2
+    # Move 3 image to group named "My Lab"
+    omero chgrp "My Lab" Image:51,52,53
 
-  What data is moved is the same as that which would be deleted by a similar
-  call to "omero delete Image:1"
+    # Move a plate but leave all images in the original group
+    omero chgrp 201 Plate:1 --exclude Image
+
+    # Move all images contained under a project
+    omero chgrp 101 Project/Dataset/Image:53
+    # Move all images contained under two projects
+    omero chgrp 101 Project/Image:201,202
+
+    # Do a dry run of a move reporting the outcome if the move had been run
+    omero chgrp 101 Dataset:53 --dry-run
+    # Do a dry run of a move, reporting all the objects
+    # that would have been moved
+    omero chgrp 101 Dataset:53 --dry-run --report
 
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -22,11 +22,11 @@ Move entire graphs of data based on the ID of the top-node.
 
 Examples:
 
-    # Move an image to group 101
+    # In each case move an image to group 101
     omero chgrp 101 Image:1
     omero chgrp Group:101 Image:2
-    omero chgrp ExperimenterGroup:101 Image:2
-    # Move 3 image to group named "My Lab"
+    omero chgrp ExperimenterGroup:101 Image:3
+    # Move three images to the group named "My Lab"
     omero chgrp "My Lab" Image:51,52,53
 
     # Move a plate but leave all images in the original group

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -96,14 +96,16 @@ class ChgrpControl(GraphControl):
             self.print_chgrp_response(rsp)
 
     def print_chgrp_response(self, rsp):
-        self.ctx.out("Included objects")
-        objIds = self._get_object_ids(rsp.includedObjects)
-        for k in objIds:
-            self.ctx.out("%s:%s" % (k, objIds[k]))
-        self.ctx.out("Deleted objects")
-        objIds = self._get_object_ids(rsp.deletedObjects)
-        for k in objIds:
-            self.ctx.out("%s:%s" % (k, objIds[k]))
+        if rsp.includedObjects:
+            self.ctx.out("Included objects")
+            objIds = self._get_object_ids(rsp.includedObjects)
+            for k in objIds:
+                self.ctx.out("%s:%s" % (k, objIds[k]))
+        if rsp.deletedObjects:
+            self.ctx.out("Deleted objects")
+            objIds = self._get_object_ids(rsp.deletedObjects)
+            for k in objIds:
+                self.ctx.out("%s:%s" % (k, objIds[k]))
 
 try:
     register("chgrp", ChgrpControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -107,12 +107,12 @@ class ChgrpControl(GraphControl):
             self.ctx.out("Included objects")
             objIds = self._get_object_ids(rsp.includedObjects)
             for k in objIds:
-                self.ctx.out("%s:%s" % (k, objIds[k]))
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
         if rsp.deletedObjects:
             self.ctx.out("Deleted objects")
             objIds = self._get_object_ids(rsp.deletedObjects)
             for k in objIds:
-                self.ctx.out("%s:%s" % (k, objIds[k]))
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
 
 try:
     register("chgrp", ChgrpControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -21,15 +21,28 @@ To delete linked annoations they must be explicitly included.
 
 Examples:
 
-    bin/omero delete --list   # Print all of the graphs
+    # Delete an image but not its linked tag, file and term annotations
+    omero delete Image:50
+    # Delete an image including linked tag, file and term annotations
+    omero delete Image:51 --include TagAnnotation,FileAnnotation,TermAnnotation
+    # Delete an image including all linked annotations
+    omero delete Image:52 --include Annotation
 
-    bin/omero delete Image:50
-    bin/omero delete Plate:1
-    bin/omero delete Image:51,52 OriginalFile:101
-    bin/omero delete Project:101 --exclude Dataset,Image
+    # Delete 3 images, 2 datasets and their contents
+    omero delete  omero delete Image:101,102,103 Dataset:201,202
+    # Delete a project excluding contained datasets and images
+    omero delete Project:101 --exclude Dataset,Image
 
-    # Force delete of linked annotations
-    bin/omero delete Image:51 --include Annotation
+    # Delete all images contained under a project
+    omero delete Project/Dataset/Image:53
+    # Delete all images contained under two projects
+    omero delete Project/Image:201,202
+
+    # Do a dry run of a delete reporting the outcome if the delete had been run
+    omero delete Dataset:53 --dry-run
+    # Do a dry run of a delete, reporting all the objects
+    # that would have been deleted
+    omero delete Dataset:53 --dry-run --report
 
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -33,8 +33,6 @@ Examples:
 
 """
 
-EXCLUDED_PACKAGES = ["ome.model.display"]
-
 
 class DeleteControl(GraphControl):
 
@@ -63,10 +61,7 @@ class DeleteControl(GraphControl):
         objIds = {}
         for k in rsp.deletedObjects.keys():
             if rsp.deletedObjects[k]:
-                for excl in EXCLUDED_PACKAGES:
-                    if not k.startswith(excl):
-                        objIds[k] = self._order_and_range_ids(
-                            rsp.deletedObjects[k])
+                objIds[k] = self._order_and_range_ids(rsp.deletedObjects[k])
         newIds = collections.OrderedDict(sorted(objIds.items()))
         objIds = collections.OrderedDict()
         for k in newIds:

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -28,10 +28,10 @@ Examples:
     # Delete an image including all linked annotations
     omero delete Image:52 --include Annotation
 
-    # Delete 3 images, 2 datasets and their contents
+    # Delete three images and two datasets including their contents
     omero delete  omero delete Image:101,102,103 Dataset:201,202
-    # Delete a project excluding contained datasets and images
-    omero delete Project:101 --exclude Dataset,Image
+    # Delete a project excluding contained datasets and linked annotations
+    omero delete Project:101 --exclude Dataset,Annotation
 
     # Delete all images contained under a project
     omero delete Project/Dataset/Image:53

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -68,7 +68,7 @@ class DeleteControl(GraphControl):
             self.ctx.out("Deleted objects")
             objIds = self._get_object_ids(rsp.deletedObjects)
             for k in objIds:
-                self.ctx.out("%s:%s" % (k, objIds[k]))
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
 
     def default_exclude(self):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -65,14 +65,29 @@ class DeleteControl(GraphControl):
             if rsp.deletedObjects[k]:
                 for excl in EXCLUDED_PACKAGES:
                     if not k.startswith(excl):
-                        ids = ','.join(map(str, rsp.deletedObjects[k]))
-                        objIds[k] = ids
+                        objIds[k] = self._order_and_range_ids(
+                            rsp.deletedObjects[k])
         newIds = collections.OrderedDict(sorted(objIds.items()))
         objIds = collections.OrderedDict()
         for k in newIds:
             key = k[k.rfind('.')+1:]
             objIds[key] = newIds[k]
         return objIds
+
+    def _order_and_range_ids(self, ids):
+        from itertools import groupby
+        from operator import itemgetter
+        out = ""
+        ids = sorted(ids)
+        for k, g in groupby(enumerate(ids), lambda (i, x): i-x):
+            g = map(str, map(itemgetter(1), g))
+            out += g[0]
+            if len(g) > 2:
+                out += "-" + g[-1]
+            elif len(g) == 2:
+                out += "," + g[1]
+            out += ","
+        return out.rstrip(",")
 
     def default_exclude(self):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -51,10 +51,11 @@ class DeleteControl(GraphControl):
             self.print_delete_response(rsp)
 
     def print_delete_response(self, rsp):
-        self.ctx.out("Deleted objects")
-        objIds = self._get_object_ids(rsp.deletedObjects)
-        for k in objIds:
-            self.ctx.out("%s:%s" % (k, objIds[k]))
+        if rsp.deletedObjects:
+            self.ctx.out("Deleted objects")
+            objIds = self._get_object_ids(rsp.deletedObjects)
+            for k in objIds:
+                self.ctx.out("%s:%s" % (k, objIds[k]))
 
     def default_exclude(self):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -52,37 +52,9 @@ class DeleteControl(GraphControl):
 
     def print_delete_response(self, rsp):
         self.ctx.out("Deleted objects")
-        objIds = self._get_object_ids(rsp)
+        objIds = self._get_object_ids(rsp.deletedObjects)
         for k in objIds:
             self.ctx.out("%s:%s" % (k, objIds[k]))
-
-    def _get_object_ids(self, rsp):
-        import collections
-        objIds = {}
-        for k in rsp.deletedObjects.keys():
-            if rsp.deletedObjects[k]:
-                objIds[k] = self._order_and_range_ids(rsp.deletedObjects[k])
-        newIds = collections.OrderedDict(sorted(objIds.items()))
-        objIds = collections.OrderedDict()
-        for k in newIds:
-            key = k[k.rfind('.')+1:]
-            objIds[key] = newIds[k]
-        return objIds
-
-    def _order_and_range_ids(self, ids):
-        from itertools import groupby
-        from operator import itemgetter
-        out = ""
-        ids = sorted(ids)
-        for k, g in groupby(enumerate(ids), lambda (i, x): i-x):
-            g = map(str, map(itemgetter(1), g))
-            out += g[0]
-            if len(g) > 2:
-                out += "-" + g[-1]
-            elif len(g) == 2:
-                out += "," + g[1]
-            out += ","
-        return out.rstrip(",")
 
     def default_exclude(self):
         """


### PR DESCRIPTION
This PR modifies the `--report` option of `delete` to order object ids and compress to ranges when possible. The same option for `chgrp` is brought to the same level with some refactoring. As the report is now relatively concise the exclusion of some classes has been lifted - this also means that some reports will not be artificially empty. Finally, both usage docstrings have been updated with a few more examples.

Testing
-------

Try a variety of `delete` and `chgrp` commands with `--report` (and `--dry-run` to prevent and actual moves or deletes. The output should be something like this:
```
omero delete Image:52,51 --report --dry-run
...
omero.cmd.Delete2 Image 52,51... ok
Steps: 1
Elapsed time: 0.268 secs.
Flags: []
Deleted objects
Channel:51,52
Image:51,52
LogicalChannel:51,52
OriginalFile:105-110,112-117
Pixels:51,52
ChannelBinding:51,52
QuantumDef:51,52
RenderingDef:51,52
Thumbnail:51,52
Fileset:51,52
FilesetEntry:51-60
FilesetJobLink:51-60
IndexingJob:55,60
JobOriginalFileLink:51,52
MetadataImportJob:52,57
PixelDataJob:53,58
ThumbnailGenerationJob:54,59
UploadJob:51,56
StatsInfo:6,7
```
If there is a straightforward `chgrp` scenario that results in the deletion of objects then please try that too. /cc @joshmoore @mtbc 

Check the `--help` for both commands.