### PR TITLE
fix SkipHead hang

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -154,6 +154,8 @@ public class SkipHeadI extends SkipHead implements IRequest {
             /* cancel because of wrapped request exception */
             throw helper.cancel(new ERR(), t, "graph-fail");
         }
+
+        /* set step count */
         graphRequestSkipStatus.steps = 1 + wrappedRequest.getStepProvidingCompleteResponse();
         helper.setSteps(graphRequestSkipStatus.steps + graphRequestPerformStatus.steps);
     }

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -87,6 +87,8 @@ public class SkipHeadI extends SkipHead implements IRequest {
 
     @Override
     public void init(Helper helper) {
+        this.helper = helper;
+
         final GraphPolicy.Action startAction;
         final WrappableRequest<GraphModify2> wrappedRequest;
 
@@ -153,8 +155,6 @@ public class SkipHeadI extends SkipHead implements IRequest {
             throw helper.cancel(new ERR(), t, "graph-fail");
         }
         graphRequestSkipStatus.steps = 1 + wrappedRequest.getStepProvidingCompleteResponse();
-
-        this.helper = helper;
         helper.setSteps(graphRequestSkipStatus.steps + graphRequestPerformStatus.steps);
     }
 

--- a/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
@@ -1,44 +1,32 @@
 /*
- * $Id$
- *
- *   Copyright 2013 University of Dundee. All rights reserved.
+ *   Copyright 2013-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
+import omero.RType;
+import omero.ServerError;
+import omero.api.IRenderingSettingsPrx;
 import omero.cmd.Delete2;
 import omero.cmd.DoAll;
 import omero.cmd.Request;
-import omero.model.Annotation;
-import omero.model.CommentAnnotationI;
+import omero.cmd.SkipHead;
 import omero.model.Dataset;
-import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
 import omero.model.Fileset;
 import omero.model.FilesetI;
 import omero.model.Image;
-import omero.model.ImageAnnotationLink;
-import omero.model.ImageAnnotationLinkI;
-import omero.model.Plate;
-import omero.model.Project;
-import omero.model.ProjectI;
-import omero.model.Roi;
-import omero.model.Screen;
-import omero.model.ScreenI;
 import omero.sys.Parameters;
 import omero.sys.ParametersI;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
@@ -102,4 +90,134 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
         doChange(client, factory, all, false, null);
     }
 
+    /* for anchored delete test cases */
+    private enum Target {IMAGES_OF_FILESET, RENDERING_SETTINGS_OF_FILESET, RENDERING_SETTINGS_OF_IMAGE, NONSENSE_OF_IMAGE};
+
+    /**
+     * Asserts that a given image has some rendering settings.
+     * @param imageId the ID of an image
+     * @param hasSettings if the image is expected to have some rendering settings
+     * @throws ServerError unexpected
+     */
+    private void assertHasRenderingDef(long imageId, boolean hasSettings) throws ServerError {
+        final String query = "SELECT id FROM RenderingDef WHERE pixels.image.id = :id";
+        final Parameters params = new ParametersI().addId(imageId);
+        final List<List<RType>> results = iQuery.projection(query, params);
+        Assert.assertEquals(results.isEmpty(), !hasSettings);
+    }
+
+    /**
+     * Test an anchored delete operation expressed using {@link SkipHead}.
+     * @param target the kind of object to actually delete
+     * @param dryRun if the deletion should be a dry run
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "anchored")
+    public void testAnchoredDelete(Target target, boolean dryRun) throws Exception {
+
+        /* create a fileset with two images, each of which has rendering settings */
+
+        final Image image1 = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage());
+        final Image image2 = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage());
+        final long image1Id = image1.getId().getValue();
+        final long image2Id = image2.getId().getValue();
+
+        Fileset fileset = newFileset();
+        fileset.addImage(image1);
+        fileset.addImage(image2);
+        fileset = (Fileset) iUpdate.saveAndReturnObject(fileset);
+        final long filesetId = fileset.getId().getValue();
+
+        final IRenderingSettingsPrx renderingSettingsService = factory.getRenderingSettingsService();
+        renderingSettingsService.setOriginalSettingsInImage(image1Id);
+        renderingSettingsService.setOriginalSettingsInImage(image2Id);
+
+        /* delete the images of the fileset, the rendering settings of one of the images, or nonsense */
+
+        final SkipHead skipHead = new SkipHead();
+        skipHead.request = new Delete2();
+        skipHead.dryRun = dryRun;
+        switch (target) {
+        case IMAGES_OF_FILESET:
+            skipHead.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
+            skipHead.startFrom = Collections.singletonList("Image");
+            break;
+        case RENDERING_SETTINGS_OF_FILESET:
+            skipHead.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
+            skipHead.startFrom = Collections.singletonList("RenderingDef");
+            break;
+        case RENDERING_SETTINGS_OF_IMAGE:
+            skipHead.targetObjects = Collections.singletonMap("Image", Collections.singletonList(image1Id));
+            skipHead.startFrom = Collections.singletonList("RenderingDef");
+            break;
+        case NONSENSE_OF_IMAGE:
+            skipHead.targetObjects = Collections.singletonMap("Image", Collections.singletonList(image1Id));
+            skipHead.startFrom = Collections.singletonList("I like penguins");
+            break;
+        }
+
+        final boolean isExpectSuccess = target != Target.NONSENSE_OF_IMAGE;
+
+        doChange(client, factory, skipHead, isExpectSuccess);
+
+        /* check the outcome */
+
+        if (target == Target.IMAGES_OF_FILESET && !dryRun) {
+            /* actually deleted the fileset via its images */
+        } else {
+
+            /* deleted no more than rendering settings, but check exactly what */
+
+            assertExists(fileset);
+            assertExists(image1);
+            assertExists(image2);
+
+            final boolean isImage1SettingsExist, isImage2SettingsExist;
+            if (target == Target.NONSENSE_OF_IMAGE || dryRun) {
+                isImage1SettingsExist = true;
+                isImage2SettingsExist = true;
+            } else {
+                isImage1SettingsExist = false;
+                isImage2SettingsExist = target == Target.RENDERING_SETTINGS_OF_IMAGE;
+            }
+            assertHasRenderingDef(image1Id, isImage1SettingsExist);
+            assertHasRenderingDef(image2Id, isImage2SettingsExist);
+
+            /* delete the fileset */
+            final Delete2 delete = new Delete2();
+            delete.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
+            doChange(delete);
+        }
+
+        /* fileset no longer exists */
+        assertDoesNotExist(fileset);
+        assertDoesNotExist(image1);
+        assertDoesNotExist(image2);
+    }
+
+    /**
+     * @return a variety of test cases for anchored delete
+     */
+    @DataProvider(name = "anchored")
+    public Object[][] provideAnchoredDeleteCases() {
+        int index = 0;
+        final int TARGET = index++;
+        final int DRY_RUN = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Target target : Target.values()) {
+            for (final boolean dryRun : booleanCases) {
+                final Object[] testCase = new Object[index];
+                testCase[TARGET] = target;
+                testCase[DRY_RUN] = dryRun;
+                // DEBUG: if (target == Target.IMAGES_OF_FILESET && dryRun == true)
+                testCases.add(testCase);
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
@@ -6,6 +6,7 @@
 package integration.delete;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -14,8 +15,6 @@ import omero.RType;
 import omero.ServerError;
 import omero.api.IRenderingSettingsPrx;
 import omero.cmd.Delete2;
-import omero.cmd.DoAll;
-import omero.cmd.Request;
 import omero.cmd.SkipHead;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
@@ -74,20 +73,16 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
     	link.setChild((Image) i2.proxy());
     	link.setParent((Dataset) d2.proxy());
     	iUpdate.saveAndReturnObject(link);
-    	List<Request> commands = new ArrayList<Request>();
     	Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(d1.getId().getValue()));
-        commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d2.getId().getValue()));
-        commands.add(dc);
-        DoAll all = new DoAll();
-        all.requests = commands;
-        doChange(client, factory, all, false, null);
+    	dc.targetObjects = ImmutableMap.<String, List<Long>>of(
+    	        Dataset.class.getSimpleName(),
+    	        Arrays.asList(d1.getId().getValue(), d2.getId().getValue()));
+    	doChange(dc);
+    	assertDoesNotExist(d1);
+    	assertDoesNotExist(d2);
+    	assertDoesNotExist(fileset);
+    	assertDoesNotExist(i1);
+    	assertDoesNotExist(i2);
     }
 
     /* for anchored delete test cases */


### PR DESCRIPTION
Fixes that `SkipHead` requests would hang for clients if an invalid class name was given. Noticed by @ximenesuk in trying something like `bin/omero delete Image/RenderingDefs:1234` (it's actually "RenderingDef" singular). The error isn't yet pretty, but at least it's now promptly delivered.

This PR also reworks and extends integration tests: https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration.delete/MultiImageFilesetDeleteTest/ should still pass.