### PR TITLE
use narrower reflective operation exception

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -1166,7 +1166,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
                                 final String message = "unexpected exception in expanding \"" + pattern + '"';
                                 throw new ServerError(null, null, message, cause);
                             }
-                        } catch (/* Java SE 7 ReflectiveOperation*/Exception e) {
+                        } catch (ReflectiveOperationException e) {
                             final String message = "unexpected exception in expanding \"" + pattern + '"';
                             throw new ServerError(null, null, message, e);
                         }

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -168,8 +168,7 @@ public class GraphRequestFactory {
                         constructor.newInstance(aclVoter, securityRoles, systemTypes, graphPathBean, deletionInstance,
                                 targetClasses, graphPolicy, unnullable);
             }
-        } catch (Exception e) {
-            /* TODO: easier to do a ReflectiveOperationException multi-catch in Java SE 7 */
+        } catch (ReflectiveOperationException e) {
             throw new IllegalArgumentException("cannot instantiate " + requestClass, e);
         }
         return request;

--- a/components/server/src/ome/services/graphs/GraphPathBean.java
+++ b/components/server/src/ome/services/graphs/GraphPathBean.java
@@ -276,7 +276,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
                         } catch (NestedNullException e) {
                             propertyIsAccessible = false;
                         }
-                    } catch (/* TODO Java SE 7 ReflectiveOperation*/Exception e) {
+                    } catch (ReflectiveOperationException e) {
                         log.error("could not probe property of " + property.holder, e);
                     }
                     /* build property report line for log */

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -181,7 +181,7 @@ public class GraphTraversal {
             try {
                 final Class<? extends IObject> actualClass = (Class<? extends IObject>) Class.forName(className);
                 return actualClass.getConstructor(Long.class, boolean.class).newInstance(id, false);
-            } catch (/* TODO Java SE 7 ReflectiveOperation*/Exception e) {
+            } catch (ReflectiveOperationException e) {
                 throw new GraphException(
                         "no invocable constructor for: new " + className + "(Long.valueOf(" + id + "L), false)");
             }

--- a/etc/local.properties.example
+++ b/etc/local.properties.example
@@ -57,7 +57,7 @@ simple.repository=ome.unstable
 jarsign.keystore=${omero.home}/lib/keystore
 jarsign.alias=omedev
 jarsign.storepass=omedev
-#Password can be stored in a file with Java>=1.7
+#Password can be stored in a file
 #jarsign.storepassfile=
 jarsign.validity=1000
 #Timestamping can be enabled by providing a server url


### PR DESCRIPTION
Should be no change in behavior, largely tested by if the code compiles at all.

--no-rebase as Java 6 does not offer `ReflectiveOperationException`