### PR TITLE
Fixing broken links email notification

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -319,10 +319,6 @@ INTERNAL_SETTINGS_MAPPING = {
          parse_boolean,
          ("Whether to use a TLS (secure) connection when talking to the SMTP"
           " server.")],
-
-    # Deprecated
-    "omero.web.send_broken_link_emails":
-        ["SEND_BROKEN_LINK_EMAILS", "true", parse_boolean, None],
 }
 
 CUSTOM_SETTINGS_MAPPINGS = {
@@ -651,6 +647,13 @@ DEPRECATED_SETTINGS_MAPPINGS = {
          None,
          leave_none_unset_int,
          ("Use omero.client.viewer.initial_zoom_level instead.")],
+    "omero.web.send_broken_link_emails":
+        ["SEND_BROKEN_LINK_EMAILS",
+         "false",
+         parse_boolean,
+         ("Replaced by django.middleware.common.BrokenLinkEmailsMiddleware."
+          "To get notification set :property:`omero.web.admins` property.")
+         ],
 }
 
 del CUSTOM_HOST
@@ -805,6 +808,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.common.BrokenLinkEmailsMiddleware',
 )
 
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -804,11 +804,11 @@ USE_I18N = True
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 # See https://docs.djangoproject.com/en/1.6/topics/http/middleware/.
 MIDDLEWARE_CLASSES = (
+    'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.common.BrokenLinkEmailsMiddleware',
 )
 
 


### PR DESCRIPTION
This PR fixed ```SEND_BROKEN_LINK_EMAILS``` that was removed in Django 1.6 infavour of ```django.middleware.common.BrokenLinkEmailsMiddleware```.

To test it:
 - set ```bin/omero config set omero.web.debug False```
 - set mail config https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/mail.html
  - locally SMTP mock (you will not get real email):
    - set ```bin/omero config set omero.mail.from "your@email``` and ```bin/omero config set omero.mail.host "localhost"```
    - start SMTP mock ```sudo python -m smtpd -n -c DebuggingServer localhost:25```. *Email message will be shown as a plane text on your console.*
 - set your email in ```bin/omero config set omero.web.admins '[["Username", "your@email"]]'```
 - try to get HTTP500 and 404 (must come from broken link in template, do not access random url) and see if you received both errors by email

