### PR TITLE
move more uses of legacy Chmod to new Chmod2

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -140,7 +140,7 @@ import omero.api.SearchPrx;
 import omero.api.ServiceFactoryPrx;
 import omero.api.StatefulServiceInterfacePrx;
 import omero.api.ThumbnailStorePrx;
-import omero.cmd.Chmod;
+import omero.cmd.Chmod2;
 import omero.cmd.HandlePrx;
 import omero.cmd.Request;
 import omero.constants.projection.ProjectionType;
@@ -4268,7 +4268,7 @@ class OMEROGateway
                         case GroupData.PERMISSIONS_PUBLIC_READ:
                             r = "rwrwr-";
                     }
-                    Chmod chmod = new Chmod(REF_GROUP, group.getId(), null, r);
+                    final Chmod2 chmod = Requests.chmod("ExperimenterGroup", group.getId(), r);
                     List<Request> l = new ArrayList<Request>();
                     l.add(chmod);
                     return getConnector(ctx, true, false).submit(l, null);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/Requests.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import omero.cmd.Chgrp2;
+import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
 import omero.cmd.GraphModify2;
@@ -355,6 +356,247 @@ public class Requests {
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             long groupId) {
           return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, childOptions, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, boolean dryRun, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetId the target object ID
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
+            String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, Collections.singletonList(targetId));
+        return new Chmod2(targetObjects, childOptions, dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, childOptions, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, boolean dryRun, String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
+            String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetClass the target object class
+     * @param targetIds the target object IDs
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
+            String permissions) {
+        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
+        targetObjects.put(targetClass, targetIds);
+        return new Chmod2(targetObjects, childOptions, dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, String permissions) {
+        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, String permissions) {
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String permissions) {
+        return new Chmod2(targetObjects, childOptions, false, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, boolean dryRun, String permissions) {
+        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param childOption how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, String permissions) {
+        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+    }
+
+    /**
+     * Create a new {@link Chmod2} request.
+     * @param targetObjects the target objects
+     * @param childOptions how to process child objects
+     * @param dryRun if this request is a dry run
+     * @param permissions the new permissions
+     * @return the new request
+     */
+    public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
+            String permissions) {
+          return new Chmod2(targetObjects, childOptions, dryRun, permissions);
     }
 
     /**

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3894,8 +3894,9 @@ class _BlitzGateway (object):
         callback.loop(20, 500)
         rsp = prx.getResponse()
         """
-        chmod = omero.cmd.Chmod(
-            type="/ExperimenterGroup", id=group_Id, permissions=permissions)
+        chmod = omero.cmd.Chmod2(
+            targetObjects={'ExperimenterGroup': [group_Id]},
+            permissions=permissions)
         prx = self.c.sf.submit(chmod)
         return prx
 

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -192,8 +192,9 @@ server-permissions.html
                          % (g.name.val, gid, perms))
         else:
             try:
-                chmod = omero.cmd.Chmod(
-                    type="/ExperimenterGroup", id=gid, permissions=str(perms))
+                chmod = omero.cmd.Chmod2(
+                    targetObjects={'ExperimenterGroup': [gid]},
+                    permissions=str(perms))
                 c.submit(chmod)
                 self.ctx.out("Changed permissions for group %s (id=%s) to %s"
                              % (g.name.val, gid, perms))

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -39,7 +39,7 @@ import omero.scripts
 
 from omero.rtypes import rbool, rint, rstring, rlong, rlist, rtime, unwrap
 from omero.model import ExperimenterI, ExperimenterGroupI
-from omero.cmd import Chmod
+from omero.cmd import Chmod2
 
 from omero.gateway import AnnotationWrapper
 from omero.gateway import OmeroGatewaySafeCallWrapper
@@ -1457,9 +1457,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         perms = str(permissions)
         logger.debug("Chmod of group ID: %s to %s" % (group.id, perms))
-        command = Chmod(type="/ExperimenterGroup",
-                        id=group.id,
-                        permissions=perms)
+        command = Chmod2(targetObjects={'ExperimenterGroup': [group.id]},
+                         permissions=perms)
         cb = None
         message = None
         try:


### PR DESCRIPTION
Integration tests should still pass. Change of group permissions should still work from all clients.

Also adds a host of Java convenience methods for constructing Chmod2 requests.

--no-rebase as the 5.1.0 server does not offer Chmod2