### PR TITLE
Improving rendering and delete tests

### DIFF
--- a/components/tests/ui/build.xml
+++ b/components/tests/ui/build.xml
@@ -249,6 +249,8 @@
             <arg value="${output}"/>
             <arg value="-v"/>
             <arg value="browser:chrome"/>
+            <arg value="-v"/>
+            <arg value="DELAY:0.2"/>
             <arg value="--loglevel"/>
             <arg value="debug"/>
             <arg value="${basedir}/testcases/${target}"/>

--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -20,8 +20,8 @@ ${SERVER_ID}            1
 ${BROWSER}              Firefox
 ${DELAY}                0
 ${WAIT}                 50
-${WAITINMINUTES}        1
-${WAITPING}             5
+${TIMEOUT}              1
+${INTERVAL}             5
 
 ${LOGIN URL}            %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/login/
 ${WELCOME URL}          %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/

--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -19,7 +19,9 @@ ${SERVER_ID}            1
 
 ${BROWSER}              Firefox
 ${DELAY}                0
-${WAIT}                 30
+${WAIT}                 50
+${WAITINMINUTES}        1
+${WAITPING}             5
 
 ${LOGIN URL}            %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/login/
 ${WELCOME URL}          %(PROTOCOL)s://${WEB HOST}${WEB PREFIX}/webclient/

--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -18,7 +18,8 @@ Xpath Should Not Have Class
 
 # All these keywords should be identical in Web and Insight
 Tree Should Be Visible
-    Element Should Be Visible    dataTree
+    Wait Until Element Is Visible   dataTree
+    Element Should Be Visible       dataTree
 
 Node Should Be Visible
     [Arguments]                 ${nodeText}
@@ -128,13 +129,15 @@ Popup Menu Item Should Be Enabled
     Click Element                       content
 
 Select Experimenter
+    Tree Should Be Visible
+    Wait Until Element Is Visible   id=experimenter-0
     Select Node By Id    experimenter-0
 
 Select First Node By Type
     [Arguments]         ${nodeType}
-    ${firstNodeId}      Get Element Attribute    css=#dataTree li[rel='${nodeType}']@id
-    Select Node By Id   ${firstNodeId}
-    [Return]            ${firstNodeId}
+    ${firstNodeId}              Get Element Attribute    css=#dataTree li[rel='${nodeType}']@id
+    Select Node By Id           ${firstNodeId}
+    [Return]                    ${firstNodeId}
 
 Select First Node With Children in Tree
     [Arguments]         ${nodeType}
@@ -144,6 +147,23 @@ Select First Node With Children in Tree
 Select Node By Id
     [Arguments]         ${nodeId}
     # Make sure node is visible (by clicking parent node)
-    Execute Javascript  if(!$("#${nodeId}").is(":visible")){$("#${nodeId}").parent().parent().children("a").click()}
+    ${nodeVisible}      ${r}    Run Keyword And Ignore Error    Element Should Be Visible   id=${nodeId}
+    Run Keyword If      '${nodeVisible}'=='FAIL'     Click Element      xpath=//li[@id='${nodeId}']/parent::ul/parent::li/a
     Sleep               1
-    Click Element       css=#${nodeId}>a
+    Click Element       xpath=//li[@id='${nodeId}']/a
+
+Wait For General Panel
+    [Arguments]         ${nodeType}
+    Wait Until Element Is Visible           xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), '${nodeType}')]  ${WAIT}
+
+Wait For General Panel And Return Id
+    [Arguments]         ${nodeType}
+    Wait For General Panel                  ${nodeType}
+    ${imageId}=                             Get Text        xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
+    [Return]                                ${imageId}
+
+Wait For General Panel And Return Name
+    [Arguments]         ${nodeType}
+    Wait For General Panel                  ${nodeType}
+    ${imageName}=                           Get Text        xpath=//div[contains(@class, 'data_heading')]//h1/span
+    [Return]                                ${imageName}

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -43,12 +43,12 @@ Test Delete Project Dataset
     Click Element                           refreshButton
     Wait Until Page Contains Element        id=project-${pid}
     Click Element                           css=#project-${pid}>a
-    Sleep                                   0.5
+    Wait Until Page Contains Element        xpath=//tr[contains(@class,'data_heading_id')]/td/strong[contains(text(), '${pid}')]  ${WAIT}
     Click Element                           id=deleteButton
     Wait Until Element Is Visible           id=delete-dialog-form
     Click Dialog Button                     Yes
     # Wait for activities to show job done, then refresh tree...
