### PR TITLE
 OME artifactory Ivy resolver

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -61,10 +61,10 @@
       <!-- Remote downloads; cached to '~/.m2/repository' -->
       <ibiblio name="maven" m2compatible="true" cache="maven"
           usepoms="true" useMavenMetadata="false"/>
-      <ibiblio name="unstable-artifactory"
+      <ibiblio name="ome-simple-artifactory"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
-           root="http://artifacts.openmicroscopy.org/artifactory/simple/ome.unstable/"/>
+           root="http://artifacts.openmicroscopy.org/artifactory/simple/${simple.repository}/"/>
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true" root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -84,6 +84,12 @@
         <resolver ref="ome-artifactory"/>
     </chain>
 
+    <!-- Resolver for OME dependencies-->
+    <chain name="ome-resolver" returnFirst="true">
+        <resolver ref="user-maven"/>
+        <resolver ref="ome-artifactory"/>
+    </chain>
+
     <!-- Spring resolver which has as its first resolver the location
     where all our jars will be published -->
     <chain name="spring-resolver" returnFirst="true">
@@ -116,6 +122,8 @@
     <module organisation="omero" name="omejava" resolver="omero-resolver" />
     <module organisation="omero" name="*-test" resolver="test-resolver" matcher="glob"/>
     <module organisation="org.springframework" resolver="spring-resolver"/>
+    <module organisation="ome" name="appbundler" resolver="ome-resolver"/>
+    <module organisation="ome" resolver="${ome.resolver}"/>
   </modules>
 
   <triggers/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -61,6 +61,10 @@
       <!-- Remote downloads; cached to '~/.m2/repository' -->
       <ibiblio name="maven" m2compatible="true" cache="maven"
           usepoms="true" useMavenMetadata="false"/>
+      <ibiblio name="unstable-artifactory"
+          usepoms="true" useMavenMetadata="true"
+          m2compatible="true"
+           root="http://artifacts.openmicroscopy.org/artifactory/simple/ome.unstable/"/>
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true" root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -49,6 +49,9 @@ ivy.log.resolved.revision=false
 
 # The resolver to use for OME dependencies like Bio-Formats
 ome.resolver=ome-resolver
+# The name of the OME artifactory repository to use when ome.resolver is
+# switched to ome-simple-artifactory
+simple.repository=ome.unstable
 
 # Default keystore values
 jarsign.keystore=${omero.home}/lib/keystore

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -47,6 +47,9 @@ ivy.log.module.when.found=false
 ivy.log.conflict.resolution=false
 ivy.log.resolved.revision=false
 
+# The resolver to use for OME dependencies like Bio-Formats
+ome.resolver=ome-resolver
+
 # Default keystore values
 jarsign.keystore=${omero.home}/lib/keystore
 jarsign.alias=omedev


### PR DESCRIPTION
This PR proposes a strategy allowing merge OMERO builds to consume merge SNAPSHOTS of Bio-Formats preserving the current statu quo in terms of deployment/review workflow. Major changes are the following:

- a new OME resolver is defined specifically for artifacts associated with the `ome` group (Bio-Formats + appbundle). The only 2 places considered are the Maven cache and the OME artifactory
- a non-Maven OME artifactory repository is registered in `ivysettings.xml`
- the last commit shows how to consume a SNAPSHOT from a non Maven repository, by setting the bioformats.versions to `5.1.3-SNAPSHOT` and setting the `ome-resolver` to use the unstable repository directly (without caching the artifacts to Maven, i.e. use the local cache only)

To test this PR,
- run the build from 533b684 and check OMERO is built/deployed with Bio-Formats 5.1.2
- run the build from 382d481 and check OMERO is built/deployed with the latest Bio-Formats 5.1.3-SNAPSHOT
- run the build from d407288 and check OMERO is built/deployed with the merge Bio-Formats 5.1.3-SNAPSHOT

/cc @joshmoore @melissalinkert