### PR TITLE
Add chown command to CLI

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1442,6 +1442,33 @@ def argv(args=sys.argv):
 # Specific argument types
 
 
+class ExperimenterArg(object):
+
+    def __init__(self, arg):
+        self.orig = arg
+        self.usr = None
+        try:
+            self.usr = long(arg)
+        except ValueError:
+            if ":" in arg:
+                parts = arg.split(":", 1)
+                if parts[0] == "User" or "Experimenter":
+                    try:
+                        self.usr = long(parts[1])
+                    except ValueError:
+                        pass
+
+    def lookup(self, client):
+        if self.usr is None:
+            import omero
+            a = client.sf.getAdminService()
+            try:
+                self.usr = a.lookupExperimenter(self.orig).id.val
+            except omero.ApiUsageException:
+                pass
+        return self.usr
+
+
 class ExperimenterGroupArg(object):
 
     def __init__(self, arg):

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1748,17 +1748,17 @@ class GraphControl(CmdControl):
         if args.exclude:
             exc = exc.extend(args.exclude.split(","))
 
-        if len(inc) > 0 or len(exc) > 0:
+        if inc or exc:
             opt = omero.cmd.graphs.ChildOption()
-            if len(inc) > 0:
+            if inc:
                 opt.includeType = inc
-            if len(exc) > 0:
+            if exc:
                 opt.excludeType = exc
 
         commands = args.obj
         for req in commands:
             req.dryRun = args.dry_run
-            if len(inc) > 0 or len(exc) > 0:
+            if inc or exc:
                 req.childOptions = [opt]
             if isinstance(req, omero.cmd.SkipHead):
                 req.request.childOptions = req.childOptions

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1746,7 +1746,7 @@ class GraphControl(CmdControl):
             inc = args.include.split(",")
         exc = self.default_exclude()
         if args.exclude:
-            exc = exc.extend(args.exclude.split(","))
+            exc.extend(args.exclude.split(","))
 
         if inc or exc:
             opt = omero.cmd.graphs.ChildOption()

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+
+"""
+   chown plugin
+
+   Plugin read by omero.cli.Cli during initialization. The method(s)
+   defined here will be added to the Cli class for later use.
+"""
+
+from omero.cli import CLI, GraphControl, ExperimenterArg
+import sys
+
+HELP = """Transfer data between usrs
+
+Transfer entire graphs of data based on the ID of the top-node.
+
+Examples:
+
+    # In each case transfer an image to user 101
+    omero chown 101 Image:1
+    omero chown User:101 Image:2
+    omero chown Experimenter:101 Image:3
+    # Transfer three images to the user named jane
+    omero chown jane Image:51,52,53
+
+    # Transfer a plate but leave all images with the original owner
+    omero chown 201 Plate:1 --exclude Image
+
+    # Transfer all images contained under a project
+    omero chown 101 Project/Dataset/Image:53
+    # Transfer all images contained under two projects
+    omero chown 101 Project/Image:201,202
+
+    # Do a dry run of a transfer reporting the outcome
+    # if the transfer had been run
+    omero chown 101 Dataset:53 --dry-run
+    # Do a dry run of a transfer, reporting all the objects
+    # that would have been transfered
+    omero chown 101 Dataset:53 --dry-run --report
+
+"""
+
+
+class ChownControl(GraphControl):
+
+    def cmd_type(self):
+        import omero
+        import omero.all
+        return omero.cmd.Chown2
+
+    def _pre_objects(self, parser):
+        parser.add_argument(
+            "usr", nargs="?", type=ExperimenterArg,
+            help="""user to transfer objects to""")
+
+    def _process_request(self, req, args, client):
+        # Retrieve user id
+        uid = args.usr.lookup(client)
+        if uid is None:
+            self.ctx.die(196, "Failed to find user: %s" % args.usr.orig)
+
+        # Set requests user
+        import omero
+        if isinstance(req, omero.cmd.DoAll):
+            for request in req.requests:
+                if isinstance(request, omero.cmd.SkipHead):
+                    request.request.userId = uid
+                else:
+                    request.userId = uid
+        else:
+            if isinstance(req, omero.cmd.SkipHead):
+                req.request.userId = uid
+            else:
+                req.userId = uid
+
+        super(ChownControl, self)._process_request(req, args, client)
+
+    def print_detailed_report(self, req, rsp, status):
+        import omero
+        if isinstance(rsp, omero.cmd.DoAllRsp):
+            for response in rsp.responses:
+                if isinstance(response, omero.cmd.Chown2Response):
+                    self.print_chown_response(response)
+        elif isinstance(rsp, omero.cmd.Chown2Response):
+            self.print_chown_response(rsp)
+
+    def print_chown_response(self, rsp):
+        if rsp.includedObjects:
+            self.ctx.out("Included objects")
+            objIds = self._get_object_ids(rsp.includedObjects)
+            for k in objIds:
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
+        if rsp.deletedObjects:
+            self.ctx.out("Deleted objects")
+            objIds = self._get_object_ids(rsp.deletedObjects)
+            for k in objIds:
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
+
+try:
+    register("chown", ChownControl, HELP)
+except NameError:
+    if __name__ == "__main__":
+        cli = CLI()
+        cli.register("chown", ChownControl, HELP)
+        cli.invoke(sys.argv[1:])

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -16,13 +16,12 @@
 from omero.cli import CLI, GraphControl, ExperimenterArg
 import sys
 