-    Wait Until Page Contains Element        xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
+    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
     Click Element                           refreshButton
     Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
     Page Should Not Contain Element         id=project-${pid}
@@ -114,7 +114,7 @@ Test Delete Images in Share
     Click Element                               id=deleteButton
     Wait Until Element Is Visible               id=delete-dialog-form
     Click Dialog Button                         Yes
-    Wait Until Page Contains Element            xpath=//span[@id='jobstatus'][contains(text(),'1')]     20
+    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
     Go To                                       ${WELCOME URL}public
     Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='share']/a
     Click Element                               xpath=//div[@id='dataTree']//li[@rel='share']/a

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -48,7 +48,7 @@ Test Delete Project Dataset
     Wait Until Element Is Visible           id=delete-dialog-form
     Click Dialog Button                     Yes
     # Wait for activities to show job done, then refresh tree...
-    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
+    Wait Until Keyword Succeeds     ${TIMEOUT}   ${INTERVAL}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
     Click Element                           refreshButton
     Wait Until Page Contains Element        xpath=//li[@rel='experimenter']/a[contains(@class, 'jstree-clicked')]
     Page Should Not Contain Element         id=project-${pid}
@@ -114,7 +114,7 @@ Test Delete Images in Share
     Click Element                               id=deleteButton
     Wait Until Element Is Visible               id=delete-dialog-form
     Click Dialog Button                         Yes
-    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
+    Wait Until Keyword Succeeds     ${TIMEOUT}   ${INTERVAL}   Page Should Contain Element     xpath=//span[@id='jobstatus'][contains(text(),'1')]
     Go To                                       ${WELCOME URL}public
     Wait Until Page Contains Element            xpath=//div[@id='dataTree']//li[@rel='share']/a
     Click Element                               xpath=//div[@id='dataTree']//li[@rel='share']/a

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -109,10 +109,10 @@ Test Rdef Copy Paste Save
     Element Should Be Enabled               id=rdef-setdef-btn
 
     # Save (with Yellow channel) & wait for thumbnail to update
-    ${thumbSrc}=                            Execute Javascript  return $.trim($("button.clicked img.rdef").attr('src'))
+    ${thumbSrc}=                            Get Element Attribute      xpath=//button[@class="rdef clicked"]/img@src
     Click Element                           id=rdef-setdef-btn
     Wait For BlockUI
-    Wait For Condition                      return ($.trim($("button.clicked img.rdef").attr('src')) != '${thumbSrc}')
+    Wait Until Page Contains Element        xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
     # Redo (to Blue channel)
     Click Element                           id=rdef-redo-btn
     Wait For Channel Color                  rgb(0, 0, 255)
@@ -221,9 +221,9 @@ Test Owners Rdef
     
     # Test 'Paste and Save' with right-click on different Image in tree
     # (check thumb refresh by change of src)
-    ${thumbSrc}=                            Execute Javascript  return $.trim($("#image_icon-${imageId_2} img").attr('src'))
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/img@src
     Right Click Rendering Settings          image-${imageId_2}            Paste and Save
-    Wait For Condition                      return ($.trim($("#image_icon-${imageId_2} img").attr('src')) != '${thumbSrc}')
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId_2}
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
@@ -231,9 +231,9 @@ Test Owners Rdef
     Textfield Value Should Be               wblitz-ch0-cw-end           200
 
     # Test Set Owner's in same way on first Image
-    ${thumbSrc}=                            Execute Javascript  return $.trim($("#image_icon-${imageId} img").attr('src'))
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img@src
     Right Click Rendering Settings          image-${imageId}            Set Owner's and Save
-    Wait For Condition                      return ($.trim($("#image_icon-${imageId} img").attr('src')) != '${thumbSrc}')
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
@@ -241,9 +241,9 @@ Test Owners Rdef
     Textfield Value Should Be               wblitz-ch0-cw-end           100
 
     # Test "Set Imported" on first Image
-    ${thumbSrc}=                            Execute Javascript  return $.trim($("#image_icon-${imageId} img").attr('src'))
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img@src
     Right Click Rendering Settings          image-${imageId}            Set Imported and Save
-    Wait For Condition                      return ($.trim($("#image_icon-${imageId} img").attr('src')) != '${thumbSrc}')
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -53,12 +53,12 @@ Wait For Preview Load
 
 Wait For Toolbar Button Enabled
     [Arguments]            ${buttonId}
-    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}      Element Should Be Enabled      id=${buttonId}
+    Wait Until Keyword Succeeds     ${TIMEOUT}   ${INTERVAL}      Element Should Be Enabled      id=${buttonId}
     Page Should Not Contain Element     xpath=//button[@id='${buttonId}'][contains(@class, 'button-disabled')]
 
 Wait For Toolbar Button Disabled
     [Arguments]            ${buttonId}
