### PR TITLE
Script from search

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -32,8 +32,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowFocusListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -1189,4 +1189,10 @@ public interface TreeViewer
      */
     boolean isSystemGroup(long groupID, String key);
 
+    /**
+     * Returns the objects selected in the central panel.
+     *
+     * @return See above.
+     */
+    Collection<DataObject> getSelectedObjectsFromBrowser();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4328,17 +4328,15 @@ class TreeViewerComponent
 		if (script == null) return;
 		model.setScript(script);
 		Browser browser = model.getSelectedBrowser();
-		Collection<DataObject> objects;
+		List<DataObject> objects;
 		if (browser == null) objects = new ArrayList<DataObject>();
 		else objects = browser.getSelectedDataObjects();
 
 		if (CollectionUtils.isEmpty(objects)) {
 		    DataBrowser db = model.getDataViewer();
-		    if (db != null) {
-		        objects = db.getBrowser().getSelectedDataObjects();
-		    }
-		    if (CollectionUtils.isEmpty(objects)) {
-	            objects = new ArrayList<DataObject>();
+		    objects = new ArrayList<DataObject>();
+		    if (db != null && db.getBrowser() != null) {
+		        objects.addAll(db.getBrowser().getSelectedDataObjects());
 		    }
 		}
 		//setStatus(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3974,8 +3974,7 @@ class TreeViewerComponent
 		
 		//reset metadata
 		MetadataViewer mv = view.resetMetadataViewer();
-		mv.addPropertyChangeListener(controller);
-		
+
 		//reset search
 		clearFoundResults();
 	}
@@ -3996,8 +3995,7 @@ class TreeViewerComponent
 		view.clearMenus();
 		//reset metadata
 		MetadataViewer mv = view.resetMetadataViewer();
