### PR TITLE
Include ome.model as part of the Javadocs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -650,6 +650,9 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                     </fileset>
                 </classpath>
 
+                <fileset dir="components/model/" defaultexcludes="yes">
+                    <patternset refid="all.java.files"/>
+                </fileset>
                 <fileset dir="components/common/" defaultexcludes="yes">
                     <patternset refid="all.java.files"/>
                 </fileset>


### PR DESCRIPTION
The ome.model package was referenced from the top-level Javadocs page but not
included as a fileset. This should allow the ome.model classes to be picked up
and published with the rest of the API. /cc @mtbc 