### PR TITLE
add ROIs to OME-TIFF export

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -75,7 +75,6 @@ import ome.formats.model.ReferenceProcessor;
 import ome.formats.model.ShapeProcessor;
 import ome.formats.model.TargetProcessor;
 import ome.formats.model.WellProcessor;
-import ome.services.blitz.repo.ManagedImportRequestI;
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Frequency;
 import ome.units.quantity.Length;
@@ -221,7 +220,6 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import omero.util.IceMapper;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1037,10 +1035,7 @@ public class OMEROMetadataStoreClient
      */
     public RInt toRType(Color value)
     {
-        java.awt.Color javaColor = new java.awt.Color(
-                value.getRed(), value.getGreen(), value.getBlue(),
-                value.getAlpha());
-        return toRType(javaColor.getRGB());
+        return toRType(value.getValue());
     }
 
     //

--- a/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
+++ b/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
@@ -22,14 +22,6 @@
  *-----------------------------------------------------------------------------
  */
 
-/*-----------------------------------------------------------------------------
- *
- * THIS IS AUTOMATICALLY GENERATED CODE.  DO NOT MODIFY.
- * Created by josh via xsd-fu on 2009-06-09 15:26:21.685835
- *
- *-----------------------------------------------------------------------------
- */
-
 package ome.services.blitz.impl;
 
 import static omero.rtypes.rstring;
@@ -39,9 +31,13 @@ import static ome.formats.model.UnitsFactory.convertTime;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.MetadataRetrieve;
@@ -50,13 +46,19 @@ import ome.conditions.ApiUsageException;
 import ome.services.db.DatabaseIdentity;
 import ome.tools.hibernate.ProxyCleanupFilter;
 import ome.tools.hibernate.QueryBuilder;
+import ome.units.quantity.Length;
 import ome.units.quantity.Time;
 import ome.xml.meta.MetadataRoot;
+import ome.xml.model.AffineTransform;
 import ome.xml.model.enums.AcquisitionMode;
 import ome.xml.model.enums.ContrastMethod;
 import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
+import ome.xml.model.enums.FillRule;
+import ome.xml.model.enums.FontFamily;
+import ome.xml.model.enums.FontStyle;
 import ome.xml.model.enums.IlluminationType;
+import ome.xml.model.enums.LineCap;
 import ome.xml.model.enums.PixelType;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
@@ -70,7 +72,13 @@ import omero.RLong;
 import omero.RString;
 import omero.RTime;
 import omero.model.Annotation;
-import omero.model.Length;
+import omero.model.Ellipse;
+import omero.model.Label;
+import omero.model.Line;
+import omero.model.Point;
+import omero.model.Polygon;
+import omero.model.Polyline;
+import omero.model.Rect;
 import omero.model.XmlAnnotation;
 import omero.model.LongAnnotation;
 import omero.model.BooleanAnnotation;
@@ -88,8 +96,11 @@ import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Pixels;
 import omero.model.PlaneInfo;
+import omero.model.Roi;
+import omero.model.Shape;
 import omero.util.IceMapper;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.joda.time.Instant;
 
 import org.slf4j.Logger;
