### PR TITLE
Fixed wrong file count (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
@@ -32,6 +32,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 
+import omero.model.Fileset;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.agents.metadata.editor.ImportType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
@@ -89,7 +91,12 @@ public class FilesetInfoDialog extends TinyDialog {
             l.setBackground(UIUtilities.BACKGROUND_COLOR);
             content.add(l, c);
         } else {
-            JLabel l = new JLabel(set.size() + " Image file");
+            int size = 0;
+            FilesetData fsd = set.iterator().next();
+            if (Fileset.class.isAssignableFrom(fsd.asIObject().getClass())) {
+                size = ((Fileset)fsd.asIObject()).sizeOfUsedFiles();
+            }
+            JLabel l = new JLabel(size + " Image file(s)");
             l.setBackground(UIUtilities.BACKGROUND_COLOR);
             content.add(l, c);
             c.gridy++;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
@@ -96,7 +96,8 @@ public class FilesetInfoDialog extends TinyDialog {
             if (Fileset.class.isAssignableFrom(fsd.asIObject().getClass())) {
                 size = ((Fileset)fsd.asIObject()).sizeOfUsedFiles();
             }
-            JLabel l = new JLabel(size + " Image file(s)");
+            String txt = size == 1 ? "Image file" : "Image files";
+            JLabel l = new JLabel(size + " " + txt);
             l.setBackground(UIUtilities.BACKGROUND_COLOR);
             content.add(l, c);
             c.gridy++;


### PR DESCRIPTION

This is the same as gh-4070 but rebased onto dev_5_1.

----

See [Ticket 12905](https://trac.openmicroscopy.org/ome/ticket/12905)

Test: Check the File path info dialog shows the correct number of files (compare with OMERO.Web)


                