### PR TITLE
Interpolate config option

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -219,6 +219,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.interpolate_pixels">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -219,7 +219,7 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    <bean class="ome.system.Preference" id="omero.client.interpolate_pixels">
+    <bean class="ome.system.Preference" id="omero.client.viewer.interpolate_pixels">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1543,7 +1543,7 @@ class _BlitzGateway (object):
         :return:    String
         """
         return (self.getConfigService().getConfigValue(
-                "omero.client.interpolate_pixels") or 'true')
+                "omero.client.viewer.interpolate_pixels") or 'true')
 
     def getWebclientHost(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1535,6 +1535,16 @@ class _BlitzGateway (object):
         return (self.getConfigService().getConfigValue(
                 "omero.client.viewer.initial_zoom_level") or 0)
 
+    def getInterpolateSetting(self):
+        """
+        Returns default interpolation setting on the server.
+        This is a string but represents a boolean, E.g. 'true'
+
+        :return:    String
+        """
+        return (self.getConfigService().getConfigValue(
+                "omero.client.interpolate_pixels") or 'true')
+
     def getWebclientHost(self):
         """
         Returns default initial zoom level set on the server.

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -37,6 +37,7 @@ from django.template import RequestContext
 from django.core.cache import cache
 
 from omeroweb.http import HttpJsonResponse
+from omero.gateway.utils import toBoolean
 
 from omeroweb.connector import Connector
 
@@ -257,6 +258,8 @@ class login_required(object):
                 conn.getEmailSettings()
             request.session['server_settings']['initial_zoom_level'] = \
                 conn.getInitialZoomLevel()
+            request.session['server_settings']['interpolate_pixels'] = \
+                toBoolean(conn.getInterpolateSetting())
 
     def get_public_user_connector(self):
         """

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -168,6 +168,11 @@
                       base_src = $this.attr('src').split('&_=')[0];
                   $this.attr('src', base_src + "&_=random"+Math.random());
               });
+
+              // Turn off interpolation if disabled
+              {% if not interpolate %}
+                OME.preview_viewport.setPixelated(true);
+              {% endif %}
             });
 
             // handle 'Color' checkbox

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -168,11 +168,6 @@
                       base_src = $this.attr('src').split('&_=')[0];
                   $this.attr('src', base_src + "&_=random"+Math.random());
               });
-
-              // Turn off interpolation if disabled
-              {% if not interpolate %}
-                OME.preview_viewport.setPixelated(true);
-              {% endif %}
             });
 
             // handle 'Color' checkbox

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1102,13 +1102,12 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
                           **kwargs):
     """
     This is the image 'Preview' tab for the right-hand panel.
-    Currently this doesn't do much except launch the view-port plugin using
-    the image Id (and share Id if necessary)
     """
     context = {}
 
     # the index of a field within a well
     index = getIntOrDefault(request, 'index', 0)
+    interpolate = request.session['server_settings']['interpolate_pixels']
 
     manager = BaseContainer(conn, index=index, **{str(c_type): long(c_id)})
     if share_id:
@@ -1149,6 +1148,7 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
     context['manager'] = manager
     context['rdefsJson'] = json.dumps(rdefQueries)
     context['rdefs'] = rdefs
+    context['interpolate'] = interpolate
     context['template'] = "webclient/annotations/metadata_preview.html"
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1107,7 +1107,6 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
 
     # the index of a field within a well
     index = getIntOrDefault(request, 'index', 0)
-    interpolate = request.session['server_settings']['interpolate_pixels']
 
     manager = BaseContainer(conn, index=index, **{str(c_type): long(c_id)})
     if share_id:
@@ -1148,7 +1147,6 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
     context['manager'] = manager
     context['rdefsJson'] = json.dumps(rdefQueries)
     context['rdefs'] = rdefs
-    context['interpolate'] = interpolate
     context['template'] = "webclient/annotations/metadata_preview.html"
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -157,7 +157,13 @@ def imageMarshal(image, key=None, request=None):
         init_zoom = 0
 
     try:
+        interpolate = request.session['server_settings']['interpolate_pixels']
+    except:
+        interpolate = False
+
+    try:
         rv.update({
+            'interpolate': interpolate,
             'size': {'width': image.getSizeX(),
                      'height': image.getSizeY(),
                      'z': image.getSizeZ(),

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -326,6 +326,11 @@ jQuery._WeblitzViewport = function (container, server, options) {
           }
         _this.viewportimg.get(0).setUpTiles(img_w, img_h, tile_w, tile_h, init_zoom, zoom_levels, hrefProvider, thref, cx, cy, zoomLevelScaling, nominalMagnification);
     }
+
+    // Turn off interpolation if disabled
+    if (!_this.loadedImg.interpolate) {
+      _this.setPixelated(true);
+    }
     
     _load(function () {
       //_this.refresh();

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1065,11 +1065,6 @@
       // disable 'Max Intensity' projection for single-Z images
       var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
       $('[name="wblitz-proj"][value=intmax]').prop('disabled', disable_intmax);
-
-      // Turn off interpolation if disabled
-      {% if not interpolate %}
-        viewport.setPixelated(true);
-      {% endif %}
     });
 
     // 'Color' checkbox to left of image

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -934,7 +934,7 @@
           </div>
           <div class="odd row">
             <label for="wblitz-interpolate">Interpolate</label>
-            <input id="wblitz-interpolate" type="checkbox" checked/>
+            <input id="wblitz-interpolate" type="checkbox" {% if interpolate %}checked{% endif %}/>
           </div>
             <h1>Current Image</h1>
           <div class="even row">
@@ -1066,6 +1066,10 @@
       var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
       $('[name="wblitz-proj"][value=intmax]').prop('disabled', disable_intmax);
 
+      // Turn off interpolation if disabled
+      {% if not interpolate %}
+        viewport.setPixelated(true);
+      {% endif %}
     });
 
     // 'Color' checkbox to left of image

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -17,6 +17,7 @@ import re
 import json
 import omero
 import omero.clients
+from omero.gateway.utils import toBoolean
 
 from django.http import HttpResponse, HttpResponseServerError
 from django.http import HttpResponseRedirect, HttpResponseNotAllowed, Http404
@@ -1905,6 +1906,10 @@ def full_viewer(request, iid, conn=None, **kwargs):
     """
 
     rid = getImgDetailsFromReq(request)
