### PR TITLE
MIF and overlay

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -22,7 +22,6 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
-import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
@@ -631,7 +630,6 @@ class ImporterModel
                     o = j.next();
                     if (o.isImagePlus()) {
                         index = o.getIndex();
-                        IJ.log("index: "+index);
                         rois = reader.readImageJROI(-1, (ImagePlus) o.getFile());
                         indexes.put(index, rois);
                         if (index < 0) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -22,6 +22,7 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
+import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
@@ -621,15 +622,21 @@ class ImporterModel
             Map<Integer, List<ROIData>> indexes =
                 new HashMap<Integer, List<ROIData>>();
             int index;
+            boolean mif = false;
             if (CollectionUtils.isNotEmpty(files)) {
+                mif = true;
                 Iterator<FileObject> j = files.iterator();
                 FileObject o;
                 while (j.hasNext()) {
                     o = j.next();
                     if (o.isImagePlus()) {
                         index = o.getIndex();
+                        IJ.log("index: "+index);
                         rois = reader.readImageJROI(-1, (ImagePlus) o.getFile());
                         indexes.put(index, rois);
+                        if (index < 0) {
+                            mif = false;
+                        }
                     }
                 }
             }
@@ -644,11 +651,14 @@ class ImporterModel
                 id = data.getId();
                 index = data.getSeries();
                 //First check overlay
+                rois = null;
                 if (indexes.containsKey(index)) {
                    rois = indexes.get(index);
                    linkRoisToImage(id, rois);
                 } else {
-                   rois = reader.readImageJROI(id, img);
+                   if (!mif) {
+                       rois = reader.readImageJROI(id, img);
+                   }
                 }
                 //check roi manager
                 if (CollectionUtils.isEmpty(rois)) {


### PR DESCRIPTION
Problem reported by @pwalczysko: see https://trello.com/c/oeLB1cl3/28-mif-roi-proliferation
To test this PR:

test 1:
 * Open a mif in imageJ from local file system
 * Select only one series
 * Draw a roi and add it as overlay. Do not use the roi manager.
 * Save the image to OMERO
 * Check that only the series opened has the overlay.

test 2:
 * Repeat the same steps but this time open few series.

test 3:
 * Repeat the same step but this time open a non mif image e.g. dv