### PR TITLE
Fixed wrong file count (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/util/FilesetInfoDialog.java
@@ -96,7 +96,7 @@ public class FilesetInfoDialog extends TinyDialog {
             if (Fileset.class.isAssignableFrom(fsd.asIObject().getClass())) {
                 size = ((Fileset)fsd.asIObject()).sizeOfUsedFiles();
             }
-            String txt = size == 1 ? "Image file" : "Image files";
+            String txt = size <= 1 ? "Image file" : "Image files";
             JLabel l = new JLabel(size + " " + txt);
             l.setBackground(UIUtilities.BACKGROUND_COLOR);
             content.add(l, c);


### PR DESCRIPTION

This is the same as gh-4070 but rebased onto dev_5_1.

----

See [Ticket 12905](https://trac.openmicroscopy.org/ome/ticket/12905)

Test: Check the File path info dialog shows the correct number of files (compare with OMERO.Web)


                