### PR TITLE
have integration tests use graph request utility methods from gateway

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
  *   Copyright 2010-2015 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static org.testng.AssertJUnit.assertFalse;
@@ -46,7 +45,6 @@ import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
-import omero.cmd.Chmod2;
 import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
@@ -59,7 +57,6 @@ import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.State;
 import omero.cmd.Status;
-import omero.gateway.util.Requests;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
 import omero.model.Arc;
@@ -1176,19 +1173,6 @@ public class AbstractServerTest extends AbstractTest {
 
         callback(passes, c, dc);
         return "ok";
-    }
-
-    /**
-     * Creates the command to change permissions.
-     *
-     * @param session
-     * @param type
-     * @param id
-     * @param perms
-     * @return
-     */
-    Chmod2 createChmodCommand(String type, long id, String perms) {
-        return Requests.chmod(type, id, perms);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -59,6 +59,7 @@ import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.State;
 import omero.cmd.Status;
+import omero.gateway.util.Requests;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
 import omero.model.Arc;
@@ -136,7 +137,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 /**
@@ -1188,10 +1188,7 @@ public class AbstractServerTest extends AbstractTest {
      * @return
      */
     Chmod2 createChmodCommand(String type, long id, String perms) {
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of(type, Collections.singletonList(id));
-        chmod.permissions = perms;
-        return chmod;
+        return Requests.chmod(type, id, perms);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -29,6 +29,7 @@ import omero.ValidationException;
 import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.cmd.Request;
+import omero.gateway.util.Requests;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
@@ -1325,7 +1326,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1366,7 +1367,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwra--";
 
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1407,7 +1408,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1446,7 +1447,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwr---";
 
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1479,7 +1480,7 @@ public class AdminServiceTest extends AbstractServerTest {
         Permissions permissions = g.getDetails().getPermissions();
         // change permissions and promote the group
         representation = "rwrw--";
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
 
         doChange(root, root.getSession(), mod, true);
@@ -1515,7 +1516,7 @@ public class AdminServiceTest extends AbstractServerTest {
 
         // change permissions and promote the group
         representation = "rwr---";
-        Request mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
 
         doChange(root, root.getSession(), mod, true);
@@ -1526,7 +1527,7 @@ public class AdminServiceTest extends AbstractServerTest {
         g = prx.getGroup(id);
         // now try to turn it back to rw----
         representation = "rw----";
-        mod = createChmodCommand(REF_GROUP, g.getId().getValue(),
+        mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
                 representation);
 
         doChange(root, root.getSession(), mod, true);

--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -35,6 +35,7 @@ import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
 import omero.model.ExperimenterI;
 import omero.model.GroupExperimenterMap;
+import omero.model.IObject;
 import omero.model.Permissions;
 import omero.model.PermissionsI;
 import omero.sys.ParametersI;
@@ -280,13 +281,13 @@ public class AdminServiceTest extends AbstractServerTest {
         ids.add(userGroup.getId().getValue());
         p = new ParametersI();
         p.addLongs("gids", ids);
-        List list = (List) query.findAllByQuery("select m "
+        List<IObject> list = query.findAllByQuery("select m "
                 + "from GroupExperimenterMap as m "
                 + "left outer join fetch m.child "
                 + "left outer join fetch m.parent"
                 + " where m.parent.id in (:gids)", p);
         assertNotNull(list);
-        Iterator i = list.iterator();
+        Iterator<IObject> i = list.iterator();
         GroupExperimenterMap geMap;
         int count = 0;
         while (i.hasNext()) {
@@ -346,13 +347,13 @@ public class AdminServiceTest extends AbstractServerTest {
         ids.add(userGroup.getId().getValue());
         p = new ParametersI();
         p.addLongs("gids", ids);
-        List list = (List) query.findAllByQuery("select m "
+        List<IObject> list = query.findAllByQuery("select m "
                 + "from GroupExperimenterMap as m "
                 + "left outer join fetch m.child "
                 + "left outer join fetch m.parent"
                 + " where m.parent.id in (:gids)", p);
         assertNotNull(list);
-        Iterator i = list.iterator();
+        Iterator<IObject> i = list.iterator();
         GroupExperimenterMap geMap;
         int count = 0;
         while (i.hasNext()) {
@@ -400,13 +401,13 @@ public class AdminServiceTest extends AbstractServerTest {
         ids.add(userGroup.getId().getValue());
         p = new ParametersI();
         p.addLongs("gids", ids);
-        List list = (List) query.findAllByQuery("select m "
+        List<IObject> list = query.findAllByQuery("select m "
                 + "from GroupExperimenterMap as m "
                 + "left outer join fetch m.child "
                 + "left outer join fetch m.parent"
                 + " where m.parent.id in (:gids)", p);
         assertNotNull(list);
-        Iterator i = list.iterator();
+        Iterator<IObject> i = list.iterator();
         GroupExperimenterMap geMap;
         int count = 0;
         while (i.hasNext()) {
@@ -780,8 +781,8 @@ public class AdminServiceTest extends AbstractServerTest {
         ParametersI p = new ParametersI();
         p.addLong("expId", expId);
         p.addLong("groupId", groupId);
-        List l = (List) query.findAllByQuery(sql, p);
-        Iterator i = l.iterator();
+        List<IObject> l = query.findAllByQuery(sql, p);
+        Iterator<IObject> i = l.iterator();
         GroupExperimenterMap map;
         while (i.hasNext()) {
             map = (GroupExperimenterMap) i.next();
@@ -1691,13 +1692,13 @@ public class AdminServiceTest extends AbstractServerTest {
         ids.add(userGroup.getId().getValue());
         p = new ParametersI();
         p.addLongs("gids", ids);
-        List list = (List) query.findAllByQuery("select m "
+        List<IObject> list = query.findAllByQuery("select m "
                 + "from GroupExperimenterMap as m "
                 + "left outer join fetch m.child "
                 + "left outer join fetch m.parent"
                 + " where m.parent.id in (:gids)", p);
         assertNotNull(list);
-        Iterator i = list.iterator();
+        Iterator<IObject> i = list.iterator();
         GroupExperimenterMap geMap;
         int count = 0;
         while (i.hasNext()) {
@@ -1736,6 +1737,7 @@ public class AdminServiceTest extends AbstractServerTest {
     /**
      * Test that the root experimenter is reported to be a member of both the system and the user groups
      * and that the guest experimenter is reported to be a member of the guest group.
+     * @throws ServerError unexpected
      */
     @Test
     public void testGroupMemberships() throws ServerError {

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
  *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -35,6 +34,7 @@ import omero.api.RawFileStorePrx;
 import omero.api.ThumbnailStorePrx;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
+import omero.gateway.util.Requests;
 import omero.grid.RawAccessRequest;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
@@ -479,10 +479,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have been created and then deleted.
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(pix.getId().getValue(), REF_PIXELS);
         assertEquals(report.deletedObjects.get(REF_PIXELS).size(), 1);
@@ -502,10 +499,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have been created and then deleted.
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
@@ -528,10 +522,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(pix.getId().getValue(), REF_PIXELS);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
@@ -558,10 +549,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
                 PyramidFileType.PYRAMID_LOCK);
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID_TMP);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
@@ -606,10 +594,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         // Now check that the files have been created and then deleted.
         assertFileExists(ofId, REF_ORIGINAL_FILE);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(ofId, REF_ORIGINAL_FILE);
         assertNoUndeletedBinaries(report);
@@ -643,10 +628,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have NOT been created and then deleted.
         assertFileDoesNotExist(pixId, REF_PIXELS);
         assertFileDoesNotExist(ofId, REF_ORIGINAL_FILE);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
         assertNoUndeletedBinaries(report);
     }
@@ -702,10 +684,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         }
 
         // delete the image.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(imageID));
+        Delete2 dc = Requests.delete("Image", imageID);
         Delete2Response report = deleteWithReport(dc);
 
         assertNoUndeletedBinaries(report);
@@ -786,10 +765,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         loginUser(ownerCtx);
         // Now try to delete the image.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(imageID));
+        Delete2 dc = Requests.delete("Image", imageID);
         Delete2Response report = deleteWithReport(dc);
         Iterator<Long> j = thumbIds.iterator();
         while (j.hasNext()) {
@@ -824,10 +800,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         ds2.linkImage(img);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds2.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
         delete(client, dc);
 
         assertDoesNotExist(ds2);
@@ -865,10 +838,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(pix1.getId().getValue(), REF_PIXELS);
         assertFileExists(pix2.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", ds.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
 
         assertNoUndeletedBinaries(report);
@@ -918,10 +888,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(of1.getId().getValue(), REF_ORIGINAL_FILE);
         assertFileExists(of2.getId().getValue(), REF_ORIGINAL_FILE);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
 
         assertNoneExist(img, of1, of2);
@@ -956,10 +923,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the file has been created.
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", ds.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
 
         // The dataset should be gone but nothing else.
@@ -989,10 +953,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         // create another user and try to delete the image
         newUserInGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         Delete2Response report = deleteWithReport(dc);
 
         // check the image exists as the owner

--- a/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
@@ -10,7 +10,6 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import omero.api.IRenderingSettingsPrx;
@@ -18,6 +17,7 @@ import omero.cmd.Delete2;
 import omero.cmd.DoAll;
 import omero.cmd.Request;
 import omero.constants.metadata.NSINSIGHTRATING;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotation;
 import omero.model.CommentAnnotationI;
@@ -47,8 +47,6 @@ import omero.sys.ParametersI;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Collections of tests for the <code>Delete</code> service related to
@@ -96,11 +94,11 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Project p = (Project) iUpdate.saveAndReturnObject(mmFactory
                 .simpleProjectData().asProject());
 
-        // Dataset
+        // Screen
         Screen s = (Screen) iUpdate.saveAndReturnObject(mmFactory
                 .simpleScreenData().asScreen());
 
-        // Dataset
+        // Plate
         Plate plate = (Plate) iUpdate.saveAndReturnObject(mmFactory
                 .simplePlateData().asPlate());
 
@@ -109,30 +107,15 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(user1Ctx);
 
         List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d.getId().getValue()));
+        dc = Requests.delete("Dataset", d.getId().getValue());
         commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
+        dc = Requests.delete("Project", p.getId().getValue());
         commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(s.getId().getValue()));
+        dc = Requests.delete("Screen", s.getId().getValue());
         commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(plate.getId().getValue()));
+        dc = Requests.delete("Plate", plate.getId().getValue());
         commands.add(dc);
 
         DoAll all = new DoAll();
@@ -170,10 +153,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // create another user and try to delete the image
         newUserInGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(imageID));
+        Delete2 dc = Requests.delete("Image", imageID);
         callback(false, client, dc);
 
         // check the image exists as the owner
@@ -198,10 +178,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Log the admin into that users group
         logRootIntoGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -238,10 +215,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -267,10 +241,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ownerEc);
         makeGroupOwner();
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img); // Deletion permitted in 4.4
@@ -295,10 +266,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(img);
     }
@@ -337,10 +305,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // owner deletes image
         loginUser(ec);
         long id = image.getId().getValue();
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
 
         // image and annotations are all gone
@@ -390,10 +355,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // owner deletes their image
         loginUser(ec);
         long id = imageOwner.getId().getValue();
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
 
         // image is gone but other image and annotations remain
@@ -434,10 +396,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // owner tries to delete image.
         loginUser(ec);
         long id = img.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -480,10 +439,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Tag's owner now deletes the tag.
         init(tagger);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(c.getId().getValue()));
+        Delete2 dc = Requests.delete("Annotation", c.getId().getValue());
         callback(false, client, dc);
         assertExists(c);
         assertExists(link);
@@ -533,10 +489,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         // Tag's owner now deletes the tag.
         init(tagger);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(c.getId().getValue()));
+        Delete2 dc = Requests.delete("Annotation", c.getId().getValue());
         callback(true, client, dc);
 
         assertNoneExist(c, link);
@@ -579,10 +532,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Delete the image.
         loginUser(ownerCtx);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(imageID));
+        Delete2 dc = Requests.delete("Image", imageID);
         callback(true, client, dc);
         assertNoneExist(image, ownerDef, otherDef);
     }
@@ -615,10 +565,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
         makeGroupOwner();
         // Now try to delete the project.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(project.getId().getValue()));
+        Delete2 dc = Requests.delete("Project", project.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(project);
         assertDoesNotExist(dataset);
@@ -649,11 +596,8 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setChild((Dataset) dataset.proxy());
         link.setParent((Project) project.proxy());
         link = (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
-        // Now try to delete the project.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
+        // Now try to delete the dataset.
+        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertExists(project);
@@ -690,10 +634,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(user2Ctx);
         // Now try to delete the dataset.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertExists(project);
@@ -733,10 +674,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         // now try to delete the dataset
         loginUser(ctx);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertDoesNotExist(image1);
@@ -767,10 +705,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setParent((Dataset) dataset.proxy());
         iUpdate.saveAndReturnObject(link);
         // Now try to delete the image
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(image);
@@ -807,10 +742,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // now try to delete the image
         loginUser(user2Ctx);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(image);
@@ -844,10 +776,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
 
         // Now try to delete the screen
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screen.getId().getValue()));
+        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
         callback(false, client, dc);
 
         assertExists(screen);
@@ -882,10 +811,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
         makeGroupOwner();
         // Now try to delete the screen
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screen.getId().getValue()));
+        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(screen);
@@ -917,10 +843,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setParent((Screen) screen.proxy());
         link = (ScreenPlateLink) iUpdate.saveAndReturnObject(link);
         // Now try to delete the plate
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plate.getId().getValue()));
+        Delete2 dc = Requests.delete("Plate", plate.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(plate);
@@ -958,10 +881,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(user2Ctx);
         // Now try to delete the plate
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plate.getId().getValue()));
+        Delete2 dc = Requests.delete("Plate", plate.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(plate);
@@ -1001,10 +921,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(ctx);
         // Now try to delete the dataset
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(dataset);
@@ -1031,10 +948,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -1059,10 +973,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -1097,10 +1008,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         // Image should be deleted.
@@ -1124,10 +1032,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // group owner deletes it
         disconnect();
         newUserInGroup(ownerEc);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(false, client, dc);
 
         assertExists(img);
@@ -1150,10 +1055,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // group owner deletes it
         disconnect();
         newUserInGroup(ownerEc);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(false, client, dc);
 
         assertExists(img);
@@ -1188,10 +1090,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(img);

--- a/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
@@ -2,6 +2,7 @@
  * Copyright 2006-2015 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static omero.rtypes.rdouble;
@@ -27,16 +28,13 @@ import java.util.UUID;
 import ome.formats.OMEROMetadataStoreClient;
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
-import omero.ApiUsageException;
-import omero.ServerError;
 import omero.api.IMetadataPrx;
 import omero.api.IPixelsPrx;
 import omero.api.IRenderingSettingsPrx;
 import omero.api.RawFileStorePrx;
 import omero.cmd.Delete2;
-import omero.cmd.DoAll;
-import omero.cmd.Request;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.grid.Column;
 import omero.grid.LongColumn;
 import omero.grid.TablePrx;
@@ -405,10 +403,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleImage());
         assertNotNull(img);
         long id = img.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -432,10 +427,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .createInstrument());
         assertNotNull(ins);
         long id = ins.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Instrument.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Instrument", id);
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -477,10 +469,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertNotNull(detector);
 
         // delete detector
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Detector.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Detector", id);
         callback(true, client, dc);
 
         // fail to find detector
@@ -500,10 +489,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simplePlateData().asIObject());
         assertNotNull(p);
         long id = p.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Plate", id);
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -525,12 +511,12 @@ public class DeleteServiceTest extends AbstractServerTest {
     public void testDeletePlate() throws Exception {
         int[] values = { 0, 1 };
         Plate p;
-        List results;
+        List<? extends IObject> results;
         PlateAcquisition pa = null;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<? extends IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
@@ -561,10 +547,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 }
             }
             // Now delete the plate
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Plate.class.getSimpleName(),
-                    Collections.singletonList(p.getId().getValue()));
+            Delete2 dc = Requests.delete("Plate", p.getId().getValue());
             callback(true, client, dc);
 
             param = new ParametersI();
