### PR TITLE
Sphinx documentation decoupling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "docs/sphinx"]
-	path = docs/sphinx
-	url = git://github.com/openmicroscopy/ome-documentation.git
-	ignore = dirty
 [submodule "components/tools/OmeroPy/scripts"]
 	path = components/tools/OmeroPy/scripts
 	url = git://github.com/ome/scripts.git

--- a/build.xml
+++ b/build.xml
@@ -110,7 +110,6 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         <delete includeemptydirs="true" quiet="true">
             <fileset dir="${omero.home}/examples" includes="config.log,**/*.o,**/*.class,**/*.exe"/>
         </delete>
-        <ant antfile="build.xml" dir="docs/sphinx" target="clean" inheritAll="false"/>
         <ant antfile="build.xml" dir="docs/sphinx-api" target="clean" inheritAll="false"/>
     </target>
 
@@ -533,19 +532,6 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
     <target name="release-docs" depends="release-javadoc,release-sphinx-api,release-slice2html" description="Generate Docs for all components under dist/docs/api">
         <zip destfile="${omero.home}/target/OMERO.docs-${omero.version}.zip">
             <zipfileset dir="${dist.dir}/docs" prefix="OMERO.docs-${omero.version}"/>
-        </zip>
-
-        <ant antfile="build.xml" dir="docs/sphinx" target="clean" inheritAll="false"/>
-        <ant antfile="build.xml" dir="docs/sphinx" target="html" inheritAll="false">
-            <property name="omero.shortversion" value="${omero.shortversion}"/>
-        </ant>
-        <ant antfile="build.xml" dir="docs/sphinx" target="latexpdf" inheritAll="false">
-            <property name="omero.shortversion" value="${omero.shortversion}"/>
-        </ant>
-
-        <copy file="${sphinx.dir}/_build/latex/OMERO-${omero.shortversion}.pdf" tofile="${omero.home}/target/OMERO-${omero.shortversion}.pdf" overwrite="true"/>
-        <zip destfile="${omero.home}/target/OMERO.sphinx-${omero.version}.zip">
-            <zipfileset dir="${sphinx.dir}/_build/html/" prefix="OMERO.sphinx-${omero.version}"/>
         </zip>
     </target>
 

--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -55,7 +55,6 @@
         <property name="lib.dir"       value="${root.dir}/lib" />
         <property name="tools.dir"     value="${root.dir}/lib/tools" />
         <property name="dist.dir"      value="${root.dir}/dist" />
-        <property name="sphinx.dir"    value="${root.dir}/docs/sphinx/omero" />
 
         <!-- Components -->
         <property name="dsl.comp"       value="${components.dir}/dsl"/>

--- a/docs/sphinx-api/build.xml
+++ b/docs/sphinx-api/build.xml
@@ -8,8 +8,7 @@ Type "ant -p" for a list of targets.
 
 <project name="sphinx-api" default="html" basedir=".">
   <description>Build file for sphinx documentation</description>
-  <property name="root.dir" location=".."/>
-  <import file="${root.dir}/sphinx/common/rules.xml"/>
+  <import file="${basedir}//rules.xml"/>
 
   <target name="sphinx-deps">
     <apidoc source="../../dist/lib/python/omero" output="omero"/>

--- a/docs/sphinx-api/conf.py
+++ b/docs/sphinx-api/conf.py
@@ -35,6 +35,7 @@ autodoc_default_flags = ['members', 'undoc-members', 'private-members']
 project = u'OMERO.py API'
 targetname = 'OmeroPyAPI'
 title = project + u' Documentation'
+master_doc = 'index'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/sphinx-api/conf.py
+++ b/docs/sphinx-api/conf.py
@@ -21,8 +21,8 @@ import os.path
 sys.path.insert(0, os.path.abspath(os.path.join('..','..','dist','lib','python')))
 sys.path.insert(0, os.path.abspath(os.path.join('..','..','dist','lib','python','omeroweb')))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'omeroweb.settings'