-		mv.addPropertyChangeListener(controller);
-		
+
 		//reset search
 		clearFoundResults();
 		model.getAdvancedFinder().reset(
@@ -4896,5 +4894,18 @@ class TreeViewerComponent
     public boolean isSystemGroup(long groupID, String key)
     {
         return model.isSystemGroup(groupID, key);
+    }
+
+    /**
+     * Implemented as specified by the {@link TreeViewer} interface.
+     * @see TreeViewer#getSelectedObjectsFromBrowser()
+     */
+    public Collection<DataObject> getSelectedObjectsFromBrowser()
+    {
+        DataBrowser db = model.getDataViewer();
+        if (db != null && db.getBrowser() != null) {
+            return db.getBrowser().getSelectedDataObjects();
+        }
+        return null;
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4328,11 +4328,19 @@ class TreeViewerComponent
 		if (script == null) return;
 		model.setScript(script);
 		Browser browser = model.getSelectedBrowser();
-		List<DataObject> objects;
+		Collection<DataObject> objects;
 		if (browser == null) objects = new ArrayList<DataObject>();
 		else objects = browser.getSelectedDataObjects();
 
-		if (objects == null) objects = new ArrayList<DataObject>();
+		if (CollectionUtils.isEmpty(objects)) {
+		    DataBrowser db = model.getDataViewer();
+		    if (db != null) {
+		        objects = db.getBrowser().getSelectedDataObjects();
+		    }
+		    if (CollectionUtils.isEmpty(objects)) {
+	            objects = new ArrayList<DataObject>();
+		    }
+		}
 		//setStatus(false);
 		//Check if the objects are in the same group.
 		Iterator<DataObject> i = objects.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -1365,9 +1365,6 @@ class TreeViewerControl
 	                if (nodes != null) {
 	                    l.addAll(nodes);
 	                }
-	                if (CollectionUtils.isEmpty(l)) {
-	                    l = model.getDisplayedImages();
-	                }
 				}
 			} else {
 				l = model.getDisplayedImages();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -58,6 +58,7 @@ import javax.swing.event.MenuKeyEvent;
 import javax.swing.event.MenuKeyListener;
 import javax.swing.event.MenuListener;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXTaskPane;
 import org.jdesktop.swingx.JXTaskPaneContainer;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
@@ -1358,11 +1359,20 @@ class TreeViewerControl
 			if (param.isSelectedObjects()) {
 				Browser b = model.getSelectedBrowser();
 				if (b != null) l = b.getSelectedDataObjects();
-				else l = model.getDisplayedImages();
+				else {
+				    l = new ArrayList<DataObject>();
+	                Collection<DataObject> nodes = model.getSelectedObjectsFromBrowser();
+	                if (nodes != null) {
+	                    l.addAll(nodes);
+	                }
+	                if (CollectionUtils.isEmpty(l)) {
+	                    l = model.getDisplayedImages();
+	                }
+				}
 			} else {
 				l = model.getDisplayedImages();
 			}
-			if (l == null) return;
+			if (CollectionUtils.isEmpty(l)) return;
 			Class klass = null;
 			Object p = null;
 			if (param.getIndex() == FigureParam.THUMBNAILS) {
@@ -1373,16 +1383,7 @@ class TreeViewerControl
 						TreeImageDisplay node = nodes[0];
 						Object ho = node.getUserObject();
 						TreeImageDisplay pNode;
-
 						if (ho instanceof DatasetData) {
-							/*
-							klass = ho.getClass();
-							pNode = node.getParentDisplay();
-							if (pNode != null) {
-								p = pNode.getUserObject();
-								if (!(p instanceof ProjectData)) p = null;
-							}
-							*/
 							klass = ho.getClass();
 							p = ho;
 						} else if (ho instanceof ImageData) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -1418,7 +1418,7 @@ class TreeViewerControl
 				}
 			}
 			if (!canRun) {
-				un.notifyInfo("Script", "You can run the script only\non" +
+				un.notifyInfo("Script", "You can run the script only\non " +
 						"objects from the same group");
 				return;
 			}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -959,10 +959,14 @@ class TreeViewerControl
 			downloadScript(new ScriptActivityParam(script,
 					ScriptActivityParam.DOWNLOAD));
 		} else {
-			GroupData g = model.getSelectedGroup();
-			if (g == null) 
-				g = TreeViewerAgent.getUserDetails().getDefaultGroup();
-			ctx = new SecurityContext(g.getId());
+		    long groupID = script.getGroupID();
+		    if (groupID < 0) {
+		        GroupData g = model.getSelectedGroup();
+	            if (g == null) 
+	                g = TreeViewerAgent.getUserDetails().getDefaultGroup();
+	            groupID = g.getId();
+		    }
+			ctx = new SecurityContext(groupID);
 			un.notifyActivity(ctx, new ScriptActivityParam(script,
 					ScriptActivityParam.RUN));
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerWin.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerWin.java
@@ -1110,6 +1110,7 @@ class TreeViewerWin
 	MetadataViewer resetMetadataViewer()
 	{
 		MetadataViewer v = model.resetMetadataViewer();
+		v.addPropertyChangeListener(controller);
 		if (rightComponent != null) rightPane.remove(rightComponent);
 		rightComponent = v.getEditorUI();
 		if (metadataVisible) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -322,6 +322,10 @@ public class ScriptingDialog
             param = inputs.get(entry.getKey());
             param.setValueToPass(c.getValue());
         }
+        if (CollectionUtils.isNotEmpty(refObjects)) {
+            DataObject node = refObjects.get(0);
+            script.setGroupID(node.getGroupId());
+        }
         firePropertyChange(RUN_SELECTED_SCRIPT_PROPERTY, null, script);
         close();
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ScriptObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ScriptObject.java
@@ -191,10 +191,13 @@ public class ScriptObject
      * Flag indicating if the script is an official script i.e.
      * release by the team or not.
      */
-    private boolean	official;
+    private boolean official;
 
     /** The specified data types if set e.g. image.*/
     private List<Class<?>> dataTypes;
+
+    /** The id of the group the object to the script on belong to.*/
+    private long groupID;
 
     /**
      * Converts the specified values to the corresponding class.
@@ -293,6 +296,7 @@ public class ScriptObject
         journalRef = "";
         mimeType = null;
         official = true;
+        groupID = -1;
     }
 
     /**
@@ -638,6 +642,23 @@ public class ScriptObject
     {
         return DATA_TYPE.equals(key);
     }
+
+    /**
+     * Sets the id of the group.
+     *
+     * @param groupID The value to set.
+     */
+    public void setGroupID(long groupID)
+    {
+        this.groupID = groupID;
+    }
+
+    /**
+     * Returns the id of the group.
+     *
+     * @return See above.
+     */
+    public long getGroupID() { return groupID; }
 
     /**
      * 


### PR DESCRIPTION
In this PR, few problems when running script from the search view (see http://trac.openmicroscopy.org/ome/ticket/12934)
to test this PR:

Test 1:
  * Log as user-2. Check that you are in private-1
  * Go to the search tab
  * Search for dv (few results are returned)
  * Select one image result from read-only group.
  * Click on the run script button in the toolbar. Select for example, channel offsets script
  * Check that the id field is populated with the id of the selected image.
  * Run the script.
  * Check that the script returns without error

Test 2:
   * Log as user-2. Check that you are in private-1
  * Go to the search tab
  * Search for dv (few results are returned)
  * Select one image result. The group context does not matter
  * Go to the right-hand pane and select one of the publishing script e.g. Thumbnail figure
  * Check that the id field is populated with the id of the selected image.
  * Check that the script is run
  * Check that the script returns without error 