@@ -623,12 +606,12 @@ public class DeleteServiceTest extends AbstractServerTest {
         int[] values = { 0, 1 };
         int b;
         Plate p;
-        List results;
+        List<IObject> results;
         PlateAcquisition pa = null;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
@@ -664,10 +647,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 }
             }
             // Now delete the plate
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Plate.class.getSimpleName(),
-                    Collections.singletonList(p.getId().getValue()));
+            Delete2 dc = Requests.delete("Plate", p.getId().getValue());
             callback(true, client, dc);
 
             // check the plate
@@ -741,17 +721,14 @@ public class DeleteServiceTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d.getId().getValue()));
+        Delete2 dc = Requests.delete("Dataset", d.getId().getValue());
         callback(true, client, dc);
 
         // Check if objects have been deleted
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Image as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         param = new ParametersI();
@@ -797,17 +774,14 @@ public class DeleteServiceTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
+        Delete2 dc = Requests.delete("Project", p.getId().getValue());
         callback(true, client, dc);
 
         // Check if objects have been deleted
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Image as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         param = new ParametersI();
@@ -849,10 +823,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screen.getId().getValue()));
+        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -863,7 +834,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Plate as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         param = new ParametersI();
@@ -909,10 +880,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             infos.add(info.getId().getValue());
         }
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -997,10 +965,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             infos.add(info.getId().getValue());
         }
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1071,10 +1036,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> settings = iQuery.findAllByQuery(sql, param);
         // now delete the image
         assertTrue(settings.size() > 0);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         // check if the settings have been deleted.
@@ -1114,10 +1076,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> settings = iQuery.findAllByQuery(sql, param);
         // now delete the image
         assertTrue(settings.size() > 0);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
         // check if the settings have been deleted.
         Iterator<IObject> i = settings.iterator();
@@ -1180,9 +1139,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = new ArrayList<Long>();
         ids.add(img.getId().getValue());
         // method already tested in PojosService test
-        List results = factory.getContainerService().getImages(
+        List<Image> results = factory.getContainerService().getImages(
                 Image.class.getName(), ids, param);
-        img = (Image) results.get(0);
+        img = results.get(0);
         ObjectiveSettings settings = img.getObjectiveSettings();
         StageLabel label = img.getStageLabel();
         ImagingEnvironment env = img.getImagingEnvironment();
@@ -1212,10 +1171,7 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now we try to delete the image.
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
         // Follow the section with acquisition data.
         // Now check if the settings are still there.
@@ -1305,10 +1261,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         // Delete the image.
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
         // check if the objects have been delete.
 
@@ -1321,7 +1274,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         param = new ParametersI();
         param.addIds(shapeIds);
         sql = "select d from Shape as d where d.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
     }
 
@@ -1357,10 +1310,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             shapeIds.add(shape.getId().getValue());
         }
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Roi.class.getSimpleName(),
-                Collections.singletonList(serverROI.getId().getValue()));
+        Delete2 dc = Requests.delete("Roi", serverROI.getId().getValue());
         callback(true, client, dc);
 
         // make sure we still have the image
@@ -1406,9 +1356,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             annotationIds = createNonSharableAnnotation(obj, null);
 
 
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    type, Collections.singletonList(id));
+            Delete2 dc = Requests.delete(type, id);
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -1439,7 +1387,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> annotationIds;
         ParametersI param;
         String sql;
-        List l;
+        List<IObject> l;
         for (int j = 0; j < values.length; j++) {
             Map<String, IObject> objects = createIObjects();
             for (Map.Entry<String, IObject> entry : objects.entrySet()) {
@@ -1448,17 +1396,13 @@ public class DeleteServiceTest extends AbstractServerTest {
                 id = obj.getId().getValue();
                 annotationIds = createSharableAnnotation(obj, null);
                 if (values[j]) {
-                    final Delete2 dc = new Delete2();
+                    final Delete2 dc = Requests.delete(type, id);
                     final ChildOption co = new ChildOption();
                     co.excludeType = SHARABLE_TO_KEEP_LIST;
-                    dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                            type, Collections.singletonList(id));
                     dc.childOptions = Collections.singletonList(co);
                     callback(true, client, dc);
                 } else {
-                    final Delete2 dc = new Delete2();
-                    dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                            type, Collections.singletonList(id));
+                    final Delete2 dc = Requests.delete(type, id);
                     callback(true, client, dc);
                 }
 
@@ -1491,17 +1435,17 @@ public class DeleteServiceTest extends AbstractServerTest {
     @Test
     public void testDeletePlateWithNonSharableAnnotations() throws Exception {
         Plate p;
-        List results;
+        List<IObject> results;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
         List<Long> annotationIds = new ArrayList<Long>();
         List<Long> r;
-        List l;
+        List<IObject> l;
         p = (Plate) iUpdate.saveAndReturnObject(mmFactory.createPlate(1, 1, 1,
                 0, false));
         param = new ParametersI();
@@ -1533,10 +1477,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             }
         }
         // Now delete the plate
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
+        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1594,7 +1535,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         Plate p = (Plate) iUpdate.saveAndReturnObject(mmFactory.createPlate(1,
                 1, 1, 0, false));
         List<Well> results = loadWells(p.getId().getValue(), true);
-        Well well = (Well) results.get(0);
+        Well well = results.get(0);
         // create the roi.
         Image image = well.getWellSample(0).getImage();
         Roi roi = new RoiI();
@@ -1637,12 +1578,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(il);
         iUpdate.saveAndReturnArray(links);
 
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
         final ChildOption co = new ChildOption();
         co.excludeType = Collections.singletonList(FileAnnotation.class.getSimpleName());
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
         // Shouldn't have measurements
@@ -1667,18 +1605,18 @@ public class DeleteServiceTest extends AbstractServerTest {
         Boolean[] annotations = { Boolean.valueOf(false), Boolean.valueOf(true) };
         int b;
         Plate p;
-        List results;
+        List<? extends IObject> results;
         PlateAcquisition pa = null;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<? extends IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
         Set<Long> annotationIds = new HashSet<Long>();
         List<Long> r;
-        List l;
+        List<IObject> l;
 
         for (int i = 0; i < values.length; i++) {
             b = values[i];
@@ -1719,19 +1657,13 @@ public class DeleteServiceTest extends AbstractServerTest {
                         annotationIds.addAll(r);
                 }
                 if (annotations[k]) {
-                    final Delete2 dc = new Delete2();
+                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
                     final ChildOption co = new ChildOption();
                     co.excludeType = SHARABLE_TO_KEEP_LIST;
-                    dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                            Plate.class.getSimpleName(),
-                            Collections.singletonList(p.getId().getValue()));
                     dc.childOptions = Collections.singletonList(co);
                     callback(true, client, dc);
                 } else {
-                    final Delete2 dc = new Delete2();
-                    dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                            Plate.class.getSimpleName(),
-                            Collections.singletonList(p.getId().getValue()));
+                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
                     callback(true, client, dc);
                 }
 
@@ -1814,10 +1746,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         l.link(new DatasetI(d.getId().getValue(), false), img2);
         iUpdate.saveAndReturnObject(l);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d.getId().getValue()));
