### PR TITLE
Table data url links

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -928,7 +928,13 @@ public class FileImportComponent
 		} else if (image instanceof List) {
 			List<ThumbnailData> list = new ArrayList<ThumbnailData>((List) image);
 			int m = list.size();
-			imageLabel.setData(list.get(0));
+			ThumbnailData data = list.get(0);
+			long iid = data.getImageID();
+			if (data.getImage() != null) {
+			    iid = data.getImage().getId();
+			}
+			getFile().setImageID(iid);
+			imageLabel.setData(data);
 			list.remove(0);
 			if (list.size() > 0) {
 				ThumbnailLabel label = imageLabels.get(0);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -561,7 +561,7 @@ class MetadataViewerComponent
 			}
 		}  else if (refObject instanceof TagAnnotationData) {
 			//Only update properties.
-			if ((toAdd.size() == 0 && toRemove.size() == 0)) {
+			if (CollectionUtils.isEmpty(toAdd) && CollectionUtils.isEmpty(toRemove)) {
 				model.fireSaving(object, metadata, toSave, asynch);
 				b = false;
 			}	

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -83,6 +83,18 @@ public class FileObject
     }
 
     /**
+     * Sets the omero image Id after saving the image.
+     *
+     * @param id The value to set.
+     */
+    public void setImageID(long id)
+    {
+        if (!isImagePlus()) return;
+        ImagePlus image = (ImagePlus) file;
+        image.setProperty(OMERO_ID, id);
+    }
+
+    /**
      * Add the associated file if any.
      * 
      * @param file The file to add.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
@@ -20,6 +20,7 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
+import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
@@ -121,7 +122,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     rois = reader.readImageJROIFromSources(id, img);
                     //create a tmp file.
@@ -145,6 +148,7 @@ public class ResultsSaver
                                             imageID, fa);
                                 }
                             } catch (Exception e) {
+                                IJ.log("error:"+e.toString());
                                 context.getLogger().error(this,
                                         "Cannot Save the ROIs results: "
                                                 +e.getMessage());
@@ -172,7 +176,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     //create a tmp file.
                     File f = createFile(img);
@@ -221,7 +227,9 @@ public class ResultsSaver
                 file = (FileObject) o;
                 id = file.getOMEROID();
                 if (id >= 0) {
-                    ctx = new SecurityContext(file.getGroupID());
+                    if (file.getGroupID() > 0) {
+                        ctx = new SecurityContext(file.getGroupID());
+                    }
                     ImagePlus img = (ImagePlus) file.getFile();
                     rois = reader.readImageJROIFromSources(id, img);
                     if (CollectionUtils.isNotEmpty(rois)) {

--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -64,6 +64,14 @@ Select And Expand Dataset
     ${firstNodeId}    Select First Node By Type    dataset
     [Return]          ${firstNodeId}
 
+Select And Expand Plate
+    ${firstNodeId}    Select First Node By Type    plate
+    [Return]          ${firstNodeId}
+
+Select And Expand Run
+    ${firstNodeId}    Select First Node By Type    acquisition
+    [Return]          ${firstNodeId}
+
 Select And Expand Image
     Select First Node With Children in Tree    dataset
     # Need to wait for data to load

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -16,6 +16,8 @@ USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-robot_ice.config}
 IMAGE_NAME=${IMAGE_NAME:-test&sizeZ=3&sizeT=10.fake}
 TINY_IMAGE_NAME=${TINY_IMAGE_NAME:-test.fake}
+PLATE_NAME=${PLATE_NAME:-SPW&plates=1&plateRows=1&plateCols=2&fields=1&plateAcqs=1.fake}
+BULK_ANNOTATION_CSV=${BULK_ANNOTATION_CSV:-bulk_annotation.csv}
 
 # Create robot user and group
 bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
@@ -25,12 +27,21 @@ bin/omero user add $USER_NAME $USER_NAME $USER_NAME $GROUP_NAME $GROUP_NAME_2 --
 bin/omero user joingroup --name $USER_NAME --group-name $GROUP_NAME --as-owner
 bin/omero logout
 
-# Create fake file
+# Create fake files
 touch $IMAGE_NAME
 touch $TINY_IMAGE_NAME
+touch $PLATE_NAME
+
+# Create batch annotation csv
+echo "Well,Well Type,Concentration" > "$BULK_ANNOTATION_CSV"
+echo "A1,Control,0" >> "$BULK_ANNOTATION_CSV"
+echo "A2,Treatment,10" >> "$BULK_ANNOTATION_CSV"
 
 # Create robot setup
 bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD
+# Parse the sessions file to get session key
+key=$(grep omero.sess $(bin/omero sessions file) | cut -d= -f2)
+echo "Session key: $key"
 nProjects=1
 nDatasets=1
 nImages=2
@@ -57,6 +68,12 @@ do
   bin/omero import -d $delDs $TINY_IMAGE_NAME --debug ERROR
 done
 
+# Import Plate
+bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1
+plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
+# Use populate_metadata to upload and attach bulk annotation csv
+python lib/python/omero/util/populate_metadata.py -k $key Plate:$plateid $BULK_ANNOTATION_CSV
+
 # Logout
 bin/omero logout
 
@@ -70,3 +87,4 @@ echo "omero.datasetid=${dataset##*:}" >> "$CONFIG_FILENAME"
 
 # Remove fake file
 rm *.fake
+rm $PLATE_NAME

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -72,6 +72,7 @@ done
 bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Use populate_metadata to upload and attach bulk annotation csv
+PYTHONPATH=$PYTHONPATH:lib/python
 python lib/python/omero/util/populate_metadata.py -k $key Plate:$plateid $BULK_ANNOTATION_CSV
 
 # Logout

--- a/components/tests/ui/testcases/web/spw_test.txt
+++ b/components/tests/ui/testcases/web/spw_test.txt
@@ -1,0 +1,41 @@
+*** Settings ***
+Documentation     Tests the display of Screen-Plate-Well data
+
+Resource          ../../resources/config.txt
+Resource          ../../resources/web/login.txt
+Resource          ../../resources/web/tree.txt
+
+Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Teardown      Close all browsers
+
+
+*** Keywords ***
+
+Click Well By Name
+    [Arguments]    ${name}
+    Wait Until Page Contains Element    xpath=//td[contains(@class,'well')]/img[@name='${name}']
+    # Have to be sure that thumbnail itself has loaded before image is clickable!
+    Sleep                               1
+    Click Element                       xpath=//td[contains(@class,'well')]/img[@name='${name}']
+
+Bulk Annotation Should Contain Row
+    [Arguments]    ${key}   ${value}
+    Wait Until Page Contains Element    xpath=//table[@id='bulk_annotations_table']//tr[descendant::td[contains(text(), '${key}')]]/td[contains(text(), '${value}')]
+
+*** Test Cases ***
+
+Test Bulk Annotations
+    [Documentation]     Test display of bulk annotations added in setup
+
+    Select Experimenter
+    Select And Expand Plate
+    Select And Expand Run
+    Click Well By Name                      A1
+    Wait Until Page Contains Element        id=bulk_annotations_table
+    Bulk Annotation Should Contain Row      Well Type       Control
+    Bulk Annotation Should Contain Row      Concentration   0
+    Click Well By Name                      A2
+    Bulk Annotation Should Contain Row      Well Type       Treatment
+    Bulk Annotation Should Contain Row      Concentration   10
+
+

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -113,7 +113,9 @@ class HeaderResolver(object):
 
     def __init__(self, target_object, headers):
         self.target_object = target_object
-        self.headers = [v.replace('/', '\\') for v in headers]
+        # TODO: why do we need to replace '/'?
+        # self.headers = [v.replace('/', '\\') for v in headers]
+        self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
 
     def create_columns(self):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -138,6 +138,7 @@ class HeaderResolver(object):
             description = ""
             if "%%" in name:
                 name, description = name.split("%%", 1)
+                name = name.strip()
                 # description is key=value. Convert to json
                 if "=" in description:
                     k, v = description.split("=", 1)
@@ -166,6 +167,7 @@ class HeaderResolver(object):
             description = ""
             if "%%" in name:
                 name, description = name.split("%%", 1)
+                name = name.strip()
                 # description is key=value. Convert to json
                 if "=" in description:
                     k, v = description.split("=", 1)

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -27,6 +27,7 @@ import logging
 import sys
 import csv
 import re
+import json
 from getpass import getpass
 from getopt import getopt, GetoptError
 
@@ -134,11 +135,20 @@ class HeaderResolver(object):
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
+            description = ""
+            if "%%" in name:
+                name, description = name.split("%%", 1)
+                # description is key=value. Convert to json
+                if "=" in description:
+                    k, v = description.split("=", 1)
+                    k = k.strip()
+                    description = json.dumps({k: v.strip()})
             try:
-                column = self.screen_keys[header_as_lower](name, '', list())
+                column = self.screen_keys[header_as_lower](name, description,
+                                                           list())
             except KeyError:
-                column = StringColumn(name, '', self.DEFAULT_COLUMN_SIZE,
-                                      list())
+                column = StringColumn(name, description,
+                                      self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:
@@ -153,11 +163,20 @@ class HeaderResolver(object):
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
+            description = ""
+            if "%%" in name:
+                name, description = name.split("%%", 1)
+                # description is key=value. Convert to json
+                if "=" in description:
+                    k, v = description.split("=", 1)
+                    k = k.strip()
+                    description = json.dumps({k: v.strip()})
             try:
-                column = self.plate_keys[header_as_lower](name, '', list())
+                column = self.plate_keys[header_as_lower](name, description,
+                                                          list())
             except KeyError:
-                column = StringColumn(name, '', self.DEFAULT_COLUMN_SIZE,
-                                      list())
+                column = StringColumn(name, description,
+                                      self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:

--- a/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 Glencoe Software, Inc. All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   Test of the Tables service with the populate_metadata.py script
+
+"""
+
+import library as lib
+import os
+
+from omero.model import PlateI, WellI, WellSampleI, OriginalFileI
+from omero.rtypes import rint, rstring, unwrap
+from omero.util.populate_metadata import ParsingContext
+from omero.constants.namespaces import NSBULKANNOTATIONS
+
+
+class TestPopulateMetadata(lib.ITest):
+
+    def createCsv(self, csvFileName):
+
+        colNames = "Well,Well Type,Concentration"
+        rowData = ["A1,Control,0", "A2,Treatment,10"]
+        csvFile = open(csvFileName, 'w')
+        try:
+            csvFile.write(colNames)
+            csvFile.write("\n")
+            csvFile.write("\n".join(rowData))
+        finally:
+            csvFile.close()
+
+    def createPlate(self, rowCount, colCount):
+        uuid = self.ctx.sessionUuid
+
+        def createWell(row, column):
+            well = WellI()
+            well.row = rint(row)
+            well.column = rint(column)
+            ws = WellSampleI()
+            image = self.new_image(name=uuid)
+            ws.image = image
+            well.addWellSample(ws)
+            return well
+
+        plate = PlateI()
+        plate.name = rstring("TestPopulateMetadata%s" % uuid)
+        for row in range(rowCount):
+            for col in range(colCount):
+                well = createWell(row, col)
+                plate.addWell(well)
+        return self.client.sf.getUpdateService().saveAndReturnObject(plate)
+
+    def testPopulateMetadataPlate(self):
+        """
+            Create a small csv file, use populate_metadata.py to parse and
+            attach to Plate. Then query to check table has expected content.
+        """
+
+        csvName = "testCreate.csv"
+        self.createCsv(csvName)
+        rowCount = 1
+        colCount = 2
+        plate = self.createPlate(rowCount, colCount)
+        ctx = ParsingContext(self.client, plate, csvName)
+        ctx.parse()
+        ctx.write_to_omero()
+        # Delete local temp file
+        os.remove(csvName)
+
+        # Get file annotations
+        query = """select p from Plate p
+            left outer join fetch p.annotationLinks links
+            left outer join fetch links.child
+            where p.id=%s""" % plate.id.val
+        qs = self.client.sf.getQueryService()
+        plate = qs.findByQuery(query, None)
+        anns = plate.linkedAnnotationList()
+        # Only expect a single annotation which is a 'bulk annotation'
+        assert len(anns) == 1
+        tableFileAnn = anns[0]
+        assert unwrap(tableFileAnn.getNs()) == NSBULKANNOTATIONS
+        fileid = tableFileAnn.file.id.val
+
+        # Open table to check contents
+        r = self.client.sf.sharedResources()
+        t = r.openTable(OriginalFileI(fileid), None)
+        cols = t.getHeaders()
+        rows = t.getNumberOfRows()
+        assert rows == rowCount * colCount
+        for hit in range(rows):
+            rowValues = [col.values[0] for col in t.read(range(len(cols)),
+                                                         hit, hit+1).columns]
+            assert len(rowValues) == 4
+            if "a1" in rowValues:
+                assert "Control" in rowValues
+            elif "a2" in rowValues:
+                assert "Treatment" in rowValues
+            else:
+                assert False, "Row does not contain 'a1' or 'a2'"

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -471,7 +471,7 @@
             white-space: nowrap;
         }
     
-        #right_panel th{
+        #right_panel th, #right_panel td.title{
             color:hsl(210,10%,30%);
             vertical-align:top;
             text-align:left;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -567,6 +567,21 @@ OME.handleDelete = function() {
     });
 };
 
+// Format a date like "2015-06-15 12:08:01"
+OME.formatDate = function formatDate(date) {
+    function padZero(number) {
+        var n = "" + number;
+        if (n.length < 2) {
+            n = "0" + n;
+        }
+        return n;
+    }
+    var d = new Date(date),
+        dt = [d.getFullYear(), padZero(d.getMonth()+1), (d.getDate())].join("-"),
+        tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
+    return dt + " " + tm;
+};
+
 
 jQuery.fn.tooltip_init = function() {
     $(this).tooltip({

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -544,6 +544,7 @@
 
                     var showBulkAnnTooltip = function(data) {
                         var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
+                            "Data from tables file:<br />" +
                             "<b>File ID:</b> " + data.id + "<br />" +
                             "<b>Owner:</b> " + data.owner + " <br />" +
                             "<b>Annotation ID:</b> " + data.annId + "<br />" +
@@ -855,7 +856,7 @@
 
             <div class="annotations_section">
 
-                <h2 id="bulk-annotations" class="bulk_annotation" style="display: none;">Bulk Annotations</h2>
+                <h2 id="bulk-annotations" class="bulk_annotation" style="display: none;">Tables</h2>
                 <div style="display: none;">
                     <table id="bulk_annotations_table">
                     </table>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -534,6 +534,16 @@
                         $("#ratingsSummary").show();
                     });
                 }
+
+                // For wells, we try to load Bulk table annotations attached to parent Screen / Plate
+                // loading just the row we need for the current well.
+                {% if manager.well %}
+                    var wellsUrl = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
+                        linksUrl = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}",
+                        wellId = {{ manager.well.id }};
+                    loadBulkAnnotations(wellsUrl, wellId);
+                    loadBulkAnnotations(linksUrl, wellId);
+                {% endif %}
             });
             
     </script>
@@ -824,6 +834,12 @@
             <hr style="margin-top:0" />
 
             <div class="annotations_section">
+
+                <h2 id="bulk-annotations" style="display: none;">Bulk Annotations</h2>
+                <div style="display: none;">
+                    <table>
+                    </table>
+                </div>
 
             <!-- RATING -->
       

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -541,8 +541,26 @@
                     var wellsUrl = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
                         linksUrl = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}",
                         wellId = {{ manager.well.id }};
-                    loadBulkAnnotations(wellsUrl, wellId);
-                    loadBulkAnnotations(linksUrl, wellId);
+
+                    var showBulkAnnTooltip = function(data) {
+                        var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
+                            "<b>File ID:</b> " + data.id + "<br />" +
+                            "<b>Annotation ID:</b> " + data.annId + "<br />" +
+                            "<b>Owner:</b> " + data.owner + " <br />" +
+                            "<b>Linked by:</b> " + data.addedBy + " <br /></span>";
+                        $("#bulk-annotations").append(bulkAnnTooltip);
+                        $("#bulk-annotations").parent().tooltip({
+                                items: '.bulk_annotation',
+                                content: function() {
+                                    return $("span.tooltip_html", this).html();
+                                },
+                                track: true,
+                                show: false,
+                                hide: false
+                            });
+                    }
+                    loadBulkAnnotations(wellsUrl, wellId, showBulkAnnTooltip);
+                    loadBulkAnnotations(linksUrl, wellId, showBulkAnnTooltip);
                 {% endif %}
             });
             
@@ -835,7 +853,7 @@
 
             <div class="annotations_section">
 
-                <h2 id="bulk-annotations" style="display: none;">Bulk Annotations</h2>
+                <h2 id="bulk-annotations" class="bulk_annotation" style="display: none;">Bulk Annotations</h2>
                 <div style="display: none;">
                     <table id="bulk_annotations_table">
                     </table>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -545,9 +545,11 @@
                     var showBulkAnnTooltip = function(data) {
                         var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
                             "<b>File ID:</b> " + data.id + "<br />" +
-                            "<b>Annotation ID:</b> " + data.annId + "<br />" +
                             "<b>Owner:</b> " + data.owner + " <br />" +
-                            "<b>Linked by:</b> " + data.addedBy + " <br /></span>";
+                            "<b>Annotation ID:</b> " + data.annId + "<br />" +
+                            "<b>Linked to:</b> " + data.parentType + " " + data.parentId + "<br />" +
+                            "<b>Linked by:</b> " + data.addedBy + " <br />" +
+                            "<b>On:</b> " + OME.formatDate(data.addedOn) + "</span>";
                         $("#bulk-annotations").append(bulkAnnTooltip);
                         $("#bulk-annotations").parent().tooltip({
                                 items: '.bulk_annotation',

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -840,6 +840,7 @@
                     <table>
                     </table>
                 </div>
+                <div style="clear:both; margin:8px"></div>
 
             <!-- RATING -->
       

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -837,7 +837,7 @@
 
                 <h2 id="bulk-annotations" style="display: none;">Bulk Annotations</h2>
                 <div style="display: none;">
-                    <table>
+                    <table id="bulk_annotations_table">
                     </table>
                 </div>
                 <div style="clear:both; margin:8px"></div>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -268,7 +268,7 @@
 
 
     // Used in the Image viewer and in metadata general panel
-    window.loadBulkAnnotations = function(url, wellId) {
+    window.loadBulkAnnotations = function(url, wellId, callback) {
         // Load bulk annotations for screen or plate
         $.getJSON(url + '?query=Well-' + wellId + '&callback=?',
             function(result) {
@@ -285,6 +285,9 @@
                         $('td:first-child', row).html(label + ":&nbsp;");
                         $('td:last-child', row).html(value);
                         table.append(row);
+                    }
+                    if (callback) {
+                        callback(result);
                     }
                 }
         });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -275,11 +275,23 @@
                 if (result.data && result.data.rows) {
                     var table = $("#bulk-annotations").show().next().show().children("table");
                     for (var col = 0; col < result.data.columns.length; col++) {
+                        var url = false;
                         var label = result.data.columns[col].escapeHTML();
-                        var value = '';
-                        for (var r = 0; r < result.data.rows.length; r++) {
-                          value += ("" + result.data.rows[r][col]).escapeHTML() + '<br />';
+                        if (result.data.descriptions && result.data.descriptions[col]) {
+                            desc = result.data.descriptions[col];
+                            url = desc.url;
                         }
+                        var values = [],
+                            v, href;
+                        for (var r = 0; r < result.data.rows.length; r++) {
+                          v = ("" + result.data.rows[r][col]).escapeHTML();
+                          if (url) {
+                            href = url.replace("%s", v);
+                            v = "<a target='new' href='" + href + "'>" + v + "</a>";
+                          }
+                          values.push(v);
+                        }
+                        var value = values.join('<br />');
                         var row = $('<tr><td class="title"></td><td></td></tr>');
                         row.addClass(col % 2 == 1 ? 'odd' : 'even');
                         $('td:first-child', row).html(label + ":&nbsp;");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -242,6 +242,54 @@
         syncRDCW(viewport);     // update undo/redo etc
     };
 
+
+    // This is called on load of viewport in Image viewer, but not preview panel
+    window._load_metadata = function(ev, viewport) {
+
+        /* Image details */
+        var tmp = viewport.getMetadata();
+        $('#wblitz-image-name').html(tmp.imageName);
+        $('#wblitz-image-description-content').html(tmp.imageDescription.replace(/\n/g, '<br />'));
+        $('#wblitz-image-author').html(tmp.imageAuthor);
+        $('#wblitz-image-pub').html(tmp.projectName);
+        $('#wblitz-image-pubid').html(tmp.projectId);
+        $('#wblitz-image-timestamp').html(tmp.imageTimestamp);
+
+        $("#bulk-annotations").hide();
+        $("#bulk-annotations").next().hide();
+        if (tmp.wellId) {
+
+            var wellsUrl = PLATE_WELLS_URL_999.replace('999', tmp.wellId),
+                linksUrl = PLATE_LINKS_URL_999.replace('999', tmp.wellId);
+            loadBulkAnnotations(wellsUrl, tmp.wellId);
+            loadBulkAnnotations(linksUrl, tmp.wellId);
+        }
+    };
+
+
+    // Used in the Image viewer and in metadata general panel
+    window.loadBulkAnnotations = function(url, wellId) {
+        // Load bulk annotations for screen or plate
+        $.getJSON(url + '?query=Well-' + wellId + '&callback=?',
+            function(result) {
+                if (result.data && result.data.rows) {
+                    var table = $("#bulk-annotations").show().next().show().children("table");
+                    for (var col = 0; col < result.data.columns.length; col++) {
+                        var label = result.data.columns[col];
+                        var value = '';
+                        for (var r = 0; r < result.data.rows.length; r++) {
+                          value += result.data.rows[r][col] + '<br />';
+                        }
+                        var row = $('<tr><td class="title"></td><td></td></tr>');
+                        row.addClass(col % 2 == 1 ? 'odd' : 'even');
+                        $('td:first-child', row).html(label + ":&nbsp;");
+                        $('td:last-child', row).html(value);
+                        table.append(row);
+                    }
+                }
+        });
+    };
+
     /**
     * Gets called when an image is initially loaded.
     * This is the place to sync everything; rendering model, quality, channel buttons, etc.
@@ -285,46 +333,6 @@
         // disable 'split' view for single channel images.
         if (channels.length < 2) {
             $("#wblitz input[value='split']").prop('disabled', true);
-        }
-
-        /* Image details */
-        var tmp = viewport.getMetadata();
-        $('#wblitz-image-name').html(tmp.imageName);
-        $('#wblitz-image-description-content').html(tmp.imageDescription.replace(/\n/g, '<br />'));
-        $('#wblitz-image-author').html(tmp.imageAuthor);
-        $('#wblitz-image-pub').html(tmp.projectName);
-        $('#wblitz-image-pubid').html(tmp.projectId);
-        $('#wblitz-image-timestamp').html(tmp.imageTimestamp);
-
-        $("#bulk-annotations").hide();
-        $("#bulk-annotations").next().hide();
-        if (tmp.wellId) {
-            // Load bulk annotations for plate
-            var onAnnotations = function(result) {
-                if (result.data && result.data.rows) {
-                    var table = $("#bulk-annotations").show().next().show().children("table");
-                    for (var col = 0; col < result.data.columns.length; col++) {
-                        var label = result.data.columns[col];
-                        var value = '';
-                        for (var r = 0; r < result.data.rows.length; r++) {
-                          value += result.data.rows[r][col] + '<br />';
-                        }
-                        var row = $('<tr><td class="title"></td><td></td></tr>');
-                        row.addClass(col % 2 == 1 ? 'odd' : 'even');
-                        $('td:first-child', row).html(label + ":&nbsp;");
-                        $('td:last-child', row).html(value);
-                        table.append(row);
-                    }
-                }
-            };
-            $.getJSON(PLATE_WELLS_URL_999.replace('999', tmp.wellId) +
-                '?query=Well-' + tmp.wellId +
-                '&callback=?',
-                onAnnotations);
-            $.getJSON(PLATE_LINKS_URL_999.replace('999', tmp.wellId) +
-                '?query=Well-' + tmp.wellId +
-                '&callback=?',
-                onAnnotations);
         }
 
         // TODO: this used anywhere?

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -275,10 +275,10 @@
                 if (result.data && result.data.rows) {
                     var table = $("#bulk-annotations").show().next().show().children("table");
                     for (var col = 0; col < result.data.columns.length; col++) {
-                        var label = result.data.columns[col];
+                        var label = result.data.columns[col].escapeHTML();
                         var value = '';
                         for (var r = 0; r < result.data.rows.length; r++) {
-                          value += result.data.rows[r][col] + '<br />';
+                          value += ("" + result.data.rows[r][col]).escapeHTML() + '<br />';
                         }
                         var row = $('<tr><td class="title"></td><td></td></tr>');
                         row.addClass(col % 2 == 1 ? 'odd' : 'even');

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -736,8 +736,8 @@
 
       <h3 class="can-collapse" id="bulk-annotations" style="display: none;">Bulk Annotations</h3>
       <div style="display: none;">
-		<table cellspacing="0">
-		</table>
+        <table cellspacing="0">
+        </table>
       </div>
 
       <!--<h3 class="can-collapse defclose"> Legend </h3>
@@ -979,6 +979,7 @@
 
     viewport = $.WeblitzViewport($('#weblitz-viewport'), '{{ viewport_server }}',{% block viewport_opts %}{'mediaroot': '{{ STATIC_URL }}' }{% endblock %});
     viewport.bind('imageLoad', _refresh_cb);
+    viewport.bind('imageLoad', _load_metadata);
 
     /* Prepare the Zoom spin button */
     $("INPUT.spin-button").SpinButton({min:0});

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2312,13 +2312,16 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
         if unwrap(annotation.getNs()) != NSBULKANNOTATIONS:
             continue
         owner = annotation.details.owner
+        ownerName = "%s %s" % (unwrap(owner.firstName), unwrap(owner.lastName))
         addedBy = link.details.owner
+        addedByName = "%s %s" % (unwrap(addedBy.firstName),
+                                 unwrap(addedBy.lastName))
         data.append(dict(id=annotation.id.val,
                          file=annotation.file.id.val,
                          parentType=objtype[0],
                          parentId=obj.id.val,
-                         owner="%s %s" % (unwrap(owner.firstName), unwrap(owner.lastName)),
-                         addedBy="%s %s" % (unwrap(addedBy.firstName), unwrap(addedBy.lastName)),
+                         owner=ownerName,
+                         addedBy=addedByName,
                          addedOn=unwrap(link.details.creationEvent._time)))
     return dict(data=data)
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2291,15 +2291,18 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
         left outer join fetch links.child
         where obj%d.id=:id""" % (len(objtype) - 1)
 
+    ctx = conn.createServiceOptsDict()
+    ctx.setOmeroGroup("-1")
+
     try:
         obj = q.findByQuery(query, omero.sys.ParametersI().addId(objid),
-                            conn.createServiceOptsDict())
+                            ctx)
     except omero.QueryException:
         return dict(error='%s cannot be queried' % objtype,
                     query=query)
 
     if not obj:
-        return dict(error='%s with id %s not found' % (objtype, objid))
+        return dict(error='%s with id %s not found' % (objtype, objid), query=query)
 
     return dict(data=[
         dict(id=annotation.id.val,
@@ -2335,9 +2338,11 @@ def _table_query(request, fileid, conn=None, **kwargs):
         return dict(
             error='Must specify query parameter, use * to retrieve all')
 
+    ctx = conn.createServiceOptsDict()
+    ctx.setOmeroGroup("-1")
+
     r = conn.getSharedResources()
-    t = r.openTable(omero.model.OriginalFileI(fileid),
-                    conn.createServiceOptsDict())
+    t = r.openTable(omero.model.OriginalFileI(fileid), ctx)
     if not t:
         return dict(error="Table %s not found" % fileid)
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2375,8 +2375,19 @@ def _table_query(request, fileid, conn=None, **kwargs):
         except Exception:
             return dict(error='Error executing query: %s' % query)
 
+    colDescriptions = []
+    for col in cols:
+        desc = col.description
+        # description might be json data
+        try:
+            if len(desc) > 0:
+                desc = json.loads(desc)
+        except:
+            pass
+        colDescriptions.append(desc)
     return dict(data=dict(
         columns=[col.name for col in cols],
+        descriptions=colDescriptions,
         rows=[[col.values[0] for col in t.read(range(len(cols)), hit,
                                                hit+1).columns]
               for hit in hits],

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2302,7 +2302,8 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
                     query=query)
 
     if not obj:
-        return dict(error='%s with id %s not found' % (objtype, objid), query=query)
+        return dict(error='%s with id %s not found' % (objtype, objid),
+                    query=query)
 
     return dict(data=[
         dict(id=annotation.id.val,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2289,6 +2289,7 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
     query += """
         left outer join fetch obj0.annotationLinks links
         left outer join fetch links.child
+        join fetch links.details.creationEvent
         where obj%d.id=:id""" % (len(objtype) - 1)
 
     ctx = conn.createServiceOptsDict()
@@ -2314,8 +2315,11 @@ def _annotations(request, objtype, objid, conn=None, **kwargs):
         addedBy = link.details.owner
         data.append(dict(id=annotation.id.val,
                          file=annotation.file.id.val,
+                         parentType=objtype[0],
+                         parentId=obj.id.val,
                          owner="%s %s" % (unwrap(owner.firstName), unwrap(owner.lastName)),
-                         addedBy="%s %s" % (unwrap(addedBy.firstName), unwrap(addedBy.lastName))))
+                         addedBy="%s %s" % (unwrap(addedBy.firstName), unwrap(addedBy.lastName)),
+                         addedOn=unwrap(link.details.creationEvent._time)))
     return dict(data=data)
 
 
@@ -2430,4 +2434,7 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
     tableData['annId'] = ann['id']
     tableData['owner'] = ann['owner']
     tableData['addedBy'] = ann['addedBy']
+    tableData['parentType'] = ann['parentType']
+    tableData['parentId'] = ann['parentId']
+    tableData['addedOn'] = ann['addedOn']
     return tableData


### PR DESCRIPTION
This PR provides 3 steps for adding urls to Table Data.
All parts of this are speculative and up for discussion.

- Add a 'url' description to the column name in your CSV file. Currently I'm using a double %% as the delimiter, but this could be changed? E.g.
    ``` Gene_Symbol %% url=http://www.ensembl.org/id/%s ```
 This will be parsed by the populate_metadata script, which will attempt to add the data as json in the Column description. E.g.
   Name: ```Gene_Symbol```
   Description: ``` '{"url": "http://www.ensembl.org/id/%s"}' ```

- Webgateway now adds the description to the json Table data, and attempts to parse the description as json. E.g. 
```
data: {
    rows: [
        [
        "ENSG00000117399",
        "CDC20",
        "44",
        ]
    ],
    descriptions: [
        "",
        {
        url: "http://www.ensembl.org/id/%s"
        },
        ""
    ],
    columns: [
        "Entity_Identifier",
        "Gene_Symbol ",
        "Entity_Number",
    ]
}
```

- Finally, if a description url is found, webclient uses it to create a link when displaying the gene name.

![screen shot 2015-06-19 at 11 54 33](https://cloud.githubusercontent.com/assets/900055/8252083/0b90bfdc-167a-11e5-820b-61bdbcf69204.png)
