### PR TITLE
Handle cmd error on downgrade 12973

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -3,7 +3,7 @@
 #
 # webclient_gateway
 #
-# Copyright (c) 2008-2014 University of Dundee.
+# Copyright (c) 2008-2015 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -1379,13 +1379,17 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             if not flag:
                 add_exps.append(nex._obj)
 
+        msgs = []
         admin_serv = self.getAdminService()
         # Should we update updateGroup so this would be atomic?
         admin_serv.updateGroup(up_gr)
         if permissions is not None:
-            self.updatePermissions(group, permissions)
+            err = self.updatePermissions(group, permissions)
+            if err is not None:
+                msgs.append(err)
         admin_serv.addGroupOwners(up_gr, add_exps)
         admin_serv.removeGroupOwners(up_gr, rm_exps)
+        return msgs
 
     def updateMyAccount(self, experimenter, firstName, lastName, email,
                         defaultGroupId, middleName=None, institution=None):
@@ -1456,8 +1460,16 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         command = Chmod(type="/ExperimenterGroup",
                         id=group.id,
                         permissions=perms)
-        cb = self.c.submit(command, loops=120)
-        cb.close(True)
+        cb = None
+        message = None
+        try:
+            cb = self.c.submit(command, loops=120)
+        except omero.CmdError, ex:
+            message = ex.err.message
+        finally:
+            if cb:
+                cb.close(True)
+        return message
 
     def saveObject(self, obj):
         """


### PR DESCRIPTION
This handles CmdError when attempting to chmod the group permissions.
See https://trac.openmicroscopy.org/ome/ticket/12973

Can reproduce this by an Owner performing a projection (or Channel_Offsets) of another users' image in Read-Annotate group, then trying to change the group to Private.
Test that you see the error:
 - When Admin changes group permissions
 - When Group owner changes permissions

![screen shot 2015-07-24 at 14 07 52](https://cloud.githubusercontent.com/assets/900055/8874935/71dc174c-320d-11e5-9d2f-23deeaa5111c.png)
