### PR TITLE
Add wrapper class for loading permission info (Fix #12474)

### DIFF
--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -444,6 +444,10 @@ public class IceMapper extends ome.util.ModelMapper implements
             String str = (String) o;
             omero.RString rstr = rstring(str);
             return rstr;
+        } else if (o instanceof ome.util.PermDetails) {
+            // Implements IObject as well!
+            ome.util.PermDetails p = (ome.util.PermDetails) o;
+            return toRType(p.getDetails().getPermissions());
         } else if (o instanceof IObject) {
             IObject obj = (IObject) o;
             omero.model.IObject om = (omero.model.IObject) map(obj);

--- a/components/model/src/ome/util/PermDetails.java
+++ b/components/model/src/ome/util/PermDetails.java
@@ -38,7 +38,7 @@ import org.hibernate.Hibernate;
  * select d.details.permissions from Dataset d
  * </code>
  *
- * which returns a {@link Permissions} object with none of the extended
+ * which returns a {@link ome.model.internal.Permissions} object with none of the extended
  * restrictions (canRead, canAnnotate, etc) properly loaded, use:
  *
  * <code>
@@ -47,8 +47,8 @@ import org.hibernate.Hibernate;
  *
  * The return value for each will be the same.
  *
- * @see "HHH-3868"
- * @see "trac-12474"
+ * @see <a href="https://hibernate.atlassian.net/browse/HHH-3868">HHH-3868</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/12474">trac-12474</a>
  */
 @SuppressWarnings("serial")
 public class PermDetails implements IObject {

--- a/components/model/src/ome/util/PermDetails.java
+++ b/components/model/src/ome/util/PermDetails.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2015 University of Dundee
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package ome.util;
+
+import java.util.Set;
+
+import ome.conditions.ApiUsageException;
+import ome.model.IObject;
+import ome.model.internal.Details;
+import ome.model.internal.GraphHolder;
+import ome.util.Filter;
+import ome.util.Validation;
+
+import org.hibernate.Hibernate;
+
+/**
+ * wrapper class which can be used in HQL queries to properly load
+ * the full context for a permissions object. Rather than writing a
+ * query of the form:
+ *
+ * <code>
+ * select d.details.permissions from Dataset d
+ * </code>
+ *
+ * which returns a {@link Permissions} object with none of the extended
+ * restrictions (canRead, canAnnotate, etc) properly loaded, use:
+ *
+ * <code>
+ * select new ome.util.PermDetails(d) from Dataset d
+ * </code>
+ *
+ * The return value for each will be the same.
+ *
+ * @see "HHH-3868"
+ * @see "trac-12474"
+ */
+@SuppressWarnings("serial")
+public class PermDetails implements IObject {
+
+    private final IObject context;
+
+    public PermDetails(IObject context) {
+        Hibernate.initialize(context);
+        this.context = context;
+    }
+
+    //
+    // DELEGATE METHODS
+    //
+
+    public Long getId() {
+        return context.getId();
+    }
+
+    public void setId(Long id) {
+        context.setId(id);
+    }
+
+    public Details getDetails() {
+        return context.getDetails();
+    }
+
+    public boolean isLoaded() {
+        return context.isLoaded();
+    }
+
+    public void unload() throws ApiUsageException {
+        context.unload();
+    }
+
+    public boolean isValid() {
+        return context.isValid();
+    }
+
+    public Validation validate() {
+        return context.validate();
+    }
+
+    public Object retrieve(String field) {
+        return context.retrieve(field);
+    }
+
+    public void putAt(String field, Object value) {
+        context.putAt(field, value);
+    }
+
+    public Set<?> fields() {
+        return context.fields();
+    }
+
+    public GraphHolder getGraphHolder() {
+        return context.getGraphHolder();
+    }
+
+    @Override
+    public boolean acceptFilter(Filter filter) {
+        return context.acceptFilter(filter);
+    }
+
+}

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -455,7 +455,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
         }
         for (int i = 0; i < size; i++) {
             Object[] x = (Object[]) rv.get(i);
-            if (x.length == 1 && x[0] instanceof Map) {
+            if (x != null && x.length == 1 && x[0] instanceof Map) {
                 Map<Object, Object> y = (Map<Object, Object>) x[0];
                 for (Map.Entry<Object, Object> z : y.entrySet()) {
                     if (z != null && z.getKey().toString().endsWith("_details_permissions")) {

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -76,7 +76,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     private HibernateTemplate getHibernateTemplate() {
         return new HibernateTemplate(getSessionFactory(), false);
     }
-    
+
     // ~ LOCAL PUBLIC METHODS
     // =========================================================================
 
@@ -246,7 +246,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 }
                 // Never reached!
                 return null;
-                
+
             }
         });
     }
@@ -382,7 +382,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                         + "Please try findAllBy methods for queries which return Lists.");
 
     }
