### PR TITLE
Make sure default "Filter" text is selected

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
@@ -446,6 +446,8 @@ public class SelectionWizardUI
             filterArea.setForeground(Color.LIGHT_GRAY);
         }
         filterArea.getDocument().addDocumentListener(this);
+        filterArea.setSelectionStart(0);
+        filterArea.setSelectionEnd(filterArea.getText().length());
     }
 
     /**


### PR DESCRIPTION
Tiny fix for [Ticket 12300](https://trac.openmicroscopy.org/ome/ticket/12300) , has to be tested on Windows.

Try to add tags to an object, which opens the Tags dialog. The "Filter" text field should have the focus, and when start typing straight away the default text "Filter" should get removed (before: typing started after the text).