### PR TITLE
Make test timeout configurable

### DIFF
--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -211,6 +211,7 @@ omero.version=${omero.version}
                 <jvmarg value="-Domero.db.pass=${omero.db.pass}"/>
                 <jvmarg value="-Domero.data.dir=${omero.data.dir}"/>
                 <jvmarg value="-Domero.testing=true"/>
+                <jvmarg value="-Domero.test.timeout=${omero.test.timeout}"/>
                 <jvmarg value="-Domero.db.poolsize=${omero.db.poolsize}"/>
             </testng>
         </presetdef>

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -12,6 +12,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
+import java.lang.Long;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -162,7 +163,7 @@ public class AbstractServerTest extends AbstractTest {
     public String GUEST_GROUP = "guest";
 
     /** Scaling factor used for CmdCallbackI loop timings. */
-    protected long scalingFactor = 500;
+    protected long scalingFactor;
 
     /** The client object, this is the entry point to the Server. */
     protected omero.client client;
@@ -246,6 +247,7 @@ public class AbstractServerTest extends AbstractTest {
         root = newRootOmeroClient();
         tmp.__del__();
 
+        scalingFactor = new Long(System.getProperty("omero.test.timeout"));
         final EventContext ctx = newUserAndGroup("rw----");
         this.userFsDir = ctx.userName + "_" + ctx.userId + FsFile.separatorChar;
         SimpleBackOff backOff = new SimpleBackOff();

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -246,7 +246,14 @@ public class AbstractServerTest extends AbstractTest {
         root = newRootOmeroClient();
         tmp.__del__();
 
-        scalingFactor = new Long(System.getProperty("omero.test.timeout"));
+        try {
+            scalingFactor = new Long(System.getProperty("omero.test.timeout"));
+        } catch {
+            log.warn("Problem setting 'omero.test.timeout' to: " +
+                    System.getProperty("omero.test.timeout") +
+                    ". Defaulting to 500.");
+            scalingFactor = 500;
+        }
         final EventContext ctx = newUserAndGroup("rw----");
         this.userFsDir = ctx.userName + "_" + ctx.userId + FsFile.separatorChar;
         SimpleBackOff backOff = new SimpleBackOff();

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -248,7 +248,7 @@ public class AbstractServerTest extends AbstractTest {
 
         try {
             scalingFactor = new Long(System.getProperty("omero.test.timeout"));
-        } catch {
+        } catch (Exception e) {
             log.warn("Problem setting 'omero.test.timeout' to: " +
                     System.getProperty("omero.test.timeout") +
                     ". Defaulting to 500.");

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -12,7 +12,6 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
-import java.lang.Long;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -73,7 +73,9 @@ testng.useDefaultListeners=false
 loci.resolver=omero-resolver
 
 # Controls how long CmdCallbackI based tests will wait
-# to finish.
+# to finish. Value is approximately the number of
+# milliseconds to wait, but depends on the specific
+# number of retries used by each test.
 omero.test.timeout=500
 
 ############################################

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -72,6 +72,10 @@ testng.useDefaultListeners=false
 # etc/ivyconf.xml for more information.
 loci.resolver=omero-resolver
 
+# Controls how long CmdCallbackI based tests will wait
+# to finish.
+omero.test.timeout=500
+
 ############################################
 # hard-wired (compile-time) values
 ############################################


### PR DESCRIPTION
This adds the ability to specify `omero.test.timeout` in
`local.properties`. This value will be used in `AbstractServerTest` for
the `scalingFactor` that is, in turn, used to determine the timeout for
`CallbackCmdI`-based tests.