### PR TITLE
A few minor CLI fixes (dev)

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -44,17 +44,6 @@ module omero {
          "java:type:java.util.ArrayList<omero.cmd.GraphModify>:java.util.List<omero.cmd.GraphModify>"]
         sequence<GraphModify> GraphModifyList;
 
-        /**
-         *
-         **/
-        ["deprecated:use LegalGraphTargets"]
-        class GraphSpecList extends Request {};
-
-        ["deprecated:use LegalGraphTargetsResponse"]
-        class GraphSpecListRsp extends Response {
-            GraphModifyList list;
-        };
-
         ["deprecated:use omero::cmd::Chgrp2 instead"]
         class Chgrp extends GraphModify {
             long grp;

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1672,9 +1672,7 @@ class GraphControl(CmdControl):
             "--list", action="store_true",
             help="Print a list of all available graph specs")
         parser.add_argument(
-            "--list-details", action="store_true",
-            help="Print a list of all available graph specs along with "
-            "detailed info")
+            "--list-details", action="store_true", help=SUPPRESS)
         parser.add_argument(
             "--report", action="store_true",
             help="Print more detailed report of each action")
@@ -1709,7 +1707,7 @@ class GraphControl(CmdControl):
         client = self.ctx.conn(args)
         if args.list_details or args.list:
             cb = None
-            req = omero.cmd.GraphSpecList()
+            req = omero.cmd.LegalGraphTargets(self.cmd_type()())
             try:
                 try:
                     speclist, status, cb = self.response(client, req)
@@ -1724,22 +1722,9 @@ class GraphControl(CmdControl):
             if err:
                 self.ctx.die(367, err)
 
-            specs = speclist.list
-            specmap = dict()
-            for s in specs:
-                specmap[s.type] = s
-            keys = sorted(specmap)
-
-            if args.list_details:
-                for key in keys:
-                    spec = specmap[key]
-                    self.ctx.out("=== %s ===" % key)
-                    for k, v in spec.options.items():
-                        self.ctx.out("%s" % (k,))
-                return  # Early exit.
-            elif args.list:
-                self.ctx.out("\n".join(keys))
-                return  # Early exit.
+            specs = sorted(speclist.targets)
+            self.ctx.out("\n".join(specs))
+            return  # Early exit.
 
         inc = []
         if args.include:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1722,7 +1722,7 @@ class GraphControl(CmdControl):
             if err:
                 self.ctx.die(367, err)
 
-            specs = sorted(speclist.targets)
+            specs = sorted([t.split(".")[-1] for t in speclist.targets])
             self.ctx.out("\n".join(specs))
             return  # Early exit.
 

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -198,11 +198,12 @@ server-permissions.html
                 c.submit(chmod)
                 self.ctx.out("Changed permissions for group %s (id=%s) to %s"
                              % (g.name.val, gid, perms))
-            except omero.GroupSecurityViolation:
+            except omero.CmdError, ce:
                 import traceback
                 self.ctx.dbg(traceback.format_exc())
                 self.ctx.die(504, "Cannot change permissions for group %s"
-                             " (id=%s) to %s" % (g.name.val, gid, perms))
+                             " (id=%s) to %s: %s"
+                             % (g.name.val, gid, perms, ce.err))
 
     def list(self, args):
         c = self.ctx.conn(args)

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -5,7 +5,7 @@
 
    :author: Sam Hart <sam@glencoesoftware.com>
 
-   Copyright (C) 2013 Glencoe Software, Inc. All rights reserved.
+   Copyright (C) 2013-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 """
 
@@ -438,8 +438,7 @@ JSON File Format:
         """
         Creates a new tag object. Returns the new tag object.
 
-        If either the name or description parameters are None, the user will be
-        prompted to input them.
+        If name parameter is None, the user will be prompted to input it.
 
         The "text" parameter should be the text description to use upon user
         input. For example, if we were creating a tag, this would be "tag"
@@ -448,11 +447,7 @@ JSON File Format:
         if name is None:
             name = raw_input("Please enter a name for this %s: " % text)
 
-        if description is None:
-            description = raw_input("Please enter a description for this %s: "
-                                    % text)
-
-        if name is not None and description is not None and name != '':
+        if name is not None and name != '':
             tag = TagAnnotationI()
             tag.textValue = rstring(name)
             if description is not None and len(description) > 0:

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -370,20 +370,29 @@ JSON File Format:
 
         tc = TagCollection()
 
