### PR TITLE
Import as crash

### DIFF
--- a/components/blitz/src/omero/gateway/SecurityContext.java
+++ b/components/blitz/src/omero/gateway/SecurityContext.java
@@ -168,4 +168,14 @@ public class SecurityContext {
                 && Objects.equal(((SecurityContext) obj).getExperimenter(),
                         this.getExperimenter());
     }
+
+    @Override
+    public String toString() {
+        return "SecurityContext [groupID=" + groupID + ", experimenter="
+                + experimenter + ", sudo=" + sudo + ", serverInformation="
+                + serverInformation + ", compression=" + compression + "]";
+    }
+
+    
+    
 }

--- a/components/blitz/src/omero/gateway/ServerInformation.java
+++ b/components/blitz/src/omero/gateway/ServerInformation.java
@@ -94,6 +94,12 @@ public class ServerInformation {
     }
 
     @Override
+    public String toString() {
+        return "ServerInformation [hostname=" + hostname + ", port=" + port
+                + "]";
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/components/blitz/src/pojos/ExperimenterData.java
+++ b/components/blitz/src/pojos/ExperimenterData.java
@@ -332,4 +332,12 @@ public class ExperimenterData extends DataObject {
         return ldap.getValue();
     }
 
+    @Override
+    public String toString() {
+        return "ExperimenterData [getUserName()=" + getUserName()
+                + ", getDefaultGroup()=" + getDefaultGroup() + ", getGroups()="
+                + getGroups() + "]";
+    }
+
+    
 }

--- a/components/blitz/src/pojos/GroupData.java
+++ b/components/blitz/src/pojos/GroupData.java
@@ -294,4 +294,11 @@ public class GroupData extends DataObject {
         experimenters = new HashSet<ExperimenterData>(m.result());
     }
 
+    @Override
+    public String toString() {
+        return "GroupData [getGroupId()=" + getGroupId() + ", getName()="
+                + getName() + "]";
+    }
+
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -449,6 +449,7 @@ class ImporterModel
 		SecurityContext ctx = new SecurityContext(data.getGroup().getId());
 		ctx.setServerInformation(this.ctx.getServerInformation());
 		ctx.setExperimenter(data.getExperimenter());
+		ctx.sudo();
 		DataObjectCreator loader = new DataObjectCreator(component, ctx,
 				data.getChild(), data.getParent());
 		loader.load();


### PR DESCRIPTION
Fix for [Ticket 12929](https://trac.openmicroscopy.org/ome/ticket/12929)

Test:
- Log in as an admin user
- Kick off an "import as" process which takes some time, so you'll have time for the next step. Important: Really start the import process, don't just add it to the queue.
- Go back to the import step, and start another "import as" job for another user. But now create a Project and/or Dataset for the import. Without the PR this step was enough to crash Insight, although the crash could happen delayed by some time, depending on how "heavy" the previous started import jobs are.
- Make sure both import jobs are passing like expected.

Note:
The first commit is the actualy bugfix. The second commit just adds a couple of toString methods to some Gateway/Pojo classes, as I found this makes debugging much easier; can remove this commit again if needed.