### PR TITLE
View well (rebased onto metadata)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/ViewAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/ViewAction.java
@@ -25,9 +25,11 @@ package org.openmicroscopy.shoola.agents.dataBrowser.actions;
 
 //Java imports
 import java.awt.event.ActionEvent;
+
 import javax.swing.Action;
 
 //Third-party libraries
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.dataBrowser.IconManager;
@@ -35,7 +37,9 @@ import org.openmicroscopy.shoola.agents.dataBrowser.browser.Browser;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageDisplay;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import pojos.ImageData;
+import pojos.WellSampleData;
 
 /** 
  * Action to view an image or a collection of images.
@@ -70,7 +74,8 @@ public class ViewAction
             setEnabled(false);
             return;
         }
-    	setEnabled(node.getHierarchyObject() instanceof ImageData);
+    	Object ho = node.getHierarchyObject();
+    	setEnabled(ho instanceof ImageData || ho instanceof WellSampleData);
     }
     
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserControl.java
@@ -586,7 +586,9 @@ class DataBrowserControl
         } else if (Browser.MAIN_VIEW_DISPLAY_PROPERTY.equals(name)) {
             ImageDisplay node = (ImageDisplay) evt.getNewValue();
             Object ho = node.getHierarchyObject();
-            if (ho instanceof ImageData) model.viewDisplay(node, true);
+            if (ho instanceof ImageData || ho instanceof WellSampleData) {
+                model.viewDisplay(node, true);
+            }
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/MeasurementsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/MeasurementsLoader.java
@@ -92,8 +92,7 @@ public class MeasurementsLoader
      */
     public void load()
     {
-        long userID = ImViewerAgent.getUserDetails().getId();
-        handle = mhView.loadROIMeasurement(ctx, object, userID, this);
+        handle = mhView.loadROIMeasurement(ctx, object, -1, this);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -524,7 +524,21 @@ class ImViewerComponent
 		EventBus bus = ImViewerAgent.getRegistry().getEventBus();
 		bus.post(evt);
 	}
-	
+
+	/**
+	 * Sets the image and starts the initialization process.
+	 *
+	 * @param data The value to set.
+	 */
+    private void setImage(DataObject data)
+    {
+        model.setImageData(data);
+        view.setImageData();
+        if (model.getMetadataViewer() != null)
+            model.getMetadataViewer().addPropertyChangeListener(controller);
+        fireStateChange();
+    }
+
 	/**
 	 * Creates a new instance.
 	 * The {@link #initialize() initialize} method should be called straight 
@@ -637,16 +651,11 @@ class ImViewerComponent
 		switch (model.getState()) {
 			case NEW:
 				model.setAlternativeSettings(settings, userID);
-				/*
-				if (model.isImageLoaded())
-					model.fireRenderingControlLoading(model.getPixelsID());
-				else model.fireImageLoading();
-				*/
 				if (!model.isImageLoaded()) {
 					model.fireImageLoading();
 				} else {
 					model.setState(ImViewer.LOADING_IMAGE_DATA);
-					setImageData(model.getImage());
+					setImage(model.getRefObject());
 				}
 				fireStateChange();
 				break;
@@ -2618,11 +2627,7 @@ class ImViewerComponent
 					"invoked in the LOADING_IMAGE_DATA.");
 		if (data == null)
 			throw new IllegalArgumentException("No image to set.");
-		model.setImageData(data);
-		view.setImageData();
-		if (model.getMetadataViewer() != null)
-			model.getMetadataViewer().addPropertyChangeListener(controller);
-		fireStateChange();
+		setImage(data);
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -49,6 +50,7 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.agents.events.iviewer.ChannelSelection;
 import org.openmicroscopy.shoola.agents.events.iviewer.ImageRendered;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurePlane;
@@ -88,6 +90,7 @@ import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 import org.openmicroscopy.shoola.util.ui.drawingtools.canvas.DrawingCanvasView;
+
 import pojos.ChannelData;
 import pojos.DataObject;
 import pojos.ExperimenterData;
