### PR TITLE
OMEROIJ_Bioformats_dependency_check

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
@@ -93,8 +93,13 @@ public final class ContainerConfigInit
 				value = values[j];
 				if (value != null) value = value.trim();
 				if (l == null) continue;
+				int idx = value.indexOf(".jar");
+				if (idx==-1){
+				    idx = value.length();
+				}
+				value = value.substring(0, idx);
 				for (int i = 0; i < l.length; i++) {
-					if (l[i].getName().equals(value)) {
+					if (l[i].getName().startsWith(value)) {
 						count++;
 					}
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
@@ -25,12 +25,15 @@ package org.openmicroscopy.shoola.env.init;
 
 //Java imports
 import ij.IJ;
+
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 
 //Third-party libraries
 
+
+import org.apache.commons.io.FilenameUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -93,11 +96,8 @@ public final class ContainerConfigInit
 				value = values[j];
 				if (value != null) value = value.trim();
 				if (l == null) continue;
-				int idx = value.indexOf(".jar");
-				if (idx==-1){
-				    idx = value.length();
-				}
-				value = value.substring(0, idx);
+				value = FilenameUtils.removeExtension(value);
+
 				for (int i = 0; i < l.length; i++) {
 					if (l[i].getName().startsWith(value)) {
 						count++;


### PR DESCRIPTION
ref : https://trac.openmicroscopy.org/ome/ticket/12925

Testing isntructions:

1) Add "OMEROIJ" plugin and bioformats_package.jar or loci-tools.jar to the plugins folder of imageJ.
2) open imageJ , "Plugins-->OMERO-->Connect to OMERO". This Should throw up the Insight login screen.

Now, rename the bioformats_package.jar (within the plugins folder) with something like,
bioformats_package-1.jar or biformats_package 1.jar or etc (concatenate any string to the name of the jar post bioformats_package or loci-tools with *.jar) and repeat the workflow specified above.

You should still get the Insight login screen.

Note : (when any string extension is added to bioformats_package or loci-tools) Without this PR the above workflow will throw a warning window  saying: can't find bioformats_package or loci-tools within the plugins folder and the login screen will not appear .