### PR TITLE
Pixels to microns

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -40,7 +40,7 @@
         <td id='pixels_type'>{{ image.getPixelsType }}</td>
     </tr>
     <tr>
-        <th>Pixels Size (XYZ) ({{ image.getPixelSizeXMicrons|lengthunit}}):</th>
+        <th>Pixels Size (XYZ) ({{ image.getPixelSizeUnits }}):</th>
         <td id='pixels_size'>
             <div class='tooltip'>{{ image.getPixelSizeXMicrons|lengthformat|floatformat:2 }} x {{ image.getPixelSizeYMicrons|lengthformat|floatformat:2 }} 
                 {% if image.getPixelSizeZMicrons %} x {{ image.getPixelSizeZMicrons|lengthformat|floatformat:2 }} {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2397,16 +2397,36 @@ class ImageWrapper (OmeroWebObjectWrapper,
         if 'link' in kwargs:
             self.link = 'link' in kwargs and kwargs['link'] or None
 
-    """
-    This override standard omero.gateway.ImageWrapper.getChannels
-    and catch exceptions.
-    """
+    def getPixelSizeUnits(self):
+        """
+        We use the pixelSizeX to find the appropriate units.
+        By default, we get the actual size in Microns, then use the
+        lengthunit filter to pick the most suitable size (same logic
+        is used for doing the length conversions).
+        However, if unit can't be converted, then we just return the
+        current unit's symbol.
+        """
+        from webgateway.templatetags.common_filters import lengthunit
+        try:
+            size = self.getPixelSizeX(units="MICROMETER")
+        except:
+            size = self.getPixelSizeX(True)
+            if size is not None:
+                return size.getSymbol()
+        if size is None:
+                size = 0
+        else:
+            size = size.getValue()
+        return lengthunit(size)
 
     def getPixelSizeXMicrons(self):
         """
         Helper for calling getPixelSizeX(units="MICROMETER") in templates
         """
-        size = self.getPixelSizeX(units="MICROMETER")
+        try:
+            size = self.getPixelSizeX(units="MICROMETER")
+        except:
+            size = self.getPixelSizeX(True)
         if size is None:
             return 0
         return size.getValue()
@@ -2415,7 +2435,10 @@ class ImageWrapper (OmeroWebObjectWrapper,
         """
         Helper for calling getPixelSizeX(units="MICROMETER") in templates
         """
-        size = self.getPixelSizeY(units="MICROMETER")
+        try:
+            size = self.getPixelSizeY(units="MICROMETER")
+        except:
+            size = self.getPixelSizeY(True)
         if size is None:
             return 0
         return size.getValue()
@@ -2424,12 +2447,19 @@ class ImageWrapper (OmeroWebObjectWrapper,
         """
         Helper for calling getPixelSizeX(units="MICROMETER") in templates
         """
-        size = self.getPixelSizeZ(units="MICROMETER")
+        try:
+            size = self.getPixelSizeZ(units="MICROMETER")
+        except:
+            size = self.getPixelSizeZ(True)
         if size is None:
             return 0
         return size.getValue()
 
     def getChannels(self, *args, **kwargs):
+        """
+        This override standard omero.gateway.ImageWrapper.getChannels
+        and catch exceptions.
+        """
         try:
             return super(ImageWrapper, self).getChannels(*args, **kwargs)
         except Exception:

--- a/components/tools/OmeroWeb/test/integration/test_metadata.py
+++ b/components/tools/OmeroWeb/test/integration/test_metadata.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 Glencoe Software, Inc.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests display of metadata in webclient
+"""
+import omero
+
+from weblibrary import IWebTest
+from weblibrary import _get_response
+
+from django.core.urlresolvers import reverse
+from omero.model.enums import UnitsLength
+
+
+class TestCoreMetadata(IWebTest):
+    """
+    Tests display of core metatada
+    """
+
+    def test_pixel_size_units(self):
+        # Create image
+        iid = self.createTestImage(sizeC=2, session=self.sf).id.val
+
+        # show right panel for image
+        request_url = reverse('load_metadata_details', args=['image', iid])
+        data = {}
+        rsp = _get_response(self.django_client, request_url, data, status_code=200)
+        html = rsp.content
+        # Units are µm by default
+        assert "Pixels Size (XYZ) (µm):" in html
+
+        # Now save units as PIXELs and view again
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        i = conn.getObject("Image", iid)
+        u = omero.model.LengthI(1.2, UnitsLength.PIXEL)
+        p = i.getPrimaryPixels()._obj
+        p.setPhysicalSizeX(u)
+        p.setPhysicalSizeY(u)
+        conn.getUpdateService().saveObject(p)
+
+        # Should now be showning pixels
+        rsp = _get_response(self.django_client, request_url, data, status_code=200)
+        html = rsp.content
+        assert "Pixels Size (XYZ) (pixel):" in html

--- a/components/tools/OmeroWeb/test/integration/test_metadata.py
+++ b/components/tools/OmeroWeb/test/integration/test_metadata.py
@@ -41,7 +41,8 @@ class TestCoreMetadata(IWebTest):
         # show right panel for image
         request_url = reverse('load_metadata_details', args=['image', iid])
         data = {}
-        rsp = _get_response(self.django_client, request_url, data, status_code=200)
+        rsp = _get_response(self.django_client, request_url,
+                            data, status_code=200)
         html = rsp.content
         # Units are µm by default
         assert "Pixels Size (XYZ) (µm):" in html
@@ -56,6 +57,7 @@ class TestCoreMetadata(IWebTest):
         conn.getUpdateService().saveObject(p)
 
         # Should now be showning pixels
-        rsp = _get_response(self.django_client, request_url, data, status_code=200)
+        rsp = _get_response(self.django_client,
+                            request_url, data, status_code=200)
         html = rsp.content
         assert "Pixels Size (XYZ) (pixel):" in html

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -18,8 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Simple integration tests to ensure that the CSRF middleware is enabled and
-working correctly.
+Tests copying and pasting of rendering settings in webclient
 """
 
 import omero
@@ -31,10 +30,9 @@ from weblibrary import _csrf_post_response, _get_response
 from django.core.urlresolvers import reverse
 
 
-class TestCsrf(IWebTest):
+class TestRendering(IWebTest):
     """
-    Tests to ensure that Django CSRF middleware for OMERO.web is enabled and
-    working correctly.
+    Tests copying and pasting of rendering settings from one image to another
     """
 
     def test_copy_past_rendering_settings_from_image(self):


### PR DESCRIPTION
See https://www.openmicroscopy.org/qa2/qa/feedback/11146/

This fixes display of pixel sizes for images that have pixel size units that are incompatible with microns.
E.g. in the example above, exception is thrown trying to convert from PIXEL to MICROMETER.

To test, set pixel sizes to E.g. PIXEL (complete code sample below) and try viewing in web:

![screen shot 2015-06-29 at 11 39 00](https://cloud.githubusercontent.com/assets/900055/8406378/928842a4-1e53-11e5-9159-ae61d007f15c.png)

```
$ omero shell --login

In [1]: from omero.gateway import BlitzGateway
In [2]: conn = BlitzGateway(client_obj=client)
In [3]: i = conn.getObject("Image", 8551)
In [4]: from omero.model.enums import UnitsLength
In [5]: u = omero.model.LengthI(9.8, UnitsLength.PIXEL)
In [6]: p = i.getPrimaryPixels()._obj
In [7]: p.setPhysicalSizeX(u)
In [8]: p.setPhysicalSizeY(u)
In [9]: conn.getUpdateService().saveObject(p)
```