### PR TITLE
Autofocus on web login username field

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -51,7 +51,8 @@ class LoginForm(NonASCIIForm):
         self.fields.keyOrder = ['server', 'username', 'password', 'ssl']
 
     username = forms.CharField(
-        max_length=50, widget=forms.TextInput(attrs={'size': 22}))
+        max_length=50, widget=forms.TextInput(attrs={
+            'size': 22, 'autofocus': 'autofocus'}))
     password = forms.CharField(
         max_length=50,
         widget=forms.PasswordInput(attrs={'size': 22, 'autocomplete': 'off'}))


### PR DESCRIPTION
Load OMERO.web. The keyboard focus should default to the username field so instead of clicking on it first you should be able to enter your username straightaway, hit tab, enter your password, and hit enter to login.