### PR TITLE
Display full name

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -1104,7 +1104,6 @@ class BrowserComponent
 		 if (model.getState() == DISCARDED)
 			 throw new IllegalStateException("This method cannot be invoked "+
 	                "in the DISCARDED state.");
-		 System.err.println(view.isPartialName());
 		 PartialNameVisitor v = new PartialNameVisitor(view.isPartialName());
 		 accept(v);
 		 view.repaint();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -1104,8 +1104,9 @@ class BrowserComponent
 		 if (model.getState() == DISCARDED)
 			 throw new IllegalStateException("This method cannot be invoked "+
 	                "in the DISCARDED state.");
+		 System.err.println(view.isPartialName());
 		 PartialNameVisitor v = new PartialNameVisitor(view.isPartialName());
-		 accept(v, TreeImageDisplayVisitor.TREEIMAGE_NODE_ONLY);
+		 accept(v);
 		 view.repaint();
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -315,7 +315,7 @@ class BrowserUI
         partialButton = new JToggleButton(
         				controller.getAction(BrowserControl.PARTIAL_NAME));
         partialButton.setBorderPainted(true);
-        //rightMenuBar.add(partialButton);
+        rightMenuBar.add(partialButton);
         rightMenuBar.add(new JSeparator(JSeparator.VERTICAL));
         button = new JButton(controller.getAction(BrowserControl.COLLAPSE));
         button.setBorderPainted(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/TreeCellRenderer.java
@@ -789,7 +789,7 @@ public class TreeCellRenderer
             int v = getPreferredSize().width;
             Rectangle r = getBounds();
             w = w-r.x;
-            if (v > w) {
+            if (v > w && node.isPartialName()) {
                 //truncate the text
                 int targetWidth = (w - getIconGap() - 5);
                 String value = text;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/PartialNameVisitor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/PartialNameVisitor.java
@@ -66,7 +66,6 @@ public class PartialNameVisitor
 	 */
 	public void visit(TreeImageNode node)
 	{
-		if (node.isPartialName() == partialName) return;
 		node.setPartialName(partialName);
 	}
 
@@ -75,6 +74,9 @@ public class PartialNameVisitor
 	 * implementation in our case.
 	 * @see TreeImageDisplayVisitor#visit(TreeImageSet)
 	 */
-	public void visit(TreeImageSet node) {}
+	public void visit(TreeImageSet node)
+	{
+	    node.setPartialName(partialName);
+	}
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
@@ -216,14 +216,14 @@ public abstract class TreeImageDisplay
      * @param b The value to set.
      */
     void setPartialName(boolean b) { partialName = b; }
-    
+
     /**
      * Returns <code>true</code> if the partial name of the node is shown, 
      * <code>false</code> otherwise.
      * 
      * @return See above.
      */
-    boolean isPartialName() { return partialName; }
+    public boolean isPartialName() { return partialName; }
     
     /**
      * Sets to <code>true</code> if the node is expanded, 


### PR DESCRIPTION
Re-add control to display the  full name  w/o having to expand the
left hand pane.

To test: 
 * Log in as any user
 * Click on the "Abc" button to display the full name
 * Check that the full name is displayed

This PR brings back a feature removed in gh-3770

cc @gusferguson @mporter-gre 