-        sql = """
-            select a.id, a.description, a.textValue,
-            a.details.owner.id, a.details.owner.firstName,
-            a.details.owner.lastName
-            from AnnotationAnnotationLink b
-            inner join b.parent a
-            where a.ns=:ns
-            """
+        if tag:
+            sql = """
+                select a.id, a.description, a.textValue,
+                a.details.owner.id, a.details.owner.firstName,
+                a.details.owner.lastName
+                from AnnotationAnnotationLink b
+                inner join b.parent a
+                where a.ns=:ns
+                """
+            sql += " and b.child.id = :tid"
+            params.map['tid'] = rlong(long(tag))
+        else:
+            sql = """
+                select a.id, a.description, a.textValue,
+                a.details.owner.id, a.details.owner.firstName,
+                a.details.owner.lastName
+                from Annotation a
+                where a.ns=:ns
+                """
+
         if args.uid:
             params.map["eid"] = rlong(long(args.uid))
             sql += " and a.details.owner.id = :eid"
-        if tag:
-            sql += " and b.child.id = :tid"
-            params.map['tid'] = rlong(long(tag))
 
         for element in q.projection(sql, params, ice_map):
             tag_id, description, text, owner, first, last = map(unwrap,

--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -380,7 +380,7 @@ JSON File Format:
             """
         if args.uid:
             params.map["eid"] = rlong(long(args.uid))
-            sql += " and a.owner.id = :eid"
+            sql += " and a.details.owner.id = :eid"
         if tag:
             sql += " and b.child.id = :tid"
             params.map['tid'] = rlong(long(tag))

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -136,9 +136,6 @@ class TestTag(AbstractTagTest):
 
         if desc_arg:
             self.args += [desc_arg, tag_desc]
-        else:
-            desc_input = 'Please enter a description for this tag: '
-            raw_input(desc_input).AndReturn(tag_desc)
         self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
@@ -147,7 +144,10 @@ class TestTag(AbstractTagTest):
         # Check tag is created
         tag = self.get_object(o)
         assert tag.textValue.val == tag_name
-        assert tag.description.val == tag_desc
+        if desc_arg:
+            assert tag.description.val == tag_desc
+        else:
+            assert tag.description is None
 
     @pytest.mark.parametrize('name_arg', [None, '--name'])
     @pytest.mark.parametrize('desc_arg', [None, '--desc'])
@@ -166,9 +166,6 @@ class TestTag(AbstractTagTest):
             raw_input(name_input).AndReturn(tag_name)
         if desc_arg:
             self.args += [desc_arg, tag_desc]
-        else:
-            desc_input = 'Please enter a description for this tag set: '
-            raw_input(desc_input).AndReturn(tag_desc)
         self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
@@ -178,7 +175,10 @@ class TestTag(AbstractTagTest):
         tagset = self.get_object(o)
         assert tagset.textValue.val == tag_name
         assert tagset.ns.val == NSINSIGHTTAGSET
-        assert tagset.description.val == tag_desc
+        if desc_arg:
+            assert tagset.description.val == tag_desc
+        else:
+            assert tagset.description is None
 
         # Check all tags are linked to the tagset
         tags = self.get_tags_in_tagset(tagset.id.val)

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -122,7 +122,7 @@ class TestTag(AbstractTagTest):
     # Tag creation commands
     # ========================================================================
     @pytest.mark.parametrize('name_arg', [None, '--name'])
-    @pytest.mark.parametrize('desc_arg', [None, '--desc'])
+    @pytest.mark.parametrize('desc_arg', [None, '--description'])
     def testCreateTag(self, name_arg, desc_arg, capfd):
         tag_name = self.uuid()
         tag_desc = self.uuid()


### PR DESCRIPTION
This is a partial rebase of gh-4061 The one difference is that the `--list` option for `delete`m etc., is handled rather than suppressed.

--rebased-from #4061

Testing
-------
```
omero delete --help
```
should not show the --list-details options. However,
```
omero delete --list
omero delete --list-details
```
should both work and give a list of legal targets for this command (and `chgrp`).

The command
```
omero group perms
```
should give a helpful message when the user does not have permission to chnage the group permissions.

Three commits remove the prompt if no description is provided, this brings the CLI in line with other clients. To test:
```
omero tag create
omero tag createset
```
should both prompt for a name if not provided, via the --name option, but not a description if not provided, via the --desc or --description. Modified integration tests should pass.

Two commits fix a bug in `tag list` and list empty tag sets when using the `listsets` subcommand. To test create a couple of tagsets, with one empty.
```
omero tag listsets
```
should include the empty tag set in the list.

