### PR TITLE
sudo sessions timeout

### DIFF
--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -855,7 +855,9 @@ class Connector
                 p.name = userName;
                 p.eventType = "Sessions";
                 ISessionPrx prx = entryEncrypted.getSessionService();
-                Session session = prx.createSessionWithTimeout(p, 0L);
+                Session session = prx.getSession(secureClient.getSessionId());
+                long timeout = session.getTimeToIdle().getValue();
+                session = prx.createSessionWithTimeout(p, timeout);
                 // Create the userSession
                 omero.client client = new omero.client(context
                         .getServerInformation().getHostname(), context

--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -857,7 +857,7 @@ class Connector
                 ISessionPrx prx = entryEncrypted.getSessionService();
                 Session session = prx.getSession(secureClient.getSessionId());
                 long timeout = session.getTimeToIdle().getValue();
-                session = prx.createSessionWithTimeout(p, timeout);
+                session = prx.createSessionWithTimeouts(p, 0, timeout);
                 // Create the userSession
                 omero.client client = new omero.client(context
                         .getServerInformation().getHostname(), context


### PR DESCRIPTION
See Ticket [12972](http://trac.openmicroscopy.org/ome/ticket/12972)
Previously if a session for another user was created a zero timeout was set, with this PR now the same timeout as the existing session is used.
Test: Code review, check that the import as other user (will initiate a sudo session) still works.