### PR TITLE
Make sure default "Filter" text is selected (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizardUI.java
@@ -446,6 +446,8 @@ public class SelectionWizardUI
             filterArea.setForeground(Color.LIGHT_GRAY);
         }
         filterArea.getDocument().addDocumentListener(this);
+        filterArea.setSelectionStart(0);
+        filterArea.setSelectionEnd(filterArea.getText().length());
     }
 
     /**


### PR DESCRIPTION

This is the same as gh-4063 but rebased onto dev_5_1.

----

Tiny fix for [Ticket 12300](https://trac.openmicroscopy.org/ome/ticket/12300) , has to be tested on Windows.

Try to add tags to an object, which opens the Tags dialog. The "Filter" text field should have the focus, and when start typing straight away the default text "Filter" should get removed (before: typing started after the text).

                