### PR TITLE
Order PlateAcquisitions by name in web (rebased onto metadata)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -342,7 +342,8 @@ def marshal_screens(conn, experimenter_id=None):
                left join splink.child plate
                left join plate.plateAcquisitions pa
         %s
-        order by lower(screen.name), screen.id, lower(plate.name), pa.id
+        order by lower(screen.name), screen.id, lower(plate.name), plate.id,
+        lower(pa.name), pa.id
         """ % (where_clause)
 
     # TODO Remove this when fixed. Workaround for bug:


### PR DESCRIPTION
This is the same as gh-3974 but rebased onto metadata.

----

https://trello.com/c/lvyNfeoJ/42-run-ordering

To test, find a Plate with multiple acquisitions- these should be ordered by name instead of by ID.

                