### PR TITLE
replacing javadeploy webstart button with direct link

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/includes/webstart_insight_script.html
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/includes/webstart_insight_script.html
@@ -21,12 +21,7 @@
 {% endcomment %}
 
 {% if insight_url %}
-<script src="//www.java.com/js/deployJava.js"></script>
-<script>
-    deployJava.launchButtonPNG='{% static "webstart/img/icon-omero-insight.png" %}';
-    var url = "{{ insight_url }}";
-    deployJava.createWebStartLaunchButton(url, '1.6.0');
-</script>
+    <a href="{{ insight_url }}"><img src="{% static "webstart/img/icon-omero-insight.png" %}"/></a>
 {% else %}
     <h1 class="error">Webstart is not available</h1>
 {% endif %}


### PR DESCRIPTION
Regarding what @rleigh-dundee requested:
> If I enter the URL directly, chrome downloads it without prompting, but if I then click on the download link it fires up webstart.  Not sure why it doesn't do that automatically, but certainly exposing it would help rather than hinder the user even if it's not 100% automated.

test all web browsers if webstart starts up nicely 
