### PR TITLE
CLI usage warnings

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -19,6 +19,17 @@ import sys
 HELP = """Transfer ownership of data between users. Entire graphs of data,
 based on the ID of the top-node, are transferred.
 
+This command can only be used by OMERO administrators and group owners.
+
+Group owners can only transfer ownership between members of the owned group.
+Administrators can transfer ownership between any users regardless of their
+respective groups.
+
+Note that after transferring ownership the data will remain in their original
+group. Thus it is possible for an administrator to make the data unavailable
+to the new user. In such cases the data must be moved to one of the user's
+groups or the user must be added to the group that the data is in.
+
 Examples:
 
     # In each case transfer the ownership of an image to user 101

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -16,7 +16,8 @@ HELP = """Group administration methods"""
 defaultperms = {
     'private': 'rw----',
     'read-only': 'rwr---',
-    'read-annotate': 'rwra--'}
+    'read-annotate': 'rwra--',
+    'read-write': 'rwrw--'}
 
 
 class GroupControl(UserGroupControl):
@@ -32,11 +33,13 @@ Group permissions come in several styles:
     * private       (rw----)   [DEFAULT]
     * read-only     (rwr---)
     * read-annotate (rwra--)   [Previously known as 'collaborative']
+    * read-write    (rwrw--)
 
 In private groups, only group and system administrators will be able
 to view someone else's data. In read-only groups, other group members
 can see data but not annotate or modify it. In read-annotate groups,
-annotation is permitted by group members.
+annotation is permitted by group members. In read-write groups, all
+group members can behave as if they co-own all the data.
 
 Changing a group to private unlinks data from other users' containers and
 unlinks other users' annotations from data. The change to private will

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -35,8 +35,8 @@ Group permissions come in several styles:
     * read-annotate (rwra--)   [Previously known as 'collaborative']
     * read-write    (rwrw--)
 
-In private groups, only group and system administrators will be able
-to view someone else's data. In read-only groups, other group members
+In private groups, only group owners and system administrators will be
+able to view someone else's data. In read-only groups, other group members
 can see data but not annotate or modify it. In read-annotate groups,
 annotation is permitted by group members. In read-write groups, all
 group members can behave as if they co-own all the data.

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -38,6 +38,10 @@ to view someone else's data. In read-only groups, other group members
 can see data but not annotate or modify it. In read-annotate groups,
 annotation is permitted by group members.
 
+Changing a group to private unlinks data from other users' containers and
+unlinks other users' annotations from data. The change to private will
+fail if different users' data is too closely related to be separated.
+
 More information is available at:
 http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/\
 server-permissions.html


### PR DESCRIPTION
This PR adds a couple of warnings and clarifications to CLI usage `chown` and `group perms`.

/cc @pwalczysko @mtbc @joshmoore 