### PR TITLE
Move filter condition static string to function

### DIFF
--- a/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
@@ -62,18 +62,6 @@ public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
 
     static public final String filterName = "securityFilter";
 
-    private static String myFilterCondition = String.format(
-                  "\n( "
-                + "\n  1 = :is_share OR "
-                + "\n  1 = :is_admin OR "
-                + "\n  (group_id in (:leader_of_groups)) OR "
-                + "\n  (owner_id = :current_user AND %s) OR " // 1st arg U
-                + "\n  (group_id in (:member_of_groups) AND %s) OR " // 2nd arg G
-                + "\n  (%s) " // 3rd arg W
-                + "\n)"
-                + "\n", isGranted(USER, READ), isGranted(GROUP, READ),
-                isGranted(WORLD, READ));
-
     final SqlAction sql;
 
     /**
@@ -96,8 +84,22 @@ public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
         this.sql = sql;
     }
 
+    private static String myFilterCondition() {
+        return String.format(
+                "\n( "
+                + "\n  1 = :is_share OR "
+                + "\n  1 = :is_admin OR "
+                + "\n  (group_id in (:leader_of_groups)) OR "
+                + "\n  (owner_id = :current_user AND %s) OR " // 1st arg U
+                + "\n  (group_id in (:member_of_groups) AND %s) OR " // 2nd arg G
+                + "\n  (%s) " // 3rd arg W
+                + "\n)"
+                + "\n", isGranted(USER, READ), isGranted(GROUP, READ),
+                isGranted(WORLD, READ));
+    }
+
     public String getDefaultCondition() {
-        return String.format(myFilterCondition, roles.getUserGroupId());
+        return String.format(myFilterCondition(), roles.getUserGroupId());
     }
 
     public Map<String, String> getParameterTypes() {

--- a/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
@@ -99,7 +99,7 @@ public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
     }
 
     public String getDefaultCondition() {
-        return String.format(myFilterCondition(), roles.getUserGroupId());
+        return myFilterCondition();
     }
 
     public Map<String, String> getParameterTypes() {

--- a/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
@@ -84,7 +84,7 @@ public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
         this.sql = sql;
     }
 
-    private static String myFilterCondition() {
+    protected String myFilterCondition() {
         return String.format(
                 "\n( "
                 + "\n  1 = :is_share OR "

--- a/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
+++ b/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
@@ -48,20 +48,6 @@ public class OneGroupSecurityFilter extends AbstractSecurityFilter {
 
     static public final String current_group = "current_group";
 
-    private static String myFilterCondition = "(\n"
-                // Should handle hidden groups at the top-level
-                // ticket:1784 - Allowing system objects to be read.
-                + "\n  ( group_id = :current_group AND "
-                + "\n     ( 1 = :is_nonprivate OR "
-                + "\n       1 = :is_adminorpi OR "
-                + "\n       owner_id = :current_user"
-                + "\n     )"
-                + "\n  ) OR"
-                + "\n  group_id = %s OR " // ticket:1794
-                // Will need to add something about world readable here.
-                + "\n 1 = :is_share"
-                + "\n)\n";
-
     /**
      * default constructor which calls all the necessary setters for this
      * {@link FactoryBean}. Also constructs the {@link #defaultFilterCondition }
@@ -81,8 +67,24 @@ public class OneGroupSecurityFilter extends AbstractSecurityFilter {
         super(roles);
     }
 
+    private static String myFilterCondition() {
+        return "(\n"
+                // Should handle hidden groups at the top-level
+                // ticket:1784 - Allowing system objects to be read.
+                + "\n  ( group_id = :current_group AND "
+                + "\n     ( 1 = :is_nonprivate OR "
+                + "\n       1 = :is_adminorpi OR "
+                + "\n       owner_id = :current_user"
+                + "\n     )"
+                + "\n  ) OR"
+                + "\n  group_id = %s OR " // ticket:1794
+                // Will need to add something about world readable here.
+                + "\n 1 = :is_share"
+                + "\n)\n";
+    }
+
     public String getDefaultCondition() {
-        return String.format(myFilterCondition, roles.getUserGroupId());
+        return String.format(myFilterCondition(), roles.getUserGroupId());
     }
 
     public Map<String, String> getParameterTypes() {

--- a/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
+++ b/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
@@ -67,7 +67,7 @@ public class OneGroupSecurityFilter extends AbstractSecurityFilter {
         super(roles);
     }
 
-    private static String myFilterCondition() {
+    protected String myFilterCondition() {
         return "(\n"
                 // Should handle hidden groups at the top-level
                 // ticket:1784 - Allowing system objects to be read.


### PR DESCRIPTION
This removes the static strings in `AllGroupsSecurityFilter` and
`OneGroupSecurityFilter` that define the filter condition and replaces
them with `static` methods of the same name. The only place this string
was being used in either class was in `getDefaultFilterCondition`, so
that reference has been changed to a call to the new method.