### PR TITLE
plate run index bug

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -600,6 +600,7 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
 
                 context['baseurl'] = reverse('webgateway').rstrip('/')
                 context['form_well_index'] = form_well_index
+                context['index'] = index
                 template = "webclient/data/plate.html"
     else:
         if view == 'tree':


### PR DESCRIPTION
Fixes https://trello.com/c/JcQw9nOY/35-python-plate-acquisitions

It turns out that we were simply failing to pass the correct field index to the plate.html template.

To test, find a plate with multiple Acquisitions. For each, check that the right images are loaded into each field (compare with Insight).