### PR TITLE
prevent data owners from chowning

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -613,8 +613,8 @@
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = [I], L.child = R:[E]{a}" p:changes="L:[O]"/>
-        <bean parent="graphPolicyRule" p:matches="S:Screen[I].reagents = R:[E]{a}" p:error="may not move {R} without {S}"/>
-        <bean parent="graphPolicyRule" p:matches="WellReagentLink.parent = W:[E], L.child = R:[E]{a}"
+        <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents = R:[I]" p:error="may not move {R} without {S}"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink.parent = W:[E], L.child = R:[I]"
                                        p:error="may not move {R} without {W}"/>
 
         <!-- Cannot move screen to a private group if it uses a differently owned reagent. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -611,8 +611,8 @@
         <bean parent="graphPolicyRule" p:matches="WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="S:Screen[I].reagents = R:[E]{a}" p:error="may not give {R} without {S}"/>
-        <bean parent="graphPolicyRule" p:matches="WellReagentLink.parent = W:[E];perms=??-???, L.child = R:[E]{a}"
+        <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents = R:[I]" p:error="may not give {R} without {S}"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink.parent = W:[E];perms=??-???, L.child = R:[I]"
                                        p:error="may not give {R} without {W}"/>
 
         <!-- Cannot give screen in a private group if it uses a differently owned reagent. -->

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -298,9 +298,8 @@ module omero {
 
         /**
          * Change the ownership of model objects.
-         * The user must be an administrator, or
-         * they must be the owner of the objects
-         * or an owner of the objects' group, with
+         * The user must be an administrator, or they
+         * must be an owner of the objects' group, with
          * the target user a member of the objects' group.
          **/
         class Chown2 extends GraphModify2 {

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -310,10 +310,10 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
 
         @Override
         public void assertMayProcess(String className, long objectId, Details details) throws GraphException {
-            final Long objectOwnerId = details.getOwner().getId();
+            /* final Long objectOwnerId = details.getOwner().getId();
+               also allow userFromId.equals(objectOwnerId) for users to chown their own data */
             final Long objectGroupId = details.getGroup().getId();
-            if (!(acceptableGroupsFrom == null || acceptableGroupsFrom.contains(objectGroupId) ||
-                    userFromId.equals(objectOwnerId))) {
+            if (!(acceptableGroupsFrom == null || acceptableGroupsFrom.contains(objectGroupId))) {
                 throw new GraphException("user " + userFromId + " is not an owner of group " + objectGroupId);
             }
             if (!(acceptableGroupsTo == null || acceptableGroupsTo.contains(objectGroupId))) {

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -76,6 +76,9 @@ class ITest(object):
     # Default permissions for the group created in setup_class
     # Can be overriden by test instances
     DEFAULT_PERMS = 'rw----'
+    # If the new user created in setup_class should own their group
+    # Can be overriden by test instances
+    DEFAULT_GROUP_OWNER = False
 
     @classmethod
     def setup_class(cls):
@@ -97,7 +100,7 @@ class ITest(object):
             raise Exception("Could not initiate a root connection")
 
         cls.group = cls.new_group(perms=cls.DEFAULT_PERMS)
-        cls.user = cls.new_user(group=cls.group)
+        cls.user = cls.new_user(group=cls.group, owner=cls.DEFAULT_GROUP_OWNER)
         cls.client = omero.client()  # ok because adds self
         cls.__clients.add(cls.client)
         cls.client.setAgent("OMERO.py.test")

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -411,7 +411,7 @@ public class PermissionsTest extends AbstractServerTest {
                         testCase[IS_ADMIN] = isAdmin;
                         testCase[IS_GROUP_OWNER] = isGroupOwner;
                         testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
-                        testCase[IS_EXPECT_SUCCESS] = isAdmin || (isGroupOwner || isDataOwner) && isRecipientInGroup;
+                        testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
                         // DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
                         //            isRecipientInGroup == true)
                         testCases.add(testCase);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -873,27 +873,28 @@ public class PermissionsTest extends AbstractServerTest {
 
         logRootIntoGroup(dataGroupId);
 
-            /* check that the objects' ownership is all as expected */
+        /* check that the objects' ownership is all as expected */
 
-            switch (target) {
-            case DATASET:
-                assertOwnedBy(dataset, recipient);
-                assertOwnedBy(images, datasetOwner);
-                assertOwnedBy(links, datasetOwner);
-                assertOwnedBy(plate, plateOwner);
-                break;
-            case IMAGES:
-                assertOwnedBy(dataset, datasetOwner);
-                assertOwnedBy(images, recipient);
-                assertOwnedBy(links, datasetOwner);
-                assertOwnedBy(plate, plateOwner);
-                break;
-            case PLATE:
-                assertOwnedBy(dataset, datasetOwner);
-                assertOwnedBy(images, datasetOwner);
-                assertOwnedBy(links, datasetOwner);
-                assertOwnedBy(plate, recipient);
-            }
+        switch (target) {
+        case DATASET:
+            assertOwnedBy(dataset, recipient);
+            assertOwnedBy(images, datasetOwner);
+            assertOwnedBy(links, datasetOwner);
+            assertOwnedBy(plate, plateOwner);
+            break;
+        case IMAGES:
+            assertOwnedBy(dataset, datasetOwner);
+            assertOwnedBy(images, recipient);
+            assertOwnedBy(links, datasetOwner);
+            assertOwnedBy(plate, plateOwner);
+            break;
+        case PLATE:
+            assertOwnedBy(dataset, datasetOwner);
+            assertOwnedBy(images, datasetOwner);
+            assertOwnedBy(links, datasetOwner);
+            assertOwnedBy(plate, recipient);
+            break;
+        }
 
         /* delete the objects as clean-up */
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -794,7 +794,7 @@ public class PermissionsTest extends AbstractServerTest {
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
 
         plateOwner = newUserInGroup(dataGroup, false);
-        recipient = newUserInGroup(dataGroup, true);
+        recipient = newUserInGroup(dataGroup, false);
 
         /* create a plate */
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -438,7 +438,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext datasetOwner, imageOwner, linkOwner, recipient;
         final ExperimenterGroup dataGroup;
 
-        datasetOwner = newUserAndGroup(groupPermissions);
+        datasetOwner = newUserAndGroup(groupPermissions, true);
 
         final long dataGroupId = datasetOwner.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
@@ -449,7 +449,7 @@ public class PermissionsTest extends AbstractServerTest {
             imageOwner = datasetOwner;
             linkOwner = isLinkOwner ? datasetOwner : newUserInGroup(dataGroup, false);
         } else {
-            imageOwner = newUserInGroup(dataGroup, false);
+            imageOwner = newUserInGroup(dataGroup, true);
             linkOwner = isLinkOwner ? datasetOwner : imageOwner;
         }
 
@@ -515,7 +515,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext datasetOwner, imageOwner, linkOwner, recipient;
         final ExperimenterGroup dataGroup;
 
-        datasetOwner = newUserAndGroup(groupPermissions);
+        datasetOwner = newUserAndGroup(groupPermissions, true);
 
         final long dataGroupId = datasetOwner.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
@@ -526,7 +526,7 @@ public class PermissionsTest extends AbstractServerTest {
             imageOwner = datasetOwner;
             linkOwner = isLinkOwner ? datasetOwner : newUserInGroup(dataGroup, false);
         } else {
-            imageOwner = newUserInGroup(dataGroup, false);
+            imageOwner = newUserInGroup(dataGroup, true);
             linkOwner = isLinkOwner ? datasetOwner : imageOwner;
         }
 
@@ -620,7 +620,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext imageOwner, projectionOwner, recipient;
         final ExperimenterGroup dataGroup;
 
-        imageOwner = newUserAndGroup("rwrw--");
+        imageOwner = newUserAndGroup("rwrw--", true);
 
         final long dataGroupId = imageOwner.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
@@ -691,7 +691,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext imageOwner, otherImageOwner, recipient;
         final ExperimenterGroup dataGroup;
 
-        imageOwner = newUserAndGroup("rwrw--");
+        imageOwner = newUserAndGroup("rwrw--", true);
 
         final long dataGroupId = imageOwner.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
@@ -788,7 +788,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext datasetOwner, plateOwner, recipient;
         final ExperimenterGroup dataGroup;
 
-        datasetOwner = newUserAndGroup("rwrw--");
+        datasetOwner = newUserAndGroup("rwrw--", true);
 
         final long dataGroupId = datasetOwner.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -216,7 +216,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext importer, chowner, recipient;
         final ExperimenterGroup dataGroup;
 
-        importer = newUserAndGroup("rw----");
+        importer = newUserAndGroup("rw----", isDataOwner && isGroupOwner);
 
         final long dataGroupId = importer.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);
@@ -316,7 +316,7 @@ public class PermissionsTest extends AbstractServerTest {
         final EventContext importer, annotator, chowner, recipient;
         final ExperimenterGroup dataGroup;
 
-        importer = newUserAndGroup("rwra--");
+        importer = newUserAndGroup("rwra--", isDataOwner && isGroupOwner);
 
         final long dataGroupId = importer.groupId;
         dataGroup = new ExperimenterGroupI(dataGroupId, false);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -852,8 +852,6 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* perform the chown */
 
-        final boolean isExpectSuccess = target != Target.PLATE;
-
         init(datasetOwner);
         final Chown2 chown = new Chown2();
 
@@ -870,12 +868,10 @@ public class PermissionsTest extends AbstractServerTest {
         }
 
         chown.userId = recipient.userId;
-        doChange(client, factory, chown, isExpectSuccess);
+        doChange(client, factory, chown, true);
         disconnect();
 
         logRootIntoGroup(dataGroupId);
-
-        if (isExpectSuccess) {
 
             /* check that the objects' ownership is all as expected */
 
@@ -893,9 +889,11 @@ public class PermissionsTest extends AbstractServerTest {
                 assertOwnedBy(plate, plateOwner);
                 break;
             case PLATE:
-                Assert.fail("cannot change plate ownership without changing that of its images");
+                assertOwnedBy(dataset, datasetOwner);
+                assertOwnedBy(images, datasetOwner);
+                assertOwnedBy(links, datasetOwner);
+                assertOwnedBy(plate, recipient);
             }
-        }
 
         /* delete the objects as clean-up */
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -32,6 +32,8 @@ all_grps = {'omero.group': '-1'}
 
 class TestChown(CLITest):
 
+    DEFAULT_GROUP_OWNER = True
+
     def setup_method(self, method):
         super(TestChown, self).setup_method(method)
         self.cli.register("chown", ChownControl, "TEST")

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -20,7 +20,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # from omero.cli import NonZeroReturnCode
-import omero
 from omero.plugins.chown import ChownControl
 from test.integration.clitest.cli import CLITest
 import pytest
@@ -50,12 +49,10 @@ class TestChown(CLITest):
                       '%s:%s' % (object_type, oid)]
         self.cli.invoke(self.args, strict=True)
 
-        # check the object has been transfered
+        # check the object has been transferred
         obj = client.sf.getQueryService().get(object_type, oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
-        with pytest.raises(omero.SecurityViolation):
-            self.query.get(object_type, oid, all_grps)
 
     def testChownBasicUsageWithName(self):
         oid = self.create_object("Image")
@@ -67,12 +64,10 @@ class TestChown(CLITest):
                       '%s:%s' % ("Image", oid)]
         self.cli.invoke(self.args, strict=True)
 
-        # check the object has been transfered
+        # check the object has been transferred
         obj = client.sf.getQueryService().get("Image", oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
-        with pytest.raises(omero.SecurityViolation):
-            self.query.get("Image", oid, all_grps)
 
     def testChownDifferentGroup(self):
         oid = self.create_object("Image")
@@ -83,9 +78,7 @@ class TestChown(CLITest):
                       '%s:%s' % ("Image", oid)]
         self.cli.invoke(self.args, strict=True)
 
-        # check the object has not been transfered
+        # check the object has been transferred
         obj = self.query.get("Image", oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == self.user.id.val
-        with pytest.raises(omero.SecurityViolation):
-            client.sf.getQueryService().get("Image", oid, all_grps)


### PR DESCRIPTION
This PR prevents data owners from chown'ing, that being a safe initial position following discussion with @joshmoore and @will-moore. Integration testing should suffice but feel free to experiment manually via the CLI to confirm.