### PR TITLE
Temporary web UI workarounds

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -518,6 +518,7 @@ class BaseContainer(BaseController):
             aList = list(self.acquisition.listAnnotations())
         elif self.well is not None:
             aList = list(self.well.getWellSample().image().listAnnotations())
+            aList.extend(self.well.listAnnotations())
 
         for ann in aList:
             annClass = ann._obj.__class__

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -58,6 +58,9 @@
                 {% endif %}
                 linkify_element($( ".commentText" ));
 
+                // Temporary hack to get links to show in MapAnnotations
+                linkify_element($( "table.keyValueTable tbody tr td" ));
+
                 var acquisition_load = false;
                 var preview_load = false;
                 var hierarchy_load = false;


### PR DESCRIPTION
Temporary OMERO.web workarounds so that other metadata PRs can be viewed:
- Display Well annotations as well as Image annotations e.g. Bulk-MapAnnotations from #4037 (normally only Image Annotations are shown when a Well is selected).
- Linkify keys/values in MapAnnotations

--on-hold