### PR TITLE
Disable SSL ciphers unsupported by Java 8u51 et al.

### DIFF
--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -469,7 +469,7 @@
           <properties refid="CppServer"/>
           <properties refid="Profile"/>
           <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
-          <property name="IceSSL.Ciphers" value="ADH"/>
+          <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
           <property name="IceSSL.VerifyPeer" value="0"/>
           <property name="IceSSL.Protocols" value="tls1"/>
           <property name="Glacier2.Client.Endpoints" value="${client-endpoints}"/>


### PR DESCRIPTION
A recent change to Java dropped support for several
SSL ciphers which were being used by Glacier2. Attempts
to login from OMERO.java including the CLI importer and
insight failed with the exception:

```
2015-07-20 21:25:02,718 1196       [      main] ERROR  formats.importer.cli.CommandLineImporter - Error during import process.
Ice.SecurityException: javax.net.ssl.SSLHandshakeException: DHPublicKey does not comply to algorithm constraints
        at IceInternal.ConnectRequestHandler.getConnection(ConnectRequestHandler.java:240) ~[ice.jar:na]
        at IceInternal.ConnectRequestHandler.sendRequest(ConnectRequestHandler.java:138) ~[ice.jar:na]
        at IceInternal.Outgoing.invoke(Outgoing.java:66) ~[ice.jar:na]
        at Ice._ObjectDelM.ice_isA(_ObjectDelM.java:30) ~[ice.jar:na]
        at Ice.ObjectPrxHelperBase.ice_isA(ObjectPrxHelperBase.java:111) ~[ice.jar:na]
        at Ice.ObjectPrxHelperBase.ice_isA(ObjectPrxHelperBase.java:77) ~[ice.jar:na]
        at Glacier2.RouterPrxHelper.checkedCast(RouterPrxHelper.java:2268) ~[ice.jar:na]
        at omero.client.getRouter(client.java:786) ~[blitz.jar:na]
        at omero.client.createSession(client.java:709) ~[blitz.jar:na]
        at omero.client.joinSession(client.java:638) ~[blitz.jar:na]
        at ome.formats.OMEROMetadataStoreClient.initialize(OMEROMetadataStoreClient.java:695) ~[blitz.jar:na]
        at ome.formats.importer.ImportConfig.createStore(ImportConfig.java:364) ~[blitz.jar:na]
        at ome.formats.importer.cli.CommandLineImporter.<init>(CommandLineImporter.java:155) ~[blitz.jar:na]
        at ome.formats.importer.cli.CommandLineImporter.main(CommandLineImporter.java:856) ~[blitz.jar:na]
```

This removes those ciphers from the handshade so that newer
versions of Java like 7u85 and 8u51 can still connect.

For more information, see
http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/