-HELP = """Transfer data between usrs
-
-Transfer entire graphs of data based on the ID of the top-node.
+HELP = """Transfer ownership of data between users. Entire graphs of data,
+based on the ID of the top-node, are transferred.
 
 Examples:
 
-    # In each case transfer an image to user 101
+    # In each case transfer the ownership of an image to user 101
     omero chown 101 Image:1
     omero chown User:101 Image:2
     omero chown Experimenter:101 Image:3
@@ -41,7 +40,7 @@ Examples:
     # if the transfer had been run
     omero chown 101 Dataset:53 --dry-run
     # Do a dry run of a transfer, reporting all the objects
-    # that would have been transfered
+    # that would have been transferred
     omero chown 101 Dataset:53 --dry-run --report
 
 """
@@ -57,7 +56,7 @@ class ChownControl(GraphControl):
     def _pre_objects(self, parser):
         parser.add_argument(
             "usr", nargs="?", type=ExperimenterArg,
-            help="""user to transfer objects to""")
+            help="""user to transfer ownership of objects to""")
 
     def _process_request(self, req, args, client):
         # Retrieve user id

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -20,8 +20,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+import omero
 from omero.cli import CLI
 from omero.plugins.sessions import SessionsControl
+from omero.rtypes import rstring
 
 from library import ITest
 from omero_ext.mox import Mox
@@ -47,6 +49,27 @@ class CLITest(AbstractCLITest):
 
     def setup_method(self, method):
         self.args = self.login_args()
+
+    def create_object(self, object_type):
+        # create object
+        if object_type == 'Dataset':
+            new_object = omero.model.DatasetI()
+        elif object_type == 'Project':
+            new_object = omero.model.ProjectI()
+        elif object_type == 'Plate':
+            new_object = omero.model.PlateI()
+        elif object_type == 'Screen':
+            new_object = omero.model.ScreenI()
+        elif object_type == 'Image':
+            new_object = self.new_image()
+        new_object.name = rstring("")
+        new_object = self.update.saveAndReturnObject(new_object)
+
+        # check object has been created
+        found_object = self.query.get(object_type, new_object.id.val)
+        assert found_object.id.val == new_object.id.val
+
+        return new_object.id.val
 
 
 class RootCLITest(AbstractCLITest):

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -23,7 +23,6 @@ import omero
 from omero.cli import NonZeroReturnCode
 from omero.plugins.chgrp import ChgrpControl
 from test.integration.clitest.cli import CLITest, RootCLITest
-from omero.rtypes import rstring
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
@@ -47,27 +46,6 @@ class TestChgrp(CLITest):
         super(TestChgrp, self).setup_method(method)
         self.cli.register("chgrp", ChgrpControl, "TEST")
         self.args += ["chgrp"]
-
-    def create_object(self, object_type):
-        # create object
-        if object_type == 'Dataset':
-            new_object = omero.model.DatasetI()
-        elif object_type == 'Project':
-            new_object = omero.model.ProjectI()
-        elif object_type == 'Plate':
-            new_object = omero.model.PlateI()
-        elif object_type == 'Screen':
-            new_object = omero.model.ScreenI()
-        elif object_type == 'Image':
-            new_object = self.new_image()
-        new_object.name = rstring("")
-        new_object = self.update.saveAndReturnObject(new_object)
-
-        # check object has been created
-        found_object = self.query.get(object_type, new_object.id.val)
-        assert found_object.id.val == new_object.id.val
-
-        return new_object.id.val
 
     @pytest.mark.parametrize("object_type", object_types)
     @pytest.mark.parametrize("target_group_perms", permissions)

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# from omero.cli import NonZeroReturnCode
+import omero
+from omero.plugins.chown import ChownControl
+from test.integration.clitest.cli import CLITest
+import pytest
+
+object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
+user_prefixes = ["", "User:", "Experimenter:"]
+all_grps = {'omero.group': '-1'}
+
+
+class TestChown(CLITest):
+
+    def setup_method(self, method):
+        super(TestChown, self).setup_method(method)
+        self.cli.register("chown", ChownControl, "TEST")
+        self.args += ["chown"]
+
+    @pytest.mark.parametrize("object_type", object_types)
+    @pytest.mark.parametrize("user_prefix", user_prefixes)
+    def testChownBasicUsageWithId(self, object_type, user_prefix):
+        oid = self.create_object(object_type)
+
+        # create a user in the same group and transfer the object to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s%s' % (user_prefix, user.id.val),
+                      '%s:%s' % (object_type, oid)]
+        self.cli.invoke(self.args, strict=True)
+
+        # check the object has been transfered
+        obj = client.sf.getQueryService().get(object_type, oid, all_grps)
+        assert obj.id.val == oid
+        assert obj.details.owner.id.val == user.id.val
+        with pytest.raises(omero.SecurityViolation):
+            self.query.get(object_type, oid, all_grps)
+
+    def testChownBasicUsageWithName(self):
+        oid = self.create_object("Image")
+
+        # create a user in the same group and transfer the object to the user
+        client, user = self.new_client_and_user()
+        self.add_experimenters(self.group, [user])
+        self.args += ['%s' % (user.omeName.val),
+                      '%s:%s' % ("Image", oid)]
+        self.cli.invoke(self.args, strict=True)
+
+        # check the object has been transfered
+        obj = client.sf.getQueryService().get("Image", oid, all_grps)
+        assert obj.id.val == oid
+        assert obj.details.owner.id.val == user.id.val
+        with pytest.raises(omero.SecurityViolation):
+            self.query.get("Image", oid, all_grps)
+
+    def testChownDifferentGroup(self):
+        oid = self.create_object("Image")
+
+        # create user and try to transfer the object to the user
+        client, user = self.new_client_and_user()
+        self.args += ['%s' % user.id.val,
+                      '%s:%s' % ("Image", oid)]
+        self.cli.invoke(self.args, strict=True)
+
+        # check the object has not been transfered
+        obj = self.query.get("Image", oid, all_grps)
+        assert obj.id.val == oid
+        assert obj.details.owner.id.val == self.user.id.val
+        with pytest.raises(omero.SecurityViolation):
+            client.sf.getQueryService().get("Image", oid, all_grps)

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -284,6 +284,64 @@ class TestDelete(CLITest):
         # Check that the image has not been deleted,
         assert self.query.find('Image', img.id.val)
 
+    # Test combinations of include and exclude other than annotations
+    @pytest.fixture()
+    def simpleHierarchy(self):
+        proj = self.make_project()
+        dset = self.make_dataset()
+        img = self.update.saveAndReturnObject(self.new_image())
+        self.link(proj, dset)
+        self.link(dset, img)
+        return proj, dset, img
+
+    def testExcludeNone(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        self.args += ['Project:%s' % proj.id.val]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that everything has been deleted.
+        assert not self.query.find('Project', proj.id.val)
+        assert not self.query.find('Dataset', dset.id.val)
+        assert not self.query.find('Image', img.id.val)
+
+    def testIncludeExcludeSecond(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Dataset']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that everything has been deleted.
+        assert not self.query.find('Project', proj.id.val)
+        assert self.query.find('Dataset', dset.id.val)
+        assert self.query.find('Image', img.id.val)
+
+    def testExcludeThird(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Image']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that everything has been deleted.
+        assert not self.query.find('Project', proj.id.val)
+        assert not self.query.find('Dataset', dset.id.val)
+        assert self.query.find('Image', img.id.val)
+
+    def testIncludeExclude(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Dataset']
+        self.args += ['--include', 'Image']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that everything has been deleted.
+        assert not self.query.find('Project', proj.id.val)
+        assert self.query.find('Dataset', dset.id.val)
+        assert not self.query.find('Image', img.id.val)
+
     # These tests check the default exclusion of the annotations:
     # FileAnnotation, TagAnnotation and TermAnnotation
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -22,7 +22,6 @@
 import omero
 from omero.plugins.delete import DeleteControl
 from test.integration.clitest.cli import CLITest
-from omero.rtypes import rstring
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
@@ -35,27 +34,6 @@ class TestDelete(CLITest):
         super(TestDelete, self).setup_method(method)
         self.cli.register("delete", DeleteControl, "TEST")
         self.args += ["delete"]
-
-    def create_object(self, object_type):
-        # create object
-        if object_type == 'Dataset':
-            new_object = omero.model.DatasetI()
-        elif object_type == 'Project':
-            new_object = omero.model.ProjectI()
-        elif object_type == 'Plate':
-            new_object = omero.model.PlateI()
-        elif object_type == 'Screen':
-            new_object = omero.model.ScreenI()
-        elif object_type == 'Image':
-            new_object = self.new_image()
-        new_object.name = rstring("")
-        new_object = self.update.saveAndReturnObject(new_object)
-
-        # check object has been created
-        found_object = self.query.get(object_type, new_object.id.val)
-        assert found_object.id.val == new_object.id.val
-
-        return new_object.id.val
 
     @pytest.mark.parametrize("object_type", object_types)
     def testDeleteMyData(self, object_type):


### PR DESCRIPTION
Idly talking with @mtbc in Paris about Chown2 it was clear that a `chown` command would pretty much be a search and replace of the `chgrp` command. So here it is. This is mainly intended to facilitate testing of `Chown2` but is exposed in the CLI. As this is a copy of `chgrp` I may have left some of the old stuff behind, particularly in docstrings and comments.

There are some minimal integration tests: two users in the same group - transfer possible, two users in different groups - transfer not possible. There are no admin tests as yet - these need to be added. The argument parsing is not tested here as the same superclass as `chgrp` and `delete` is used and so that is tested sufficiently elsewhere.

To test try various `chown` operations between different users, different groups, etc. The `--help` text provides some examples.
