### PR TITLE
Add ability to run scripts against fa's from OMERO.Insight

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AcquisitionDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AcquisitionDataUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.editor.AcquisitionDataUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -603,7 +603,7 @@ class AcquisitionDataUI
 		DocComponent doc;
 		docPane.removeAll();
 		while (i.hasNext()) {
-			docPane.add(new DocComponent(i.next(), model, false));
+			docPane.add(new DocComponent(i.next(), model, false, false));
 		}
 		revalidate();
 		repaint();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
@@ -421,17 +421,17 @@ class AnnotationDataUI
 		removeOtherAnnotationsButton.setActionCommand(
 				""+EditorControl.REMOVE_OTHER_ANNOTATIONS);
 		
-		selectButton = new JButton(icons.getIcon(IconManager.SCRIPT_WITH_UI));
-		selectButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-		selectButton.setToolTipText("Select Files for Scripts");
-		selectButton.addMouseListener(new MouseAdapter() {
-            
+        selectButton = new JButton(icons.getIcon(IconManager.SCRIPT_WITH_UI));
+        selectButton.setBackground(UIUtilities.BACKGROUND_COLOR);
+        selectButton.setToolTipText("Select Files for Scripts");
+        selectButton.addMouseListener(new MouseAdapter() {
+
             public void mouseReleased(MouseEvent e) {
                 if (selectButton.isEnabled()) {
                     setFileAnnotationSelectable(!isFileAnnotationSelectable());
                 }
             }
-        
+
         });
         UIUtilities.unifiedButtonLookAndFeel(selectButton);
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
@@ -1873,6 +1873,7 @@ class AnnotationDataUI
 		content.revalidate();
 		content.repaint();
 		mapsPane.clear();
+		setFileAnnotationSelectable(false);
 		revalidate();
 		repaint();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
@@ -421,7 +421,7 @@ class AnnotationDataUI
 		removeOtherAnnotationsButton.setActionCommand(
 				""+EditorControl.REMOVE_OTHER_ANNOTATIONS);
 		
-        selectButton = new JButton(icons.getIcon(IconManager.SCRIPT_WITH_UI));
+        selectButton = new JButton(icons.getIcon(IconManager.ANALYSIS));
         selectButton.setBackground(UIUtilities.BACKGROUND_COLOR);
         selectButton.setToolTipText("Select Files for Scripts");
         selectButton.addMouseListener(new MouseAdapter() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationDataUI.java
@@ -158,6 +158,9 @@ class AnnotationDataUI
 	/** Button to remove all tags. */
 	private JButton							removeTagsButton;
 	
+	/** Button to make the FileAnnotations selectable */
+	private JButton selectButton;
+	
 	/** Button to remove the rate of the object. */
 	private JButton							unrateButton;
 	
@@ -226,6 +229,9 @@ class AnnotationDataUI
 	
 	/** The component displaying the MapAnnotations */
 	private MapAnnotationsComponent mapsPane;
+	
+	/** Flag to indicate if the FileAnnotations should be selectable */
+	private boolean selectable;
 	
 	/**
 	 * Creates and displays the menu 
@@ -415,6 +421,20 @@ class AnnotationDataUI
 		removeOtherAnnotationsButton.setActionCommand(
 				""+EditorControl.REMOVE_OTHER_ANNOTATIONS);
 		
+		selectButton = new JButton(icons.getIcon(IconManager.SCRIPT_WITH_UI));
+		selectButton.setBackground(UIUtilities.BACKGROUND_COLOR);
+		selectButton.setToolTipText("Select Files for Scripts");
+		selectButton.addMouseListener(new MouseAdapter() {
+            
+            public void mouseReleased(MouseEvent e) {
+                if (selectButton.isEnabled()) {
+                    setFileAnnotationSelectable(!isFileAnnotationSelectable());
+                }
+            }
+        
+        });
+        UIUtilities.unifiedButtonLookAndFeel(selectButton);
+        
 		selectedValue = 0;
 		initialValue = selectedValue;
 		rating = new RatingComponent(selectedValue, 
@@ -464,20 +484,37 @@ class AnnotationDataUI
 	}
 	
 	/**
-	 * Creates a tool bar and adds the passed buttons to it.
-	 * 
-	 * @param addButton The button to add.
-	 * @param removeButton The button to add.
+	 * Returns if the FileAnnotations are selectable
 	 * @return See above.
 	 */
-	private JToolBar createBar(JButton addButton, JButton removeButton)
+	private boolean isFileAnnotationSelectable() {
+	    return this.selectable;
+	}
+	
+	/**
+	 * Make the FileAnnotations selectable
+	 * @param b Pass <code>true</code> to make them selectable, 
+	 * <code>false</code> otherwise
+	 */
+	private void setFileAnnotationSelectable(boolean b) {
+	    this.selectable = b;
+	    filterAnnotations();
+	}
+	
+	/**
+	 * Creates a tool bar and adds the passed buttons to it.
+	 * 
+	 * @param buttons The buttons to add.
+	 * @return See above.
+	 */
+	private JToolBar createBar(JButton... buttons)
 	{
 		JToolBar bar = new JToolBar();
 		bar.setFloatable(false);
 		bar.setBorder(null);
 		bar.setBackground(UIUtilities.BACKGROUND_COLOR);
-		if (addButton != null) bar.add(addButton);
-		if (removeButton != null) bar.add(removeButton);
+		for (JButton button : buttons)
+		    bar.add(button);
 		return bar;
 	}
 	
@@ -520,7 +557,7 @@ class AnnotationDataUI
 		}
 
 		// filters
-		content.add(createBar(filterButton, null), c);
+		content.add(createBar(filterButton), c);
 		c.gridy++;
 
 		// rating
@@ -531,7 +568,7 @@ class AnnotationDataUI
 		JPanel p = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 		p.setBackground(UIUtilities.BACKGROUND_COLOR);
 		p.add(UIUtilities.setTextFont("Rating:", Font.BOLD, size));
-		p.add(createBar(unrateButton, null));
+		p.add(createBar(unrateButton));
 		content.add(p, c);
 		c.gridx = 1;
 		c.weightx = 1;
@@ -561,7 +598,7 @@ class AnnotationDataUI
 		p = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 		p.setBackground(UIUtilities.BACKGROUND_COLOR);
 		p.add(UIUtilities.setTextFont("Attachments:", Font.BOLD, size));
-		p.add(createBar(addDocsButton, removeDocsButton));
+		p.add(createBar(addDocsButton, removeDocsButton, selectButton));
 		content.add(p, c);
 		c.gridy++;
 		content.add(docRef, c);
@@ -578,7 +615,7 @@ class AnnotationDataUI
 			p = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 			p.setBackground(UIUtilities.BACKGROUND_COLOR);
 			p.add(UIUtilities.setTextFont("Others:", Font.BOLD, size));
-			p.add(createBar(null, removeOtherAnnotationsButton));
+			p.add(createBar( removeOtherAnnotationsButton));
 			content.add(p, c);
 			c.gridy++;
 			content.add(otherPane, c);
@@ -600,6 +637,25 @@ class AnnotationDataUI
 		return p;
 	}
   
+	/**
+	 * Returns the selected FileAnnotations or an empty Collection
+	 * if there are no FileAnnotations
+	 * 
+	 * @return See above
+	 */
+    public Collection<FileAnnotationData> getSelectedFileAnnotations() {
+        Collection<FileAnnotationData> annos = new ArrayList<FileAnnotationData>();
+        for (Component comp : docPane.getComponents()) {
+            if (comp instanceof DocComponent) {
+                DocComponent doc = (DocComponent) comp;
+                if (doc.isSelected()
+                        && (doc.getData() instanceof FileAnnotationData)) {
+                    annos.add((FileAnnotationData) doc.getData());
+                }
+            }
+        }
+        return annos;
+    }
 	
 	/** 
 	 * Lays out the attachments. 
@@ -624,7 +680,7 @@ class AnnotationDataUI
 					while (i.hasNext()) {
 						data = (DataObject) i.next();
 						if (!toReplace.contains(data)) {
-							doc = new DocComponent(data, model);
+							doc = new DocComponent(data, model, true, selectable);
 							doc.addPropertyChangeListener(controller);
 							if (doc.hasThumbnailToLoad()) {
 								loadThumbnails.put((FileAnnotationData) data, 
@@ -641,7 +697,7 @@ class AnnotationDataUI
 					while (i.hasNext()) {
 						data = (DataObject) i.next();
 						if (!toReplace.contains(data)) {
-							doc = new DocComponent(data, model);
+							doc = new DocComponent(data, model, true, selectable);
 							doc.addPropertyChangeListener(controller);
 							filesDocList.add(doc);
 							if (model.isAnnotatedByOther(data)) {
@@ -660,7 +716,7 @@ class AnnotationDataUI
 					while (i.hasNext()) {
 						data = (DataObject) i.next();
 						if (!toReplace.contains(data)) {
-							doc = new DocComponent(data, model);
+							doc = new DocComponent(data, model, true, selectable);
 							doc.addPropertyChangeListener(controller);
 							filesDocList.add(doc);
 							if (model.isLinkOwner(data)) {
@@ -684,7 +740,7 @@ class AnnotationDataUI
 			*/
 		}
 		if (filesDocList.size() == 0 || docPane.getComponentCount() == 0) {
-			doc = new DocComponent(null, model);
+			doc = new DocComponent(null, model, true, false);
 			filesDocList.add(doc);
 			docPane.add(doc);
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -42,6 +42,7 @@ import java.util.Map.Entry;
 import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -198,7 +199,13 @@ class DocComponent
 
 	/** Flag indicating if it is a XML modulo annotation.*/
 	private boolean isModulo;
-
+	
+	/** Flag inidicating if the component is selectable */
+	private boolean selectable;
+	
+	/** Checkbox which enables the component to be selected */
+	private JCheckBox checkbox;
+	
 	/**
 	 * Enables or disables the various buttons depending on the passed value.
 	 * Returns <code>true</code> if some controls are visible, 
@@ -585,6 +592,7 @@ class DocComponent
 		initButtons();
 		label = new JLabel();
 		label.setForeground(UIUtilities.DEFAULT_FONT_COLOR);
+		checkbox = new JCheckBox();
 		if (data == null) {
 			label.setText(AnnotationUI.DEFAULT_TEXT);
 		} else {
@@ -720,6 +728,8 @@ class DocComponent
 	{
 		setBackground(UIUtilities.BACKGROUND_COLOR);
 		setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
+		if (selectable)
+		    add(checkbox);
 		add(label);
 		JToolBar bar = new JToolBar();
 		bar.setBackground(UIUtilities.BACKGROUND_COLOR);
@@ -791,8 +801,10 @@ class DocComponent
 	 * @param deletable Pass <code>false</code> to indicate that the document
 	 *					cannot be deleted regardless of the permissions,
 	 *					<code>true</code> otherwise.
+	 * @param selectable Pass <code>true</code> to add a checkbox, so that the component
+	 *                     can be selected
 	 */
-	DocComponent(Object data, EditorModel model, boolean deletable)
+	DocComponent(Object data, EditorModel model, boolean deletable, boolean selectable)
 	{
 		if (model == null)
 			throw new IllegalArgumentException("No Model.");
@@ -800,6 +812,7 @@ class DocComponent
 		this.model = model;
 		this.data = data;
 		this.deletable = deletable;
+		this.selectable = selectable;
 		initComponents();
 		buildGUI();
 	}
@@ -812,7 +825,7 @@ class DocComponent
 	 */
 	DocComponent(Object data, EditorModel model)
 	{
-		this(data, model, true);
+		this(data, model, true, false);
 	}
 	
 	/**
@@ -831,7 +844,7 @@ class DocComponent
 	 * 
 	 * @return See above.
 	 */
-	Object getData() { return data; }
+	public Object getData() { return data; }
 
 	/**
 	 * Returns <code>true</code> if the description of the tag has been 
@@ -860,6 +873,16 @@ class DocComponent
 	 * @return See above.
 	 */
 	boolean isImageLoaded() { return thumbnail != null; }
+	
+	/**
+	 * Returns <code>true</code> if the component is selected,
+	 * <code>false</code> otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean isSelected() {
+	    return selectable && checkbox.isSelected();
+	}
 	
 	/**
 	 * Returns <code>true</code> if the object can be unlinked,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -546,4 +546,13 @@ public interface Editor
     void setLDAPDetails(long userID, String result);
 
     ScriptObject getScriptFromName(String name);
+    
+    /**
+     * Returns the selected FileAnnotations or an empty Collection
+     * if there are no FileAnnotations
+     * 
+     * @return See above
+     */
+    public Collection<FileAnnotationData> getSelectedFileAnnotations();
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -1233,4 +1233,12 @@ class EditorComponent
     {
         return model.getScriptFromName(name);
     }
+    
+    /** 
+     * Implemented as specified by the {@link Editor} interface.
+     * @see Editor#getSelectedFileAnnotations()
+     */
+    public Collection<FileAnnotationData> getSelectedFileAnnotations() {
+        return view.getSelectedFileAnnotations();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -1097,4 +1097,13 @@ class EditorUI
 	    userUI.setLDAPDetails(result);
 	}
 
+	/**
+     * Returns the selected FileAnnotations or an empty Collection
+     * if there are no FileAnnotations
+     * 
+     * @return See above
+     */
+	public Collection<FileAnnotationData> getSelectedFileAnnotations() { 
+	    return generalPane.getSelectedFileAnnotations();
+	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -555,4 +555,13 @@ class GeneralPaneUI
 		annotationUI.onRelatedNodesSet();
 	}
 	
+	/**
+     * Returns the selected FileAnnotations or an empty Collection
+     * if there are no FileAnnotations
+     * 
+     * @return See above
+     */
+	public Collection<FileAnnotationData> getSelectedFileAnnotations() {
+	    return annotationUI.getSelectedFileAnnotations();
+	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -264,6 +264,13 @@ public interface MetadataViewer
 	 */
 	public JComponent getEditorUI();
 	
+	/**
+     * Returns the Editor to select the metadata.
+     * 
+     * @return See above.
+     */
+    public Editor getEditor();
+    
 	/**
 	 * Checks if the renderer has already been initialized
 	 * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerComponent 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -370,6 +370,18 @@ class MetadataViewerComponent
 		return model.getEditor().getUI();
 	}
 	
+	/** 
+     * Implemented as specified by the {@link MetadataViewer} interface.
+     * @see MetadataViewer#getEditor()
+     */
+    public Editor getEditor()
+    {
+        if (model.getState() == DISCARDED)
+            throw new IllegalStateException("This method cannot be invoked " +
+                    "in the DISCARDED state.");
+        return model.getEditor();
+    }
+    
 	/** 
          * Implemented as specified by the {@link MetadataViewer} interface.
          * @see MetadataViewer#isRendererLoaded()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4354,20 +4354,21 @@ class TreeViewerComponent
 		    }
 		}
 		
-		// if it is a script which operates on FileAnnotations, pass on the selected
-		// FileAnnotations in the MetadataViewer as additional reference objects
-		ListMultimap<String, DataObject> addObjects = null;
-		Pattern p = Pattern.compile("file.?annotation.*", Pattern.CASE_INSENSITIVE);
-		for(String paramName : script.getInputs().keySet()) {
-		    Matcher m = p.matcher(paramName);
-		    if(m.matches()) {
-		        addObjects = ArrayListMultimap.create();
+        // if it is a script which operates on FileAnnotations, pass on the selected
+        // FileAnnotations in the MetadataViewer as additional reference objects
+        ListMultimap<String, DataObject> addObjects = null;
+        Pattern p = Pattern.compile("file.?annotation.*",
+                Pattern.CASE_INSENSITIVE);
+        for (String paramName : script.getInputs().keySet()) {
+            Matcher m = p.matcher(paramName);
+            if (m.matches()) {
+                addObjects = ArrayListMultimap.create();
                 if (model.getMetadataViewer() != null) {
-                    addObjects.putAll(paramName, model.getMetadataViewer().getEditor()
-                            .getSelectedFileAnnotations());
+                    addObjects.putAll(paramName, model.getMetadataViewer()
+                            .getEditor().getSelectedFileAnnotations());
                 }
-		    }
-		}
+            }
+        }
 		
 		//setStatus(false);
 		//Check if the objects are in the same group.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.swing.Icon;
 import javax.swing.JDialog;
@@ -131,6 +133,9 @@ import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 
 import pojos.DataObject;
 import pojos.DatasetData;
@@ -4336,8 +4341,10 @@ class TreeViewerComponent
 		model.setScript(script);
 		Browser browser = model.getSelectedBrowser();
 		List<DataObject> objects;
-		if (browser == null) objects = new ArrayList<DataObject>();
-		else objects = browser.getSelectedDataObjects();
+		if (browser == null)
+		    objects = new ArrayList<DataObject>();
+		else 
+		    objects = browser.getSelectedDataObjects();
 
 		if (CollectionUtils.isEmpty(objects)) {
 		    DataBrowser db = model.getDataViewer();
@@ -4346,6 +4353,22 @@ class TreeViewerComponent
 		        objects.addAll(db.getBrowser().getSelectedDataObjects());
 		    }
 		}
+		
+		// if it is a script which operates on FileAnnotations, pass on the selected
+		// FileAnnotations in the MetadataViewer as additional reference objects
+		ListMultimap<String, DataObject> addObjects = null;
+		Pattern p = Pattern.compile("file.?annotation.*", Pattern.CASE_INSENSITIVE);
+		for(String paramName : script.getInputs().keySet()) {
+		    Matcher m = p.matcher(paramName);
+		    if(m.matches()) {
+		        addObjects = ArrayListMultimap.create();
+                if (model.getMetadataViewer() != null) {
+                    addObjects.putAll(paramName, model.getMetadataViewer().getEditor()
+                            .getSelectedFileAnnotations());
+                }
+		    }
+		}
+		
 		//setStatus(false);
 		//Check if the objects are in the same group.
 		Iterator<DataObject> i = objects.iterator();
@@ -4368,12 +4391,12 @@ class TreeViewerComponent
 		}
 		if (scriptDialog == null) {
 			scriptDialog = new ScriptingDialog(view, 
-					model.getScript(script.getScriptID()), objects, 
+					model.getScript(script.getScriptID()), objects, addObjects,
 					TreeViewerAgent.isBinaryAvailable());
 			scriptDialog.addPropertyChangeListener(controller);
 			UIUtilities.centerAndShow(scriptDialog);
 		} else {
-			scriptDialog.reset(model.getScript(script.getScriptID()), objects);
+			scriptDialog.reset(model.getScript(script.getScriptID()), objects, addObjects);
 			if (!scriptDialog.isVisible())
 				UIUtilities.centerAndShow(scriptDialog);
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -76,6 +76,8 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.omeeditpane.OMEWikiComponent;
 import org.openmicroscopy.shoola.util.ui.tdialog.TinyDialog;
 
+import com.google.common.collect.ListMultimap;
+
 import pojos.DataObject;
 
 /** 
@@ -182,6 +184,12 @@ public class ScriptingDialog
     /** Flag indicating if the binary data are available.*/
     private boolean binaryAvailable;
 
+    /**
+     * Map which holds additional reference objects per parameter name for
+     * pre-setting the dialog
+     */
+    private ListMultimap<String, DataObject> additionalObjects; 
+    
     /** Populates the changes of data types.*/
     private void handleDataTypeChanges()
     {
@@ -429,7 +437,7 @@ public class ScriptingDialog
                         if (CollectionUtils.isNotEmpty(refObjects)) {
                             //support of image type
                             DataObject object = refObjects.get(0);
-                            if (script.isSupportedType(object, name)){
+                            if (script.isSupportedType(object)){
                                 defValue = object.getId();
                             }
                         }
@@ -512,7 +520,18 @@ public class ScriptingDialog
                     identifier.setValues(refObjects);
                     identifier.addDocumentListener(this);
                     comp = identifier;
-                } else {
+                }
+                else if (Long.class.isAssignableFrom(param.getKeyType())) {
+                    // a list of longs is usually another field holding ids;
+                    IdentifierParamPane id2 = new IdentifierParamPane(Long.class);
+                    // check if there are default values for this parameter in the additionalObjects map
+                    if(additionalObjects!=null) {
+                        List<DataObject> objs = additionalObjects.get(name);
+                        id2.setValues(objs);
+                    }
+                    comp = id2;
+                }
+                else {
                     if (comp == null)
                         comp = new ComplexParamPane(param.getKeyType());
                     else 
@@ -799,9 +818,24 @@ public class ScriptingDialog
     public ScriptingDialog(JFrame parent, ScriptObject script,
             List<DataObject> refObjects, boolean binaryAvailable)
     {
+        this(parent, script, refObjects, null, binaryAvailable);
+    }
+    
+    /**
+     * Creates a new instance.
+     *
+     * @param parent The parent of the frame.
+     * @param script The script to run. Mustn't be <code>null</code>.
+     * @param refObjects The objects of reference.
+     * @param additionalObjects Additional reference objects per input parameter name
+     * @param binaryAvailable Flag indicating if binary data are available.
+     */
+    public ScriptingDialog(JFrame parent, ScriptObject script,
+            List<DataObject> refObjects, ListMultimap<String, DataObject> additionalObjects, boolean binaryAvailable)
+    {
         super(parent);
         this.binaryAvailable = binaryAvailable;
-        reset(script, refObjects);
+        reset(script, refObjects, additionalObjects);
     }
 
     /**
@@ -812,10 +846,23 @@ public class ScriptingDialog
      */
     public void reset(ScriptObject script, List<DataObject> refObjects)
     {
+        reset(script, refObjects, null);
+    }
+    
+    /**
+     * Resets the value.
+     *
+     * @param script The script to run. Mustn't be <code>null</code>.
+     * @param refObjects The objects of reference.
+     * @param additionalObjects Additional reference objects per input parameter name
+     */
+    public void reset(ScriptObject script, List<DataObject> refObjects, ListMultimap<String, DataObject> additionalObjects)
+    {
         if (script == null)
             throw new IllegalArgumentException("No script specified");
         this.script = script;
         this.refObjects = refObjects;
+        this.additionalObjects = additionalObjects;
         initComponents();
         buildGUI();
         pack();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ScriptObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ScriptObject.java
@@ -663,21 +663,15 @@ public class ScriptObject
     /**
      * Returns <code>true</code> if the specified object is supported,
      * <code>false</code> otherwise.
-     *
-     * @param data The object to set.
-     * @param key The key to determine if the object is supported.
+     * 
+     * @param data
      * @return See above.
      */
-    public boolean isSupportedType(pojos.DataObject data, String key)
+    public boolean isSupportedType(pojos.DataObject data)
     {
-        if (data == null || CommonsLangUtils.isBlank(key)) return false;
-        if (key.contains("_")) {
-            String[] values = key.split("_");
-            Class<?> type = convertDataType(values[0]);
-            return (data.getClass().equals(type));
-        }
-        return false;
+        return getDataTypes().contains(data.getClass());
     }
+    
     /**
      * Overridden to return the name of the script.
      * @see java.lang.Object#toString()


### PR DESCRIPTION
Same as #3993 just for Insight

Test:
- Install @emilroz  's script which uses file annotations: https://github.com/emilroz/omero-user-scripts/blob/populate_metadata_fa_additions/util_scripts/Populate_Metadata.py 
- Add some file annotations to a plate
- Select the plate and some file annotations and run the script, which should open the script dialog
- Make sure the Plate ID and the the file annotations IDs are set in the dialog
- Run the script. Will fail, but in 'Info' in the activities popup you should see, that the parameters were passed correctly to the script.
- Additional test: Run some other scripts, to make sure the changes didn't break the script dialog for other scripts.


