### PR TITLE
Small fix

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
@@ -1,0 +1,85 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+<VirtualHost _default_:1234>
+
+  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
+
+  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  
+  WSGIProcessGroup omeroweb
+
+  WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+
+  <Directory /home/omero/OMERO.server/lib/python/omeroweb>
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /test-static /home/omero/OMERO.server/lib/python/omeroweb/static
+  <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
+      Options -Indexes FollowSymLinks
+      Order allow,deny
+      Allow from all
+  </Directory>
+
+</VirtualHost>
+
+# see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
+WSGISocketPrefix run/wsgi
+# WSGISocketPrefix /var/run/wsgi
+
+
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
@@ -1,0 +1,85 @@
+###
+# apache config for omero
+# this file should be loaded *after* ssl.conf
+#
+# -D options to control configurations
+#  OmeroForceSSL - redirect all http requests to https
+
+###
+### Example SSL stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+# Eliminate overlap warnings with the default ssl vhost
+# Requires SNI (http://wiki.apache.org/httpd/NameBasedSSLVHostsWithSNI)
+# support most later versions of mod_ssl and OSes will support it if you see
+# "You should not use name-based virtual hosts in conjunction with SSL!!"
+# or similar start apache with -D DISABLE_SNI and modify ssl.conf
+#<IfDefine !DISABLE_SNI>
+#  NameVirtualHost *:443
+#</IfDefine>
+#
+## force https/ssl
+#<IfDefine OmeroForceSSL>
+#  RewriteEngine on
+#  RewriteCond %{HTTPS} !on
+#  RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [L]
+#</IfDefine>
+#
+#<VirtualHost _default_:443>
+#
+#  ErrorLog logs/ssl_error_log
+#  TransferLog logs/ssl_access_log
+#  LogLevel warn
+#
+#  SSLEngine on
+#  SSLProtocol all -SSLv2
+#  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#  SSLCertificateFile /etc/pki/tls/certs/server.crt
+#  SSLCertificateKeyFile /etc/pki/tls/private/server.key
+#
+#  # SSL Protocol Adjustments:
+#  SetEnvIf User-Agent ".*MSIE.*" \
+#    nokeepalive ssl-unclean-shutdown \
+#    downgrade-1.0 force-response-1.0
+#
+#  # Per-Server Logging:
+#  CustomLog logs/ssl_request_log \
+#    "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>
+
+###
+### Stanza for OMERO.web created 0000-00-00 00:00:00.000000
+###
+
+<VirtualHost _default_:80>
+
+  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
+
+  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  
+  WSGIProcessGroup omeroweb
+
+  WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+
+  <Directory /home/omero/OMERO.server/lib/python/omeroweb>
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /static /home/omero/OMERO.server/lib/python/omeroweb/static
+  <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
+      Options -Indexes FollowSymLinks
+      Order allow,deny
+      Allow from all
+  </Directory>
+
+</VirtualHost>
+
+# see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
+WSGISocketPrefix run/wsgi
+# WSGISocketPrefix /var/run/wsgi
+
+
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
@@ -1,0 +1,40 @@
+upstream omeroweb_server {
+    server 0.0.0.0:12345 fail_timeout=0;
+}
+
+server {
+    listen 1234;
+    server_name $hostname;
+
+    sendfile on;
+    client_max_body_size 2m;
+
+    # maintenance page serve from here
+    location @maintenance {
+        root /home/omero/OMERO.server/etc/templates/error;
+        try_files $uri /maintainance.html =502;
+    }
+
+    # weblitz django apps serve media from here
+    location /test-static {
+        alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+    }
+
+    location @proxy_to_app {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+
+        proxy_pass http://omeroweb_server;
+    }
+
+    location /test {
+
+        error_page 502 @maintenance;
+        # checks for static file, if not found proxy to app
+        try_files $uri @proxy_to_app;
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi.conf
@@ -1,0 +1,40 @@
+upstream omeroweb_server {
+    server 127.0.0.1:4080 fail_timeout=0;
+}
+
+server {
+    listen 80;
+    server_name $hostname;
+
+    sendfile on;
+    client_max_body_size 0;
+
+    # maintenance page serve from here
+    location @maintenance {
+        root /home/omero/OMERO.server/etc/templates/error;
+        try_files $uri /maintainance.html =502;
+    }
+
+    # weblitz django apps serve media from here
+    location /static {
+        alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+    }
+
+    location @proxy_to_app {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+
+        proxy_pass http://omeroweb_server;
+    }
+
+    location / {
+
+        error_page 502 @maintenance;
+        # checks for static file, if not found proxy to app
+        try_files $uri @proxy_to_app;
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -96,6 +96,8 @@ class TestWeb(object):
         s = re.sub('\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}',
                    '0000-00-00 00:00:00.000000', s)
         s = s.replace(serverdir, '/home/omero/OMERO.server')
+        s = s.replace(os.path.dirname(Ice.__file__), '/home/omero/ice/python')
+        s = s.replace('user=%s' % getpass.getuser(), 'user=omero')
         return s
 
     def compare_with_reference(self, refname, generated):
@@ -325,7 +327,8 @@ class TestWeb(object):
         assert not missing, 'Line not found: ' + str(missing)
 
     @pytest.mark.parametrize('server_type', [
-        "nginx", "nginx-development", "apache", "apache-fcgi"])
+        "nginx", "nginx-wsgi", "nginx-development",
+        "apache", "apache-fcgi", "apache-wsgi"])
     def testFullTemplateDefaults(self, server_type, capsys, monkeypatch):
         self.args += ["config", server_type]
         self.set_templates_dir(monkeypatch)
@@ -340,7 +343,9 @@ class TestWeb(object):
     @pytest.mark.parametrize('server_type', [
         ['nginx', '--http', '1234', '--max-body-size', '2m'],
         ['nginx-development', '--http', '1234', '--max-body-size', '2m'],
+        ['nginx-wsgi', '--http', '1234', '--max-body-size', '2m'],
         ['apache'],
+        ['apache-wsgi', '--http', '1234'],
         ['apache-fcgi']])
     def testFullTemplateWithOptions(self, server_type, capsys, monkeypatch):
         prefix = '/test'

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -24,6 +24,7 @@ from difflib import unified_diff
 import re
 import os
 from path import path
+import getpass
 import Ice
 import omero.cli
 from omero.plugins.web import WebControl

--- a/etc/templates/apache-wsgi.conf.template
+++ b/etc/templates/apache-wsgi.conf.template
@@ -68,7 +68,7 @@
   </Directory>
 
   Alias %(STATIC_URL)s %(OMEROWEBROOT)s/static
-  <Directory "%(OMEROWEBROOT)s//static">
+  <Directory "%(OMEROWEBROOT)s/static">
       Options -Indexes FollowSymLinks
       Order allow,deny
       Allow from all


### PR DESCRIPTION
Discovered in https://github.com/openmicroscopy/ome-documentation/pull/1244

to test:
```
bin/omero config set omero.web.application_server "wsgi"
bin/omero web config apache-wsgi
```
and check if 
```
<Directory "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static">
```

contains just 1 ``/`` in the end