### PR TITLE
rewrite the policy rules for Chown2

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -313,8 +313,6 @@
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/d"
                                        p:changes="I:{r}"/>
 
-        <!-- If a container is moved then consider its contents for moving if they are deletable and not going to a private group. -->
-
         <!-- In considering moving a container's contents, do not move an object if it is in another container. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E]{ia}, L.child = D:[E]{r}" p:changes="D:{a}"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -379,17 +379,16 @@
         <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{i}.file = [E]{r}" p:changes="FA:{r}"/>
         <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{i}.originalFile = [E]{r}" p:changes="FE:{r}"/>
         <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{i}.source = [E]{r}" p:changes="ROI:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{i}, L.child = [E]{r}" p:changes="J:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{i}, L.parent = [E]{r}"
-                                       p:changes="P:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{i}, L.child = [E]{r}" p:changes="J:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{i}, L.parent = [E]{r}" p:changes="P:{r}"/>
 
         <!-- Consider deleting or moving an original file if it is unlinked from an object. -->
 
-        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [I], L.child = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [I], L.parent = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [I], L.child = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [I], L.parent = OF:[E]{i}" p:changes="OF:{r}"/>
 
         <!-- Do not move an original file that is being used by an object. -->
 
@@ -410,9 +409,8 @@
         <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{r}.file = [E]{a}" p:changes="FA:{a}"/>
         <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{r}.originalFile = [E]{a}" p:changes="FE:{a}"/>
         <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{r}.source = [E]{a}" p:changes="ROI:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:[E]{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}"
-                                       p:changes="P:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}" p:changes="P:{a}"/>
 
         <!-- Delete remaining settings if holder object is moved. -->
 
@@ -626,10 +624,10 @@
 
         <!-- If a screen is moved then also move the plate if it is used in no other screen. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [I], L.child = P:[E]{i}/o" p:changes="P:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [I], L.child = P:[E]{i}/o" p:changes="P:{r}"/>
         <bean parent="graphPolicyRule" p:matches="$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{r}, S =/!o P"
-                                       p:changes="P:[E]{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:[E]{a}"/>
+                                       p:changes="P:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}" p:changes="P:[I]"/>
 
         <!--

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -96,6 +96,21 @@
         <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
 
+        <!-- An instrument may not be linked directly to the image, so note relevance via settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[ED], S.detector = D:[E]{i}"
+                                       p:changes="D:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[ED], S.lightSource = LS:[E]{i}"
+                                       p:changes="LS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[ED], S.objective = O:[E]{i}"
+                                       p:changes="O:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [I]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [I]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [I]" p:changes="IN:{r}"/>
+
         <!-- Move emission and excitation filter links if both parent and child are moved. -->
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[ED].parent = [I], L.child = [I]"

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -437,6 +437,7 @@
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
 
         <!-- DISPLAY -->
@@ -568,12 +569,11 @@
         <!-- Move contained objects: shapes of moved ROIs, pixels of moved masks. -->
 
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]{i}" p:changes="I:{r}"/>
 
-        <!-- Delete contained objects: shapes of deleted ROIs, pixels of deleted masks. -->
+        <!-- Delete the shapes of deleted ROIs. -->
 
         <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E]" p:changes="P:[D]"/>
 
         <!-- SCREEN -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -448,7 +448,6 @@
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
 
         <!-- DISPLAY -->
@@ -580,6 +579,7 @@
         <!-- Move contained objects: shapes of moved ROIs, pixels of moved masks. -->
 
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]{i}" p:changes="I:{r}"/>
 
         <!-- Delete the shapes of deleted ROIs. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -462,7 +462,6 @@
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
 
         <!-- DISPLAY -->
@@ -566,6 +565,7 @@
 
         <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- Cannot give ROI out of image in a private or read-only group. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -82,94 +82,561 @@
 
         <!-- see blitz-graph-rules.xml for rule syntax -->
 
