### PR TITLE
Improving robot framework tests

### DIFF
--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -19,6 +19,7 @@ ${SERVER_ID}            1
 
 ${BROWSER}              Firefox
 ${DELAY}                0
+${WAIT}                 30
 
 ${LOGIN URL}            %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/login/
 ${WELCOME URL}          %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/

--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -93,16 +93,22 @@ Create Button Should Be Disabled
 
 Create Container
     [Arguments]                 ${dType}    ${newName}=testCreateContainerRobot
+    # Check if metadata panel was loaded and get and old object
+    # This is important when two the same objects are created in a row.
+    ${status}    ${oldId}    Run Keyword And Ignore Error    Get Text                css=tr.data_heading_id strong
     Click Button                add${dType}Button
     Element Should Be Visible   new-container-form
     Input Text                  name    ${newName}
     # Make sure we pick 'OK' button from visible dialog
     Click Element               xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//button/span[contains(text(), 'OK')]
-    Set Selenium Speed          1
-    Wait Until Page Contains Element    css=tr.data_heading_id
-    Set Selenium Speed                  ${DELAY}
+    # Wait until metadata panel reloads based on status.
+    # This is work arround as unfortunately there is no Wait Until Page NOT Contains Element
+    # This is important when two the same objects are created in a row.
+    Run Keyword If  '${status}'=='PASS'     Wait Until Page Contains Element    xpath=//tr[contains(@class,'data_heading_id')]/td/strong[not(contains(text(), '${oldId}'))]  ${WAIT}
+    Wait Until Page Contains            ${dType.title()} ID:  ${WAIT}
+    Wait Until Element Is Visible       css=tr.data_heading_id  ${WAIT}
     ${newId}    Get Text                css=tr.data_heading_id strong
-    Wait Until Page Contains Element    css=#${dType}-${newId}>a.jstree-clicked
+    Wait Until Page Contains Element    css=#${dType}-${newId}>a.jstree-clicked  ${WAIT}
     [Return]                            ${newId}
 
 Key Down

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -54,18 +54,21 @@ Test Cut Paste Dataset
 
     Select Experimenter
     ${p1id}=                                Create project      robot test paste1
-    ${p2id}=                                Create project      robot test paste2
     ${did}=                                 Create Dataset
     Click Element                           refreshButton
+    # Check hierarchy
+    Wait Until Element Is Visible           xpath=//li[@rel='experimenter']/ul/li[@id='project-${p1id}']/ul/li[@id='dataset-${did}']  ${WAIT}
+    Click Element                           xpath=//li[@id='dataset-${did}']/a
+    # Wait until metadata panel loads
+    Wait Until Page Contains                Dataset ID:  30
     Wait Until Page Contains Element        id=dataset-${did}
     Click Element                           id=cutButton
     # POST a /move/ action - wait for Orphaned Dataset
-    Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/ul/li[@id='dataset-${did}']
+    Wait Until Element Is Visible           xpath=//li[@rel='experimenter']/ul/li[@id='dataset-${did}']  ${WAIT}
     # Another /move/ to different Project
     Click Element                           xpath=//li[@id='project-${p1id}']/a
     Click Element                           id=pasteButton
-    Click Element                           refreshButton
-    Wait Until Page Contains Element        xpath=//li[@id='project-${p1id}']//li[@id='dataset-${did}']
+    Wait Until Element Is Visible           xpath=//li[@rel='experimenter']/ul/li[@id='project-${p1id}']/ul/li[@id='dataset-${did}']  ${WAIT}
 
 
 Test Cut Paste Image


### PR DESCRIPTION
As *Tree Test.Test Create Project Dataset*, *Post Test.Test Copy Paste Dataset* and *Post Test.Test Cut Paste Dataset* have been failing the most recently, this small improvement on waiting for reloading metadata panel should help.
In general is a bad idea to add sleep or delay in test. It should be determined by adding appropriate waiting time to **Wait Until...** keywords as a second argument.
