### PR TITLE
Fixed storing of ROIs from non-hyperstack images from ImageJ

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -324,13 +324,13 @@ public class ROIReader {
     {
         if (image == null) return null;
         Overlay overlay = image.getOverlay();
-        Roi[] rois = overlay.toArray();
+        if (overlay == null) return null;
         
+        Roi[] rois = overlay.toArray();
         for (Roi roi : rois) {
-        	roi.setImage(image);
+            roi.setImage(image);
         }
         
-        if (overlay == null) return null;
         return read(imageID, rois);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -207,10 +207,28 @@ public class ROIReader {
         if (roi.getFillColor() != null) {
             settings.setFill(roi.getFillColor());
         }
-
+      
+        int pos = roi.getPosition();
         int c = roi.getCPosition();
         int z = roi.getZPosition();
         int t = roi.getTPosition();
+        
+        ImagePlus image = roi.getImage();        
+        if (!image.isHyperStack()) {
+			int imageC = image.getNChannels();
+			int imageT = image.getNFrames();
+        	
+        	if (imageT > 1) {
+        		shape.setC(0);
+        		shape.setZ(0);
+        		t = pos;
+        	} else if (imageC > 1) {
+        		c = pos;
+        		shape.setZ(0);
+        		shape.setT(0);
+        	}
+        }
+        
         if (c != 0) {
             shape.setC(c-1);
         }
@@ -306,8 +324,14 @@ public class ROIReader {
     {
         if (image == null) return null;
         Overlay overlay = image.getOverlay();
+        Roi[] rois = overlay.toArray();
+        
+        for (Roi roi : rois) {
+        	roi.setImage(image);
+        }
+        
         if (overlay == null) return null;
-        return read(imageID, overlay.toArray());
+        return read(imageID, rois);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -215,18 +215,18 @@ public class ROIReader {
         
         ImagePlus image = roi.getImage();        
         if (!image.isHyperStack()) {
-			int imageC = image.getNChannels();
-			int imageT = image.getNFrames();
-        	
-        	if (imageT > 1) {
-        		shape.setC(0);
-        		shape.setZ(0);
-        		t = pos;
-        	} else if (imageC > 1) {
-        		c = pos;
-        		shape.setZ(0);
-        		shape.setT(0);
-        	}
+            int imageC = image.getNChannels();
+            int imageT = image.getNFrames();
+
+            if (imageT > 1) {
+                shape.setC(0);
+                shape.setZ(0);
+                t = pos;
+            } else if (imageC > 1) {
+                c = pos;
+                shape.setZ(0);
+                shape.setT(0);
+            }
         }
         
         if (c != 0) {


### PR DESCRIPTION
ROIs aren't imported with their correct positions to OMERO because of the weird hyperstack handling of ImageJ. This PR fixes the issue for images with the following dimensions:
* C=1, Z=1, T=5
* C=3, Z=1, T=5
* C=1, Z=3, T=5
* C=3, Z=1, T=1
* C=1, Z=3, T=1