### PR TITLE
Graph targets query

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -373,6 +373,30 @@ module omero {
         };
 
         /**
+         * Graph requests typically allow only specific model object classes
+         * to be targeted. This request lists the legal targets for a given
+         * request. The request's fields are ignored, only its class matters.
+         **/
+        class LegalGraphTargets extends Request {
+
+            /**
+             * A request of the type being queried.
+             **/
+            GraphModify2 request;
+        };
+
+        /**
+         * A list of the legal targets for a graph request.
+         **/
+        class LegalGraphTargetsResponse extends OK {
+
+            /**
+             * The legal targets for the given request's type.
+             **/
+            omero::api::StringSet targets;
+        };
+
+        /**
          * Returned when specifically a ome.services.graphs.GraphException
          * is thrown. The contents of that internal exception are passed in
          * this instance.

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -47,10 +47,10 @@ module omero {
         /**
          *
          **/
-        ["deprecated:GraphSpecs in general are deprecated"]
+        ["deprecated:use LegalGraphTargets"]
         class GraphSpecList extends Request {};
 
-        ["deprecated:GraphSpecs in general are deprecated"]
+        ["deprecated:use LegalGraphTargetsResponse"]
         class GraphSpecListRsp extends Response {
             GraphModifyList list;
         };

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -51,6 +51,7 @@ import omero.cmd.graphs.DeleteFacadeI;
 import omero.cmd.graphs.DiskUsageI;
 import omero.cmd.graphs.GraphRequestFactory;
 import omero.cmd.graphs.GraphSpecListI;
+import omero.cmd.graphs.LegalGraphTargetsI;
 import omero.cmd.graphs.SkipHeadI;
 import omero.cmd.mail.SendEmailRequestI;
 
@@ -245,6 +246,13 @@ public class RequestObjectFactoryRegistry extends
                         return graphRequestFactory.getRequest(SkipHeadI.class);
                     }
 
