### PR TITLE
have model object glossary link unit properties to best Javadoc

### DIFF
--- a/components/model/src/ome/model/units/GenericEnumType.java
+++ b/components/model/src/ome/model/units/GenericEnumType.java
@@ -89,6 +89,10 @@ public class GenericEnumType<E extends Enum<E>> implements UserType, Parameteriz
         return (Class<E>) units.enumType;
     }
 
+    public Class<? extends Unit> getQuantityClass() {
+        return (Class<? extends Unit>) units.quantityType;
+    }
+
     public int[] sqlTypes() {
         return new int[] { units.sqlType };
     }

--- a/components/model/src/ome/model/units/UNITS.java
+++ b/components/model/src/ome/model/units/UNITS.java
@@ -37,14 +37,14 @@ public enum UNITS {
             UnitsTime.class,
             3007);
 
-    Class<?> quantityType;
+    Class<? extends Unit> quantityType;
     Class<? extends Enum<?>> enumType;
     int sqlType;
     Enum<? extends Enum<?>>[] values;
     Map<String, Enum<? extends Enum<?>>> enumMap;
     Map<Enum<? extends Enum<?>>, String> valueMap;
 
-    UNITS(Class<?> quantityType, Class<? extends Enum<?>> enumType, int sqlType) {
+    UNITS(Class<? extends Unit> quantityType, Class<? extends Enum<?>> enumType, int sqlType) {
         this.quantityType = quantityType;
         this.enumType = enumType;
         this.sqlType = sqlType;

--- a/components/server/src/ome/services/graphs/GraphPathReport.java
+++ b/components/server/src/ome/services/graphs/GraphPathReport.java
@@ -193,7 +193,7 @@ public class GraphPathReport {
         sb.append(' ');
         sb.append('<');
         sb.append(className.replace('.', '/'));
-        sb.append(".java");
+        sb.append(".html");
         sb.append('>');
         sb.append('`');
         return sb.toString();

--- a/components/server/src/ome/services/graphs/GraphPathReport.java
+++ b/components/server/src/ome/services/graphs/GraphPathReport.java
@@ -60,6 +60,7 @@ import com.google.common.collect.TreeMultimap;
 
 import ome.model.IObject;
 import ome.model.units.GenericEnumType;
+import ome.model.units.Unit;
 import ome.services.graphs.GraphPathBean.PropertyDetails;
 import ome.services.scheduler.ThreadPool;
 import ome.system.OmeroContext;
@@ -131,7 +132,7 @@ public class GraphPathReport {
      * @return a Sphinx label for that class
      */
     private static String labelFor(String className) {
-        return Joiner.on('.').join("Hibernate version of class omero.model", className);
+        return "OMERO model class " + className;
     }
 
     /**
@@ -140,7 +141,7 @@ public class GraphPathReport {
      * @return a Sphinx label for that class property
      */
     private static String labelFor(String className, String propertyName) {
-        return Joiner.on('.').join("Hibernate version of property omero.model", className, propertyName);
+        return "OMERO model property " + className + '.' + propertyName;
     }
 
     /**
@@ -181,18 +182,17 @@ public class GraphPathReport {
     }
 
     /**
-     * @param interfaceName the name of an OMERO model Java interface
-     * @return a Sphinx link to that interface's source code
+     * @param className the name of an OMERO model Java class
+     * @return a Sphinx link to that class' documentation
      */
-    private static String interfaceSource(String interfaceName) {
+    private static String linkToJavadoc(String className) {
         final StringBuffer sb = new StringBuffer();
-        sb.append(":source:");
+        sb.append(":javadoc:");
         sb.append('`');
-        sb.append(getSimpleName(interfaceName));
+        sb.append(getSimpleName(className));
         sb.append(' ');
         sb.append('<');
-        sb.append("components/model/src/");
-        sb.append(interfaceName.replace('.', '/'));
+        sb.append(className.replace('.', '/'));
         sb.append(".java");
         sb.append('>');
         sb.append('`');
@@ -312,8 +312,12 @@ public class GraphPathReport {
                     } else {
                         userType = null;
                     }
-                    if (property.type instanceof EnumType || userType instanceof GenericEnumType) {
+                    if (property.type instanceof EnumType) {
                         valueClassName = "enumeration";
+                    } else if (userType instanceof GenericEnumType) {
+                        @SuppressWarnings("unchecked")
+                        final Class<? extends Unit> unitQuantityClass = ((GenericEnumType) userType).getQuantityClass();
+                        valueClassName = "enumeration of " + linkToJavadoc(unitQuantityClass.getName());
                     } else if (property.type instanceof ListType || userType instanceof ListAsSQLArrayUserType) {
                         valueClassName = "list";
                     } else if (property.type instanceof MapType) {
@@ -350,7 +354,7 @@ public class GraphPathReport {
                 } else {
                     if (interfaceForProperty != null) {
                         sb.append(", see ");
-                        sb.append(interfaceSource(interfaceForProperty.getName()));
+                        sb.append(linkToJavadoc(interfaceForProperty.getName()));
                     }
                 }
                 SortedMap<String, String> byProperty = classPropertyReports.get(holderSimpleName);
@@ -362,8 +366,8 @@ public class GraphPathReport {
             }
         }
         /* the information is gathered, now write the report */
-        out.write("Every OMERO model object\n");
-        out.write("========================\n\n");
+        out.write("Glossary of all OMERO Model Objects\n");
+        out.write("===================================\n\n");
         out.write("Overview\n");
         out.write("--------\n\n");
         out.write("Reference\n");


### PR DESCRIPTION
Generates https://github.com/openmicroscopy/ome-documentation/pull/1251 which is staged at http://www.openmicroscopy.org/site/support/omero5.2-staging/developers/Model/EveryObject.html. There should now be links from dimensioned quantities to reasonable units Javadoc.

Also shortens anchor names.

--rebased-to #4027