### PR TITLE
Map annotation tooltips

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -572,7 +572,7 @@ jQuery.fn.tooltip_init = function() {
     $(this).tooltip({
         items: '.tooltip',
         content: function() {
-            return $(this).parent().children("span.tooltip_html").html();
+            return $(this).parent().find("span.tooltip_html").html();
         },
         track: true,
         show: false,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
@@ -25,9 +25,16 @@
             data-added-by="{% if ma %}{{ ma.getOwner.id }}{% else %}{{ ome.user.id }}{% endif %}"
             class="keyValueTable{% if canEdit %} editableKeyValueTable{% endif %}">
         <thead>
-          <tr>
+          <tr class="tooltip">
               <th colspan="2">
                 {% if ma %} Added by: {{ ma.getOwner.getFullName }} {% endif %}
+
+                <span class="tooltip_html" style='display:none'>
+                    <b>ID:</b> {{ ma.id }}<br />
+                    <b>Owner:</b> {{ ma.getOwner.getFullName }}<br />
+                    <b>Linked by:</b> {{ ma.link.getDetails.getOwner.getFullName }}<br />
+                    <b>On:</b> {{ ma.link.creationEventDate|date:"Y-m-d H:i:s" }}
+                </span>
               </th>
             </tr>
           {% if showTableHead %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotation.html
@@ -27,14 +27,16 @@
         <thead>
           <tr class="tooltip">
               <th colspan="2">
-                {% if ma %} Added by: {{ ma.getOwner.getFullName }} {% endif %}
+                {% if ma %}
+                    Added by: {{ ma.getOwner.getFullName }}
 
-                <span class="tooltip_html" style='display:none'>
-                    <b>ID:</b> {{ ma.id }}<br />
-                    <b>Owner:</b> {{ ma.getOwner.getFullName }}<br />
-                    <b>Linked by:</b> {{ ma.link.getDetails.getOwner.getFullName }}<br />
-                    <b>On:</b> {{ ma.link.creationEventDate|date:"Y-m-d H:i:s" }}
-                </span>
+                    <span class="tooltip_html" style='display:none'>
+                        <b>ID:</b> {{ ma.id }}<br />
+                        <b>Owner:</b> {{ ma.getOwner.getFullName }}<br />
+                        <b>Linked by:</b> {{ ma.link.getDetails.getOwner.getFullName }}<br />
+                        <b>On:</b> {{ ma.link.creationEventDate|date:"Y-m-d H:i:s" }}
+                    </span>
+                {% endif %}
               </th>
             </tr>
           {% if showTableHead %}


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12774

Tooltip for map annotations is now displayed for the header.
Test that tooltip is displayed for map annotations, and still works for Tags & Files in right panel.

![screen shot 2015-06-15 at 15 07 03](https://cloud.githubusercontent.com/assets/900055/8161804/3790c6c4-1371-11e5-9640-62a238b68205.png)
