### PR TITLE
Fix for QA 11139

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserControl.java
@@ -447,6 +447,9 @@ class BrowserControl
      */
     public void navigate(int direction, boolean multiSel) {
         ImageDisplay current = model.getLastSelectedDisplay();
+        if (current == null)
+            return;
+        
         Rectangle b = current.getBounds();
         
         int x = b.x;


### PR DESCRIPTION
Fixes a potential NPE, see [QA 11139](https://www.openmicroscopy.org/qa2/qa/feedback/11139/)
I don't know how to trigger the bug, because navigation via arrow keys shouldn't be possible if nothing is selected in the central panel, so I think for testing it's sufficient to check if the arrow key navigation in central panel still works.
