### PR TITLE
enable more downgrade to private groups

### DIFF
--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -390,6 +390,11 @@
       <constructor-arg value="${omero.graphs.wrap}"/>
   </bean>
 
+  <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <property name="staticMethod" value="ome.services.graphs.GroupPredicate.setSecuritySystem"/>
+    <property name="arguments"><list><ref bean="securitySystem"/></list></property>
+  </bean>
+
   <bean class="ome.services.blitz.impl.commands.RequestObjectFactoryRegistry"
     lazy-init="false">
       <property name="iceCommunicator" ref="Ice.Communicator"/>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -357,6 +357,7 @@
 
   <bean id="graphRequestFactory" class="omero.cmd.graphs.GraphRequestFactory">
       <constructor-arg ref="aclVoter"/>
+      <constructor-arg ref="roles"/>
       <constructor-arg ref="systemTypes"/>
       <constructor-arg ref="graphPathBean"/>
       <constructor-arg ref="ome.services.delete.Deletion"/>
@@ -388,11 +389,6 @@
         </set>
       </constructor-arg>
       <constructor-arg value="${omero.graphs.wrap}"/>
-  </bean>
-
-  <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-    <property name="staticMethod" value="ome.services.graphs.GroupPredicate.setSecuritySystem"/>
-    <property name="arguments"><list><ref bean="securitySystem"/></list></property>
   </bean>
 
   <bean class="ome.services.blitz.impl.commands.RequestObjectFactoryRegistry"

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -167,7 +167,7 @@
 
         <!-- Cannot downgrade to a private group if jobs have differently owned original files. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E], L.child = OF:[E], J =/!o OF"
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E], L.child = OF:[E];group=!user, J =/!o OF"
                                        p:error="cannot downgrade to private as {J} has differently owned {OF}"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -50,6 +50,7 @@ import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
 import ome.system.EventContext;
 import ome.system.Login;
+import ome.system.Roles;
 import omero.cmd.Chgrp2;
 import omero.cmd.Chgrp2Response;
 import omero.cmd.HandleI.Cancel;
@@ -91,6 +92,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
     /**
      * Construct a new <q>chgrp</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
@@ -98,8 +100,9 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
      * @param graphPolicy the graph policy to apply for chgrp
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */
-    public Chgrp2I(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
-            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy, SetMultimap<String, String> unnullable) {
+    public Chgrp2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable) {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -55,6 +55,7 @@ import ome.services.graphs.GraphTraversal;
 import ome.services.graphs.GroupPredicate;
 import ome.system.EventContext;
 import ome.system.Login;
+import ome.system.Roles;
 import ome.util.Utils;
 import omero.cmd.Chmod2;
 import omero.cmd.Chmod2Response;
@@ -76,6 +77,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.CHMOD);
 
     private final ACLVoter aclVoter;
+    private final Roles securityRoles;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Deletion deletionInstance;
@@ -99,6 +101,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
     /**
      * Construct a new <q>chmod</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
@@ -106,9 +109,11 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
      * @param graphPolicy the graph policy to apply for chmod
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */
-    public Chmod2I(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
-            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy, SetMultimap<String, String> unnullable) {
+    public Chmod2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable) {
         this.aclVoter = aclVoter;
+        this.securityRoles = securityRoles;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.deletionInstance = deletionInstance;
@@ -161,7 +166,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
         }
         graphPolicyAdjusters = null;
 
-        graphPolicyWithOptions.registerPredicate(new GroupPredicate());
+        graphPolicyWithOptions.registerPredicate(new GroupPredicate(securityRoles));
 
         GraphTraversal.Processor processor = new InternalProcessor();
         if (dryRun) {

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -52,6 +52,7 @@ import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
+import ome.services.graphs.GroupPredicate;
 import ome.system.EventContext;
 import ome.system.Login;
 import ome.util.Utils;
@@ -159,6 +160,8 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);
         }
         graphPolicyAdjusters = null;
