### PR TITLE
Fixed 'Empty' and 'Loading...' nodes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/Browser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/Browser.java
@@ -220,6 +220,15 @@ public interface Browser
      */
     public static final String     ADMIN_TITLE = "Administration";
     
+    /** The text of the dummy default node. */
+    public static final String     LOADING_MSG = "Loading...";
+    
+    /** 
+     * The text of the node added to a {@link TreeImageSet} node
+     * containing no element.
+     */
+    public static final String     EMPTY_MSG = "Empty";
+    
     /**
      * Sets the selected {@link TreeImageDisplay node}.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -120,17 +120,7 @@ import pojos.TagAnnotationData;
 class BrowserUI
     extends JPanel
     implements PropertyChangeListener
-{
-    
-	/** The text of the dummy default node. */
-    private static final String     LOADING_MSG = "Loading...";
-	
-    /** 
-     * The text of the node added to a {@link TreeImageSet} node
-     * containing no element.
-     */
-    private static final String     EMPTY_MSG = "Empty";
-    
+{   
     /** The <code>Attachments</code> smart folder. */
     private static final int[] VALUES = {TreeFileSet.MOVIE, TreeFileSet.OTHER};
     
@@ -1104,7 +1094,7 @@ class BrowserUI
                                 Collection nodes, DefaultTreeModel tm)
     {
         if (nodes.size() == 0) {
-            tm.insertNodeInto(new DefaultMutableTreeNode(EMPTY_MSG), 
+            tm.insertNodeInto(new DefaultMutableTreeNode(Browser.EMPTY_MSG), 
                     parent, parent.getChildCount());
             return;
         }
@@ -1154,24 +1144,24 @@ class BrowserUI
                 } else {
                 	uo = display.getUserObject();
                 	if (uo instanceof DatasetData) {
-                		tm.insertNodeInto(new DefaultMutableTreeNode(EMPTY_MSG), 
+                		tm.insertNodeInto(new DefaultMutableTreeNode(Browser.EMPTY_MSG), 
                 				display, display.getChildCount());
                 	} else if (uo instanceof TagAnnotationData) {
                 		TagAnnotationData tag = (TagAnnotationData) uo;
                 		if (!(TagAnnotationData.INSIGHT_TAGSET_NS.equals(
                 				tag.getNameSpace()))) {
                 			tm.insertNodeInto(
-                					new DefaultMutableTreeNode(EMPTY_MSG), 
+                					new DefaultMutableTreeNode(Browser.EMPTY_MSG), 
                     				display, display.getChildCount());
                 		}
                 	} else if (uo instanceof GroupData) {
-                		tm.insertNodeInto(new DefaultMutableTreeNode(EMPTY_MSG), 
+                		tm.insertNodeInto(new DefaultMutableTreeNode(Browser.EMPTY_MSG), 
                 				display, display.getChildCount());
                 	} else if (uo instanceof FileAnnotationData) {
                 		if (browserType == Browser.SCREENS_EXPLORER) {
                 			TreeImageSet n = new TreeImageSet(uo);
                 			tm.insertNodeInto(
-                					new DefaultMutableTreeNode(EMPTY_MSG), 
+                					new DefaultMutableTreeNode(Browser.EMPTY_MSG), 
                     				n, n.getChildCount());
                 		}
                 	}
@@ -1208,7 +1198,7 @@ class BrowserUI
     private void buildEmptyNode(DefaultMutableTreeNode node)
     {
         DefaultTreeModel tm = (DefaultTreeModel) treeDisplay.getModel();
-        tm.insertNodeInto(new DefaultMutableTreeNode(EMPTY_MSG), node,
+        tm.insertNodeInto(new DefaultMutableTreeNode(Browser.EMPTY_MSG), node,
                             node.getChildCount());
     }
     
@@ -1467,7 +1457,7 @@ class BrowserUI
     {
         DefaultTreeModel tm = (DefaultTreeModel) treeDisplay.getModel();
         parent.removeAllChildren();
-        tm.insertNodeInto(new DefaultMutableTreeNode(LOADING_MSG), parent,
+        tm.insertNodeInto(new DefaultMutableTreeNode(Browser.LOADING_MSG), parent,
                 			parent.getChildCount());
         tm.reload(parent);
     }
@@ -1486,7 +1476,7 @@ class BrowserUI
     	DefaultMutableTreeNode node = 
 			 (DefaultMutableTreeNode) parent.getChildAt(0);
     	Object uo = node.getUserObject();
-    	if (LOADING_MSG.equals(uo) || EMPTY_MSG.equals(uo))
+    	if (Browser.LOADING_MSG.equals(uo) || Browser.EMPTY_MSG.equals(uo))
     		return true;
     	return false;
     }
@@ -2009,7 +1999,7 @@ class BrowserUI
 			Object o = childNode.getUserObject();
 			if (o instanceof String) {
 				String s = (String) o;
-				if (EMPTY_MSG.equals(s)) {
+				if (Browser.EMPTY_MSG.equals(s)) {
 					remove.add(childNode);
 				}
 			}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -38,6 +38,7 @@ import javax.swing.JViewport;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
+import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserFactory;
 import org.openmicroscopy.shoola.agents.util.browser.SmartFolder;
 import org.openmicroscopy.shoola.agents.util.browser.TreeFileSet;
@@ -697,10 +698,6 @@ public class TreeCellRenderer
         FontMetrics fm = getFontMetrics(getFont());
         Object ho = node.getUserObject();
         if (node.getLevel() == 0) {
-            String text = node.getNodeName();
-            if (numberChildrenVisible) 
-                text = node.getNodeText();
-            
         	if (ho instanceof ExperimenterData) 
         	    setIcon(OWNER_ICON);
         	else 
@@ -709,7 +706,7 @@ public class TreeCellRenderer
             if (getIcon() != null)
                 w += getIcon().getIconWidth();
             w += getIconTextGap();
-            w += fm.stringWidth(text);
+            w += fm.stringWidth(getText());
             setPreferredSize(new Dimension(w, fm.getHeight()));
             
             Color c = node.getHighLight();
@@ -780,7 +777,8 @@ public class TreeCellRenderer
 
     @Override
     public String getText() {
-        if (ref != null) {
+        if (ref != null && !super.getText().equals(Browser.LOADING_MSG)
+                && !super.getText().equals(Browser.EMPTY_MSG)) {
             // trim the text so that it fits into the given space
             JViewport vp = ref.getViewport();
             int w = vp.getSize().width;


### PR DESCRIPTION
Fixes a bug introduced by #3927 ; instead showing the nodes "Loading..." and "Empty" a node with the same name like the dataset was displayed.

Test: Expand a dataset in treeviewer, make sure it shows a childnode named "Loading..." while loading the dataset content. Expand an empty dataset, make sure it shows one childnode named "Empty"


