### PR TITLE
render "API" as an acronym in docs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -640,7 +640,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 <doctitle><![CDATA[<h1> Omero API </h1>]]></doctitle>
                 <bottom><![CDATA[
                 <div id="ome-logo-for-top" style="display:none"><div id="ome-logo-inner"><img src="http://hudson.openmicroscopy.org.uk/userContent/ome_docs_trac_banner.png" alt="OME Docs"></div></div>
-                <div id="doc-name-right" style="position: absolute;top: 90px;right: 20px;"><b>OmeroJava Api</b></div>
+                <div id="doc-name-right" style="position: absolute;top: 90px;right: 20px;"><b>OmeroJava API</b></div>
                 <p><i>Version: ${omero.version}</i></p>
                 <p><b><i>Copyright &#169; @@YEAR@@ The University of Dundee &amp; Open Microscopy Environment. All Rights Reserved.</i></b></p>
                 ]]></bottom>

--- a/components/blitz/resources/header.txt
+++ b/components/blitz/resources/header.txt
@@ -18,5 +18,5 @@ TITLE
              <img src="http://hudson.openmicroscopy.org.uk/userContent/ome_docs_trac_banner.png" alt="OME-XML">
           </div>
           <div id="version-top"><p>Version: @VERSION@</p></div>
-          <div id="doc-name-right" style="position: absolute;top: 117px;right: 25px;font-size: 24px;font-weight: bold;"><b>OmeroBlitz Api</b></div>
+          <div id="doc-name-right" style="position: absolute;top: 117px;right: 25px;font-size: 24px;font-weight: bold;"><b>OmeroBlitz API</b></div>
        </div>


### PR DESCRIPTION
This trivial PR simply changes "Api" in titles in public API docs to "API".

--no-rebase