### PR TITLE
Minor improvements in OMERO.web ROIs interface

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -387,11 +387,11 @@
       else
         $("#show-rois-a").off("click");
       $("#show-rois-a").removeAttr("href");
-      $("#show-rois-a").attr("style", "color:gray");
+      $("#show-rois-a").css("color", "gray");
       // ... and enable the "Hide ROIs" button
       $("#hide-rois-a").on("click", function(){hide_rois(); console.log("hide rois"); return false;});
       $("#hide-rois-a").attr("href", "#");
-      $("#hide-rois-a").removeAttr("style");
+      $("#hide-rois-a").css("color", "");
 
       // loads ROIs (if needed) and shows.
       viewport.viewportimg.get(0).show_rois(theZ, theT, filter);
@@ -407,11 +407,11 @@
       // Disable the "Hide ROIs" button ...
       $("#hide-rois-a").off("click");
       $("#hide-rois-a").removeAttr("href");
-      $("#hide-rois-a").attr("style", "color:gray");
+      $("#hide-rois-a").css("color", "gray");
       // ... and enable the "Show ROIs" button
       $("#show-rois-a").on("click", function(){show_rois(); console.log("show rois"); return false;});
       $("#show-rois-a").attr("href", "#");
-      $("#show-rois-a").removeAttr("style");
+      $("#show-rois-a").css("color", "");
 
       $("#roi_table_postit").hide();
       $(".postit-close-btn").off("click");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -373,6 +373,12 @@
 
       // Show postit. Table will be built on callback from loading
       $("#roi_table_postit").show();
+      // Check all ROI visibility buttons
+      $('#toggle_roi_visibility').prop("checked", true);
+      $('[class^="shape_visibility"]').each(function(index, checkbox) {
+        checkbox.checked = true;
+      });
+      // if roi_table_postit is closed using close button, hide ROIs
       $(".postit-close-btn").on("click", function() {hide_rois(); return false;});
 
       // Disable the "Show ROIs" button ...

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -381,17 +381,18 @@
       // if roi_table_postit is closed using close button, hide ROIs
       $(".postit-close-btn").on("click", function() {hide_rois(); return false;});
 
+      var $show_rois_a = $("#show-rois-a");
       // Disable the "Show ROIs" button ...
-      if ($("#show-rois-a").attr("onclick") != undefined)
-        $("#show-rois-a").removeAttr("onclick");
+      if ($show_rois_a.attr("onclick") != undefined)
+        $show_rois_a.removeAttr("onclick");
       else
-        $("#show-rois-a").off("click");
-      $("#show-rois-a").removeAttr("href");
-      $("#show-rois-a").css("color", "gray");
+        $show_rois_a.off("click");
+      $show_rois_a.removeAttr("href");
+      $show_rois_a.css("color", "gray");
       // ... and enable the "Hide ROIs" button
-      $("#hide-rois-a").on("click", function(){hide_rois(); return false;});
-      $("#hide-rois-a").attr("href", "#");
-      $("#hide-rois-a").css("color", "");
+      $("#hide-rois-a").on("click", function(){hide_rois(); return false;})
+              .attr("href", "#")
+              .css("color", "");
 
       // loads ROIs (if needed) and shows.
       viewport.viewportimg.get(0).show_rois(theZ, theT, filter);
@@ -405,13 +406,13 @@
       }
 
       // Disable the "Hide ROIs" button ...
-      $("#hide-rois-a").off("click");
-      $("#hide-rois-a").removeAttr("href");
-      $("#hide-rois-a").css("color", "gray");
+      $("#hide-rois-a").off("click")
+              .removeAttr("href")
+              .css("color", "gray");
       // ... and enable the "Show ROIs" button
-      $("#show-rois-a").on("click", function(){show_rois(); return false;});
-      $("#show-rois-a").attr("href", "#");
-      $("#show-rois-a").css("color", "");
+      $("#show-rois-a").on("click", function () { show_rois(); return false; })
+              .attr("href", "#")
+              .css("color", "");
 
       $("#roi_table_postit").hide();
       $(".postit-close-btn").off("click");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -373,6 +373,19 @@
 
       // Show postit. Table will be built on callback from loading
       $("#roi_table_postit").show();