+        final Delete2 dc = Requests.delete("Dataset", d.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1868,10 +1797,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         pl.link(new ProjectI(p.getId().getValue(), false), d2);
         iUpdate.saveAndReturnObject(pl);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
+        final Delete2 dc = Requests.delete("Project", p.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1924,10 +1850,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             link.link(screen, plate);
             iUpdate.saveAndReturnObject(link);
 
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Screen.class.getSimpleName(),
-                    Collections.singletonList(screen.getId().getValue()));
+            final Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
             callback(true, client, dc);
 
             param = new ParametersI();
@@ -1972,12 +1895,9 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         long id = fa.getId().getValue();
 
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
         final ChildOption co = new ChildOption();
         co.excludeType = Collections.singletonList(FileAnnotation.class.getSimpleName());
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
 
@@ -2008,12 +1928,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = createSharableAnnotation(img1, img2);
         assertEquals(n, ids.size());
         // now delete the image 1.
-        Delete2 dc = new Delete2();
+        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
         ChildOption co = new ChildOption();
         co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
         ParametersI param = new ParametersI();
@@ -2029,12 +1946,9 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleDatasetData().asIObject());
         ids = createSharableAnnotation(d1, d2);
         // now delete the dataset 1.
-        dc = new Delete2();
+        dc = Requests.delete("Dataset", d1.getId().getValue());
         co = new ChildOption();
         co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d1.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
         param = new ParametersI();
@@ -2049,12 +1963,9 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleProjectData().asIObject());
         ids = createSharableAnnotation(p1, p2);
         // now delete the project 1.
-        dc = new Delete2();
+        dc = Requests.delete("Project", p1.getId().getValue());
         co = new ChildOption();
         co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p1.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
 
@@ -2070,12 +1981,9 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleScreenData().asIObject());
         ids = createSharableAnnotation(s1, s2);
         // now delete the screen 1.
-        dc = new Delete2();
+        dc = Requests.delete("Screen", s1.getId().getValue());
         co = new ChildOption();
         co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(s1.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
 
@@ -2091,12 +1999,9 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simplePlateData().asIObject());
         ids = createSharableAnnotation(plate1, plate2);
         // now delete the plate 1.
-        dc = new Delete2();
+        dc = Requests.delete("Plate", plate1.getId().getValue());
         co = new ChildOption();
         co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plate1.getId().getValue()));
         dc.childOptions = Collections.singletonList(co);
         callback(true, client, dc);
         param = new ParametersI();
@@ -2152,10 +2057,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(tagId));
+        Delete2 dc = Requests.delete("Annotation", tagId);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2237,10 +2139,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(tagId));
+        Delete2 dc = Requests.delete("Annotation", tagId);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2324,10 +2223,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(tagId));
+        Delete2 dc = Requests.delete("Annotation", tagId);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2396,10 +2292,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screenId));
+        Delete2 dc = Requests.delete("Screen", screenId);
         callback(true, client, dc);
 
         sql = "select r from Screen as r ";
@@ -2455,12 +2348,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plateID));
+        Delete2 dc = Requests.delete("Plate", plateID);
         callback(true, client, dc);
-
 
         sql = "select r from Screen as r ";
         sql += "where r.id = :id";
@@ -2506,17 +2395,14 @@ public class DeleteServiceTest extends AbstractServerTest {
         pa = (PlateAcquisition) iQuery.findByQuery(sb.toString(), param);
         annotationIds.addAll(createSharableAnnotation(pa, null));
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
+        Delete2 dc = Requests.delete("Plate",p.getId().getValue());
         callback(true, client, dc);
         // Check if annotations have been deleted.
         param = new ParametersI();
         param.addIds(annotationIds);
         sb = new StringBuilder();
         sb.append("select i from Annotation as i where i.id in (:ids)");
-        List l = iQuery.findAllByQuery(sb.toString(), param);
+        List<IObject> l = iQuery.findAllByQuery(sb.toString(), param);
         assertEquals(l.toString(), 0, l.size());
     }
 
@@ -2541,7 +2427,6 @@ public class DeleteServiceTest extends AbstractServerTest {
         ParametersI param;
         String sql;
         List<IObject> l;
-        Map<String, String> options;
         for (Map.Entry<String, IObject> entry : objects.entrySet()) {
             type = entry.getKey();
             obj = entry.getValue();
@@ -2549,9 +2434,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             annotationIds = createNonSharableAnnotation(obj, null);
             annotationIdsNS = createNonSharableAnnotation(obj, NAMESPACE);
 
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    type, Collections.singletonList(id));
+            final Delete2 dc = Requests.delete(type, id);
             final ChildOption co = new ChildOption();
             co.includeNs = Collections.singletonList(NAMESPACE);
             co.excludeType = Collections.singletonList(Annotation.class.getSimpleName());
@@ -2598,7 +2481,6 @@ public class DeleteServiceTest extends AbstractServerTest {
         ParametersI param;
         String sql;
         List<IObject> l;
-        Map<String, String> options;
         for (Map.Entry<String, IObject> entry : objects.entrySet()) {
             type = entry.getKey();
             obj = entry.getValue();
@@ -2610,9 +2492,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             List<String> ns = new ArrayList<String>();
             ns.add(NAMESPACE);
             ns.add(NAMESPACE_2);
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    type, Collections.singletonList(id));
+            final Delete2 dc = Requests.delete(type, id);
             final ChildOption co = new ChildOption();
             co.includeNs = ns;
             co.excludeType = Collections.singletonList(Annotation.class.getSimpleName());
@@ -2685,9 +2565,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = new ArrayList<Long>();
         ids.add(img.getId().getValue());
         // method already tested in PojosService test
-        List results = factory.getContainerService().getImages(
+        List<Image> results = factory.getContainerService().getImages(
                 Image.class.getName(), ids, param);
-        img = (Image) results.get(0);
+        img = results.get(0);
         ObjectiveSettings settings = img.getObjectiveSettings();
         StageLabel label = img.getStageLabel();
         ImagingEnvironment env = img.getImagingEnvironment();
@@ -2716,10 +2596,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
 
         // Now we try to delete the image.
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         // Follow the section with acquisition data.
@@ -2843,9 +2720,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = new ArrayList<Long>();
         ids.add(img.getId().getValue());
         // method already tested in PojosService test
-        List results = factory.getContainerService().getImages(
+        List<Image> results = factory.getContainerService().getImages(
                 Image.class.getName(), ids, param);
-        img = (Image) results.get(0);
+        img = results.get(0);
         ObjectiveSettings settings = img.getObjectiveSettings();
         StageLabel label = img.getStageLabel();
         ImagingEnvironment env = img.getImagingEnvironment();
@@ -2874,10 +2751,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
 
         // Now we try to delete the image.
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
         callback(true, client, dc);
 
         // Follow the section with acquisition data.
@@ -2967,10 +2841,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> wellSamples = iQuery.findAllByQuery(sql, param);
         assertEquals(wellSamples.size(), fields);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                PlateAcquisition.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("PlateAcquisition", id);
         callback(true, client, dc);
 
         sql = "select pa from PlateAcquisition as pa ";
@@ -3012,10 +2883,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertEquals(imageIds.size(), fields);
         assertTrue(annotationIds.size() > 0);
         // now delete the plate acquisition
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                PlateAcquisition.class.getSimpleName(),
-                Collections.singletonList(id));
+        dc = Requests.delete("PlateAcquisition", id);
         callback(true, client, dc);
 
         // Annotation should be gone
@@ -3060,10 +2928,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         options.add(Dataset.class.getSimpleName());
         options.add(Image.class.getSimpleName());
         long id = p.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Project", id);
         ChildOption co = new ChildOption();
         co.excludeType = options;
         dc.childOptions = Collections.singletonList(co);
@@ -3099,10 +2964,7 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now delete the screen
         long id = s.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Screen", id);
         ChildOption co = new ChildOption();
         co.excludeType = Collections.singletonList(Plate.class.getSimpleName());
         dc.childOptions = Collections.singletonList(co);
@@ -3134,10 +2996,7 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now delete the dataset
         long id = d.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Dataset", id);
         ChildOption co = new ChildOption();
         co.excludeType = Collections.singletonList(Image.class.getSimpleName());
         dc.childOptions = Collections.singletonList(co);
@@ -3227,21 +3086,9 @@ public class DeleteServiceTest extends AbstractServerTest {
             lcs.add(lc);
         }
         iUpdate.saveAndReturnArray(lcs);
-        List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
-        commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
-        commands.add(dc);
-        DoAll all = new DoAll();
-        all.requests = commands;
-        doChange(client, factory, all, true, null);
+        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
         // Now delete the image.
+        doChange(client, factory, dc, true, null);
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
@@ -3395,20 +3242,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             lcs.add(lc);
         }
         iUpdate.saveAndReturnArray(lcs);
-        List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
-        commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
-        commands.add(dc);
-        DoAll all = new DoAll();
-        all.requests = commands;
-        doChange(client, factory, all, true, null);
+        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
+        doChange(client, factory, dc, true, null);
         // Now delete the image.
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
@@ -3526,20 +3361,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             l.add(channel);
         }
         iUpdate.saveAndReturnArray(l);
-        List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
-        commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
-        commands.add(dc);
-        DoAll all = new DoAll();
-        all.requests = commands;
-        doChange(client, factory, all, true, null);
+        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
+        doChange(client, factory, dc, true, null);
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
@@ -3580,10 +3403,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         assertTrue(images.size() > 0);
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(images.get(0).getId().getValue()));
+            Delete2 dc = Requests.delete("Image", images.get(0).getId().getValue());
             callback(true, client, dc);
             fail("Should not be allowed.");
         } catch (AssertionError afe) {
@@ -3606,12 +3426,10 @@ public class DeleteServiceTest extends AbstractServerTest {
         img1 = (Image) iUpdate.saveAndReturnObject(img1);
         Image img2 = mmFactory.createImage();
         img2 = (Image) iUpdate.saveAndReturnObject(img2);
-        Delete2 dc = new Delete2();
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),ids);
+        Delete2 dc = Requests.delete("Image", ids);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -3635,20 +3453,13 @@ public class DeleteServiceTest extends AbstractServerTest {
         img1 = (Image) iUpdate.saveAndReturnObject(img1);
         Dataset d = (Dataset) iUpdate.saveAndReturnObject(mmFactory
                 .simpleDatasetData().asIObject());
-        List<Request> commands = new ArrayList<Request>();
         Delete2 dc = new Delete2();
         dc.targetObjects = ImmutableMap.<String, List<Long>>of(
                 Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
-        commands.add(dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
+                Collections.singletonList(img1.getId().getValue()),
                 Dataset.class.getSimpleName(),
                 Collections.singletonList(d.getId().getValue()));
-        commands.add(dc);
-        DoAll all = new DoAll();
-        all.requests = commands;
-        doChange(client, factory, all, true, null);
+        doChange(client, factory, dc, true, null);
         ParametersI param = new ParametersI();
         param.addId(img1.getId().getValue());
 
@@ -3678,10 +3489,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleImage());
         List<Long> ids = createSharableAnnotation(img1, img2);
         assertTrue(ids.size() > 0);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -3711,10 +3519,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         fa.setFile(of);
         Annotation data = (Annotation) iUpdate.saveAndReturnObject(fa);
         long id = data.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Annotation", id);
         callback(true, client, dc);
         assertDoesNotExist(data);
         assertDoesNotExist(of);
@@ -3768,10 +3573,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         link1.link(image1, fa);
         link1 = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link1);
 
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image0.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image0.getId().getValue());
         callback(true, client, dc);
         //
         // Check results
@@ -3826,10 +3628,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         m = (PixelsOriginalFileMapI) iUpdate.saveAndReturnObject(m);
 
         long imageID = image.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(imageID));
+        Delete2 dc = Requests.delete("Image", imageID);
         callback(true, client, dc);
         sql = "select i from Pixels i where i.id = :id";
         param = new ParametersI();
@@ -3856,10 +3655,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertNotNull(thumbnail);
         long imageID = image.getId().getValue();
         long thumbnailID = thumbnail.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", imageID);
         callback(true, client, dc);
         String sql = "select i from Thumbnail i where i.id = :id";
         ParametersI param = new ParametersI();
