### PR TITLE
Enable 'Show ROIs' after loaded

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -964,7 +964,8 @@
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
                 {% ifnotequal roiCount 0 %}
-                    <a id="show-rois-a" href="#" onclick="show_rois(); return false;">Show ROIs</a> |
+                  <!-- 'link is enabled on imageLoad callback -->
+                    <a id="show-rois-a" href="#" style="color:gray">Show ROIs</a> |
                     <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endifnotequal %}
           </div>
@@ -1041,6 +1042,11 @@
 
     // once image loads, check session via /getImgRDef/ to see if we can paste
     viewport.bind('imageLoad', function() {
+
+      // Enable 'Show ROIs' button
+      $("#show-rois-a").on("click", function () { show_rois(); return false; })
+        .attr("href", "#").css("color", "");
+
       $.getJSON(viewport.viewport_server + "/getImgRDef/",
         function(data){
             if (data.rdef) {


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/12983

This ensures that the "Show ROIs" button is not enabled until the image has loaded since it fails if used before then (noted on Big Images in particular).

To test:
 - Open a Big Image with ROIs in the main image viewer.
 - Note that the "Show ROIs" link doesn't become enabled until the viewer has loaded.
 - Try to click it before and after loading. Should only work after loading and ROIs should load OK.

This has been cherry-picked to the jstree_2015 branch:
https://github.com/will-moore/openmicroscopy/commit/a4876000c03f8e2414da5e552072bf5ae73d1816

--no-rebase