### PR TITLE
Quick fix to Python client ctor test

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_client_ctors.py
+++ b/components/tools/OmeroPy/test/integration/test_client_ctors.py
@@ -57,6 +57,7 @@ class TestClientConstructors(lib.ITest):
         id = Ice.InitializationData()
         id.properties = Ice.createProperties()
         id.properties.setProperty("omero.host", self.host)
+        id.properties.setProperty("omero.port", str(self.port))
         id.properties.setProperty("omero.user", "root")
         id.properties.setProperty("omero.pass", self.rootpasswd)
         c = omero.client(id=id)


### PR DESCRIPTION
This fixes a broken test by setting the port.