### PR TITLE
PixelSize in px fix

### DIFF
--- a/components/blitz/src/pojos/PixelsData.java
+++ b/components/blitz/src/pojos/PixelsData.java
@@ -268,7 +268,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeX(UnitsLength unit) throws BigResult {
     	Length l = asPixels().getPhysicalSizeX();
-    	if(l == null)
+        if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
     		return null;
     	return unit == null ? l : new LengthI(l, unit);
     }
@@ -320,7 +320,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeY(UnitsLength unit) throws BigResult {
     	Length l = asPixels().getPhysicalSizeY();
-    	if(l == null)
+    	if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
     		return null;
     	return unit == null ? l : new LengthI(l, unit);
     }
@@ -372,7 +372,7 @@ public class PixelsData extends DataObject {
      */
     public Length getPixelSizeZ(UnitsLength unit) throws BigResult {
     	Length l = asPixels().getPhysicalSizeZ();
-    	if(l == null)
+    	if (l == null || l.getUnit().equals(UnitsLength.PIXEL))
     		return null;
     	return unit == null ? l : new LengthI(l, unit);
     }


### PR DESCRIPTION
If an image uses pixel as unit for the pixel size, Insight crashes because the transformation into microns is not possible. With this PR pixel sizes in pixel will be ignored and treated like no pixel size is provided.
`PixelsData.getPixelSizeX/Y/Z()' is the only place where I can think of this could be an issue.  Are there other places? @jburel

See [QA 11140](https://www.openmicroscopy.org/qa2/qa/feedback/11140)