+
+        graphPolicyWithOptions.registerPredicate(new GroupPredicate());
 
         GraphTraversal.Processor processor = new InternalProcessor();
         if (dryRun) {

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -52,6 +52,7 @@ import ome.services.graphs.GraphTraversal;
 import ome.services.graphs.PermissionsPredicate;
 import ome.system.EventContext;
 import ome.system.Login;
+import ome.system.Roles;
 import omero.cmd.Chown2;
 import omero.cmd.Chown2Response;
 import omero.cmd.HandleI.Cancel;
@@ -95,6 +96,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
     /**
      * Construct a new <q>chown</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
@@ -102,8 +104,9 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
      * @param graphPolicy the graph policy to apply for chown
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */
-    public Chown2I(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
-            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy, SetMultimap<String, String> unnullable) {
+    public Chown2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable) {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -46,6 +46,7 @@ import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
 import ome.system.EventContext;
 import ome.system.Login;
+import ome.system.Roles;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
 import omero.cmd.HandleI.Cancel;
@@ -86,6 +87,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
     /**
      * Construct a new <q>delete</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
@@ -93,8 +95,9 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
      * @param graphPolicy the graph policy to apply for delete
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */
-    public Delete2I(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
-            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy, SetMultimap<String, String> unnullable) {
+    public Delete2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable) {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -40,6 +40,7 @@ import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphPolicyRule;
+import ome.system.Roles;
 import omero.cmd.GraphModify2;
 import omero.cmd.Request;
 import omero.cmd.SkipHead;
@@ -54,6 +55,7 @@ public class GraphRequestFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphRequestFactory.class);
 
     private final ACLVoter aclVoter;
+    private final Roles securityRoles;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Deletion deletionInstance;
@@ -66,6 +68,7 @@ public class GraphRequestFactory {
     /**
      * Construct a new graph request factory.
      * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean
      * @param deletionInstance a deletion instance for deleting files
@@ -76,10 +79,12 @@ public class GraphRequestFactory {
      * @param isGraphsWrap if {@link omero.cmd.GraphModify2} requests should substitute for the requests that they replace
      * @throws GraphException if the graph path rules could not be parsed
      */
-    public GraphRequestFactory(ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean, Deletion deletionInstance,
-            Map<Class<? extends Request>, List<String>> allTargets, Map<Class<? extends Request>, List<GraphPolicyRule>> allRules,
-            List<String> unnullable, Set<String> defaultExcludeNs, boolean isGraphsWrap) throws GraphException {
+    public GraphRequestFactory(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Map<Class<? extends Request>, List<String>> allTargets,
+            Map<Class<? extends Request>, List<GraphPolicyRule>> allRules, List<String> unnullable, Set<String> defaultExcludeNs,
+            boolean isGraphsWrap) throws GraphException {
         this.aclVoter = aclVoter;
+        this.securityRoles = securityRoles;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.deletionInstance = deletionInstance;
@@ -157,11 +162,11 @@ public class GraphRequestFactory {
                 } else {
                     graphPolicy = graphPolicy.getCleanInstance();
                 }
-                final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, SystemTypes.class,
+                final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, Roles.class, SystemTypes.class,
                         GraphPathBean.class, Deletion.class, Set.class, GraphPolicy.class, SetMultimap.class);
                 request =
-                        constructor.newInstance(aclVoter, systemTypes, graphPathBean, deletionInstance, targetClasses, graphPolicy,
-                                unnullable);
+                        constructor.newInstance(aclVoter, securityRoles, systemTypes, graphPathBean, deletionInstance,
+                                targetClasses, graphPolicy, unnullable);
             }
         } catch (Exception e) {
             /* TODO: easier to do a ReflectiveOperationException multi-catch in Java SE 7 */

--- a/components/server/src/ome/services/graphs/GroupPredicate.java
+++ b/components/server/src/ome/services/graphs/GroupPredicate.java
@@ -28,6 +28,11 @@ import org.hibernate.Session;
 
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * A predicate that allows {@code group=system} and similar to be used in graph policy rule matches.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.3
+ */
 public class GroupPredicate implements GraphPolicyRulePredicate {
 
     private static enum GroupMarker { SYSTEM, USER, GUEST };
@@ -39,6 +44,10 @@ public class GroupPredicate implements GraphPolicyRulePredicate {
 
     private static ImmutableMap<Long, GroupMarker> groupsById;
 
+    /**
+     * Set the security system with whose roles this predicate is to work.
+     * @param securitySystem the security system
+     */
     public static void setSecuritySystem(SecuritySystem securitySystem) {
         final Roles roles = securitySystem.getSecurityRoles();
         groupsById = ImmutableMap.of(

--- a/components/server/src/ome/services/graphs/GroupPredicate.java
+++ b/components/server/src/ome/services/graphs/GroupPredicate.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.graphs;
+
+import ome.model.IObject;
+import ome.security.SecuritySystem;
+import ome.services.graphs.GraphPolicy.Details;
+import ome.system.Roles;
+
+import org.hibernate.Session;
+
+import com.google.common.collect.ImmutableMap;
+
+public class GroupPredicate implements GraphPolicyRulePredicate {
+
+    private static enum GroupMarker { SYSTEM, USER, GUEST };
+
+    private static ImmutableMap<String, GroupMarker> groupsByName = ImmutableMap.of(
+            "system", GroupMarker.SYSTEM,
+            "user",   GroupMarker.USER,
+            "guest",  GroupMarker.GUEST);
+
+    private static ImmutableMap<Long, GroupMarker> groupsById;
+
+    public static void setSecuritySystem(SecuritySystem securitySystem) {
+        final Roles roles = securitySystem.getSecurityRoles();
+        groupsById = ImmutableMap.of(
+                roles.getSystemGroupId(), GroupMarker.SYSTEM,
+                roles.getUserGroupId(),   GroupMarker.USER,
+                roles.getGuestGroupId(),  GroupMarker.GUEST);
+    }
+
+    @Override
+    public String getName() {
+        return "group";
+    }
+
+    @Override
+    public void noteDetails(Session session, IObject object, String realClass, long id) {
+        /* nothing to do */
+    }
+
+    @Override
+    public boolean isMatch(Details object, String parameter) throws GraphException {
+        if (object.groupId == null) {
+            throw new GraphException("no group for " + object);
+        }
+        final boolean isInvert;
+        if (parameter.startsWith("!")) {
+            parameter = parameter.substring(1);
+            isInvert = true;
+        } else {
+            isInvert = false;
+        }
+        final GroupMarker sought = groupsByName.get(parameter);
+        if (sought == null) {
+            throw new GraphException("unknown group: " + parameter);
+        }
+        final GroupMarker actual = groupsById.get(object.groupId);
+        return isInvert != (sought == actual);
+    }
+}

--- a/components/server/src/ome/services/graphs/GroupPredicate.java
+++ b/components/server/src/ome/services/graphs/GroupPredicate.java
@@ -20,7 +20,6 @@
 package ome.services.graphs;
 
 import ome.model.IObject;
-import ome.security.SecuritySystem;
 import ome.services.graphs.GraphPolicy.Details;
 import ome.system.Roles;
 
@@ -42,18 +41,17 @@ public class GroupPredicate implements GraphPolicyRulePredicate {
             "user",   GroupMarker.USER,
             "guest",  GroupMarker.GUEST);
 
-    private static ImmutableMap<Long, GroupMarker> groupsById;
+    private final ImmutableMap<Long, GroupMarker> groupsById;
 
     /**
-     * Set the security system with whose roles this predicate is to work.
-     * @param securitySystem the security system
+     * Construct a new group predicate.
+     * @param securityRoles the security roles
      */
-    public static void setSecuritySystem(SecuritySystem securitySystem) {
-        final Roles roles = securitySystem.getSecurityRoles();
+    public GroupPredicate(Roles securityRoles) {
         groupsById = ImmutableMap.of(
-                roles.getSystemGroupId(), GroupMarker.SYSTEM,
-                roles.getUserGroupId(),   GroupMarker.USER,
-                roles.getGuestGroupId(),  GroupMarker.GUEST);
+                securityRoles.getSystemGroupId(), GroupMarker.SYSTEM,
+                securityRoles.getUserGroupId(),   GroupMarker.USER,
+                securityRoles.getGuestGroupId(),  GroupMarker.GUEST);
     }
 
     @Override

--- a/components/server/src/ome/services/graphs/PermissionsPredicate.java
+++ b/components/server/src/ome/services/graphs/PermissionsPredicate.java
@@ -22,7 +22,6 @@ package ome.services.graphs;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.Query;
 import org.hibernate.Session;
 
 import ome.model.IObject;


### PR DESCRIPTION
Allow downgrade to private groups even when a root-owned script has been run by a user in the group. To test: import `test_images_good/bd-pathway/2009-05-01_000/` into a read-only group, then downgrade the group to private.