@@ -2001,13 +2004,8 @@ class ImViewerComponent
 	 */
 	public void showMeasurementTool(Point point)
 	{
-		//TODO: Review for HCS.
-		if (!model.isHCSImage()) {
-			postMeasurementEvent(null);
-			return;
-		}
 		Collection measurements = model.getMeasurements();
-		if (measurements == null || measurements.size() == 0) {
+		if (CollectionUtils.isEmpty(measurements)) {
 			postMeasurementEvent(null);
 			return;
 		}
@@ -2016,23 +2014,20 @@ class ImViewerComponent
 		JPanel p = new JPanel();
 		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
 		Iterator i;
-		if (measurements != null) {
-			i = measurements.iterator();
-			FileAnnotationData fa;
-			JCheckBox box;
-			Object object;
-			while (i.hasNext()) {
-				object = i.next();
-				if (object instanceof FileAnnotationData) {
-					fa = (FileAnnotationData) object;
-					box = new JCheckBox(fa.getDescription());
-					box.setSelected(true);
-					p.add(box);
-					boxes.put(box, fa);
-				}
-			}
-		}
-		
+		i = measurements.iterator();
+        FileAnnotationData fa;
+        JCheckBox box;
+        Object object;
+        while (i.hasNext()) {
+            object = i.next();
+            if (object instanceof FileAnnotationData) {
+                fa = (FileAnnotationData) object;
+                box = new JCheckBox(fa.getDescription());
+                box.setSelected(true);
+                p.add(box);
+                boxes.put(box, fa);
+            }
+        }
 		if (boxes.size() == 0)  return;
 		
 		view.setMeasurementLaunchingStatus(true);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -565,9 +565,9 @@ class ImViewerModel
 				getSecurityContext());
 		
 		// there might already exist another MetadataViewer with modified
-		// rendering settings; if so copy it's original settings
+		// rendering settings; if so copy its original settings
                 MetadataViewer otherViewer = MetadataViewerFactory.getViewerFromId(
-                        ImageData.class.getName(), image.getId());
+                        ImageData.class.getName(), getImageID());
                 if (otherViewer != null) {
                     Renderer otherRenderer = otherViewer.getRenderer();
                     if (otherRenderer != null)
@@ -598,6 +598,7 @@ class ImViewerModel
 		this.ctx = ctx;
 		this.imageID = imageID;
 		initialize(bounds, separateWindow);
+		System.err.println(imageID);
 	}
 	
 	/**
@@ -635,6 +636,12 @@ class ImViewerModel
 		}
 	}
 
+	/**
+	 * Returns the object of reference.
+	 *
+	 * @return See above.
+	 */
+	DataObject getRefObject() { return image; }
 	/**
 	 * Called by the <code>ImViewer</code> after creation to allow this
 	 * object to store a back reference to the embedding component.
@@ -2199,12 +2206,12 @@ class ImViewerModel
 	 * 
 	 * @param image The value to set.
 	 */
-	void setImageData(ImageData image)
+	void setImageData(DataObject image)
 	{
 		state = ImViewer.LOADING_RND;
 		this.image = image;
 		initializeMetadataViewer();
-		currentPixelsID = image.getDefaultPixels().getId();
+		currentPixelsID = getImage().getDefaultPixels().getId();
 		if (metadataViewer != null)
 			metadataViewer.setParentRootObject(parent, grandParent);
 	}
@@ -2570,7 +2577,7 @@ class ImViewerModel
 	 */
 	boolean isHCSImage()
 	{
-		return (image instanceof WellSampleData);
+		return image instanceof WellSampleData;
 	}
 
         /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2125,7 +2125,7 @@ class ImViewerModel
 		this.grandParent = grandParent;
 		if (metadataViewer != null)
 			metadataViewer.setParentRootObject(parent, grandParent);
