### PR TITLE
Disable SSL ciphers unsupported by Java

### DIFF
--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -469,7 +469,7 @@
           <properties refid="CppServer"/>
           <properties refid="Profile"/>
           <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
-          <property name="IceSSL.Ciphers" value="ADH"/>
+          <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
           <property name="IceSSL.VerifyPeer" value="0"/>
           <property name="IceSSL.Protocols" value="tls1"/>
           <property name="Glacier2.Client.Endpoints" value="${client-endpoints}"/>


### PR DESCRIPTION
A recent change to Java dropped support for several
SSL ciphers which were being used by Glacier2. This
removes those ciphers from the list so that newer
versions of Java can still connect.