### PR TITLE
ROI split figure

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PublishingDialog.java
@@ -286,11 +286,11 @@ class PublishingDialog
     			}
     			movieButton.setEnabled(data.getSizeT() > 1 ||
                         data.getSizeZ() > 1);
-                splitViewFigureButton.setEnabled(data.getSizeC() > 1);
+                splitViewFigureButton.setEnabled(b && data.getSizeC() > 1);
                 movieItem.setEnabled(data.getSizeT() > 1 ||
                         data.getSizeZ() > 1);
-                splitViewFigureItem.setEnabled(b && data.getSizeC() > 1);
-                splitViewROIFigureItem.setEnabled(b && data.getSizeC() > 1);
+                splitViewFigureItem.setEnabled(b);
+                splitViewROIFigureItem.setEnabled(b);
                 movieFigureItem.setEnabled(true);
 			} catch (Exception e) {}
     	} else {


### PR DESCRIPTION
Enable roi split view figure for images with one channel. see https://trac.openmicroscopy.org.uk/ome/ticket/11164

To test:
 * Select an image with one channel
 * Draw a roi e.g. rectangle
 * Go to the right-hand pane
 * Click on the "publishing" button.Check that the "ROI split figure" is enabled.
 * Run the script.