### PR TITLE
Update Chmod to Chmod2 in Python codebase

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3894,8 +3894,9 @@ class _BlitzGateway (object):
         callback.loop(20, 500)
         rsp = prx.getResponse()
         """
-        chmod = omero.cmd.Chmod(
-            type="/ExperimenterGroup", id=group_Id, permissions=permissions)
+        chmod = omero.cmd.Chmod2(
+            targetObjects={'ExperimenterGroup': [group_Id]},
+            permissions=permissions)
         prx = self.c.sf.submit(chmod)
         return prx
 

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -185,8 +185,9 @@ server-permissions.html
                          % (g.name.val, gid, perms))
         else:
             try:
-                chmod = omero.cmd.Chmod(
-                    type="/ExperimenterGroup", id=gid, permissions=str(perms))
+                chmod = omero.cmd.Chmod2(
+                    targetObjects={'ExperimenterGroup': [gid]},
+                    permissions=str(perms))
                 c.submit(chmod)
                 self.ctx.out("Changed permissions for group %s (id=%s) to %s"
                              % (g.name.val, gid, perms))

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -39,7 +39,7 @@ import omero.scripts
 
 from omero.rtypes import rbool, rint, rstring, rlong, rlist, rtime, unwrap
 from omero.model import ExperimenterI, ExperimenterGroupI
-from omero.cmd import Chmod
+from omero.cmd import Chmod2
 
 from omero.gateway import AnnotationWrapper
 from omero.gateway import OmeroGatewaySafeCallWrapper
@@ -1452,10 +1452,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         """
 
         perms = str(permissions)
-        logger.debug("Chmod of group ID: %s to %s" % (group.id, perms))
-        command = Chmod(type="/ExperimenterGroup",
-                        id=group.id,
-                        permissions=perms)
+        logger.debug("Chmod2 of group ID: %s to %s" % (group.id, perms))
+        command = Chmod2(
+            targetObjects={'ExperimenterGroup': [group.id]},
+            permissions=perms)
         cb = self.c.submit(command, loops=120)
         cb.close(True)
 


### PR DESCRIPTION
This PR updates the CLI and Python gateways to use Chmod2 over Chmod.

Testing
-------
Changing group permissions via the CLI `omero group perms` or the webclient should function as before.  Relevant integration tests `clitest/group` should pass.