-        <bean parent="graphPolicyRule" p:matches="F:Fileset[!I].images = [I], F.images = [!I]" p:error="may not split {F}"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:Instrument, Image[!I].instrument = IN"
-                                       p:error="may not split images that share {IN}"/>
-        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:OriginalFile, FileAnnotation[!I].file = OF"
-                                       p:error="may not split file annotations that share {OF}"/>
-        <bean parent="graphPolicyRule" p:matches="WS:WellSample[!I].image = I:[I]" p:error="may give {I} only via {WS}"/>
-        <bean parent="graphPolicyRule" p:matches="G:IGlobal[E]" p:changes="G:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="[I] =? X:!ILink[E]{o}/o" p:changes="X:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="[I] =?/o X:!ILink[E]{o}" p:changes="X:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].parent =/!o [!O]" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].child =/!o [!O]" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap[!IO].parent = [E]/!d, POFM.child = Pixels[I]"
-                                       p:changes="POFM:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = [I], POFM.child = P:Pixels[E]{r}"
-                                       p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = OF:[E]{o}/o, POFM.child = Pixels[I]"
-                                       p:changes="OF:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = OF:[E]{o}/d, POFM.child = Pixels[I]"
-                                       p:changes="OF:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!IO].parent = [I], L.child = C:!Job[E]/!d" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [I], L.child = C:[E]{o}/o" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink.parent = [I], L.child = C:[E]{o}" p:changes="C:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [I], L.child = C:Job[E]{o}" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="[I] == X:[E]{o}" p:changes="X:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{r}.images = Image[E]{i}" p:changes="F:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.rois = [I]" p:changes="I:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="I:Image[E]{!a}.stageLabel = [I]" p:changes="I:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].wellSamples = WS:[E]" p:changes="WS:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.channels = [I]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.settings = [I]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[E]{!a}.relatedTo = [I]" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="Pixels[I].relatedTo = P:[E]{!a}" p:changes="P:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].plate = C:[E]{!a}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="Well[I].plate = C:[E]{!a}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="WellSample[I].plateAcquisition = C:[E]{!a}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="WellSample[I].well = C:[E]{!a}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="WRL:WellReagentLink.parent = [E], WRL.child = R:Reagent[E]{!a}"
-                                       p:changes="R:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="Screen[E].reagents = R:Reagent[E]{!a}" p:changes="R:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="R:Roi[!O].image =/!o [I]" p:changes="R:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[!O].pixels =/!o [I]" p:changes="RD:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[!O].pixels =/!o [I]" p:changes="T:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/o == [I]" p:changes="X:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="X:!ILink[E]/!o == [I]" p:changes="X:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[E]{r} = X:[E]{i}" p:changes="X:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[I] = X:[E]{i}" p:changes="X:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!I].parent = [I], L.child = [I]" p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = [I]" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [I], L.child = C:[E]{i}" p:changes="C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = OF:[E]{i}, POFM.child = Pixels[I]"
-                                       p:changes="OF:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="DS:DetectorSettings[E]{i}.detector = [E]{r}" p:changes="DS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="LS:LightSettings[E]{i}.lightSource = [E]{r}" p:changes="LS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="OS:ObjectiveSettings[E]{i}.objective = [E]{r}" p:changes="OS:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="X:[E]{ia} == [I]" p:changes="X:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Fileset[I] = I:Image[E].fileset" p:changes="I:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{i}.images = Image[I]" p:changes="F:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{o}.images = Image[I]" p:changes="F:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Fileset[I] = E:FilesetEntry[E].fileset" p:changes="E:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="E:FilesetEntry[E]{r}" p:changes="E:[E]{o}"/>
-        <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:Channel[E]" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Pixels[I].settings =/o RD:RenderingDef[E]" p:changes="RD:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails =/o T:Thumbnail[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:PlaneInfo[E]" p:changes="PI:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="CB:ChannelBinding[!I].renderingDef = RD:[I]" p:changes="CB:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = PA:PlateAcquisition[E]" p:changes="PA:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Plate[I].wells = W:Well[E]" p:changes="W:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:WellSample[E]" p:changes="WS:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:WellSample[E]" p:changes="WS:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E].file = [I]" p:changes="FA:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:Shape[E]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].filter = F:Filter[E]" p:changes="F:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap.parent = OF:[E]{r}, POFM.child = Pixels[E]/o"
+        <!-- ACQUISITION -->
+
+        <!-- If an instrument is given then give the subgraph below it. -->
+
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filter = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+
+        <!-- Continue instrument give deeper into subgraph. -->
+
+        <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <!-- Give emission and excitation filter links if both parent and child are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[ED].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[ED].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[ED].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[ED].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+
+        <!-- Delete remaining emission and excitation filter links if either parent or child is deleted. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].child = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].child = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].child = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [D]" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].child = [D]" p:changes="L:[D]"/>
+
+        <!-- Delete remaining emission and excitation filter links if either parent or child is given in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].child = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].child = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].child = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I];perms=??-???" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].child = [I];perms=??-???" p:changes="L:[D]"/>
+
+        <!-- Give settings if both holder and underlying object are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[ED], S.detector = [I]"
+                                       p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[ED], S.lightSource = [I]"
+                                       p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[ED], S.objective = [I]"
+                                       p:changes="S:[I]"/>
+
+        <!-- Delete settings if only the underlying object is given in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I];perms=??-???" p:changes="S:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I];perms=??-???" p:changes="S:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I];perms=??-???" p:changes="S:[D]"/>
+
+        <!-- Images may be given only if doing so would not remove an imaging environment from any of them. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{r}.imagingEnvironment = IE:[E]{i}" p:changes="IE:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]{i}" p:changes="IE:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.imagingEnvironment = IE:[E]{r}" p:changes="IE:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="IE:ImagingEnvironment[E]{o}" p:changes="IE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I1:Image[I].imagingEnvironment = IE:[EI];perms=??-???, I2:Image[E].imagingEnvironment = IE"
+                                       p:error="may not give {I1} while {I2} remains as they share {IE}"/>
+
+        <!-- Cannot give image with other user's imaging environment in private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image.imagingEnvironment =/!o IE:[E]{r};perms=??-???" p:changes="IE:{a}"/>
+
+        <!-- If an imaging environment cannot be given then nor can images that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{r}.imagingEnvironment = [E]{a}" p:changes="I:{a}"/>
+
+        <!-- Images may be given only if doing so would not remove an instrument from any of them. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{r}.instrument = IN:[E]{i}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]{i}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.instrument = IN:[E]{r}" p:changes="IN:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{o}" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I1:Image[I].instrument = IN:[EI];perms=??-???, I2:Image[E].instrument = IN"
+                                       p:error="may not give {I1} while {I2} remains as they share {IN}"/>
+
+        <!-- Cannot give image with other user's instrument in private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image.instrument =/!o IN:[E]{r};perms=??-???" p:changes="IN:{a}"/>
+
+        <!-- If an instrument cannot be given then nor can images that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{r}.instrument = [E]{a}" p:changes="I:{a}"/>
+
+        <!-- Give light path if all the filters are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink.parent = LP:[E]{i}, L.child = [I]"
+                                       p:changes="LP:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink.parent = LP:[E]{i}, L.child = [I]"
+                                       p:changes="LP:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink.parent = LP:[E]{r}, L.child = [E]"
+                                       p:changes="LP:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink.parent = LP:[E]{r}, L.child = [E]"
+                                       p:changes="LP:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{o}" p:changes="LP:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{a}" p:error="may not give some but not all of {LP}'s filters"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[!O]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[!O]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[!O]" p:changes="S:[-]"/>
+
+        <!-- ANNOTATIONS -->
+
+        <!--
+             If an annotated object is deleted or given then consider deleting or giving its basic or comment annotations regardless
+             of permissions.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = [DI], L.child = A:BasicAnnotation[E]{i}"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = [DI], L.child = A:CommentAnnotation[E]{i}"
+                                       p:changes="A:{r}"/>
+
+        <!--
+             If an annotated object is deleted or given then consider its file or tag annotations for deletion or giving only if
+             they are owned by the object's owner.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/d, X =/o A"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/d, X =/o A"
+                                       p:changes="A:{r}"/>
+
+        <!-- If an annotated object is deleted or given then consider its list, map, or XML annotations for deletion or giving. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = [DI], L.child = A:ListAnnotation[E]{i}"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = [DI], L.child = A:MapAnnotation[E]{i}"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = [DI], L.child = A:XmlAnnotation[E]{i}"
+                                       p:changes="A:{r}"/>
+
+        <!-- In considering deleting or giving an annotation then do not delete the annotation if it remains linked. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [E]{ia}, L.child = A:Annotation[E]{r}"
+                                       p:changes="A:{a}"/>
+
+        <!-- Do not delete nor give orphaned file or tag annotations that are not owned by the deleted or given object's owner.. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{!a}, X =/!o A"
+                                       p:changes="A:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{!a}, X =/!o A"
+                                       p:changes="A:{a}"/>
+
+        <!-- Delete or give orphaned annotations that are owned by the deleted or given object's owner. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}, X =/o A"
+                                       p:changes="A:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D], X =/o A"
+                                       p:changes="A:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[D], L.child = A:Annotation[E]{o}, X =/o A"
+                                       p:changes="A:[D]"/>
+
+        <!-- Delete remaining orphaned annotations in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o};perms=??-???" p:changes="A:[D]"/>
+
+        <!-- If an original file is given then any corresponding file annotation must also be given. -->
+
+        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E].file = OF:[I]" p:error="may not give {OF} while used by {A}"/>
+
+        <!-- If both parent and child are given then give the annotation link regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[ED].parent = [I], L.child = [I]" p:changes="L:[I]/n"/>
+
+        <!-- If an annotation link's parent or child is deleted then delete the link regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = [D]" p:changes="L:[D]/n"/>
+
+        <!-- If an annotation link is to become cross-owner in a private group then delete it regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [E];perms=??-???, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I];perms=??-???, L.child = [E]{!r}"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
+
+        <!-- CONTAINERS -->
+
+        <!-- If a container is given then consider its contents for giving if its owner is the same. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}, P =/o D"
+                                       p:changes="D:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}, D =/o I"
+                                       p:changes="I:{r}"/>
+
+        <!-- If a container is given then consider its contents for giving if they are deletable and not going to a private group. -->
+
+        <!-- In considering giving a container's contents, do not give an object if it is in another container. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E]{ia}, L.child = D:[E]{r}" p:changes="D:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
+
+        <!-- A private group cannot have container and contents differently owned. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I];perms=??-???, L.child = D:[E]{r}, P =/!o D"
+                                       p:changes="D:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=??-???, L.child = I:[E]{r}, D =/!o I"
+                                       p:changes="I:{a}"/>
+
+        <!-- Give orphaned datasets. -->
+
+        <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/o" p:changes="D:[I]"/>
+
+        <!--
+             If a project, dataset or image is given for both sides of a link then, regardless of permissions, give the link if
+             same owners or not in private group.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent = P:[I], L.child = D:[I], P =/o D"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent = D:[I], L.child = I:[I], D =/o I"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=??r???, L.child = [I]"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=??r???, L.child = [I]"
+                                       p:changes="L:[I]/n"/>
+
+        <!--
+             If a project, dataset or image is given then delete any remaining cross-owner links regardless of permissions in a
+             private group.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=??-???, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E];perms=??-???, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=??-???, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=??-???, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
+
+        <!-- CORE -->
+
+        <!-- Give pixels link to archived files if both pixels and files are to be given. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[E].parent = OF:[I], L.child = [I]" p:changes="L:[I]"/>
+
+        <!-- Cannot break link from pixels to archived files. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[E].parent = OF:[E], L.child = P:[I]"
+                                       p:error="may not give {P} until {OF} can be given"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[E].parent = OF:[I], L.child = P:[E]"
+                                       p:error="may not give {OF} while {P} remains"/>
+
+        <!-- Consider deleting or giving an original file if it may be unlinked from an object. -->
+
+        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{i}.file = [E]{r}" p:changes="FA:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{i}.originalFile = [E]{r}" p:changes="FE:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{i}.source = [E]{r}" p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{i}, L.child = [E]{r}" p:changes="J:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{i}, L.parent = [E]{r}"
+                                       p:changes="P:[E]{r}"/>
+
+        <!-- Consider deleting or giving an original file if it is unlinked from an object. -->
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [I], L.child = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [I], L.parent = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+
+        <!-- Do not give an original file that is being used by an object. -->
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[E]{ia}.file = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[E]{ia}.originalFile = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[E]{ia}.source = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [E]{ia}, L.child = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [E]{ia}, L.parent = OF:[E]{r}"
                                        p:changes="OF:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].child = C:!Job[E]{r}/!d" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:TagAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="A:TermAnnotation[E]{r}/!o" p:changes="A:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[!O].parent = [E], L.child = C:!Pixels[E]{r}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="!ILink[E]{ia} = X:!ILink[E]{r}" p:changes="X:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="X:[E]{r} == [E]{a}" p:changes="X:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="[I].instrument == I:Instrument[E]{r}" p:changes="I:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="C:Channel[E]{r}.pixels = Pixels[E]{i}" p:changes="C:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [I], L.child = [E]{a}" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E].parent = [E], L.child = [I]" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ILink[E]{a}.parent = [I]" p:changes="L:[O]"/>
