### PR TITLE
Add get subcommand to CLI obj command

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -340,8 +340,8 @@ class ObjGetTxAction(NonFieldTxAction):
 
     def on_go(self, ctx, args):
 
-        if len(self.tx_cmd.arg_list) not in (3, 4):
-            ctx.die(335, "usage: get OBJ FIELD [INDEX]")
+        if len(self.tx_cmd.arg_list) != 3:
+            ctx.die(335, "usage: get OBJ FIELD")
 
         field = self.tx_cmd.arg_list[2]
         try:
@@ -350,26 +350,11 @@ class ObjGetTxAction(NonFieldTxAction):
             ctx.die(336, "Unknown field '%s' for %s:%s" % (
                 field, self.kls, self.obj.id.val))
 
-        if len(self.tx_cmd.arg_list) == 3:
-            if isinstance(current, list):
-                ctx.die(336, "Index required for field '%s' of %s:%s" % (
-                    field, self.kls, self.obj.id.val))
-            else:
-                if current is None:
-                    proxy = ""
-                else:
-                    try:
-                        proxy = current.val
-                    except AttributeError, ae:
-                        ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
-                            field, self.kls, self.obj.id.val, ae.message))
+        if current is None:
+            proxy = ""
         else:
-            index = int(self.tx_cmd.arg_list[3])
             try:
-                proxy = current[index]
-            except IndexError:
-                ctx.die(336, "Unknown index %s in field '%s' for %s:%s" % (
-                    index, field, self.kls, self.obj.id.val))
+                proxy = current.val
             except AttributeError, ae:
                 ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
                     field, self.kls, self.obj.id.val, ae.message))

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -340,42 +340,39 @@ class ObjGetTxAction(NonFieldTxAction):
 
     def on_go(self, ctx, args):
 
-        if len(self.tx_cmd.arg_list) not in (2, 3, 4):
-            ctx.die(335, "usage: get OBJ [FIELD [INDEX]]")
+        if len(self.tx_cmd.arg_list) not in (3, 4):
+            ctx.die(335, "usage: get OBJ FIELD [INDEX]")
 
-        if len(self.tx_cmd.arg_list) == 2:
-            proxy = self.obj
-        else:
-            field = self.tx_cmd.arg_list[2]
-            try:
-                current = getattr(self.obj, field)
-            except AttributeError:
-                ctx.die(336, "Unknown field '%s' for %s:%s" % (
+        field = self.tx_cmd.arg_list[2]
+        try:
+            current = getattr(self.obj, field)
+        except AttributeError:
+            ctx.die(336, "Unknown field '%s' for %s:%s" % (
+                field, self.kls, self.obj.id.val))
+
+        if len(self.tx_cmd.arg_list) == 3:
+            if isinstance(current, list):
+                ctx.die(336, "Index required for field '%s' of %s:%s" % (
                     field, self.kls, self.obj.id.val))
-
-            if len(self.tx_cmd.arg_list) == 3:
-                if isinstance(current, list):
-                    ctx.die(336, "Index required for field '%s' of %s:%s" % (
-                        field, self.kls, self.obj.id.val))
-                else:
-                    if current is None:
-                        proxy = ""
-                    else:
-                        try:
-                            proxy = current.val
-                        except AttributeError, ae:
-                            ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
-                                field, self.kls, self.obj.id.val, ae.message))
             else:
-                index = int(self.tx_cmd.arg_list[3])
-                try:
-                    proxy = current[index]
-                except IndexError:
-                    ctx.die(336, "Unknown index %s in field '%s' for %s:%s" % (
-                        index, field, self.kls, self.obj.id.val))
-                except AttributeError, ae:
-                    ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
-                        field, self.kls, self.obj.id.val, ae.message))
+                if current is None:
+                    proxy = ""
+                else:
+                    try:
+                        proxy = current.val
+                    except AttributeError, ae:
+                        ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
+                            field, self.kls, self.obj.id.val, ae.message))
+        else:
+            index = int(self.tx_cmd.arg_list[3])
+            try:
+                proxy = current[index]
+            except IndexError:
+                ctx.die(336, "Unknown index %s in field '%s' for %s:%s" % (
+                    index, field, self.kls, self.obj.id.val))
+            except AttributeError, ae:
+                ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
+                    field, self.kls, self.obj.id.val, ae.message))
 
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -135,11 +135,14 @@ class TxAction(object):
     def go(self, ctx, args):
         raise Exception("Unimplemented")
 
-    def class_name(self):
-        kls = self.tx_cmd.type.split(":")[0]
-        if not kls.endswith("I"):
-            kls = "%sI" % kls
-        return kls
+    def class_name(self, ctx):
+        try:
+            kls = self.tx_cmd.type.split(":")[0]
+            if not kls.endswith("I"):
+                kls = "%sI" % kls
+            return kls
+        except AttributeError:
+            ctx.die(102, "No object argument provided. Use e.g. 'Image:123'")
 
     def obj_id(self):
         parts = self.tx_cmd.type.split(":")
@@ -152,7 +155,7 @@ class TxAction(object):
         import omero
         import omero.all
         try:
-            kls = getattr(omero.model, self.class_name())
+            kls = getattr(omero.model, self.class_name(ctx))
             obj = kls()
             oid = self.obj_id()
             if oid is not None:

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -126,14 +126,24 @@ class TestObj(CLITest):
         assert state.get_row(2).startswith("DatasetAnnotationLink")
         path.remove()
 
-    def test_new_and_update(self):
+    def test_new_get_and_update(self):
+        name = "foo"
+        desc = "bar"
         self.args = self.login_args() + [
-            "obj", "new", "Project", "name=foo"]
+            "obj", "new", "Project", "name=%s" % name]
         state = self.go()
         project = state.get_row(0)
         self.args = self.login_args() + [
-            "obj", "update", project, "description=bar"]
+            "obj", "get", project, "name"]
+        state = self.go()
+        assert state.get_row(0) == name
+        self.args = self.login_args() + [
+            "obj", "update", project, "description=%s" % desc]
         self.go()
+        self.args = self.login_args() + [
+            "obj", "get", project, "description"]
+        state = self.go()
+        assert state.get_row(0) == desc
 
     def test_map_mods(self):
         self.args = self.login_args() + [


### PR DESCRIPTION
See https://trello.com/c/5M0gWeCw/43-omero-obj-new-commands This addresses just the first bullet point.
```
omero obj get Object:XX field
```
should return the value of a simple field, name, description, etc. More complex fields should cause an error.

The one modified test, which checks one use of `get` should pass.