-    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}      Element Should Be Disabled     id=${buttonId}
+    Wait Until Keyword Succeeds     ${TIMEOUT}   ${INTERVAL}      Element Should Be Disabled     id=${buttonId}
     Page Should Contain Element     xpath=//button[@id='${buttonId}'][contains(@class, 'button-disabled')]
 
 Right Click Rendering Settings

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -183,9 +183,6 @@ Test Owners Rdef
     Click Link                              Preview
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 
-    # Bit more reliable with this, but try to remove it if possible...
-    Set Selenium Speed                      0.5
-
     # Set to "Imported"
     Click Element                           id=rdef-reset-btn
     Wait For Channel Color                  ${importedChColor}
@@ -255,12 +252,15 @@ Test Owners Rdef
 
     # Open full image viewer
     # Toggle the color, then paste settings and check it has reverted
+
+    # Bit more reliable with this, but try to remove it if possible...
+    Set Selenium Speed                      0.5
+
     Go To                                   ${WELCOME URL}img_detail/${imageId}
     Wait Until Page Contains Element        id=wblitz-ch0
-    ${checked1}=                            Execute Javascript  return ($("#wblitz-rmodel:checked").length == 1)
+    ${checked1}=                            Checkbox Should Be Selected  id=wblitz-rmodel
     Click Element                           id=wblitz-rmodel
-    ${checked2}=                            Execute Javascript  return ($("#wblitz-rmodel:checked").length == 1)
-    Should Not Be True                      "${checked1}" == "${checked2}"
+    ${checked2}=                            Checkbox Should Not Be Selected  id=wblitz-rmodel
     Click Link                              Edit
     # We are currently at 'Imported' settings
     Textfield Value Should Be               wblitz-ch0-cw-end    255

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -44,12 +44,14 @@ Wait For BlockUI
     Wait For Condition                      return ($("div.blockOverlay").length == 0)
 
 Wait For Preview Load
-    # Wait For Condition                      return ($("#viewport-img").length == 0)
-    Sleep                                   0.5
+    [Arguments]          ${status}          ${oldIdentifier}
+    Run Keyword If  '${status}'=='PASS'     Wait Until Page Contains Element        xpath=//button[@id='preview_open_viewer'][@rel!='${oldIdentifier}']       ${WAIT}
     Wait Until Page Contains Element        xpath=//button[@id="wblitz-ch0-color"]
+    ${status}    ${oldId}    Run Keyword And Ignore Error    Get Element Attribute      xpath=//button[@id="preview_open_viewer"]@rel
+    [Return]                                ${status}          ${oldId}
 
 Wait For Image Panel
-    Wait Until Page Contains Element        xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]
+    Wait Until Element Is Visible           xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]  ${WAIT}
     ${imageId}=                             Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
     [Return]                                ${imageId}
 
@@ -69,7 +71,7 @@ Test Rdef Copy Paste Save
     Select And Expand Image
     ${imageId}=                             Wait For Image Panel
     Click Link                              Preview
-    Wait For Preview Load
+    ${status}    ${oldId}                   Wait For Preview Load       FAIL      '1'
 
     # Undo, Redo & Save should be disabled
     Element Should Be Disabled              id=rdef-undo-btn
@@ -100,6 +102,7 @@ Test Rdef Copy Paste Save
     # Click Undo - Channel should be Yellow
     Click Element                           id=rdef-undo-btn
     Wait For Channel Color                  rgb(255, 255, 0)
+
     # And all buttons Undo, Redo & Save enabled
     Element Should Be Enabled               id=rdef-undo-btn
     Element Should Be Enabled               id=rdef-redo-btn
@@ -119,13 +122,14 @@ Test Rdef Copy Paste Save
 
     # Check that 'Save' has worked by refreshing right panel (click on thumbnail)
     Click Element                           id=image_icon-${imageId}
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     # Channel should be Yellow
     Wait For Channel Color                  rgb(255, 255, 0)
 
     # Select Next Image by using 'Down Arrow'
     Key Down                                40
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
+
     # Images should be compatible, so 'Paste' should become enabled.
     Wait Until Page Contains Element        xpath=//button[contains(@class, "paste_rdef")][not(@disabled="disabled")]
 
