### PR TITLE
Make all Ice properties configurable

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -120,7 +120,7 @@ public class client {
      * See {@link #setAgent(String)}
      */
     private volatile String __agent = "OMERO.java";
-    
+
     /**
      * See {@link #setIP(String)}
      */
@@ -294,6 +294,14 @@ public class client {
         init(id);
     }
 
+    private void optionallySetProperty(Ice.InitializationData id, String key, String def) {
+        String val = id.properties.getProperty(key);
+        if (val == null || val.length() == 0) {
+            val = def;
+        }
+        id.properties.setProperty(key, val);
+    }
+
     /**
      * Initializes the current client via an {@link Ice.InitializationData}
      * instance. This is called by all of the constructors, but may also be
@@ -311,39 +319,28 @@ public class client {
         }
 
         // Strictly necessary for this class to work
-        id.properties.setProperty("Ice.ImplicitContext", "Shared");
-        id.properties.setProperty("Ice.ACM.Client", "0");
-        id.properties.setProperty("Ice.CacheMessageBuffers", "0");
-        id.properties.setProperty("Ice.RetryIntervals", "-1");
-        id.properties.setProperty("Ice.Default.EndpointSelection", "Ordered");
-        id.properties.setProperty("Ice.Default.PreferSecure", "1");
-        id.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
-        id.properties.setProperty("IceSSL.Protocols", "tls1");
-        id.properties.setProperty("IceSSL.Ciphers", "NONE (DH_anon)");
-        id.properties.setProperty("IceSSL.VerifyPeer", "0");
-
-        // Setting default block size
-        String blockSize = id.properties.getProperty("omero.block_size");
-        if (blockSize == null || blockSize.length() == 0) {
-            id.properties.setProperty("omero.block_size", Integer
-                    .toString(omero.constants.DEFAULTBLOCKSIZE.value));
-        }
+        optionallySetProperty(id, "Ice.ImplicitContext", "Shared");
+        optionallySetProperty(id, "Ice.ACM.Client", "0");
+        optionallySetProperty(id, "Ice.CacheMessageBuffers", "0");
+        optionallySetProperty(id, "Ice.RetryIntervals", "-1");
+        optionallySetProperty(id, "Ice.Default.EndpointSelection", "Ordered");
+        optionallySetProperty(id, "Ice.Default.PreferSecure", "1");
+        optionallySetProperty(id, "Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
+        optionallySetProperty(id, "IceSSL.Protocols", "tls1");
+        optionallySetProperty(id, "IceSSL.Ciphers", "NONE (DH_anon)");
+        optionallySetProperty(id, "IceSSL.VerifyPeer", "0");
+        optionallySetProperty(id, "omero.block_size", Integer
+            .toString(omero.constants.DEFAULTBLOCKSIZE.value));
 
         // Set the default encoding if this is Ice 3.5 or later
         // and none is set.
         if (Ice.Util.intVersion() >= 30500) {
-            String encoding = id.properties.getProperty("Ice.Default.EncodingVersion");
-            if (encoding == null || encoding.length() == 0) {
-                id.properties.setProperty("Ice.Default.EncodingVersion", "1.0");
-            }
+            optionallySetProperty(id, "Ice.Default.EncodingVersion", "1.0");
         }
 
         // Setting MessageSizeMax
-        String messageSize = id.properties.getProperty("Ice.MessageSizeMax");
-        if (messageSize == null || messageSize.length() == 0) {
-            id.properties.setProperty("Ice.MessageSizeMax", Integer
-                    .toString(omero.constants.MESSAGESIZEMAX.value));
-        }
+        optionallySetProperty(id, "Ice.MessageSizeMax", Integer
+            .toString(omero.constants.MESSAGESIZEMAX.value));
 
         // Setting ConnectTimeout
         parseAndSetInt(id, "Ice.Override.ConnectTimeout",
@@ -439,7 +436,7 @@ public class client {
     public void setAgent(String agent) {
         __agent = agent;
     }
-    
+
     /**
      * Sets the {@link omero.model.Session#getUserIP() user ip} string for
      * this client. Every session creation will be passed this argument. Finding

--- a/components/tools/OmeroCpp/src/omero/client.cpp
+++ b/components/tools/OmeroCpp/src/omero/client.cpp
@@ -40,6 +40,16 @@ using namespace std;
 
 namespace omero {
 
+    void client::optionallySetProperty(const Ice::InitializationData& id,
+            const std::string& key, const std::string& def) {
+        std::string val(id.properties->getProperty(key));
+        if (val.empty()) {
+            id.properties->setProperty(key, def);
+        } else {
+            id.properties->setProperty(key, val);
+        }
+    }
+
     void client::init(const Ice::InitializationData& data) {
 
         // Not possible for id to be null since its a struct
@@ -52,23 +62,21 @@ namespace omero {
         }
 
         // Strictly necessary for this class to work
-        id.properties->setProperty("Ice.ImplicitContext", "Shared");
-        id.properties->setProperty("Ice.ACM.Client", "0");
-        id.properties->setProperty("Ice.CacheMessageBuffers", "0");
-        id.properties->setProperty("Ice.RetryIntervals", "-1");
-        id.properties->setProperty("Ice.Default.EndpointSelection", "Ordered");
-        id.properties->setProperty("Ice.Default.PreferSecure", "1");
-        id.properties->setProperty("Ice.Plugin.IceSSL" , "IceSSL:createIceSSL");
-        id.properties->setProperty("IceSSL.Ciphers" , "ADH");
-        id.properties->setProperty("IceSSL.Protocols" , "tls1");
-        id.properties->setProperty("IceSSL.VerifyPeer" , "0");
+        optionallySetProperty(id, "Ice.ImplicitContext", "Shared");
+        optionallySetProperty(id, "Ice.ACM.Client", "0");
+        optionallySetProperty(id, "Ice.CacheMessageBuffers", "0");
+        optionallySetProperty(id, "Ice.RetryIntervals", "-1");
+        optionallySetProperty(id, "Ice.Default.EndpointSelection", "Ordered");
+        optionallySetProperty(id, "Ice.Default.PreferSecure", "1");
+        optionallySetProperty(id, "Ice.Plugin.IceSSL" , "IceSSL:createIceSSL");
+        optionallySetProperty(id, "IceSSL.Ciphers" , "ADH");
+        optionallySetProperty(id, "IceSSL.Protocols" , "tls1");
+        optionallySetProperty(id, "IceSSL.VerifyPeer" , "0");
 
         // Set the default encoding if this is Ice 3.5 or later
         // and none is set.
 #if ICE_INT_VERSION / 100 >= 305
-        if (id.properties->getProperty("Ice.Default.EncodingVersion").empty()) {
-            id.properties->setProperty("Ice.Default.EncodingVersion", "1.0");
-        }
+        optionallySetProperty(id, "Ice.Default.EncodingVersion", "1.0");
 #endif
 
         // C++ only
@@ -100,10 +108,7 @@ namespace omero {
             omero::constants::CONNECTTIMEOUT);
 
         // Endpoints set to tcp if not present
-        std::string endpoints = id.properties->getProperty("omero.ClientCallback.Endpoints");
-        if ( endpoints.length() == 0 ) {
-            id.properties->setProperty("omero.ClientCallback.Endpoints", "tcp");
-        }
+        optionallySetProperty(id, "omero.ClientCallback.Endpoints", "tcp");
 
         // Set large thread pool max values for all communicators
         std::string xs[] = {"Client", "Server"};

--- a/components/tools/OmeroCpp/src/omero/client.h
+++ b/components/tools/OmeroCpp/src/omero/client.h
@@ -69,6 +69,8 @@ namespace omero {
     private:
         client& operator=(const client& rv);
         client(client&);
+        void optionallySetProperty(const Ice::InitializationData& id,
+                const std::string& key, const std::string& def="");
 
         // These are the central instances provided by this class.
     protected:

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -186,35 +186,30 @@ class BaseClient(object):
             raise omero.ClientError("No initialization data provided.")
 
         # Strictly necessary for this class to work
-        id.properties.setProperty("Ice.ImplicitContext", "Shared")
-        id.properties.setProperty("Ice.ACM.Client", "0")
-        id.properties.setProperty("Ice.CacheMessageBuffers", "0")
-        id.properties.setProperty("Ice.RetryIntervals", "-1")
-        id.properties.setProperty("Ice.Default.EndpointSelection", "Ordered")
-        id.properties.setProperty("Ice.Default.PreferSecure", "1")
-        id.properties.setProperty("Ice.Plugin.IceSSL", "IceSSL:createIceSSL")
-        id.properties.setProperty("IceSSL.Ciphers", "ADH")
-        id.properties.setProperty("IceSSL.VerifyPeer", "0")
-        id.properties.setProperty("IceSSL.Protocols", "tls1")
+        self._optSetProp(id, "Ice.ImplicitContext", "Shared")
+        self._optSetProp(id, "Ice.ACM.Client", "0")
+        self._optSetProp(id, "Ice.CacheMessageBuffers", "0")
+        self._optSetProp(id, "Ice.RetryIntervals", "-1")
+        self._optSetProp(id, "Ice.Default.EndpointSelection", "Ordered")
+        self._optSetProp(id, "Ice.Default.PreferSecure", "1")
+        self._optSetProp(id, "Ice.Plugin.IceSSL", "IceSSL:createIceSSL")
+        self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+        self._optSetProp(id, "IceSSL.VerifyPeer", "0")
+        self._optSetProp(id, "IceSSL.Protocols", "tls1")
 
         # Setting block size
-        blockSize = id.properties.getProperty("omero.block_size")
-        if not blockSize or len(blockSize) == 0:
-            id.properties.setProperty(
-                "omero.block_size", str(omero.constants.DEFAULTBLOCKSIZE))
+        self._optSetProp(
+            id, "omero.block_size", str(omero.constants.DEFAULTBLOCKSIZE))
 
         # Set the default encoding if this is Ice 3.5 or later
         # and none is set.
         if Ice.intVersion() >= 30500:
-            if not id.properties.getProperty("Ice.Default.EncodingVersion"):
-                id.properties.setProperty(
-                    "Ice.Default.EncodingVersion", "1.0")
+            self._optSetProp(
+                id, "Ice.Default.EncodingVersion", "1.0")
 
         # Setting MessageSizeMax
-        messageSize = id.properties.getProperty("Ice.MessageSizeMax")
-        if not messageSize or len(messageSize) == 0:
-            id.properties.setProperty(
-                "Ice.MessageSizeMax", str(omero.constants.MESSAGESIZEMAX))
+        self._optSetProp(
+            id, "Ice.MessageSizeMax", str(omero.constants.MESSAGESIZEMAX))
 
         # Setting ConnectTimeout
         self.parseAndSetInt(id, "Ice.Override.ConnectTimeout",
@@ -1108,6 +1103,12 @@ class BaseClient(object):
     #
     # Misc.
     #
+
+    def _optSetProp(self, id, key, default=""):
+        val = id.properties.getProperty(key)
+        if not val:
+            val = default
+        id.properties.setProperty(key, val)
 
     def parseAndSetInt(self, data, key, newValue):
         currentValue = data.properties.getProperty(key)


### PR DESCRIPTION
The OMERO.client implementations: omero/client.java,
omero/clients.py, and omero/client.{h,cpp} were all
setting a number of Ice properties regardless of what
the client had passed in. This seems overly draconian.
The primary reason for allowing it, however, is that
if there are issues with upstream libraries like Java
or OpenSSL, it may be necessary to work around issues
as seen in:

http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/

cc: @manics @ximenesuk -- closing gh-3970 / gh-3971 for the moment.