-sys.path.insert(0, os.path.join('..', 'sphinx', 'common'))
-from conf import *
+
+author = u'The Open Microscopy Environment'
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/sphinx-api/rules.xml
+++ b/docs/sphinx-api/rules.xml
@@ -1,0 +1,98 @@
+<!--
+build.xml
+
+Ant build file for common sphinx targets.
+Download Apache Ant from http://ant.apache.org/.
+Type "ant -p" for a list of targets.
+-->
+
+<project name="rules" basedir=".">
+  <description>Common sphinx targets</description>
+  <dirname property="imported.basedir" file="${ant.file.rules}"/>
+  <import file="${imported.basedir}/sphinx.xml"/>
+
+  <!-- Ant-Contrib Tasks: http://ant-contrib.sourceforge.net/ -->
+  <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+    classpath="${imported.basedir}/ant-contrib-1.0b3.jar"/>
+  <!-- HACK - some environments do not install the antcontrib tasks properly
+    from antcontrib.properties above; also load them from antlib.xml -->
+  <taskdef resource="net/sf/antcontrib/antlib.xml"
+    classpath="${imported.basedir}/ant-contrib-1.0b3.jar"/>
+
+  <property name="omero.shortversion" value=""/>
+  <if>
+    <equals arg1="omero.shortversion" arg2=""/>
+    <then>
+      <property name="source.branch" value="v.${omero.shortversion}"/>
+    </then>
+  </if>
+  <property name="source.branch" value=""/>
+  <property name="source.user" value="openmicroscopy"/>
+  <property name="omero.release" value="${omero.shortversion}"/>
+  <property name="formats.release" value="${omero.shortversion}"/>
+  <property name="jenkins.job" value=""/>
+
+  <target name="sphinx-deps"/>
+  <target name="clean-deps"/>
+
+  <target name="html" depends="sphinx-deps">
+    <exec executable="${sphinx.build}" failonerror="true">
+        <env key="SOURCE_BRANCH" value="${source.branch}"/>
+        <env key="SOURCE_USER" value="${source.user}"/>
+        <env key="OMERO_RELEASE" value="${omero.release}"/>
+        <env key="FORMATS_RELEASE" value="${formats.release}"/>
+        <env key="JENKINS_JOB" value="${jenkins.job}"/>
+        <arg value="-b"/>
+        <arg value="html"/>
+        <arg line="${sphinx.opts}"/>
+        <arg value="."/>
+        <arg value="${sphinx.builddir}/html"/>
+      </exec>
+  </target>
+
+  <target name="latexpdf" depends="sphinx-deps">
+    <exec executable="${sphinx.build}" failonerror="true">
+        <env key="SOURCE_BRANCH" value="${source.branch}"/>
+        <env key="SOURCE_USER" value="${source.user}"/>
+        <env key="OMERO_RELEASE" value="${omero.release}"/>
+        <env key="FORMATS_RELEASE" value="${formats.release}"/>
+        <env key="JENKINS_JOB" value="${jenkins.job}"/>
+        <arg value="-b"/>
+        <arg value="latex"/>
+        <arg line="${sphinx.opts}"/>
+        <arg value="."/>
+        <arg value="${sphinx.builddir}/latex"/>
+    </exec>
+
+    <for param="file">
+      <path>
+       <fileset dir="${sphinx.builddir}/latex" includes="*.tex"/>
+      </path>
+      <sequential>
+        <runlatex file="@{file}"/>
+      </sequential>
+    </for>
+  </target>
+
+  <target name="pdf" depends="latexpdf"/>
+
+  <target name="linkcheck" depends="sphinx-deps">
+    <exec executable="${sphinx.build}" failonerror="true">
+        <env key="SOURCE_BRANCH" value="${source.branch}"/>
+        <env key="SOURCE_USER" value="${source.user}"/>
+        <env key="OMERO_RELEASE" value="${omero.release}"/>
+        <env key="FORMATS_RELEASE" value="${formats.release}"/>
+        <env key="JENKINS_JOB" value="${jenkins.job}"/>
+        <arg value="-b"/>
+        <arg value="linkcheck"/>
+        <arg line="${sphinx.opts}"/>
+        <arg value="."/>
+        <arg value="${sphinx.builddir}/linkcheck"/>
+      </exec>
+  </target>
+
+  <target name="clean" depends="clean-deps">
+    <delete dir="${sphinx.builddir}"/>
+  </target>
+
+</project>

--- a/docs/sphinx-api/sphinx.xml
+++ b/docs/sphinx-api/sphinx.xml
@@ -1,0 +1,71 @@
+<!--
+build.xml
+
+Ant build file for Bio-Formats Sphinx documentation.
+Download Apache Ant from http://ant.apache.org/.
+Type "ant -p" for a list of targets.
+-->
+
+<project>
+  <description>Sphinx macros</description>
+
+  <property name="sphinx.build" value="sphinx-build"/>
+  <property name="sphinx.opts" value=""/>
+  <property name="sphinx.builddir" location="_build"/>
+  <property name="latex.opts" value=""/>
+
+  <macrodef name="xelatex" description="Run XeLaTeX">
+    <attribute name="file" default=""/>
+    <sequential>
+      <basename property="file.basename" file="@{file}"/>
+      <dirname property="file.dirname" file="@{file}"/>
+      <exec executable="xelatex" failonerror="true" dir="${file.dirname}">
+        <arg line="${latex.opts}"/>
+        <arg value="${file.basename}"/>
+      </exec>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="makeindex" description="Run makeindex">
+    <attribute name="file" default=""/>
+    <sequential>
+      <basename property="file.basename" file="@{file}"/>
+      <dirname property="file.dirname" file="@{file}"/>
+      <propertyregex property="file.index" input="${file.basename}" regexp="(.*)\.tex" select="\1.idx"/>
+      <exec executable="makeindex" failonerror="true" dir="${file.dirname}">
+        <arg value="-s"/>
+        <arg value="python.ist"/>
+        <arg value="${file.index}"/>
+      </exec>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="runlatex">
+    <attribute name="file" default=""/>
+    <sequential>
+      <basename property="jar.filename" file="${lib.jarfile}"/>
+      <xelatex file="@{file}"/>
+      <xelatex file="@{file}"/>
+      <makeindex file="@{file}"/>
+      <xelatex file="@{file}"/>
+      <xelatex file="@{file}"/>
+      <xelatex file="@{file}"/>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="apidoc" description="Run sphinx-apidoc">
+    <attribute name="source" default=""/>
+    <attribute name="output" default=""/>
+    <sequential>
+      <dirname property="output.path" file="@{output}"/>
+      <mkdir dir="@{output}"/>
+      <exec executable="sphinx-apidoc" failonerror="true" dir="${output.path}">
+        <arg value="-T"/>
+        <arg value="-o"/>
+        <arg value="@{output}"/>
+        <arg value="@{source}"/>
+      </exec>
+    </sequential>
+  </macrodef>
+
+</project>


### PR DESCRIPTION
Following https://github.com/openmicroscopy/openmicroscopy/pull/3931, this PR decouples the OMERO Sphinx documentation from the OMERO source code. This should simplify development and remove unnecessary cyclic dependencies when entering the release process.

Main changes are described below:
- the `docs/sphinx` submodule is removed
- the `release-docs` target is modified to build the API documentation (Java, Python, slice2html) only
- the components from the Sphinx submodule required for building the Sphinx API documentation are copied over (may require some cleanup in a follow-up PR).

/cc @hflynn 