+                });
+        factories.put(LegalGraphTargetsI.ice_staticId(),
+                new ObjectFactory(LegalGraphTargetsI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return new LegalGraphTargetsI(graphRequestFactory);
+                    }
                 });
         factories.put(OriginalMetadataRequestI.ice_staticId(),
                 new ObjectFactory(OriginalMetadataRequestI.ice_staticId()) {

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -141,6 +141,19 @@ public class GraphRequestFactory {
     }
 
     /**
+     * Get the legal target object classes for the given request.
+     * @param requestClass a request class
+     * @return the legal target object classes for that type of request
+     */
+    public <R extends GraphModify2> Set<Class<? extends IObject>> getLegalTargets(Class<R> requestClass) {
+        final Set<Class<? extends IObject>> targetClasses = allTargets.get(requestClass);
+        if (targetClasses.isEmpty()) {
+            throw new IllegalArgumentException("no legal target classes defined for request class " + requestClass);
+        }
+        return targetClasses;
+    }
+
+    /**
      * Construct a request.
      * @param requestClass a request class
      * @return a new instance of that class
@@ -152,10 +165,7 @@ public class GraphRequestFactory {
                 final Constructor<R> constructor = requestClass.getConstructor(GraphPathBean.class, GraphRequestFactory.class);
                 request = constructor.newInstance(graphPathBean, this);
             } else {
-                final Set<Class<? extends IObject>> targetClasses = allTargets.get(requestClass);
-                if (targetClasses.isEmpty()) {
-                    throw new IllegalArgumentException("no legal target classes defined for request class " + requestClass);
-                }
+                final Set<Class<? extends IObject>> targetClasses = getLegalTargets(requestClass);
                 GraphPolicy graphPolicy = graphPolicies.get(requestClass);
                 if (graphPolicy == null) {
                     throw new IllegalArgumentException("no graph traversal policy rules defined for request class " + requestClass);

--- a/components/blitz/src/omero/cmd/graphs/LegalGraphTargetsI.java
+++ b/components/blitz/src/omero/cmd/graphs/LegalGraphTargetsI.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import ome.model.IObject;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.LegalGraphTargets;
+import omero.cmd.LegalGraphTargetsResponse;
+import omero.cmd.Response;
+
+/**
+ * Query which model object classes are legal as targets for a request.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.4
+ */
+public class LegalGraphTargetsI extends LegalGraphTargets implements IRequest {
+
+    private final GraphRequestFactory graphRequestFactory;
+    private Helper helper;
+
+    /**
+     * Construct a new legal graph targets query.
+     * @param graphRequestFactory the graph request factory
+     */
+    public LegalGraphTargetsI(GraphRequestFactory graphRequestFactory) {
+        this.graphRequestFactory = graphRequestFactory;
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+        return null;
+    }
+
+    @Override
+    public void init(Helper helper) {
+        this.helper = helper;
+        helper.setSteps(1);
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        if (step == 0) {
+            try {
+                return graphRequestFactory.getLegalTargets(request.getClass());
+            } catch (Exception e) {
+                throw helper.cancel(new ERR(), e, "graph-no-targets");
+            }
+        } else {
+            final Exception e = new IllegalArgumentException("request has no step " + step);
+            throw helper.cancel(new ERR(), e, "bad-step");
+        }
+    }
+
+    @Override
+    public void finish() throws Cancel {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (step == 0) {
+            final LegalGraphTargetsResponse response = new LegalGraphTargetsResponse();
+            final Collection<Class<? extends IObject>> legalTargetClasses = (Collection<Class<? extends IObject>>) object;
+            response.targets = new ArrayList<String>(legalTargetClasses.size());
+            for (final Class<? extends IObject> legalTargetClass : legalTargetClasses) {
+                response.targets.add(legalTargetClass.getName());
+            }
+            helper.setResponseIfNull(response);
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+}

--- a/components/tools/OmeroJava/test/integration/LegalGraphTargetsTest.java
+++ b/components/tools/OmeroJava/test/integration/LegalGraphTargetsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import ome.model.core.Image;
+import ome.model.meta.Experimenter;
+import ome.model.meta.ExperimenterGroup;
+import omero.cmd.Chgrp2;
+import omero.cmd.Chmod2;
+import omero.cmd.Chown2;
+import omero.cmd.Delete2;
+import omero.cmd.LegalGraphTargets;
+import omero.cmd.LegalGraphTargetsResponse;
+import omero.cmd.SkipHead;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test which model object classes are reported as being legal as targets for a request.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.4
+ */
+public class LegalGraphTargetsTest extends AbstractServerTest {
+    /**
+     * Test a model object class that is expected to be legal for {@link Chgrp2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testInclusionChgrp() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chgrp2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertTrue(response.targets.contains(Image.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is not expected to be legal for {@link Chgrp2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testExclusionChgrp() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chgrp2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertFalse(response.targets.contains(Experimenter.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is expected to be legal for {@link Chmod2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testInclusionChmod() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chmod2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertTrue(response.targets.contains(ExperimenterGroup.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is not expected to be legal for {@link Chmod2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testExclusionChmod() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chmod2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertFalse(response.targets.contains(Image.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is expected to be legal for {@link Chown2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testInclusionChown() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chown2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertTrue(response.targets.contains(Image.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is not expected to be legal for {@link Chown2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testExclusionChown() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Chown2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertFalse(response.targets.contains(Experimenter.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is expected to be legal for {@link Delete2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testInclusionDelete() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Delete2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertTrue(response.targets.contains(Image.class.getName()));
+    }
+
+    /**
+     * Test a model object class that is not expected to be legal for {@link Delete2}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testExclusionDelete() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new Delete2();
+        final LegalGraphTargetsResponse response = (LegalGraphTargetsResponse) doChange(query);
+        Assert.assertFalse(response.targets.contains(Experimenter.class.getName()));
+    }
+
+    /**
+     * Test that {@link SkipHead} cannot be queried for legal targets.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testSkipHeadFails() throws Exception {
+        final LegalGraphTargets query = new LegalGraphTargets();
+        query.request = new SkipHead();
+        doChange(client, factory, query, false);
+    }
+}


### PR DESCRIPTION
Adds a new `LegalGraphsTarget` request that enables querying of which model object classes are legal targets for `Chgrp2`, `Chmod2`, `Chown2`, `Delete2`. Tested automatically by https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/LegalGraphTargetsTest/. Cc: @ximenesuk.

--no-rebase