### PR TITLE
Revert "Temporary exclude ExporterTest from the integration suite"

### DIFF
--- a/components/tools/OmeroJava/test/integration.testng.xml
+++ b/components/tools/OmeroJava/test/integration.testng.xml
@@ -10,13 +10,6 @@
     <packages>
       <package name="integration.*"/>
     </packages>
-    <classes>
-       <class name="integration.ExporterTest">
-    <methods>
-    <exclude name=".*" />
-    </methods>
-       </class>
-    </classes>
   </test>
   <test name="broken">
     <groups>


### PR DESCRIPTION
This reverts commit 3340ce1460bd73a0452f675c87f0a568818c9eee.

Now we consume merge Bio-Formats artifacts after merging the decoupling branch, we should be able to re-enable the OmeroJava exporter tests on the mainline. The execution of these tests depends on https://github.com/openmicroscopy/bioformats/pull/1866.

To review this PR, check https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/ reincludes the `ExporterTest` and that these tests are passing.

Note: independently of the test results, this PR should not be merged until Bio-Formats 5.1.3 is released and `versions.bioformats` has been bumped to 5.1.3.