### PR TITLE
Handle new ROI Points string format (rebased onto metadata)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/ROI_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/ROI_utils.py
@@ -51,6 +51,54 @@ from omero.model import PolygonI
 from omero.model import MaskI
 from omero.rtypes import rdouble, rint, rstring
 
+#
+# HELPERS
+#
+
+
+def pointsStringToXYlist(string):
+    """
+    Method for converting the string returned from
+    omero.model.ShapeI.getPoints() into list of (x,y) points.
+    E.g: "points[309,427, 366,503, 190,491] points1[309,427, 366,503,
+    190,491] points2[309,427, 366,503, 190,491]"
+    or the new format: "309,427 366,503 190,491"
+    """
+    pointLists = string.strip().split("points")
+    if len(pointLists) < 2:
+        if len(pointLists) == 1 and pointLists[0]:
+            xys = pointLists[0].split()
+            xyList = [tuple(map(int, xy.split(','))) for xy in xys]
+            return xyList
+
+        msg = "Unrecognised ROI shape 'points' string: %s" % string
+        raise ValueError(msg)
+
+    firstList = pointLists[1]
+    xyList = []
+    for xy in firstList.strip(" []").split(", "):
+        x, y = xy.split(",")
+        xyList.append((int(x.strip()), int(y.strip())))
+    return xyList
+
+
+def xyListToBbox(xyList):
+    """
+    Returns a bounding box (x,y,w,h) that will contain the shape
+    represented by the XY points list
+    """
+    xList, yList = [], []
+    for xy in xyList:
+        x, y = xy
+        xList.append(x)
+        yList.append(y)
+    return (min(xList), min(yList), max(xList)-min(xList),
+            max(yList)-min(yList))
+
+
+#
+# Data implementation
+#
 
 ##
 # abstract, defines the method that call it as abstract.

--- a/components/tools/OmeroPy/test/unit/test_rois.py
+++ b/components/tools/OmeroPy/test/unit/test_rois.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Simple tests of various ROI utilities
+"""
+
+from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox
+
+
+class TestRoiUtils(object):
+
+    def testOldFormat(self):
+        xyList = pointsStringToXYlist((
+            "points[1,2, 3,4, 5,6] "
+        ))
+        assert xyList == [(1, 2), (3, 4), (5, 6)]
+        return xyList
+
+    def testNewFormat(self):
+        xyList = pointsStringToXYlist((
+            "1,2 3,4 5,6"
+        ))
+        assert xyList == [(1, 2), (3, 4), (5, 6)]
+        return xyList
+
+    def testBBox(self):
+        xyList = self.testOldFormat()
+        bbox = xyListToBbox(xyList)
+        assert bbox == (1, 2, 4, 4)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -451,12 +451,19 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
         omero.model.ShapeI.getPoints() into list of (x,y) points.
         E.g: "points[309,427, 366,503, 190,491] points1[309,427, 366,503,
         190,491] points2[309,427, 366,503, 190,491]"
+        or the new format: "309,427 366,503 190,491"
         """
         pointLists = string.strip().split("points")
         if len(pointLists) < 2:
-            logger.error(
-                "Unrecognised ROI shape 'points' string: %s" % string)
-            return ""
+            if len(pointLists) == 1 and pointLists[0]:
+                xys = pointLists[0].split()
+                xyList = [tuple(map(int, xy.split(','))) for xy in xys]
+                return xyList
+
+            msg = "Unrecognised ROI shape 'points' string: %s" % string
+            logger.error(msg)
+            raise ValueError(msg)
+
         firstList = pointLists[1]
         xyList = []
         for xy in firstList.strip(" []").split(", "):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -28,6 +28,7 @@ from django.template import RequestContext as Context
 from django.core.servers.basehttp import FileWrapper
 from omero.rtypes import rlong, unwrap
 from omero.constants.namespaces import NSBULKANNOTATIONS
+from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox
 from plategrid import PlateGrid
 from omero_version import build_year
 from marshal import imageMarshal, shapeMarshal
@@ -444,45 +445,6 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
         lineColour = colours[color]
     # used for padding if we go outside the image area
     bg_color = (221, 221, 221)
-
-    def pointsStringToXYlist(string):
-        """
-        Method for converting the string returned from
-        omero.model.ShapeI.getPoints() into list of (x,y) points.
-        E.g: "points[309,427, 366,503, 190,491] points1[309,427, 366,503,
-        190,491] points2[309,427, 366,503, 190,491]"
-        or the new format: "309,427 366,503 190,491"
-        """
-        pointLists = string.strip().split("points")
-        if len(pointLists) < 2:
-            if len(pointLists) == 1 and pointLists[0]:
-                xys = pointLists[0].split()
-                xyList = [tuple(map(int, xy.split(','))) for xy in xys]
-                return xyList
-
-            msg = "Unrecognised ROI shape 'points' string: %s" % string
-            logger.error(msg)
-            raise ValueError(msg)
-
-        firstList = pointLists[1]
-        xyList = []
-        for xy in firstList.strip(" []").split(", "):
-            x, y = xy.split(",")
-            xyList.append((int(x.strip()), int(y.strip())))
-        return xyList
-
-    def xyListToBbox(xyList):
-        """
-        Returns a bounding box (x,y,w,h) that will contain the shape
-        represented by the XY points list
-        """
-        xList, yList = [], []
-        for xy in xyList:
-            x, y = xy
-            xList.append(x)
-            yList.append(y)
-        return (min(xList), min(yList), max(xList)-min(xList),
-                max(yList)-min(yList))
 
     bBox = None   # bounding box: (x, y, w, h)
     shape = {}


### PR DESCRIPTION

This is the same as gh-3932 but rebased onto metadata.

----

There are (at least) 2 formats for storing Points in ROI Polygons. The webgateway only had one of them.

https://trello.com/c/hJLlf1Xr/47-error-on-preview-rois

Are there any other formats?

                