+        <bean parent="graphPolicyRule" p:matches="OF:OriginalFile[E]{a}" p:error="cannot give {OF} while objects using it remain"/>
+
+        <!-- If an original file is orphaned then give it. -->
+
+        <bean parent="graphPolicyRule" p:matches="OF:OriginalFile[E]{o}" p:changes="OF:[I]"/>
+
+        <!-- If an original file cannot be given then nor can objects that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{r}.file = [E]{a}" p:changes="FA:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{r}.originalFile = [E]{a}" p:changes="FE:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{r}.source = [E]{a}" p:changes="ROI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}"
+                                       p:changes="P:[E]{a}"/>
+
+        <!-- Delete remaining settings if holder object is given but not the settings in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E];perms=??-???" p:changes="DS:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E];perms=??-???" p:changes="LS:[D]"/>
+
+        <!-- Give a stage label only if all the images using it are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{r}.stageLabel = SL:[E]{i}" p:changes="SL:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]{i}" p:changes="SL:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.stageLabel = SL:[E]{r}" p:changes="SL:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="SL:StageLabel[E]{o}" p:changes="SL:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I1:Image[I].stageLabel = SL:[EI];perms=??-???, I2:Image[E].stageLabel = SL"
+                                       p:error="may not give {I1} while {I2} remains as they share {SL}"/>
+
+        <!-- If a stage label cannot be given then nor can images that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{r}.stageLabel = [E]{a}" p:changes="I:{a}"/>
+
+        <!-- If an image is given then give the subgraph below it. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <!-- Delete remaining settings if holder object is given but not the settings in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = OS:[E];perms=??-???" p:changes="OS:[D]"/>
+
+        <!-- Give orphaned images. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/o" p:changes="I:[I]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
+
+        <!-- DISPLAY -->
+
+        <!-- Give rendering settings only in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].settings = RD:[E];perms=??-???" p:changes="RD:[I]"/>
+
+        <!-- If rendering settings are given then give the subgraph below. -->
+
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+
+        <!-- Give thumbnails only in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails = T:[E];perms=??-???" p:changes="T:[I]"/>
+
+        <!-- EXPERIMENT -->
+
+        <!--
+             Give an experiment regardless of permissions only if giving all images that use it, and not in private group yet used
+             by differently owned image.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{r}.experiment = E:[E]{i}" p:changes="E:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment = E:[E]{i}" p:changes="E:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment =/!o E:[E]{r}" p:changes="E:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.experiment = E:[E]{r}" p:changes="E:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment =/o E:[E]{o}" p:changes="E:[I]"/>
+
+        <!-- If an experiment is given then give associated microbeam manipulation. -->
+
+        <bean parent="graphPolicyRule" p:matches="Experiment[I].microbeamManipulation = M:[E]" p:changes="M:[I]"/>
+
+        <!-- Cannot give experiment without associated images. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].experiment = E:[I];perms=??-???"
+                                       p:error="cannot give {E} while {I} remains"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[I].experiment =/!o E:[EI];perms=??-???"
+                                       p:error="cannot give {I} while linked to {E}"/>
+        <bean parent="graphPolicyRule" p:matches="I1:Image[I].experiment = E:[EI];perms=??-???, I2:Image[E].experiment = E"
+                                       p:error="cannot give {I1} while {I2} remains as they share {E}"/>
+
+        <!-- If an experiment cannot be given then nor can images that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E]{r}.experiment = [E]{a}" p:changes="I:{a}"/>
+
+        <!-- FS -->
+
+        <!-- If a fileset is given then give the subgraph below, down to the linked jobs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].images = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].usedFiles = FE:[E]" p:changes="FE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].jobLinks = L:[E]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].child = J:[E]" p:changes="J:[I]"/>
+
+        <!-- A fileset may be given by means of its images only if all of its images are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{i}.images = [I]" p:changes="F:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{r}.images = [E]{ia}" p:changes="F:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{o}" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E].images = I1:[I], F.images = I2:[E]"
+                                       p:error="within {F} may not give {I1} while {I2} remains"/>
+
+        <!-- Considering an image for giving entails considering its fileset for giving. -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{i}.images = [E]{r}" p:changes="F:{r}"/>
+
+        <!-- If a fileset is not to be given then nor are its images. -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{a}.images = I:[E]{r}" p:changes="I:{a}"/>
+
+        <!-- JOB -->
+
+        <!-- Give job link to original file if both job and file are to be given. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[I], L.child = [I]" p:changes="L:[I]"/>
+
+        <!-- Cannot break link from job to original file. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[E], L.child = OF:[I]"
+                                       p:error="may not give {OF} until {J} can be given"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[I], L.child = OF:[E]"
+                                       p:error="may not give {J} while {OF} remains"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
+
+        <!-- META -->
+
+        <!-- If an object is deleted or given then also delete or give its external info regardless of permissions. -->
+
+        <bean parent="graphPolicyRule" p:matches="[D].details.externalInfo = EI:[E]" p:changes="EI:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="[I].details.externalInfo = EI:[E]" p:changes="EI:[I]/n"/>
+
+        <!-- ROI -->
+
+        <!-- Give the ROIs of the owner of a given image. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]" p:changes="ROI:[I]"/>
+
+        <!-- Cannot give ROI out of image in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].rois = ROI:[I];perms=??-???"
+                                       p:error="cannot give {ROI} while {I} remains"/>
+
+        <!-- Give contained objects: shapes of given ROIs, pixels of given masks. -->
+
+        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E]" p:changes="P:[I]"/>
+
+        <!-- SCREEN -->
+
+        <!-- If a field is given then consider giving its image. -->
+
+        <bean parent="graphPolicyRule" p:matches="WellSample[I].image = I:[E]{i}" p:changes="I:{r}"/>
+
+        <!-- In considering giving an image, do not give it if it is used for a field that is not to be given. -->
+
+        <bean parent="graphPolicyRule" p:matches="WellSample[E]{ia}.image = I:[E]{r}" p:changes="I:{a}"/>
+
+        <!-- Cannot give image in a private group if it is used for a differently owned field. -->
+
+        <bean parent="graphPolicyRule" p:matches="WS:WellSample.image =/!o I:[I];perms=??-???"
+              p:error="may not give {I} as {WS} has a different owner"/>
+
+        <!-- Give images and corresponding well samples only together. -->
+
+        <bean parent="graphPolicyRule" p:matches="WS:WellSample[E].image = I:[I];perms=??-???"
+                                       p:error="may not give {I} while {WS} remains"/>
+        <bean parent="graphPolicyRule" p:matches="WS:WellSample[I].image = I:[E];perms=??-???"
+                                       p:error="may not give {WS} while {I} remains"/>
+
+        <!-- Give a reagent only if also giving screens and wells that use it. -->
+
+        <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = [I], L.child = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:Screen[I].reagents = R:[E]{a}" p:error="may not give {R} without {S}"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink.parent = W:[E];perms=??-???, L.child = R:[E]{a}"
+                                       p:error="may not give {R} without {W}"/>
+
+        <!-- Cannot give screen in a private group if it uses a differently owned reagent. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:Screen[I].reagents =/!o R:Reagent;perms=??-???"
+                                       p:error="may not give {S} while it uses differently owned {R}"/>
+
+        <!-- If a screen is given then also give the plate if it is used in no other screen. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [I], L.child = P:[E]{i}/o" p:changes="P:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}" p:changes="P:[I]"/>
+
+        <!--
+             If a screen and plate are given for both sides of a link then, regardless of permissions, give the link if same owners
+             or not to private group.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[ED].parent = S:[I], L.child = P:[I], S =/o P"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I];perms=??r???, L.child = [I]"
+                                       p:changes="L:[I]/n"/>
+
+        <!-- If a screen or plate are given then delete their remaining links regardless of permissions in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I];perms=??-???, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E];perms=??-???, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+
+        <!-- Give contained objects: wells and runs of plates, fields of wells and runs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Plate[I].wells = W:[E]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:[E]" p:changes="WS:[I]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[!O]" p:changes="L:[-]"/>
+
+        <!-- STATS -->
+
+        <!-- Give stats info only if owned by channel owner and all its channels are given. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].statsInfo =/o SI:[E]{i}" p:changes="SI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[E].statsInfo = SI:[E]{r}" p:changes="SI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[I].statsInfo =/o SI:[E]{o}" p:changes="SI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="C1:Channel[I].statsInfo = SI:[EI];perms=??-???, C2:Channel[E].statsInfo = SI"
+                                       p:error="may not give {C1} while {C2} remains as they share {SI}"/>
+
     </util:list>
 
 </beans>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -449,6 +449,7 @@
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
 
         <!-- DISPLAY -->
@@ -548,19 +549,23 @@
 
         <!-- ROI -->
 
-        <!-- Give the ROIs of the owner of a given image. -->
+        <!-- Give the ROIs, shapes and mask images of the owner of a given image. -->
 
         <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]" p:changes="I:[I]"/>
 
-        <!-- Cannot give ROI out of image in a private group. -->
+        <!-- Cannot give ROI out of image in a private or read-only group. -->
 
-        <bean parent="graphPolicyRule" p:matches="I:Image[E].rois = ROI:[I];perms=??-???"
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].rois = ROI:[I];perms=???-??"
                                        p:error="cannot give {ROI} while {I} remains"/>
 
-        <!-- Give contained objects: shapes of given ROIs, pixels of given masks. -->
+        <!-- Cannot separate mask from its image in a private group. -->
 