-		if (isHCSImage()) fireMeasurementsLoading();
+		fireMeasurementsLoading();
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -561,7 +561,7 @@ class ImViewerModel
 	{
 		metadataViewer = MetadataViewerFactory.getViewer("",
 				MetadataViewer.RND_SPECIFIC);
-		metadataViewer.setRootObject(image, metadataViewer.getUserID(),
+		metadataViewer.setRootObject(getImage(), metadataViewer.getUserID(),
 				getSecurityContext());
 		
 		// there might already exist another MetadataViewer with modified
@@ -1499,7 +1499,7 @@ class ImViewerModel
 	 * 
 	 * @return See above.
 	 */
-	boolean isImageLoaded() { return (image != null); }
+	boolean isImageLoaded() { return image != null; }
 	
 	/**
 	 * Returns the ID of the viewed image.
@@ -1942,7 +1942,7 @@ class ImViewerModel
 	 * 
 	 * @return See above.
 	 */
-	long getOwnerID() { return image.getOwner().getId(); }
+	long getOwnerID() { return getImage().getOwner().getId(); }
 
 	/**
 	 * Returns <code>true</code> if data to save, <code>false</code>
@@ -2664,7 +2664,7 @@ class ImViewerModel
     void fireImagAcquisitionDataLoading() {
         if (component.getImageAcquisitionData() == null) {
             AcquisitionDataLoader loader = new AcquisitionDataLoader(component,
-                    ctx, image);
+                    ctx, getImage());
             loader.load();
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -807,14 +807,24 @@ class EditorControl
 				break;
 			case VIEW_IMAGE:
 				Object refObject = view.getRefObject();
-				ImageData img = null;
-				if (refObject instanceof ImageData) {
-		        	img = (ImageData) refObject;
-		        } else if (refObject instanceof WellSampleData) {
-		        	img = ((WellSampleData) refObject).getImage();
+				DataObject img = null;
+				if (refObject instanceof ImageData ||
+				   refObject instanceof WellSampleData) {
+		        	img = (DataObject) refObject;
 		        }
 				if (img != null) {
 					ViewImageObject vio = new ViewImageObject(img);
+					DataObject po = null;
+		            DataObject gpo = null;
+		            refObject = view.getParentRootObject();
+		            if (refObject instanceof DataObject) {
+		                po = (DataObject) refObject;
+		            }
+		            refObject = view.getGrandParentRootObject();
+                    if (refObject instanceof DataObject) {
+                        gpo = (DataObject) refObject;
+                    }
+					vio.setContext(po, gpo);
 					MetadataViewerAgent.getRegistry().getEventBus().post(
 						new ViewImage(model.getSecurityContext(), vio, null));
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -3559,7 +3559,8 @@ class EditorModel
 			renderer.onSettingsApplied(rndControl);
 		} else {
 		    renderer = RendererFactory.createRenderer(getSecurityContext(),
-                    rndControl, getImage(), getRndIndex(), getXMLAnnotations());
+                    rndControl, (DataObject) getRefObject(), getRndIndex(),
+                    getXMLAnnotations());
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -48,6 +48,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
 
 
+
 //Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXTaskPane;
@@ -909,7 +910,24 @@ class EditorUI
 	 * @return See above.
 	 */
 	Object getRefObject() { return model.getRefObject(); }
-	
+
+	/**
+     * Returns the parent of the object of reference.
+     * 
+     * @return See above.
+     */
+    Object getParentRootObject() { return model.getParentRootObject(); }
+    
+    /**
+     * Returns the parent of the object of reference.
+     * 
+     * @return See above.
+     */
+    Object getGrandParentRootObject()
+    {
+        return model.getGrandParentRootObject();
+    }
+
 	/** Cleans up the view or adds the components
 	 * 
 	 * @param cleanup 	Pass <code>true</code> to clean up, <code>false</code>

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 
@@ -57,6 +58,7 @@ import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 
 import pojos.ChannelData;
+import pojos.DataObject;
 import pojos.ImageData;
 import pojos.PixelsData;
 
@@ -1251,7 +1253,7 @@ class RendererComponent
 	 */
 	public void viewImage()
 	{
-		ImageData image = model.getRefImage();
+		DataObject image = model.getObject();
 		if (image == null) return;
 		EventBus bus = MetadataViewerAgent.getRegistry().getEventBus();
 		if (MetadataViewerAgent.runAsPlugin() == LookupNames.IMAGE_J) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererFactory.java
@@ -23,15 +23,12 @@
 package org.openmicroscopy.shoola.agents.metadata.rnd;
 
 
-//Java imports
 import java.util.Collection;
 
-//Third-party libraries
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
-import pojos.ImageData;
+
+import pojos.DataObject;
 import pojos.XMLAnnotationData;
 
 /** 
@@ -59,7 +56,7 @@ public class RendererFactory
      * @return See above.
      */
     public static Renderer createRenderer(SecurityContext ctx,
-    		RenderingControl rndControl, ImageData image, int rndIndex,
+    		RenderingControl rndControl, DataObject image, int rndIndex,
     		Collection<XMLAnnotationData> modulo)
     {
         RendererModel model = new RendererModel(ctx, rndControl, rndIndex);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -35,11 +35,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+
+
 //Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
 
+
+
 //Application-internal dependencies
 import omero.romio.PlaneDef;
+
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.RenderingControlShutDown;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
@@ -55,9 +60,12 @@ import org.openmicroscopy.shoola.env.rnd.data.ResolutionLevel;
 import org.openmicroscopy.shoola.util.file.modulo.ModuloInfo;
 import org.openmicroscopy.shoola.util.file.modulo.ModuloParser;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
+
 import pojos.ChannelData;
+import pojos.DataObject;
 import pojos.ImageData;
 import pojos.PixelsData;
+import pojos.WellSampleData;
 import pojos.XMLAnnotationData;
 
 /** 
@@ -167,7 +175,7 @@ class RendererModel
     private RenderingDefinitionHistory history = new RenderingDefinitionHistory();
     
     /** Reference to the image. */
-    private ImageData image;
+    private DataObject image;
 
     /** The security context.*/
     private SecurityContext ctx;
@@ -210,7 +218,7 @@ class RendererModel
 	 * 
 	 * @param image The value to set.
 	 */
-	void setImage(ImageData image) { this.image = image; }
+	void setImage(DataObject image) { this.image = image; }
 
 	/**
 	 * Sets the rendering control.
@@ -232,7 +240,19 @@ class RendererModel
 	 *
 	 * @return See above.
 	 */
-	ImageData getRefImage() { return image; }
+	ImageData getRefImage()
+	{
+	    if (image instanceof ImageData) {
+	        return (ImageData) image;
+	    }
+	    return ((WellSampleData) image).getImage();
+	}
+
+	/**
+	 * Returns the ref object.
+	 * @return
+	 */
+	DataObject getObject() { return image; }
 
 	/**
 	 * Returns <code>true</code> if one channel is selected,
@@ -1736,7 +1756,7 @@ class RendererModel
 	 * @return See above
 	 */
 	boolean isIntegerPixelData() {
-        String t = image.getDefaultPixels().getPixelType();
+        String t = getRefImage().getDefaultPixels().getPixelType();
         return t.equals(OmeroImageService.INT_8)
                 || t.equals(OmeroImageService.UINT_8)
                 || t.equals(OmeroImageService.INT_16)
@@ -1744,4 +1764,5 @@ class RendererModel
                 || t.equals(OmeroImageService.INT_32)
                 || t.equals(OmeroImageService.UINT_32);
 	}
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -7248,7 +7248,9 @@ class OMEROGateway
 		try {
 		    IRoiPrx svc = c.getROIService();
 			RoiOptions options = new RoiOptions();
-			options.userId = omero.rtypes.rlong(userID);
+			if (userID >= 0) {
+			    options.userId = omero.rtypes.rlong(userID);
+			}
 			Collection files = PojoMapper.asDataObjects(
 					svc.getRoiMeasurements(imageID, options));
 			List results = new ArrayList();


### PR DESCRIPTION

This is the same as gh-3926 but rebased onto metadata.

----

Keep origin of the image i.e. if the image is going from Well sample
This will allow the loading of ROI measurements when the mt is opened. cc @joshmoore 
To test;
 * Make sure you can open a standard image (right-click ,toolbar, double click, right-hand panel: general/preview)
* Make sure you can open an image from well sample (right-click , double click, right-hand panel)

To test the roi measurements section, the annotation will either have to be linked to plate cc @manics  or @joshmoore will open a PR to adjust the query in ROIService

@manics has linked the file to the plate
Looking closely at the query, the table also needs to be linked to the roi in order to work. This could potentially imply a lot of links
@manics is going to add the links to the roi so we can test it. This will not be part of the IDR import script

                