### PR TITLE
Imagej fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -772,7 +772,7 @@ class LocationDialog extends JDialog implements ActionListener,
                     activeWindow = (e.getStateChange() == ItemEvent.SELECTED);
                 }
             });
-            b = new JRadioButton("Add Image from all image windows");
+            b = new JRadioButton("Add Images from all image windows");
             buttons.add(b);
             group.add(b);
             pane = new JPanel();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -498,11 +498,9 @@ public class TreeViewerAgent
     /** Display the save dialog when used in plugin mode.*/
     private void handleSaveEvent(SaveEvent evt)
     {
-        if (evt == null) return;
         ExperimenterData exp = (ExperimenterData) registry.lookup(
                 LookupNames.CURRENT_USER_DETAILS);
-        if (exp == null) 
-            return;
+        if (evt == null || exp == null) return;
         TreeViewer viewer = TreeViewerFactory.getTreeViewer(exp);
         SaveResultsAction a = new SaveResultsAction(viewer, LookupNames.IMAGE_J);
         a.actionPerformed(

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -503,6 +503,7 @@ public class TreeViewerAgent
         if (evt == null || exp == null) return;
         TreeViewer viewer = TreeViewerFactory.getTreeViewer(exp);
         SaveResultsAction a = new SaveResultsAction(viewer, LookupNames.IMAGE_J);
+        a.setSaveIndex(evt.getSaveIndex());
         a.actionPerformed(
                 new ActionEvent(new JButton(), ActionEvent.ACTION_PERFORMED, ""));
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
@@ -239,7 +239,7 @@ public class SaveResultsDialog
                 activeWindow = (e.getStateChange() == ItemEvent.SELECTED);
             }
         });
-        b = new JRadioButton("Image from all image windows");
+        b = new JRadioButton("Images from all image windows");
         b.setSelected(activeWindow);
         buttons.add(b);
         group.add(b);


### PR DESCRIPTION
Fix problem reported while presenting to local users
Check the following:

 * tick as default only the appropriate box in the Save ROIs... and Save Results... workflows (this means Save ROIs... would have the ROIs box ticked and Measurements unticked, and the Save Results... would have it the other way round
 * reformulate the ```image from all image windows``` to ```images from all image windows```