+      $(".postit-close-btn").on("click", function() {hide_rois(); return false;});
+
+      // Disable the "Show ROIs" button ...
+      if ($("#show-rois-a").attr("onclick") != undefined)
+        $("#show-rois-a").removeAttr("onclick");
+      else
+        $("#show-rois-a").off("click");
+      $("#show-rois-a").removeAttr("href");
+      $("#show-rois-a").attr("style", "color:gray");
+      // ... and enable the "Hide ROIs" button
+      $("#hide-rois-a").on("click", function(){hide_rois(); console.log("hide rois"); return false;});
+      $("#hide-rois-a").attr("href", "#");
+      $("#hide-rois-a").removeAttr("style");
 
       // loads ROIs (if needed) and shows.
       viewport.viewportimg.get(0).show_rois(theZ, theT, filter);
@@ -384,7 +397,18 @@
       if (viewport.viewportimg.get(0).hide_rois) {
           viewport.viewportimg.get(0).hide_rois();
       }
+
+      // Disable the "Hide ROIs" button ...
+      $("#hide-rois-a").off("click");
+      $("#hide-rois-a").removeAttr("href");
+      $("#hide-rois-a").attr("style", "color:gray");
+      // ... and enable the "Show ROIs" button
+      $("#show-rois-a").on("click", function(){show_rois(); console.log("show rois"); return false;});
+      $("#show-rois-a").attr("href", "#");
+      $("#show-rois-a").removeAttr("style");
+
       $("#roi_table_postit").hide();
+      $(".postit-close-btn").off("click");
   }
 
   var NOZT = "";
@@ -933,8 +957,9 @@
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
                 {% ifnotequal roiCount 0 %}
-                    <a href="#" onclick="show_rois(); return false;">Show ROIs</a> |
-                    <a href="#" onclick="hide_rois(); return false;">Hide</a>
+                    <a id="show-rois-a" href="#" onclick="show_rois(); console.log('show rois ORIGINAL'); return false;">Show ROIs</a> |
+                    <!-- <a id="hide-rois-a" href="#" onclick="hide_rois(); return false;">Hide</a> -->
+                    <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endifnotequal %}
           </div>
 {% endblock roi_buttons %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -389,7 +389,7 @@
       $("#show-rois-a").removeAttr("href");
       $("#show-rois-a").css("color", "gray");
       // ... and enable the "Hide ROIs" button
-      $("#hide-rois-a").on("click", function(){hide_rois(); console.log("hide rois"); return false;});
+      $("#hide-rois-a").on("click", function(){hide_rois(); return false;});
       $("#hide-rois-a").attr("href", "#");
       $("#hide-rois-a").css("color", "");
 
@@ -409,7 +409,7 @@
       $("#hide-rois-a").removeAttr("href");
       $("#hide-rois-a").css("color", "gray");
       // ... and enable the "Show ROIs" button
-      $("#show-rois-a").on("click", function(){show_rois(); console.log("show rois"); return false;});
+      $("#show-rois-a").on("click", function(){show_rois(); return false;});
       $("#show-rois-a").attr("href", "#");
       $("#show-rois-a").css("color", "");
 
@@ -963,7 +963,7 @@
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
                 {% ifnotequal roiCount 0 %}
-                    <a id="show-rois-a" href="#" onclick="show_rois(); console.log('show rois ORIGINAL'); return false;">Show ROIs</a> |
+                    <a id="show-rois-a" href="#" onclick="show_rois(); return false;">Show ROIs</a> |
                     <!-- <a id="hide-rois-a" href="#" onclick="hide_rois(); return false;">Hide</a> -->
                     <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endifnotequal %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -964,7 +964,6 @@
                 <h1>ROI Count: {{ roiCount }}</h1>
                 {% ifnotequal roiCount 0 %}
                     <a id="show-rois-a" href="#" onclick="show_rois(); return false;">Show ROIs</a> |
-                    <!-- <a id="hide-rois-a" href="#" onclick="hide_rois(); return false;">Hide</a> -->
                     <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endifnotequal %}
           </div>


### PR DESCRIPTION
I fixed a few bugs in OMERO.web related to ROIs management.
It was possible to click the "Show ROIs" button when ROIs were already on screen and this action restored all the ROIs, even the ones deactivated using the web UI filter.
Hiding ROIs with the "Hide "button or the "X" button on the table with ROIs details turned ROIs OFF but didn't reset ROIs table, so when hitting "Show ROIs" again all ROIs were displayed by the checkboxes of the deactivated ones will be shown as unchecked even if ROIs are visible on screen.
What I introduce with this PR is:

* the "Show ROIs" and "Hide" buttons will disable each other when used; if ROIs are on screen only the "Hide" button will listen to a click action and vice versa
* when showing ROIs with the "Show ROIs" button all the checkboxes of the ROIs table will be checked because all ROIs will be rendered on screen (ROIs filter is discarded when ROIs view is closed)