### PR TITLE
Downgrade to private warnings updated. See #12974

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -82,8 +82,11 @@
                 hideSystemUserX();
                 
                 $('#id_permissions_0').click(function(){
-                    OME.confirm_dialog("Changing group to Private may fail if links have been created under Read-Annotate permissions",
-                        null, "WARNING", ['OK'], null, 180);
+                    OME.confirm_dialog("Changing group to Private unlinks data from other users'" +
+                                    " containers and unlinks other users' annotations from data." +
+                                    " The change to Private will abort if different users' data" +
+                                    " is too closely related to be separated.",
+                        null, "WARNING", ['OK'], null, 200);
                 });
                 $('#id_permissions_3').click(function(){
                     OME.confirm_dialog("Read-Write groups allow members to delete other members' data. " +

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -66,8 +66,11 @@
                 highlightCurrent();
                 
                 $('#id_permissions_0').click(function(){
-                    OME.confirm_dialog("Changing group to Private may fail if links have been created under Read-Annotate permissions",
-                        null, "WARNING", ['OK'], null, 180);
+                    OME.confirm_dialog("Changing group to Private unlinks data from other users'" +
+                                    " containers and unlinks other users' annotations from data." +
+                                    " The change to Private will abort if different users' data" +
+                                    " is too closely related to be separated.",
+                        null, "WARNING", ['OK'], null, 200);
                 });
 
                 // Disable the "Read-Write" permissions option for group owners (if it's not checked)


### PR DESCRIPTION
This is the web equivalent of https://github.com/openmicroscopy/openmicroscopy/pull/3989/ in Insight.

To test, try downgrading a non-Private group to Private:
 - As owner of the group
 - As Admin.

Should see same error as Insight (screenshot below).

![screen shot 2015-07-24 at 11 09 36](https://cloud.githubusercontent.com/assets/900055/8872408/a15f700e-31f4-11e5-8adc-ebaff3febb1c.png)
