### PR TITLE
Empty node fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -573,6 +573,7 @@ class BrowserComponent
     {
         if (model.getState() != LOADING_LEAVES) return;
         if (leaves == null || leaves.isEmpty())  {
+            view.setLeavesViews(Collections.EMPTY_SET, parent);
             model.setState(READY);
             fireStateChange();
             return;


### PR DESCRIPTION
Fixes the issue that an empty dataset/project (and orphaned images folder) continuously showed a child node named "Loading..." instead of "Empty" noticed by @mtbc  and @pwalczysko  (the problem arose as a combination of the decoupling PR with #3968 ).
