### PR TITLE
Fix delete notOwned warning

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -463,7 +463,6 @@ OME.handleDelete = function() {
         if (dtype in dtypes) dtypes[dtype] += 1;
         else dtypes[dtype] = 1;
         if (!q && $this.attr('rel').indexOf('image')<0) q = true;
-        console.log($this, $this.hasClass('isOwned'));
         if (!$this.hasClass('isOwned')) notOwned = true;
     });
     if (notOwned) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
@@ -94,7 +94,7 @@ if (typeof OME === "undefined") { OME={}; }
 </form>
 
 <form id="share_dialog_form" action="#" title="Create Share" style="display:none">
-    <p id="deleteOthersWarning" style="font-size: 120%; font-weight: bold">
+    <p style="font-size: 120%; font-weight: bold">
         Share was created successfully.
     </p>
 </form>


### PR DESCRIPTION
This fixes the display of the warning that you will delete another user's data.

To test, try to delete your own data.
 - You should not see any warning that you will delete anyone else's data.
 - Delete someone else's data (need read-write permissions) and check that you DO see the warning in the delete confirm dialog.

This is fixed independently in jstree_2015 branch.

--no-rebase