### PR TITLE
web logging

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -134,19 +134,6 @@ def send_comment(request):
     return HttpResponse(t.render(c))
 
 
-def custom_server_error(request, error500):
-    """
-    Custom 500 error handler.
-
-    Templates: `500.html`
-    Context: ErrorForm
-    """
-    form = ErrorForm(initial={'error': error500})
-    context = {'form': form}
-    t = template_loader.get_template('500.html')
-    c = RequestContext(request, context)
-    return HttpResponse(t.render(c))
-
 ##############################################################################
 # handlers
 
@@ -180,7 +167,11 @@ def handler500(request):
     if request.is_ajax():
         return HttpResponseServerError(error500)
 
-    return custom_server_error(request, error500)
+    form = ErrorForm(initial={'error': error500})
+    context = {'form': form}
+    t = template_loader.get_template('500.html')
+    c = RequestContext(request, context)
+    return HttpResponse(t.render(c))
 
 
 def handler404(request):

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -78,6 +78,11 @@ STANDARD_LOGFORMAT = (
     '%(asctime)s %(levelname)5.5s [%(name)40.40s]'
     ' (proc.%(process)5.5d) %(funcName)s:%(lineno)d %(message)s')
 
+FULL_REQUEST_LOGFORMAT = (
+    '%(asctime)s %(levelname)5.5s [%(name)40.40s]'
+    ' (proc.%(process)5.5d) %(funcName)s:%(lineno)d'
+    ' HTTP %(status_code)d %(request)s')
+
 if platform.system() in ("Windows",):
     LOGGING_CLASS = 'logging.handlers.RotatingFileHandler'
 else:
@@ -89,6 +94,17 @@ LOGGING = {
     'formatters': {
         'standard': {
             'format': STANDARD_LOGFORMAT
+        },
+        'full_request': {
+            'format': FULL_REQUEST_LOGFORMAT
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
         },
     },
     'handlers': {
@@ -105,10 +121,11 @@ LOGGING = {
             'level': 'DEBUG',
             'class': LOGGING_CLASS,
             'filename': os.path.join(
-                LOGDIR, 'OMEROweb_request.log').replace('\\', '/'),
+                LOGDIR, 'OMEROweb_brokenrequest.log').replace('\\', '/'),
             'maxBytes': 1024*1024*5,  # 5 MB
             'backupCount': 10,
-            'formatter': 'standard',
+            'filters': ['require_debug_false'],
+            'formatter': 'full_request',
         },
         'null': {
             'level': 'DEBUG',
@@ -116,17 +133,19 @@ LOGGING = {
         },
         'console': {
             'level': 'DEBUG',
+            'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
             'formatter': 'standard'
         },
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },
     'loggers': {
         'django.request': {  # Stop SQL debug from logging to main logger
-            'handlers': ['request_handler', 'mail_admins'],
+            'handlers': ['default', 'request_handler', 'mail_admins'],
             'level': 'DEBUG',
             'propagate': False
         },


### PR DESCRIPTION
This PR improves logging by logging full request and status code 

To test go to:
  - http://host/weberror/error_404/
  - http://host/weberror/error_500/

and check if OMEROweb_brokenrequest.log contains entire REQUEST OBJECT like:

```
2015-08-24 16:42:39,349 ERROR [                          django.request] (proc.34016) handle_uncaught_exception:226 HTTP 500 <WSGIRequest
path:/weberror/error_500/,
GET:<QueryDict: {}>,
POST:<QueryDict: {}>,
...
```

note that OMEROweb.log will only contains python stacktrace and HTTP 404 as a WARNING

cc @manics @sbesson 