### PR TITLE
Tagging fixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeViewerTranslator.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeViewerTranslator.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treemng.TreeViewerTranslator
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -244,6 +244,7 @@ public class TreeViewerTranslator
             DataObject tmp;
             ProjectData p;
             ScreenData screen;
+            PlateData plate;
             while (i.hasNext()) {
                 tmp = (DataObject) i.next();
                 if (EditorUtil.isReadable(tmp)) {
@@ -260,6 +261,11 @@ public class TreeViewerTranslator
                         screen = (ScreenData) tmp;
                         tag.addChildDisplay(
                                 transformScreen(screen, screen.getPlates()));
+                    }
+                    else if (tmp instanceof PlateData) {
+                        plate = (PlateData) tmp;
+                        tag.addChildDisplay(
+                                transformPlate(plate, null));
                     }
                 }
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -1372,6 +1372,10 @@ class OmeroMetadataServiceImpl
 	    List<String> toExclude = new ArrayList<String>();
 	    if (nameSpace != null) 
 	        toInclude.add(nameSpace);
+        if (TagAnnotationData.class.equals(annotationType)) {
+            po.orphan();
+            return gateway.loadTagSets(ctx, po);
+        }
 	    if (FileAnnotationData.class.equals(annotationType)) {
 	        if (!FileAnnotationData.COMPANION_FILE_NS.equals(nameSpace))
 	            toExclude.add(FileAnnotationData.COMPANION_FILE_NS);


### PR DESCRIPTION
- Enables Tagset selection on import stage, see [Ticket 12920](http://trac.openmicroscopy.org.uk/ome/ticket/12920); *Test: Create a Tagset, open the import dialog, and make sure you can see and select the tagset there.*
- Fixes a problem that tagged plates disappeared from the tree view after switching and returning to the Tag browser. *Test: Tag a plate; switch to the Tags browser; expand the tag the plate was tagged with and make sure the plate is displayed as a sub node of the tag node. Switch to another browser, Search, Screens, whatever. Return to the Tags browser and make sure it still looks like before (tag node expanded showing the plate).*
See [Trello - Tagging problems](https://trello.com/c/eo1Svfvp/30-tagging-problems)