@@ -107,8 +118,15 @@ public class OmeroMetadata extends DummyMetadata {
 
     private final static Logger log = LoggerFactory.getLogger(OmeroMetadata.class);
 
+    private static final Pattern AFFINE_TRANSFORM =
+            Pattern.compile("\\[\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+\\]");
+
     // -- State --
 
+    // Objects already in lists below, to avoid duplication
+    private final Set<String> seenLSIDs = new HashSet<String>();
+
+    // Images
     private final List<Image> imageList = new ArrayList<Image>();
 
     // Annotations
@@ -128,6 +146,9 @@ public class OmeroMetadata extends DummyMetadata {
         new ArrayList<TagAnnotation>();
     private final List<TermAnnotation> termAnnotationList = 
         new ArrayList<TermAnnotation>();
+
+    // ROIs
+    private final List<Roi> roiList = new ArrayList<Roi>();
 
     private final DatabaseIdentity db;
 
@@ -174,7 +195,7 @@ public class OmeroMetadata extends DummyMetadata {
         // Otherwise if we have an ID use that as the value.
         if (obj.getId() != null) {
 
-            Class k = obj.getClass();
+            Class<? extends IObject> k = obj.getClass();
             if (Annotation.class.isAssignableFrom(k)) {
                 k = Annotation.class;
             }
@@ -245,6 +266,16 @@ public class OmeroMetadata extends DummyMetadata {
                 qb.join("l.mode",             "a_mode",   true, true);
                 qb.join("l.illumination",     "i_type",   true, true);
                 qb.join("l.contrastMethod",   "c_method", true, true);
+                qb.join("i.rois",             "r",        true, true);
+                qb.join("r.details.owner",    "r_o",      false, true);
+                qb.join("r.details.group",    "r_g",      false, true);
+                qb.join("r.annotationLinks",  "r_a_link", true, true);
+                qb.join("r_a_link.child",     "r_a",      true, true);
+                qb.join("r.shapes",           "s",        true, true);
+                qb.join("s.details.owner",    "s_o",      false, true);
+                qb.join("s.details.group",    "s_g",      false, true);
+                qb.join("s.annotationLinks",  "s_a_link", true, true);
+                qb.join("s_a_link.child",     "s_a",      true, true);
                 qb.where();
                 qb.and("i.id = " + id);
                 ome.model.core.Image _i =(ome.model.core.Image) qb.query(session).uniqueResult();
@@ -281,12 +312,16 @@ public class OmeroMetadata extends DummyMetadata {
         for (int i = 0; i < imageList.size(); i++) {
             Image image = imageList.get(i);
             Image replacement = replacements.get(image);
-            if (replacement != null) {
-                newImages.add(replacement);
-                initializeAnnotations(replacement);
-            } else {
-                newImages.add(image);
-                initializeAnnotations(image);
+            if (seenLSIDs.add(handleLsid(replacement))) {
+                if (replacement != null) {
+                    newImages.add(replacement);
+                    initializeAnnotations(replacement.linkedAnnotationList());
+                    initializeRois(replacement);
+                } else {
+                    newImages.add(image);
+                    initializeAnnotations(image.linkedAnnotationList());
+                    initializeRois(image);
+                }
             }
         }
         this.imageList.clear();
@@ -294,10 +329,14 @@ public class OmeroMetadata extends DummyMetadata {
 
     }
 
-    private void initializeAnnotations(Image image)
+    private void initializeAnnotations(Iterable<Annotation> annotations)
     {
-        for (Annotation annotation : image.linkedAnnotationList())
+        for (Annotation annotation : annotations)
         {
+            if (!seenLSIDs.add(handleLsid(annotation))) {
+                /* already included this annotation in a list */
+                continue;
+            }
             if (annotation instanceof XmlAnnotation)
             {
                 xmlAnnotationList.add((XmlAnnotation) annotation);
@@ -339,6 +378,18 @@ public class OmeroMetadata extends DummyMetadata {
         }
     }
 
+    private void initializeRois(Image image) {
+        for (final Roi roi : image.copyRois()) {
+            if (seenLSIDs.add(handleLsid(roi))) {
+                roiList.add(roi);
+                initializeAnnotations(roi.linkedAnnotationList());
+                for (final Shape shape : roi.copyShapes()) {
+                    initializeAnnotations(shape.linkedAnnotationList());
+                }
+            }
+        }
+    }
+
     private Image _getImage(int imageIndex)
     {
         try
@@ -351,38 +402,54 @@ public class OmeroMetadata extends DummyMetadata {
         }
     }
 
-    private Boolean fromRType(RBool v)
+    private <X extends Shape> X getShape(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        if (ROIIndex < 0 || shapeIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        final List<Shape> shapes = roi.copyShapes();
+        if (shapeIndex >= shapes.size()) {
+            return null;
+        }
+        final Shape shape = shapes.get(shapeIndex);
+        if (!expectedSubclass.isAssignableFrom(shape.getClass())) {
+            return null;
+        }
+        return expectedSubclass.cast(shape);
+    }
+
+    private static Boolean fromRType(RBool v)
     {
         return v == null? null : v.getValue();
     }
 
-    private String fromRType(RString v)
+    private static String fromRType(RString v)
     {
         return v == null? null : v.getValue();
     }
 
-    private Double fromRType(RDouble v)
+    private static Double fromRType(RDouble v)
     {
         return v == null? null : v.getValue();
     }
 
-    private Time fromRType(omero.model.Time v)
+    private static Time fromRType(omero.model.Time v)
     {
         if (v == null) return null;
         return convertTime(v);
     }
 
-    private Integer fromRType(RInt v)
+    private static Integer fromRType(RInt v)
     {
         return v == null? null : v.getValue();
     }
 
-    private Long fromRType(RLong v)
+    private static Long fromRType(RLong v)
     {
         return v == null? null : v.getValue();
     }
 
-    private PositiveInteger toPositiveInteger(RInt v)
+    private static PositiveInteger toPositiveInteger(RInt v)
     {
         try
         {
@@ -396,7 +463,7 @@ public class OmeroMetadata extends DummyMetadata {
         }
     }
 
-    private NonNegativeInteger toNonNegativeInteger(RInt v)
+    private static NonNegativeInteger toNonNegativeInteger(RInt v)
     {
         try
         {
@@ -410,6 +477,30 @@ public class OmeroMetadata extends DummyMetadata {
         }
     }
 
+    private static AffineTransform toTransform(RString v) {
+        final String transformString = fromRType(v);
+        if (transformString == null) {
+            return null;
+        }
+        final Matcher transformMatcher = AFFINE_TRANSFORM.matcher(transformString);
+        if (!transformMatcher.matches()) {
+            return null;
+        }
+        final AffineTransform transform = new AffineTransform();
+        try {
+            transform.setA00(Double.valueOf(transformMatcher.group(1)));
+            transform.setA01(Double.valueOf(transformMatcher.group(2)));
+            transform.setA02(Double.valueOf(transformMatcher.group(3)));
+            transform.setA10(Double.valueOf(transformMatcher.group(4)));
+            transform.setA11(Double.valueOf(transformMatcher.group(5)));
+            transform.setA12(Double.valueOf(transformMatcher.group(6)));
+            return transform;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /* IMAGE */
 
     @Override
     public Timestamp getImageAcquisitionDate(int imageIndex)
@@ -480,6 +571,29 @@ public class OmeroMetadata extends DummyMetadata {
     {
         Image o = _getImage(imageIndex);
         return o != null? fromRType(o.getName()) : null;
+    }
+
+    @Override
+    public String getImageROIRef(int imageIndex, int ROIRefIndex) {
+        if (imageIndex < 0 || ROIRefIndex < 0 || imageIndex >= imageList.size()) {
+            return null;
+        }
+        final Image image = imageList.get(imageIndex);
+        final List<Roi> rois = image.copyRois();
+        if (ROIRefIndex >= rois.size()) {
+            return null;
+        }
+        final Roi roi = rois.get(ROIRefIndex);
+        return handleLsid(roi);
+    }
+
+    @Override
+    public int getImageROIRefCount(int imageIndex) {
+        if (imageIndex < 0 || imageIndex >= imageList.size()) {
+            return -1;
+        }
+        final Image image = imageList.get(imageIndex);
+        return image.sizeOfRois();
     }
 
     @Override
@@ -869,6 +983,8 @@ public class OmeroMetadata extends DummyMetadata {
         return toNonNegativeInteger(o.getTheZ());
     }
 
+    /* ANNOTATION */
+
     private <T extends Annotation> T getAnnotation(Class<T> klass, int index)
     {
         try
@@ -1208,6 +1324,1126 @@ public class OmeroMetadata extends DummyMetadata {
         TermAnnotation o = getAnnotation(
                 TermAnnotation.class, termAnnotationIndex);
         return o != null? fromRType(o.getTermValue()) : null;
+    }
+
+    /* ROI */
+
+    @Override
+    public int getROICount() {
+        return roiList.size();
+    }
+
+    @Override
+    public String getROIAnnotationRef(int ROIIndex, int annotationRefIndex) {
+        if (ROIIndex < 0 || annotationRefIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        final List<Annotation> annotations = roi.linkedAnnotationList();
+        if (annotationRefIndex >= annotations.size()) {
+            return null;
+        }
+        final Annotation annotation = annotations.get(annotationRefIndex);
+        return handleLsid(annotation);
+    }
+
+    @Override
+    public int getROIAnnotationRefCount(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return -1;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        return roi.sizeOfAnnotationLinks();
+    }
+
+    @Override
+    public String getROIDescription(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        return fromRType(roi.getDescription());
+    }
+
+    @Override
+    public String getROIID(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        return handleLsid(roi);
+    }
+
+    @Override
+    public String getROIName(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        return fromRType(roi.getName());
+    }
+
+    @Override
+    public String getROINamespace(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return null;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        final String[] namespaces = roi.getNamespaces();
+        if (ArrayUtils.isEmpty(namespaces)) {
+            return null;
+        }
+        return namespaces[0];
+    }
+
+    @Override
+    public int getShapeCount(int ROIIndex) {
+        if (ROIIndex < 0 || ROIIndex >= roiList.size()) {
+            return -1;
+        }
+        final Roi roi = roiList.get(ROIIndex);
+        return roi.sizeOfShapes();
+    }
+
+    @Override
+    public String getShapeType(int ROIIndex, int shapeIndex) {
+        final Shape shape = getShape(ROIIndex, shapeIndex, Shape.class);
+        if (shape == null) {
+            return null;
+        }
+        Class<? extends Shape> shapeClass = null;
+        Class<? extends Shape> currentClass = shape.getClass();
+        while (currentClass != Shape.class) {
+            shapeClass = currentClass;
+            currentClass = currentClass.getSuperclass().asSubclass(Shape.class);
+        }
+        if (shapeClass == Rect.class) {
+            return "Rectangle";
+        } else {
+            return shapeClass.getSimpleName();
+        }
+    }
+
+    @Override
+    public int getShapeAnnotationRefCount(int ROIIndex, int shapeIndex) {
+        final Shape shape = getShape(ROIIndex, shapeIndex, Shape.class);
+        if (shape == null) {
+            return -1;
+        }
+        return shape.sizeOfAnnotationLinks();
+    }
+
+    private <X extends Shape> String getShapeAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex,
+            Class<X> expectedSubclass) {
+        if (annotationRefIndex < 0) {
+            return null;
+        }
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final List<Annotation> annotations = shape.linkedAnnotationList();
+        if (annotationRefIndex >= annotations.size()) {
+            return null;
+        }
+        final Annotation annotation = annotations.get(annotationRefIndex);
+        return handleLsid(annotation);
+    }
+
+    private <X extends Shape> Color getShapeFillColor(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final Integer color = fromRType(shape.getFillColor());
+        if (color == null) {
+            return null;
+        }
+        return new Color(color);
+    }
+
+    private <X extends Shape> FillRule getShapeFillRule(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final String fillRuleName = fromRType(shape.getFillRule());
+        if (fillRuleName == null) {
+            return null;
+        }
+        final FillRule fillRule;
+        try {
+            fillRule = FillRule.fromString(fillRuleName);
+        } catch (EnumerationException e) {
+            return null;
+        }
+        return fillRule;
+    }
+
+    private <X extends Shape> FontFamily getShapeFontFamily(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final String fontFamilyName = fromRType(shape.getFontFamily());
+        if (fontFamilyName == null) {
+            return null;
+        }
+        final FontFamily fontFamily;
+        try {
+            fontFamily = FontFamily.fromString(fontFamilyName);
+        } catch (EnumerationException e) {
+            return null;
+        }
+        return fontFamily;
+    }
+
+    private <X extends Shape> Length getShapeFontSize(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return convertLength(shape.getFontSize());
+    }
+
+    private <X extends Shape> FontStyle getShapeFontStyle(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final String fontStyleName = fromRType(shape.getFontStyle());
+        if (fontStyleName == null) {
+            return null;
+        }
+        final FontStyle fontStyle;
+        try {
+            fontStyle = FontStyle.fromString(fontStyleName);
+        } catch (EnumerationException e) {
+            return null;
+        }
+        return fontStyle;
+    }
+
+    private <X extends Shape> String getShapeID(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return handleLsid(shape);
+    }
+
+    private <X extends Shape> LineCap getShapeLineCap(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final String lineCapName = fromRType(shape.getStrokeLineCap());
+        if (lineCapName == null) {
+            return null;
+        }
+        final LineCap lineCap;
+        try {
+            lineCap = LineCap.fromString(lineCapName);
+        } catch (EnumerationException e) {
+            return null;
+        }
+        return lineCap;
+    }
+
+    private <X extends Shape> Boolean getShapeLocked(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return fromRType(shape.getLocked());
+    }
+
+    private <X extends Shape> Color getShapeStrokeColor(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        final Integer color = fromRType(shape.getStrokeColor());
+        if (color == null) {
+            return null;
+        }
+        return new Color(color);
+    }
+
+    private <X extends Shape> String getShapeStrokeDashArray(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return fromRType(shape.getStrokeDashArray());
+    }
+
+    private <X extends Shape> Length getShapeStrokeWidth(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return convertLength(shape.getStrokeWidth());
+    }
+
+    private <X extends Shape> NonNegativeInteger getShapeTheC(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return toNonNegativeInteger(shape.getTheC());
+    }
+
+    private <X extends Shape> NonNegativeInteger getShapeTheT(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return toNonNegativeInteger(shape.getTheT());
+    }
+
+    private <X extends Shape> NonNegativeInteger getShapeTheZ(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return toNonNegativeInteger(shape.getTheZ());
+    }
+
+    private <X extends Shape> AffineTransform getShapeTransform(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return toTransform(shape.getTransform());
+    }
+
+    private <X extends Shape> Boolean getShapeVisible(int ROIIndex, int shapeIndex, Class<X> expectedSubclass) {
+        final X shape = getShape(ROIIndex, shapeIndex, expectedSubclass);
+        if (shape == null) {
+            return null;
+        }
+        return fromRType(shape.getVisibility());
+    }
+
+    @Override
+    public String getEllipseAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Ellipse.class);
+    }
+
+    @Override
+    public Color getEllipseFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public FillRule getEllipseFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public FontFamily getEllipseFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Length getEllipseFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public FontStyle getEllipseFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public String getEllipseID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public LineCap getEllipseLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Boolean getEllipseLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Color getEllipseStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public String getEllipseStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Length getEllipseStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public NonNegativeInteger getEllipseTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public NonNegativeInteger getEllipseTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public NonNegativeInteger getEllipseTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public AffineTransform getEllipseTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Boolean getEllipseVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Ellipse.class);
+    }
+
+    @Override
+    public Double getEllipseRadiusX(int ROIIndex, int shapeIndex) {
+        final Ellipse ellipse = getShape(ROIIndex, shapeIndex, Ellipse.class);
+        if (ellipse == null) {
+            return null;
+        }
+        return fromRType(ellipse.getRx());
+    }
+
+    @Override
+    public Double getEllipseRadiusY(int ROIIndex, int shapeIndex) {
+        final Ellipse ellipse = getShape(ROIIndex, shapeIndex, Ellipse.class);
+        if (ellipse == null) {
+            return null;
+        }
+        return fromRType(ellipse.getRy());
+    }
+
+    @Override
+    public String getEllipseText(int ROIIndex, int shapeIndex) {
+        final Ellipse ellipse = getShape(ROIIndex, shapeIndex, Ellipse.class);
+        if (ellipse == null) {
+            return null;
+        }
+        return fromRType(ellipse.getTextValue());
+    }
+
+    @Override
+    public Double getEllipseX(int ROIIndex, int shapeIndex) {
+        final Ellipse ellipse = getShape(ROIIndex, shapeIndex, Ellipse.class);
+        if (ellipse == null) {
+            return null;
+        }
+        return fromRType(ellipse.getCx());
+    }
+
+    @Override
+    public Double getEllipseY(int ROIIndex, int shapeIndex) {
+        final Ellipse ellipse = getShape(ROIIndex, shapeIndex, Ellipse.class);
+        if (ellipse == null) {
+            return null;
+        }
+        return fromRType(ellipse.getCy());
+    }
+
+    @Override
+    public String getLabelAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Label.class);
+    }
+
+    @Override
+    public Color getLabelFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public FillRule getLabelFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public FontFamily getLabelFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public Length getLabelFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public FontStyle getLabelFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public String getLabelID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public LineCap getLabelLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public Boolean getLabelLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public Color getLabelStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public String getLabelStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public Length getLabelStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLabelTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLabelTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLabelTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public AffineTransform getLabelTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public Boolean getLabelVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Label.class);
+    }
+
+    @Override
+    public String getLabelText(int ROIIndex, int shapeIndex) {
+        final Label label = getShape(ROIIndex, shapeIndex, Label.class);
+        if (label == null) {
+            return null;
+        }
+        return fromRType(label.getTextValue());
+    }
+
+    @Override
+    public Double getLabelX(int ROIIndex, int shapeIndex) {
+        final Label label = getShape(ROIIndex, shapeIndex, Label.class);
+        if (label == null) {
+            return null;
+        }
+        return fromRType(label.getX());
+    }
+
+    @Override
+    public Double getLabelY(int ROIIndex, int shapeIndex) {
+        final Label label = getShape(ROIIndex, shapeIndex, Label.class);
+        if (label == null) {
+            return null;
+        }
+        return fromRType(label.getY());
+    }
+
+    @Override
+    public String getLineAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Line.class);
+    }
+
+    @Override
+    public Color getLineFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public FillRule getLineFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public FontFamily getLineFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public Length getLineFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public FontStyle getLineFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public String getLineID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public LineCap getLineLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public Boolean getLineLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public Color getLineStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public String getLineStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public Length getLineStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLineTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLineTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public NonNegativeInteger getLineTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public AffineTransform getLineTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public Boolean getLineVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Line.class);
+    }
+
+    @Override
+    public String getLineText(int ROIIndex, int shapeIndex) {
+        final Line line = getShape(ROIIndex, shapeIndex, Line.class);
+        if (line == null) {
+            return null;
+        }
+        return fromRType(line.getTextValue());
+    }
+
+    @Override
+    public Double getLineX1(int ROIIndex, int shapeIndex) {
+        final Line line = getShape(ROIIndex, shapeIndex, Line.class);
+        if (line == null) {
+            return null;
+        }
+        return fromRType(line.getX1());
+    }
+
+    @Override
+    public Double getLineX2(int ROIIndex, int shapeIndex) {
+        final Line line = getShape(ROIIndex, shapeIndex, Line.class);
+        if (line == null) {
+            return null;
+        }
+        return fromRType(line.getX2());
+    }
+
+    @Override
+    public Double getLineY1(int ROIIndex, int shapeIndex) {
+        final Line line = getShape(ROIIndex, shapeIndex, Line.class);
+        if (line == null) {
+            return null;
+        }
+        return fromRType(line.getY1());
+    }
+
+    @Override
+    public Double getLineY2(int ROIIndex, int shapeIndex) {
+        final Line line = getShape(ROIIndex, shapeIndex, Line.class);
+        if (line == null) {
+            return null;
+        }
+        return fromRType(line.getY2());
+    }
+
+    @Override
+    public String getPointAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Point.class);
+    }
+
+    @Override
+    public Color getPointFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public FillRule getPointFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public FontFamily getPointFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public Length getPointFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public FontStyle getPointFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public String getPointID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public LineCap getPointLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public Boolean getPointLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public Color getPointStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public String getPointStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public Length getPointStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPointTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPointTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPointTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public AffineTransform getPointTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public Boolean getPointVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Point.class);
+    }
+
+    @Override
+    public String getPointText(int ROIIndex, int shapeIndex) {
+        final Point point = getShape(ROIIndex, shapeIndex, Point.class);
+        if (point == null) {
+            return null;
+        }
+        return fromRType(point.getTextValue());
+    }
+
+    @Override
+    public Double getPointX(int ROIIndex, int shapeIndex) {
+        final Point point = getShape(ROIIndex, shapeIndex, Point.class);
+        if (point == null) {
+            return null;
+        }
+        return fromRType(point.getCx());
+    }
+
+    @Override
+    public Double getPointY(int ROIIndex, int shapeIndex) {
+        final Point point = getShape(ROIIndex, shapeIndex, Point.class);
+        if (point == null) {
+            return null;
+        }
+        return fromRType(point.getCy());
+    }
+
+    @Override
+    public String getPolygonAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Polygon.class);
+    }
+
+    @Override
+    public Color getPolygonFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public FillRule getPolygonFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public FontFamily getPolygonFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public Length getPolygonFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public FontStyle getPolygonFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public String getPolygonID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public LineCap getPolygonLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public Boolean getPolygonLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public Color getPolygonStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public String getPolygonStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public Length getPolygonStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolygonTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolygonTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolygonTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public AffineTransform getPolygonTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public Boolean getPolygonVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Polygon.class);
+    }
+
+    @Override
+    public String getPolygonPoints(int ROIIndex, int shapeIndex) {
+        final Polygon polygon = getShape(ROIIndex, shapeIndex, Polygon.class);
+        if (polygon == null) {
+            return null;
+        }
+        return fromRType(polygon.getPoints());
+    }
+
+    @Override
+    public String getPolygonText(int ROIIndex, int shapeIndex) {
+        final Polygon polygon = getShape(ROIIndex, shapeIndex, Polygon.class);
+        if (polygon == null) {
+            return null;
+        }
+        return fromRType(polygon.getTextValue());
+    }
+
+    @Override
+    public String getPolylineAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Polyline.class);
+    }
+
+    @Override
+    public Color getPolylineFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public FillRule getPolylineFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public FontFamily getPolylineFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public Length getPolylineFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public FontStyle getPolylineFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public String getPolylineID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public LineCap getPolylineLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public Boolean getPolylineLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public Color getPolylineStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public String getPolylineStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public Length getPolylineStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolylineTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolylineTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public NonNegativeInteger getPolylineTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public AffineTransform getPolylineTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public Boolean getPolylineVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Polyline.class);
+    }
+
+    @Override
+    public String getPolylinePoints(int ROIIndex, int shapeIndex) {
+        final Polyline polyline = getShape(ROIIndex, shapeIndex, Polyline.class);
+        if (polyline == null) {
+            return null;
+        }
+        return fromRType(polyline.getPoints());
+    }
+
+    @Override
+    public String getPolylineText(int ROIIndex, int shapeIndex) {
+        final Polyline polyline = getShape(ROIIndex, shapeIndex, Polyline.class);
+        if (polyline == null) {
+            return null;
+        }
+        return fromRType(polyline.getTextValue());
+    }
+
+    @Override
+    public String getRectangleAnnotationRef(int ROIIndex, int shapeIndex, int annotationRefIndex) {
+        return getShapeAnnotationRef(ROIIndex, shapeIndex, annotationRefIndex, Rect.class);
+    }
+
+    @Override
+    public Color getRectangleFillColor(int ROIIndex, int shapeIndex) {
+        return getShapeFillColor(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public FillRule getRectangleFillRule(int ROIIndex, int shapeIndex) {
+        return getShapeFillRule(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public FontFamily getRectangleFontFamily(int ROIIndex, int shapeIndex) {
+        return getShapeFontFamily(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public Length getRectangleFontSize(int ROIIndex, int shapeIndex) {
+        return getShapeFontSize(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public FontStyle getRectangleFontStyle(int ROIIndex, int shapeIndex) {
+        return getShapeFontStyle(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public String getRectangleID(int ROIIndex, int shapeIndex) {
+        return getShapeID(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public LineCap getRectangleLineCap(int ROIIndex, int shapeIndex) {
+        return getShapeLineCap(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public Boolean getRectangleLocked(int ROIIndex, int shapeIndex) {
+        return getShapeLocked(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public Color getRectangleStrokeColor(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeColor(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public String getRectangleStrokeDashArray(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeDashArray(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public Length getRectangleStrokeWidth(int ROIIndex, int shapeIndex) {
+        return getShapeStrokeWidth(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public NonNegativeInteger getRectangleTheC(int ROIIndex, int shapeIndex) {
+        return getShapeTheC(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public NonNegativeInteger getRectangleTheT(int ROIIndex, int shapeIndex) {
+        return getShapeTheT(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public NonNegativeInteger getRectangleTheZ(int ROIIndex, int shapeIndex) {
+        return getShapeTheZ(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public AffineTransform getRectangleTransform(int ROIIndex, int shapeIndex) {
+        return getShapeTransform(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public Boolean getRectangleVisible(int ROIIndex, int shapeIndex) {
+        return getShapeVisible(ROIIndex, shapeIndex, Rect.class);
+    }
+
+    @Override
+    public String getRectangleText(int ROIIndex, int shapeIndex) {
+        final Rect rectangle = getShape(ROIIndex, shapeIndex, Rect.class);
+        if (rectangle == null) {
+            return null;
+        }
+        return fromRType(rectangle.getTextValue());
+    }
+
+    @Override
+    public Double getRectangleHeight(int ROIIndex, int shapeIndex) {
+        final Rect rectangle = getShape(ROIIndex, shapeIndex, Rect.class);
+        if (rectangle == null) {
+            return null;
+        }
+        return fromRType(rectangle.getHeight());
+    }
+
+    @Override
+    public Double getRectangleWidth(int ROIIndex, int shapeIndex) {
+        final Rect rectangle = getShape(ROIIndex, shapeIndex, Rect.class);
+        if (rectangle == null) {
+            return null;
+        }
+        return fromRType(rectangle.getWidth());
+    }
+
+    @Override
+    public Double getRectangleX(int ROIIndex, int shapeIndex) {
+        final Rect rectangle = getShape(ROIIndex, shapeIndex, Rect.class);
+        if (rectangle == null) {
+            return null;
+        }
+        return fromRType(rectangle.getX());
+    }
+
+    @Override
+    public Double getRectangleY(int ROIIndex, int shapeIndex) {
+        final Rect rectangle = getShape(ROIIndex, shapeIndex, Rect.class);
+        if (rectangle == null) {
+            return null;
+        }
+        return fromRType(rectangle.getY());
     }
 
     class OmeroMetadataRoot implements MetadataRoot

--- a/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
+++ b/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
@@ -267,13 +267,13 @@ public class OmeroMetadata extends DummyMetadata {
                 qb.join("l.illumination",     "i_type",   true, true);
                 qb.join("l.contrastMethod",   "c_method", true, true);
                 qb.join("i.rois",             "r",        true, true);
-                qb.join("r.details.owner",    "r_o",      false, true);
-                qb.join("r.details.group",    "r_g",      false, true);
+                qb.join("r.details.owner",    "r_o",      true, true);
+                qb.join("r.details.group",    "r_g",      true, true);
                 qb.join("r.annotationLinks",  "r_a_link", true, true);
                 qb.join("r_a_link.child",     "r_a",      true, true);
                 qb.join("r.shapes",           "s",        true, true);
-                qb.join("s.details.owner",    "s_o",      false, true);
-                qb.join("s.details.group",    "s_g",      false, true);
+                qb.join("s.details.owner",    "s_o",      true, true);
+                qb.join("s.details.group",    "s_g",      true, true);
                 qb.join("s.annotationLinks",  "s_a_link", true, true);
                 qb.join("s_a_link.child",     "s_a",      true, true);
                 qb.where();

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -9,7 +9,6 @@ package integration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
-import integration.PermissionsTestAll.TestParam;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,10 +21,12 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -55,6 +56,7 @@ import omero.api.ExporterPrx;
 import omero.api.RawFileStorePrx;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
+import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLinkI;
 import omero.model.ImageI;
@@ -62,6 +64,8 @@ import omero.model.OriginalFile;
 import omero.model.Pixels;
 import omero.model.PixelsI;
 import omero.model.PixelsOriginalFileMapI;
+import omero.model.Shape;
+import omero.sys.Parameters;
 import omero.sys.ParametersI;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -1202,6 +1206,42 @@ public class ExporterTest extends AbstractServerTest {
             if (transformed != null) transformed.delete();
             if (upgraded != null) upgraded.delete();
         }
+    }
+
+    /**
+     * Test that the shapes in an image's ROI survive export then import.
+     * @throws Throwable unexpected
+     */
+    @Test
+    public void testExportImportROIs() throws Throwable {
+        /* export then import an image */
+        final File exportedFile = export(OME_TIFF, IMAGE_ROI);
+        final Pixels pixels = importFile(exportedFile, OME_TIFF).get(0);
+
+        /* find which kinds of shape are expected */
+        final Set<String> remainingClasses = new HashSet<String>();
+        for (final String fullClassName : XMLMockObjects.SHAPES) {
+            remainingClasses.add(fullClassName.substring(fullClassName.lastIndexOf('.') + 1));
+        }
+
+        /* find the image's shapes */
+        final String hql = "FROM Shape WHERE roi.image.id = :id";
+        final Parameters params = new ParametersI().addId(pixels.getImage().getId().getValue());
+        final List<IObject> shapes = iQuery.findAllByQuery(hql, params);
+
+        /* check that the image has the expected shapes */
+        for (final IObject result : shapes) {
+            Class<? extends IObject> resultClass = result.getClass();
+            while (resultClass.getSuperclass() != Shape.class) {
+                resultClass = resultClass.getSuperclass().asSubclass(IObject.class);
+            }
+            String resultClassName = resultClass.getSimpleName();
+            if ("Rect".equals(resultClassName)) {
+                resultClassName = "Rectangle";  /* the OME-XML name differs */
+            }
+            assertTrue(remainingClasses.remove(resultClassName));
+        }
+        assertTrue(remainingClasses.isEmpty());
     }
 
     class Target {


### PR DESCRIPTION
Try exporting then importing an image with ROIs and make sure that the ROIs are preserved. Of course, this preserves only the properties defined in `ROI.xsd`. Also check that https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ExporterTest/ passes.

Still does not work for mask ROIs, sorry @imunro.

--no-rebase