### PR TITLE
Disable Romio tests in Travis build

### DIFF
--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -33,7 +33,7 @@ java_build()
 java_test()
 {
     NAME=java_test
-    for dir in dsl model common rendering romio server blitz
+    for dir in dsl model common rendering server blitz
     do
         fold start $dir
         ant -f components/$dir/build.xml test -Dtest.with.fail=true -Dtestng.useDefaultListeners=true


### PR DESCRIPTION
Lately Romio tests have been hanging frequently on Travis causing the build to fail.