### PR TITLE
Fix for ticket 12816

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3211,7 +3211,8 @@ class ImViewerComponent
 	 */
 	public void loadTiles(Rectangle region)
 	{
-		if (model.getState() == DISCARDED) return;
+		if (model.getState() == DISCARDED || !model.isRendererLoaded()) 
+		    return;
 		if (region == null) 
 			region = model.getBrowser().getVisibleRectangle();
 		Map<Integer, Tile> tiles = getTiles();


### PR DESCRIPTION
Tiny fix to prevent a potential NPE, see [Ticket 12816](https://trac.openmicroscopy.org/ome/ticket/12816)
Unfortunately I couldn't reproduce the NPE, so code review must be sufficient and maybe check if you can still load big images (which triggers the affected loadTiles()` method).
