### PR TITLE
Postit panels scrolling

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.postit.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.postit.js
@@ -47,14 +47,6 @@ $.fn.postit = function(cfg) {
     /* Some extra details on the dragbar */
     var dragbar = self.find('h1:first');
     dragbar.dblclick(function(e) { self.toggleClass('collapsed'); });
-    self.bind("mousewheel", function(e){
-      // Respond to mouse wheel in IE. (It returns up/dn motion in multiples of 120)
-      if (e.wheelDelta >= 120)
-        self.addClass('collapsed');
-      else if (e.wheelDelta <= -120)
-        self.removeClass('collapsed');
-      e.preventDefault();
-    })
 
     if (dragbar.get(0).addEventListener) {
       // Respond to mouse wheel in Firefox


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12894

To test, using **Chrome** browser, open an image that has a lot of ROIs (E.g. 30) in the web image viewer and "Show ROIs" so that the ROIs table is bigger than the 'postit' popup panel.
Use the mouse-wheel to scroll to the bottom of the table.
A scroll bar may or may not be shown initially but should appear while scrolling?