### PR TITLE
remove workaround for namespace bug in old gcc

### DIFF
--- a/components/tools/OmeroCpp/test/integration/chgrp.cpp
+++ b/components/tools/OmeroCpp/test/integration/chgrp.cpp
@@ -42,8 +42,8 @@ TEST(ChgrpTest, testSimpleChgrp ) {
     image->setName( rstring("testSimpleChgrp") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    omero::api::LongList imageIds;
-    omero::api::StringLongListMap objects;
+    LongList imageIds;
+    StringLongListMap objects;
     ChildOptions options;
     Chgrp2Ptr chgrpCmd = new Chgrp2();
     imageIds.push_back( image->getId()->getValue() );

--- a/components/tools/OmeroCpp/test/integration/delete.cpp
+++ b/components/tools/OmeroCpp/test/integration/delete.cpp
@@ -35,8 +35,8 @@ TEST(DeleteTest, testSimpleDelete ) {
     image->setName( rstring("testSimpleDelete") );
     image = ImagePtr::dynamicCast( iupdate->saveAndReturnObject( image ) );
 
-    omero::api::LongList imageIds;
-    omero::api::StringLongListMap objects;
+    LongList imageIds;
+    StringLongListMap objects;
     ChildOptions options;
     Delete2Ptr deleteCmd = new Delete2();
     imageIds.push_back( image->getId()->getValue() );

--- a/components/tools/OmeroCpp/utils/chgrp.cpp
+++ b/components/tools/OmeroCpp/utils/chgrp.cpp
@@ -163,8 +163,8 @@ public:
         grp = strToNum<long>(grpstr);
         wait = strToNum<long>(waitstr);
 
-        omero::api::LongList objectIds;
-        omero::api::StringLongListMap objects;
+        LongList objectIds;
+        StringLongListMap objects;
         ChildOptions options;
         req = new Chgrp2();
         objectIds.push_back(id);


### PR DESCRIPTION
C++ integration tests should pass even with gcc 4.6. Cc: @rleigh-dundee.

--no-rebase because a bug in gcc 4.4 requires the namespace specifications