### PR TITLE
Copy to clipboard

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -290,12 +290,18 @@ public class FileImportComponent
 	    String logText = "View Import Log";
 	    String checksumText = "View Checksum";
 	    String exceptionText = "View Exception";
+	    String copyExceptionText = "Copy Exception to Clipboard";
 	    Object result = statusLabel.getImportResult();
 	    switch (resultIndex) {
 	    case FAILURE_LIBRARY:
 	        menu.add(new JMenuItem(new AbstractAction(exceptionText) {
                 public void actionPerformed(ActionEvent e) {
                     viewError();
+                }
+            }));
+	        menu.add(new JMenuItem(new AbstractAction(copyExceptionText) {
+                public void actionPerformed(ActionEvent e) {
+                    copyErrorToClipboard();
                 }
             }));
 	        break;
@@ -308,6 +314,11 @@ public class FileImportComponent
 	        menu.add(new JMenuItem(new AbstractAction(exceptionText) {
                 public void actionPerformed(ActionEvent e) {
                     viewError();
+                }
+            }));
+	        menu.add(new JMenuItem(new AbstractAction(copyExceptionText) {
+                public void actionPerformed(ActionEvent e) {
+                    copyErrorToClipboard();
                 }
             }));
 	        break;
@@ -517,6 +528,16 @@ public class FileImportComponent
 	        UIUtilities.centerAndShow(d);
 	    }
 	}
+
+	/** Copies the error to the clipboard.*/
+    private void copyErrorToClipboard()
+    {
+        Object o = statusLabel.getImportResult();
+        if (o instanceof ImportException) {
+            String v = UIUtilities.printErrorText((ImportException) o);
+            UIUtilities.copyToClipboard(v);
+        }
+    }
 
 	/** Browses the node or the data object. */
 	private void browse()

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -38,6 +38,8 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.PrintWriter;
@@ -54,6 +56,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.prefs.Preferences;
 import java.util.regex.Pattern;
+
 import javax.swing.AbstractButton;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -83,12 +86,14 @@ import javax.swing.text.StyleContext;
 import javax.swing.text.StyledDocument;
 import javax.swing.text.TabSet;
 import javax.swing.text.TabStop;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.jdesktop.swingx.JXDatePicker;
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.util.ui.border.TitledLineBorder;
+
 import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.enums.UnitsLength;
@@ -2798,5 +2803,17 @@ public class UIUtilities
             return findParent(parent, c);
         }
         return null;
+    }
+
+    /**
+     * Copies the passed value to the System clipboard
+     * @param value
+     */
+    public static void copyToClipboard(String value)
+    {
+        Toolkit toolkit = Toolkit.getDefaultToolkit();
+        Clipboard clipboard = toolkit.getSystemClipboard();
+        StringSelection strSel = new StringSelection(value);
+        clipboard.setContents(strSel, null);
     }
 }


### PR DESCRIPTION
Add option to copy import error to the clip board. See https://trac.openmicroscopy.org.uk/ome/ticket/12889

To test:
 * Import a bad image e.g. test_images_bad/mike.dv
 * Click on the failed button
 * Click on "Copy Exception to Clipboard"
 * Then go an text editor for example. Click Cmd+v to paste the exception