### PR TITLE
Metadata/table data url links

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -113,7 +113,9 @@ class HeaderResolver(object):
 
     def __init__(self, target_object, headers):
         self.target_object = target_object
-        self.headers = [v.replace('/', '\\') for v in headers]
+        # TODO: why do we need to replace '/'?
+        # self.headers = [v.replace('/', '\\') for v in headers]
+        self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
 
     def create_columns(self):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -113,8 +113,6 @@ class HeaderResolver(object):
 
     def __init__(self, target_object, headers):
         self.target_object = target_object
-        # TODO: why do we need to replace '/'?
-        # self.headers = [v.replace('/', '\\') for v in headers]
         self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
 
@@ -146,6 +144,8 @@ class HeaderResolver(object):
                     k, v = description.split("=", 1)
                     k = k.strip()
                     description = json.dumps({k: v.strip()})
+            # HDF5 does not allow / in column names
+            name = name.replace('/', '\\')
             try:
                 column = self.screen_keys[header_as_lower](name, description,
                                                            list())
@@ -175,6 +175,8 @@ class HeaderResolver(object):
                     k, v = description.split("=", 1)
                     k = k.strip()
                     description = json.dumps({k: v.strip()})
+            # HDF5 does not allow / in column names
+            name = name.replace('/', '\\')
             try:
                 column = self.plate_keys[header_as_lower](name, description,
                                                           list())

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -138,6 +138,7 @@ class HeaderResolver(object):
             description = ""
             if "%%" in name:
                 name, description = name.split("%%", 1)
+                name = name.strip()
                 # description is key=value. Convert to json
                 if "=" in description:
                     k, v = description.split("=", 1)
@@ -166,6 +167,7 @@ class HeaderResolver(object):
             description = ""
             if "%%" in name:
                 name, description = name.split("%%", 1)
+                name = name.strip()
                 # description is key=value. Convert to json
                 if "=" in description:
                     k, v = description.split("=", 1)

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -27,6 +27,7 @@ import logging
 import sys
 import csv
 import re
+import json
 from getpass import getpass
 from getopt import getopt, GetoptError
 
@@ -134,11 +135,20 @@ class HeaderResolver(object):
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
+            description = ""
+            if "%%" in name:
+                name, description = name.split("%%", 1)
+                # description is key=value. Convert to json
+                if "=" in description:
+                    k, v = description.split("=", 1)
+                    k = k.strip()
+                    description = json.dumps({k: v.strip()})
             try:
-                column = self.screen_keys[header_as_lower](name, '', list())
+                column = self.screen_keys[header_as_lower](name, description,
+                                                           list())
             except KeyError:
