### PR TITLE
Shape Alpha

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -502,7 +502,7 @@ $.fn.roi_display = function(options) {
                                     // need *some* fill so that shape is clickable
                                     newShape.attr({'fill':'#000', 'fill-opacity': 0.01 });
                                 }
-                                if (shape['strokeAlpha']) { newShape.attr({'opacity': shape['strokeAlpha']}); }
+                                if (shape['strokeAlpha']) { newShape.attr({'stroke-opacity': shape['strokeAlpha']}); }
                                 if (shape['strokeColor']) { newShape.attr({'stroke': shape['strokeColor']}); }
                                 else { newShape.attr({'stroke': '#ffffff'}); }  // white is default
                             }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12394

Previously, the whole shape (stroke and fill) were getting set opacity set according to the line "alpha" in Insight. Now, we set the opacity of the fill and stroke independently.

To test:
 - In Insight, create a shape (E.g. rectangle) that has different opacity for fill and line.
 - Check display in web to see that opacity is same for stroke and line.

![screen shot 2015-06-30 at 16 39 54](https://cloud.githubusercontent.com/assets/900055/8434983/b5c1e98e-1f46-11e5-9838-b81004af71cc.png)