-        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="M:Mask[I].pixels = P:[E];perms=??-???, P.image = I:[E]"
+                                       p:error="cannot give {M} while {I} remains"/>
+        <bean parent="graphPolicyRule" p:matches="M:Mask[E].pixels = P:[I];perms=??-???, P.image = I:[I]"
+                                       p:error="cannot give {I} while {M} remains"/>
 
         <!-- SCREEN -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -300,18 +300,20 @@
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}, D =/o I"
                                        p:changes="I:{r}"/>
 
-        <!-- If a container is given then consider its contents for giving if they are deletable and not going to a private group. -->
-
         <!-- In considering giving a container's contents, do not give an object if it is in another container. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E]{ia}, L.child = D:[E]{r}" p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
 
-        <!-- A private group cannot have container and contents differently owned. -->
+        <!-- Only a read-write group may have container and contents differently owned. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I];perms=??-???, L.child = D:[E]{r}, P =/!o D"
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I];perms=???-??, L.child = D:[E]{r}, P =/!o D"
                                        p:changes="D:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=??-???, L.child = I:[E]{r}, D =/!o I"
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=???-??, L.child = I:[E]{r}, D =/!o I"
+                                       p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I];perms=???a??, L.child = D:[E]{r}, P =/!o D"
+                                       p:changes="D:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=???a??, L.child = I:[E]{r}, D =/!o I"
                                        p:changes="I:{a}"/>
 
         <!-- Give orphaned datasets. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -394,17 +394,16 @@
         <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{i}.file = [E]{r}" p:changes="FA:{r}"/>
         <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{i}.originalFile = [E]{r}" p:changes="FE:{r}"/>
         <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{i}.source = [E]{r}" p:changes="ROI:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{i}, L.child = [E]{r}" p:changes="J:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{i}, L.parent = [E]{r}"
-                                       p:changes="P:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{i}, L.child = [E]{r}" p:changes="J:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{i}, L.parent = [E]{r}" p:changes="P:{r}"/>
 
         <!-- Consider deleting or giving an original file if it is unlinked from an object. -->
 
-        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [I], L.child = OF:[E]{i}" p:changes="OF:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [I], L.parent = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [I], L.child = OF:[E]{i}" p:changes="OF:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [I], L.parent = OF:[E]{i}" p:changes="OF:{r}"/>
 
         <!-- Do not give an original file that is being used by an object. -->
 
@@ -425,9 +424,8 @@
         <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E]{r}.file = [E]{a}" p:changes="FA:{a}"/>
         <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E]{r}.originalFile = [E]{a}" p:changes="FE:{a}"/>
         <bean parent="graphPolicyRule" p:matches="ROI:Roi[E]{r}.source = [E]{a}" p:changes="ROI:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:[E]{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}"
-                                       p:changes="P:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}" p:changes="P:{a}"/>
 
         <!-- Delete remaining settings if holder object is given but not the settings in a private group. -->
 
@@ -624,8 +622,8 @@
 
         <!-- If a screen is given then also give the plate if it is used in no other screen. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [I], L.child = P:[E]{i}/o" p:changes="P:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [I], L.child = P:[E]{i}/o" p:changes="P:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}" p:changes="P:[I]"/>
 
         <!--

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -333,17 +333,25 @@
                                        p:changes="L:[I]/n"/>
 
         <!--
-             If a project, dataset or image is given then delete any remaining cross-owner links regardless of permissions in a
-             private group.
+             If a project, dataset or image is given then delete any remaining cross-owner links regardless of permissions
+             outside read-write groups.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=??-???, L.child = [E]{ia}"
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=???-??, L.child = [E]{ia}"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E];perms=??-???, L.child = [I]"
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E];perms=???-??, L.child = [I]"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=??-???, L.child = [E]{ia}"
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=???-??, L.child = [E]{ia}"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=??-???, L.child = [I]"
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=???-??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=???a??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E];perms=???a??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=???a??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=???a??, L.child = [I]"
                                        p:changes="L:[D]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -103,6 +103,21 @@
         <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
 
+        <!-- An instrument may not be linked directly to the image, so note relevance via settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[ED], S.detector = D:[E]{i}"
+                                       p:changes="D:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[ED], S.lightSource = LS:[E]{i}"
+                                       p:changes="LS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[ED], S.objective = O:[E]{i}"
+                                       p:changes="O:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [I]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [I]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [I]" p:changes="IN:{r}"/>
+
         <!-- Give emission and excitation filter links if both parent and child are given. -->
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[ED].parent = [I], L.child = [I]"

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -351,6 +351,10 @@
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/d" p:changes="I:[D]"/>
 
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
+
         <!-- DISPLAY -->
 
         <!-- If rendering settings are deleted then delete the subgraph below. -->
@@ -415,11 +419,11 @@
 
         <!-- ROI -->
 
-        <!-- Delete contained objects: ROIs of deleted images, shapes of deleted ROIs, pixels of deleted masks. -->
+        <!-- Delete contained objects: ROIs of deleted images, shapes of deleted ROIs, pixels of deleted masks if possible. -->
 
         <bean parent="graphPolicyRule" p:matches="Image[D].rois = ROI:[E]" p:changes="ROI:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E]" p:changes="P:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E], P.image = I:[E]{i}/d" p:changes="I:{r}"/>
 
         <!-- SCREEN -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -307,7 +307,7 @@
         <bean parent="graphPolicyRule" p:matches="FilesetEntry[D].originalFile = OF:[E]{i}" p:changes="OF:{r}"/>
         <bean parent="graphPolicyRule" p:matches="JobOriginalFileLink[D].child = OF:[E]{i}" p:changes="OF:{r}"/>
         <bean parent="graphPolicyRule" p:matches="PixelsOriginalFileMap[D].parent = OF:[E]{i}" p:changes="OF:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Roi[D].source = OF:[E]{i}" p:changes="OF:[E]{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[D].source = OF:[E]{i}" p:changes="OF:{r}"/>
 
         <!-- Consider deleting an original file if it is linked to a job that is deleted. -->
 
@@ -471,8 +471,8 @@
 
         <!-- If a screen is deleted then also delete the plate if it is used in no other screen. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [D], L.child = P:[E]{i}/d" p:changes="P:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = [D], L.child = P:[E]{i}/d" p:changes="P:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}/d" p:changes="P:[D]"/>
 
         <!-- Delete screen-plate links if either the screen or plate is deleted regardless of permissions. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -132,6 +132,21 @@
         <bean parent="graphPolicyRule" p:matches="OTF[D].filterSet = FS:[E]" p:changes="FS:[D]"/>
         <bean parent="graphPolicyRule" p:matches="OTF[D].objective = O:[E]" p:changes="O:[D]"/>
 
+        <!-- An instrument may not be linked directly to the image, so note relevance via settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].detectorSettings = S:[ED], S.detector = D:[E]{i}"
+                                       p:changes="D:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].lightSourceSettings = S:[ED], S.lightSource = LS:[E]{i}"
+                                       p:changes="LS:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[D].objectiveSettings = S:[ED], S.objective = O:[E]{i}"
+                                       p:changes="O:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [E]{o}" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.detector = [D]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.lightSource = [D]" p:changes="IN:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E]{i}.objective = [D]" p:changes="IN:{r}"/>
+
         <!-- Delete emission and excitation filter links if either parent or child is deleted. -->
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [D]" p:changes="L:[D]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -366,10 +366,6 @@
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/d" p:changes="I:[D]"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="P:Pixels[!O]" p:changes="P:[-]"/>  <!-- for ROI masks -->
-
         <!-- DISPLAY -->
 
         <!-- If rendering settings are deleted then delete the subgraph below. -->
@@ -438,6 +434,7 @@
 
         <bean parent="graphPolicyRule" p:matches="Image[D].rois = ROI:[E]" p:changes="ROI:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E], P.image = I:[E]{i}/d" p:changes="I:{r}"/>
 
         <!-- SCREEN -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -477,8 +477,8 @@
 
         <!-- If the last channel referencing stats info is deleted then delete the stats info itself regardless of permissions. -->
 
-        <bean parent="graphPolicyRule" p:matches="Channel[D].statsInfo = SI:[E]{i}" p:changes="SI:[E]{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Channel[E].statsInfo = SI:[E]{r}" p:changes="SI:[E]{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[D].statsInfo = SI:[E]{i}" p:changes="SI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[E].statsInfo = SI:[E]{r}" p:changes="SI:{a}"/>
         <bean parent="graphPolicyRule" p:matches="SI:StatsInfo[E]{o}" p:changes="SI:[D]/n"/>
 
     </util:list>

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
@@ -29,6 +29,7 @@ import org.hibernate.Session;
 import ome.model.IObject;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphPolicyRulePredicate;
 
 /**
  * The base class assists adjustment of an existing graph traversal policy.
@@ -73,6 +74,16 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
      */
     protected boolean isBlockedFromAdjustment(Details object) {
         return false;
+    }
+
+    @Override
+    public void registerPredicate(GraphPolicyRulePredicate predicate) {
+        graphPolicy.registerPredicate(predicate);
+    }
+
+    @Override
+    public GraphPolicy getCleanInstance() {
+        return graphPolicy.getCleanInstance();
     }
 
     @Override

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -49,6 +49,7 @@ import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
+import ome.services.graphs.PermissionsPredicate;
 import ome.system.EventContext;
 import ome.system.Login;
 import omero.cmd.Chown2;
