### PR TITLE
Version history for 5.1.3

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -9,14 +9,14 @@ A bug-fix release. Improvements include:
 -  better reporting for the 'delete' and 'chgrp' functionality in the CLI
 -  tagging fixes, including for tagging ome-tiff images at import
 -  fixed display of images in plates with multiple acquisitions
--  Support for WSGI OMERO.web deployment
--  Group admins and owners can now change ownership of data via the CLI
+-  support for WSGI OMERO.web deployment
+-  group admins and owners can now change ownership of data via the CLI
 -  fixed OMERO.mail service for web errors
 
 Developer updates include:
 
 -  OMERO.web clean-up (removal of '-locked')
--  refactoring of 'Chown2' and 'Chmod2'
+-  refactoring of 'Chown2', 'Chmod2', 'Chgrp2' and 'Delete2'
 -  Bio-Formats submodule removed from OMERO; decoupling effort means OMERO now
    consumes the Bio-Formats release build from the artifactory
 

--- a/history.txt
+++ b/history.txt
@@ -11,7 +11,7 @@ include:
 -  tagging ome-tiff images at import has also been fixed
 -  greatly improved workflow and bug fixes for the Share functionality in
    OMERO.web which enables you to share images with users outside of your
-   group
+   group (including removal of part of the UI)
 -  group admins and owners can now change ownership of data via the CLI
 -  better reporting for the 'delete' and 'chgrp' functionality in the CLI
 -  fixed display of images in plates with multiple acquisitions
@@ -25,7 +25,12 @@ include:
 Developer updates include:
 
 -  OMERO.web clean-up (removal of '-locked')
+-  reorganization of the server bundle to move various licenses and 
+   dependencies under a new 'share' folder
 -  refactoring of 'Chown2', 'Chmod2', 'Chgrp2' and 'Delete2'
+-  addition of dynamic scripts
+-  the 'rstring' implementation is now more lenient and should better handle
+   unicode
 -  Bio-Formats submodule removed from OMERO; decoupling effort means OMERO now
    consumes the Bio-Formats release build from the artifactory
 

--- a/history.txt
+++ b/history.txt
@@ -4,14 +4,23 @@ OMERO version history
 5.1.3 (July 2015)
 -----------------
 
-A bug-fix release. Improvements include:
+A bug-fix release which also introduces some new functionality. Improvements
+include:
 
--  better reporting for the 'delete' and 'chgrp' functionality in the CLI
--  tagging fixes, including for tagging ome-tiff images at import
--  fixed display of images in plates with multiple acquisitions
--  support for WSGI OMERO.web deployment
+-  tagging actions extended; you can now use tag sets to tag images on import
+-  tagging ome-tiff images at import has also been fixed
+-  greatly improved workflow and bug fixes for the Share functionality in
+   OMERO.web which enables you to share images with users outside of your
+   group
 -  group admins and owners can now change ownership of data via the CLI
+-  better reporting for the 'delete' and 'chgrp' functionality in the CLI
+-  fixed display of images in plates with multiple acquisitions
+-  fixed export of results as .xls files from OMERO.insight
+-  improved workflow for ImageJ and OMERO interactions
+-  support for WSGI OMERO.web deployment
 -  fixed OMERO.mail service for web errors
+-  fixes for ROI display in OMERO.web (thanks to Luca Lianas of CRS4)
+-  fixes and workflow improvements for running scripts and script dialogs
 
 Developer updates include:
 

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,31 @@
 OMERO version history
 =====================
 
+5.1.3 (July 2015)
+-----------------
+
+A bug-fix release. Improvements include:
+
+-  better reporting for the 'delete' and 'chgrp' functionality in the CLI
+-  tagging fixes, including for tagging ome-tiff images at import
+-  fixed display of images in plates with multiple acquisitions
+-  Support for WSGI OMERO.web deployment
+-  Group admins and owners can now change ownership of data via the CLI
+-  fixed OMERO.mail service for web errors
+
+Developer updates include:
+
+-  OMERO.web clean-up (removal of '-locked')
+-  refactoring of 'Chown2' and 'Chmod2'
+-  Bio-Formats submodule removed from OMERO; decoupling effort means OMERO now
+   consumes the Bio-Formats release build from the artifactory
+
+This release also includes the fix for the Java security issue, as discussed
+in the
+`recent blog post <http://blog.openmicroscopy.org/tech-issues/2015/07/21/java-issue/>`_. Testing
+suggests this fix should not have any performance implications. You should
+upgrade your Java version to take advantage of the security fix.
+
 5.1.2 (May 2015)
 ----------------
 


### PR DESCRIPTION
Will be staged at https://www.openmicroscopy.org/site/support/omero5.1-staging/users/history.html tomorrow.

Final decisions still needed on whether to include ROI preview fixes, gateway...