### PR TITLE
Rendering settings fixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2669,8 +2669,13 @@ class TreeViewerComponent
 			"you wish to apply the settings to.");
 			return;
 		}
-		model.firePasteRenderingSettings(ids, klass);
-		fireStateChange();
+		
+        MessageBox box = new MessageBox(getUI(), "Save rendering settings",
+                RENDERINGSETTINGS_WARNING);
+        if (box.centerMsgBox() == MessageBox.YES_OPTION) {
+            model.firePasteRenderingSettings(ids, klass);
+            fireStateChange();
+        }
 	}
 
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
@@ -678,21 +678,12 @@ class TreeViewerModel
 	 * @param klass The type of nodes to handle.
 	 */
         void firePasteRenderingSettings(List<Long> ids, Class klass) {
-                long id = refImage.getId();
-                List<Long> toKeep = new ArrayList<Long>();
-                Iterator<Long> i = ids.iterator();
-                long id1;
-                while (i.hasNext()) {
-                        id1 = i.next();
-                        if (id1 != id) toKeep.add(id1);
-                }
-                if (toKeep.size() == 0) return;
                 state = TreeViewer.SETTINGS_RND;
                 SecurityContext ctx = getSecurityContext();
                 if (ctx == null) {
                         ctx = new SecurityContext(refImage.getGroupId());
                 }
-                currentLoader = new RndSettingsSaver(component, ctx, klass, toKeep, refRndSettings, refImage);
+                currentLoader = new RndSettingsSaver(component, ctx, klass, ids, refRndSettings, refImage);
                 currentLoader.load();
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/RenderingSettingsSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/RenderingSettingsSaver.java
@@ -208,7 +208,9 @@ extends BatchCallTree
                         ids);
                 result = map;
 
-                if (rnd != null && original != null) {
+                boolean refImagePartOfSaved = ((List<Long>)map.get(Boolean.TRUE)).contains(refImage.getId());
+                
+                if (rnd != null && original != null && !refImagePartOfSaved) {
                     // reset the reference image to it's previous settings
                     rnd.resetSettings(original, true);
                     rnd.saveCurrentSettings();
@@ -244,6 +246,7 @@ extends BatchCallTree
                         element = (DataObject) i.next();
                         ids.add(element.getId());
                     }
+
                     OmeroImageService rds = context.getImageService();
                     switch (index) {
                         case PASTE:


### PR DESCRIPTION
Fixes two minor issues with rendering settings:
- Copy the rendering settings from an image. "Paste and Save" them on to other images. Make sure a warning dialog is shown (like it is for other actions e. g. "Set Imported and Save"
- Modify the rendering settings of an image in the preview panel, *do not* save them but copy them. Select the dataset the image belongs to and trigger a "Paste and Save" action. Make sure that the rendering settings of all compatible images are modified accordingly *including* the image from which you copied the rendering settings.
- Do the same again, but now "Paste and Save" onto some other images excluding the image the rendering settings were copied from. Make sure this image does *not* change.