@@ -3892,10 +3688,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertEquals(fileset, image1.getFileset());
 
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(image0.getId().getValue()));
+            Delete2 dc = Requests.delete("Image", image0.getId().getValue());
             callback(true, client, dc);
             fail("Should throw on constraint violation");
         } catch (AssertionError e) {
@@ -3922,10 +3715,7 @@ public class DeleteServiceTest extends AbstractServerTest {
     public void testSlowDeleteOfOriginalFile() throws Exception {
         OriginalFile of = (OriginalFile) iUpdate.saveAndReturnObject(mmFactory
                 .createOriginalFile());
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                OriginalFile.class.getSimpleName(),
-                Collections.singletonList(of.getId().getValue()));
+        Delete2 dc = Requests.delete("OriginalFile", of.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(of);
     }
@@ -3941,10 +3731,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         OriginalFile of = (OriginalFile) iUpdate.saveAndReturnObject(mmFactory
                 .createOriginalFile());
         createSharableAnnotation(of, null);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                OriginalFile.class.getSimpleName(),
-                Collections.singletonList(of.getId().getValue()));
+        Delete2 dc = Requests.delete("OriginalFile", of.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(of);
     }
@@ -3960,15 +3747,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         Image img = (Image) iUpdate
                 .saveAndReturnObject(mmFactory.createImage());
         long id = img.getId().getValue();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
+        Delete2 dc = Requests.delete("Image", id);
         callback(true, client, dc);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
         callback(false, client, dc);
     }
 
@@ -3985,10 +3765,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .createImage());
 
         List<Long> ids = createNonSharableAnnotation(image, null);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
         String sql = "select a from Annotation as a where a.id in (:ids)";
         ParametersI p = new ParametersI();
@@ -4014,10 +3791,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         planeInfo = (PlaneInfo) iUpdate.saveAndReturnObject(planeInfo);
         // now Delete the image.
         assertExists(planeInfo);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(image);
         assertDoesNotExist(pixels);
@@ -4063,7 +3837,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         long lcID;
         List<Long> ids;
         LogicalChannel lc;
-        List l;
+        List<LogicalChannel> l;
         List<LogicalChannel> logicalChannels = new ArrayList<LogicalChannel>();
         List<LightPath> lightPaths = new ArrayList<LightPath>();
         List<DetectorSettings> detectorSettings = new ArrayList<DetectorSettings>();
@@ -4093,9 +3867,9 @@ public class DeleteServiceTest extends AbstractServerTest {
         po.acquisitionData();
         ids = new ArrayList<Long>(1);
         ids.add(imageID);
-        List images = factory.getContainerService().getImages(
+        List<Image> images = factory.getContainerService().getImages(
                 Image.class.getName(), ids, po);
-        Image image = (Image) images.get(0);
+        Image image = images.get(0);
         long instrumentID = image.getInstrument().getId().getValue();
 
         Instrument instrument = factory.getMetadataService().loadInstrument(
@@ -4114,10 +3888,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<OTF> otfs = instrument.copyOtf();
 
         // Delete the image.
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", image.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(image);
         assertDoesNotExist(pixels);
@@ -4129,7 +3900,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertDoesNotExist(settings);
         assertDoesNotExist(experiment);
 
-        Iterator i = planes.iterator();
+        Iterator<? extends IObject> i = planes.iterator();
         while (i.hasNext()) {
             assertDoesNotExist((IObject) i.next());
         }
@@ -4201,18 +3972,12 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertExists(img1);
         assertExists(img2);
         assertExists(file);
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img1.getId().getValue()));
+        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(img1);
         assertExists(img2);
         assertExists(file);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
+        dc = Requests.delete("Image", img2.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(img1);
         assertDoesNotExist(img2);

--- a/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
@@ -2377,7 +2377,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         pa = (PlateAcquisition) iQuery.findByQuery(sb.toString(), param);
         annotationIds.addAll(createSharableAnnotation(pa, null));
 
-        Delete2 dc = Requests.delete("Plate",p.getId().getValue());
+        Delete2 dc = Requests.delete("Plate", p.getId().getValue());
         callback(true, client, dc);
         // Check if annotations have been deleted.
         param = new ParametersI();

--- a/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
@@ -1396,10 +1396,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 id = obj.getId().getValue();
                 annotationIds = createSharableAnnotation(obj, null);
                 if (values[j]) {
-                    final Delete2 dc = Requests.delete(type, id);
-                    final ChildOption co = new ChildOption();
-                    co.excludeType = SHARABLE_TO_KEEP_LIST;
-                    dc.childOptions = Collections.singletonList(co);
+                    final ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+                    final Delete2 dc = Requests.delete(type, id, co);
                     callback(true, client, dc);
                 } else {
                     final Delete2 dc = Requests.delete(type, id);
@@ -1578,10 +1576,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(il);
         iUpdate.saveAndReturnArray(links);
 
-        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
-        final ChildOption co = new ChildOption();
-        co.excludeType = Collections.singletonList(FileAnnotation.class.getSimpleName());
-        dc.childOptions = Collections.singletonList(co);
+        final ChildOption co = Requests.option(null, "FileAnnotation");
+        final Delete2 dc = Requests.delete("Plate", p.getId().getValue(), co);
         callback(true, client, dc);
         // Shouldn't have measurements
         ParametersI param = new ParametersI();
@@ -1657,10 +1653,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                         annotationIds.addAll(r);
                 }
                 if (annotations[k]) {
-                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
-                    final ChildOption co = new ChildOption();
-                    co.excludeType = SHARABLE_TO_KEEP_LIST;
-                    dc.childOptions = Collections.singletonList(co);
+                    final ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue(), co);
                     callback(true, client, dc);
                 } else {
                     final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
@@ -1895,10 +1889,8 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         long id = fa.getId().getValue();
 
-        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
-        final ChildOption co = new ChildOption();
-        co.excludeType = Collections.singletonList(FileAnnotation.class.getSimpleName());
-        dc.childOptions = Collections.singletonList(co);
+        final ChildOption co = Requests.option(null, "FileAnnotation");
+        final Delete2 dc = Requests.delete("Image", img.getId().getValue(), co);
         callback(true, client, dc);
 
         // File annotation should be deleted even if
@@ -1928,10 +1920,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = createSharableAnnotation(img1, img2);
         assertEquals(n, ids.size());
         // now delete the image 1.
-        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
-        ChildOption co = new ChildOption();
-        co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(co);
+        ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+        Delete2 dc = Requests.delete("Image", img1.getId().getValue(), co);
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addIds(ids);
@@ -1946,10 +1936,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleDatasetData().asIObject());
         ids = createSharableAnnotation(d1, d2);
         // now delete the dataset 1.
-        dc = Requests.delete("Dataset", d1.getId().getValue());
-        co = new ChildOption();
-        co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(co);
+        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+        dc = Requests.delete("Dataset", d1.getId().getValue(), co);
         callback(true, client, dc);
         param = new ParametersI();
         param.addIds(ids);
@@ -1963,10 +1951,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleProjectData().asIObject());
         ids = createSharableAnnotation(p1, p2);
         // now delete the project 1.
-        dc = Requests.delete("Project", p1.getId().getValue());
-        co = new ChildOption();
-        co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(co);
+        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+        dc = Requests.delete("Project", p1.getId().getValue(), co);
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1981,10 +1967,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleScreenData().asIObject());
         ids = createSharableAnnotation(s1, s2);
         // now delete the screen 1.
-        dc = Requests.delete("Screen", s1.getId().getValue());
-        co = new ChildOption();
-        co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(co);
+        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+        dc = Requests.delete("Screen", s1.getId().getValue(), co);
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1999,10 +1983,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simplePlateData().asIObject());
         ids = createSharableAnnotation(plate1, plate2);
         // now delete the plate 1.
-        dc = Requests.delete("Plate", plate1.getId().getValue());
-        co = new ChildOption();
-        co.excludeType = SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(co);
+        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
+        dc = Requests.delete("Plate", plate1.getId().getValue(), co);
         callback(true, client, dc);
         param = new ParametersI();
         param.addIds(ids);
@@ -2434,11 +2416,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             annotationIds = createNonSharableAnnotation(obj, null);
             annotationIdsNS = createNonSharableAnnotation(obj, NAMESPACE);
 
-            final Delete2 dc = Requests.delete(type, id);
-            final ChildOption co = new ChildOption();
-            co.includeNs = Collections.singletonList(NAMESPACE);
-            co.excludeType = Collections.singletonList(Annotation.class.getSimpleName());
-            dc.childOptions = Collections.singletonList(co);
+            final ChildOption co = Requests.option(null, "Annotation", NAMESPACE, null);
+            final Delete2 dc = Requests.delete(type, id, co);
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -2492,11 +2471,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             List<String> ns = new ArrayList<String>();
             ns.add(NAMESPACE);
             ns.add(NAMESPACE_2);
-            final Delete2 dc = Requests.delete(type, id);
-            final ChildOption co = new ChildOption();
-            co.includeNs = ns;
-            co.excludeType = Collections.singletonList(Annotation.class.getSimpleName());
-            dc.childOptions = Collections.singletonList(co);
+            final ChildOption co = Requests.option(null, "Annotation", ns, null);
+            final Delete2 dc = Requests.delete(type, id, co);
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -2928,10 +2904,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         options.add(Dataset.class.getSimpleName());
         options.add(Image.class.getSimpleName());
         long id = p.getId().getValue();
-        Delete2 dc = Requests.delete("Project", id);
-        ChildOption co = new ChildOption();
-        co.excludeType = options;
-        dc.childOptions = Collections.singletonList(co);
+        ChildOption co = Requests.option(null, options);
+        Delete2 dc = Requests.delete("Project", id, co);
         callback(true, client, dc);
 
         assertDoesNotExist(p);
@@ -2964,10 +2938,8 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now delete the screen
         long id = s.getId().getValue();
-        Delete2 dc = Requests.delete("Screen", id);
-        ChildOption co = new ChildOption();
-        co.excludeType = Collections.singletonList(Plate.class.getSimpleName());
-        dc.childOptions = Collections.singletonList(co);
+        ChildOption co = Requests.option(null, "Plate");
+        Delete2 dc = Requests.delete("Screen", id, co);
         callback(true, client, dc);
 
         assertDoesNotExist(s);
@@ -2996,10 +2968,8 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now delete the dataset
         long id = d.getId().getValue();
-        Delete2 dc = Requests.delete("Dataset", id);
-        ChildOption co = new ChildOption();
-        co.excludeType = Collections.singletonList(Image.class.getSimpleName());
-        dc.childOptions = Collections.singletonList(co);
+        ChildOption co = Requests.option(null, "Image");
+        Delete2 dc = Requests.delete("Dataset", id, co);
         callback(true, client, dc);
 
         assertDoesNotExist(d);

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -290,12 +290,8 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
             }
         } finally {
-            final Delete2 request = Requests.delete("Project", projectId);
-
-            final ChildOption option = new ChildOption();
-            option.excludeType = Collections.singletonList("Image");
-            request.childOptions = Collections.singletonList(option);
-
+            final ChildOption option = Requests.option(null, "Image");
+            final Delete2 request = Requests.delete("Project", projectId, option);
             doChange(request);
         }
     }

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -40,6 +40,7 @@ import omero.cmd.DiskUsageResponse;
 import omero.cmd.ManageImageBinaries;
 import omero.cmd.ManageImageBinariesResponse;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.Channel;
 import omero.model.Dataset;
