### PR TITLE
CLI: add sessions key (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -241,7 +241,10 @@ class SessionsControl(BaseControl):
         file = parser.add(
             sub, self.file, "Print the path to the current session file")
 
-        for x in (file, logout, keepalive, list, clear, group):
+        key = parser.add(
+            sub, self.key, "Print the key of the current active session")
+
+        for x in (file, key, logout, keepalive, list, clear, group):
             self._configure_dir(x)
 
     def _configure_login(self, login):
@@ -820,10 +823,18 @@ class SessionsControl(BaseControl):
             t.event.set()
 
     def file(self, args):
+        """Return the file associated to the current active sessions"""
         store = self.store(args)
         srv, usr, uuid, port = store.get_current()
         if srv and usr and uuid:
             self.ctx.out(str(store.dir / srv / usr / uuid))
+
+    def key(self, args):
+        """Return the key associated to the current active sessions"""
+        store = self.store(args)
+        srv, usr, uuid, port = store.get_current()
+        if uuid:
+            self.ctx.out(uuid)
 
     def conn(self, properties=None, profile=None, args=None):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -823,14 +823,14 @@ class SessionsControl(BaseControl):
             t.event.set()
 
     def file(self, args):
-        """Return the file associated to the current active sessions"""
+        """Return the file associated with the current active session"""
         store = self.store(args)
         srv, usr, uuid, port = store.get_current()
         if srv and usr and uuid:
             self.ctx.out(str(store.dir / srv / usr / uuid))
 
     def key(self, args):
-        """Return the key associated to the current active sessions"""
+        """Return the key associated with the current active session"""
         store = self.store(args)
         srv, usr, uuid, port = store.get_current()
         if uuid:

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -267,8 +267,22 @@ class TestSessions(CLITest):
     # ========================================================================
     def testFile(self):
 
-        self.args = ["sessions", "file"]
+        self.args += ["file"]
         self.cli.invoke(self.args, strict=True)
+
+    # Key subcommand
+    # ========================================================================
+    def testKey(self, capsys):
+
+        user = self.new_user()
+        self.set_login_args(user)
+        self.args += ["-w", user.omeName.val]
+        self.cli.invoke(self.args, strict=True)
+
+        self.args = ["sessions", "key"]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+        assert o == "%s\n" % self.cli.get_event_context().sessionUuid
 
     # who subcommand
     # ========================================================================


### PR DESCRIPTION

This is the same as gh-4005 but rebased onto develop.

----

See https://trello.com/c/dyRbaNiM/19-key-omero-sessions-key

Implement a simple RFE to return the current session key via the CLI. To test this PR:
- check the new integration test is green
- from the command line check the output of `bin/omero sessions key` is null if logged out and the current session key if logged in
- test a simple workflow reusing the session key:

  ```
   bin/omero login USER@HOSTNAME
   bin/omero -C -s HOSTNAME -k $(bin/omero sessions key) COMMAND
```

                