### PR TITLE
Revert to the *.ivy pattern for Ivy files in the local repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     - python-imaging
     - python-numpy
     - python-tables
-    - python-genshi
     - cmake
     - libgtest-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: java
 jdk:
   - openjdk7
 
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
+# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ jdk:
 
 sudo: false
 
+cache:
+  - $HOME/.m2
+
 matrix:
       fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 sudo: false
 
 cache:
+  directories:
   - $HOME/.m2
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,36 @@
 language: java
 
-env:
-    - BUILD="build-python"
-    - BUILD="build-java"
+jdk:
+  - openjdk7
+
+sudo: false
 
 matrix:
       fast_finish: true
 
-jdk:
-  - openjdk7
+addons:
+  apt_packages:
+    - git
+    - zeroc-ice34
+    - python-imaging
+    - python-numpy
+    - python-tables
+    - python-genshi
+    - cmake
+    - libgtest-dev
+
+env:
+    - BUILD="build-python"
+    - BUILD="build-java"
 
 before_install:
-    - sudo apt-get -qq update
-    - travis_retry sudo apt-get install -qq git
-    - travis_retry sudo apt-get install -qq zeroc-ice34
-    - travis_retry sudo apt-get install -qq python-imaging python-numpy python-tables python-genshi
-    - if [[ $BUILD == 'build-cpp' ]]; then travis_retry sudo apt-get install -qq cmake libgtest-dev; fi
     - git config github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
     - git config --global user.email snoopycrimecop@gmail.com
     - git config --global user.name 'Snoopy Crime Cop'
-    - sudo pip install scc pytest
+    - pip install --user scc pytest
+    - export PATH=$PATH:$HOME/.local/bin
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry sudo pip install flake8==2.4.0; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
 # retries the build due to:

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -42,7 +42,7 @@
     </filesystem>
     <filesystem name="repo" cache="local">
         <artifact pattern="${ivy.settings.dir}/../lib/repository/[artifact]-[revision].[type]" />
-        <ivy pattern="${ivy.settings.dir}/../lib/repository/[module]-[revision].xml"/>
+        <ivy pattern="${ivy.settings.dir}/../lib/repository/[module]-[revision].ivy"/>
     </filesystem>
     <filesystem name="test" checkmodified="true" changingMatcher="regexp" changingPattern=".*SNAPSHOT.*" cache="local">
         <artifact pattern="${ivy.settings.dir}/../target/test-repository/[artifact]-[revision].[type]" />


### PR DESCRIPTION
As part of https://github.com/openmicroscopy/openmicroscopy/pull/3931, the Ivy pattern for the local repository (under `lib/repository`) was erroneously modified, causing the Ivy resolution to unnecessarily interrogate the OME artifactory.

This PR also reverts to the container-based infrastructure in order to cache the Maven cache from build to build.