### PR TITLE
Javadoc cleanup: romio and rendering

### DIFF
--- a/components/rendering/src/ome/util/math/geom2D/EllipseArea.java
+++ b/components/rendering/src/ome/util/math/geom2D/EllipseArea.java
@@ -7,16 +7,12 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-// Third-party libraries
-
-// Application-internal dependencies
 import ome.util.mem.Handle;
 
 /**

--- a/components/rendering/src/ome/util/math/geom2D/EllipseAreaAdapter.java
+++ b/components/rendering/src/ome/util/math/geom2D/EllipseAreaAdapter.java
@@ -7,14 +7,9 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
 import java.awt.Rectangle;
 import java.awt.geom.Ellipse2D;
 import java.util.ArrayList;
-
-// Third-party libraries
-
-// Application-internal dependencies
 
 /**
  * This following class is the <code>body</code> of the

--- a/components/rendering/src/ome/util/math/geom2D/Line.java
+++ b/components/rendering/src/ome/util/math/geom2D/Line.java
@@ -7,12 +7,6 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * An orientated line in the Euclidean space <b>R</b><sup>2</sup>.
  * 

--- a/components/rendering/src/ome/util/math/geom2D/PlaneArea.java
+++ b/components/rendering/src/ome/util/math/geom2D/PlaneArea.java
@@ -7,12 +7,8 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
 import java.awt.Shape;
 
-// Third-party libraries
-
-// Application-internal dependencies
 import ome.util.mem.Copiable;
 
 /**

--- a/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
+++ b/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
@@ -7,12 +7,6 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * Represents a point in the Euclidean space <b>R</b><sup>2</sup>.
  * <p>

--- a/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
+++ b/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
@@ -42,10 +42,8 @@ public class PlanePoint {
     /**
      * Creates a new instance.
      * 
-     * @param x1
-     *            The first element.
-     * @param x2
-     *            The second element.
+     * @param x1  The first element of the point
+     * @param x2  The second element of the point
      */
     public PlanePoint(double x1, double x2) {
         this.x1 = x1;
@@ -154,6 +152,8 @@ public class PlanePoint {
      * This method returns <nobr><i>f(t, p)</i></nobr>, where <i>t</i> is
      * this point and <i>p</i> is the specified argument.
      * 
+     * @param x1  The first element of the point
+     * @param x2  The second element of the point
      * @return The vector associated to this point and <i>p</i>.
      */
     public PlanePoint vec(double x1, double x2) {

--- a/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
+++ b/components/rendering/src/ome/util/math/geom2D/PlanePoint.java
@@ -154,8 +154,6 @@ public class PlanePoint {
      * This method returns <nobr><i>f(t, p)</i></nobr>, where <i>t</i> is
      * this point and <i>p</i> is the specified argument.
      * 
-     * @param p
-     *            The other point. Mustn't be a <code>null</code> reference.
      * @return The vector associated to this point and <i>p</i>.
      */
     public PlanePoint vec(double x1, double x2) {

--- a/components/rendering/src/ome/util/math/geom2D/RectangleArea.java
+++ b/components/rendering/src/ome/util/math/geom2D/RectangleArea.java
@@ -7,16 +7,12 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-// Third-party libraries
-
-// Application-internal dependencies
 import ome.util.mem.Handle;
 
 /**

--- a/components/rendering/src/ome/util/math/geom2D/RectangleAreaAdapter.java
+++ b/components/rendering/src/ome/util/math/geom2D/RectangleAreaAdapter.java
@@ -7,13 +7,8 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
 import java.awt.Rectangle;
 import java.util.ArrayList;
-
-// Third-party libraries
-
-// Application-internal dependencies
 
 /**
  * This following class is the <code>body</code> of the

--- a/components/rendering/src/ome/util/math/geom2D/Segment.java
+++ b/components/rendering/src/ome/util/math/geom2D/Segment.java
@@ -7,12 +7,6 @@
 
 package ome.util.math.geom2D;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * A segment in the Euclidean space <b>R</b><sup>2</sup>.
  * 

--- a/components/rendering/src/ome/util/math/geom2D/Segment.java
+++ b/components/rendering/src/ome/util/math/geom2D/Segment.java
@@ -43,8 +43,7 @@ public class Segment {
      * Creates a new instance.
      * 
 	 * @param originX1 The origin of the segment's first element.
-	 * @param originX2 The origin of the segment's first element.
-     * @param o The origin point of the segment.
+	 * @param originX2 The origin of the segment's second element.
      * @param endX1 The end point's first element.
      * @param endX2 The end point's second element.
      */
@@ -75,7 +74,7 @@ public class Segment {
     /**
      * Returns the point of this line defined by <code>k</code>. More
      * precisely, this method returns the
-     * <code>{@link #origin}+k{@link #direction}</code> point.
+     * <code>{@code origin}+k{@code direction}</code> point.
      * 
      * @param k
      *            The coefficient to select the point. Must be in the range
@@ -94,8 +93,8 @@ public class Segment {
     /**
      * Tells whether a specified point lies on this line.
      * 
-     * @param p
-     *            The point to test. Mustn't be <code>null</code>.
+     * @param x1 The first element of the point to test
+     * @param x2 The second element of the point to test
      * @return <code>true</code> if <code>p</code> lies on this line,
      *         <code>false</code> otherwise.
      */
@@ -132,7 +131,8 @@ public class Segment {
     
     /**
      * Performs an equality test based on a point on this line defined
-     * by <code>k</code> as in {@link getPoint()} and another given point.
+     * by <code>k</code> as in {@link #getPoint(double)} and another given
+     * point.
      * @param k The coefficient to select the point. Must be in the range
      * <code>[0, 1]</code>.
      * @param x1 The point to test's first element.

--- a/components/rendering/src/ome/util/mem/ByteArray.java
+++ b/components/rendering/src/ome/util/mem/ByteArray.java
@@ -7,13 +7,8 @@
 
 package ome.util.mem;
 
-// Java imports
 import java.io.IOException;
 import java.io.InputStream;
-
-// Third-party libraries
-
-// Application-internal dependencies
 
 /**
  * A read-write slice of a given array. This class extends

--- a/components/rendering/src/ome/util/mem/Copiable.java
+++ b/components/rendering/src/ome/util/mem/Copiable.java
@@ -7,12 +7,6 @@
 
 package ome.util.mem;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * Requires an implementing class to provide <i>deep</i> copies of its
  * instances. More precisely, an invocation of the {@link #copy() copy} method,

--- a/components/rendering/src/ome/util/mem/CopiableArray.java
+++ b/components/rendering/src/ome/util/mem/CopiableArray.java
@@ -7,12 +7,6 @@
 
 package ome.util.mem;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * This abstract class provides an implementation of the {@link Copiable}
  * interface. It constructs an array of {@link Copiable}s , note that all

--- a/components/rendering/src/ome/util/mem/Handle.java
+++ b/components/rendering/src/ome/util/mem/Handle.java
@@ -7,12 +7,6 @@
 
 package ome.util.mem;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * Provides the basic machinery to share the same logical state across objects
  * with different identities.

--- a/components/rendering/src/ome/util/mem/ReadOnlyByteArray.java
+++ b/components/rendering/src/ome/util/mem/ReadOnlyByteArray.java
@@ -7,12 +7,6 @@
 
 package ome.util.mem;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * A read-only slice of a given array. Given a <code>base</code> array and an
  * interval <code>[offset, offset+length]

--- a/components/rendering/src/omeis/providers/re/GreyScaleStrategy.java
+++ b/components/rendering/src/omeis/providers/re/GreyScaleStrategy.java
@@ -7,18 +7,16 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.io.IOException;
 
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.conditions.ResourceError;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.display.ChannelBinding;
+
 import omeis.providers.re.codomain.CodomainChain;
 import omeis.providers.re.data.PlaneFactory;
 import omeis.providers.re.data.Plane2D;

--- a/components/rendering/src/omeis/providers/re/HSBStrategy.java
+++ b/components/rendering/src/omeis/providers/re/HSBStrategy.java
@@ -7,7 +7,6 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.awt.Color;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -18,11 +17,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.conditions.ResourceError;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
@@ -30,6 +27,7 @@ import ome.model.display.ChannelBinding;
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 import ome.util.PixelData;
+
 import omeis.providers.re.codomain.CodomainChain;
 import omeis.providers.re.data.PlaneFactory;
 import omeis.providers.re.data.Plane2D;

--- a/components/rendering/src/omeis/providers/re/QuantumManager.java
+++ b/components/rendering/src/omeis/providers/re/QuantumManager.java
@@ -7,19 +7,16 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.util.Iterator;
 import java.util.List;
 
-//Third-party libraries
-
-// Application-internal dependencies
 import ome.model.core.Channel;
 import ome.model.core.Pixels;
 import ome.model.display.ChannelBinding;
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
 import ome.model.stats.StatsInfo;
+
 import omeis.providers.re.metadata.StatsFactory;
 import omeis.providers.re.quantum.QuantumFactory;
 import omeis.providers.re.quantum.QuantumStrategy;

--- a/components/rendering/src/omeis/providers/re/RenderHSBRegionTask.java
+++ b/components/rendering/src/omeis/providers/re/RenderHSBRegionTask.java
@@ -7,13 +7,13 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-// Application-internal dependencies
+
 import ome.util.PixelData;
+
 import omeis.providers.re.codomain.CodomainChain;
 import omeis.providers.re.data.Plane2D;
 import omeis.providers.re.quantum.BinaryMaskQuantizer;

--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -7,7 +7,6 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.awt.Dimension;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,11 +14,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.conditions.ResourceError;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
@@ -29,6 +26,7 @@ import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
 import ome.model.enums.RenderingModel;
+
 import omeis.providers.re.codomain.CodomainChain;
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.PlaneFactory;

--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -385,7 +385,6 @@ public class Renderer {
      * @param z
      *            The stack index.
      * @see #setDefaultT(int)
-     * @see #getDefaultPlaneDef()
      */
     public void setDefaultZ(int z)
     {
@@ -399,7 +398,6 @@ public class Renderer {
      * @param t
      *            The timepoint index.
      * @see #setDefaultZ(int)
-     * @see #getDefaultPlaneDef()
      */
     public void setDefaultT(int t) {
         rndDef.setDefaultT(Integer.valueOf(t));
@@ -826,7 +824,7 @@ public class Renderer {
      * Returns an array  whose ascending indices represent the color
      * components Red, Green and Blue.
      * 
-     * @param color the color to decompose into an array.
+     * @param channel  the color to decompose into an array.
      * @return See above.
      */
     public static int[] getColorArray(ChannelBinding channel)

--- a/components/rendering/src/omeis/providers/re/RenderingStats.java
+++ b/components/rendering/src/omeis/providers/re/RenderingStats.java
@@ -7,13 +7,9 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.util.HashMap;
 import java.util.Map;
 
-// Third-party libraries
-
-// Application-internal dependencies
 import omeis.providers.re.data.PlaneDef;
 
 /**

--- a/components/rendering/src/omeis/providers/re/RenderingStrategy.java
+++ b/components/rendering/src/omeis/providers/re/RenderingStrategy.java
@@ -7,16 +7,14 @@
 
 package omeis.providers.re;
 
-// Java imports
 import java.io.IOException;
 
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.model.core.Pixels;
 import ome.model.enums.RenderingModel;
+
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.RegionDef;
 import omeis.providers.re.quantum.QuantizationException;

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -7,16 +7,11 @@
 
 package omeis.providers.re.codomain;
 
-// Java imports
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import omeis.providers.re.quantum.QuantumStrategy;
-
-// Third-party libraries
-
-// Application-internal dependencies
 
 /**
  * Queues the contexts that define the spatial domain transformations that have

--- a/components/rendering/src/omeis/providers/re/data/Plane2D.java
+++ b/components/rendering/src/omeis/providers/re/data/Plane2D.java
@@ -7,13 +7,9 @@
 
 package omeis.providers.re.data;
 
-// Java imports
-
-// Third-party libraries
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Application-internal dependencies
 import ome.util.PixelData;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;

--- a/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
+++ b/components/rendering/src/omeis/providers/re/metadata/StatsFactory.java
@@ -21,6 +21,7 @@ import ome.model.core.Channel;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 import ome.model.stats.StatsInfo;
+
 import omeis.providers.re.data.Plane2D;
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.PlaneFactory;

--- a/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
+++ b/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
@@ -28,7 +28,7 @@ public class BinaryMaskQuantizer extends QuantumStrategy
      * Creates a new strategy.
      * 
      * @param qd Quantum definition object, contained mapping data.
-     * @param type The pixels. Must be of type <code>bit</code>.
+     * @param pixels The pixels
      */
     public BinaryMaskQuantizer(QuantumDef qd, Pixels pixels)
     {

--- a/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
+++ b/components/rendering/src/omeis/providers/re/quantum/BinaryMaskQuantizer.java
@@ -7,14 +7,10 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
 import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
 import ome.model.enums.PixelsType;
+
 import omeis.providers.re.data.PlaneFactory;
 
 /**

--- a/components/rendering/src/omeis/providers/re/quantum/ExponentialMap.java
+++ b/components/rendering/src/omeis/providers/re/quantum/ExponentialMap.java
@@ -7,12 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * This class implements the {@link QuantumMap} interface. Each method is a
  * wrapper around the composition (in the mathematical sense) of

--- a/components/rendering/src/omeis/providers/re/quantum/LogarithmicMap.java
+++ b/components/rendering/src/omeis/providers/re/quantum/LogarithmicMap.java
@@ -7,12 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * This class implements the {@link QuantumMap} interface. Each method is a
  * wrapper around the {@link Math#log(double)} method, which returns the natural

--- a/components/rendering/src/omeis/providers/re/quantum/PolynomialMap.java
+++ b/components/rendering/src/omeis/providers/re/quantum/PolynomialMap.java
@@ -7,12 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * This class implements the {@link QuantumMap} interface. Each method is a
  * wrapper around the {@link Math#pow(double, double)} method, which returns the

--- a/components/rendering/src/omeis/providers/re/quantum/QuantizationException.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantizationException.java
@@ -7,12 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * This exception is thrown during the quantization process if something goes
  * wrong. For example, quantization strategies that depend on an interval

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -7,11 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
 import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
 

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -284,7 +284,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
      * 
      * @param qd
      *            Quantum definition object, contained mapping data.
-     * @param type
+     * @param pixels
      *            The pixels
      */
     public Quantization_8_16_bit(QuantumDef qd, Pixels pixels) {

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_float.java
@@ -168,7 +168,7 @@ public class Quantization_float extends QuantumStrategy {
      *
      * @param qd
      *            Quantum definition object, contained mapping data.
-     * @param type
+     * @param pixels
      *            The pixels
      */
     public Quantization_float(QuantumDef qd, Pixels pixels) {

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumFactory.java
@@ -7,18 +7,13 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
 import java.util.List;
 
-// Third-party libraries
-
-
-
 import ome.model.core.Pixels;
-// Application-internal dependencies
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
 import ome.model.enums.PixelsType;
+
 import omeis.providers.re.data.PlaneFactory;
 
 /**

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumMap.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumMap.java
@@ -7,12 +7,6 @@
 
 package omeis.providers.re.quantum;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
-
 /**
  * Provides methods to map value. Each method is wrapper around a method exposed
  * by the {@link Math} class. Each value mapper should implements this I/F.

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -10,6 +10,7 @@ package omeis.providers.re.quantum;
 import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
 import ome.model.enums.Family;
+
 import omeis.providers.re.data.PlaneFactory;
 import omeis.providers.re.metadata.StatsFactory;
 

--- a/components/romio/src/ome/io/bioformats/BfPyramidPixelBuffer.java
+++ b/components/romio/src/ome/io/bioformats/BfPyramidPixelBuffer.java
@@ -135,7 +135,7 @@ public class BfPyramidPixelBuffer implements PixelBuffer {
      * Upon construction, the pixel buffer is available for reading or writing.
      * However, on the first read, writing will be subsequently disabled.
      *
-     * @see ticket:5083
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/5083">ticket 5083</a>
      */
     public BfPyramidPixelBuffer(Pixels pixels, String filePath, boolean write)
     throws IOException, FormatException
@@ -215,7 +215,7 @@ public class BfPyramidPixelBuffer implements PixelBuffer {
 
     /**
      * Initializes the writer. Since the reader location is not present until
-     * this instance is closed, other {@link ByPyramidPixelBuffer} instances
+     * this instance is closed, other {@link BfPyramidPixelBuffer} instances
      * may try to also call this method in which case {@link #acquireLock()}
      * will throw a {@link LockTimeout}.
      *

--- a/components/romio/src/ome/io/nio/AbstractFileSystemService.java
+++ b/components/romio/src/ome/io/nio/AbstractFileSystemService.java
@@ -68,46 +68,37 @@ public class AbstractFileSystemService {
 
     /**
      * Returns a numbered path relative to the root of this service, but is
-     * ignorant of FS and similar constructs. For example, given an id of 123456
-     * this will return "ROOT/Pixels/Dir-123/Dir-456/123456"
+     * ignorant of FS and similar constructs. For example, given an id of
+     * 12345 this will return "ROOT/Pixels/Dir-123/Dir-456/123456"
      *
-     * Should be marked protected in 4.4  because assumptions on the existence
-     * of this file can be dangerous.
-     *
-     * @param id
-     * @return
+     * @param id   the Pixels identifier
+     * @return     the path relative to the root
      */
-    public /*protected*/ String getPixelsPath(Long id) {
+    public String getPixelsPath(Long id) {
         return getPath(PIXELS_PATH, id);
     }
 
     /**
      * Returns a numbered path relative to the root of this service, but is
-     * ignorant of FS and similar constructs. For example, given an id of 123456
-     * this will return "ROOT/Files/Dir-123/Dir-456/123456"
+     * ignorant of FS and similar constructs. For example, given an id of
+     * 123456 this will return "ROOT/Files/Dir-123/Dir-456/123456"
      *
-     * Should be marked protected in 4.4  because assumptions on the existence
-     * of this file can be dangerous.
-     *
-     * @param id
-     * @return
+     * @param id   the Files identifier
+     * @return     the path relative to the root
      */
-    public /*protected*/ String getFilesPath(Long id) {
+    public String getFilesPath(Long id) {
         return getPath(FILES_PATH, id);
     }
 
     /**
      * Returns a numbered path relative to the root of this service, but is
-     * ignorant of FS and similar constructs. For example, given an id of 123456
-     * this will return "ROOT/Thumbnails/Dir-123/Dir-456/123456"
+     * ignorant of FS and similar constructs. For example, given an id of
+     * 123456 this will return "ROOT/Thumbnails/Dir-123/Dir-456/123456"
      *
-     * Should be marked protected in 4.4  because assumptions on the existence
-     * of this file can be dangerous.
-     *
-     * @param id
-     * @return
+     * @param id     the thumbnail identifier
+     * @return       the path relative to the root
      */
-    public /*protected*/ String getThumbnailPath(Long id) {
+    public String getThumbnailPath(Long id) {
         return getPath(THUMBNAILS_PATH, id);
     }
 

--- a/components/romio/src/ome/io/nio/ConfiguredTileSizes.java
+++ b/components/romio/src/ome/io/nio/ConfiguredTileSizes.java
@@ -12,7 +12,7 @@ package ome.io.nio;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.1
- * @see ticket:5952
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/5952">ticket 5952</a>
  */
 public class ConfiguredTileSizes implements TileSizes {
 

--- a/components/romio/src/ome/io/nio/FileBuffer.java
+++ b/components/romio/src/ome/io/nio/FileBuffer.java
@@ -82,36 +82,36 @@ public class FileBuffer extends AbstractBuffer {
     }
 
     /**
-     * Delegates to {@link java.nio.FileChannel}
+     * Delegates to {@link FileChannel}
      * 
-     * @see java.nio.FileChannel#read(java.nio.ByteBuffer)
+     * @see FileChannel#read(ByteBuffer)
      */
     public int read(ByteBuffer dst) throws IOException {
         return getFileChannel().read(dst);
     }
 
     /**
-     * Delegates to {@link java.nio.FileChannel}
+     * Delegates to {@link FileChannel}
      * 
-     * @see java.nio.FileChannel#read(java.nio.ByteBuffer, long)
+     * @see FileChannel#read(ByteBuffer, long)
      */
     public int read(ByteBuffer dst, long position) throws IOException {
         return getFileChannel().read(dst, position);
     }
 
     /**
-     * Delegates to {@link java.nio.FileChannel}
+     * Delegates to {@link FileChannel}
      * 
-     * @see java.nio.FileChannel#write(java.nio.ByteBuffer, long)
+     * @see FileChannel#write(ByteBuffer, long)
      */
     public int write(ByteBuffer src, long position) throws IOException {
         return getFileChannel().write(src, position);
     }
 
     /**
-     * Delegates to {@link java.nio.FileChannel}
+     * Delegates to {@link FileChannel}
      * 
-     * @see java.nio.FileChannel#write(java.nio.ByteBuffer)
+     * @see FileChannel#write(ByteBuffer)
      */
     public int write(ByteBuffer src) throws IOException {
         return getFileChannel().write(src);

--- a/components/romio/src/ome/io/nio/PixelBuffer.java
+++ b/components/romio/src/ome/io/nio/PixelBuffer.java
@@ -625,6 +625,8 @@ public interface PixelBuffer extends Closeable
     
     /**
      * Returns whether or not the pixel buffer has floating point pixels. 
+     * @return {@code true} if the pixel buffer as floating point,
+     *         {@code false} otherwise
      */
     public boolean isFloat();
     
@@ -696,8 +698,11 @@ public interface PixelBuffer extends Closeable
     /**
      * Return a list of lists each of which has sizeX, sizeY for the resolution
      * level matching the index of the outer index. For example, if an image
-     * has 2 resolution levels of size 2048x1024 and 1024x512 then this returns:
+     * has 2 resolution levels of size 2048x1024 and 1024x512 then this
+     * returns:
      * [[2048,1024],[1024,512]]
+     * @return a list of lists containing sizeX, sizeY for each resolution
+     *         level
      *
      */
     public List<List<Integer>> getResolutionDescriptions();

--- a/components/romio/src/ome/io/nio/PixelBuffer.java
+++ b/components/romio/src/ome/io/nio/PixelBuffer.java
@@ -115,7 +115,7 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @return offset of the row or scaline.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public Long getRowOffset(Integer y, Integer z, Integer c, Integer t)
             throws DimensionsOutOfBoundsException;
@@ -128,7 +128,7 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @return offset of the 2D image plane.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public Long getPlaneOffset(Integer z, Integer c, Integer t)
             throws DimensionsOutOfBoundsException;
@@ -141,7 +141,7 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @return offset of the stack.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public Long getStackOffset(Integer c, Integer t)
             throws DimensionsOutOfBoundsException;
@@ -153,7 +153,7 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @return offset of the timepoint.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public Long getTimepointOffset(Integer t)
             throws DimensionsOutOfBoundsException;
@@ -194,7 +194,7 @@ public interface PixelBuffer extends Closeable
      * given 2D image plane. It is guaranteed that this buffer will have been 
      * byte swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
-     * @see getRegionDirect()
+     * @see #getRegionDirect(Integer, Long, byte[])
      */
     public byte[] getPlaneRegionDirect(Integer z, Integer c, Integer t, 
     		Integer count, Integer offset, byte[] buffer)
@@ -213,7 +213,7 @@ public interface PixelBuffer extends Closeable
      * given 2D image plane. It is guaranteed that this buffer will have been
      * byte swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
-     * @see getTileDirect()
+     * @see #getTileDirect(Integer, Integer, Integer, Integer, Integer, Integer, Integer, byte[])
      */
     public PixelData getTile(Integer z, Integer c, Integer t, Integer x,
                              Integer y, Integer w, Integer h)
@@ -233,7 +233,7 @@ public interface PixelBuffer extends Closeable
      * region. It is guaranteed that this buffer will have been byte
      * swapped. <b>The buffer is essentially directly from disk.</b>
      * @throws IOException if there is a problem reading from the pixel buffer.
-     * @see getTile()
+     * @see #getTile(Integer, Integer, Integer, Integer, Integer, Integer, Integer)
      */
     public byte[] getTileDirect(Integer z, Integer c, Integer t, Integer x,
                                 Integer y, Integer w, Integer h, byte[] buffer)
@@ -248,7 +248,7 @@ public interface PixelBuffer extends Closeable
      * backing buffer will have been byte swapped. <b>The buffer is essentially 
      * directly from disk.</b>
      * @throws IOException if there is a problem reading from the pixel buffer.
-     * @see getRegionDirect()
+     * @see #getRegionDirect(Integer, Long, byte[])
      */
     public PixelData getRegion(Integer size, Long offset)
             throws IOException;
@@ -262,7 +262,7 @@ public interface PixelBuffer extends Closeable
      * region. It is guaranteed that this buffer will have been byte 
      * swapped. <b>The buffer is essentially directly from disk.</b>
      * @throws IOException if there is a problem reading from the pixel buffer.
-     * @see getRegion()
+     * @see #getRegion(Integer, Long)
      */
     public byte[] getRegionDirect(Integer size, Long offset, byte[] buffer)
     	throws IOException;
@@ -279,8 +279,8 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
-     * @see getRowDirect()
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
+     * @see #getRowDirect(Integer, Integer, Integer, Integer, byte[])
      */
     public PixelData getRow(Integer y, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException;
@@ -297,8 +297,8 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
-     * @see getColDirect()
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
+     * @see #getColDirect(Integer, Integer, Integer, Integer, byte[])
      */
     public PixelData getCol(Integer x, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException;
@@ -315,8 +315,8 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
-     * @see getRow()
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
+     * @see #getRow(Integer, Integer, Integer, Integer)
      */
     public byte[] getRowDirect(Integer y, Integer z, Integer c, 
     		                   Integer t, byte[] buffer)
@@ -333,8 +333,8 @@ public interface PixelBuffer extends Closeable
      * column. It is guaranteed that this buffer will have been byte swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
-     * @see getCol()
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
+     * @see #getCol(Integer, Integer, Integer, Integer)
      */
     public byte[] getColDirect(Integer x, Integer z, Integer c, 
                                Integer t, byte[] buffer)
@@ -351,7 +351,7 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public PixelData getPlane(Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException;
@@ -373,7 +373,7 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public PixelData getPlaneRegion(Integer x, Integer y, Integer width, Integer
     		height, Integer z, Integer c, Integer t, Integer stride)
@@ -390,7 +390,7 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public byte[] getPlaneDirect(Integer z, Integer c, Integer t, byte[] buffer)
             throws IOException, DimensionsOutOfBoundsException;
@@ -406,7 +406,7 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public PixelData getStack(Integer c, Integer t)
     	throws IOException, DimensionsOutOfBoundsException;
@@ -421,7 +421,7 @@ public interface PixelBuffer extends Closeable
      * stack. It is guaranteed that this buffer will have been byte swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public byte[] getStackDirect(Integer c, Integer t, byte[] buffer) 
     	throws IOException, DimensionsOutOfBoundsException;
@@ -436,7 +436,7 @@ public interface PixelBuffer extends Closeable
      * swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public PixelData getTimepoint(Integer t) 
     	throws IOException, DimensionsOutOfBoundsException;
@@ -449,7 +449,7 @@ public interface PixelBuffer extends Closeable
      * timepoint. It is guaranteed that this buffer will have been byte swapped.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      */
     public byte[] getTimepointDirect(Integer t, byte[] buffer) 
     	throws IOException, DimensionsOutOfBoundsException;
@@ -503,9 +503,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem reading from the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getRowSize()}</code>.
+     * <code>buffer.length > {@link #getRowSize()}</code>.
      */
     public void setRow(ByteBuffer buffer, Integer y, Integer z, Integer c,
             Integer t) throws IOException, DimensionsOutOfBoundsException,
@@ -519,9 +519,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getPlaneSize()}</code>.
+     * <code>buffer.length > {@link #getPlaneSize()}</code>.
      */
     public void setPlane(ByteBuffer buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -535,9 +535,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getPlaneSize()}</code>.
+     * <code>buffer.length > {@link #getPlaneSize()}</code>.
      */
     public void setPlane(byte[] buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -551,9 +551,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getStackSize()}</code>.
+     * <code>buffer.length > {@link #getStackSize()}</code>.
      */
     public void setStack(ByteBuffer buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -568,9 +568,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getStackSize()()}</code>.
+     * <code>buffer.length > {@link #getStackSize()()}</code>.
      */
     public void setStack(byte[] buffer, Integer z, Integer c, Integer t)
             throws IOException, DimensionsOutOfBoundsException,
@@ -583,9 +583,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getTimepointSize()}</code>.
+     * <code>buffer.length > {@link #getTimepointSize()}</code>.
      */
     public void setTimepoint(ByteBuffer buffer, Integer t) throws IOException,
             DimensionsOutOfBoundsException, BufferOverflowException;
@@ -597,9 +597,9 @@ public interface PixelBuffer extends Closeable
      * @param t offset across the T-axis of the pixel buffer.
      * @throws IOException if there is a problem writing to the pixel buffer.
      * @throws DimensionsOutOfBoundsException if offsets are out of bounds
-     * after checking with {@link checkBounds()}.
+     * after checking with {@link #checkBounds(Integer, Integer, Integer, Integer, Integer)}.
      * @throws BufferOverflowException if
-     * <code>buffer.length > {@link getTimepointSize()}</code>.
+     * <code>buffer.length > {@link #getTimepointSize()}</code>.
      */
     public void setTimepoint(byte[] buffer, Integer t) throws IOException,
             DimensionsOutOfBoundsException, BufferOverflowException;
@@ -625,7 +625,6 @@ public interface PixelBuffer extends Closeable
     
     /**
      * Returns whether or not the pixel buffer has floating point pixels. 
-     * @return
      */
     public boolean isFloat();
     
@@ -636,32 +635,32 @@ public interface PixelBuffer extends Closeable
     public String getPath();
 
 	/**
-	 * Delegates to {@link Pixels.getId()}.
+	 * Retrieves the identifier of this pixel buffer
 	 */
 	public long getId();
 	
 	/**
-	 * Delegates to {@link Pixels.getSizeX()}.
+	 * Retrieves the size in X of this pixel buffer
 	 */
 	public int getSizeX();
 
 	/**
-	 * Delegates to {@link Pixels.getSizeY()}.
+	 * Retrieves the size in Y of this pixel buffer
 	 */
 	public int getSizeY();
 
 	/**
-	 * Delegates to {@link Pixels.getSizeZ()}.
+	 * Retrieves the size in Z of this pixel buffer
 	 */
 	public int getSizeZ();
 
 	/**
-	 * Delegates to {@link Pixels.getSizeC()}.
+	 * Retrieves the size in C of this pixel buffer
 	 */
 	public int getSizeC();
 
 	/**
-	 * Delegates to {@link Pixels.getSizeT()}.
+	 * Retrieves the size in T of this pixel buffer
 	 */
 	public int getSizeT();
 
@@ -700,7 +699,6 @@ public interface PixelBuffer extends Closeable
      * has 2 resolution levels of size 2048x1024 and 1024x512 then this returns:
      * [[2048,1024],[1024,512]]
      *
-     * @return
      */
     public List<List<Integer>> getResolutionDescriptions();
 }

--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -592,11 +592,13 @@ public class PixelsService extends AbstractFileSystemService
     }
 
     /**
-     * Returns true if a pyramid should be used for the given {@link Pixels}.
+     * Returns whether a pyramid should be used for the given {@link Pixels}.
      * This usually implies that this is a "Big image" and therefore will
      * need tiling.
      *
      * @param pixels
+     * @return {@code true} if a pyramid should be used, {@code false}
+     *         otherwise
      */
     public boolean requiresPixelsPyramid(Pixels pixels) {
         String type = pixels.getPixelsType().getValue();
@@ -795,6 +797,7 @@ public class PixelsService extends AbstractFileSystemService
      * Helper method to properly log any exceptions raised by Bio-Formats.
      * @param filePath Non-null.
      * @param series series to use
+     * @return the initialized {@link BfPixelBuffer}
      */
     protected BfPixelBuffer createBfPixelBuffer(final String filePath,
                                               final int series) {
@@ -819,6 +822,7 @@ public class PixelsService extends AbstractFileSystemService
      * Helper method to properly log any exceptions raised by Bio-Formats.
      * @param pixels passed to {@link BfPixelBuffer}
      * @param filePath Non-null.
+     * @return the initialized {@link BfPyramidPixelBuffer}
      */
     protected BfPyramidPixelBuffer createPyramidPixelBuffer(final Pixels pixels,
             final String filePath, boolean write) {

--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -139,7 +139,7 @@ public class PixelsService extends AbstractFileSystemService
     }
 
     /**
-     * Call {@link #PixelsService(String, File, long, FilePathResolver, BackOff, TileSizes)}
+     * Call {@link #PixelsService(String, File, long, FilePathResolver, BackOff, TileSizes, IQuery)}
      * with {@link #MEMOIZER_WAIT}.
      */
     public PixelsService(String path, long memoizerWait,
@@ -149,7 +149,7 @@ public class PixelsService extends AbstractFileSystemService
     }
 
     /**
-     * Call {@link #PixelsService(String, File, long, FilePathResolver, BackOff, TileSizes)}
+     * Call {@link #PixelsService(String, File, long, FilePathResolver, BackOff, TileSizes, IQuery)}
      * with {@link #MEMOIZER_WAIT}.
      */
     public PixelsService(String path, File memoizerDirectory,
@@ -597,7 +597,6 @@ public class PixelsService extends AbstractFileSystemService
      * need tiling.
      *
      * @param pixels
-     * @return
      */
     public boolean requiresPixelsPyramid(Pixels pixels) {
         String type = pixels.getPixelsType().getValue();
@@ -713,7 +712,6 @@ public class PixelsService extends AbstractFileSystemService
 	 *
 	 * @param pixels
 	 * @param pixelsPyramidFilePath
-	 * @return
 	 * @throws MissingPyramidException
 	 */
     protected void handleMissingPyramid(Pixels pixels,
@@ -735,10 +733,8 @@ public class PixelsService extends AbstractFileSystemService
      * Helper method to properly log any exceptions raised by Bio-Formats and
      * add a min/max calculator wrapper to the reader stack.
      * @param filePath Non-null.
-     * @param store Min/max store to use with the min/max calculator.
      * @param series series to use
-     * @param reader passed to {@link BfPixelBuffer}
-     * @return
+     * @param store Min/max store to use with the min/max calculator.
      */
     protected BfPixelBuffer createMinMaxBfPixelBuffer(final String filePath,
                                                       final int series,
@@ -798,9 +794,7 @@ public class PixelsService extends AbstractFileSystemService
     /**
      * Helper method to properly log any exceptions raised by Bio-Formats.
      * @param filePath Non-null.
-     * @param reader passed to {@link BfPixelBuffer}
      * @param series series to use
-     * @return
      */
     protected BfPixelBuffer createBfPixelBuffer(final String filePath,
                                               final int series) {
@@ -823,9 +817,8 @@ public class PixelsService extends AbstractFileSystemService
 
     /**
      * Helper method to properly log any exceptions raised by Bio-Formats.
+     * @param pixels passed to {@link BfPixelBuffer}
      * @param filePath Non-null.
-     * @param reader passed to {@link BfPixelBuffer}
-     * @return
      */
     protected BfPyramidPixelBuffer createPyramidPixelBuffer(final Pixels pixels,
             final String filePath, boolean write) {
@@ -855,7 +848,6 @@ public class PixelsService extends AbstractFileSystemService
      * @param pixelsFilePath
      * @param pixels
      * @param allowModification
-     * @return
      */
     protected PixelBuffer createRomioPixelBuffer(String pixelsFilePath,
         Pixels pixels, boolean allowModification) {
@@ -866,7 +858,7 @@ public class PixelsService extends AbstractFileSystemService
 	 * Removes files from data repository based on a parameterized List of Long
 	 * pixels ids
 	 *
-	 * @param pixelsIds Long file keys to be deleted
+	 * @param pixelIds Long file keys to be deleted
 	 * @throws ResourceError If deletion fails.
 	 */
 	public void removePixels(List<Long> pixelIds) {

--- a/components/romio/src/ome/io/nio/ReorderedPixelData.java
+++ b/components/romio/src/ome/io/nio/ReorderedPixelData.java
@@ -17,13 +17,13 @@ import ome.util.PixelData;
  * Represents a block of pixel data that needs to be re-ordered in accordance 
  * with a DeltaVision file. <b>NOTE:</b> This buffer does not re-order the
  * actual backing buffer so <code>read-only</code> buffers may be used and 
- * potential callers of {@link getData()} should be aware of this restriction.
+ * potential callers of {@link #getData()} should be aware of this restriction.
  *
  * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:chris@glencoesoftware.com">chris@glencoesoftware.com</a>
  * @version $Revision$
  * @since 3.0
- * @see PixelBuffer
+ * @see PixelData
  */
 public class ReorderedPixelData extends PixelData
 {

--- a/components/romio/src/ome/io/nio/RomioPixelBuffer.java
+++ b/components/romio/src/ome/io/nio/RomioPixelBuffer.java
@@ -438,7 +438,7 @@ public class RomioPixelBuffer extends AbstractBuffer implements PixelBuffer {
 
     /**
      * Implemented as specified by {@link PixelBuffer} I/F.
-     * @see PixelBuffer#getHypercube(List<Integer>, IList<Integer>, List<Integer>)
+     * @see PixelBuffer#getHypercube(List, List, List)
 	 */
     public PixelData getHypercube(List<Integer> offset, List<Integer> size, 
             List<Integer> step) throws IOException, DimensionsOutOfBoundsException 
@@ -451,7 +451,7 @@ public class RomioPixelBuffer extends AbstractBuffer implements PixelBuffer {
                 
     /**
      * Implemented as specified by {@link PixelBuffer} I/F.
-     * @see PixelBuffer#getHypercubeDirect(List<Integer>, IList<Integer>, List<Integer>, byte[])
+     * @see PixelBuffer#getHypercubeDirect(List, List, List, byte[])
 	 */
     public byte[] getHypercubeDirect(List<Integer> offset, List<Integer> size, 
             List<Integer> step, byte[] buffer) 
@@ -504,7 +504,7 @@ public class RomioPixelBuffer extends AbstractBuffer implements PixelBuffer {
     }
     
     /**
-     * Implemented as specified by {@link PixelBuffer} I/F.
+     * Implemented as specified by {@link ByteBuffer} I/F.
      * @see PixelBuffer#getPlaneRegion(Integer, Integer, Integer, Integer, 
      * Integer, Integer, Integer, Integer)
 	 */

--- a/components/romio/src/ome/io/nio/SimpleBackOff.java
+++ b/components/romio/src/ome/io/nio/SimpleBackOff.java
@@ -28,7 +28,7 @@ import org.perf4j.slf4j.Slf4JStopWatch;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.1
- * @see ticket:5910
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/5910">ticket 5910</a>
  */
 public class SimpleBackOff implements BackOff {
 

--- a/components/romio/src/ome/io/nio/ThumbnailService.java
+++ b/components/romio/src/ome/io/nio/ThumbnailService.java
@@ -58,7 +58,6 @@ public class ThumbnailService extends AbstractFileSystemService {
 	 * Returns length of Thumbnail on disk
 	 * 
 	 * @param thumbnail
-	 * @return
 	 */
 	public long getThumbnailLength(Thumbnail thumbnail) {
 		File f = new File(getThumbnailPath(thumbnail.getId()));
@@ -69,7 +68,6 @@ public class ThumbnailService extends AbstractFileSystemService {
 	 * Return byte array of Thumbnail
 	 * 
 	 * @param thumbnail
-	 * @return
 	 * @throws IOException
 	 */
 	public byte[] getThumbnail(Thumbnail thumbnail) throws IOException {
@@ -82,7 +80,6 @@ public class ThumbnailService extends AbstractFileSystemService {
 	 * 
 	 * @param thumbnail
 	 * @param buf
-	 * @return
 	 * @throws IOException
 	 */
 	public byte[] getThumbnail(Thumbnail thumbnail, byte[] buf)
@@ -101,7 +98,6 @@ public class ThumbnailService extends AbstractFileSystemService {
 	 * Return FileOutputStream of Thumbnail
 	 * 
 	 * @param thumbnail
-	 * @return
 	 * @throws IOException
 	 */
 	public FileOutputStream getThumbnailOutputStream(Thumbnail thumbnail)

--- a/components/romio/src/ome/io/nio/ThumbnailService.java
+++ b/components/romio/src/ome/io/nio/ThumbnailService.java
@@ -25,91 +25,94 @@ import ome.util.Utils;
  */
 public class ThumbnailService extends AbstractFileSystemService {
 
-	/* The logger for this class. */
-	private transient static Logger log = LoggerFactory
-			.getLogger(ThumbnailService.class);
+    /* The logger for this class. */
+    private transient static Logger log = LoggerFactory
+            .getLogger(ThumbnailService.class);
 
-	/**
-	 * Constructor
-	 * @param path
-	 */
-	public ThumbnailService(String path) {
-		super(path);
-	}
+    /**
+     * Constructor
+     * @param path
+     */
+    public ThumbnailService(String path) {
+        super(path);
+    }
 
-	/**
-	 * Creates thumbnail on disk using byte array
-	 * 
-	 * @param thumbnail
-	 * @param buf
-	 * @throws IOException
-	 */
-	public void createThumbnail(Thumbnail thumbnail, byte[] buf)
-			throws IOException {
-		String path = getThumbnailPath(thumbnail.getId());
-		createSubpath(path);
+    /**
+     * Creates thumbnail on disk using byte array
+     *
+     * @param thumbnail
+     * @param buf
+     * @throws IOException
+     */
+    public void createThumbnail(Thumbnail thumbnail, byte[] buf)
+            throws IOException {
+        String path = getThumbnailPath(thumbnail.getId());
+        createSubpath(path);
 
-		FileOutputStream stream = new FileOutputStream(path);
-		stream.write(buf);
-		stream.close();
-	}
+        FileOutputStream stream = new FileOutputStream(path);
+        stream.write(buf);
+        stream.close();
+    }
 
-	/**
-	 * Returns length of Thumbnail on disk
-	 * 
-	 * @param thumbnail
-	 */
-	public long getThumbnailLength(Thumbnail thumbnail) {
-		File f = new File(getThumbnailPath(thumbnail.getId()));
-		return f.length();
-	}
+    /**
+     * Returns length of Thumbnail on disk
+     *
+     * @param thumbnail
+     */
+    public long getThumbnailLength(Thumbnail thumbnail) {
+        File f = new File(getThumbnailPath(thumbnail.getId()));
+        return f.length();
+    }
 
-	/**
-	 * Return byte array of Thumbnail
-	 * 
-	 * @param thumbnail
-	 * @throws IOException
-	 */
-	public byte[] getThumbnail(Thumbnail thumbnail) throws IOException {
-		byte[] buf = new byte[(int) getThumbnailLength(thumbnail)];
-		return getThumbnail(thumbnail, buf);
-	}
+    /**
+     * Return byte array of Thumbnail
+     *
+     * @param thumbnail
+     * @return a byte array
+     * @throws IOException
+     */
+    public byte[] getThumbnail(Thumbnail thumbnail) throws IOException {
+        byte[] buf = new byte[(int) getThumbnailLength(thumbnail)];
+        return getThumbnail(thumbnail, buf);
+    }
 
-	/**
-	 * Return byte array of Thumbnail, providing byte array
-	 * 
-	 * @param thumbnail
-	 * @param buf
-	 * @throws IOException
-	 */
-	public byte[] getThumbnail(Thumbnail thumbnail, byte[] buf)
-			throws IOException {
-		String path = getThumbnailPath(thumbnail.getId());
-		FileInputStream stream = new FileInputStream(path);
-		try {
-		    stream.read(buf, 0, buf.length);
-		} finally {
-		    Utils.closeQuietly(stream);
-		}
-		return buf;
-	}
+    /**
+     * Return byte array of Thumbnail, providing byte array
+     *
+     * @param thumbnail
+     * @param buf
+     * @return a byte array
+     * @throws IOException
+     */
+    public byte[] getThumbnail(Thumbnail thumbnail, byte[] buf)
+            throws IOException {
+        String path = getThumbnailPath(thumbnail.getId());
+        FileInputStream stream = new FileInputStream(path);
+        try {
+            stream.read(buf, 0, buf.length);
+        } finally {
+            Utils.closeQuietly(stream);
+        }
+        return buf;
+    }
 
-	/**
-	 * Return FileOutputStream of Thumbnail
-	 * 
-	 * @param thumbnail
-	 * @throws IOException
-	 */
-	public FileOutputStream getThumbnailOutputStream(Thumbnail thumbnail)
-			throws IOException {
-		String path = getThumbnailPath(thumbnail.getId());
-		createSubpath(path);
-		return new FileOutputStream(path);
-	}
+    /**
+     * Return FileOutputStream of Thumbnail
+     * 
+     * @param thumbnail
+     * @return a {@link FileOutputStream}
+     * @throws IOException
+     */
+    public FileOutputStream getThumbnailOutputStream(Thumbnail thumbnail)
+            throws IOException {
+        String path = getThumbnailPath(thumbnail.getId());
+        createSubpath(path);
+        return new FileOutputStream(path);
+    }
 
     /**
      * Returns whether or not a thumbnail exists on disk.
-     * 
+     *
      * @param thumbnail The thumbnail metadata.
      * @return See above.
      */
@@ -119,39 +122,39 @@ public class ThumbnailService extends AbstractFileSystemService {
         return new File(path).exists();
     }
 
-	/**
-	 * Removes files from data repository based on a parameterized List of Long
-	 * thumbnail ids
-	 * 
-	 * @param thumbnailIds -
-	 *            Long file keys to be deleted
-	 * @throws ResourceError If deletion fails.
-	 */
-	public void removeThumbnails(List<Long> thumbnailIds) {
-		File file;
-		boolean success = false;
+    /**
+     * Removes files from data repository based on a parameterized List of Long
+     * thumbnail ids
+     *
+     * @param thumbnailIds -
+     *            Long file keys to be deleted
+     * @throws ResourceError If deletion fails.
+     */
+    public void removeThumbnails(List<Long> thumbnailIds) {
+        File file;
+        boolean success = false;
 
-		for (Long id : thumbnailIds)
-		{
-			String thumbnailPath = getThumbnailPath(id);
-			file = new File(thumbnailPath);
-			if (file.exists())
-			{
-				success = file.delete();
-				if (!success)
-				{
-					throw new ResourceError("Thumbnail " + file.getName()
-							+ " deletion failed");
-				}
-				else
-				{
-					if (log.isInfoEnabled())
-					{
-						log.info("INFO: Thumbnail " + file.getName()
-								+ " deleted.");
-					}
-				}
-			}
-		}
-	}
+        for (Long id : thumbnailIds)
+        {
+            String thumbnailPath = getThumbnailPath(id);
+            file = new File(thumbnailPath);
+            if (file.exists())
+            {
+                success = file.delete();
+                if (!success)
+                {
+                    throw new ResourceError("Thumbnail " + file.getName()
+                            + " deletion failed");
+                }
+                else
+                {
+                    if (log.isInfoEnabled())
+                    {
+                        log.info("INFO: Thumbnail " + file.getName()
+                                + " deleted.");
+                    }
+                }
+            }
+        }
+    }
 }

--- a/components/romio/src/ome/io/nio/TileSizes.java
+++ b/components/romio/src/ome/io/nio/TileSizes.java
@@ -13,7 +13,7 @@ package ome.io.nio;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3.1
- * @see ticket:5192
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/5192">ticket 5192</a>
  */
 public interface TileSizes {
 

--- a/components/romio/src/ome/io/nio/Utils.java
+++ b/components/romio/src/ome/io/nio/Utils.java
@@ -44,7 +44,6 @@ public class Utils
      * Iterates over every tile in a given pixel buffer based on the
      * over arching dimensions and a requested maximum tile width and height.
      * @param iteration Invoker to call for each tile.
-     * @param pixelBuffer Pixel buffer which is backing the pixel data.
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
      * <code>x + tileWidth > sizeX</code>.


### PR DESCRIPTION
As part of the build system cleanup, this PR reviews the Javadoc warnings for the `rendering` and `romio` components of the server. 

To test this PR, check no more warning is reported for either component when running `./build.py build-default`.