@@ -138,7 +142,7 @@ Test Rdef Copy Paste Save
 
     # Return to Previous Image (now Blue)
     Click Element                           id=image_icon-${imageId}
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  rgb(0, 0, 255)
 
 
@@ -150,7 +154,7 @@ Test Owners Rdef
     Select And Expand Image
     ${imageId}=                             Wait For Image Panel
     Click Link                              Preview
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load      FAIL    '1'
 
     # Set to "Imported"
     Click Element                           id=rdef-reset-btn
@@ -177,7 +181,7 @@ Test Owners Rdef
     Go To                                   ${WELCOME URL}?show=image-${imageId}
     Wait For Image Panel
     Click Link                              Preview
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 
     # Bit more reliable with this, but try to remove it if possible...
     Set Selenium Speed                      0.5
@@ -225,7 +229,7 @@ Test Owners Rdef
     Wait For Condition                      return ($.trim($("#image_icon-${imageId_2} img").attr('src')) != '${thumbSrc}')
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId_2}
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  rgb(255, 255, 255)
     Textfield Value Should Be               wblitz-ch0-cw-end           200
 
@@ -235,7 +239,7 @@ Test Owners Rdef
     Wait For Condition                      return ($.trim($("#image_icon-${imageId} img").attr('src')) != '${thumbSrc}')
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  rgb(0, 255, 0)
     Textfield Value Should Be               wblitz-ch0-cw-end           100
 
@@ -245,7 +249,7 @@ Test Owners Rdef
     Wait For Condition                      return ($.trim($("#image_icon-${imageId} img").attr('src')) != '${thumbSrc}')
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
-    Wait For Preview Load
+    ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  ${importedChColor}
     Textfield Value Should Be               wblitz-ch0-cw-end           ${importedMax}
 
@@ -274,4 +278,3 @@ Test Owners Rdef
     Wait Until Page Contains Element        id=wblitz-ch0
     Click Link                              Edit
     Textfield Value Should Be               wblitz-ch0-cw-end    200
-

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -46,7 +46,8 @@ Wait For BlockUI
 Wait For Preview Load
     [Arguments]          ${status}          ${oldIdentifier}
     Run Keyword If  '${status}'=='PASS'     Wait Until Page Contains Element        xpath=//button[@id='preview_open_viewer'][@rel!='${oldIdentifier}']       ${WAIT}
-    Wait Until Page Contains Element        xpath=//button[@id="wblitz-ch0-color"]
+    Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"]
+    Wait Until Element Is Visible           xpath=//button[@class="rdef clicked"]
     ${status}    ${oldId}    Run Keyword And Ignore Error    Get Element Attribute      xpath=//button[@id="preview_open_viewer"]@rel
     [Return]                                ${status}          ${oldId}
 

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -36,7 +36,7 @@ Pick Color
 
 Wait For Channel Color
     [Arguments]          ${rgbColor}
-    Wait Until Page Contains Element        xpath=//button[@id="rd-wblitz-ch0"][contains(@style, "background-color: ${rgbColor}")]
+    Wait Until Element Is Visible           xpath=//button[@id="rd-wblitz-ch0"][contains(@style, "background-color: ${rgbColor}")]      ${WAIT}
 
 Wait For BlockUI
     # Wait Until Element Is Visible           xpath=//div[contains(@class, 'blockOverlay')]

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -46,8 +46,8 @@ Wait For BlockUI
 Wait For Preview Load
     [Arguments]          ${status}          ${oldIdentifier}
     Run Keyword If  '${status}'=='PASS'     Wait Until Page Contains Element        xpath=//button[@id='preview_open_viewer'][@rel!='${oldIdentifier}']       ${WAIT}
-    Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"]
-    Wait Until Element Is Visible           xpath=//button[@class="rdef clicked"]
+    Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"]      ${WAIT}
+    Wait Until Element Is Visible           xpath=//button[@class="rdef clicked"]       ${WAIT}
     ${status}    ${oldId}    Run Keyword And Ignore Error    Get Element Attribute      xpath=//button[@id="preview_open_viewer"]@rel
     [Return]                                ${status}          ${oldId}
 
@@ -127,13 +127,14 @@ Test Rdef Copy Paste Save
     Wait For Toolbar Button Enabled         rdef-paste-btn
 
     # Check that 'Save' has worked by refreshing right panel (click on thumbnail)
-    Click Element                           id=image_icon-${imageId}
+    Click Element                           id=refreshButton
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
+    Wait For Toolbar Button Enabled         rdef-paste-btn
     # Channel should be Yellow
     Wait For Channel Color                  rgb(255, 255, 0)
 
     # Select Next Image by using 'Down Arrow'