@@ -221,8 +222,7 @@ public class DiskUsageTest extends AbstractServerTest {
     @AfterClass
     public void teardown() throws Exception {
         if (imageId != null) {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
+            final Delete2 request = Requests.delete("Image", imageId);
             doChange(request);
         }
     }
@@ -290,8 +290,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Project", Collections.singletonList(projectId));
+            final Delete2 request = Requests.delete("Project", projectId);
 
             final ChildOption option = new ChildOption();
             option.excludeType = Collections.singletonList("Image");
@@ -367,8 +366,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }
@@ -407,8 +405,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }
@@ -441,8 +438,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }
@@ -492,8 +488,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }
@@ -528,8 +523,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }
@@ -558,8 +552,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = new Delete2();
-            request.targetObjects = ImmutableMap.of("Annotation", annotationIds);
+            final Delete2 request = Requests.delete("Annotation", annotationIds);
             doChange(request);
         }
     }

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2014-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -24,7 +24,6 @@ import static org.testng.AssertJUnit.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +43,7 @@ import omero.cmd.HandlePrx;
 import omero.cmd.OK;
 import omero.cmd.Request;
 import omero.cmd.Response;
+import omero.gateway.util.Requests;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
@@ -75,7 +75,6 @@ import pojos.GroupData;
 import pojos.PermissionData;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 /**
  * 
@@ -388,11 +387,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                                 && targetGroup != sourceGroup) {
                             img = images.get(k);
                             long imageId = img.getId().getValue();
-                            final Chgrp2 dc = new Chgrp2();
-                            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                                    Image.class.getSimpleName(),
-                                    Collections.singletonList(imageId));
-                            dc.groupId = targetGroup;
+                            final Chgrp2 dc = Requests.chgrp("Image", imageId, targetGroup);
                             testParams.add(new TestParam(dc, testUserNames[i],
                                     PASSWORD, sourceGroup));
                         }

--- a/components/tools/OmeroJava/test/integration/TableTest.java
+++ b/components/tools/OmeroJava/test/integration/TableTest.java
@@ -1,34 +1,29 @@
 /*
- * $Id$
- *
- *   Copyright 2006-2010 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 import omero.ApiUsageException;
 import omero.ServerError;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.grid.Column;
 import omero.grid.Data;
 import omero.grid.LongColumn;
 import omero.grid.StringColumn;
 import omero.grid.TablePrx;
-import omero.model.ImageAnnotationLink;
 import omero.model.OriginalFile;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Collections of tests for the <code>IUpdate</code> service.
@@ -111,10 +106,7 @@ public class TableTest extends AbstractServerTest {
     private void deleteTable() throws Exception {
         if (myTable != null) {
             OriginalFile f = myTable.getOriginalFile();
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    OriginalFile.class.getSimpleName(),
-                    Collections.singletonList(f.getId().getValue()));
+            final Delete2 dc = Requests.delete("OriginalFile", f.getId().getValue());
             callback(true, client, dc);
             myTable = null;
         }

--- a/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
- *   Copyright 2006-2010 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import static omero.rtypes.rlong;
@@ -17,14 +16,13 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import omero.cmd.Delete2;
-import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.AnnotationAnnotationLinkI;
 import omero.model.BooleanAnnotation;
@@ -104,8 +102,6 @@ import omero.model.XmlAnnotationI;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import pojos.BooleanAnnotationData;
 import pojos.DatasetData;
@@ -557,7 +553,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         ParametersI param = new ParametersI();
         param.exp(rlong(self));
         //method tested in PojosServiceTest
-        List results = factory.getContainerService().loadContainerHierarchy(
+        List<IObject> results = factory.getContainerService().loadContainerHierarchy(
                 Plate.class.getName(),
                 Arrays.asList(pp.getId().getValue()), param);
         pp = (Plate) results.get(0);
@@ -741,10 +737,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         assertNotNull(l);
         long id = l.getId().getValue();
         // annotation and image are linked. Remove the link.
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                ImageAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        final Delete2 dc = Requests.delete("ImageAnnotationLink", l.getId().getValue());
         callback(true, client, dc);
         // now check that the image is no longer linked to the annotation
         String sql = "select link from ImageAnnotationLink as link";

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
- * Copyright 2006-2013 University of Dundee. All rights reserved.
+ * Copyright 2006-2015 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
@@ -15,6 +14,7 @@ import java.util.List;
 
 import omero.cmd.Chgrp2;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.ExperimenterGroup;
 import omero.model.IObject;
 import omero.model.Image;
@@ -26,8 +26,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -77,11 +75,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         // reconnect as user1
         init(clientUser1);
         // now move the image.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         // Annotation of user1 should be removed
@@ -132,11 +126,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         List<Long> annotationIds = createNonSharableAnnotation(img, null);
         // now move the image.
         long id = img.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -178,11 +168,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         List<Long> annotationIds = createSharableAnnotation(img, null);
         // now move the image.
         long id = img.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -224,11 +210,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         assertTrue(annotationIds.size() > 0);
         // now move the image.
         long id = img.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         final ChildOption option = new ChildOption();
         option.excludeType = DeleteServiceTest.SHARABLE_TO_KEEP_LIST;
         dc.childOptions = Collections.singletonList(option);
@@ -550,11 +532,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         long id = img1.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         final ChildOption option = new ChildOption();
         option.excludeType = DeleteServiceTest.SHARABLE_TO_KEEP_LIST;
         dc.childOptions = Collections.singletonList(option);

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -9,7 +9,6 @@ import integration.AbstractServerTest;
 import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import omero.cmd.Chgrp2;
@@ -210,10 +209,8 @@ public class AnnotationMoveTest extends AbstractServerTest {
         assertTrue(annotationIds.size() > 0);
         // now move the image.
         long id = img.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
-        final ChildOption option = new ChildOption();
-        option.excludeType = DeleteServiceTest.SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, DeleteServiceTest.SHARABLE_TO_KEEP_LIST);
+        final Chgrp2 dc = Requests.chgrp("Image", id, option, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -532,10 +529,8 @@ public class AnnotationMoveTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         long id = img1.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
-        final ChildOption option = new ChildOption();
-        option.excludeType = DeleteServiceTest.SHARABLE_TO_KEEP_LIST;
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, DeleteServiceTest.SHARABLE_TO_KEEP_LIST);
+        final Chgrp2 dc = Requests.chgrp("Image", id, option, g.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -1,19 +1,17 @@
 /*
- * $Id$
- *
- * Copyright 2006-2011 University of Dundee. All rights reserved.
+ * Copyright 2006-2015 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
@@ -23,8 +21,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -63,11 +59,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         // Create a new group and make owner of first group an owner.
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -109,11 +101,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -153,11 +141,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -198,11 +182,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -246,11 +226,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -291,11 +267,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser("rwr---", ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -336,11 +308,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser("rw----", ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -381,11 +349,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -426,11 +390,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -470,11 +430,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         // admin logs into first group
         disconnect();
         logRootIntoGroup(ctx);
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -526,11 +482,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -597,11 +549,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -671,11 +619,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -751,11 +695,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -820,11 +760,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // user2 tries to move it.
         ctx2 = init(ctx2);
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
@@ -2,7 +2,7 @@
  * integration.chgrp.HierarchyMoveCombinedDataTest
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -21,18 +21,17 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import omero.cmd.Chgrp2;
-import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
@@ -44,8 +43,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -135,11 +132,7 @@ public class HierarchyMoveCombinedDataTest extends AbstractServerTest {
                 logRootIntoGroup(ctx.groupId);
         }
         // Create commands to move and create the link in target
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", d.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         // Check if the dataset has been removed.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -19,25 +19,23 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chgrp;
 
 /**
- *
- *
  * @author Scott Littlewood, <a href="mailto:sylittlewood@dundee.ac.uk">sylittlewood@dundee.ac.uk</a>
  * @since Beta4.4
  */
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import omero.api.Save;
 import omero.cmd.Chgrp2;
 import omero.cmd.DoAll;
 import omero.cmd.Request;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
@@ -54,8 +52,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -155,11 +151,7 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
 
         // Create commands to move and create the link in target
         List<Request> list = new ArrayList<Request>();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(d.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", d.getId().getValue(), g.getId().getValue());
         list.add(dc);
 
         ProjectDatasetLink link = null;
@@ -276,11 +268,7 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(s1.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", s1.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -289,7 +277,7 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Image as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), ids.size());
 
         // S1 should have moved

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2012 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -19,19 +19,19 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import ome.xml.model.OME;
 import omero.ServerError;
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.ExperimenterGroup;
 import omero.model.Image;
@@ -45,15 +45,11 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
 
 /**
- *
- *
  * @author Scott Littlewood, <a
  *         href="mailto:sylittlewood@dundee.ac.uk">sylittlewood@dundee.ac.uk</a>
  * @since Beta4.4
@@ -151,11 +147,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         loginUser(sourceGroup);
 
         // Perform the move operation.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(originalImageId));
-        dc.groupId = targetGroupId;
+        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, targetGroupId);
         callback(true, client, dc);
 
         // check if the image have been moved.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -19,20 +19,20 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chgrp;
 
 import static omero.rtypes.rdouble;
 import static omero.rtypes.rint;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import omero.ServerError;
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.ExperimenterGroup;
 import omero.model.IObject;
@@ -47,13 +47,9 @@ import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 
 /**
- *
- *
  * @author Scott Littlewood, <a
  *         href="mailto:sylittlewood@dundee.ac.uk">sylittlewood@dundee.ac.uk</a>
  * @since Beta4.4
@@ -111,11 +107,7 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
         loginUser(imageOwnerContext);
 
         // Perform the move operation as original user
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(originalImageId));
-        dc.groupId = targetGroup.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, targetGroup.getId().getValue());
         callback(true, client, dc);
 
         // check the roi has been moved to target group

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -19,19 +19,19 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chgrp;
 
 import static omero.rtypes.rdouble;
 import static omero.rtypes.rint;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import omero.ServerError;
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.model.ExperimenterGroup;
 import omero.model.IObject;
 import omero.model.Image;
@@ -45,13 +45,9 @@ import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 
 /**
- *
- *
  * @author Scott Littlewood, <a
  *         href="mailto:sylittlewood@dundee.ac.uk">sylittlewood@dundee.ac.uk</a>
  * @since Beta4.4
@@ -99,11 +95,7 @@ public class HierarchyMoveImageWithRoiTest extends AbstractServerTest {
         loginUser(sourceGroup);
 
         // Perform the move operation.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(originalImageId));
-        dc.groupId = rwGroupId;
+        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, rwGroupId);
         callback(true, client, dc);
 
         // check if the objects have been moved.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -10,14 +10,12 @@ import static omero.rtypes.rint;
 import integration.AbstractServerTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.grid.Column;
 import omero.grid.LongColumn;
 import omero.grid.TablePrx;
@@ -62,8 +60,6 @@ import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 import pojos.FileAnnotationData;
 
@@ -92,11 +88,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         Image img = (Image) iUpdate
                 .saveAndReturnObject(mmFactory.createImage());
         long id = img.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -154,11 +146,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         // Move the image
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -289,11 +277,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
             shapeIds.add(shape.getId().getValue());
         }
         // Move the image.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(image.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Image", image.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         // check if the objects have been delete.
@@ -307,7 +291,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         param = new ParametersI();
         param.addIds(shapeIds);
         sql = "select d from Shape as d where d.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         // Check that the data moved
@@ -339,12 +323,12 @@ public class HierarchyMoveTest extends AbstractServerTest {
         iAdmin.getEventContext(); // Refresh
 
         Plate p;
-        List results;
+        List<IObject> results;
         PlateAcquisition pa = null;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
@@ -377,13 +361,8 @@ public class HierarchyMoveTest extends AbstractServerTest {
                 imageIds.add(field.getImage().getId().getValue());
             }
         }
-        // Now delete the plate
         // Move the plate.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         // check the well
@@ -471,11 +450,11 @@ public class HierarchyMoveTest extends AbstractServerTest {
         iAdmin.getEventContext(); // Refresh
 
         Plate p;
-        List results;
+        List<IObject> results;
         StringBuilder sb;
         Well well;
         WellSample field;
-        Iterator j;
+        Iterator<IObject> j;
         ParametersI param;
         List<Long> wellSampleIds;
         List<Long> imageIds;
@@ -505,11 +484,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         // Move the plate.
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         // check the well
@@ -599,11 +574,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screen.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Screen", screen.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -614,7 +585,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Plate as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         param = new ParametersI();
@@ -675,11 +646,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screenId));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Screen", screenId, g.getId().getValue());
         callback(true, client, dc);
 
         sql = "select r from Screen as r ";
@@ -760,11 +727,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ScreenPlateLink link = (ScreenPlateLink) iQuery.findByQuery(sql, param);
         p = link.getChild();
         long plateID = p.getId().getValue();
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plateID));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Plate", plateID, g.getId().getValue());
         callback(true, client, dc);
         sql = "select r from Screen as r ";
         sql += "where r.id = :id";
@@ -864,11 +827,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(il);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
  
         // Shouldn't have measurements
@@ -925,18 +884,14 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Project", p.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         // Check if objects have been deleted
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Image as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
 
         param = new ParametersI();
@@ -1004,11 +959,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(s1.getId().getValue()));
-        dc.groupId = g.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Screen", s1.getId().getValue(), g.getId().getValue());
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -1018,7 +969,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ParametersI param = new ParametersI();
         param.addIds(ids);
         String sql = "select i from Plate as i where i.id in (:ids)";
-        List results = iQuery.findAllByQuery(sql, param);
+        List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), ids.size());
 
         param = new ParametersI();
@@ -1095,11 +1046,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         /* move the dataset */
-        final Chgrp2 chgrp = new Chgrp2();
-        chgrp.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
-        chgrp.groupId = destination.getId().getValue();
+        final Chgrp2 chgrp = Requests.chgrp("Dataset", dataset.getId().getValue(), destination.getId().getValue());
         callback(true, client, chgrp);
 
         /* check what remains in the source group */

--- a/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
@@ -15,19 +15,16 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.testng.annotations.BeforeClass;
@@ -45,10 +42,10 @@ import omero.api.IMetadataPrx;
 import omero.api.IUpdatePrx;
 import omero.cmd.Chgrp2;
 import omero.cmd.Delete2;
-import omero.cmd.DoAll;
 import omero.cmd.OK;
 import omero.cmd.Request;
 import omero.cmd.Response;
+import omero.gateway.util.Requests;
 import omero.model.Arc;
 import omero.model.Channel;
 import omero.model.Dataset;
@@ -174,11 +171,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
         long fs1 = f.images.get(1).getFileset().getId().getValue();
         assertEquals(fs0, fs1);
 
-        final Chgrp2 mv = new Chgrp2();
-        mv.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img0));
-        mv.groupId = secondGroup.getId().getValue();
+        final Chgrp2 mv = Requests.chgrp("Image", img0, secondGroup.getId().getValue());
 
         Response rsp = doChange(client, factory, mv, false); // Don't pass
         // However, it should still be possible to delete the 2 images
