### PR TITLE
Create report of the dependencies bundled into the server

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -786,6 +786,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
             <ivy:resolve file="ivy.xml" type="jar,egg" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
             <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
+            <ivy:report conf="client" todir="${target.dir}" settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="copy-server" depends="init">
@@ -793,6 +794,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
             <ivy:resolve file="ivy.xml" type="jar,egg" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
             <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
+            <ivy:report conf="server" todir="${target.dir}" settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="create-workdirs" depends="init">

--- a/build.xml
+++ b/build.xml
@@ -786,7 +786,8 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
             <ivy:resolve file="ivy.xml" type="jar,egg" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
             <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
-            <ivy:report conf="client" todir="${target.dir}" settingsRef="ivy.toplevel"/>
+            <ivy:report conf="client" todir="${dist.dir}/lib"
+                graph="false" settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="copy-server" depends="init">
@@ -794,7 +795,8 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
             <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
             <ivy:resolve file="ivy.xml" type="jar,egg" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
             <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
-            <ivy:report conf="server" todir="${target.dir}" settingsRef="ivy.toplevel"/>
+            <ivy:report conf="server" todir="${dist.dir}/lib"
+                graph="false" settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="create-workdirs" depends="init">


### PR DESCRIPTION
While working on the decoupling effort, we are reconsidering the use of transitive dependencies. This PR should allow to create an HTML report of the JARs bundled with the server (`lib/client` and `lib/server`) together with their provenance under `dist/lib`.

To test this PR, download the zip bundle of OMERO.server and check that `lib` contains two HTML reports: one for the server dependencies and one for the client dependencies.