### PR TITLE
do not chown images' annotations and ROIs in read-annotate groups

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -269,6 +269,11 @@
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{!a}, X =/!o A"
                                        p:changes="A:{a}"/>
 
+        <!-- Do not give annotations in a read-annotate group. -->
+
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{r};perms=???a??" p:changes="A:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{r};perms=???w??" p:changes="A:{a}"/>
+
         <!-- Delete or give orphaned annotations that are owned by the deleted or given object's owner. -->
 
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}, X =/o A"
@@ -561,9 +566,10 @@
 
         <!-- ROI -->
 
-        <!-- Give the ROIs, shapes and mask images of the owner of a given image. -->
+        <!-- Give the ROIs, shapes and mask images of the owner of a given image if not in a read-annotate group. -->
 
-        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E];perms=???-??" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E];perms=???r??" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]" p:changes="I:[I]"/>

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -371,13 +371,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(image, recipient);
-        for (final IObject annotation : ownerAnnotations) {
-            if (annotation instanceof Thumbnail) {
-                assertOwnedBy(annotation, importer);
-            } else {
-                assertOwnedBy(annotation, recipient);
-            }
-        }
+        assertOwnedBy(ownerAnnotations, importer);
         assertOwnedBy(otherAnnotations, annotator);
         disconnect();
     }


### PR DESCRIPTION
Arises from experimentation by @ximenesuk and discussion with @pwalczysko. If chowning an image, in read-annotate and read-write groups the annotations and ROIs should not be chowned. Integration tests should continue to pass.