### PR TITLE
Updating ldap warning in config

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -724,10 +724,12 @@ omero.ldap.referral=ignore
 # not just the username, email, etc, but also the
 # groups that the user is a member of.
 #
-# .. warning::
-#    Currently setting this to true the user will be
-#    removed from any groups to which they have been
-#    added outside of LDAP! Please use carefully.
+# .. note::
+#    Admin actions carried out in the clients may
+#    not survive this synchronization e.g. LDAP
+#    users removed from an LDAP group in the UI
+#    will be re-added to the group when logging in
+#    again after the synchronization.
 #
 omero.ldap.sync_on_login=false
 


### PR DESCRIPTION
When I removed this warning from the docs, I missed that it was in the config file still too.