@@ -203,11 +196,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     	List<Image> images = importMIF(imageCount);
         long fs0 = images.get(0).getFileset().getId().getValue();
 
-        final Chgrp2 mv = new Chgrp2();
-        mv.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Fileset.class.getSimpleName(),
-                Collections.singletonList(fs0));
-        mv.groupId = secondGroup.getId().getValue();
+        final Chgrp2 mv = Requests.chgrp("Fileset", fs0, secondGroup.getId().getValue());
 
         Response rsp = doChange(client, factory, mv, true);
         OK err = (OK) rsp;
@@ -250,11 +239,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     		set.addImage(j.next());
 		}
     	set = (Fileset) iUpdate.saveAndReturnObject(set);
-    	final Chgrp2 mv = new Chgrp2();
-        mv.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Fileset.class.getSimpleName(),
-                Collections.singletonList(set.getId().getValue()));
-        mv.groupId = secondGroup.getId().getValue();
+    	final Chgrp2 mv = Requests.chgrp("Fileset", set.getId().getValue(), secondGroup.getId().getValue());
     	Response rsp = doChange(client, factory, mv, true);
     	OK err = (OK) rsp;
     	assertNotNull(err);
@@ -439,11 +424,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
 		}
         long filesetID = images.get(0).getFileset().getId().getValue();
         iUpdate.saveAndReturnArray(links);
-        final Chgrp2 dc = new Chgrp2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
-        dc.groupId = secondGroup.getId().getValue();
+        final Chgrp2 dc = Requests.chgrp("Dataset", dataset.getId().getValue(), secondGroup.getId().getValue());
 
     	doAllChanges(client, factory, true, dc);
     	disconnect();

--- a/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
@@ -30,8 +30,6 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
@@ -179,10 +177,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
         List<Long> ids = new ArrayList<Long>();
         ids.add(img0);
         ids.add(img1);
-        List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(), ids);
+        Delete2 dc = Requests.delete("Image", ids);
         callback(true, client, dc);
         assertDoesNotExist(new FilesetI(fs0, false));
     }

--- a/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
@@ -1,21 +1,19 @@
 /*
- * $Id$
- *
- * Copyright 2006-2013 University of Dundee. All rights reserved.
+ * Copyright 2006-2015 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.chgrp;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import omero.api.IPixelsPrx;
 import omero.api.IRenderingSettingsPrx;
 import omero.cmd.Chgrp2;
+import omero.gateway.util.Requests;
 import omero.model.ExperimenterGroup;
 import omero.model.IObject;
 import omero.model.Image;
@@ -23,8 +21,6 @@ import omero.model.Pixels;
 import omero.sys.EventContext;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -104,11 +100,7 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
         //move the image(s)
         long id = img.getId().getValue();
         // Move the image
-        final Chgrp2 mv = new Chgrp2();
-        mv.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(id));
-        mv.groupId = g.getId().getValue();
+        final Chgrp2 mv = Requests.chgrp("Image", id, g.getId().getValue());
         callback(true, client, mv);
 
         //Check if the settings have been deleted.

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -108,8 +108,7 @@ public class PermissionsTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = new Delete2();
-        delete.targetObjects = ImmutableMap.of("Image", testImages);
+        final Delete2 delete = Requests.delete("Image", testImages);
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -31,6 +31,7 @@ import omero.RType;
 import omero.ServerError;
 import omero.cmd.Chmod2;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
@@ -223,9 +224,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chmod */
 
         init(chmodder);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = toPerms;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
         disconnect();
 
@@ -386,9 +385,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chmod */
 
         init(chmodder);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = "rw----";
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, "rw----");
         doChange(client, factory, chmod, true);
         disconnect();
 
@@ -480,9 +477,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = toPerms;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
         disconnect();
 
@@ -549,9 +544,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = toPerms;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
         disconnect();
 
@@ -639,9 +632,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = toPerms;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
         disconnect();
 

--- a/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
@@ -2,7 +2,7 @@
  * integration.chmod.RolesTest 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -21,21 +21,18 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.chmod;
 
-
-import java.util.Collections;
 import java.util.List;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.testng.AssertJUnit.*;
 import static omero.rtypes.rstring;
 import omero.cmd.Delete2;
-import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotation;
 import omero.model.CommentAnnotationI;
@@ -52,7 +49,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import pojos.DatasetData;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 /**
  * Tests the can edit, can annotate.
@@ -67,6 +63,7 @@ public class RolesTest extends AbstractServerTest {
      * Since we are creating a new client on each invocation, we should also
      * clean it up. Note: {@link #newUserAndGroup(String)} also closes, but not
      * the very last invocation.
+     * @throws Exception unexpected
      */
     @AfterMethod
     public void close() throws Exception {
@@ -122,10 +119,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetImageLink.class.getSimpleName(),
-                    Collections.singletonList(l.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -134,10 +128,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetAnnotationLink.class.getSimpleName(),
-                    Collections.singletonList(dl.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -146,13 +137,10 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Annotation.class.getSimpleName(),
-                    Collections.singletonList(ann.getId().getValue()));
+            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
-            fail("Member should not be allowed to delete " + "the annotation.");
+            fail("Member should not be allowed to delete the annotation.");
         }
 
 
@@ -180,7 +168,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to edit i.e. canEdit
         try {
-            d.setName(rstring("newNAme"));
+            d.setName(rstring("newName"));
             iUpdate.saveAndReturnObject(d);
             fail("Member should not be allowed to edit a dataset.");
         } catch (Exception e) {
@@ -241,24 +229,15 @@ public class RolesTest extends AbstractServerTest {
 
         // Create a link canLink
         // Try to delete the link i.e. canDelete
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -286,7 +265,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -344,24 +323,15 @@ public class RolesTest extends AbstractServerTest {
 
         // Create a link canLink
         // Try to delete the link i.e. canDelete
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -387,7 +357,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -458,10 +428,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetImageLink.class.getSimpleName(),
-                    Collections.singletonList(l.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -470,10 +437,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetAnnotationLink.class.getSimpleName(),
-                    Collections.singletonList(dl.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -482,10 +446,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Annotation.class.getSimpleName(),
-                    Collections.singletonList(ann.getId().getValue()));
+            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete " + "the annotation.");
@@ -515,7 +476,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to edit i.e. canEdit
         try {
-            d.setName(rstring("newNAme"));
+            d.setName(rstring("newName"));
             iUpdate.saveAndReturnObject(d);
             fail("Member should not be allowed to edit a dataset.");
         } catch (Exception e) {
@@ -578,24 +539,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -613,7 +565,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -672,24 +624,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -707,7 +650,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -772,10 +715,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetImageLink.class.getSimpleName(),
-                    Collections.singletonList(l.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -784,10 +724,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    DatasetAnnotationLink.class.getSimpleName(),
-                    Collections.singletonList(dl.getId().getValue()));
+            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -796,10 +733,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Annotation.class.getSimpleName(),
-                    Collections.singletonList(ann.getId().getValue()));
+            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete " + "the annotation.");
@@ -825,7 +759,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to edit i.e. canEdit
         try {
-            d.setName(rstring("newNAme"));
+            d.setName(rstring("newName"));
             iUpdate.saveAndReturnObject(d);
             fail("Member should not be allowed to edit a dataset.");
         } catch (Exception e) {
@@ -888,24 +822,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -923,7 +848,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -982,24 +907,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -1017,7 +933,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -1075,24 +991,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
         // Try to delete the dataset i.e. canDelete
 
@@ -1111,11 +1018,9 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(), Collections.singletonList(id));
+        dc = Requests.delete("Dataset", id);
         callback(true, client, dc);
     }
 
@@ -1175,24 +1080,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -1210,7 +1106,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 
@@ -1268,24 +1164,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetImageLink.class.getSimpleName(),
-                Collections.singletonList(l.getId().getValue()));
+        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                DatasetAnnotationLink.class.getSimpleName(),
-                Collections.singletonList(dl.getId().getValue()));
+        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Annotation.class.getSimpleName(),
-                Collections.singletonList(ann.getId().getValue()));
+        dc = Requests.delete("Annotation", ann.getId().getValue());
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -1303,7 +1190,7 @@ public class RolesTest extends AbstractServerTest {
         dl = (DatasetAnnotationLink) iUpdate.saveAndReturnObject(dl);
 
         // Try to edit i.e. canEdit
-        d.setName(rstring("newNAme"));
+        d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
     }
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -32,6 +32,7 @@ import omero.ServerError;
 import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
@@ -648,9 +649,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = groupPermissions;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
         doChange(client, factory, chmod, true);
         disconnect();
 
@@ -719,9 +718,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
-        final Chmod2 chmod = new Chmod2();
-        chmod.targetObjects = ImmutableMap.of("ExperimenterGroup", Collections.singletonList(dataGroupId));
-        chmod.permissions = groupPermissions;
+        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
         doChange(client, factory, chmod, true);
         disconnect();
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -422,7 +422,7 @@ public class PermissionsTest extends AbstractServerTest {
      * Test a specific case of using {@link Chown2} on an image that is in a dataset.
      * @param isImageOwner if the user who owns the dataset also owns the image
      * @param isLinkOwner if the user who owns the dataset also linked the image to the dataset
-     * @param groupPerms the permissions on the group in which the data exists
+     * @param groupPermissions the permissions on the group in which the data exists
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown container test cases")
@@ -499,7 +499,7 @@ public class PermissionsTest extends AbstractServerTest {
      * Test a specific case of using {@link Chown2} on a dataset that contains an image.
      * @param isImageOwner if the user who owns the dataset also owns the image
      * @param isLinkOwner if the user who owns the dataset also linked the image to the dataset
-     * @param groupPerms the permissions on the group in which the data exists
+     * @param groupPermissions the permissions on the group in which the data exists
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown container test cases")

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -262,9 +262,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(chowner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, isExpectSuccess);
         disconnect();
 
@@ -358,9 +356,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(chowner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, isExpectSuccess);
         disconnect();
 
@@ -474,9 +470,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
         disconnect();
 
@@ -552,9 +546,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(datasetOwner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Dataset", datasetId, recipient.userId);
         doChange(client, factory, chown, true);
         disconnect();
 
@@ -656,9 +648,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
         disconnect();
 
@@ -725,9 +715,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = new Chown2();
-        chown.targetObjects = ImmutableMap.of("Image", Collections.singletonList(imageId));
-        chown.userId = recipient.userId;
+        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
         disconnect();
 
@@ -844,21 +832,23 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(datasetOwner);
-        final Chown2 chown = new Chown2();
+        final Chown2 chown;
 
         switch (target) {
         case DATASET:
-            chown.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+            chown = Requests.chown("Dataset", datasetId, recipient.userId);
             break;
         case IMAGES:
-            chown.targetObjects = ImmutableMap.of("Image", imageIds);
+            chown = Requests.chown("Image", imageIds, recipient.userId);
             break;
         case PLATE:
-            chown.targetObjects = ImmutableMap.of("Plate", Collections.singletonList(plateId));
+            chown = Requests.chown("Plate", plateId, recipient.userId);
             break;
+        default:
+            chown = null;
+            Assert.fail("unexpected target for chown");
         }
 
-        chown.userId = recipient.userId;
         doChange(client, factory, chown, true);
         disconnect();
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -105,8 +105,7 @@ public class PermissionsTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = new Delete2();
-        delete.targetObjects = ImmutableMap.of("Image", testImages);
+        final Delete2 delete = Requests.delete("Image", testImages);
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -9,7 +9,6 @@ import integration.AbstractServerTest;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import ome.testing.ObjectFactory;
@@ -401,10 +400,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Image", pid);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList("TagAnnotation");
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "TagAnnotation");
+        final Delete2 dc = Requests.delete("Image", pid, option);
         callback(true, client, dc);
 
         // Make sure the image is deleted but the annotation remains.
@@ -441,10 +438,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Image", pid);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList("FileAnnotation");
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "FileAnnotation");
+        final Delete2 dc = Requests.delete("Image", pid, option);
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -480,11 +475,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Image", pid);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList("FileAnnotation");
-        option.excludeNs = Collections.singletonList("keepme");
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "FileAnnotation", null, "keepme");
+        final Delete2 dc = Requests.delete("Image", pid, option);
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -517,11 +509,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         List<Long> annotationIds = createNonSharableAnnotation(obj, null);
         List<Long> annotationIdsNS = createNonSharableAnnotation(obj, "TEST");
 
-        final Delete2 dc = Requests.delete(type, id);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList("Annotation");
-        option.excludeNs = Collections.singletonList("TEST");
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "Annotation", null, "TEST");
+        final Delete2 dc = Requests.delete(type, id, option);
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -581,10 +570,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long id = file.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("OriginalFile", id);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList("Annotation");
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "Annotation");
+        final Delete2 dc = Requests.delete("OriginalFile", id, option);
         callback(true, client, dc);
 
         assertGone(ann);

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -20,6 +20,7 @@ import omero.RType;
 import omero.cmd.Delete2;
 import omero.cmd.SkipHead;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.AnnotationAnnotationLink;
 import omero.model.AnnotationAnnotationLinkI;
 import omero.model.Dataset;
