### PR TITLE
Add gitversion.xml to all build.xml import blocks (rebased onto metadata)

### DIFF
--- a/components/blitz/build.xml
+++ b/components/blitz/build.xml
@@ -2,6 +2,7 @@
 <project name="blitz" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/common/build.xml
+++ b/components/common/build.xml
@@ -2,6 +2,7 @@
 <project name="common" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/dsl/build.xml
+++ b/components/dsl/build.xml
@@ -2,6 +2,7 @@
 <project name="dsl" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/insight/build.xml
+++ b/components/insight/build.xml
@@ -29,6 +29,7 @@
     <property name="test.dir"         value="${basedir}/TEST" />
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/model/build.xml
+++ b/components/model/build.xml
@@ -2,6 +2,7 @@
 <project name="model" default="install" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/rendering/build.xml
+++ b/components/rendering/build.xml
@@ -2,6 +2,7 @@
 <project name="rendering" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/romio/build.xml
+++ b/components/romio/build.xml
@@ -2,6 +2,7 @@
 <project name="romio" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/server/build.xml
+++ b/components/server/build.xml
@@ -3,6 +3,7 @@
 
     <property name="main.class" value="ome.services.fulltext.Main"/>
     <property name="import.dir" value="${basedir}/../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/tests/build.xml
+++ b/components/tests/build.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project name="tests" default="help" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
 
-	<dirname property="up-one" file="${basedir}"/>
-	<property name="import.dir" value="${up-one}/antlib/resources"/>
-	<import file="${import.dir}/global.xml"/>
-	<import file="${import.dir}/version.xml"/>
-	<import file="${import.dir}/lifecycle.xml"/>
+    <dirname property="up-one" file="${basedir}"/>
+    <property name="import.dir" value="${up-one}/antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
+    <import file="${import.dir}/global.xml"/>
+    <import file="${import.dir}/version.xml"/>
+    <import file="${import.dir}/lifecycle.xml"/>
 
 	<target name="buildlist" unless="deps.build.path">
 		<installIvy/>

--- a/components/tests/ui/build.xml
+++ b/components/tests/ui/build.xml
@@ -90,6 +90,7 @@
     <!-- file created while running the web-chrome target -->
     <property name="google.log" value="${basedir}/libpeerconnection.log"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/tests/ui/library/java/build.xml
+++ b/components/tests/ui/library/java/build.xml
@@ -1,6 +1,7 @@
 <project name="javauilibrary" default="install" basedir=".">
 
     <property name="import.dir" value="${basedir}/../../../../antlib/resources"/>
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/tools/OmeroCpp/build.xml
+++ b/components/tools/OmeroCpp/build.xml
@@ -9,6 +9,7 @@
     <property name="import.dir"       value="${up-one}/antlib/resources"/>
     <property name="copy.dir"         value="target/"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="../common.xml"/>

--- a/components/tools/OmeroFS/build.xml
+++ b/components/tools/OmeroFS/build.xml
@@ -24,6 +24,7 @@
     <property name="import.dir"       value="${up-one}/antlib/resources"/>
     <property name="copy.dir"         value="target"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="../common.xml"/>

--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -25,6 +25,7 @@
     <property name="import.dir" value="${up-one}/antlib/resources"/>
     <property name="integration.suite" value="integration.testng.xml"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/tools/OmeroM/build.xml
+++ b/components/tools/OmeroM/build.xml
@@ -23,6 +23,8 @@
     <dirname property="up-two" file="${basedir}"/>
     <dirname property="up-one" file="${up-two}"/>
     <property name="import.dir" value="${up-one}/antlib/resources"/>
+
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${import.dir}/lifecycle.xml"/>

--- a/components/tools/OmeroPy/build.xml
+++ b/components/tools/OmeroPy/build.xml
@@ -24,6 +24,7 @@
     <property name="import.dir"       value="${up-one}/antlib/resources"/>
     <property name="copy.dir"         value="target"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="../python.xml"/>

--- a/components/tools/OmeroWeb/build.xml
+++ b/components/tools/OmeroWeb/build.xml
@@ -25,6 +25,7 @@
     <dirname property="up-one"        file="${up-two}"/>
     <property name="import.dir"       value="${up-one}/antlib/resources"/>
 
+    <import file="${import.dir}/gitversion.xml" optional="true"/>
     <import file="${import.dir}/global.xml"/>
     <import file="${import.dir}/version.xml"/>
     <import file="${up-two}/common.xml"/>

--- a/components/tools/build.xml
+++ b/components/tools/build.xml
@@ -3,6 +3,8 @@
 
    <dirname property="up-one" file="${basedir}"/>
    <property name="import.dir" value="${up-one}/antlib/resources"/>
+
+   <import file="${import.dir}/gitversion.xml" optional="true"/>
    <import file="${import.dir}/global.xml"/>
    <import file="${import.dir}/version.xml"/>
    <import file="${import.dir}/lifecycle.xml"/>


### PR DESCRIPTION

This is the same as gh-3948 but rebased onto metadata.

----

Without gitversion.xml imported, any component-level
build like ant -f components/tools/OmeroJava/build.xml
will fail with a version of UNKNOWN. Top-level builds
do not show this behavior since gitversion.xml is imported.

Testing:
 * download the appropriate src build (openmicroscopy*.zip)
 * run `./build.py build-dev`
 * run `./build.py -f components/tools/OmeroJava/build.xml -Dtestng.useDefaultListeners=true -Dtestreports.dir=target/reports/unit test`

                