@@ -144,6 +145,8 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);
         }
         graphPolicyAdjusters = null;
+
+        graphPolicyWithOptions.registerPredicate(new PermissionsPredicate());
 
         graphTraversal = new GraphTraversal(helper.getSession(), eventContext, aclVoter, systemTypes, graphPathBean, unnullable,
                 graphPolicyWithOptions, dryRun ? new NullGraphTraversalProcessor(REQUIRED_ABILITIES) : new InternalProcessor());

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadPolicy.java
@@ -39,6 +39,7 @@ import ome.model.IObject;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphPolicyRulePredicate;
 import omero.cmd.SkipHead;
 
 /**
@@ -99,6 +100,11 @@ public class SkipHeadPolicy {
         /* construct the function corresponding to the model graph descent truncation */
 
         return new GraphPolicy() {
+            @Override
+            public void registerPredicate(GraphPolicyRulePredicate predicate) {
+                graphPolicy.registerPredicate(predicate);
+            }
+
             @Override
             public GraphPolicy getCleanInstance() {
                 throw new IllegalStateException("not expecting to provide a clean instance");

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -21,6 +21,7 @@ package ome.services.graphs;
 
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -177,11 +178,22 @@ public abstract class GraphPolicy {
     }
 
     /**
-     * A stateful graph policy must override this method to provide a clone that has fresh state.
+     * The predicates that have been registered with {@link GraphPolicy#registerPredicate(GraphPolicyRulePredicate)}.
+     */
+    protected final Map<String, GraphPolicyRulePredicate> predicates = new HashMap<String, GraphPolicyRulePredicate>();
+
+    /**
+     * Create a clone of this graph policy that has fresh state.
      * @return an instance ready to begin a new graph traversal
      */
-    public GraphPolicy getCleanInstance() {
-        return this;
+    public abstract GraphPolicy getCleanInstance();
+
+    /**
+     * Use the given predicate in executing this graph policy.
+     * @param predicate a graph policy predicate
+     */
+    public void registerPredicate(GraphPolicyRulePredicate predicate) {
+        predicates.put(predicate.getName(), predicate);
     }
 
     /**
@@ -207,7 +219,9 @@ public abstract class GraphPolicy {
      * @param id the ID of the object
      */
     public void noteDetails(Session session, IObject object, String realClass, long id) {
-        /* This method is a no-op that subclasses may override. */
+        for (final GraphPolicyRulePredicate predicate : predicates.values()) {
+            predicate.noteDetails(session, object, realClass, id);
+        }
     }
 
     /**

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -851,239 +851,239 @@ public class GraphPolicyRule {
             }
             return changedObjects;
         }
-    }
 
-    /**
-     * If there is only a single match, the policy rule may apply multiple times to the root object,
-     * through applying to multiple properties or to collection properties.
-     * @param linkedFrom details of the objects linking to the root object, by property
-     * @param rootObject details of the root objects
-     * @param linkedTo details of the objects linked by the root object, by property
-     * @param notNullable which properties are not nullable
-     * @param policyRule the policy rule to consider applying
-     * @param changedObjects the set of details of objects that result from applied changes
-     * @throws GraphException if a term named for a change is not defined in the matching
-     */
-    private static void reviewWithSingleMatch(Map<String, Set<Details>> linkedFrom,
-            Details rootObject, Map<String, Set<Details>> linkedTo, Set<String> notNullable,
-            ParsedPolicyRule policyRule, Set<Details> changedObjects) throws GraphException {
-        final SortedMap<String, Details> namedTerms = new TreeMap<String, Details>();
-        final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
-        if (!policyRule.termMatchers.isEmpty()) {
-            /* apply the term matchers */
-            final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
-            for (final TermMatch matcher : policyRule.termMatchers) {
-                for (final Details object : allTerms) {
-                    if (matcher.isMatch(namedTerms, isCheckAllPermissions, object)) {
-                        recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
-                        namedTerms.clear();
-                        isCheckAllPermissions.setValue(true);
-                    }
-                }
-            }
-        }
-        /* apply the relationship matchers */
-        for (final RelationshipMatch matcher : policyRule.relationshipMatchers) {
-            /* consider the root object as the linked object */
-            for (final Entry<String, Set<Details>> dataPerProperty : linkedFrom.entrySet()) {
-                final String classProperty = dataPerProperty.getKey();
-                final boolean isNotNullable = notNullable.contains(classProperty);
-                for (final Details linkerObject : dataPerProperty.getValue()) {
-                    if (matcher.isMatch(namedTerms, isCheckAllPermissions,
-                            linkerObject, rootObject, classProperty, isNotNullable)) {
-                        recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
-                        namedTerms.clear();
-                        isCheckAllPermissions.setValue(true);
-                    }
-                }
-            }
-            /* consider the root object as the linker object */
-            for (final Entry<String, Set<Details>> dataPerProperty : linkedTo.entrySet()) {
-                final String classProperty = dataPerProperty.getKey();
-                final boolean isNotNullable = notNullable.contains(classProperty);
-                for (final Details linkedObject : dataPerProperty.getValue()) {
-                    if (matcher.isMatch(namedTerms, isCheckAllPermissions,
-                            rootObject, linkedObject, classProperty, isNotNullable)) {
-                        recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
-                        namedTerms.clear();
-                        isCheckAllPermissions.setValue(true);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * If there are multiple matches, the policy rule may apply only once to the root object.
-     * Terms named in any of the matches may be used in any of the changes.
-     * @param linkedFrom details of the objects linking to the root object, by property
-     * @param rootObject details of the root objects
-     * @param linkedTo details of the objects linked by the root object, by property
-     * @param notNullable which properties are not nullable
-     * @param policyRule the policy rule to consider applying
-     * @param changedObjects the set of details of objects that result from applied changes
-     * @throws GraphException if a term named for a change is not defined in the matching
-     */
-    private static void reviewWithManyMatches(Map<String, Set<Details>> linkedFrom,
-            Details rootObject, Map<String, Set<Details>> linkedTo, Set<String> notNullable,
-            ParsedPolicyRule policyRule, Set<Details> changedObjects) throws GraphException {
-        final SortedMap<String, Details> namedTerms = new TreeMap<String, Details>();
-        final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
-        final Set<TermMatch> unmatchedTerms = new HashSet<TermMatch>(policyRule.termMatchers);
-        final Set<Details> allTerms = unmatchedTerms.isEmpty() ? Collections.<Details>emptySet()
-                : GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
-        final Set<RelationshipMatch> unmatchedRelationships = new HashSet<RelationshipMatch>(policyRule.relationshipMatchers);
-        /* try all the matchers against all the terms */
-        do {
-            final int namedTermCount = namedTerms.size();
-            Iterator<TermMatch> unmatchedTermIterator;
-            Iterator<RelationshipMatch> unmatchedRelationshipIterator;
-            /* apply the term matchers */
-            unmatchedTermIterator = unmatchedTerms.iterator();
-            while (unmatchedTermIterator.hasNext()) {
-                final TermMatch matcher = unmatchedTermIterator.next();
-                for (final Details object : allTerms) {
-                    if (matcher.isMatch(namedTerms, isCheckAllPermissions, object)) {
-                        unmatchedTermIterator.remove();
-                    }
-                }
-            }
-            /* consider the root object as the linked object */
-            for (final Entry<String, Set<Details>> dataPerProperty : linkedFrom.entrySet()) {
-                final String classProperty = dataPerProperty.getKey();
-                final boolean isNotNullable = notNullable.contains(classProperty);
-                for (final Details linkerObject : dataPerProperty.getValue()) {
-                    unmatchedTermIterator = unmatchedTerms.iterator();
-                    while (unmatchedTermIterator.hasNext()) {
-                        final TermMatch matcher = unmatchedTermIterator.next();
-                        if (matcher.isMatch(namedTerms, isCheckAllPermissions, linkerObject)) {
-                            unmatchedTermIterator.remove();
+        /**
+         * If there is only a single match, the policy rule may apply multiple times to the root object,
+         * through applying to multiple properties or to collection properties.
+         * @param linkedFrom details of the objects linking to the root object, by property
+         * @param rootObject details of the root objects
+         * @param linkedTo details of the objects linked by the root object, by property
+         * @param notNullable which properties are not nullable
+         * @param policyRule the policy rule to consider applying
+         * @param changedObjects the set of details of objects that result from applied changes
+         * @throws GraphException if a term named for a change is not defined in the matching
+         */
+        private void reviewWithSingleMatch(Map<String, Set<Details>> linkedFrom,
+                Details rootObject, Map<String, Set<Details>> linkedTo, Set<String> notNullable,
+                ParsedPolicyRule policyRule, Set<Details> changedObjects) throws GraphException {
+            final SortedMap<String, Details> namedTerms = new TreeMap<String, Details>();
+            final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
+            if (!policyRule.termMatchers.isEmpty()) {
+                /* apply the term matchers */
+                final Set<Details> allTerms = GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
+                for (final TermMatch matcher : policyRule.termMatchers) {
+                    for (final Details object : allTerms) {
+                        if (matcher.isMatch(namedTerms, isCheckAllPermissions, object)) {
+                            recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
+                            namedTerms.clear();
+                            isCheckAllPermissions.setValue(true);
                         }
                     }
-                    unmatchedRelationshipIterator = unmatchedRelationships.iterator();
-                    while (unmatchedRelationshipIterator.hasNext()) {
-                        final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
+                }
+            }
+            /* apply the relationship matchers */
+            for (final RelationshipMatch matcher : policyRule.relationshipMatchers) {
+                /* consider the root object as the linked object */
+                for (final Entry<String, Set<Details>> dataPerProperty : linkedFrom.entrySet()) {
+                    final String classProperty = dataPerProperty.getKey();
+                    final boolean isNotNullable = notNullable.contains(classProperty);
+                    for (final Details linkerObject : dataPerProperty.getValue()) {
                         if (matcher.isMatch(namedTerms, isCheckAllPermissions,
                                 linkerObject, rootObject, classProperty, isNotNullable)) {
-                            unmatchedRelationshipIterator.remove();
+                            recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
+                            namedTerms.clear();
+                            isCheckAllPermissions.setValue(true);
+                        }
+                    }
+                }
+                /* consider the root object as the linker object */
+                for (final Entry<String, Set<Details>> dataPerProperty : linkedTo.entrySet()) {
+                    final String classProperty = dataPerProperty.getKey();
+                    final boolean isNotNullable = notNullable.contains(classProperty);
+                    for (final Details linkedObject : dataPerProperty.getValue()) {
+                        if (matcher.isMatch(namedTerms, isCheckAllPermissions,
+                                rootObject, linkedObject, classProperty, isNotNullable)) {
+                            recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
+                            namedTerms.clear();
+                            isCheckAllPermissions.setValue(true);
                         }
                     }
                 }
             }
-            /* consider the root object as the linker object */
-            for (final Entry<String, Set<Details>> dataPerProperty : linkedTo.entrySet()) {
-                final String classProperty = dataPerProperty.getKey();
-                final boolean isNotNullable = notNullable.contains(classProperty);
-                for (final Details linkedObject : dataPerProperty.getValue()) {
-                    unmatchedTermIterator = unmatchedTerms.iterator();
-                    while (unmatchedTermIterator.hasNext()) {
-                        final TermMatch matcher = unmatchedTermIterator.next();
-                        if (matcher.isMatch(namedTerms, isCheckAllPermissions, linkedObject)) {
+        }
+
+        /**
+         * If there are multiple matches, the policy rule may apply only once to the root object.
+         * Terms named in any of the matches may be used in any of the changes.
+         * @param linkedFrom details of the objects linking to the root object, by property
+         * @param rootObject details of the root objects
+         * @param linkedTo details of the objects linked by the root object, by property
+         * @param notNullable which properties are not nullable
+         * @param policyRule the policy rule to consider applying
+         * @param changedObjects the set of details of objects that result from applied changes
+         * @throws GraphException if a term named for a change is not defined in the matching
+         */
+        private void reviewWithManyMatches(Map<String, Set<Details>> linkedFrom,
+                Details rootObject, Map<String, Set<Details>> linkedTo, Set<String> notNullable,
+                ParsedPolicyRule policyRule, Set<Details> changedObjects) throws GraphException {
+            final SortedMap<String, Details> namedTerms = new TreeMap<String, Details>();
+            final MutableBoolean isCheckAllPermissions = new MutableBoolean(true);
+            final Set<TermMatch> unmatchedTerms = new HashSet<TermMatch>(policyRule.termMatchers);
+            final Set<Details> allTerms = unmatchedTerms.isEmpty() ? Collections.<Details>emptySet()
+                    : GraphPolicy.allObjects(linkedFrom.values(), rootObject, linkedTo.values());
+            final Set<RelationshipMatch> unmatchedRelationships = new HashSet<RelationshipMatch>(policyRule.relationshipMatchers);
+            /* try all the matchers against all the terms */
+            do {
+                final int namedTermCount = namedTerms.size();
+                Iterator<TermMatch> unmatchedTermIterator;
+                Iterator<RelationshipMatch> unmatchedRelationshipIterator;
+                /* apply the term matchers */
+                unmatchedTermIterator = unmatchedTerms.iterator();
+                while (unmatchedTermIterator.hasNext()) {
+                    final TermMatch matcher = unmatchedTermIterator.next();
+                    for (final Details object : allTerms) {
+                        if (matcher.isMatch(namedTerms, isCheckAllPermissions, object)) {
                             unmatchedTermIterator.remove();
                         }
                     }
-                    unmatchedRelationshipIterator = unmatchedRelationships.iterator();
-                    while (unmatchedRelationshipIterator.hasNext()) {
-                        final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
-                        if (matcher.isMatch(namedTerms, isCheckAllPermissions,
-                                rootObject, linkedObject, classProperty, isNotNullable)) {
-                            unmatchedRelationshipIterator.remove();
+                }
+                /* consider the root object as the linked object */
+                for (final Entry<String, Set<Details>> dataPerProperty : linkedFrom.entrySet()) {
+                    final String classProperty = dataPerProperty.getKey();
+                    final boolean isNotNullable = notNullable.contains(classProperty);
+                    for (final Details linkerObject : dataPerProperty.getValue()) {
+                        unmatchedTermIterator = unmatchedTerms.iterator();
+                        while (unmatchedTermIterator.hasNext()) {
+                            final TermMatch matcher = unmatchedTermIterator.next();
+                            if (matcher.isMatch(namedTerms, isCheckAllPermissions, linkerObject)) {
+                                unmatchedTermIterator.remove();
+                            }
+                        }
+                        unmatchedRelationshipIterator = unmatchedRelationships.iterator();
+                        while (unmatchedRelationshipIterator.hasNext()) {
+                            final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
+                            if (matcher.isMatch(namedTerms, isCheckAllPermissions,
+                                    linkerObject, rootObject, classProperty, isNotNullable)) {
+                                unmatchedRelationshipIterator.remove();
+                            }
                         }
                     }
                 }
-            }
-            /* match relationships among existing terms without any property link via the root object */
-            unmatchedRelationshipIterator = unmatchedRelationships.iterator();
-            while (unmatchedRelationshipIterator.hasNext()) {
-                final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
-                if (matcher.propertyName != null || matcher.notNullable != null) continue;
-                final String leftTermName = matcher.getExistingLeftTerm();
-                if (leftTermName == null) continue;
-                final String rightTermName = matcher.getExistingRightTerm();
-                if (rightTermName == null) continue;
-                final Details leftDetails = namedTerms.get(leftTermName);
-                if (leftDetails == null) continue;
-                final Details rightDetails = namedTerms.get(rightTermName);
-                if (rightDetails == null) continue;
-                if (matcher.isMatch(namedTerms, isCheckAllPermissions, leftDetails, rightDetails, null, false)) {
-                    unmatchedRelationshipIterator.remove();
+                /* consider the root object as the linker object */
+                for (final Entry<String, Set<Details>> dataPerProperty : linkedTo.entrySet()) {
+                    final String classProperty = dataPerProperty.getKey();
+                    final boolean isNotNullable = notNullable.contains(classProperty);
+                    for (final Details linkedObject : dataPerProperty.getValue()) {
+                        unmatchedTermIterator = unmatchedTerms.iterator();
+                        while (unmatchedTermIterator.hasNext()) {
+                            final TermMatch matcher = unmatchedTermIterator.next();
+                            if (matcher.isMatch(namedTerms, isCheckAllPermissions, linkedObject)) {
+                                unmatchedTermIterator.remove();
+                            }
+                        }
+                        unmatchedRelationshipIterator = unmatchedRelationships.iterator();
+                        while (unmatchedRelationshipIterator.hasNext()) {
+                            final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
+                            if (matcher.isMatch(namedTerms, isCheckAllPermissions,
+                                    rootObject, linkedObject, classProperty, isNotNullable)) {
+                                unmatchedRelationshipIterator.remove();
+                            }
+                        }
+                    }
                 }
-            }
-            if (unmatchedTerms.isEmpty() && unmatchedRelationships.isEmpty()) {
-                /* success, all matched */
-                recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
-                return;
-            } else if (namedTerms.size() == namedTermCount) {
-                /* failure, all matchers will fail on retry */
-                return;
-            }
-        } while (true);
-    }
-
-    /**
-     * Effect the changes.
-     * @param policyRule the policy rule that is now to be effected
-     * @param changedObjects the objects affected by the policy rules (to be updated by this method)
-     * @param namedTerms the name dictionary of matched terms
-     * @param isCheckAllPermissions if permissions are to be checked for all of the matched objects
-     * @throws GraphException if a term to change is one not named among the policy rule's matchers,
-     * or if the policy rule's consequence is itself an error condition
-     */
-    private static void recordChanges(ParsedPolicyRule policyRule, Set<Details> changedObjects,
-            Map<String, Details> namedTerms, boolean isCheckAllPermissions) throws GraphException {
-        final StringBuffer logMessage;
-        if (LOGGER != null && LOGGER.isDebugEnabled()) {
-            /* log applicable rule match and old status of terms */
-            logMessage = new StringBuffer();
-            logMessage.append("matched ");
-            logMessage.append(policyRule.asString);
-            logMessage.append(", where ");
-            for (final Entry<String, Details> namedTerm : namedTerms.entrySet()) {
-                logMessage.append(namedTerm.getKey());
-                logMessage.append(" is ");
-                logMessage.append(namedTerm.getValue());
-                logMessage.append(", ");
-            }
-        } else {
-            /* not logging rule matches */
-            logMessage = null;
+                /* match relationships among existing terms without any property link via the root object */
+                unmatchedRelationshipIterator = unmatchedRelationships.iterator();
+                while (unmatchedRelationshipIterator.hasNext()) {
+                    final RelationshipMatch matcher = unmatchedRelationshipIterator.next();
+                    if (matcher.propertyName != null || matcher.notNullable != null) continue;
+                    final String leftTermName = matcher.getExistingLeftTerm();
+                    if (leftTermName == null) continue;
+                    final String rightTermName = matcher.getExistingRightTerm();
+                    if (rightTermName == null) continue;
+                    final Details leftDetails = namedTerms.get(leftTermName);
+                    if (leftDetails == null) continue;
+                    final Details rightDetails = namedTerms.get(rightTermName);
+                    if (rightDetails == null) continue;
+                    if (matcher.isMatch(namedTerms, isCheckAllPermissions, leftDetails, rightDetails, null, false)) {
+                        unmatchedRelationshipIterator.remove();
+                    }
+                }
+                if (unmatchedTerms.isEmpty() && unmatchedRelationships.isEmpty()) {
+                    /* success, all matched */
+                    recordChanges(policyRule, changedObjects, namedTerms, isCheckAllPermissions.booleanValue());
+                    return;
+                } else if (namedTerms.size() == namedTermCount) {
+                    /* failure, all matchers will fail on retry */
+                    return;
+                }
+            } while (true);
         }
-        if (policyRule.errorMessage != null) {
-            /* throw the error that is this rule's consequence */
-            String message = policyRule.errorMessage;
-            for (final Entry<String, Details> namedTerm : namedTerms.entrySet()) {
-                /* expand each named term to its actual match */
-                final String termName = namedTerm.getKey();
-                final IObject termMatch = namedTerm.getValue().subject;
-                message = message.replace("{" + termName + "}",
-                        termMatch.getClass().getSimpleName() + '[' + termMatch.getId() + ']');
+
+        /**
+         * Effect the changes.
+         * @param policyRule the policy rule that is now to be effected
+         * @param changedObjects the objects affected by the policy rules (to be updated by this method)
+         * @param namedTerms the name dictionary of matched terms
+         * @param isCheckAllPermissions if permissions are to be checked for all of the matched objects
+         * @throws GraphException if a term to change is one not named among the policy rule's matchers,
+         * or if the policy rule's consequence is itself an error condition
+         */
+        private static void recordChanges(ParsedPolicyRule policyRule, Set<Details> changedObjects,
+                Map<String, Details> namedTerms, boolean isCheckAllPermissions) throws GraphException {
+            final StringBuffer logMessage;
+            if (LOGGER != null && LOGGER.isDebugEnabled()) {
+                /* log applicable rule match and old status of terms */
+                logMessage = new StringBuffer();
+                logMessage.append("matched ");
+                logMessage.append(policyRule.asString);
+                logMessage.append(", where ");
+                for (final Entry<String, Details> namedTerm : namedTerms.entrySet()) {
+                    logMessage.append(namedTerm.getKey());
+                    logMessage.append(" is ");
+                    logMessage.append(namedTerm.getValue());
+                    logMessage.append(", ");
+                }
+            } else {
+                /* not logging rule matches */
+                logMessage = null;
+            }
+            if (policyRule.errorMessage != null) {
+                /* throw the error that is this rule's consequence */
+                String message = policyRule.errorMessage;
+                for (final Entry<String, Details> namedTerm : namedTerms.entrySet()) {
+                    /* expand each named term to its actual match */
+                    final String termName = namedTerm.getKey();
+                    final IObject termMatch = namedTerm.getValue().subject;
+                    message = message.replace("{" + termName + "}",
+                            termMatch.getClass().getSimpleName() + '[' + termMatch.getId() + ']');
+                }
+                if (logMessage != null) {
+                    /* log error rule match */
+                    logMessage.append("error thrown");
+                    LOGGER.debug(logMessage.toString());
+                }
+                throw new GraphException(message);
+            }
+            /* note the new changes to the terms */
+            final Map<Change, Details> changedTerms = new HashMap<Change, Details>();
+            for (final Change change : policyRule.changes) {
+                changedTerms.put(change, change.toChanged(namedTerms));
+            }
+            /* a permissions override on any match propagates to all truly changed terms */
+            if (!isCheckAllPermissions) {
+                for (final Entry<Change, Details> changedTerm : changedTerms.entrySet()) {
+                    if (changedTerm.getKey().isEffectiveChange()) {
+                        changedTerm.getValue().isCheckPermissions = false;
+                    }
+                }
             }
             if (logMessage != null) {
-                /* log error rule match */
-                logMessage.append("error thrown");
+                /* log new status of terms */
+                logMessage.append("making ");
+                logMessage.append(Joiner.on(", ").join(changedTerms.values()));
                 LOGGER.debug(logMessage.toString());
             }
-            throw new GraphException(message);
+            changedObjects.addAll(changedTerms.values());
         }
-        /* note the new changes to the terms */
-        final Map<Change, Details> changedTerms = new HashMap<Change, Details>();
-        for (final Change change : policyRule.changes) {
-            changedTerms.put(change, change.toChanged(namedTerms));
-        }
-        /* a permissions override on any match propagates to all truly changed terms */
-        if (!isCheckAllPermissions) {
-            for (final Entry<Change, Details> changedTerm : changedTerms.entrySet()) {
-                if (changedTerm.getKey().isEffectiveChange()) {
-                    changedTerm.getValue().isCheckPermissions = false;
-                }
-            }
-        }
-        if (logMessage != null) {
-            /* log new status of terms */
-            logMessage.append("making ");
-            logMessage.append(Joiner.on(", ").join(changedTerms.values()));
-            LOGGER.debug(logMessage.toString());
-        }
-        changedObjects.addAll(changedTerms.values());
     }
 }

--- a/components/server/src/ome/services/graphs/GraphPolicyRulePredicate.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRulePredicate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.graphs;
+
+import org.hibernate.Session;
+
+import ome.model.IObject;
+
+/**
+ * A plug-in for graph policy rule matches whereby an object may be matched against named values.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.3
+ */
+public interface GraphPolicyRulePredicate {
+    /**
+     * @return the name of this predicate
+     */
+    String getName();
+
+    /**
+     * Once this instance is submitted to {@link GraphPolicy#registerPredicate(GraphPolicyPredicate)} then this method is called by
+     * {@link GraphPolicy#noteDetails(org.hibernate.Session, IObject, String, long)}.
+     * @param session the Hibernate session, for obtaining more information about the object
+     * @param object an unloaded model object that may satisfy this predicate
+     * @param realClass the real class name of the object
+     * @param id the ID of the object
+     */
+    void noteDetails(Session session, IObject object, String realClass, long id);
+
+    /**
+     * If this predicate is satisfied by the given object.
+     * @param object a model object
+     * @param parameter the parameter that the object must match
+     * @return if the object satisfies this predicate
+     * @throws GraphException if the predicate could not be tested
+     */
+    boolean isMatch(GraphPolicy.Details object, String parameter) throws GraphException;
+}

--- a/components/server/src/ome/services/graphs/PermissionsPredicate.java
+++ b/components/server/src/ome/services/graphs/PermissionsPredicate.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.graphs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+
+import ome.model.IObject;
+import ome.model.internal.Permissions;
+import ome.model.meta.ExperimenterGroup;
+import ome.services.graphs.GraphPolicy.Details;
+
+/**
+ * A predicate that allows {@code perms=rwr---} and similar to be used in graph policy rule matches.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.3
+ */
+public class PermissionsPredicate implements GraphPolicyRulePredicate {
+
+    private Map<Long, String> groupPermissions = new HashMap<Long, String>();
+
+    @Override
+    public String getName() {
+        return "perms";
+    }
+
+    @Override
+    public void noteDetails(Session session, IObject object, String realClass, long id) {
+        if (!(object instanceof ExperimenterGroup)) {
+            /* This is a small object and should typically hit the ORM cache but if still too slow then we could exploit that
+             * GraphTraversal.planning.detailsNoted already has the details object cached. */
+            final String hql = "SELECT details FROM " + realClass + " WHERE id = " + id;
+            final ome.model.internal.Details details = (ome.model.internal.Details) session.createQuery(hql).uniqueResult();
+            if (details == null) {
+                return;
+            }
+            object = details.getGroup();
+            if (object == null) {
+                return;
+            }
+        }
+        final Long groupId = object.getId();
+        if (!groupPermissions.containsKey(groupId)) {
+            final ExperimenterGroup group = (ExperimenterGroup) session.get(ExperimenterGroup.class, groupId);
+            final Permissions permissions = group.getDetails().getPermissions();
+            groupPermissions.put(groupId, permissions.toString());
+        }
+    }
+
+    @Override
+    public boolean isMatch(Details object, String parameter) throws GraphException {
+        if (object.groupId == null) {
+            throw new GraphException("no group for " + object);
+        }
+        final String permissions = groupPermissions.get(object.groupId);
+        if (permissions == null) {
+            throw new GraphException("no group permissions for " + object);
+        }
+        if (parameter.length() != permissions.length()) {
+            throw new GraphException(
+                    "parameter " + parameter + " has different length from permissions " + permissions + " on " + object);
+        }
+        int index = permissions.length();
+        while (--index >= 0) {
+            final char parameterChar = parameter.charAt(index);
+            if (parameterChar != '?' && parameterChar != permissions.charAt(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -22,7 +22,9 @@ package integration.chown;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import omero.RLong;
 import omero.RType;
@@ -40,8 +42,10 @@ import omero.model.ImageAnnotationLinkI;
 import omero.model.RectI;
 import omero.model.Roi;
 import omero.model.RoiI;
+import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.sys.EventContext;
+import omero.sys.ParametersI;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -72,7 +76,7 @@ public class PermissionsTest extends AbstractServerTest {
     @BeforeClass
     public void setupOtherGroup() throws Exception {
         systemGroup = new ExperimenterGroupI(iAdmin.getSecurityRoles().systemGroupId, false);
-        userOtherGroup = newUserAndGroup("rw----");
+        userOtherGroup = newUserAndGroup("rwr---");
         final ExperimenterGroup group = new ExperimenterGroupI(userOtherGroup.groupId, false);
         adminOtherGroup = newUserInGroup(group, false);
         addUsers(systemGroup, Collections.singletonList(adminOtherGroup.userId), false);
@@ -99,20 +103,41 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Add a comment and a ROI to the given image.
-     * @param imageId an image ID
+     * Add the given annotation to the given image.
+     * @param image an image
+     * @param annotation an annotation
+     * @return the new loaded link from the image to the annotation
+     * @throws ServerError unexpected
+     */
+    private ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+        if (annotation.isLoaded() && annotation.getId() != null) {
+            annotation = (Annotation) annotation.proxy();
+        }
+
+        final ImageAnnotationLink link = new ImageAnnotationLinkI();
+        link.setParent(image);
+        link.setChild(annotation);
+        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
+    }
+
+    /**
+     * Add a comment, tag and a ROI to the given image.
+     * @param image an image
      * @return the new model objects
      * @throws ServerError unexpected
      */
-    private List<IObject> annotateImage(long imageId) throws ServerError {
+    private List<IObject> annotateImage(Image image) throws ServerError {
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+
         final List<IObject> annotationObjects = new ArrayList<IObject>();
-        final Image image = (Image) iQuery.get("Image", imageId);
 
         for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(), new TagAnnotationI()}) {
-            ImageAnnotationLink link = new ImageAnnotationLinkI();
-            link.setParent((Image) image.proxy());
-            link.setChild(annotation);
-            link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
+            final ImageAnnotationLink link = annotateImage(image, annotation);
             annotationObjects.add(link.proxy());
             annotationObjects.add(link.getChild().proxy());
         }
@@ -143,7 +168,10 @@ public class PermissionsTest extends AbstractServerTest {
      * @param expectedOwner a user's event context
      * @throws ServerError unexpected
      */
-    private void assertOwnedBy(Collection<IObject> objects, EventContext expectedOwner) throws ServerError {
+    private void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
+        if (objects.isEmpty()) {
+            throw new IllegalArgumentException("must assert about some objects");
+        }
         for (final IObject object : objects) {
             final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
             final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
@@ -155,7 +183,7 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Test that a specific case of using {@link Chown2} behaves as expected.
+     * Test a specific case of using {@link Chown2} with owner's shared annotations in a private group.
      * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
      * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
@@ -163,7 +191,105 @@ public class PermissionsTest extends AbstractServerTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown test cases")
-    public void testChown(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
+    public void testChownPrivate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
+            throws Exception {
+
+        /* set up the users and group for this test case */
+
+        final EventContext importer, chowner, recipient;
+        final ExperimenterGroup dataGroup;
+
+        importer = newUserAndGroup("rw----");
+
+        final long dataGroupId = importer.groupId;
+        dataGroup = new ExperimenterGroupI(dataGroupId, false);
+
+        recipient = isRecipientInGroup ? newUserInGroup(dataGroup, false) : userOtherGroup;
+
+        if (isDataOwner) {
+            chowner = importer;
+        } else {
+            chowner = isAdmin ? adminOtherGroup : recipient;
+        }
+
+        if (isAdmin && chowner != adminOtherGroup) {
+            addUsers(systemGroup, Collections.singletonList(chowner.userId), false);
+        }
+
+        /* note which objects were used to annotate an image */
+
+        final List<IObject> imageAnnotations;
+        final List<ImageAnnotationLink> tagLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
+
+        /* import and annotate an image */
+
+        init(importer);
+        final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        final long imageId = image.getId().getValue();
+        testImages.add(imageId);
+        imageAnnotations = annotateImage(image);
+
+        /* tag another image with the tags from the first image */
+
+        final Image otherImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        for (final IObject annotation : imageAnnotations) {
+            if (annotation instanceof TagAnnotation) {
+                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
+                tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
+            }
+        }
+        disconnect();
+
+        /* perform the chown */
+
+        init(chowner);
+        final Chown2 chown = new Chown2();
+        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+        chown.userId = recipient.userId;
+        doChange(client, factory, chown, isExpectSuccess);
+        disconnect();
+
+        if (!isExpectSuccess) {
+            return;
+        }
+
+        /* check that the objects' ownership is all as expected */
+
+        final Set<Long> imageLinkIds = new HashSet<Long>();
+
+        logRootIntoGroup(dataGroupId);
+        assertOwnedBy(image, recipient);
+        for (final IObject annotation : imageAnnotations) {
+            if (annotation instanceof TagAnnotation) {
+                assertOwnedBy(annotation, importer);
+            } else if (annotation instanceof ImageAnnotationLink) {
+                imageLinkIds.add(annotation.getId().getValue());
+            } else {
+                assertOwnedBy(annotation, recipient);
+            }
+        }
+        assertOwnedBy(tagLinksOnOtherImage, importer);
+
+        /* check that the image's links to the tags that were also linked to the other image were deleted */
+
+        final String query = "SELECT COUNT(id) FROM ImageAnnotationLink WHERE id IN (:ids)";
+        final ParametersI params = new ParametersI().addIds(imageLinkIds);
+        final List<List<RType>> results = iQuery.projection(query, params);
+        final long remainingLinkCount = ((RLong) results.get(0).get(0)).getValue();
+        Assert.assertEquals(remainingLinkCount, imageLinkIds.size() - tagLinksOnOtherImage.size());
+        disconnect();
+    }
+
+    /**
+     * Test a specific case of using {@link Chown2} with owner's and others' annotations in a read-annotate group.
+     * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
+     * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group
+     * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
+     * @param isExpectSuccess if the chown is expected to succeed
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "chown test cases")
+    public void testChownReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup, boolean isExpectSuccess)
             throws Exception {
 
         /* set up the users and group for this test case */
@@ -200,13 +326,13 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        ownerAnnotations = annotateImage(imageId);
+        ownerAnnotations = annotateImage(image);
         disconnect();
 
         /* have another user annotate the image */
 
         init(annotator);
-        otherAnnotations = annotateImage(image.getId().getValue());
+        otherAnnotations = annotateImage(image);
         disconnect();
 
         /* perform the chown */

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -232,6 +232,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* tag another image with the tags from the first image */
 
         final Image otherImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
+        testImages.add(otherImage.getId().getValue());
         for (final IObject annotation : imageAnnotations) {
             if (annotation instanceof TagAnnotation) {
                 final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);


### PR DESCRIPTION
This PR rewrites how the `Chown2` requests work to make them easier to adjust in the future. It introduces and uses a pluggable matcher for objects among the graph policy rules and adds more integration testing.

Testing: #3879 will help, especially its `--report` option. This PR should not introduce any regressions but change-owner has been rather untested anyway, so at this stage I'll be happy enough if it doesn't have obvious misbehaviors! We can fix smaller RFEs in later PRs.