### PR TITLE
Add and amend delete tests (dev 5.1)

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -505,7 +505,7 @@ class TestTagDelete(AbstractTagTest):
         assert not self.query.find('TagAnnotation', self.ts1_id)
         assert not self.query.find('TagAnnotation', self.tag_ids[0])
         assert self.query.find('TagAnnotation', self.ts2_id)
-        assert self.query.find('TagAnnotation', self.tag_ids[1])
+        assert not self.query.find('TagAnnotation', self.tag_ids[1])
         assert self.query.find('TagAnnotation', self.tag_ids[2])
 
     def testDeleteTwoTagSetsIncludingTags(self):

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -330,7 +330,7 @@ class TestDelete(CLITest):
         assert not self.query.find('Dataset', dset.id.val)
         assert self.query.find('Image', img.id.val)
 
-    def testIncludeExclude(self, simpleHierarchy):
+    def testExcludeOverridesInclude(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
 
         self.args += ['Project:%s' % proj.id.val]
@@ -338,10 +338,10 @@ class TestDelete(CLITest):
         self.args += ['--include', 'Image']
         self.cli.invoke(self.args, strict=True)
 
-        # Check that everything has been deleted.
+        # Check that only the Project has been deleted.
         assert not self.query.find('Project', proj.id.val)
         assert self.query.find('Dataset', dset.id.val)
-        assert not self.query.find('Image', img.id.val)
+        assert self.query.find('Image', img.id.val)
 
     # These tests check the default exclusion of the annotations:
     # FileAnnotation, TagAnnotation and TermAnnotation

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -306,26 +306,26 @@ class TestDelete(CLITest):
         assert not self.query.find('Dataset', dset.id.val)
         assert not self.query.find('Image', img.id.val)
 
-    def testIncludeExcludeSecond(self, simpleHierarchy):
+    def testExcludeDataset(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
 
         self.args += ['Project:%s' % proj.id.val]
         self.args += ['--exclude', 'Dataset']
         self.cli.invoke(self.args, strict=True)
 
-        # Check that everything has been deleted.
+        # Check that only the Project has been deleted.
         assert not self.query.find('Project', proj.id.val)
         assert self.query.find('Dataset', dset.id.val)
         assert self.query.find('Image', img.id.val)
 
-    def testExcludeThird(self, simpleHierarchy):
+    def testExcludeImage(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
 
         self.args += ['Project:%s' % proj.id.val]
         self.args += ['--exclude', 'Image']
         self.cli.invoke(self.args, strict=True)
 
-        # Check that everything has been deleted.
+        # Check that only Project & Dataset have been deleted.
         assert not self.query.find('Project', proj.id.val)
         assert not self.query.find('Dataset', dset.id.val)
         assert self.query.find('Image', img.id.val)


### PR DESCRIPTION
See gh-4097 the Python delete tests should pass with gh-4098 in place.

--depends-on #4098

--rebased-from #4097 