-    Click Element                           xpath=//li[@id='image_icon-${imageId}']/following-sibling::li
+    Click Element                           xpath=//li[@id='image-${imageId}']/following-sibling::li/a
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 
     # Images should be compatible, so 'Paste' should become enabled.

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -126,14 +126,14 @@ Test Rdef Copy Paste Save
     Click Element                           id=rdef-copy-btn
     Wait For Toolbar Button Enabled         rdef-paste-btn
 
-    # Check that 'Save' has worked by refreshing right panel (click on thumbnail)
+    # Check that 'Save' has worked by refreshing right panel (click refresh)
     Click Element                           id=refreshButton
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
     Wait For Toolbar Button Enabled         rdef-paste-btn
     # Channel should be Yellow
     Wait For Channel Color                  rgb(255, 255, 0)
 
-    # Select Next Image by using 'Down Arrow'
+    # Select Next Image
     Click Element                           xpath=//li[@id='image-${imageId}']/following-sibling::li/a
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -51,6 +51,16 @@ Wait For Preview Load
     ${status}    ${oldId}    Run Keyword And Ignore Error    Get Element Attribute      xpath=//button[@id="preview_open_viewer"]@rel
     [Return]                                ${status}          ${oldId}
 
+Wait For Toolbar Button Enabled
+    [Arguments]            ${buttonId}
+    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}      Element Should Be Enabled      id=${buttonId}
+    Page Should Not Contain Element     xpath=//button[@id='${buttonId}'][contains(@class, 'button-disabled')]
+
+Wait For Toolbar Button Disabled
+    [Arguments]            ${buttonId}
+    Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}      Element Should Be Disabled     id=${buttonId}
+    Page Should Contain Element     xpath=//button[@id='${buttonId}'][contains(@class, 'button-disabled')]
+
 Wait For Image Panel
     Wait Until Element Is Visible           xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]  ${WAIT}
     ${imageId}=                             Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
@@ -83,13 +93,13 @@ Test Rdef Copy Paste Save
     Element Text Should Be                  id=wblitz-z-count       ${sizeZ}
     Element Text Should Be                  id=wblitz-z-curr        ${defaultZ}
     Click Element                           id=viewport-zsl-bup
-    Wait Until Page Contains Element        xpath=//button[@id='rdef-setdef-btn'][not(@disabled="disabled")]
+    Wait For Toolbar Button Enabled         rdef-setdef-btn
     Element Text Should Be                  id=wblitz-z-curr        ${currZ}
     Element Should Be Disabled              id=rdef-undo-btn
     Element Should Be Disabled              id=rdef-redo-btn
     # change back again...
     Click Element                           id=viewport-zsl-bdn
-    Wait Until Page Contains Element        xpath=//button[@id='rdef-setdef-btn'][@disabled="disabled"]
+    Wait For Toolbar Button Disabled        rdef-setdef-btn
     Element Text Should Be                  id=wblitz-z-curr        ${defaultZ}
 
     # Color-picker, Yellow then Blue.
@@ -118,8 +128,8 @@ Test Rdef Copy Paste Save
     Click Element                           id=rdef-redo-btn
     Wait For Channel Color                  rgb(0, 0, 255)
     # Copy (paste button is enabled)
-    Click Element                           xpath=//button[contains(@class, "copy_rdef")]
-    Wait Until Page Contains Element        xpath=//button[contains(@class, "paste_rdef")][not(@disabled="disabled")]
+    Click Element                           id=rdef-copy-btn
+    Wait For Toolbar Button Enabled         rdef-paste-btn
 
     # Check that 'Save' has worked by refreshing right panel (click on thumbnail)
     Click Element                           id=image_icon-${imageId}
@@ -128,14 +138,14 @@ Test Rdef Copy Paste Save
     Wait For Channel Color                  rgb(255, 255, 0)
 
     # Select Next Image by using 'Down Arrow'
-    Key Down                                40
+    Click Element                           xpath=//li[@id='image_icon-${imageId}']/following-sibling::li
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 
     # Images should be compatible, so 'Paste' should become enabled.
-    Wait Until Page Contains Element        xpath=//button[contains(@class, "paste_rdef")][not(@disabled="disabled")]
+    Wait For Toolbar Button Enabled         rdef-paste-btn
 
     # Paste (Blue channel)
-    Click Element                           xpath=//button[contains(@class, "paste_rdef")]
+    Click Element                           xpath=//button[@id='rdef-paste-btn']
     Wait For Channel Color                  rgb(0, 0, 255)
 
     # Save to all (Blue channel)
@@ -173,7 +183,7 @@ Test Owners Rdef
     # Get Id for next Image by using 'Down Arrow'
     Click Link                              General
     Key Down                                40