-                column = StringColumn(name, '', self.DEFAULT_COLUMN_SIZE,
-                                      list())
+                column = StringColumn(name, description,
+                                      self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:
@@ -153,11 +163,20 @@ class HeaderResolver(object):
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
+            description = ""
+            if "%%" in name:
+                name, description = name.split("%%", 1)
+                # description is key=value. Convert to json
+                if "=" in description:
+                    k, v = description.split("=", 1)
+                    k = k.strip()
+                    description = json.dumps({k: v.strip()})
             try:
-                column = self.plate_keys[header_as_lower](name, '', list())
+                column = self.plate_keys[header_as_lower](name, description,
+                                                          list())
             except KeyError:
-                column = StringColumn(name, '', self.DEFAULT_COLUMN_SIZE,
-                                      list())
+                column = StringColumn(name, description,
+                                      self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -954,7 +954,10 @@
 	}
 	
 	
-	
+	/* Bulk Annotations */
+	.bulk_annotations_table td {
+		white-space: normal !important;
+	}
 		
 	
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -858,7 +858,7 @@
 
                 <h2 id="bulk-annotations" class="bulk_annotation" style="display: none;">Tables</h2>
                 <div style="display: none;">
-                    <table id="bulk_annotations_table">
+                    <table id="bulk_annotations_table" class="bulk_annotations_table">
                     </table>
                 </div>
                 <div style="clear:both; margin:8px"></div>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -275,11 +275,23 @@
                 if (result.data && result.data.rows) {
                     var table = $("#bulk-annotations").show().next().show().children("table");
                     for (var col = 0; col < result.data.columns.length; col++) {
+                        var url = false;
                         var label = result.data.columns[col].escapeHTML();
-                        var value = '';
-                        for (var r = 0; r < result.data.rows.length; r++) {
-                          value += ("" + result.data.rows[r][col]).escapeHTML() + '<br />';
+                        if (result.data.descriptions && result.data.descriptions[col]) {
+                            desc = result.data.descriptions[col];
+                            url = desc.url;
                         }
+                        var values = [],
+                            v, href;
+                        for (var r = 0; r < result.data.rows.length; r++) {
+                          v = ("" + result.data.rows[r][col]).escapeHTML();
+                          if (url) {
+                            href = url.replace("%s", v);
+                            v = "<a target='new' href='" + href + "'>" + v + "</a>";
+                          }
+                          values.push(v);
+                        }
+                        var value = values.join('<br />');
                         var row = $('<tr><td class="title"></td><td></td></tr>');
                         row.addClass(col % 2 == 1 ? 'odd' : 'even');
                         $('td:first-child', row).html(label + ":&nbsp;");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -286,8 +286,17 @@
                         for (var r = 0; r < result.data.rows.length; r++) {
                           v = ("" + result.data.rows[r][col]).escapeHTML();
                           if (url) {
-                            href = url.replace("%s", v);
-                            v = "<a target='new' href='" + href + "'>" + v + "</a>";
+                            // split links on ';' and create link for each
+                            var tokens = v.split(";"),
+                                token,
+                                links = [];
+                            for (var t=0; t<tokens.length; t++) {
+                                token = $.trim(tokens[t]);
+                                href = url.replace("%s", token);
+                                token = "<a target='new' href='" + href + "'>" + token + "</a>";
+                                links.push(token);
+                            }
+                            v = links.join("; ");
                           }
                           values.push(v);
                         }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2375,8 +2375,19 @@ def _table_query(request, fileid, conn=None, **kwargs):
         except Exception:
             return dict(error='Error executing query: %s' % query)
 
+    colDescriptions = []
+    for col in cols:
+        desc = col.description
+        # description might be json data
+        try:
+            if len(desc) > 0:
+                desc = json.loads(desc)
+        except:
+            pass
+        colDescriptions.append(desc)
     return dict(data=dict(
         columns=[col.name for col in cols],
+        descriptions=colDescriptions,
         rows=[[col.values[0] for col in t.read(range(len(cols)), hit,
                                                hit+1).columns]
               for hit in hits],


### PR DESCRIPTION
This is https://github.com/openmicroscopy/openmicroscopy/pull/3884 rebased onto metadata (on top of https://github.com/openmicroscopy/openmicroscopy/pull/3875).

========================================================================

See: https://trello.com/c/e4Jxa6My/11-adding-links-within-metadata

This PR provides 3 steps for adding urls to Table Data.
All parts of this are speculative and up for discussion.

- Add a 'url' description to the column name in your CSV file. Currently I'm using a double %% as the delimiter, but this could be changed? E.g.
    ``` Gene_Symbol %% url=http://www.ensembl.org/id/%s ```
 This will be parsed by the populate_metadata script, which will attempt to add the data as json in the Column description. E.g.
   Name: ```Gene_Symbol```
   Description: ``` '{"url": "http://www.ensembl.org/id/%s"}' ```

- Webgateway now adds the description to the json Table data, and attempts to parse the description as json. E.g. 
```
data: {
    rows: [
        [
        "ENSG00000117399",
        "CDC20",
        "44",
        ]
    ],
    descriptions: [
        "",
        {
        url: "http://www.ensembl.org/id/%s"
        },
        ""
    ],
    columns: [
        "Entity_Identifier",
        "Gene_Symbol ",
        "Entity_Number",
    ]
}
```

- Finally, if a description url is found, webclient uses it to create a link when displaying the gene name.

![screen shot 2015-06-19 at 11 54 33](https://cloud.githubusercontent.com/assets/900055/8252083/0b90bfdc-167a-11e5-820b-61bdbcf69204.png)