### PR TITLE
Fix composite ROI import from ImageJ

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -270,6 +270,7 @@ public class ROIReader {
                 Roi shape;
                 for (int j = 0; j < subRois.length; j++) {
                     shape = subRois[j];
+                    type = shape.getTypeAsString();
                     if (shape instanceof Line) {
                         roiData.addShapeData(convertLine((Line) shape));
                     } else if (shape instanceof OvalRoi) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -270,6 +270,25 @@ public class ROIReader {
                 Roi shape;
                 for (int j = 0; j < subRois.length; j++) {
                     shape = subRois[j];
+                    
+                    // Set ImagePlus reference in subROIs for the check in L216 to work
+                    ImagePlus imp = r.getImage();
+                    if (imp != null) {
+                    	shape.setImage(imp);
+                    }
+                    
+                    // Transfer correct ROI positions (according to IJ) from superROI
+                    int pos = r.getPosition();
+                    int c = r.getCPosition();
+                    int z = r.getZPosition();
+                    int t = r.getTPosition();
+                    
+                    if (c == 0 || z == 0 || t == 0) {
+                    	shape.setPosition(pos);
+                    } else {
+                    	shape.setPosition(c, z, t);
+                    }
+                    
                     type = shape.getTypeAsString();
                     if (shape instanceof Line) {
                         roiData.addShapeData(convertLine((Line) shape));


### PR DESCRIPTION
The subROIs of a composite ROI were never actually read because the type of the parent was checked instead of the subROI's type.

Furthermore, the position of the subROIs is not properly set if they are acquired via ```ShapeRoi.getRois()```. If have fixed that for now, but it might also be a good idea to propose a change to Wayne to address that issue on the IJ side. This fix is crucial for PR #4045 to work properly.