-    ${imageId_2}=                            Wait For Image Panel
+    ${imageId_2}=                           Wait For Image Panel
     Log Out
 
     # Log in as Root - go to user's Image
@@ -217,8 +227,8 @@ Test Owners Rdef
     # Set Selenium Speed                      1
     Input Text                              id=wblitz-ch0-cw-end        200
     Pick Color                              fff         FFFFFF          rgb(255, 255, 255)
-    Click Element                           xpath=//button[contains(@class, "copy_rdef")]
-    Wait Until Page Contains Element        xpath=//button[contains(@class, "paste_rdef")][not(@disabled="disabled")]
+    Click Element                           xpath=//button[@id='rdef-copy-btn']
+    Wait For Toolbar Button Enabled         rdef-paste-btn
     
     # Test 'Paste and Save' with right-click on different Image in tree
     # (check thumb refresh by change of src)
@@ -267,7 +277,7 @@ Test Owners Rdef
     Textfield Value Should Be               wblitz-ch0-cw-end    255
 
     # Paste to settings above
-    Click Element                           xpath=//button[contains(@class, "paste_rdef")]
+    Click Element                           xpath=//button[@id='rdef-paste-btn']
     # Save
     Click Element                           id=rdef-setdef-btn
     # Wait for response

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -61,11 +61,6 @@ Wait For Toolbar Button Disabled
     Wait Until Keyword Succeeds     ${WAITINMINUTES}   ${WAITPING}      Element Should Be Disabled     id=${buttonId}
     Page Should Contain Element     xpath=//button[@id='${buttonId}'][contains(@class, 'button-disabled')]
 
-Wait For Image Panel
-    Wait Until Element Is Visible           xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]  ${WAIT}
-    ${imageId}=                             Get Text                    xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
-    [Return]                                ${imageId}
-
 Right Click Rendering Settings
     [Arguments]            ${treeId}        ${optionText}
     Open Context Menu                       xpath=//li[@id='${treeId}']/a
@@ -80,7 +75,7 @@ Test Rdef Copy Paste Save
 
     Select Experimenter
     Select And Expand Image
-    ${imageId}=                             Wait For Image Panel
+    ${imageId}=                             Wait For General Panel And Return Id    Image
     Click Link                              Preview
     ${status}    ${oldId}                   Wait For Preview Load       FAIL      '1'
 
@@ -163,7 +158,7 @@ Test Owners Rdef
     Go To                                   ${WELCOME URL}
     Select Experimenter
     Select And Expand Image
-    ${imageId}=                             Wait For Image Panel
+    ${imageId}=                             Wait For General Panel And Return Id      Image
     Click Link                              Preview
     ${status}    ${oldId}    Wait For Preview Load      FAIL    '1'
 
@@ -183,14 +178,14 @@ Test Owners Rdef
     # Get Id for next Image by using 'Down Arrow'
     Click Link                              General
     Key Down                                40
-    ${imageId_2}=                           Wait For Image Panel
+    ${imageId_2}=                           Wait For General Panel And Return Id      Image
     Log Out
 
     # Log in as Root - go to user's Image
     User "${ROOT USERNAME}" logs in with password "${ROOT PASSWORD}"
     Maximize Browser Window
     Go To                                   ${WELCOME URL}?show=image-${imageId}
-    Wait For Image Panel
+    Wait For General Panel                  Image
     Click Link                              Preview
     ${status}    ${oldId}    Wait For Preview Load   ${status}   ${oldId}
 

--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -13,12 +13,12 @@ Suite Teardown      Close all browsers
 Test Open Viewer
     [Documentation]     Tests double-click to open image viewer
 
+    Tree Should Be Visible
     Select And Expand Project
     Select And Expand Dataset
     Select And Expand Image
-    Wait Until Page Contains Element    xpath=//tr[contains(@class, 'data_heading_id')]/th[contains(text(), 'Image')]
-    ${imageName}=                       Get Text         xpath=//div[contains(@class, 'data_heading')]//h1/span
-    ${imageId}=                         Get Text         xpath=//tr[contains(@class, 'data_heading_id')]/td/strong
+    ${imageName}=                       Wait For General Panel And Return Name      Image
+    ${imageId}=                         Wait For General Panel And Return Id        Image
     # Open Image Viewer 3 different ways and check
     Click Element                       xpath=//button[@title='Open full image viewer in new window']
     Check Image Viewer                  ${imageName}    2

