### PR TITLE
updating string formatting

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
@@ -631,11 +631,15 @@ class WebGatewayCache (object):
             rv = 'img_%s/%s/%s/%%s-c%s-m%s-q%s-r%s-t%s' % (
                 client_base, pre, str(iid), c, m, q, region, tile)
             if p:
-                return rv % ('%s-%s' % (p, str(t)))
+                logger.debug('rv: {0} {1}'.format(rv, type(rv)))
+                logger.debug('p: {0} {1}'.format(str(p), type(p)))
+                logger.debug('t: {0} {1}'.format(str(t), type(t)))
+                pt = '%s-%s' % (p, str(t))
+                return rv % (pt)
             else:
-                logger.info('rv: {0} {1}'.format(rv, type(rv)))
-                logger.info('z: {0} {1}'.format(str(z), type(z)))
-                logger.info('t: {0} {1}'.format(str(t), type(t)))
+                logger.debug('rv: {0} {1}'.format(rv, type(rv)))
+                logger.debug('z: {0} {1}'.format(str(z), type(z)))
+                logger.debug('t: {0} {1}'.format(str(t), type(t)))
                 zt = '%sx%s' % (str(z), str(t))
                 return rv % (zt)
         else:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
@@ -633,7 +633,11 @@ class WebGatewayCache (object):
             if p:
                 return rv % ('%s-%s' % (p, str(t)))
             else:
-                return rv % ('%sx%s' % (str(z), str(t)))
+                logger.info('rv: {0} {1}'.format(rv, type(rv)))
+                logger.info('z: {0} {1}'.format(str(z), type(z)))
+                logger.info('t: {0} {1}'.format(str(t), type(t)))
+                zt = '%sx%s' % (str(z), str(t))
+                return rv % (zt)
         else:
             return 'img_%s/%s/%s' % (client_base, pre, str(iid))
 


### PR DESCRIPTION
Due to unknown circumstances in https://trac.openmicroscopy.org/ome/ticket/12969 this PR adds more logging details.

To test open image viewer, check if rendered image is visible and see if you get similar in logs
```
2015-07-16 13:47:02,367  INFO [             webgateway.webgateway_cache] (proc.14963) _imageKey:636 rv: img_1/0/2717/%s-c1-166.75:2129.6875-0000FF-2-237.65:2489.0625-00FF00-3-605.6:1851.2000000000003-FF0000-mc-q0.9-r-t <type 'unicode'>
2015-07-16 13:47:02,367  INFO [             webgateway.webgateway_cache] (proc.14963) _imageKey:637 z: 35 <type 'unicode'>
2015-07-16 13:47:02,367  INFO [             webgateway.webgateway_cache] (proc.14963) _imageKey:638 t: 0 <type 'unicode'>
```
First line should contain ``%s``

cc: @joshmoore @kennethgillen 