### PR TITLE
allow group owners to chown

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -298,8 +298,9 @@ module omero {
 
         /**
          * Change the ownership of model objects.
-         * The user must be either an administrator,
-         * or the owner of the objects with
+         * The user must be an administrator, or
+         * they must be the owner of the objects
+         * or an owner of the objects' group, with
          * the target user a member of the objects' group.
          **/
         class Chown2 extends GraphModify2 {

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -275,37 +275,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for annotation chmod
-     */
-    @DataProvider(name = "chmod annotation test cases (debug)")
-    public Object[][] provideChmodAnnotationCaseDebug() {
-        int index = 0;
-        final int IS_GROUP_OWNER = index++;
-        final int IS_GROUP_MEMBER = index++;
-        final int IS_DATA_OWNER = index++;
-        final int IS_ADMIN = index++;
-        final int FROM_PERMS = index++;
-        final int TO_PERMS = index++;
-        final int IS_EXPECT_SUCCESS = index++;
-        final int IS_EXPECT_DELETE_OTHER = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[IS_GROUP_OWNER] = true;
-        testCase[IS_GROUP_MEMBER] = true;
-        testCase[IS_DATA_OWNER] = true;
-        testCase[IS_ADMIN] = false;
-        testCase[FROM_PERMS] = "rwra--";
-        testCase[TO_PERMS] = "rw----";
-        testCase[IS_EXPECT_SUCCESS] = true;
-        testCase[IS_EXPECT_DELETE_OTHER] = true;
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for annotation chmod
      */
     @DataProvider(name = "chmod annotation test cases")
@@ -342,13 +311,15 @@ public class PermissionsTest extends AbstractServerTest {
                                 }
                                 final Object[] testCase = new Object[index];
                                 testCase[IS_GROUP_OWNER] = isGroupOwner;
-                                testCase[IS_GROUP_MEMBER] = isGroupOwner;
+                                testCase[IS_GROUP_MEMBER] = isGroupMember;
                                 testCase[IS_DATA_OWNER] = isDataOwner;
                                 testCase[IS_ADMIN] = isAdmin;
                                 testCase[FROM_PERMS] = fromPerms;
                                 testCase[TO_PERMS] = toPerms;
                                 testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner;
                                 testCase[IS_EXPECT_DELETE_OTHER] = "rwra--".equals(fromPerms) && "rw----".equals(toPerms);
+                                // DEBUG: if (isGroupOwner == true && isGroupMember == true && isDataOwner == true &&
+                                //            isAdmin == true && "rwra--".equals(fromPerms) && "rw----".equals(toPerms))
                                 testCases.add(testCase);
                             }
                         }
@@ -435,25 +406,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for container chmod
-     */
-    @DataProvider(name = "chmod container test cases (debug)")
-    public Object[][] provideChmodContainerCaseDebug() {
-        int index = 0;
-        final int IS_IMAGE_OWNER = index++;
-        final int IS_LINK_OWNER = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[IS_IMAGE_OWNER] = true;
-        testCase[IS_LINK_OWNER] = true;
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for container chmod
      */
     @DataProvider(name = "chmod container test cases")
@@ -471,6 +423,7 @@ public class PermissionsTest extends AbstractServerTest {
                 final Object[] testCase = new Object[index];
                 testCase[IS_IMAGE_OWNER] = isImageOwner;
                 testCase[IS_LINK_OWNER] = isLinkOwner;
+                // DEBUG: if (isImageOwner == true && isLinkOwner == true)
                 testCases.add(testCase);
             }
         }
@@ -715,23 +668,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return group permissions for a specific private-group failure test case
-     */
-    @DataProvider(name = "private-group failure test cases (debug)")
-    public Object[][] providePrivateGroupFailureCaseDebug() {
-        int index = 0;
-        final int GROUP_PERMS = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[GROUP_PERMS] = "rw----";
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return group permissions for private-group failure test cases
      */
     @DataProvider(name = "private-group failure test cases")
@@ -746,6 +682,7 @@ public class PermissionsTest extends AbstractServerTest {
                 for (final String groupPerms : permsCases) {
                     final Object[] testCase = new Object[index];
                     testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG: if ("rwr---".equals(groupPerms))
                     testCases.add(testCase);
         }
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -78,8 +78,7 @@ public class PermissionsTest extends AbstractServerTest {
 
     private final List<Long> testImages = Collections.synchronizedList(new ArrayList<Long>());
 
-    private ExperimenterGroup systemGroup;
-    private EventContext userOtherGroup, adminOtherGroup;
+    private ExperimenterGroup systemGroup, otherGroup;
 
     /**
      * Set up admin and non-admin users who are not a member of the groups created by tests.
@@ -88,10 +87,7 @@ public class PermissionsTest extends AbstractServerTest {
     @BeforeClass
     public void setupOtherGroup() throws Exception {
         systemGroup = new ExperimenterGroupI(iAdmin.getSecurityRoles().systemGroupId, false);
-        userOtherGroup = newUserAndGroup("rwr---");
-        final ExperimenterGroup group = new ExperimenterGroupI(userOtherGroup.groupId, false);
-        adminOtherGroup = newUserInGroup(group, false);
-        addUsers(systemGroup, Collections.singletonList(adminOtherGroup.userId), false);
+        otherGroup = new ExperimenterGroupI(iAdmin.getEventContext().groupId, false);
     }
 
     /**
@@ -206,12 +202,13 @@ public class PermissionsTest extends AbstractServerTest {
      * Test a specific case of using {@link Chown2} with owner's shared annotations in a private group.
      * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
      * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group
+     * @param isGroupOwner if the user submitting the {@link Chown2} request owns the group itself
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
      * @param isExpectSuccess if the chown is expected to succeed
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown annotation test cases")
-    public void testChownAnnotationPrivate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup,
+    public void testChownAnnotationPrivate(boolean isDataOwner, boolean isAdmin, boolean isGroupOwner, boolean isRecipientInGroup,
             boolean isExpectSuccess) throws Exception {
 
         /* set up the users and group for this test case */
@@ -224,15 +221,15 @@ public class PermissionsTest extends AbstractServerTest {
         final long dataGroupId = importer.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
 
-        recipient = isRecipientInGroup ? newUserInGroup(dataGroup, false) : userOtherGroup;
+        recipient = newUserInGroup(isRecipientInGroup ? dataGroup : otherGroup, false);
 
         if (isDataOwner) {
             chowner = importer;
         } else {
-            chowner = isAdmin ? adminOtherGroup : recipient;
+            chowner = newUserInGroup(dataGroup, isGroupOwner);
         }
 
-        if (isAdmin && chowner != adminOtherGroup) {
+        if (isAdmin) {
             addUsers(systemGroup, Collections.singletonList(chowner.userId), false);
         }
 
@@ -305,13 +302,14 @@ public class PermissionsTest extends AbstractServerTest {
      * Test a specific case of using {@link Chown2} with owner's and others' annotations in a read-annotate group.
      * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
      * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group
+     * @param isGroupOwner if the user submitting the {@link Chown2} request owns the group itself
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
      * @param isExpectSuccess if the chown is expected to succeed
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown annotation test cases")
-    public void testChownAnnotationReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isRecipientInGroup,
-            boolean isExpectSuccess) throws Exception {
+    public void testChownAnnotationReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isGroupOwner,
+            boolean isRecipientInGroup, boolean isExpectSuccess) throws Exception {
 
         /* set up the users and group for this test case */
 
@@ -323,15 +321,15 @@ public class PermissionsTest extends AbstractServerTest {
         final long dataGroupId = importer.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
 
-        recipient = isRecipientInGroup ? newUserInGroup(dataGroup, false) : userOtherGroup;
+        recipient = newUserInGroup(isRecipientInGroup ? dataGroup : otherGroup, false);
 
         if (isDataOwner) {
             chowner = importer;
         } else {
-            chowner = isAdmin ? adminOtherGroup : recipient;
+            chowner = newUserInGroup(dataGroup, isGroupOwner);
         }
 
-        if (isAdmin && chowner != adminOtherGroup) {
+        if (isAdmin) {
             addUsers(systemGroup, Collections.singletonList(chowner.userId), false);
         }
 
@@ -392,6 +390,7 @@ public class PermissionsTest extends AbstractServerTest {
         int index = 0;
         final int IS_DATA_OWNER = index++;
         final int IS_ADMIN = index++;
+        final int IS_GROUP_OWNER = index++;
         final int IS_RECIPIENT_IN_GROUP = index++;
         final int IS_EXPECT_SUCCESS = index++;
 
@@ -400,6 +399,7 @@ public class PermissionsTest extends AbstractServerTest {
         final Object[] testCase = new Object[index];
         testCase[IS_DATA_OWNER] = true;
         testCase[IS_ADMIN] = true;
+        testCase[IS_GROUP_OWNER] = true;
         testCase[IS_RECIPIENT_IN_GROUP] = true;
         testCase[IS_EXPECT_SUCCESS] = true;
         testCases.add(testCase);
@@ -415,6 +415,7 @@ public class PermissionsTest extends AbstractServerTest {
         int index = 0;
         final int IS_DATA_OWNER = index++;
         final int IS_ADMIN = index++;
+        final int IS_GROUP_OWNER = index++;
         final int IS_RECIPIENT_IN_GROUP = index++;
         final int IS_EXPECT_SUCCESS = index++;
 
@@ -424,13 +425,16 @@ public class PermissionsTest extends AbstractServerTest {
 
         for (final boolean isDataOwner : booleanCases) {
             for (final boolean isAdmin : booleanCases) {
-                for (final boolean isRecipientInGroup : booleanCases) {
-                    final Object[] testCase = new Object[index];
-                    testCase[IS_DATA_OWNER] = isDataOwner;
-                    testCase[IS_ADMIN] = isAdmin;
-                    testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
-                    testCase[IS_EXPECT_SUCCESS] = isAdmin || isDataOwner && isRecipientInGroup;
-                    testCases.add(testCase);
+                for (final boolean isGroupOwner : booleanCases) {
+                    for (final boolean isRecipientInGroup : booleanCases) {
+                        final Object[] testCase = new Object[index];
+                        testCase[IS_DATA_OWNER] = isDataOwner;
+                        testCase[IS_ADMIN] = isAdmin;
+                        testCase[IS_GROUP_OWNER] = isGroupOwner;
+                        testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
+                        testCase[IS_EXPECT_SUCCESS] = isAdmin || (isGroupOwner || isDataOwner) && isRecipientInGroup;
+                        testCases.add(testCase);
+                    }
                 }
             }
         }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -383,31 +383,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for annotation chown
-     */
-    @DataProvider(name = "chown annotation test cases (debug)")
-    public Object[][] provideChownAnnotationCaseDebug() {
-        int index = 0;
-        final int IS_DATA_OWNER = index++;
-        final int IS_ADMIN = index++;
-        final int IS_GROUP_OWNER = index++;
-        final int IS_RECIPIENT_IN_GROUP = index++;
-        final int IS_EXPECT_SUCCESS = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[IS_DATA_OWNER] = true;
-        testCase[IS_ADMIN] = true;
-        testCase[IS_GROUP_OWNER] = true;
-        testCase[IS_RECIPIENT_IN_GROUP] = true;
-        testCase[IS_EXPECT_SUCCESS] = true;
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for annotation chown
      */
     @DataProvider(name = "chown annotation test cases")
@@ -433,6 +408,8 @@ public class PermissionsTest extends AbstractServerTest {
                         testCase[IS_GROUP_OWNER] = isGroupOwner;
                         testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
                         testCase[IS_EXPECT_SUCCESS] = isAdmin || (isGroupOwner || isDataOwner) && isRecipientInGroup;
+                        // DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
+                        //            isRecipientInGroup == true)
                         testCases.add(testCase);
                     }
                 }
@@ -592,27 +569,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for container chown
-     */
-    @DataProvider(name = "chown container test cases (debug)")
-    public Object[][] provideChownContainerCaseDebug() {
-        int index = 0;
-        final int IS_IMAGE_OWNER = index++;
-        final int IS_LINK_OWNER = index++;
-        final int GROUP_PERMS = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[IS_IMAGE_OWNER] = true;
-        testCase[IS_LINK_OWNER] = true;
-        testCase[GROUP_PERMS] = "rw----";
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for container chown
      */
     @DataProvider(name = "chown container test cases")
@@ -638,6 +594,7 @@ public class PermissionsTest extends AbstractServerTest {
                     testCase[IS_IMAGE_OWNER] = isImageOwner;
                     testCase[IS_LINK_OWNER] = isLinkOwner;
                     testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG: if (isImageOwner == true && isLinkOwner == true && "rwr---".equals(groupPerms))
                     testCases.add(testCase);
                 }
             }
@@ -788,24 +745,6 @@ public class PermissionsTest extends AbstractServerTest {
         disconnect();
     }
 
-
-    /**
-     * @return group permissions for a specific image sharing test case
-     */
-    @DataProvider(name = "image sharing test cases (debug)")
-    public Object[][] provideImageSharingCaseDebug() {
-        int index = 0;
-        final int GROUP_PERMS = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[GROUP_PERMS] = "rwr---";
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
     /**
      * @return group permissions for image sharing test cases
      */
@@ -821,6 +760,7 @@ public class PermissionsTest extends AbstractServerTest {
         for (final String groupPerms : permsCases) {
             final Object[] testCase = new Object[index];
             testCase[GROUP_PERMS] = groupPerms;
+            // DEBUG: if ("rwr---".equals(groupPerms))
             testCases.add(testCase);
         }
 
@@ -965,25 +905,6 @@ public class PermissionsTest extends AbstractServerTest {
 }
 
     /**
-     * @return a specific test case for dataset to plate
-     */
-    @DataProvider(name = "dataset to plate test cases (debug)")
-    public Object[][] provideDatasetToPlateCaseDebug() {
-        int index = 0;
-        final int GROUP_PERMS = index++;
-        final int TARGET = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[GROUP_PERMS] = "rwr---";
-        testCase[TARGET] = Target.IMAGES;
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for dataset to plate
      */
     @DataProvider(name = "dataset to plate test cases")
@@ -1001,6 +922,7 @@ public class PermissionsTest extends AbstractServerTest {
                 final Object[] testCase = new Object[index];
                 testCase[GROUP_PERMS] = groupPerms;
                 testCase[TARGET] = target;
+                // DEBUG: if ("rwr---".equals(groupPerms) && target == Target.DATASET)
                 testCases.add(testCase);
             }
         }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -402,6 +402,10 @@ public class PermissionsTest extends AbstractServerTest {
             for (final boolean isAdmin : booleanCases) {
                 for (final boolean isGroupOwner : booleanCases) {
                     for (final boolean isRecipientInGroup : booleanCases) {
+                        if (isAdmin && isGroupOwner) {
+                            /* not an interesting case */
+                            continue;
+                        }
                         final Object[] testCase = new Object[index];
                         testCase[IS_DATA_OWNER] = isDataOwner;
                         testCase[IS_ADMIN] = isAdmin;

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -685,23 +685,6 @@ public class HierarchyDeleteTest extends AbstractServerTest {
     }
 
     /**
-     * @return a specific test case for dataset to plate
-     */
-    @DataProvider(name = "dataset to plate test cases (debug)")
-    public Object[][] provideDatasetToPlateCaseDebug() {
-        int index = 0;
-        final int TARGET = index++;
-
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        final Object[] testCase = new Object[index];
-        testCase[TARGET] = Target.IMAGES;
-        testCases.add(testCase);
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
      * @return a variety of test cases for dataset to plate
      */
     @DataProvider(name = "dataset to plate test cases")
@@ -714,6 +697,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         for (final Target target : Target.values()) {
             final Object[] testCase = new Object[index];
             testCase[TARGET] = target;
+            // DEBUG: if (target == Target.DATASET)
             testCases.add(testCase);
         }
 


### PR DESCRIPTION
This PR expands `Chown2` such that it allows a non-admin to chown somebody else's data if they are an owner of the group in which the data is. Perhaps most easily tested from the CLI.

https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration.chown/ should continue to pass.