### PR TITLE
Fix release-sphinx-api target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -564,7 +564,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
        </apply>
     </target>
 
-    <target name="release-sphinx-api" depends="build-py"
+    <target name="release-sphinx-api" depends="build-py,build-web"
         description="The OMERO.py Sphinx API Documentation">
         <mkdir dir="${dist.dir}/docs/api/python"/>
 

--- a/docs/hudson/OMERO.sh
+++ b/docs/hudson/OMERO.sh
@@ -12,9 +12,7 @@ set -x
 source docs/hudson/functions.sh
 echo Building $OMERO_BRANCH
 
-./build.py clean
-./build.py build-default test-compile
-./build.py release-all
+./build.py build-dev release-all
 if [ -d .git ]
 then
   ./build.py release-src


### PR DESCRIPTION
Addresses @rleigh-dundee's comment https://github.com/openmicroscopy/openmicroscopy/pull/4006#issuecomment-127222532 and modifies the CI build command to use `build-dev`.

To test this PR:
- check the https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-build/ job is still green
- run `./build.py clean release-sphinx-api` and check the API doc is correctly generated.