+
+    interpolate = toBoolean(conn.getConfigService().getConfigValue(
+        "omero.client.interpolate_pixels"))
+
     try:
         image = conn.getObject("Image", iid)
         if image is None:
@@ -1913,6 +1918,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
         d = {'blitzcon': conn,
              'image': image,
              'opts': rid,
+             'interpolate': interpolate,
              'build_year': build_year,
              'roiCount': image.getROICount(),
              'viewport_server': kwargs.get(

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -17,7 +17,6 @@ import re
 import json
 import omero
 import omero.clients
-from omero.gateway.utils import toBoolean
 
 from django.http import HttpResponse, HttpResponseServerError
 from django.http import HttpResponseRedirect, HttpResponseNotAllowed, Http404
@@ -1907,8 +1906,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
     rid = getImgDetailsFromReq(request)
 
-    interpolate = toBoolean(conn.getConfigService().getConfigValue(
-        "omero.client.interpolate_pixels"))
+    interpolate = request.session['server_settings']['interpolate_pixels']
 
     try:
         image = conn.getObject("Image", iid)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1906,8 +1906,6 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
     rid = getImgDetailsFromReq(request)
 
-    interpolate = request.session['server_settings']['interpolate_pixels']
-
     try:
         image = conn.getObject("Image", iid)
         if image is None:
@@ -1916,7 +1914,6 @@ def full_viewer(request, iid, conn=None, **kwargs):
         d = {'blitzcon': conn,
              'image': image,
              'opts': rid,
-             'interpolate': interpolate,
              'build_year': build_year,
              'roiCount': image.getROICount(),
              'viewport_server': kwargs.get(

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -3,7 +3,7 @@
 #
 # webgateway/views.py - django application view handling functions
 #
-# Copyright (c) 2007-2013 Glencoe Software, Inc. All rights reserved.
+# Copyright (c) 2007-2015 Glencoe Software, Inc. All rights reserved.
 #
 # This software is distributed under the terms described by the LICENCE file
 # you can find at the root of the distribution bundle, which states you are
@@ -1905,6 +1905,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
     """
 
     rid = getImgDetailsFromReq(request)
+    interpolate = request.session['server_settings']['interpolate_pixels']
 
     try:
         image = conn.getObject("Image", iid)
@@ -1914,6 +1915,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
         d = {'blitzcon': conn,
              'image': image,
              'opts': rid,
+             'interpolate': interpolate,
              'build_year': build_year,
              'roiCount': image.getROICount(),
              'viewport_server': kwargs.get(

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -826,6 +826,9 @@ omero.client.ui.menu.dropdown.everyone=All Members
 # Flag to show/hide all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
+# Client viewers interpolate pixels by default.
+omero.client.interpolate_pixels=true
+
 #############################################
 ## Ice overrides
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -827,7 +827,7 @@ omero.client.ui.menu.dropdown.everyone=All Members
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
 # Client viewers interpolate pixels by default.
-omero.client.interpolate_pixels=true
+omero.client.viewer.interpolate_pixels=true
 
 #############################################
 ## Ice overrides


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/12924

To test:
 - Check in web full image viewer, that by default, interpolation is ON (checkbox is checked and image is not pixelated when zoomed right in).
```
$ bin/omero config set omero.client.viewer.interpolate_pixels False
$ bin/omero admin restart
```
 - Re-open image viewer. Interpolation should be OFF (checkbox unchecked and pixellated image on zoom).