-    
+
     /**
      * @see ome.api.IQuery#findAllByQuery(java.lang.String,
      *      ome.parameters.Parameters)
@@ -452,6 +452,18 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                     rv.set(i, new Object[]{obj});
                 }
             }
+        }
+        for (int i = 0; i < size; i++) {
+            Object[] x = (Object[]) rv.get(i);
+            if (x.length == 1 && x[0] instanceof Map) {
+                Map<Object, Object> y = (Map<Object, Object>) x[0];
+                for (Map.Entry<Object, Object> z : y.entrySet()) {
+                    if (z != null && z.getKey().toString().endsWith("_details_permissions")) {
+                        z.setValue(new ome.util.PermDetails((IObject) z.getValue()));
+                    }
+                }
+            }
+
         }
         return rv;
     }

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -883,16 +883,23 @@ class TestPermissionProjections(lib.ITest):
         project = update.saveAndReturnObject(project)
 
         try:
-            perms = unwrap(reader.projection((
+            perms1 = unwrap(reader.projection((
                 "select new ome.util.PermDetails(p) "
                 "from Project p where p.id = :id"),
                 ParametersI().addId(project.id.val)))[0][0]
+            perms2 = unwrap(reader.projection((
+                "select new map(p.id as id, p as p_details_permissions) "
+                "from Project p where p.id = :id"),
+                ParametersI().addId(project.id.val)))[0][0]
+            perms2 = perms2["p_details_permissions"]
+            assert perms1 == perms2
             assert fixture.canRead
         except IndexError:
             # No permissions were returned.
             assert not fixture.canRead
         else:
-            self.assertPerms(perms, fixture)
+            self.assertPerms(perms1, fixture)
+            self.assertPerms(perms2, fixture)
 
     @pytest.mark.parametrize("fixture", lib.PFS,
                              ids=[x.get_name() for x in lib.PFS])


### PR DESCRIPTION
Since no solution for properly loading a Permissions object
when the target of a project query (`select d.details.permissions`),
this workaround is being added which will allow wrapping a
object in HQL (`select new ome.util.PermDetails(d)`) to produce
the desired effect.

#### Testing ####

Primary effect of this PR is that the test_permissions.py tests which were marked xfail should start passing:

```
components/tools/OmeroPy$ ./setup.py test -t test/integration/test_permissions.py -k Projection -svx
...
test/integration/test_permissions.py::TestPermissionProjections::testProjectionPermissions[rw-----admin-admin] PASSED
test/integration/test_permissions.py::TestPermissionProjections::testProjectionPermissions[rw-----admin-owner] PASSED
test/integration/test_permissions.py::TestPermissionProjections::testProjectionPermissionsWorkaround[rwrw---member-owner] PASSED
test/integration/test_permissions.py::TestPermissionProjections::testProjectionPermissionsWorkaround[rwrw---member-member] PASSED
test/integration/test_permissions.py::TestPermissionProjections::testExtendedRestrictions[PlateI] SKIPPED
test/integration/test_permissions.py::TestPermissionProjections::testExtendedRestrictions[WellI] SKIPPED
test/integration/test_permissions.py::TestPermissionProjections::testExtendedRestrictions[ImageI] SKIPPED
test/integration/test_permissions.py::TestPermissionProjections::testExtendedRestrictions[FileAnnotationI] SKIPPED

================================================================== 30 tests deselected by '-kProjection' ===================================================================
========================================================== 72 passed, 4 skipped, 30 deselected in 141.34 seconds ===========================================================
```

**For there to be further effects, queries will need to be changed from `select d.details.permissions` to `new map(d as d_details_permissions)`.**