@@ -142,8 +143,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
      */
     public void testImage() throws Exception {
         final long imageId = iUpdate.saveAndReturnObject(mmFactory.createImage()).getId().getValue();
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(imageId));
+        final Delete2 dc = Requests.delete("Image", imageId);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -167,8 +167,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long annId = link.getChild().getId().getValue();
 
         // Perform delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(imageId));
+        final Delete2 dc = Requests.delete("Image", imageId);
         callback(true, client, dc);
 
         // Check that the annotation is gone
@@ -204,8 +203,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         link2 = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link2);
 
         // Perform delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(imageId1));
+        final Delete2 dc = Requests.delete("Image", imageId1);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -239,8 +237,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long id = p.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Project", Collections.singletonList(id));
+        final Delete2 dc = Requests.delete("Project", id);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -274,8 +271,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long did = d.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Project", Collections.singletonList(pid));
+        final Delete2 dc = Requests.delete("Project", pid);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -312,8 +308,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long wsid = ws.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Plate", Collections.singletonList(pid));
+        final Delete2 dc = Requests.delete("Plate", pid);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -349,8 +344,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long aid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(iid));
+        final Delete2 dc = Requests.delete("Image", iid);
         callback(true, client, dc);
 
         // Check that data is gone
@@ -382,8 +376,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Annotation", Collections.singletonList(cid));
+        final Delete2 dc = Requests.delete("Annotation", cid);
         callback(true, client, dc);
 
         // Make sure the parent annotation still exists, but both the annotation
@@ -416,11 +409,10 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Image", pid);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList("TagAnnotation");
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(pid));
         callback(true, client, dc);
 
         // Make sure the image is deleted but the annotation remains.
@@ -457,11 +449,10 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Image", pid);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList("FileAnnotation");
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(pid));
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -497,12 +488,11 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Image", pid);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList("FileAnnotation");
         option.excludeNs = Collections.singletonList("keepme");
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(pid));
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -535,12 +525,11 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         List<Long> annotationIds = createNonSharableAnnotation(obj, null);
         List<Long> annotationIdsNS = createNonSharableAnnotation(obj, "TEST");
 
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete(type, id);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList("Annotation");
         option.excludeNs = Collections.singletonList("TEST");
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(type, Collections.singletonList(id));
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -582,8 +571,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long id = file.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("OriginalFile", Collections.singletonList(id));
+        final Delete2 dc = Requests.delete("OriginalFile", id);
         callback(true, client, dc);
 
         assertGone(file);
@@ -601,11 +589,10 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long id = file.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("OriginalFile", id);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList("Annotation");
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("OriginalFile", Collections.singletonList(id));
         callback(true, client, dc);
 
         assertGone(ann);

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -57,8 +57,6 @@ import org.springframework.util.ResourceUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Tests deletion of various elements of the graph.
  * These tests are resurrected from the previous DeleteITest class, now deleted.
@@ -81,10 +79,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         Assert.assertFalse(ids.isEmpty());
 
         // Perform delete
-        final SkipHead dc = new SkipHead();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(imageId));
-        dc.startFrom = Collections.singletonList("Channel");
-        dc.request = new Delete2();
+        final SkipHead dc = Requests.skipHead("Image", imageId, "Channel", new Delete2());
         callback(true, client, dc);
 
         // Check that data is gone
@@ -115,10 +110,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         Assert.assertFalse(ids.isEmpty());
 
         // Perform delete
-        final SkipHead dc = new SkipHead();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of("Image", Collections.singletonList(imageId));
-        dc.startFrom = Collections.singletonList("RenderingDef");
-        dc.request = new Delete2();
+        final SkipHead dc = Requests.skipHead("Image", imageId, "RenderingDef", new Delete2());
         callback(true, client, dc);
 
         // Check that data is gone

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -1,26 +1,22 @@
 /*
- * $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import static omero.rtypes.rlong;
 import static omero.rtypes.rstring;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import omero.RLong;
 import omero.RString;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.Channel;
 import omero.model.FileAnnotation;
@@ -38,10 +34,6 @@ import omero.model.TagAnnotationI;
 import omero.sys.EventContext;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
-
-import static org.testng.AssertJUnit.*;
 
 /**
  * Tests for deleting user ratings.
@@ -91,9 +83,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
                 .saveAndReturnObject(new TagAnnotationI());
         IObject link = mmFactory.createAnnotationLink(obj.proxy(), ann);
         link = iUpdate.saveAndReturnObject(link);
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(command,
-                Collections.singletonList(id.getValue()));
+        final Delete2 dc = Requests.delete(command, id.getValue());
         callback(true, client, dc);
         assertDoesNotExist(obj);
         assertDoesNotExist(link);
@@ -125,10 +115,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             fa.setFile(mmFactory.createOriginalFile());
             fa = (FileAnnotation) iUpdate.saveAndReturnObject(fa);
             file = fa.getFile();
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Annotation.class.getSimpleName(),
-                    Collections.singletonList(fa.getId().getValue()));
+            final Delete2 dc = Requests.delete("Annotation", fa.getId().getValue());
             callback(true, client, dc);
             assertDoesNotExist(fa);
             assertDoesNotExist(file);
@@ -160,10 +147,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         disconnect();
 
         loginUser(owner);
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(i1.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(i1);
         assertDoesNotExist(link);

--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -1,38 +1,30 @@
 /*
- * $Id$
- *
- * Copyright 2013 University of Dundee. All rights reserved.
+ * Copyright 2013-2015 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 import omero.SecurityViolation;
 import omero.api.IProjectionPrx;
 import omero.cmd.Delete2;
-import omero.cmd.DoAll;
-import omero.cmd.Request;
 import omero.constants.projection.ProjectionType;
+import omero.gateway.util.Requests;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Pixels;
 import omero.sys.EventContext;
-import omero.sys.ParametersI;
 
 import org.springframework.util.ResourceUtils;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Deleted projected image and/or source image.
@@ -138,34 +130,17 @@ public class DeleteProjectedImageTest  extends AbstractServerTest {
         Delete2 dc;
         switch (action) {
         case SOURCE_IMAGE:
-            dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(id));
+            dc = Requests.delete("Image", id);
             callback(passes, client, dc);
             break;
         case PROJECTED_IMAGE:
-            dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(projectedID));
+            dc = Requests.delete("Image", projectedID);
             callback(passes, client, dc);
             break;
         case BOTH_IMAGES:
-            List<Request> commands = new ArrayList<Request>();
-            dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(id));
-            commands.add(dc);
-            dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    Image.class.getSimpleName(),
-                    Collections.singletonList(projectedID));
-            commands.add(dc);
-            DoAll all = new DoAll();
-            all.requests = commands;
-            doChange(client, factory, all, passes, null);
+            dc = Requests.delete("Image", Arrays.asList(id, projectedID));
+            callback(passes, client, dc);
+            break;
         }
 
         //Check the result

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import static omero.rtypes.rbool;
@@ -31,6 +30,7 @@ import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
@@ -118,10 +118,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         ds2.linkImage(i2);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(ds2);
@@ -166,10 +163,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         link.setParent((Image) i.proxy());
         iUpdate.saveAndReturnObject(link);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(ds2);
         assertExists(ds1);
@@ -204,10 +198,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         ds2.linkImage(i);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(ds2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(ds2);
@@ -244,10 +235,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         p2.linkDataset(d);
         p2 = (Project) iUpdate.saveAndReturnObject(p2);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Project.class.getSimpleName(),
-                Collections.singletonList(p2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Project", p2.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(p2);
@@ -283,10 +271,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         s2.linkPlate(p);
         s2 = (Screen) iUpdate.saveAndReturnObject(s2);
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(s2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Screen", s2.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(s2);
@@ -473,10 +458,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
 
             /* Delete the run. */
 
