### PR TITLE
Skip testTiles if Python is not 2.7 or above

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -4,7 +4,7 @@
 """
    Tests for the stateful RawPixelsStore service.
 
-   Copyright 2011-2014 Glencoe Software, Inc. All rights reserved.
+   Copyright 2011-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -12,6 +12,8 @@
 import omero
 import threading
 import library as lib
+import pytest
+__import__("sys")
 
 from omero.util.tiles import TileLoopIteration
 from omero.util.tiles import RPSTileLoop
@@ -221,6 +223,8 @@ class TestRPS(lib.ITest):
 
 class TestTiles(lib.ITest):
 
+    @pytest.mark.skipif("sys.version_info < (2,7)",
+                        reason="This fails with Python < 2.7 and Ice >= 3.5")
     def testTiles(self):
         from omero.model import PixelsI
         from omero.sys import ParametersI


### PR DESCRIPTION
With the Ice3.5 and Python 2.6 the following test fails (due to changes in Ice effectively), see:

https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/50/testReport/OmeroPy.test.integration.test_rawpixelsstore/TestTiles/testTiles/

This PR skips that test unless Python is 2.7 or higher. This commit can be reverted once support of Python 2.6 is removed. The awkward mport is due to `flake8`.

The above test should be skipped on that ci node, it should pass locally with Python 2.7 and Ice 3.5.

--no-rebase
