### PR TITLE
have child options ignore parents (rebased from develop)

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/ChildOptionsPolicy.java
@@ -105,9 +105,8 @@ public class ChildOptionsPolicy {
 
             @Override
             protected boolean isAdjustedBeforeReview(Details object) {
-                if (object.action == GraphPolicy.Action.EXCLUDE &&
-                        object.orphan != GraphPolicy.Orphan.IS_LAST && object.orphan != GraphPolicy.Orphan.IS_NOT_LAST) {
-                    /* the model object is [E]{ir} */
+                if (object.action == GraphPolicy.Action.EXCLUDE && object.orphan == GraphPolicy.Orphan.RELEVANT) {
+                    /* the model object is [E]{r} */
                     for (final ChildOptionI childOption : childOptions) {
                         final Boolean isIncludeVerdict = childOption.isIncludeType(object.subject.getClass());
                         if (isIncludeVerdict == Boolean.TRUE && (requiredPermissions == null ||

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -264,7 +264,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
     }
 
     /* child options to try using in deletion */
-    private enum Option { INCLUDE, EXCLUDE, NONE };
+    private enum Option { NONE, INCLUDE, EXCLUDE, BOTH };
 
     /**
      * Test deletion of tag sets with variously linked tags.
@@ -310,6 +310,8 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tagsets.get(0).getId().getValue()));
 
         switch (option) {
+        case NONE:
+            break;
         case INCLUDE:
             delete.childOptions = Collections.<ChildOption>singletonList(new ChildOption());
             delete.childOptions.get(0).includeType = Collections.singletonList("Annotation");
@@ -318,7 +320,10 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             delete.childOptions = Collections.<ChildOption>singletonList(new ChildOption());
             delete.childOptions.get(0).excludeType = Collections.singletonList("Annotation");
             break;
-        case NONE:
+        case BOTH:
+            delete.childOptions = Collections.<ChildOption>singletonList(new ChildOption());
+            delete.childOptions.get(0).includeType = Collections.singletonList("Annotation");
+            delete.childOptions.get(0).excludeType = Collections.singletonList("Annotation");
             break;
         default:
             Assert.fail("unexpected option for delete");
@@ -331,6 +336,13 @@ public class AnnotationDeleteTest extends AbstractServerTest {
 
         /* check that only the expected tags are deleted */
         switch (option) {
+        case NONE:
+            assertDoesNotExist(tags.get(0));
+            assertExists(tags.get(1));
+            assertExists(tags.get(2));
+            break;
+        case BOTH:
+            /* include overrides exclude */
         case INCLUDE:
             assertDoesNotExist(tags.get(0));
             assertDoesNotExist(tags.get(1));
@@ -344,11 +356,6 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             delete = new Delete2();
             delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tags.get(0).getId().getValue()));
             doChange(delete);
-            break;
-        case NONE:
-            assertDoesNotExist(tags.get(0));
-            assertExists(tags.get(1));
-            assertExists(tags.get(2));
             break;
         }
 

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -361,6 +361,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
 
         /* delete the second tag set */
         delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tagsets.get(1).getId().getValue()));
+        doChange(delete);
 
         /* check that the tag set and the remaining tags are deleted */
         assertNoneExist(tagsets);

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import omero.RLong;
 import omero.RString;
 import omero.cmd.Delete2;
+import omero.cmd.graphs.ChildOption;
 import omero.model.Annotation;
 import omero.model.AnnotationAnnotationLink;
 import omero.model.AnnotationAnnotationLinkI;
@@ -40,6 +41,8 @@ import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.sys.EventContext;
 
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.HashMultimap;
@@ -260,12 +263,16 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         annotateSaveDeleteAndCheck(roi, Roi.class.getSimpleName(), roi.getId());
     }
 
+    /* child options to try using in deletion */
+    private enum Option { INCLUDE, EXCLUDE, NONE };
+
     /**
      * Test deletion of tag sets with variously linked tags.
+     * @param option the child option to use in the deletion
      * @throws Exception unexpected
      */
-    @Test
-    public void testDeleteTargetSharedTag() throws Exception {
+    @Test(dataProvider = "child option")
+    public void testDeleteTargetSharedTag(Option option) throws Exception {
         /* create two tag sets */
         final List<TagAnnotation> tagsets = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= 2; i++) {
@@ -299,15 +306,51 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         }
 
         /* delete the first tag set */
-        final Delete2 delete = new Delete2();
+        Delete2 delete = new Delete2();
         delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tagsets.get(0).getId().getValue()));
 
-        /* check that the tag set is deleted and only the tags that are thus orphaned */
+        switch (option) {
+        case INCLUDE:
+            delete.childOptions = Collections.<ChildOption>singletonList(new ChildOption());
+            delete.childOptions.get(0).includeType = Collections.singletonList("Annotation");
+            break;
+        case EXCLUDE:
+            delete.childOptions = Collections.<ChildOption>singletonList(new ChildOption());
+            delete.childOptions.get(0).excludeType = Collections.singletonList("Annotation");
+            break;
+        case NONE:
+            break;
+        default:
+            Assert.fail("unexpected option for delete");
+        }
+        doChange(delete);
+
+        /* check that the tag set is deleted and the other remains */
         assertDoesNotExist(tagsets.get(0));
         assertExists(tagsets.get(1));
-        assertDoesNotExist(tags.get(0));
-        assertExists(tags.get(1));
-        assertExists(tags.get(2));
+
+        /* check that only the expected tags are deleted */
+        switch (option) {
+        case INCLUDE:
+            assertDoesNotExist(tags.get(0));
+            assertDoesNotExist(tags.get(1));
+            assertExists(tags.get(2));
+            break;
+        case EXCLUDE:
+            assertExists(tags.get(0));
+            assertExists(tags.get(1));
+            assertExists(tags.get(2));
+            /* delete the tag that is not in the second tag set */
+            delete = new Delete2();
+            delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tags.get(0).getId().getValue()));
+            doChange(delete);
+            break;
+        case NONE:
+            assertDoesNotExist(tags.get(0));
+            assertExists(tags.get(1));
+            assertExists(tags.get(2));
+            break;
+        }
 
         /* delete the second tag set */
         delete.targetObjects = ImmutableMap.of("Annotation", Collections.singletonList(tagsets.get(1).getId().getValue()));
@@ -315,5 +358,19 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         /* check that the tag set and the remaining tags are deleted */
         assertNoneExist(tagsets);
         assertNoneExist(tags);
+    }
+
+    /**
+     * @return the child options to try using in deletion
+     */
+    @DataProvider(name = "child option")
+    public Object[][] provideChildOption() {
+        final Option[] values = Option.values();
+        final Object[][] testCases = new Object[values.length][1];
+        int index = 0;
+        for (final Option value : values) {
+            testCases[index++][0] = value;
+        }
+        return testCases;
     }
 }


### PR DESCRIPTION
In graph operations child options previously had a bug such that they could affect how parents were treated. Intended child option behaviors are documented at http://downloads.openmicroscopy.org/omero/5.1.3/api/slice2html/omero/cmd/graphs.html. This PR fixes the bug and adds integration test coverage accordingly: make sure that the test looks sensible and check that https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration.delete/AnnotationDeleteTest/ passes.

--rebased-from #4089
--rebased-from #4094