### PR TITLE
Make rstring more tolerant of non-`str`

### DIFF
--- a/components/tools/OmeroPy/src/omero/rtypes.py
+++ b/components/tools/OmeroPy/src/omero/rtypes.py
@@ -56,7 +56,7 @@ def rtype(val):
         return rlong(val)
     elif isinstance(val, float):
         return rfloat(val)
-    elif isinstance(val, str):
+    elif isinstance(val, StringTypes):
         return rstring(val)
     elif isinstance(val, omero.model.IObject):
         return robject(val)

--- a/components/tools/OmeroPy/src/omero/rtypes.py
+++ b/components/tools/OmeroPy/src/omero/rtypes.py
@@ -28,6 +28,8 @@ IceImport.load("omero_RTypes_ice")
 IceImport.load("omero_Scripts_ice")
 IceImport.load("omero_model_RTypes_ice")
 
+from types import StringTypes
+
 
 def rtype(val):
     """
@@ -294,12 +296,13 @@ def rstring(val):
         return remptystr
     elif isinstance(val, omero.RString):
         return val
-    elif isinstance(val, str):
+    elif isinstance(val, StringTypes):
         if len(val) == 0:
             return remptystr
         else:
             return RStringI(val)
-    raise ValueError("Not string type: %s" % type(val))
+    else:
+        return RStringI(str(val))
 
 # Static factory methods (collections)
 # =========================================================================

--- a/components/tools/OmeroPy/src/omero/rtypes.py
+++ b/components/tools/OmeroPy/src/omero/rtypes.py
@@ -300,9 +300,11 @@ def rstring(val):
         if len(val) == 0:
             return remptystr
         else:
+            if isinstance(val, unicode):
+                val = val.encode("utf-8")
             return RStringI(val)
     else:
-        return RStringI(str(val))
+        return rstring(unicode(val))
 
 # Static factory methods (collections)
 # =========================================================================

--- a/components/tools/OmeroPy/test/unit/test_rtypes.py
+++ b/components/tools/OmeroPy/test/unit/test_rtypes.py
@@ -316,7 +316,7 @@ class TestModel(object):
         # String
         assert rstring("") == rstring(None)
         assert rstring("a") == rstring(rstring("a"))
-        pytest.raises(ValueError, lambda: rstring(0))
+        assert rstring("0") == rstring(0)
         # Class
         assert rclass("") == rclass(None)
         assert rclass("c") == rclass(rclass("c"))
@@ -445,3 +445,26 @@ class TestModel(object):
         ctor1 = myLong.__class__(5)
         ctor2 = myLongFromString.__class__("5")
         assert ctor1.val == ctor2.val
+
+    u = unicode("u")
+
+    class UStr(object):
+
+        def __init__(self, rv):
+            self.rv = rv
+
+        def __str__(self):
+            return self.rv
+
+    @pytest.mark.parametrize("data", (
+        (rstring, 1, "1"),
+        (rstring, u, "u"),
+        (rstring, u.encode("utf-8"), "u"),
+        (rstring, UStr(u), "u"),
+    ))
+    def testMoreConversions(self, data):
+        # Some useful conversions were not supported in 5.1.2 and
+        # earlier. This tests each of those which should no longer
+        # be an error condition.
+        meth, arg, expected = data
+        assert meth(arg).val == expected

--- a/components/tools/OmeroPy/test/unit/test_rtypes.py
+++ b/components/tools/OmeroPy/test/unit/test_rtypes.py
@@ -447,6 +447,8 @@ class TestModel(object):
         assert ctor1.val == ctor2.val
 
     u = unicode("u")
+    cn = '中國'
+    cnu = u'中國'
 
     class UStr(object):
 
@@ -461,6 +463,8 @@ class TestModel(object):
         (rstring, u, "u"),
         (rstring, u.encode("utf-8"), "u"),
         (rstring, UStr(u), "u"),
+        (rstring, cn, cn),
+        (rstring, cnu, cn),
     ))
     def testMoreConversions(self, data):
         # Some useful conversions were not supported in 5.1.2 and


### PR DESCRIPTION
Rather than have consumers start using the essentially
hidden and more lenient RStringI implementation, this
makes the `omero.rtypes.rstring` wrapper as lenient of
non-`str` types, including `unicode`.

See: https://trello.com/c/hjCA90az/18-rfe-rtype-methods-should-auto-convert

Testing:

 * unit tests should suffice to show whether or no this will cause any problems since the method is now **more** lenient.
 * However, discussion is needed on whether the change in behavior (i.e. no longer throwing a `ValueError` on non-`str` arguments) is acceptable for 5.1.x.

cc: @will-moore @sbesson @chris-allan @aleksandra-tarkowska @ximenesuk  