### PR TITLE
Modify IceSSL Ciphers to ALL with exceptions

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -319,7 +319,7 @@ public class client {
         id.properties.setProperty("Ice.Default.PreferSecure", "1");
         id.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
         id.properties.setProperty("IceSSL.Protocols", "tls1");
-        id.properties.setProperty("IceSSL.Ciphers", "NONE (DH_anon)");
+        id.properties.setProperty("IceSSL.Ciphers", "ALL");
         id.properties.setProperty("IceSSL.VerifyPeer", "0");
 
         // Setting default block size

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2013 Glencoe Software, Inc. All rights reserved.
+ * Copyright (C) 2008-2015 Glencoe Software, Inc. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -319,7 +319,7 @@ public class client {
         id.properties.setProperty("Ice.Default.PreferSecure", "1");
         id.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
         id.properties.setProperty("IceSSL.Protocols", "tls1");
-        id.properties.setProperty("IceSSL.Ciphers", "ALL");
+        id.properties.setProperty("IceSSL.Ciphers", "ALL !ADH !LOW !EXP !MD5");
         id.properties.setProperty("IceSSL.VerifyPeer", "0");
 
         // Setting default block size

--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -2,7 +2,7 @@
 
 <!--
     OMERO.grid Application Descriptor
-    Copyright 2008 Glencoe Software, Inc.  All Rights Reserved.
+    Copyright 2008-2015 Glencoe Software, Inc.  All Rights Reserved.
     Use is subject to license terms supplied in LICENSE.txt
 -->
 

--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -48,7 +48,7 @@
       <target name="adh">
         <property name="Ice.Default.Protocol" value="ssl"/>
         <property name="Ice.Plugin.IceSSL" value="IceSSL.PluginFactory"/>
-        <property name="IceSSL.Ciphers" value="ALL"/>
+        <property name="IceSSL.Ciphers" value="ALL !ADH !LOW !EXP !MD5"/>
         <property name="IceSSL.VerifyPeer" value="0"/>
       </target>
       <target name="ssl">

--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -48,7 +48,7 @@
       <target name="adh">
         <property name="Ice.Default.Protocol" value="ssl"/>
         <property name="Ice.Plugin.IceSSL" value="IceSSL.PluginFactory"/>
-        <property name="IceSSL.Ciphers" value="NONE (DH_anon)"/>
+        <property name="IceSSL.Ciphers" value="ALL"/>
         <property name="IceSSL.VerifyPeer" value="0"/>
       </target>
       <target name="ssl">


### PR DESCRIPTION
See https://trello.com/c/vvivb0o7/567-java-8u51-connection-problems for full discussion.

This PR changes two of the instances of `IceSSL.Ciphers` relevant to Java to `ALL`. This may have a security impact on other versions of Java.

Tesing: Insight running on machines with Java 8_51 should be able to connect to OMERO servers. The CLI importer on machines with Java 8_51 should work.

--rebased-to #3971

Added: only the single client change may be required but it seemed sensible to change both uses. It might also be worth reviewing the C++ and Python config, should that mirror the Java settings?