### PR TITLE
Add tag set test

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
@@ -105,9 +105,8 @@ public class ChildOptionsPolicy {
 
             @Override
             protected boolean isAdjustedBeforeReview(Details object) {
-                if (object.action == GraphPolicy.Action.EXCLUDE &&
-                        object.orphan != GraphPolicy.Orphan.IS_LAST && object.orphan != GraphPolicy.Orphan.IS_NOT_LAST) {
-                    /* the model object is [E]{ir} */
+                if (object.action == GraphPolicy.Action.EXCLUDE && object.orphan == GraphPolicy.Orphan.RELEVANT) {
+                    /* the model object is [E]{r} */
                     for (final ChildOptionI childOption : childOptions) {
                         final Boolean isIncludeVerdict = childOption.isIncludeType(object.subject.getClass());
                         if (isIncludeVerdict == Boolean.TRUE && (requiredPermissions == null ||

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -251,7 +251,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
     }
 
     /* child options to try using in deletion */
-    private enum Option { INCLUDE, EXCLUDE, NONE };
+    private enum Option { NONE, INCLUDE, EXCLUDE, BOTH };
 
     /**
      * Test deletion of tag sets with variously linked tags.
@@ -296,14 +296,17 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         final Delete2 request;
         final Long tagset0Id = tagsets.get(0).getId().getValue();
         switch (option) {
+        case NONE:
+            request = Requests.delete("Annotation", tagset0Id);
+            break;
         case INCLUDE:
             request = Requests.delete("Annotation", tagset0Id, Requests.option("Annotation", null));
             break;
         case EXCLUDE:
             request = Requests.delete("Annotation", tagset0Id, Requests.option(null, "Annotation"));
             break;
-        case NONE:
-            request = Requests.delete("Annotation", tagset0Id);
+        case BOTH:
+            request = Requests.delete("Annotation", tagset0Id, Requests.option("Annotation", "Annotation"));
             break;
         default:
             request = null;
@@ -317,6 +320,13 @@ public class AnnotationDeleteTest extends AbstractServerTest {
 
         /* check that only the expected tags are deleted */
         switch (option) {
+        case NONE:
+            assertDoesNotExist(tags.get(0));
+            assertExists(tags.get(1));
+            assertExists(tags.get(2));
+            break;
+        case BOTH:
+            /* include overrides exclude */
         case INCLUDE:
             assertDoesNotExist(tags.get(0));
             assertDoesNotExist(tags.get(1));
@@ -328,11 +338,6 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             assertExists(tags.get(2));
             /* delete the tag that is not in the second tag set */
             doChange(Requests.delete("Annotation", tags.get(0).getId().getValue()));
-            break;
-        case NONE:
-            assertDoesNotExist(tags.get(0));
-            assertExists(tags.get(1));
-            assertExists(tags.get(2));
             break;
         }
 


### PR DESCRIPTION
In investigating http://trac.openmicroscopy.org/ome/ticket/12998 @ximenesuk uncovered an issue with how the server processes child options. This PR adjusts the behavior and expands an integration test to cover the case. Testing: both https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.delete/AnnotationDeleteTest/ and @ximenesuk should be happy.

--rebased-to #4098