### PR TITLE
OmeroIJ: Switch dimensions and save image

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -307,7 +307,7 @@ public class FileObject
                 try {
                     sw.close();
                 } catch (IOException e) {
-                    IJ.log("I/O Excception:" + e.getMessage());
+                    IJ.log("I/O Exception:" + e.getMessage());
                 }
                 pw.close();
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -25,16 +25,29 @@ import ij.IJ;
 import ij.ImagePlus;
 import ij.io.FileInfo;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import loci.formats.codec.CompressionType;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Object hosting the information about the "file" to import.
@@ -237,10 +250,62 @@ public class FileObject
                 if (CommonsLangUtils.isBlank(name) || "Untitled".equals(name))
                     return true;
             }
+
+            //Get Current Dimensions
+            int SizeC_cur = img.getNChannels();
+            int SizeT_cur = img.getNFrames();
+            int SizeZ_cur = img.getNSlices();
+
+            String xmlStr = info.description;
+            Document doc = xmlParser(xmlStr);
+
+            NodeList nodeList = doc.getElementsByTagName("Pixels");
+            int size = nodeList.getLength();
+            int SizeC_org = SizeC_cur;
+            int SizeT_org = SizeT_cur;
+            int SizeZ_org = SizeZ_cur;
+            for(int x=0; x<size; x++) {
+                SizeC_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeC").getNodeValue());
+                SizeT_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeT").getNodeValue());
+                SizeZ_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeZ").getNodeValue());
+            }
+            if (SizeC_cur != SizeC_org || SizeT_cur != SizeT_org || SizeZ_cur != SizeZ_org){
+                return true;
+            }
         }
         return false;
     }
-    
+
+    /**
+     * Parses Xml String
+     * @param xmlStr
+     * @return
+     */
+    public Document xmlParser(String xmlStr)
+    {
+        InputSource stream = new InputSource();
+        stream.setCharacterStream(new StringReader(xmlStr));
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        DocumentBuilder builder;
+        Document doc = null;
+            try {
+                builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                doc = builder.parse(stream);
+            } catch (ParserConfigurationException e) {
+                e.printStackTrace(pw);
+                IJ.log(pw.toString());
+            } catch (SAXException e) {
+                e.printStackTrace(pw);
+                IJ.log(pw.toString());
+            } catch (IOException e) {
+                e.printStackTrace(pw);
+                IJ.log(pw.toString());
+            }
+
+        return doc;
+    }
+
     /**
      * Returns the file to import.
      *

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -307,8 +307,7 @@ public class FileObject
                 try {
                     sw.close();
                 } catch (IOException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    IJ.log("I/O Excception:" + e.getMessage());
                 }
                 pw.close();
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -265,9 +266,10 @@ public class FileObject
             int SizeT_org = SizeT_cur;
             int SizeZ_org = SizeZ_cur;
             for(int x=0; x<size; x++) {
-                SizeC_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeC").getNodeValue());
-                SizeT_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeT").getNodeValue());
-                SizeZ_org = Integer.valueOf(nodeList.item(x).getAttributes().getNamedItem("SizeZ").getNodeValue());
+                NamedNodeMap attributes = nodeList.item(x).getAttributes();
+                SizeC_org = Integer.valueOf(attributes.getNamedItem("SizeC").getNodeValue());
+                SizeT_org = Integer.valueOf(attributes.getNamedItem("SizeT").getNodeValue());
+                SizeZ_org = Integer.valueOf(attributes.getNamedItem("SizeZ").getNodeValue());
             }
             if (SizeC_cur != SizeC_org || SizeT_cur != SizeT_org || SizeZ_cur != SizeZ_org){
                 return true;
@@ -301,8 +303,15 @@ public class FileObject
             } catch (IOException e) {
                 e.printStackTrace(pw);
                 IJ.log(pw.toString());
+            } finally {
+                try {
+                    sw.close();
+                } catch (IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+                pw.close();
             }
-
         return doc;
     }
 


### PR DESCRIPTION
ref: https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7843

Testing Instructions:

1) Open OMERO Image (Multi-dimensional image) in ImageJ, and Click on Image-->Properties (in the ImageJ Menu).
2) Switch the Z and T values and click OK. This should switch the image properties in the ImageJ Image Window.
3) Plugins->OMERO->Save Image(s) to OMERO

This should save the modified image back to OMERO as an ome-tiff.

Without this PR, "add to queue"  in the import dialog will be active but not functional. (i.e you won't be allowed to add the modified image back to the import dialog).

For more details please read the thread (above).