--- a/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
+++ b/components/tests/ui/testcases/web/webadmin_create_group_and_user.txt
@@ -122,7 +122,7 @@ Create Edit User
     # find row which contains user name, and click 'btn_edit' of that row
     Click Element           xpath=//table[@id="experimenterTable"]/tbody/tr[descendant::td[contains(text(), '${user_name}')]]//a[contains(@class, "btn_edit")]
 
-    Wait Until Page Contains Element    id=id_first_name
+    Wait Until Page Contains Element    id=id_first_name    ${WAIT}
     ${createdName}=                     Get Element Attribute   xpath=//input[@id='id_first_name']@value
     Should Be Equal                     "${user_name}"    "${createdName}"
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -135,7 +135,6 @@
             // but we also save to session in case of page reload etc
             $("#rdef-copy-btn").click(function() {
                 copyRdefs(OME.preview_viewport);
-                $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
             });
             $("#rdef-paste-btn").click(function() {
                 pasteRdefs(OME.preview_viewport);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -133,11 +133,11 @@
 
             // copy and paste refs is in browser via query string,
             // but we also save to session in case of page reload etc
-            $("button.copy_rdef").click(function() {
+            $("#rdef-copy-btn").click(function() {
                 copyRdefs(OME.preview_viewport);
-                $("button.paste_rdef").removeAttr('disabled').removeClass("button-disabled");
+                $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
             });
-            $("button.paste_rdef").click(function() {
+            $("#rdef-paste-btn").click(function() {
                 pasteRdefs(OME.preview_viewport);
             });
             // once image loads, check session via /getImgRDef/ to see if we can paste
@@ -149,11 +149,11 @@
                       if (channels.length != OME.preview_viewport.getChannels().length ||
                         data.rdef.pixel_range != OME.preview_viewport.loadedImg.pixel_range.join(":")) {
                           // images are not compatible
-                          $("button.paste_rdef")
+                          $("#rdef-paste-btn")
                             .attr('title', 'Copied settings are not compatible with this image');
                           return;
                         }
-                        $("button.paste_rdef").removeAttr('disabled').removeClass("button-disabled");
+                        $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
                     }
                 }
               );
@@ -404,11 +404,11 @@
       
       <li class="seperator"></li>
 
-      <li><button class="copy_rdef button" title="Copy Rendering Settings">
+      <li><button id="rdef-copy-btn" class="button" title="Copy Rendering Settings">
         <img src="{% static "webclient/image/icon_toolbar_copy.png" %}"/><br>
         Copy
       </button></li>
-      <li><button class="paste_rdef button button-disabled"
+      <li><button id="rdef-paste-btn" class="button button-disabled"
           title="Paste Rendering Settings" disabled="disabled">
         <img src="{% static "webclient/image/icon_toolbar_paste.png" %}"/><br>
         Paste

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-
+{% load common_tags %}
 
 {% comment %}
 <!--
@@ -352,7 +352,7 @@
 	
 <!-- open-image link -->
 
-			<button id="preview_open_viewer" class="btn silver btn_text" href="#" alt="View" title="Open full viewer">
+			<button id="preview_open_viewer" class="btn silver btn_text" href="#" alt="View" title="Open full viewer" rel="{% content_identifier "preview" manager.image.id %}"> <!-- rel is used by robot framework, do not remove it! -->
 				<span>
                 {% trans "Full viewer" %} 
 				</span>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1008,7 +1008,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
     /* Channels (verbose as IE7 does not support Array.filter */
     var chs = [];
     var channels = this.loadedImg.channels;
-    for (i=0; i<channels.length; i++) {
+    for (var i=0; i<channels.length; i++) {
       var ch = channels[i].active ? '' : '-';
       ch += parseInt(i, 10)+1;
       ch += '|' + channels[i].window.start + ':' + channels[i].window.end;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -29,7 +29,10 @@
         // Need imageId for 'apply to all'
         rdefQry = rdefQry + "&imageId=" + viewport.loadedImg.id;
         // save to session
-        $.getJSON(viewport.viewport_server + "/copyImgRDef/?" + rdefQry);
+        var jqxhr = $.getJSON(viewport.viewport_server + "/copyImgRDef/?" + rdefQry);
+        jqxhr.complete(function() {
+            $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
+        });
     };
 
     window.pasteRdefs = function (viewport) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -148,7 +148,7 @@
         }
         //var t = $('#rd-wblitz-ch'+idx).get(0);
         //if (t != undefined) t.checked=ch.active;
-        $('#wblitz-ch'+idx).css('background-color', "#"+OME.rgbToHex(ch.color)).attr('title', ch.label);
+        $('#wblitz-ch'+idx).css('background-color', OME.hexToRgb(ch.color)).attr('title', ch.label);
     };
 
 
@@ -278,7 +278,7 @@
         for (i=0; i<channels.length; i++) {
             $('<button id="wblitz-ch'+i+
                 '"class="squared' + (channels[i].active?' pressed':'') +
-                '"style="background-color: #' + OME.rgbToHex(channels[i].color) +
+                '"style="background-color: ' + OME.hexToRgb(channels[i].color) +
                 '"title="' + channels[i].label +
                 '">'+channels[i].label+'</button>')
             .appendTo(box)
@@ -355,7 +355,7 @@
 
         var template = '' +
           '<tr class="$cls rdef-window">' +
-          '<td><button id="rd-wblitz-ch$idx0" class="rd-wblitz-ch squared $class" style="background-color: #$col" ' +
+          '<td><button id="rd-wblitz-ch$idx0" class="rd-wblitz-ch squared $class" style="background-color: $col" ' +
             'title="$label">$l</button></td>' +
           '<td><table><tr id="wblitz-ch$idx0-cw" class="rangewidget"></tr></table></td>' +
           '<td><button id="wblitz-ch$idx0-color" class="picker squarred" title="Choose Color">&nbsp;</button></td>' +
@@ -456,7 +456,7 @@
             }
             tmp.after(template
                 .replace(/\$class/g, btnClass)
-                .replace(/\$col/g, OME.rgbToHex(channels[i].color))
+                .replace(/\$col/g, OME.hexToRgb(channels[i].color))
                 .replace(/\$label/g, channels[i].label)
                 .replace(/\$l/g, lbl)
                 .replace(/\$idx0/g, i) // Channel Index, 0 based

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -809,11 +809,11 @@
 
           <li class="seperator"></li>
 
-          <li><button class="copy_rdef button" title="Copy Rendering Settings">
+          <li><button id="rdef-copy-btn" class="button" title="Copy Rendering Settings">
             <img src="{% static "webclient/image/icon_toolbar_copy.png" %}"/><br>
             Copy
           </button></li>
-          <li><button class="paste_rdef button button-disabled"
+          <li><button id="rdef-paste-btn" class="button button-disabled"
              title="Paste Rendering Settings" disabled="disabled">
             <img src="{% static "webclient/image/icon_toolbar_paste.png" %}"/><br>
             Paste
@@ -924,11 +924,11 @@
 	    {% endif %}-->{% endcomment %}
             <br />
             <label>Rendering Settings</label><br />
-            <button class="btn silver btn_text copy_rdef" title="Copy Rendering Settings">
+            <button id="rdef-copy-btn" class="btn silver btn_text" title="Copy Rendering Settings">
                 <span>Copy</span>
             </button>
 
-            <button class="btn silver btn_text paste_rdef" title="Paste Rendering Settings">
+            <button id="rdef-paste-btn" class="btn silver btn_text" title="Paste Rendering Settings">
                 <span>Paste</span>
             </button>
           </div>
@@ -1048,11 +1048,11 @@
               if (channels.length != viewport.getChannels().length ||
                 data.rdef.pixel_range != viewport.loadedImg.pixel_range.join(":")) {
                   // images are not compatible
-                  $("button.paste_rdef")
+                  $("#rdef-paste-btn")
                     .attr('title', 'Copied settings are not compatible with this image');
                   return;
                 }
-                $("button.paste_rdef").removeAttr('disabled').removeClass("button-disabled");
+                $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
             }
         }
       );
@@ -1171,12 +1171,12 @@
     });
 
     var copy_paste_rdef_url = "{% url 'webgateway.views.copy_image_rdef_json' %}";
-    $(".copy_rdef").click(function() {
+    $("#rdef-copy-btn").click(function() {
         copyRdefs(viewport);
-        $("button.paste_rdef").removeAttr('disabled').removeClass("button-disabled");
+        $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
     });
 
-    $(".paste_rdef").click(function() {
+    $("#rdef-paste-btn").click(function() {
         pasteRdefs(viewport);
     });
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1173,7 +1173,6 @@
     var copy_paste_rdef_url = "{% url 'webgateway.views.copy_image_rdef_json' %}";
     $("#rdef-copy-btn").click(function() {
         copyRdefs(viewport);
-        $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
     });
 
     $("#rdef-paste-btn").click(function() {


### PR DESCRIPTION
Following #3942 this should improve tests that requires reloading preview panel. It was mandatory to introduce token to identify content (it shouldn't have any effect on application), clarify channell background-colour as FF convert hex  to rgb. Introducing delay for chrome resolved general  timing issues that affected http session.


cc: @will-moore 

