### PR TITLE
Plate acquisition date (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5706,7 +5706,8 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
             if t > 0:
                 return datetime.fromtimestamp(t / 1000)
         except:
-            return super(_PlateAcquisitionWrapper, self).getDate()
+            pass
+        return super(_PlateAcquisitionWrapper, self).getDate()
 
     def getName(self):
         name = super(_PlateAcquisitionWrapper, self).getName()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5700,6 +5700,14 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
     def __bstrap__(self):
         self.OMERO_CLASS = 'PlateAcquisition'
 
+    def getDate(self):
+        try:
+            t = self._obj.startTime.val
+            if t > 0:
+                return datetime.fromtimestamp(t / 1000)
+        except:
+            return super(_PlateAcquisitionWrapper, self).getDate()
+
     def getName(self):
         name = super(_PlateAcquisitionWrapper, self).getName()
         if name is None:

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -87,7 +87,8 @@ class TestPlateAcquistionWrapper(object):
 
         plateacq = update_service.saveAndReturnObject(plateacq)
         plate_id = plateacq.plate.id.val
-        return gw.getObject('Plate', plate_id)
+        plate = gw.getObject('Plate', plate_id)
 
         acq = list(plate.listPlateAcquisitions())[0]
-        assert acq.getStartTime() > 0
+        assert acq.getStartTime() is None
+        assert acq.getDate() > datetime.fromtimestamp(0)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -6,16 +6,17 @@
 # Use is subject to license terms supplied in LICENSE.txt
 
 """
-   gateway tests - Testing the gateway plate wrapper
+   gateway tests - Testing the gateway plate and plate acquisition wrappers
 
    pytest fixtures used as defined in conftest.py:
    - gatewaywrapper
 
 """
 
+from datetime import datetime
 import pytest
 
-from omero.model import PlateI, WellI, WellSampleI, ImageI
+from omero.model import PlateAcquisitionI, PlateI, WellI, WellSampleI, ImageI
 from omero.rtypes import rstring, rint, rtime
 from uuid import uuid4
 
@@ -32,6 +33,12 @@ def plate(request, gatewaywrapper):
     update_service = gw.getUpdateService()
     plate = PlateI()
     plate.name = rstring(uuid())
+
+    plateacq = PlateAcquisitionI()
+    plateacq.name = rstring(uuid())
+    plateacq.plate = plate
+    plateacq.startTime = rtime(1436227200L * 1000)
+
     for well_index in range(3):
         well = WellI()
         well.row = rint(well_index**2)
@@ -43,8 +50,10 @@ def plate(request, gatewaywrapper):
             image.acquisitionDate = rtime(0)
             well_sample.image = image
             well.addWellSample(well_sample)
+            well_sample.plateAcquisition = plateacq
         plate.addWell(well)
-    plate_id, = update_service.saveAndReturnIds([plate])
+    plateacq = update_service.saveAndReturnObject(plateacq)
+    plate_id = plateacq.plate.id.val
     return gw.getObject('Plate', plate_id)
 
 
@@ -52,3 +61,33 @@ class TestPlateWrapper(object):
 
     def testGetGridSize(self, gatewaywrapper, plate):
         assert plate.getGridSize() == {'rows': 5L, 'columns': 9L}
+
+
+class TestPlateAcquistionWrapper(object):
+
+    def testListPlateAcquisitions(self, gatewaywrapper, plate):
+        acqs = list(plate.listPlateAcquisitions())
+        assert len(acqs) == 1
+
+    def testGetDate(self, gatewaywrapper, plate):
+        acq = list(plate.listPlateAcquisitions())[0]
+        assert acq.getStartTime() == 1436227200L * 1000
+        # Note OMERO currently uses localtime not utctime
+        assert acq.getDate() == datetime.fromtimestamp(1436227200L)
+
+    def testGetDateDefault(self, gatewaywrapper):
+        gatewaywrapper.loginAsAuthor()
+        gw = gatewaywrapper.gateway
+        update_service = gw.getUpdateService()
+        plate = PlateI()
+        plate.name = rstring(uuid())
+
+        plateacq = PlateAcquisitionI()
+        plateacq.plate = plate
+
+        plateacq = update_service.saveAndReturnObject(plateacq)
+        plate_id = plateacq.plate.id.val
+        return gw.getObject('Plate', plate_id)
+
+        acq = list(plate.listPlateAcquisitions())[0]
+        assert acq.getStartTime() > 0


### PR DESCRIPTION
This is the same as gh-3939 but rebased onto develop.

----
https://trello.com/c/oPlGJKqQ/60-plateacquisitions-in-web-should-show-starttime
Show `PlateAcquisition.startDate` if it's set, otherwise fallback to the previous behaviour.

To test: find a PlateAcquisition with a startTime set. OMERO.web should show this time as the Creation date instead of the import time.
                