### PR TITLE
improve Server and Blitz Javadoc

### DIFF
--- a/components/blitz/src/ome/formats/OMEROImportFixture.java
+++ b/components/blitz/src/ome/formats/OMEROImportFixture.java
@@ -74,7 +74,7 @@ public class OMEROImportFixture {
     /**
      * checks for the necessary fields and initializes the {@link ImportLibrary}
      *
-     * @throws Exception
+     * @throws Exception if the import library could not be instantiated
      */
     public void setUp() throws Exception {
         this.library = new ImportLibrary(store, reader);
@@ -106,6 +106,10 @@ public class OMEROImportFixture {
 
     /**
      * Provides one complete import cycle.
+     * @param f the file to import
+     * @param name the name (ignored)
+     * @return the {@link Pixels} instance(s) created by the import
+     * @throws Exception if the import failed
      */
     public List<Pixels> fullImport(File f, String name) throws Exception {
         this.setUp();
@@ -120,19 +124,9 @@ public class OMEROImportFixture {
     }
 
     /**
-     * runs import by looping through all files and then calling:
-     * <ul>
-     * <li>{@link ImportLibrary#open(String)}</li>
-     * <li>{@link ImportLibrary#calculateImageCount(String)}</li>
-     * <li>{@link ImportLibrary#importMetadata()}</li>
-     * <li>
-     * {@link ImportLibrary#importData(long, String, ome.formats.testclient.ImportLibrary.Step)}
-     * </li>
-     * </ul>
-     *
-     * @param step
-     *            an action to take per plane. not null.
-     * @throws Exception
+     * Runs import by looping through all files and then calling
+     * {@link ImportLibrary#importCandidates(ImportConfig, ImportCandidates)}.
+     * @throws Exception if import failed in a way that is not handled by an {@link EXCEPTION_EVENT}
      */
     public void doImport() throws Exception {
         String fileName = file.getAbsolutePath();
@@ -165,6 +159,8 @@ public class OMEROImportFixture {
     /**
      * Accessor for the created pixels. Should be called before the next call to
      * {@link #doImport()}
+     * @return the {@link Pixels} instance(s) created by the import
+     * @throws Exception from an {@link EXCEPTION_EVENT} if the import failed
      */
     public List<Pixels> getPixels() throws Exception {
         if (exception != null) {

--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -529,12 +529,12 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * Sets the id which will be used by {@link #initializeServices(boolean)}
+     * Sets the id which will be used
      * to set the call context for all services. If null, the call context
      * will be left which will then use the context of the session.
      *
-     * @param groupID
-     * @return
+     * @param groupID the group ID to use for call contexts
+     * @return the previous group ID, may be {@code null}
      */
     public Long setGroup(Long groupID) {
         Long old = this.groupID;
@@ -547,6 +547,7 @@ public class OMEROMetadataStoreClient
      * service factory. When finished with this instance, close stateful
      * services via {@link #closeServices()}.
      * @param serviceFactory The factory. Mustn't be <code>null</code>.
+     * @throws ServerError if the services could not be initialized
      */
     public void initialize(ServiceFactoryPrx serviceFactory)
         throws ServerError
@@ -563,6 +564,7 @@ public class OMEROMetadataStoreClient
      * services via {@link #closeServices()}.
      *
      * @param c The client. Mustn't be <code>null</code>.
+     * @throws ServerError if the services could not be initialized
      */
     public void initialize(omero.client c)
         throws ServerError
@@ -671,6 +673,9 @@ public class OMEROMetadataStoreClient
      * @param server Server hostname.
      * @param port Server port.
      * @param sessionKey Bind session key.
+     * @throws CannotCreateSessionException if a session could not be created
+     * @throws PermissionDeniedException if the services may not be initialized
+     * @throws ServerError if the services could not be initialized
      */
     public void initialize(String server, int port, String sessionKey)
         throws CannotCreateSessionException, PermissionDeniedException, ServerError
@@ -687,6 +692,10 @@ public class OMEROMetadataStoreClient
      * @param server Server hostname.
      * @param port Server port.
      * @param sessionKey Bind session key.
+     * @param isSecure if a secure session should be created
+     * @throws CannotCreateSessionException if a session could not be created
+     * @throws PermissionDeniedException if the services may not be initialized
+     * @throws ServerError if the services could not be initialized
      */
     public void initialize(String server, int port, String sessionKey, boolean isSecure)
         throws CannotCreateSessionException, PermissionDeniedException, ServerError
@@ -807,7 +816,7 @@ public class OMEROMetadataStoreClient
     /**
      * Sets the active instance provider.
      *
-     * @param enumProvider Enumeration provider to use.
+     * @param instanceProvider the instance provider to use
      */
     public void setInstanceProvider(InstanceProvider instanceProvider)
     {
@@ -815,7 +824,7 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * Retrieves the active enumeration provider.
+     * Retrieves the active instance provider.
      *
      * @return See above.
      */
@@ -1424,7 +1433,7 @@ public class OMEROMetadataStoreClient
     /**
      * Adds a model processor to the end of the processing chain.
      * @param processor Model processor to add.
-     * @return <code>true</code> as specified by {@link Collection.add(E)}.
+     * @return <code>true</code> as specified by {@link Collection#add(Object)}
      */
     public boolean addModelProcessor(ModelProcessor processor)
     {
@@ -1594,8 +1603,7 @@ public class OMEROMetadataStoreClient
      * Changes the default group of the currently logged in user.
      *
      * @param groupID The id of the group.
-     * @throws Exception If an error occurred while trying to
-     * retrieve data from OMERO service.
+     * @throws ServerError if the group could not be set or the services initialized accordingly
      */
     public void setCurrentGroup(long groupID)
         throws ServerError
@@ -1643,7 +1651,7 @@ public class OMEROMetadataStoreClient
      * Also strips system groups from this map
      *
      * @return map of group id & name
-     * @throws ServerError
+     * @throws ServerError if the groups could not be mapped
      */
     public Map<Long, String> mapUserGroups() throws ServerError
     {
@@ -1691,8 +1699,8 @@ public class OMEROMetadataStoreClient
     /**
      * Retrieve the default group's name
      *
-     * @return name
-     * @throws ServerError
+     * @return the name of the default group
+     * @throws ServerError if the default group could not be retrieved
      */
     public String getDefaultGroupName() throws ServerError
     {
@@ -1709,7 +1717,7 @@ public class OMEROMetadataStoreClient
      * Retrieve the default group's permission 'level'.
      *
      * @return ImportEvent's group level
-     * @throws ServerError
+     * @throws ServerError if the default group could not be retrieved
      */
     @Deprecated
     public int getDefaultGroupLevel() throws ServerError {
@@ -1750,7 +1758,7 @@ public class OMEROMetadataStoreClient
 
     /**
      * Post processes the internal structure of the client side MetadataStore.
-     * Should be called before {@link saveToDB()}.
+     * Should be called before {@link #saveToDB(FilesetJobLink)}.
      */
     public void postProcess()
     {
@@ -1764,6 +1772,7 @@ public class OMEROMetadataStoreClient
     /**
      * Updates the server side MetadataStore with a list of our objects and
      * references and saves them into the database.
+     * @param link the link to save to the database
      * @return List of Pixels after database commit.
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -1885,10 +1894,10 @@ public class OMEROMetadataStoreClient
     /**
      * Helper method to retrieve an object from iQuery
      *
-     * @param <T>
-     * @param klass
-     * @param id
-     * @return
+     * @param <T> the kind of model object to retrieve
+     * @param klass the class of the model object
+     * @param id the ID of the model object
+     * @return the model object
      */
     @SuppressWarnings("unchecked")
     public <T extends IObject> T getTarget(Class<T> klass, long id)
@@ -1917,8 +1926,8 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @param projectId
-     * @return
+     * @param projectId the ID of the project
+     * @return the project
      */
     public Project getProject(long projectId)
     {
@@ -1933,10 +1942,10 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @param datasetName
-     * @param datasetDescription
-     * @param project
-     * @return
+     * @param datasetName the name of the dataset
+     * @param datasetDescription the description of the dataset
+     * @param project the project in which the dataset is (if any)
+     * @return the newly persisted dataset
      */
     public Dataset addDataset(String datasetName, String datasetDescription,
             Project project)
@@ -1991,7 +2000,7 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @return
+     * @return the screens
      */
     public List<Screen> getScreens()
     {
@@ -2014,7 +2023,7 @@ public class OMEROMetadataStoreClient
 
 
     /**
-     * @return
+     * @return the projects
      */
     public List<Project> getProjects()
     {
@@ -2039,8 +2048,8 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @param p
-     * @return
+     * @param p the project whose datasets to get ({@code null} for orphaned datasets)
+     * @return the datasets
      */
     public List<Dataset> getDatasets(Project p)
     {
@@ -2069,7 +2078,7 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @return
+     * @return the orphaned datasets
      */
     public List<Dataset> getDatasetsWithoutProjects()
     {
@@ -2095,9 +2104,9 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @param projectName
-     * @param projectDescription
-     * @return
+     * @param projectName the name of the project
+     * @param projectDescription the description of the project
+     * @return the newly persisted project
      */
     public Project addProject(String projectName, String projectDescription)
     {
@@ -2117,9 +2126,9 @@ public class OMEROMetadataStoreClient
     }
 
     /**
-     * @param screenName
-     * @param screenDescription
-     * @return
+     * @param screenName the name of the screen
+     * @param screenDescription the description of the screen
+     * @return the newly persisted screen
      */
     public Screen addScreen(String screenName, String screenDescription)
     {
@@ -2161,8 +2170,9 @@ public class OMEROMetadataStoreClient
      * The call to close on the RawPixelsStorePrx may throw, in which case
      * the current import should be considered failed, since the saving of
      * the pixels server-side will have not completed successfully.
-     *
-     * @see ticket:5594
+     * 
+     * @throws ServerError if the pixel store could not be finalized or a new one created
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/5594">Trac ticket #5594</a>
      */
     public void finalizePixelStore() throws ServerError
     {
@@ -2538,9 +2548,9 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve Arc
-     * @param instrumentIndex
-     * @param lightSourceIndex
-     * @return
+     * @param instrumentIndex the index of the instrument
+     * @param lightSourceIndex the index of the light source within the instrument
+     * @return the arc
      */
     private Arc getArc(int instrumentIndex, int lightSourceIndex)
     {
@@ -2646,8 +2656,8 @@ public class OMEROMetadataStoreClient
     //////// BooleanAnnotation /////////
 
     /**
-     * @param booleanAnnotationIndex
-     * @return
+     * @param booleanAnnotationIndex the index of the Boolean annotation
+     * @return the Boolean annotation
      */
     private BooleanAnnotation getBooleanAnnotation(int booleanAnnotationIndex)
     {
@@ -2789,8 +2799,8 @@ public class OMEROMetadataStoreClient
         o.getLogicalChannel().setEmissionWave(convertLength(emissionWavelength));
     }
 
-    /** (non-Javadoc)
-     * @see loci.formats.meta.MetadataStore#setChannelExcitationWavelength(ome.xml.model.primitives.PositiveFloat, int, int)
+    /**
+     * @see loci.formats.meta.MetadataStore#setChannelExcitationWavelength(Length, int, int)
      */
     @Override
     public void setChannelExcitationWavelength(
@@ -2908,9 +2918,9 @@ public class OMEROMetadataStoreClient
     /**
      * Logical Channel and Channel combined in the new model
      *
-     * @param imageIndex
-     * @param logicalChannelIndex
-     * @return
+     * @param imageIndex the index of the image
+     * @param channelIndex the index of the channel within the image
+     * @return the light settings
      */
     private LightSettings getChannelLightSourceSettings(int imageIndex, int channelIndex)
     {
@@ -3015,9 +3025,9 @@ public class OMEROMetadataStoreClient
     ////////Detector/////////
 
     /**
-     * @param instrumentIndex
-     * @param detectorIndex
-     * @return
+     * @param instrumentIndex the instrument index
+     * @param detectorIndex the detector index within the instrument
+     * @return the detector
      */
     public Detector getDetector(int instrumentIndex, int detectorIndex)
     {
@@ -3158,9 +3168,9 @@ public class OMEROMetadataStoreClient
     ////////Detector Settings/////////
 
     /**
-     * @param instrumentIndex
-     * @param detectorIndex
-     * @return
+     * @param imageIndex the index of the image
+     * @param channelIndex the index of the channel within the image
+     * @return the detector settings
      */
     private DetectorSettings getDetectorSettings(int imageIndex, int channelIndex)
     {
@@ -3262,9 +3272,9 @@ public class OMEROMetadataStoreClient
     ////////Dichroic/////////
 
     /**
-     * @param instrumentIndex
-     * @param dichroicIndex
-     * @return
+     * @param instrumentIndex the index of the instrument
+     * @param dichroicIndex the index of the dichroic within the instrument
+     * @return the dichroic
      */
     private Dichroic getDichroic(int instrumentIndex, int dichroicIndex)
     {
@@ -3384,9 +3394,9 @@ public class OMEROMetadataStoreClient
     ////////Eclipse/////////
 
     /**
-     * @param ROIIndex
-     * @param shapeIndex
-     * @return
+     * @param ROIIndex the index of the ROI
+     * @param shapeIndex the index of the shape within the ROI
+     * @return the ellipse
      */
     private Ellipse getEllipse(int ROIIndex, int shapeIndex)
     {
@@ -4142,8 +4152,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve Image
-     * @param imageIndex
-     * @return
+     * @param imageIndex the index of the image
+     * @return the image
      */
     private Image getImage(int imageIndex)
     {
@@ -6479,9 +6489,9 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve Reagent
-     * @param screenIndex
-     * @param reagentIndex
-     * @return
+     * @param screenIndex the index of the screen
+     * @param reagentIndex the index of the reagent within the screen
+     * @return the reagent
      */
     private Reagent getReagent(int screenIndex, int reagentIndex)
     {
@@ -6556,9 +6566,9 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve the Rectangle object (as a Rect object)
-     * @param ROIIndex
-     * @param shapeIndex
-     * @return
+     * @param ROIIndex the index of the ROI
+     * @param shapeIndex the index of the shape within the ROI
+     * @return the rectangle
      */
     private Rect getRectangle(int ROIIndex, int shapeIndex)
     {
@@ -6743,8 +6753,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve Screen
-     * @param screenIndex
-     * @return
+     * @param screenIndex the index of the screen
+     * @return the screen
      */
     private Screen getScreen(int screenIndex)
     {
@@ -6869,8 +6879,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve StageLabel
-     * @param imageIndex
-     * @return
+     * @param imageIndex the index of the image
+     * @return the image's stage label
      */
     private StageLabel getStageLabel(int imageIndex)
     {
@@ -6924,8 +6934,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve CommentAnnotation object
-     * @param commentAnnotationIndex
-     * @return
+     * @param commentAnnotationIndex the index of the comment annotation
+     * @return the comment annotation
      */
     private CommentAnnotation getCommentAnnotation(int commentAnnotationIndex)
     {
@@ -6984,9 +6994,9 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve the Label object
-     * @param ROIIndex
-     * @param shapeIndex
-     * @return
+     * @param ROIIndex the index of the ROI
+     * @param shapeIndex the index of the shape within the ROI
+     * @return the label
      */
     private Label getLabel(int ROIIndex, int shapeIndex)
     {
@@ -7191,8 +7201,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve TimestampAnnotation
-     * @param timestampAnnotationIndex
-     * @return
+     * @param timestampAnnotationIndex the index of the timestamp annotation
+     * @return the timestamp annotation
      */
     private TimestampAnnotation getTimestampAnnotation(int timestampAnnotationIndex)
     {
@@ -7339,9 +7349,9 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve Well
-     * @param plateIndex
-     * @param wellIndex
-     * @return
+     * @param plateIndex the index of the plate
+     * @param wellIndex the index of the well within the plate
+     * @return the well
      */
     private Well getWell(int plateIndex, int wellIndex)
     {
@@ -7449,10 +7459,10 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve WellSample
-     * @param plateIndex
-     * @param wellIndex
-     * @param wellSampleIndex
-     * @return
+     * @param plateIndex the index of the plate
+     * @param wellIndex the index of the well within the plate
+     * @param wellSampleIndex the index of the field within the well
+     * @return the well sample
      */
     private WellSample getWellSample(int plateIndex, int wellIndex, int wellSampleIndex)
     {
@@ -7549,8 +7559,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve XMLAnnotation
-     * @param XMLAnnotationIndex
-     * @return
+     * @param XMLAnnotationIndex the index of the XML annotation
+     * @return the XML annotation
      */
 
     private XmlAnnotation getXMLAnnotation(int XMLAnnotationIndex)
@@ -7837,8 +7847,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve TagAnnotation object
-     * @param tagAnnotationIndex
-     * @return
+     * @param tagAnnotationIndex the index of the tag annotation
+     * @return the tag annotation
      */
     private TagAnnotation getTagAnnotation(int tagAnnotationIndex)
     {
@@ -7917,8 +7927,8 @@ public class OMEROMetadataStoreClient
 
     /**
      * Retrieve TermAnnotation object
-     * @param termAnnotationIndex
-     * @return
+     * @param termAnnotationIndex the index of the term annotation
+     * @return the term annotation
      */
     private TermAnnotation getTermAnnotation(int termAnnotationIndex)
     {

--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClientRoot.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClientRoot.java
@@ -29,9 +29,9 @@ import ome.xml.meta.MetadataRoot;
 import omero.model.Pixels;
 
 /**
- * {@link MetadataRoot} implementation for the client side
- * implementation of the Bio-Formats {@link MetadataStore}.  This
- * class merely provides access to the pixels list.
+ * {@link MetadataRoot} implementation for the client-side
+ * implementation of the Bio-Formats {@link loci.formats.meta.MetadataStore}.
+ * This class merely provides access to the pixels list.
  *
  * @author Roger Leigh, rleigh at lifesci.dundee.ac.uk
  */
@@ -43,7 +43,10 @@ public class OMEROMetadataStoreClientRoot extends ArrayList<Pixels> implements M
     super();
   }
 
-  /** Copy constructor. */
+  /**
+   * Copy constructor. 
+   * @param list the list of {@link Pixels} objects for this instance
+   */
   public OMEROMetadataStoreClientRoot(List<Pixels> list)
   {
     super(list);

--- a/components/blitz/src/ome/formats/OMEXMLModelComparator.java
+++ b/components/blitz/src/ome/formats/OMEXMLModelComparator.java
@@ -96,7 +96,7 @@ public class OMEXMLModelComparator implements Comparator<LSID>
      * Assigns a value to a particular class based on its location in the
      * OME-XML hierarchy.
      * @param klass Class to assign a value to.
-     * @param indexed Number of class indexes that were present in its LSID.
+     * @param indexes Number of class indexes that were present in its LSID.
      * @return The value.
      */
     public int getValue(Class<? extends IObject> klass, int indexes)

--- a/components/blitz/src/ome/formats/enums/EnumerationProvider.java
+++ b/components/blitz/src/ome/formats/enums/EnumerationProvider.java
@@ -53,7 +53,6 @@ public interface EnumerationProvider
     /**
      * Retrieves all enumerations of a specific type.
      * @param klass Enumeration's base class from <code>ome.model.enums</code>.
-     * @param value Enumeration's string value.
      * @return Enumeration object.
      */
 	<T extends IObject> HashMap<String, T> getEnumerations(Class<T> klass);

--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -55,7 +55,7 @@ public class ImportCandidates extends DirectoryWalker
 
     /**
      * Event raised during a pass through the directory structure given to
-     * {@link ImportCandidates}. A {@link Scanning} event will not necessarily
+     * {@link ImportCandidates}. A {@link SCANNING} event will not necessarily
      * be raised for every file or directory, but the values will be valid for
      * each event.
      *
@@ -181,9 +181,8 @@ public class ImportCandidates extends DirectoryWalker
     }
 
     /**
-     * Main constructor which iterates over all the paths calling
-     * {@link #walk(File, Collection)} and permitting a descent to the given
-     * depth.
+     * Main constructor which starts depth-first descent into all the paths
+     * and permits a descent to the given depth.
      *
      * @param depth
      *            number of directory levels to search down.
@@ -254,8 +253,11 @@ public class ImportCandidates extends DirectoryWalker
      * other software layers. The format is: 1) any empty lines are ignored, 2)
      * any blocks of comments separate groups, 3) each group is begun by the
      * "key", 4) all other files in a group will also be imported.
-     *
-     * Similar logic is contained in {@link Groups#print()} but it does not
+     * 
+     * The ordering of the used files is taken into account.
+     */
+    /*
+     * Similar logic is contained in Groups.print() below but that does not
      * take the ordering of the used files into account.
      */
     public void print()
@@ -538,9 +540,9 @@ public class ImportCandidates extends DirectoryWalker
     /**
      * Handle a file import
      *
-     * @param file - file selected
-     * @param depth - depth of scan
-     * @param collection
+     * @param file the selected file
+     * @param depth the depth of the scan
+     * @param collection the result objects, ignored
      */
     @Override
     public void handleFile(File file, int depth, Collection collection) {

--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -203,10 +203,9 @@ public class ImportConfig {
     /**
      * Complete constructor. All values can be null.
      *
-     * @param prefs
-     * @param ctx
-     * @param ini
-     * @param props
+     * @param prefs user and system preference and configuration data
+     * @param ini loads {@code importer.ini} or other specified file
+     * @param props a Java properties object overriding other sources of preferences and configuration data
      */
     public ImportConfig(final Preferences prefs,
             IniFileLoader ini, Properties props) {
@@ -320,8 +319,8 @@ public class ImportConfig {
      * Modifies the logging level of everything under the
      * <code>ome.formats</code>, <code>ome.services.blitz</code>,
      * <code>ome.system</code> and <code>loci</code> packages hierarchically.
-     * @param levelString if null, then {@link #ini#getDebugLevel()} will be
-     * used.
+     * @param levelString the level to set or, if {@code null}, then the
+     * initial debug level is used as before having been changed.
      */
      public void configureDebug(String levelString) {
          Level level;
@@ -348,8 +347,8 @@ public class ImportConfig {
 
     /**
      * Create and return a new OMEROMetadataStoreClient
-     * @return - OMEORMetadataStoreClient
-     * @throws Exception
+     * @return a new OMEROMetadataStoreClient
+     * @throws Exception if the creation failed
      */
     public OMEROMetadataStoreClient createStore() throws Exception {
         if (!canLogin()) {
@@ -369,6 +368,7 @@ public class ImportConfig {
 
     /**
      * Check online to see if this is the current version
+     * @return if it is <em>not</em> the current version
      */
     public boolean isUpgradeNeeded() {
 
@@ -551,35 +551,35 @@ public class ImportConfig {
     }
 
     /**
-     * @return ini user full path
+     * @param b ini user full path
      */
     public void setUserFullPath(boolean b) {
         ini.setUserFullPath(b);
     }
 
     /**
-     * @return ini user full path
+     * @return custom image naming
      */
     public boolean getCustomImageNaming() {
         return ini.getCustomImageNaming();
     }
 
     /**
-     * @return ini user full path
+     * @param b custom image naming
      */
     public void setCustomImageNaming(boolean b) {
         ini.setCustomImageNaming(b);
     }
 
     /**
-     * @return ini user full path
+     * @return number of directories
      */
     public int getNumOfDirectories() {
         return ini.getNumOfDirectories();
     }
 
     /**
-     * @return ini user full path
+     * @param i number of directories
      */
     public void setNumOfDirectories(int i) {
         ini.setNumOfDirectories(i);
@@ -592,11 +592,12 @@ public class ImportConfig {
     /**
      * Build prompt
      *
-     * @param value
-     * @param prompt
-     * @param hide - use *s for characters
+     * @param value the value
+     * @param prompt the prompt
+     * @param hide use {@code *}s for characters
+     * @param <T> the kind of value contained by the "value" argument
      */
-    protected void prompt(Value value, String prompt, boolean hide) {
+    protected <T> void prompt(Value<T> value, String prompt, boolean hide) {
 
         String v = value.toString();
         if (hide) {
@@ -743,7 +744,7 @@ public class ImportConfig {
      * Container which thread-safely makes a generic configuration value
      * available, without requiring getters and setters.
      *
-     * @param <T>
+     * @param <T> the kind of value to associate with the key
      */
     public static abstract class Value<T> {
 
@@ -785,6 +786,7 @@ public class ImportConfig {
         /**
          * Returns the generic type contained by this holder. This does not
          * touch the persistent stores, but only accesses the value in-memory.
+         * @return the held value
          */
         public T get() {
             if (_current.get() == null)
@@ -795,6 +797,7 @@ public class ImportConfig {
         /**
          * Sets the in-memory value, which will get persisted on
          * {@link #store()} when {@link ImportConfig#saveAll()} is called.
+         * @param t the value to hold
          */
         public void set(T t) {
             _current.set(t);
@@ -811,8 +814,7 @@ public class ImportConfig {
         }
 
         /**
-         * Stores the current value back to some medium. The decision of which
-         * medium is based on the current value of {@link #which}. In each case,
+         * Stores the current value back to some medium. In each case,
          * the type-matching source is used <em>except</em> when the
          * {@link Properties} are used, since this is most likely not a
          * persistent store.

--- a/components/blitz/src/ome/formats/importer/ImportFixture.java
+++ b/components/blitz/src/ome/formats/importer/ImportFixture.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
  * @author Josh Moore, josh.moore at gmx.de
  * @version $Revision: 1167 $, $Date: 2006-12-15 10:39:34 +0000 (Fri, 15 Dec 2006) $
  * @see OMEROMetadataStoreClient
- * @see ExampleUnitTest
  * @since 3.0-M3
  */
 // @RevisionDate("$Date: 2006-12-15 10:39:34 +0000 (Fri, 15 Dec 2006) $")
@@ -39,8 +38,6 @@ public class ImportFixture
 {
 
     Logger                        log = LoggerFactory.getLogger(ImportFixture.class);
-
-    @SuppressWarnings("unused")
 
     private OMEROMetadataStoreClient store;
 
@@ -77,7 +74,7 @@ public class ImportFixture
     /**
      * checks for the necessary fields and initializes the {@link ImportLibrary}
      *
-     * @throws Exception
+     * @throws Exception if setup failed
      */
     public void setUp() throws Exception
     {
@@ -106,16 +103,9 @@ public class ImportFixture
     }
 
     /**
-     * runs import by looping through all files and then calling:
-     * <ul>
-     * <li>{@link ImportLibrary#open(String)}</li>
-     * <li>{@link ImportLibrary#calculateImageCount(String)}</li>
-     * <li>{@link ImportLibrary#importMetadata()}</li>
-     * <li>{@link ImportLibrary#importData(long, String)}</li>
-     * </ul>
-     *
-     * @param step an action to take per plane. not null.
-     * @throws Exception
+     * Runs import by looping through all files and then calling
+     * {@link ImportLibrary#importImage(ImportContainer, int, int, int)}.
+     * @throws Throwable reporting a problem with import
      */
     public void doImport() throws Throwable
     {

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -97,6 +97,10 @@ public class CommandLineImporter {
 
     /**
      * Legacy constructor which uses a {@link UploadFileTransfer}.
+     * @param config the import configuration
+     * @param paths files or directories to search
+     * @param getUsedFiles if only getting a list of used files
+     * @throws Exception if the import could not be set up
      */
     public CommandLineImporter(final ImportConfig config, String[] paths,
             boolean getUsedFiles) throws Exception {
@@ -105,6 +109,12 @@ public class CommandLineImporter {
 
     /**
      * Legacy constructor without any file exclusions.
+     * @param config the import configuration
+     * @param paths files or directories to search
+     * @param getUsedFiles if only getting a list of used files
+     * @param transfer how files are to be transferred to the server
+     * @param minutesToWait for how many minutes to wait for an import (negative for indefinitely)
+     * @throws Exception if the import could not be set up
      */
     public CommandLineImporter(final ImportConfig config, String[] paths,
             boolean getUsedFiles, FileTransfer transfer, int minutesToWait)
@@ -114,6 +124,13 @@ public class CommandLineImporter {
 
     /**
      * Main entry class for the application.
+     * @param config the import configuration
+     * @param paths files or directories to search
+     * @param getUsedFiles if only getting a list of used files
+     * @param transfer how files are to be transferred to the server
+     * @param exclusions mechanisms to be used for skipping candidates
+     * @param minutesToWait for how many minutes to wait for an import (negative for indefinitely)
+     * @throws Exception if the import could not be set up
      */
     public CommandLineImporter(final ImportConfig config, String[] paths,
             boolean getUsedFiles, FileTransfer transfer,
@@ -171,6 +188,9 @@ public class CommandLineImporter {
     /**
      * Look for all {@link ImportProcessPrx} in the current session and close
      * them if they return a non-null {@link Response} (i.e. they are done).
+     * @param config the import configuration
+     * @return how many import processes could not be accessed
+     * @throws Exception in the event of error
      */
     public static int closeCompleted(ImportConfig config) throws Exception {
         config.loadAll();
@@ -184,6 +204,9 @@ public class CommandLineImporter {
     /**
      * Look for all {@link ImportProcessPrx} in the current session and close
      * them if they return a non-null {@link Response} (i.e. they are done).
+     * @param config the import configuration
+     * @return exit code, {@code 0} for success
+     * @throws Exception in the event of error
      */
     public static int waitCompleted(ImportConfig config) throws Exception {
         long wait = 5000L;
@@ -475,6 +498,7 @@ public class CommandLineImporter {
      * </ul>
      * @param args
      *            Command line arguments.
+     * @throws Exception in the event of error
      */
     public static void main(String[] args) throws Exception {
 
@@ -884,7 +908,7 @@ public class CommandLineImporter {
 
     /**
      * Reads a list of paths from stdin.
-     * @return
+     * @return the paths
      */
     static String[] stdin() throws IOException {
         BufferedReader in = new BufferedReader(new InputStreamReader(System.in));

--- a/components/blitz/src/ome/formats/importer/exclusions/package-info.java
+++ b/components/blitz/src/ome/formats/importer/exclusions/package-info.java
@@ -18,7 +18,7 @@
  */
 
 /**
- * {@FileExclude File exclusion} mechanism for determing
- * which potential filesets should be excluded from import.
+ * {@link ome.formats.importer.exclusions.FileExclusion} provides a mechanism
+ * for determining which potential filesets should be excluded from import.
  */
 package ome.formats.importer.exclusions;

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -48,7 +48,7 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     /**
      * "Transfer" files by soft-linking them into place. This method is likely
      * re-usable for other general "linking" strategies by overriding
-     * {@code createProcessBuilder(File, File)} and the other protected methods here.
+     * {@link #createProcessBuilder(File, File)} and the other protected methods here.
      */
     public String transfer(TransferState state) throws IOException, ServerError {
         RawFileStorePrx rawFileStore = start(state);
@@ -97,10 +97,10 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      * written to by the server. If either condition fails, no linking takes
      * place.
      *
-     * @param location
-     * @param rawFileStore
-     * @throws ServerError
-     * @throws IOException
+     * @param location the source file
+     * @param rawFileStore the target on the server
+     * @throws ServerError if the raw file store could not be used
+     * @throws IOException for problems with the source file
      */
     protected void checkLocation(File location, RawFileStorePrx rawFileStore)
             throws ServerError, IOException {
@@ -153,9 +153,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     /**
      * Executes a local command and fails on non-0 return codes.
      *
-     * @param file
-     * @param location
-     * @throws IOException
+     * @param file the source file
+     * @param location the target on the server
+     * @throws IOException for problems with the source file
      */
     protected void exec(File file, File location) throws IOException {
         ProcessBuilder pb = createProcessBuilder(file, location);

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -48,7 +48,7 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     /**
      * "Transfer" files by soft-linking them into place. This method is likely
      * re-usable for other general "linking" strategies by overriding
-     * {@link #createProcessBuilder(File, File)} and the other protected methods here.
+     * {@code createProcessBuilder(File, File)} and the other protected methods here.
      */
     public String transfer(TransferState state) throws IOException, ServerError {
         RawFileStorePrx rawFileStore = start(state);
@@ -76,9 +76,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     /**
      * Build a path of the form "root.path/root.name/file.path/file.name".
      *
-     * @param root
-     * @param ofile
-     * @return
+     * @param root the root directory
+     * @param ofile a path relative to the root
+     * @return the assembled path with separators suitable for the local filesystem
      */
     protected File getLocalLocation(OriginalFile root, OriginalFile ofile) {
         StringBuilder sb = new StringBuilder();
@@ -237,9 +237,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      * {@link ProcessBuilder#start()} called on it. The only critical
      * piece of information should be the return code.
      *
-     * @param file
-     * @param location
-     * @return
+     * @param file File to be copied.
+     * @param location Location to copy to.
+     * @return an instance ready for performing the transfer
      */
     protected abstract ProcessBuilder createProcessBuilder(File file, File location);
 

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base {@link FileTransfer} implementation primarily providing the
- * {@code start(TransferState)} and {@code finish(TransferState, long)}
+ * {@link #start(TransferState)} and {@link #finish(TransferState, long)}
  * methods. Also used as the factory for {@link FileTransfer} implementations
  * via {@link #createTransfer(String)}.
  *
@@ -93,7 +93,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
      *
      * @param state the transfer state
      * @return a raw file store proxy for the upload
-     * @throws ServerError
+     * @throws ServerError if the uploader could not be obtained
      */
     protected RawFileStorePrx start(TransferState state) throws ServerError {
         log.info("Transferring {}...", state.getFile());
@@ -107,7 +107,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
      * @param state non-null
      * @param offset total length transferred.
      * @return client-side digest string.
-     * @throws ServerError
+     * @throws ServerError if the upload could not be completed and checksummed
      */
     protected String finish(TransferState state, long offset) throws ServerError {
         state.start();
@@ -122,7 +122,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
      *
      * @param rawFileStore possibly null
      * @param stream possibly null
-     * @throws ServerError
+     * @throws ServerError presently not at all as errors are simply logged, but possibly in the future
      */
     protected void cleanupUpload(RawFileStorePrx rawFileStore,
             FileInputStream stream) throws ServerError {
@@ -160,7 +160,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
     }
 
     /**
-     * Method used by subclasses during {@link ome.formats.importer.transfers.FileTransfer#afterTransfer(int, List)}
+     * Method used by subclasses during {@link FileTransfer#afterTransfer(int, List)}
      * if they would like to remove all the files transferred in the set.
      */
     protected void deleteTransferredFiles(int errors, List<String> srcFiles)

--- a/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/AbstractFileTransfer.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base {@link FileTransfer} implementation primarily providing the
- * {@link #start(TransferState)} and {@link #finish(TransferState, long)}
+ * {@code start(TransferState)} and {@code finish(TransferState, long)}
  * methods. Also used as the factory for {@link FileTransfer} implementations
  * via {@link #createTransfer(String)}.
  *
@@ -64,7 +64,8 @@ public abstract class AbstractFileTransfer implements FileTransfer {
      * Factory method for instantiating {@link FileTransfer} objects from
      * a string. Supported values can be found in the {@link Transfers} enum.
      * Otherwise, a FQN for a class on the classpath should be passed in.
-     * @param arg non-null
+     * @param arg a type of {@link FileTransfer} instance as named among {@link Transfers}
+     * @return the new {@link FileTransfer} instance of the requested type
      */
     public static FileTransfer createTransfer(String arg) {
         Logger tmp = LoggerFactory.getLogger(AbstractFileTransfer.class);
@@ -90,8 +91,8 @@ public abstract class AbstractFileTransfer implements FileTransfer {
      * {@link TransferState#start()}, and loads the {@link RawFileStorePrx}
      * which any implementation will need.
      *
-     * @param state non-null.
-     * @return
+     * @param state the transfer state
+     * @return a raw file store proxy for the upload
      * @throws ServerError
      */
     protected RawFileStorePrx start(TransferState state) throws ServerError {
@@ -159,7 +160,7 @@ public abstract class AbstractFileTransfer implements FileTransfer {
     }
 
     /**
-     * Method used by subclasses during {@link #afterTransfer(int, List<String>)}
+     * Method used by subclasses during {@link ome.formats.importer.transfers.FileTransfer#afterTransfer(int, List)}
      * if they would like to remove all the files transferred in the set.
      */
     protected void deleteTransferredFiles(int errors, List<String> srcFiles)

--- a/components/blitz/src/ome/formats/importer/transfers/HardlinkFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/HardlinkFileTransfer.java
@@ -41,8 +41,9 @@ public class HardlinkFileTransfer extends AbstractExecFileTransfer {
      * @param file File to be copied.
      * @param location Location to copy to.
      * @throws IOException
-     * @TODO Java7: replace ln once Java6 is dropped
+     *
      */
+    // TODO Java7: replace ln once Java6 is dropped
     protected ProcessBuilder createProcessBuilder(File file, File location) {
         ProcessBuilder pb = new ProcessBuilder();
         List<String> args = new ArrayList<String>();

--- a/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/components/blitz/src/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -41,8 +41,8 @@ public class SymlinkFileTransfer extends AbstractExecFileTransfer {
      * @param file File to be copied.
      * @param location Location to copy to.
      * @throws IOException
-     * @TODO Java7: replace ln once Java6 is dropped
      */
+    // TODO Java7: replace ln once Java6 is dropped
     protected ProcessBuilder createProcessBuilder(File file, File location) {
         ProcessBuilder pb = new ProcessBuilder();
         List<String> args = new ArrayList<String>();

--- a/components/blitz/src/ome/formats/importer/transfers/TransferState.java
+++ b/components/blitz/src/ome/formats/importer/transfers/TransferState.java
@@ -86,9 +86,11 @@ public class TransferState implements TimeEstimator {
      * @param total Total number of files to upload.
      * @param proc {@link ImportProcessPrx} which is being imported to.
      * @param library {@link ImportLibrary} to use for notifications.
-     * @param estimator
-     * @param cp
+     * @param estimator a time-to-completion estimator.
+     * @param cp a checksum provider, for calculating file content checksums.
      * @param buf optional buffer. Need not be used or updated.
+     * @throws IOException I/O exception
+     * @throws ServerError server error
      */
     public TransferState(File file,
             int index, int total, // as index of
@@ -114,7 +116,7 @@ public class TransferState implements TimeEstimator {
      * checksum. (The remote checksum is available from the
      * {@link OriginalFile}.
      *
-     * @throws ServerError
+     * @throws ServerError server error
      */
     public void save() throws ServerError {
         // We don't need write access here, and considering that
@@ -142,6 +144,7 @@ public class TransferState implements TimeEstimator {
      * <em>(Not thread safe)</em> Get a moderately large buffer for use in
      * reading/writing data. To prevent the creation of many MB-sized byte
      * arrays, this value can be re-used but requires external synchronization.
+     * @return the buffer
      */
     public byte[] getBuffer() {
         return this.buf;
@@ -150,6 +153,7 @@ public class TransferState implements TimeEstimator {
     /**
      * Get the digest string for the local file. This will only be available,
      * i.e. non-null, after {@link #save()} has been called.
+     * @return the checksum
      */
     public String getChecksum() {
         return this.checksum;
@@ -160,6 +164,7 @@ public class TransferState implements TimeEstimator {
      * Since the {@link ChecksumProvider} has a number of different usage styles,
      * {@link TransferState} doesn't attempt to delegate but just returns the
      * instance.
+     * @return the checksum provider used for calculating the checksum
      */
     public ChecksumProvider getChecksumProvider() {
         return this.cp;
@@ -167,6 +172,7 @@ public class TransferState implements TimeEstimator {
 
     /**
      * Return the target file passed to the constructor.
+     * @return the source file
      */
     public File getFile() {
         return this.file;
@@ -174,6 +180,7 @@ public class TransferState implements TimeEstimator {
 
     /**
      * Return the length of the {@link #getFile() target file}.
+     * @return the length of the source file
      */
     public long getLength() {
         return this.length;
@@ -182,6 +189,8 @@ public class TransferState implements TimeEstimator {
     /**
      * Find original file as defined by the ID in the {@link RawFileStorePrx}
      * regardless of group.
+     * @return the original file from the upload process
+     * @throws ServerError server error
      */
     public OriginalFile getOriginalFile() throws ServerError {
         return library.loadOriginalFile(getUploader());
@@ -190,13 +199,16 @@ public class TransferState implements TimeEstimator {
     /**
      * Find original file represented by the managed repository that
      * import is taking place to.
+     * @return the original file at the root of the repository targeted by the upload process
+     * @throws ServerError server error
      */
     public OriginalFile getRootFile() throws ServerError {
         return library.lookupManagedRepository().root();
     }
 
     /**
-     * Return the {@link RawFileStorePrx} instance for this index.
+     * @return the {@link RawFileStorePrx} instance for this index
+     * @throws ServerError server error
      */
     public RawFileStorePrx getUploader() throws ServerError {
         return getUploader(null);
@@ -205,11 +217,15 @@ public class TransferState implements TimeEstimator {
     /**
      * Return the {@link RawFileStorePrx} instance for this index setting
      * the mode if not null. Valid values include "r" and "rw". If a non-null
-     * {@link #prx} is available, it will be returned <em>instead</em>.
+     * uploader is available, it will be returned <em>instead</em>.
      *
      * <em>Every</em> instance which is returned from this method should
      * eventually have {@link RawFileStorePrx#close()} called on it.
-     * {@link #close()} can be used to facilitate this.
+     * {@link RawFileStorePrx#close()} can be used to facilitate this.
+     * @param mode the mode as understood by
+     * {@link ome.services.blitz.repo.PublicRepositoryI#file(String, String, Ice.Current)}
+     * @return the {@link RawFileStorePrx} instance
+     * @throws ServerError server error
      */
     public RawFileStorePrx getUploader(String mode) throws ServerError {
         if (prx != null) {
@@ -225,7 +241,7 @@ public class TransferState implements TimeEstimator {
     }
 
     /**
-     * Call {@link RawFileStorePrx#close()} on the cached {@link #prx}
+     * Call {@link RawFileStorePrx#close()} on the cached uploader
      * instance if non-null and null the instance. If
      * {@link Ice.ObjectNotExistException} is thrown, the service is
      * assumed closed. All other exceptions will be printed at WARN.
@@ -249,8 +265,8 @@ public class TransferState implements TimeEstimator {
     //
 
     /**
-     * Raise the {@link ImportEvent.FILE_UPLOAD_STARTED} event to all
-     * observers.
+     * Raise the {@link ome.formats.importer.ImportEvent.FILE_UPLOAD_STARTED}
+     * event to all observers.
      */
     public void uploadStarted() {
         library.notifyObservers(
@@ -260,8 +276,9 @@ public class TransferState implements TimeEstimator {
     }
 
     /**
-     * Raise the {@link ImportEvent.FILE_UPLOAD_BYTES} event to all
-     * observers.
+     * Raise the {@link ome.formats.importer.ImportEvent.FILE_UPLOAD_BYTES}
+     * event to all observers.
+     * @param offset how many bytes are uploaded
      */
     public void uploadBytes(long offset) {
         library.notifyObservers(
@@ -271,8 +288,9 @@ public class TransferState implements TimeEstimator {
     }
 
     /**
-     * Raise the {@link ImportEvent.FILE_UPLOAD_COMPLETE} event to all
-     * observers.
+     * Raise the {@link ome.formats.importer.ImportEvent.FILE_UPLOAD_COMPLETE}
+     * event to all observers.
+     * @param offset how many bytes are uploaded
      */
     public void uploadComplete(long offset) {
         library.notifyObservers(new ImportEvent.FILE_UPLOAD_COMPLETE(

--- a/components/blitz/src/ome/formats/importer/transfers/package-info.java
+++ b/components/blitz/src/ome/formats/importer/transfers/package-info.java
@@ -18,8 +18,8 @@
  */
 
 /**
- * {@FileTransfer File transfer} mechanism for shipping
- * client-side files to the server-side. See individual
- * implementations for details.
+ * {@link ome.formats.importer.transfers.FileTransfer} provides
+ * a mechanism for shipping client-side files to the server-side.
+ * See individual implementations for details.
  */
 package ome.formats.importer.transfers;

--- a/components/blitz/src/ome/formats/importer/util/ClientKeepAlive.java
+++ b/components/blitz/src/ome/formats/importer/util/ClientKeepAlive.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link Runnable} which keeps a {@link Connector}'s server side resources
+ * A {@link Runnable} which keeps a {@link IceInternal.Connector}'s server-side resources
  * from timing out. <b>NOTE:</b> Upon catching an exception, the
  * <code>Connector</code> is logged out.
  *

--- a/components/blitz/src/ome/formats/importer/util/ErrorContainer.java
+++ b/components/blitz/src/ome/formats/importer/util/ErrorContainer.java
@@ -375,7 +375,7 @@ public class ErrorContainer
     /**
      * set file format for import
      *
-     * @param file_format
+     * @param file_format the file format
      */
     public void setReaderType(String file_format)
     {
@@ -385,7 +385,7 @@ public class ErrorContainer
     /**
      * get the file format for import
      *
-     * @return
+     * @return the file format
      */
     public String getFileFormat()
     {
@@ -395,7 +395,7 @@ public class ErrorContainer
     /**
      * set path for file
      *
-     * @param absolute_path
+     * @param absolute_path the file's absolute path
      */
     public void setAbsolutePath(String absolute_path)
     {
@@ -405,7 +405,7 @@ public class ErrorContainer
 
     /**
      * get path for file
-     * @return
+     * @return the file's absolute path
      */
     public String getAbsolutePath()
     {
@@ -415,7 +415,7 @@ public class ErrorContainer
 	/**
 	 * return the error status
 	 *
-	 * @return
+	 * @return the error status
 	 */
 	public int getStatus() {
 		return status;
@@ -423,7 +423,7 @@ public class ErrorContainer
 
 	/**
 	 * set the status for this error
-	 * @param status
+	 * @param status the error status
 	 */
 	public void setStatus(int status) {
 		this.status = status;
@@ -431,7 +431,7 @@ public class ErrorContainer
 
 	/**
 	 * get the index for this error container
-	 * @return
+	 * @return the error container's index
 	 */
 	public int getIndex() {
 		return index;
@@ -439,7 +439,7 @@ public class ErrorContainer
 
 	/**
 	 * Set index
-	 * @param index
+	 * @param index the error container's index
 	 */
 	public void setIndex(int index) {
 		this.index = index;

--- a/components/blitz/src/ome/formats/importer/util/ErrorHandler.java
+++ b/components/blitz/src/ome/formats/importer/util/ErrorHandler.java
@@ -46,8 +46,8 @@ import com.google.common.io.Files;
 
 /**
  * Top of the error handling hierarchy. Will add errors to a queue
- * which can be sent with {@link #sendErrors()}. Subclasses will get
- * a change to handle all {@link ImportEvent} instances, but should
+ * which can be sent with {@code sendErrors()}. Subclasses will get
+ * a chance to handle all {@link ImportEvent} instances, but should
  * try not to duplicate handling.
  *
  * @author Brian W. Loranger
@@ -112,9 +112,9 @@ public abstract class ErrorHandler implements IObserver, IObservable {
         public final Object source;
 
         /**
-         * @param filename
-         * @param exception
-         * @param source
+         * @param filename the filename
+         * @param exception the exception
+         * @param source the source (e.g., {@link ImportCandidates})
          */
         public UNKNOWN_FORMAT(String filename, Exception exception, Object source) {
             super(exception);
@@ -144,9 +144,9 @@ public abstract class ErrorHandler implements IObserver, IObservable {
         public final Object source;
 
         /**
-         * @param filename
-         * @param exception
-         * @param source
+         * @param filename the filename
+         * @param exception the exception
+         * @param source the source
          */
         public UNREADABLE_FILE(String filename, Exception exception, Object source) {
             super(exception);
@@ -167,9 +167,7 @@ public abstract class ErrorHandler implements IObserver, IObservable {
      * file and otherwise unspecified exception takes place. An example of an
      * exception which receives separate handling is {@link UNKNOWN_FORMAT} which
      * can be considered less serious than {@link FILE_EXCEPTION}. Subclasses of
-     * this class may should receive special handling. For example,
-     * {@link ImportCandidates#SCANNING_FILE_EXCEPTION} may be considered less
-     * significant if the user was trying to import a large directory.
+     * this class may should receive special handling.
      * {@link MISSING_LIBRARY} below is probably more of a warn situation rather
      * than an error.
      */
@@ -236,7 +234,7 @@ public abstract class ErrorHandler implements IObserver, IObservable {
     /**
      * Initialize
      *
-     * @param config
+     * @param config the import configuration
      */
     public ErrorHandler(ImportConfig config)
     {
@@ -663,9 +661,9 @@ public abstract class ErrorHandler implements IObserver, IObservable {
      * to test error handling without touching QA. The server reply should be
      * non-null, but is otherwise unimportant.
      *
-     * @param sendUrl
-     * @param postList
-     * @throws HtmlMessengerException
+     * @param sendUrl the HTTP POST URL
+     * @param postList the form values
+     * @throws HtmlMessengerException if POST fails
      */
     public void executePost(String sendUrl, Map<String, String> postList)
             throws HtmlMessengerException {
@@ -677,7 +675,7 @@ public abstract class ErrorHandler implements IObserver, IObservable {
      * Upload a single {@link ErrorContainer}. This can be overwritten in order
      * to test error handling without touching QA.
      *
-     * @param errorContainer
+     * @param errorContainer the error container
      */
     public void uploadFile(ErrorContainer errorContainer) {
         errorContainer.setToken(serverReply);
@@ -692,9 +690,9 @@ public abstract class ErrorHandler implements IObserver, IObservable {
     }
     
     /**
-     * Return stack trace from throwable
-     * @param throwable
-     * @return stack trace
+     * Return the stack trace from a {@link Throwable}.
+     * @param throwable the {@link Throwable} to inspect
+     * @return the stack trace
      */
     public static String getStackTrace(Throwable throwable)
     {

--- a/components/blitz/src/ome/formats/importer/util/ErrorHandler.java
+++ b/components/blitz/src/ome/formats/importer/util/ErrorHandler.java
@@ -46,7 +46,7 @@ import com.google.common.io.Files;
 
 /**
  * Top of the error handling hierarchy. Will add errors to a queue
- * which can be sent with {@code sendErrors()}. Subclasses will get
+ * which can be sent with {@link #sendErrors()}. Subclasses will get
  * a chance to handle all {@link ImportEvent} instances, but should
  * try not to duplicate handling.
  *
@@ -297,7 +297,7 @@ public abstract class ErrorHandler implements IObserver, IObservable {
     /**
      * abstract on update method
      *
-     * @param importLibrary
+     * @param importLibrary the import library
      * @param event - importEvent
      */
     protected abstract void onUpdate(IObservable importLibrary, ImportEvent event);
@@ -603,22 +603,22 @@ public abstract class ErrorHandler implements IObserver, IObservable {
     }
 
     /**
-     * @param index
+     * @param index the index in the error container
      */
     protected void onSending(int index)
     {
     }
 
     /**
-     * @param index
+     * @param index the index in the error container
      */
     protected void onSent(int index)
     {
     }
 
     /**
-     * @param index
-     * @param serverReply
+     * @param index the index in the error container
+     * @param serverReply the reply from the server
      */
     protected void onNotSending(int index, String serverReply)
     {
@@ -626,7 +626,7 @@ public abstract class ErrorHandler implements IObserver, IObservable {
 
     /**
      * Action to take on exception
-     * @param exception
+     * @param exception the exception
      */
     protected void onException(Exception exception)
     {

--- a/components/blitz/src/ome/formats/importer/util/FileUploader.java
+++ b/components/blitz/src/ome/formats/importer/util/FileUploader.java
@@ -84,7 +84,7 @@ public class FileUploader implements IObservable
     /**
      * Initialize upload with httpClient
      *
-     * @param httpClient
+     * @param httpClient the HTTP client to use
      */
     public FileUploader(CloseableHttpClient httpClient)
     {
@@ -158,10 +158,10 @@ public class FileUploader implements IObservable
 
     /**
      * Upload files from error container to url
-     *
-     * @param url The URL to use.
-     * @param timeout - timeout
-     * @param upload - error container with files in it
+     * @param path the URL to which to POST
+     * @param timeout the timeout (ignored)
+     * @param upload the error container with files in it
+     * @throws HtmlMessengerException if the POST failed
      */
     public void uploadFiles(String path, int timeout, ErrorContainer upload)
         throws HtmlMessengerException

--- a/components/blitz/src/ome/formats/importer/util/HtmlMessenger.java
+++ b/components/blitz/src/ome/formats/importer/util/HtmlMessenger.java
@@ -152,9 +152,9 @@ public class HtmlMessenger
 	/**
 	 * Instantiate messenger
 	 *
-	 * @param url
+	 * @param url the HTTP POST URL
 	 * @param postList variables list in post
-	 * @throws HtmlMessengerException
+	 * @throws HtmlMessengerException if the POST failed
 	 */
 	public HtmlMessenger(String url, Map<String, String> postList)
 	        throws HtmlMessengerException
@@ -185,9 +185,9 @@ public class HtmlMessenger
 	/**
 	 * Creates a client to communicate.
 	 *
-	 * @param url
-	 * @return
-	 * @throws HtmlMessengerException
+	 * @param url get a HTTP client connection
+	 * @return if the connection is encrypted
+	 * @throws HtmlMessengerException if connection to the URL failed
 	 */
 	public CloseableHttpClient getCommunicationLink(String url)
 	        throws HtmlMessengerException
@@ -202,7 +202,7 @@ public class HtmlMessenger
 	 * This method executes the post created when this class is instantiated
 	 *
 	 * @return server reply
-	 * @throws HtmlMessengerException
+	 * @throws HtmlMessengerException if the HTTP POST failed
 	 */
 	 public String executePost() throws HtmlMessengerException
 	 {

--- a/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
+++ b/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
@@ -59,7 +59,7 @@ public class IniFileLoader {
     /**
      * Public in order to configure LogAppenderProxy, but then the value
      * might as well be configured in the log4j.properties file
-     * @see ticket:1479
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/1479">Trac ticket #1479</a>
      */
     public final static String LOGFILE = LOGDIR + File.separator
             + "importer.log";
@@ -78,7 +78,7 @@ public class IniFileLoader {
     /**
      * Load given file
      *
-     * @param userConfigFile
+     * @param userConfigFile the file to load
      */
     public IniFileLoader(File userConfigFile) {
         staticConfigDirectory = System.getProperty("user.dir") + File.separator
@@ -124,6 +124,7 @@ public class IniFileLoader {
     /**
      * Returns the level of debugging which should be set on {@link ImportConfig}
      * Any value lower than null will not call configureDebug.
+     * @return the debug level
      */
     public int getDebugLevel() {
     	if (userPrefs == null) return -1;
@@ -197,9 +198,8 @@ public class IniFileLoader {
     }
 
     /**
-     * Set debug level for application
-     *
-     * @param level
+     * Set if history should be disabled.
+     * @param b if history should be disabled
      */
     public void setUserDisableHistory(boolean b)
     {
@@ -209,7 +209,7 @@ public class IniFileLoader {
     }    
     
     /**
-     * @return if debug console should be shown
+     * @return if history should be disabled
      */
     public Boolean getUserDisableHistory()
     {
@@ -220,7 +220,7 @@ public class IniFileLoader {
     /**
      * Set debug level for application
      *
-     * @param level
+     * @param level a debug level
      */
     public void setDebugLevel(int level)
     {
@@ -301,8 +301,8 @@ public class IniFileLoader {
     /**
      * Parse Flex reader server maps
      *
-     * @param maps
-     * @return
+     * @param maps the Flex reader server maps
+     * @return the parsed maps
      */
     public Map<String, List<String>> parseFlexMaps(Preferences maps)
     {
@@ -380,7 +380,7 @@ public class IniFileLoader {
     /**
      * Set ui bounds for application
      *
-     * @param bounds
+     * @param bounds the bounds
      */
     public void setUIBounds(Rectangle bounds)
     {

--- a/components/blitz/src/ome/formats/model/IObjectContainerStore.java
+++ b/components/blitz/src/ome/formats/model/IObjectContainerStore.java
@@ -90,21 +90,21 @@ public interface IObjectContainerStore
 
     /**
      * Sets the user specified image/plate description.
-     * @param name user specified image/plate description
+     * @param description user-specified image/plate description
      */
     void setUserSpecifiedDescription(String description);
 
     /**
-     * Returns the user specified linkage target (usually a Dataset for Images
+     * Returns the user-specified linkage target (usually a Dataset for Images)
      * and a Screen for Plates).
      * @return See above.
      */
     IObject getUserSpecifiedTarget();
 
     /**
-     * Sets the user specified linkage target (usually a Dataset for Images
+     * Sets the user-specified linkage target (usually a Dataset for Images)
      * and a Screen for Plates).
-     * @param name user specified image description
+     * @param target user-specified linkage target
      */
     void setUserSpecifiedTarget(IObject target);
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/DataObjectRemover.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/DataObjectRemover.java
@@ -38,7 +38,7 @@ import pojos.DataObject;
 
 /** 
  * Removes data objects. Depending on the specified parameters, 
- * This class calls one of the <code>deleteDataObjects</code> methods in the
+ * This class calls one of the {@code deleteObjects} methods in the
  * <code>AdminView</code>.
  *
  * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/config/Entry.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/config/Entry.java
@@ -117,7 +117,7 @@ abstract class Entry
     }
     
     /**
-     * Holds the contents of the <i>name</i> and <i>type<i> attributes of an
+     * Holds the contents of the <i>name</i> and <i>type</i> attributes of an
      * entry tag (either <i>entry</i> or <i>structuredEntry</i>).
      */
     private static class NameTypePair

--- a/components/model/src/ome/parameters/Parameters.java
+++ b/components/model/src/ome/parameters/Parameters.java
@@ -26,7 +26,7 @@ import ome.conditions.ApiUsageException;
  * container object for {@link QueryParameter} and {@link Filter} instances.
  * 
  * The public Strings available here are used throughout this class and should
- * also be used in query strings as named parameteres. For example, the field
+ * also be used in query strings as named parameters. For example, the field
  * {@link Parameters#ID} has the value "id", and a query which would like to use
  * the {@link Parameters#addId(Long)} method, should define a named parameter of
  * the form ":id".

--- a/components/rendering/src/omeis/providers/re/RenderHSBRegionTask.java
+++ b/components/rendering/src/omeis/providers/re/RenderHSBRegionTask.java
@@ -54,7 +54,7 @@ class RenderHSBRegionTask implements RenderingTask {
      */
     private List<int[]> colors;
 
-    /** The <i>X1/<i>-axis start */
+    /** The <i>X1</i>-axis start */
     private int x1Start;
 
     /** The <i>X1</i>-axis end */

--- a/components/server/src/ome/api/local/LocalAdmin.java
+++ b/components/server/src/ome/api/local/LocalAdmin.java
@@ -35,28 +35,36 @@ public interface LocalAdmin extends ome.api.IAdmin {
     /**
      * returns a possibly uninitialized proxy for the given
      * {@link Experimenter#getOmeName() user name}. Use of the
-     * {@link Experimenter} instance will initial its values.
+     * {@link Experimenter} instance will initialize its values.
+     * @param omeName the name of a user
+     * @return the user (may be uninitialized)
      */
     Experimenter userProxy(String omeName);
 
     /**
      * returns a possibly uninitialized proxy for the given
      * {@link Experimenter#getId() user id}. Use of the {@link Experimenter}
-     * instance will initial its values.
+     * instance will initialize its values.
+     * @param userId the ID of a user
+     * @return the user (may be uninitialized)
      */
     Experimenter userProxy(Long userId);
 
     /**
      * returns a possibly uninitialized proxy for the given
      * {@link ExperimenterGroup#getId() group id}. Use of the
-     * {@link Experimenter} instance will initial its values.
+     * {@link Experimenter} instance will initialize its values.
+     * @param groupId the ID of a group
+     * @return the group (may be uninitialized)
      */
     ExperimenterGroup groupProxy(Long groupId);
 
     /**
      * returns a possibly uninitialized proxy for the given
      * {@link ExperimenterGroup#getName() group name}. Use of the
-     * {@link Experimenter} instance will initial its values.
+     * {@link Experimenter} instance will initialize its values.
+     * @param groupName the name of a group
+     * @return the group (may be uninitialized)
      */
     ExperimenterGroup groupProxy(String groupName);
 
@@ -66,6 +74,7 @@ public interface LocalAdmin extends ome.api.IAdmin {
      * 
      * @param e
      *            Non-null, managed (i.e. with id) {@link Experimenter}
+     * @return the groups of which the user is a member
      * @see ExperimenterGroup#getDetails()
      * @see Details#getOwner()
      */
@@ -74,8 +83,11 @@ public interface LocalAdmin extends ome.api.IAdmin {
     /**
      * Checks password for given user. ReadOnly determines if a actions can be
      * taken to create the given user, for example in the case of LDAP.
-     *
-     * @see ticket:4626
+     * @param user the name of a user
+     * @param password the user's password
+     * @param readOnly if the password check should be transactionally read-only
+     * @return if the user's password is correct
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/4626">Trac ticket #4626</a>
      */
     boolean checkPassword(String user, String password, boolean readOnly);
 
@@ -85,6 +97,10 @@ public interface LocalAdmin extends ome.api.IAdmin {
      * the sum of all the locks.
      * 
      * TODO This will eventually return a list of ids
+     * @param klass the name of a model class
+     * @param id the ID of an instance of {@code klass}
+     * @param groupId the ID of a group to omit from the results, may be {@code null}
+     * @return the classes and counts of the objects that point to the given object
      */
     Map<String, Long> getLockingIds(Class<IObject> klass, long id, Long groupId);
 
@@ -92,13 +108,15 @@ public interface LocalAdmin extends ome.api.IAdmin {
      * Like {@link #getEventContext()} but will not reload the context.
      * This also has the result that values from the current call context
      * will be applied as simply the session context.
+     * @return the current event context
      */
     EventContext getEventContextQuiet();
 
     /**
-     * Companion to {@link IAdmin#canUpdate(IObject)} but not yet remotely
+     * Companion to {@link ome.api.IAdmin#canUpdate(IObject)} but not yet remotely
      * accessible.
      * @param obj Not null.
+     * @return if the object can be annotated
      */
     boolean canAnnotate(IObject obj);
 

--- a/components/server/src/ome/api/local/LocalCompress.java
+++ b/components/server/src/ome/api/local/LocalCompress.java
@@ -29,7 +29,7 @@ public interface LocalCompress {
      * @param outputStream
      *            the stream to write to.
      * @throws IOException
-     *             if there is a problem when writing to <i>stream<i>.
+     *             if there is a problem when writing to <i>stream</i>.
      */
 	void compressToStream(BufferedImage image, OutputStream outputStream)
 		throws IOException;

--- a/components/server/src/ome/api/local/LocalCompress.java
+++ b/components/server/src/ome/api/local/LocalCompress.java
@@ -39,15 +39,14 @@ public interface LocalCompress {
 	 * 
 	 * @param percentage A percentage compression level from 1.00 (100%) to 
 	 * 0.01 (1%).
-	 * @throws ValidationException if the <code>percentage</code> is out of
-	 * range.
+	 * @throws ome.conditions.ValidationException if the {@code percentage} is out of
+	 * range. (actually doesn't but might should)
 	 */
 	void setCompressionLevel(float percentage);
 	
 	/**
 	 * Returns the current compression level for the service.
-	 * 
-	 * @returns See above.
+	 * @return the current compression level
 	 */
 	float getCompressionLevel();
 }

--- a/components/server/src/ome/api/local/LocalShare.java
+++ b/components/server/src/ome/api/local/LocalShare.java
@@ -13,7 +13,7 @@ package ome.api.local;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2
- * @see ticket:2219
+ * @see  <a href="http://trac.openmicroscopy.org/ome/ticket/2219">Trac ticket #2219</a>
  */
 public interface LocalShare extends ome.api.IShare {
 

--- a/components/server/src/ome/formats/OMEROMetadataStore.java
+++ b/components/server/src/ome/formats/OMEROMetadataStore.java
@@ -61,6 +61,7 @@ import ome.model.screen.PlateAcquisition;
 import ome.model.stats.StatsInfo;
 import ome.system.ServiceFactory;
 import ome.conditions.ApiUsageException;
+import ome.conditions.ValidationException;
 import ome.util.LSID;
 import ome.util.SqlAction;
 
@@ -72,7 +73,8 @@ import org.perf4j.StopWatch;
 
 /**
  * An OMERO metadata store. This particular metadata store requires the user to
- * be logged into OMERO prior to use with the {@link #login()} method. While
+ * be logged into OMERO prior to use with the
+ * {@link ome.security.SecuritySystem#login(ome.system.Principal)} method. While
  * attempts have been made to allow the caller to switch back and forth between 
  * Images and Pixels during metadata population it is <b>strongly</b> 
  * encouraged that at least Images and Pixels are populated in ascending order. 
@@ -1847,14 +1849,15 @@ public class OMEROMetadataStore
      * Creates a new instance.
      * 
      * @param factory a non-null, active {@link ServiceFactory}
-     * @throws MetadataStoreException if the factory is null or there
+     * @param sql the SQL action instance
+     * @throws ValidationException if the factory is null or there
      *             is another error instantiating required services.
      */
     public OMEROMetadataStore(ServiceFactory factory, SqlAction sql)
-    	throws Exception
+            throws ValidationException
     {
         if (factory == null || sql == null)
-            throw new Exception("arguments cannot be null.");
+            throw new ValidationException("arguments cannot be null");
         sf = factory;
         this.sql = sql;
     }
@@ -1973,7 +1976,7 @@ public class OMEROMetadataStore
     }
 
     /**
-     * For all plates and all image which are not contained within a well,
+     * For all plates and all images which are not contained within a well,
      * create a link from the {@link Fileset} to the given object.
      */
     private void linkFileset(FilesetJobLink link)
@@ -2162,7 +2165,7 @@ public class OMEROMetadataStore
 
     /**
      * Saves the current object graph to the database.
-     * 
+     * @param link a link from the fileset to be linked from
      * @return List of the Pixels objects with their attached object graphs
      * that have been saved.
      */

--- a/components/server/src/ome/formats/importer/util/TinyImportFixture.java
+++ b/components/server/src/ome/formats/importer/util/TinyImportFixture.java
@@ -7,6 +7,7 @@
 package ome.formats.importer.util;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.UUID;
 
 import ome.model.containers.Dataset;
@@ -22,9 +23,7 @@ import org.springframework.util.ResourceUtils;
  * classpath, and adds them to a new UUID-named dataset.
  *
  * @author Josh Moore, josh.moore at gmx.de
- * @version $Revision: 1167 $, $Date: 2006-12-15 10:39:34 +0000 (Fri, 15 Dec 2006) $
- * @see OMEROMetadataStore
- * @see ExampleUnitTest
+ * @see ome.formats.OMEROMetadataStore
  * @since 3.0-M3
  */
 public class TinyImportFixture
@@ -45,11 +44,10 @@ public class TinyImportFixture
     }
 
     /**
-     * checks for the necessary fields and initializes the {@link ImportLibrary}
-     *
-     * @throws Exception
+     * Creates a dataset and locates the test image file.
+     * @throws FileNotFoundException if the test image file could not be found
      */
-    public void setUp() throws Exception
+    public void setUp() throws FileNotFoundException
     {
         d = new Dataset();
         d.setName(UUID.randomUUID().toString());
@@ -62,6 +60,7 @@ public class TinyImportFixture
     public void tearDown() {}
 
     /** provides access to the created {@link Dataset} instance.
+     * @return the dataset
      */
     public Dataset getDataset()
     {

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -1046,7 +1046,7 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
      * Helpers which unconditionally moves the object to the common space. This
      * can be used by other methods like {@link #uploadMyUserPhoto(String, String, byte[])}
      *
-     * @param not null object. Should be linked to the current session.
+     * @param obj a model object, linked to the current session; never {@code null}
      */
     public void internalMoveToCommonSpace(IObject obj) {
         /* Can this next line be removed? - ajp */

--- a/components/server/src/ome/logic/ConfigImpl.java
+++ b/components/server/src/ome/logic/ConfigImpl.java
@@ -115,7 +115,7 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
     /**
      * {@link SqlAction} setter for dependency injection.
      * 
-     * @param sql
+     * @param sql the SQL action instance
      * @see ome.services.util.BeanHelper#throwIfAlreadySet(Object, Object)
      */
     /*
@@ -136,7 +136,7 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
     /**
      * {@link PreferenceContext} setter for dependency injection.
      * 
-     * @param prefs
+     * @param prefs the preference context
      * @see ome.services.util.BeanHelper#throwIfAlreadySet(Object, Object)
      */
     public final void setPreferenceContext(PreferenceContext prefs) {
@@ -145,9 +145,9 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
     }
 
     /**
-     * {@link PreferenceContext} setter for dependency injection.
+     * {@link CurrentDetails} setter for dependency injection.
      * 
-     * @param prefs
+     * @param currentDetails the details of the current thread's security context
      * @see ome.services.util.BeanHelper#throwIfAlreadySet(Object, Object)
      */
     public final void setCurrentDetails(CurrentDetails currentDetails) {

--- a/components/server/src/ome/logic/LdapImpl.java
+++ b/components/server/src/ome/logic/LdapImpl.java
@@ -186,10 +186,10 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
      * Apache DS (the testing framework used) does not yet support
      * :caseExactMatch:. When it does, the check here can be removed.
      *
-     * @param username
-     * @param mapper
-     * @return a non null Experimenter.
-     * @see ticket:2557
+     * @param username a user's name
+     * @param mapper the map to contexts
+     * @return a non-{@code null} Experimenter
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/2557">Trac ticket #2557</a>
      */
     @SuppressWarnings("unchecked")
     private Experimenter mapUserName(String username, PersonContextMapper mapper) {
@@ -635,8 +635,9 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
     /**
      * Validates password for base. Base is user's DN. When context was created
      * successful specified requirements are valid.
-     *
-     * @return boolean
+     * @param dn the user's distinguished name
+     * @param password the user's password
+     * @return boolean if the user's password is correct
      */
     public boolean validatePassword(String dn, String password) {
         try {
@@ -762,8 +763,9 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
      * Creates the initial context with no connection request controls in order
      * to check authentication. If authentication fails, this method throws
      * a {@link SecurityViolation}.
-     *
-     * @return {@link javax.naming.ldap.LdapContext}
+     * @param username the user's name
+     * @param password the user's password
+     * @throws SecurityViolation if authentication failed
      */
     @SuppressWarnings("unchecked")
     private void isAuthContext(String username, String password) {

--- a/components/server/src/ome/logic/MetadataImpl.java
+++ b/components/server/src/ome/logic/MetadataImpl.java
@@ -392,10 +392,8 @@ public class MetadataImpl
     	return result;
     }
     
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadInstrument(Long)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Instrument loadInstrument(long id)
@@ -473,11 +471,8 @@ public class MetadataImpl
     	}
     	return value;
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadChannelAcquisitionData(Set)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Set loadChannelAcquisitionData(@NotNull 
@@ -579,10 +574,7 @@ public class MetadataImpl
     	return new HashSet<LogicalChannel>(list);
     }
 
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadAnnotations(Class, Set, Set, Set)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public <T extends IObject, A extends Annotation> 
@@ -666,10 +658,7 @@ public class MetadataImpl
          return map;
     }
 
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadSpecifiedAnnotations(Class, Set, Set, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public <A extends Annotation> Set<A> loadSpecifiedAnnotations(
@@ -701,11 +690,8 @@ public class MetadataImpl
 		}
     	return set;
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#countSpecifiedAnnotations(Class, Set, Set, Parameters)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Long countSpecifiedAnnotations(
@@ -716,11 +702,8 @@ public class MetadataImpl
     	if (list != null) return new Long(list.size());
     	return -1L;
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadAnnotation(Set)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public <A extends Annotation> Set<A> loadAnnotation(
@@ -752,11 +735,8 @@ public class MetadataImpl
 		}
     	return new HashSet<A>(list);
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadTagContent(Set, Parameters)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Map<Long, Set<IObject>> 
@@ -772,11 +752,8 @@ public class MetadataImpl
 		}
     	return m;
 	}
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadTagSets(Parameters)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Set<IObject> loadTagSets(Parameters options)
@@ -851,10 +828,8 @@ public class MetadataImpl
 		return result;
 	}
     
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#lgetTaggedObjectsCount(Set, Parameters)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Map getTaggedObjectsCount(@NotNull @Validate(Long.class) 
@@ -869,11 +844,8 @@ public class MetadataImpl
 		}
     	return counts;
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadAnnotationUsedNotOwned(Class, Long)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Set<IObject> loadAnnotationsUsedNotOwned(@NotNull Class annotationType,
@@ -989,11 +961,8 @@ public class MetadataImpl
 		}
     	return result;
     }
-    
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#countAnnotationsUsedNotOwned(Class, Long)
-     */
+
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Long countAnnotationsUsedNotOwned(@NotNull Class annotationType, 
@@ -1004,10 +973,7 @@ public class MetadataImpl
     	return -1L;
     }
 
-    /**
-     * Implemented as specified by the {@link IMetadata} I/F
-     * @see IMetadata#loadSpecifiedAnnotationsLinkedTo(Class, Set, Set, Class, Set, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public <A extends Annotation> Map<Long, Set<A>> loadSpecifiedAnnotationsLinkedTo(

--- a/components/server/src/ome/logic/PixelsImpl.java
+++ b/components/server/src/ome/logic/PixelsImpl.java
@@ -80,10 +80,7 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
 		return p;
 	}
 
-	/**
-	 * Implemented as specified by the {@link IPixels} I/F.
-	 * @see IPixels#retrieveRndSettingsFor(long, long)
-	 */
+    @Override
 	@RolesAllowed("user")
 	public RenderingDef retrieveRndSettingsFor(long pixId, long userId)
 	{
@@ -92,10 +89,7 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
 		return (RenderingDef) list.get(0);
 	}
 
-	/**
-	 * Implemented as specified by the {@link IPixels} I/F.
-	 * @see IPixels#retrieveAllRndSettingsFor(long, long)
-	 */
+    @Override
 	@RolesAllowed("user")
 	public List<IObject> retrieveAllRndSettings(long pixId, long userId)
 	{
@@ -113,10 +107,7 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
 		return l;
 	}
 
-	/**
-	 * Implemented as specified by the {@link IPixels} I/F.
-	 * @see IPixels#retrieveRndSettings(long)
-	 */
+    @Override
 	@RolesAllowed("user")
 	public RenderingDef retrieveRndSettings(long pixId) {
         Long userId = sec.getEffectiveUID();
@@ -136,10 +127,7 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
         return rd;
 	}
 
-	/**
-	 * Implemented as specified by the {@link IPixels} I/F.
-	 * @see IPixels#loadRndSettings(long)
-	 */
+    @Override
 	@RolesAllowed("user")
 	public RenderingDef loadRndSettings(long renderingDefId) {
 		return (RenderingDef) iQuery.findByQuery(
@@ -147,7 +135,7 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
 				new Parameters().addId(renderingDefId));
 	}
 
-	/** Actually performs the work declared in {@link copyAndResizePixels()}. */
+	/** Actually performs the work declared in {@link #copyAndResizePixels()}. */
 	private Pixels _copyAndResizePixels(long pixelsId, Integer sizeX, 
 			Integer sizeY, Integer sizeZ, Integer sizeT, 
 			List<Integer> channelList, String methodology, boolean copyStats)

--- a/components/server/src/ome/logic/PojosImpl.java
+++ b/components/server/src/ome/logic/PojosImpl.java
@@ -707,9 +707,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
      * Implemented as specified by the {@link IContainer} I/F
      * @see IContainer#deleteDataObject(IObject, Parameters)
      */
-    @RolesAllowed("user")
-    @Transactional(readOnly = false)
-    public void deleteDataObject(IObject row, Parameters arg1) {
+    private void deleteDataObject(IObject row, Parameters options) {
         iUpdate.deleteObject(row);
     }
 
@@ -717,9 +715,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
      * Implemented as specified by the {@link IContainer} I/F
      * @see IContainer#deleteDataObjects(IObject[], Parameters)
      */
-    @RolesAllowed("user")
-    @Transactional(readOnly = false)
-    public void deleteDataObjects(IObject[] rows, Parameters options) {
+    private void deleteDataObjects(IObject[] rows, Parameters options) {
         for (IObject object : rows) {
             deleteDataObject(object, options);
         }

--- a/components/server/src/ome/logic/PojosImpl.java
+++ b/components/server/src/ome/logic/PojosImpl.java
@@ -147,10 +147,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         }
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#loadContainerHierarchy(Class, Set, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Set loadContainerHierarchy(Class rootNodeType, Set rootNodeIds,
@@ -341,10 +338,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         return new HashSet<IObject>(l);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#findContainerHierarchies(Class, Set, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Set findContainerHierarchies(final Class rootNodeType,
@@ -404,10 +398,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
                                 + "where pdl.parent.id in (:ids) order by dil.child.id");
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#getImages(Class, Set, Map)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     @SuppressWarnings("unchecked")
@@ -467,10 +458,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         return new HashSet<IObject>(l);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#getImagesByOptions(Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     @SuppressWarnings("unchecked")
@@ -492,10 +480,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
 
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#getImagesBySplitFilesets(Map)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Map<Long, Map<Boolean, List<Long>>> getImagesBySplitFilesets(Map<Class<? extends IObject>, List<Long>> included,
@@ -567,10 +552,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         return imagesBySplitFilesets;
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#getUserImages(Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     @SuppressWarnings("unchecked")
@@ -591,10 +573,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
 
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#getCollectionCount(String, String, Set, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Map getCollectionCount(String type, String property, Set ids,
@@ -622,10 +601,7 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         return results;
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#retrieveCollection(IObject, String, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public Collection retrieveCollection(IObject arg0, String arg1, Parameters arg2) {
@@ -639,40 +615,28 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
     // ~ WRITE
     // =========================================================================
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#createDataObject(IObject, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public IObject createDataObject(IObject arg0, Parameters arg1) {
         return iUpdate.saveAndReturnObject(arg0);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#createDataObject(IObject[], Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public IObject[] createDataObjects(IObject[] arg0, Parameters arg1) {
         return iUpdate.saveAndReturnArray(arg0);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#unlink(ILink[], Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public void unlink(ILink[] arg0, Parameters arg1) {
         deleteDataObjects(arg0, arg1);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#link(ILink[], Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public ILink[] link(ILink[] arg0, Parameters arg1) {
@@ -683,20 +647,14 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
         return links;
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#updateDataObject(IObject, Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public IObject updateDataObject(IObject arg0, Parameters arg1) {
         return iUpdate.saveAndReturnObject(arg0);
     }
 
-    /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#updateDataObject(IObject[], Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @Transactional(readOnly = false)
     public IObject[] updateDataObjects(IObject[] arg0, Parameters arg1) {
@@ -704,16 +662,18 @@ public class PojosImpl extends AbstractLevel2Service implements IContainer {
     }
 
     /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#deleteDataObject(IObject, Parameters)
+     * Delete a data object.
+     * @param row the object to delete
+     * @param options the parameters to apply (ignored)
      */
     private void deleteDataObject(IObject row, Parameters options) {
         iUpdate.deleteObject(row);
     }
 
     /**
-     * Implemented as specified by the {@link IContainer} I/F
-     * @see IContainer#deleteDataObjects(IObject[], Parameters)
+     * Delete some data objects.
+     * @param rows the objects to delete
+     * @param options the parameters to apply (ignored)
      */
     private void deleteDataObjects(IObject[] rows, Parameters options) {
         for (IObject object : rows) {

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -360,10 +360,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                         + "Please try findAllBy methods for queries which return Lists.");
     }
 
-    /**
-     * @see ome.api.IQuery#findAllByQuery(java.lang.String,
-     *      ome.parameters.Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     public <T extends IObject> List<T> findAllByQuery(String queryName,
             Parameters params) {

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -147,13 +147,10 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     // ~ INTERFACE METHODS
     // =========================================================================
 
-    /**
-     * @see ome.api.IQuery#get(java.lang.Class, long)
-     * @see org.hibernate.Session#load(java.lang.Class, java.io.Serializable)
-     * @DEV.TODO weirdness here; learn more about CGLIB initialization.
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
+    // TODO weirdness here; learn more about CGLIB initialization.
     public IObject get(final Class klass, final long id)
             throws ValidationException {
         return (IObject) getHibernateTemplate().execute(
@@ -180,13 +177,10 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 });
     }
 
-    /**
-     * @see ome.api.IQuery#find(java.lang.Class, long)
-     * @see org.hibernate.Session#get(java.lang.Class, java.io.Serializable)
-     * @DEV.TODO weirdness here; learn more about CGLIB initialization.
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
+    // TODO weirdness here; learn more about CGLIB initialization.
     public IObject find(final Class klass, final long id) {
         return (IObject) getHibernateTemplate().execute(
                 new HibernateCallback() {
@@ -201,9 +195,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 });
     }
 
-    /**
-     * @see ome.api.IQuery#getByClass(java.lang.Class)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> List<T> findAll(final Class<T> klass,
@@ -224,9 +216,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 });
     }
 
-    /**
-     * @see ome.api.IQuery#findByExample(ome.model.IObject)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> T findByExample(final T example)
@@ -251,10 +241,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
         });
     }
 
-    /**
-     * @see ome.api.IQuery#findAllByExample(ome.model.IObject,
-     *      ome.parameters.Filter)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> List<T> findAllByExample(final T example,
@@ -273,10 +260,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 });
     }
 
-    /**
-     * @see ome.api.IQuery#findByString(java.lang.Class, java.lang.String,
-     *      java.lang.String)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> T findByString(final Class<T> klass,
@@ -302,10 +286,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
         });
     }
 
-    /**
-     * @see ome.api.IQuery#findAllByString(java.lang.Class, java.lang.String,
-     *      java.lang.String, boolean, ome.parameters.Filter)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> List<T> findAllByString(final Class<T> klass,
@@ -334,10 +315,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                 });
     }
 
-    /**
-     * @see ome.api.IQuery#findByQuery(java.lang.String,
-     *      ome.parameters.Parameters)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> T findByQuery(String queryName, Parameters params)
@@ -380,9 +358,8 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                         + "has returned more than one Object\n"
                         + "findBy methods must return a single value.\n"
                         + "Please try findAllBy methods for queries which return Lists.");
-
     }
-    
+
     /**
      * @see ome.api.IQuery#findAllByQuery(java.lang.String,
      *      ome.parameters.Parameters)
@@ -394,10 +371,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
         return execute(q);
     }
 
-    /**
-     * @see ome.api.IQuery#findAllByFullText(java.lang.String,
-     *      ome.parameters.Parameteres)
-     */
+    @Override
     @RolesAllowed("user")
     @SuppressWarnings("unchecked")
     public <T extends IObject> List<T> findAllByFullText(final Class<T> type,
@@ -435,6 +409,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     // ~ Aggregations
     // =========================================================================
 
+    @Override
     @SuppressWarnings("unchecked")
     @RolesAllowed("user")
     public List<Object[]> projection(final String query, Parameters p) {
@@ -532,9 +507,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     // ~ Others
     // =========================================================================
 
-    /**
-     * @see IQuery#refresh(IObject)
-     */
+    @Override
     public <T extends IObject> T refresh(T iObject) throws ApiUsageException {
         getHibernateTemplate().refresh(iObject);
         return iObject;
@@ -544,9 +517,11 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     // =========================================================================
 
     /**
-     * responsible for applying the information provided in a
-     * {@link ome.parameters.Filter} to a {@link org.hibernate.Critieria}
+     * Responsible for applying the information provided in a
+     * {@link ome.parameters.Filter} to a {@link org.hibernate.Criteria}
      * instance.
+     * @param c a criteria instance
+     * @param f a filter to limit a query
      */
     protected void parseFilter(Criteria c, Filter f) {
         // ticket:1232 - Reverting for 4.0

--- a/components/server/src/ome/logic/RepositoryInfoImpl.java
+++ b/components/server/src/ome/logic/RepositoryInfoImpl.java
@@ -107,8 +107,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
 
     /**
      * Bean injection setter for ROMIO thumbnail service
-     * 
-     * @param rootdir
+     * @param thumbnailService the thumbnail service
      */
     public void setThumbnailService(ThumbnailService thumbnailService) {
         getBeanHelper().throwIfAlreadySet(this.thumbnailService,
@@ -118,8 +117,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
 
     /**
      * Bean injection setter for ROMIO pixels service
-     * 
-     * @param rootdir
+     * @param pixelsService the pixels service
      */
     public void setPixelsService(PixelsService pixelsService) {
         getBeanHelper().throwIfAlreadySet(this.pixelsService, pixelsService);
@@ -128,8 +126,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
 
     /**
      * Bean injection setter for ROMIO file service
-     * 
-     * @param rootdir
+     * @param fileService the raw file service
      */
     public void setFileService(OriginalFilesService fileService) {
         getBeanHelper().throwIfAlreadySet(this.fileService, fileService);
@@ -138,8 +135,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
 
     /**
      * Bean injection setter for SQL operations
-     * 
-     * @param rootdir
+     * @param sql the SQL action instance
      */
     public void setSqlAction(SqlAction sql) {
         getBeanHelper().throwIfAlreadySet(this.sql, sql);
@@ -203,17 +199,17 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
 
     /**
      * Bean injection setter for data repository directory
-     * 
-     * @param datadir
+     * @param datadir the data repository directory
      */
     public void setDatadir(String datadir) {
         this.datadir = datadir;
     }
 
     /**
-     * Calculates based on the {@link #lastUsage cached usage} and the
-     * {@link #lastCheck elapsed time} whether or not a real
+     * Calculates based on the cached usage and the
+     * elapsed time whether or not a real
      * {@link #sanityCheckRepository()} should be calculated.
+     * @return if the repository needs a sanity check
      */
     public boolean needsSanityCheck() {
 
@@ -248,7 +244,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
     }
 
     /**
-     * @see ome.api.IRepository#sanityCheckRepository()
+     * @see ome.api.IRepositoryInfo#sanityCheckRepository()
      */
     @RolesAllowed("user")
     public void sanityCheckRepository() throws InternalException {

--- a/components/server/src/ome/logic/TypesImpl.java
+++ b/components/server/src/ome/logic/TypesImpl.java
@@ -64,7 +64,9 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
 
     protected transient SessionFactory sf;
 
-    /** injector for usage by the container. Not for general use */
+    /** injector for usage by the container. Not for general use 
+     * @param sessions the session factory
+     */
     public final void setSessionFactory(SessionFactory sessions) {
         getBeanHelper().throwIfAlreadySet(this.sf, sessions);
         sf = sessions;
@@ -165,7 +167,7 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
 
     @RolesAllowed("system")
     public <T extends IEnum> List<T> getOriginalEnumerations() {
-        List<IEnum> orygin = new ArrayList<IEnum>();
+        List<IEnum> original = new ArrayList<IEnum>();
         InputStream in = null;
         try {
             URL file = ResourceUtils.getURL("classpath:enums.properties");
@@ -186,9 +188,9 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
                 className = className.substring(0, (className.length() - 1));
                 String val = property.getProperty(key);
                 Class klass = Class.forName(className);
-                IEnum orygninEntry = (IEnum) klass.getConstructor(String.class)
+                IEnum originalEntry = (IEnum) klass.getConstructor(String.class)
                         .newInstance(val);
-                orygin.add(orygninEntry);
+                original.add(originalEntry);
             }
         } catch (ClassNotFoundException e) {
             throw new RuntimeException("Class not found. " + e.getMessage());
@@ -217,7 +219,7 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
             } catch (IOException e) {
             }
         }
-        return (List<T>) orygin;
+        return (List<T>) original;
     }
 
     @RolesAllowed("system")
@@ -342,7 +344,7 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
     }
     
     /**
-     * @see ticket:1204
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/1204">Trac ticket #1204</a>
      */
     private void worldReadable(IObject obj) {
         Permissions p = obj.getDetails().getPermissions();

--- a/components/server/src/ome/logic/UpdateImpl.java
+++ b/components/server/src/ome/logic/UpdateImpl.java
@@ -245,7 +245,7 @@ public class UpdateImpl extends AbstractLevel1Service implements LocalUpdate {
 
     /**
      * Note if we use anything other than merge here, functionality from
-     * {@link ome.tools.hibernate.MergeEventListener} needs to be moved to
+     * {@link ome.security.basic.MergeEventListener} needs to be moved to
      * {@link UpdateFilter} or to another event listener.
      */
     protected Long internalSave(IObject obj, ReloadFilter filter,
@@ -261,7 +261,7 @@ public class UpdateImpl extends AbstractLevel1Service implements LocalUpdate {
 
     /**
      * Note if we use anything other than merge here, functionality from
-     * {@link ome.tools.hibernate.MergeEventListener} needs to be moved to
+     * {@link ome.security.basic.MergeEventListener} needs to be moved to
      * {@link UpdateFilter} or to another event listener.
      */
     protected IObject internalMerge(IObject obj, UpdateFilter filter,
@@ -297,13 +297,11 @@ public class UpdateImpl extends AbstractLevel1Service implements LocalUpdate {
 
     }
 
-    @SuppressWarnings("unchecked")
     private <T> T doAction(final T graph, final UpdateAction<T> action) {
         final UpdateFilter filter = new UpdateFilter();
         return doAction(graph, filter, action);
     }
 
-    @SuppressWarnings("unchecked")
     private <T> T doAction(final T graph, final UpdateFilter filter,
             final UpdateAction<T> action) {
         final Session session = session();


### PR DESCRIPTION
This PR should improve the Javadoc within certain packages. Building the Javadoc should report no warnings within those classes. They are:

* `ome.api.*`
* `ome.formats.*`
* `ome.logic.*`

--no-rebase