-            final Delete2 dc = new Delete2();
-            dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                    PlateAcquisition.class.getSimpleName(),
-                    Collections.singletonList(runIdToDelete));
+            final Delete2 dc = Requests.delete("PlateAcquisition", runIdToDelete);
             callback(true, client, dc);
             
             /* Verify that exactly the expected entities remain. */
@@ -488,10 +470,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
        }
  
         /* Delete the plate. */
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(plateId));
+        final Delete2 dc = Requests.delete("Plate", plateId);
         callback(true, client, dc);
 
         /* Verify that no entities remain. */
@@ -563,10 +542,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnObject(link);
 
         /* delete the dataset */
-        final Delete2 delete = new Delete2();
-        delete.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Dataset.class.getSimpleName(),
-                Collections.singletonList(dataset.getId().getValue()));
+        final Delete2 delete = Requests.delete("Dataset", dataset.getId().getValue());
         callback(true, client, delete);
 
         /* check what is left afterward */
@@ -620,18 +596,21 @@ public class HierarchyDeleteTest extends AbstractServerTest {
 
         final boolean isExpectSuccess = target != Target.IMAGES;
 
-        final Delete2 delete = new Delete2();
+        final Delete2 delete;
 
         switch (target) {
         case DATASET:
-            delete.targetObjects = ImmutableMap.of("Dataset", Collections.singletonList(datasetId));
+            delete = Requests.delete("Dataset", datasetId);
             break;
         case IMAGES:
-            delete.targetObjects = ImmutableMap.of("Image", imageIds);
+            delete = Requests.delete("Image", imageIds);
             break;
         case PLATE:
-            delete.targetObjects = ImmutableMap.of("Plate", Collections.singletonList(plateId));
+            delete = Requests.delete("Plate", plateId);
             break;
+        default:
+            delete = null;
+            Assert.fail("unexpected target for delete");
         }
 
         doChange(client, factory, delete, isExpectSuccess);

--- a/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
@@ -16,6 +16,7 @@ import omero.ServerError;
 import omero.api.IRenderingSettingsPrx;
 import omero.cmd.Delete2;
 import omero.cmd.SkipHead;
+import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
@@ -28,8 +29,6 @@ import omero.sys.ParametersI;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests for deleting hierarchies and the effects that that should have under
@@ -73,10 +72,7 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
     	link.setChild((Image) i2.proxy());
     	link.setParent((Dataset) d2.proxy());
     	iUpdate.saveAndReturnObject(link);
-    	Delete2 dc = new Delete2();
-    	dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-    	        Dataset.class.getSimpleName(),
-    	        Arrays.asList(d1.getId().getValue(), d2.getId().getValue()));
+    	Delete2 dc = Requests.delete("Dataset", Arrays.asList(d1.getId().getValue(), d2.getId().getValue()));
     	doChange(dc);
     	assertDoesNotExist(d1);
     	assertDoesNotExist(d2);
@@ -179,8 +175,7 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
             assertHasRenderingDef(image2Id, isImage2SettingsExist);
 
             /* delete the fileset */
-            final Delete2 delete = new Delete2();
-            delete.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
+            final Delete2 delete = Requests.delete("Fileset", filesetId);
             doChange(delete);
         }
 

--- a/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
@@ -7,7 +7,6 @@ package integration.delete;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import integration.AbstractServerTest;
@@ -125,26 +124,23 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
 
         /* delete the images of the fileset, the rendering settings of one of the images, or nonsense */
 
-        final SkipHead skipHead = new SkipHead();
-        skipHead.request = new Delete2();
-        skipHead.dryRun = dryRun;
+        final SkipHead skipHead;
         switch (target) {
         case IMAGES_OF_FILESET:
-            skipHead.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
-            skipHead.startFrom = Collections.singletonList("Image");
+            skipHead = Requests.skipHead("Fileset", filesetId, dryRun, "Image", new Delete2());
             break;
         case RENDERING_SETTINGS_OF_FILESET:
-            skipHead.targetObjects = Collections.singletonMap("Fileset", Collections.singletonList(filesetId));
-            skipHead.startFrom = Collections.singletonList("RenderingDef");
+            skipHead = Requests.skipHead("Fileset", filesetId, dryRun, "RenderingDef", new Delete2());
             break;
         case RENDERING_SETTINGS_OF_IMAGE:
-            skipHead.targetObjects = Collections.singletonMap("Image", Collections.singletonList(image1Id));
-            skipHead.startFrom = Collections.singletonList("RenderingDef");
+            skipHead = Requests.skipHead("Image", image1Id, dryRun, "RenderingDef", new Delete2());
             break;
         case NONSENSE_OF_IMAGE:
-            skipHead.targetObjects = Collections.singletonMap("Image", Collections.singletonList(image1Id));
-            skipHead.startFrom = Collections.singletonList("I like penguins");
+            skipHead = Requests.skipHead("Image", image1Id, dryRun, "I like penguins", new Delete2());
             break;
+        default:
+            skipHead = null;
+            Assert.fail("unexpected target for delete");
         }
 
         final boolean isExpectSuccess = target != Target.NONSENSE_OF_IMAGE;

--- a/components/tools/OmeroJava/test/integration/delete/RelatedToTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/RelatedToTest.java
@@ -1,25 +1,20 @@
 /*
- * $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
-package integration.delete;
 
-import java.util.Collections;
-import java.util.List;
+package integration.delete;
 
 import integration.AbstractServerTest;
 import integration.DeleteServiceTest;
 
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Image;
 import omero.model.Pixels;
 import omero.sys.ParametersI;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -45,10 +40,7 @@ public class RelatedToTest extends AbstractServerTest {
         p2 = (Pixels) iUpdate.saveAndReturnObject(p2);
         assertEquals(p1.getId(), p2.getRelatedTo().getId());
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(i1.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(i1);
@@ -79,10 +71,7 @@ public class RelatedToTest extends AbstractServerTest {
         assertNotNull(pixels);
         assertEquals(pixels.getId().getValue(), pixels2.getId().getValue());
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", img2.getId().getValue());
         callback(true, client, dc);
 
         String sql = "select i from Image i where i.id = :id";
@@ -122,10 +111,7 @@ public class RelatedToTest extends AbstractServerTest {
         assertNotNull(pixels);
         assertEquals(pixels.getId().getValue(), pixels2.getId().getValue());
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(img2.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", img2.getId().getValue());
         callback(true, client, dc);
 
         String sql = "select i from Image i where i.id = :id";

--- a/components/tools/OmeroJava/test/integration/delete/RoiDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/RoiDeleteTest.java
@@ -1,24 +1,22 @@
 /*
- * $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import static omero.rtypes.rdouble;
 import static omero.rtypes.rint;
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import omero.api.IRoiPrx;
 import omero.api.RoiOptions;
 import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.grid.Column;
 import omero.grid.LongColumn;
 import omero.grid.TablePrx;
@@ -42,8 +40,6 @@ import omero.model.Well;
 import omero.sys.EventContext;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 import pojos.FileAnnotationData;
@@ -76,10 +72,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         disconnect();
 
         loginUser(owner);
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Image.class.getSimpleName(),
-                Collections.singletonList(i1.getId().getValue()));
+        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(i1);
@@ -152,10 +145,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         // Now delete the rois.
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Roi.class.getSimpleName(),
-                Collections.singletonList(roiID));
+        final Delete2 dc = Requests.delete("Roi", roiID);
         callback(true, client, dc);
         assertDoesNotExist(roi);
         l = svc.getRoiMeasurements(image.getId().getValue(), options);
@@ -228,11 +218,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         // Now delete the plate
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Plate.class.getSimpleName(),
-                Collections.singletonList(p.getId()
-                        .getValue()));
+        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
         callback(true, client, dc);
         assertDoesNotExist(p);
         assertDoesNotExist(roi);

--- a/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
@@ -1,25 +1,22 @@
 /*
- * $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import integration.AbstractServerTest;
-import integration.DeleteServiceTest;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import ome.xml.model.OME;
 import omero.cmd.Delete2;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.util.Requests;
 import omero.model.Experiment;
 import omero.model.Image;
 import omero.model.Pixels;
@@ -28,8 +25,6 @@ import omero.model.Screen;
 import omero.model.WellSample;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 import ome.specification.XMLMockObjects;
@@ -78,10 +73,7 @@ public class SpwDeleteTest extends AbstractServerTest {
         // see XMLMockObjects.createScreen()
         scalingFactor *= 1*2*2*2*2;
 
-        final Delete2 dc = new Delete2();
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(),
-                Collections.singletonList(screen.getId().getValue()));
+        final Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
         callback(true, client, dc);
 
         assertDoesNotExist(screen);
@@ -109,12 +101,10 @@ public class SpwDeleteTest extends AbstractServerTest {
         Screen screen = plate.copyScreenLinks().get(0).getParent();
         long sid = screen.getId().getValue();
 
-        final Delete2 dc = new Delete2();
+        final Delete2 dc = Requests.delete("Screen", sid);
         final ChildOption option = new ChildOption();
         option.excludeType = Collections.singletonList(Plate.class.getSimpleName());
         dc.childOptions = Collections.singletonList(option);
-        dc.targetObjects = ImmutableMap.<String, List<Long>>of(
-                Screen.class.getSimpleName(), Collections.singletonList(sid));
         callback(true, client, dc);
 
         assertDoesNotExist(screen);

--- a/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
@@ -10,7 +10,6 @@ import integration.AbstractServerTest;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import ome.xml.model.OME;
@@ -101,10 +100,8 @@ public class SpwDeleteTest extends AbstractServerTest {
         Screen screen = plate.copyScreenLinks().get(0).getParent();
         long sid = screen.getId().getValue();
 
-        final Delete2 dc = Requests.delete("Screen", sid);
-        final ChildOption option = new ChildOption();
-        option.excludeType = Collections.singletonList(Plate.class.getSimpleName());
-        dc.childOptions = Collections.singletonList(option);
+        final ChildOption option = Requests.option(null, "Plate");
+        final Delete2 dc = Requests.delete("Screen", sid, option);
         callback(true, client, dc);
 
         assertDoesNotExist(screen);

--- a/examples/Delete/FileAnnotationDelete.java
+++ b/examples/Delete/FileAnnotationDelete.java
@@ -3,6 +3,7 @@ import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
 import omero.cmd.OK;
 import omero.cmd.Response;
+import omero.gateway.util.Requests;
 import omero.api.ServiceFactoryPrx;
 import omero.model.*;
 import static omero.rtypes.*;
@@ -38,12 +39,9 @@ public class FileAnnotationDelete {
             d.linkAnnotation(fa);
             d = (Dataset) s.getUpdateService().saveAndReturnObject(d);
             fa = (FileAnnotation) d.linkedAnnotationList().get(0);
+            long faID = fa.getId().getValue();
 
-
-            Delete2 deleteCmd = new Delete2();
-            List<Long> ids = Collections.singletonList(fa.getId().getValue());
-            deleteCmd.targetObjects = new HashMap<String, List<Long>>();
-            deleteCmd.targetObjects.put("Annotation", ids);
+            Delete2 deleteCmd = Requests.delete("Annotation", faID);
             Map<String, String> callContext = new HashMap<String, String>();
             CmdCallbackI cb = null;
             try {


### PR DESCRIPTION
The new gateway convenience methods for constructing graph requests are now available to the Java integration tests. This PR turns those tests into a good example of how one should now be constructing graph requests.

The integration tests should continue to pass and the code changes should not semantically change what the tests actually do.

--no-rebase