### PR TITLE
Deprecatig fastcgi (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -239,11 +239,10 @@ class WebControl(BaseControl):
                                 "apache", "apache-fcgi")):
             mismatch = True
         if mismatch:
-            self.ctx.die(1, ("ERROR: configuration mismatch. "
-                             "omero.web.application_server=%s cannot be used "
-                             " with 'omero web config %s'"
-                             ".") % (settings.APPLICATION_SERVER, argtype))
-            self._fastcgi_deprecation(settings)  # to be removed in 5.2
+            self.ctx.die(680, ("ERROR: configuration mismatch. "
+                               "omero.web.application_server=%s cannot be"
+                               " used with 'omero web config %s'"
+                               ".") % (settings.APPLICATION_SERVER, argtype))
 
     def config(self, args):
         """Generate a configuration file from a template"""

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -86,7 +86,7 @@ class WebControl(BaseControl):
             nginx_start_group.add_argument(
                 "--wsgi-args", type=str, default="",
                 help=("Additional arguments. Check Gunicorn Documentation "
-                      "http://docs.gunicorn.org/en/latest/settings.htm"))
+                      "http://docs.gunicorn.org/en/latest/settings.html"))
         #
         # Advanced
         #

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -282,6 +282,9 @@ class WebControl(BaseControl):
                       "nginx-wsgi", "nginx-wsgi-development",
                       "apache-wsgi"):
             d["HTTPPORT"] = port
+
+        if server in ("nginx", "nginx-development",
+                      "nginx-wsgi", "nginx-wsgi-development"):
             d["MAX_BODY_SIZE"] = args.max_body_size
 
         # FORCE_SCRIPT_NAME always has a starting /, and will not have a

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -468,9 +468,9 @@ using bin\omero web start on Windows with FastCGI.
             except:
                 pass
             cmd = "gunicorn -D -p %(base)s/var/django.pid"
-            cmd += " --bind %(host)s:%(port)s"
-            cmd += " --workers %(workers)s "
-            cmd += " --worker-connections %(worker_conn)s"
+            cmd += " --bind %(host)s:%(port)d"
+            cmd += " --workers %(workers)d "
+            cmd += " --worker-connections %(worker_conn)d"
             cmd += " --max-requests %(maxrequests)d"
             cmd += " %(wsgi_args)s"
             cmd += " omeroweb.wsgi:application"

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
@@ -1,0 +1,67 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
+worker_processes  5;
+working_directory /home/omero/OMERO.server/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+    keepalive_timeout 65;
+
+    upstream omeroweb_server {
+        server 0.0.0.0:12345 fail_timeout=0;
+    }
+    
+    server {
+        listen 1234;
+        server_name _;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 2m;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root /home/omero/OMERO.server/etc/templates/error;
+            try_files $uri /maintainance.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /test-static {
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+
+            proxy_pass http://omeroweb_server;
+        }
+
+        location /test {
+
+            error_page 502 @maintenance;
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app;
+        }
+
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development.conf
@@ -1,0 +1,67 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
+worker_processes  5;
+working_directory /home/omero/OMERO.server/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+    keepalive_timeout 65;
+
+    upstream omeroweb_server {
+        server 127.0.0.1:4080 fail_timeout=0;
+    }
+    
+    server {
+        listen 8080;
+        server_name _;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 0;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root /home/omero/OMERO.server/etc/templates/error;
+            try_files $uri /maintainance.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /static {
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+
+            proxy_pass http://omeroweb_server;
+        }
+
+        location / {
+
+            error_page 502 @maintenance;
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app;
+        }
+
+    }
+
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -302,7 +302,7 @@ class TestWeb(object):
         o, e = capsys.readouterr()
 
         lines = self.clean_generated_file(o)
-        print lines
+
         if prefix:
             missing = self.required_lines_in([
                 ("<VirtualHost _default_:%s>" % (http or 80)),
@@ -336,7 +336,9 @@ class TestWeb(object):
         self.cli.invoke(self.args, strict=True)
 
         o, e = capsys.readouterr()
-        assert not e
+        # to be removed in 5.2
+        assert e.split(os.linesep)[0].startswith(
+            "WARNING: FastCGI support is deprecated")
         o = self.normalise_generated(o)
         d = self.compare_with_reference(server_type + '.conf', o)
         assert not d, 'Files are different:\n' + d
@@ -360,7 +362,9 @@ class TestWeb(object):
         self.cli.invoke(self.args, strict=True)
 
         o, e = capsys.readouterr()
-        assert not e
+        # to be removed in 5.2
+        assert e.split(os.linesep)[0].startswith(
+            "WARNING: FastCGI support is deprecated")
         o = self.normalise_generated(o)
         d = self.compare_with_reference(
             server_type[0] + '-withoptions.conf', o)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -362,7 +362,9 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.application_server.port":
         ["APPLICATION_SERVER_PORT", "4080", str, "Upstream application port"],
     "omero.web.application_server.max_requests":
-        ["APPLICATION_SERVER_MAX_REQUESTS", 400, int, None],
+        ["APPLICATION_SERVER_MAX_REQUESTS", 0, int,
+         ("The maximum number ofrequests a worker will process before "
+          "restarting.")],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",
          None,


### PR DESCRIPTION

This is the same as gh-4056 but rebased onto develop.

----

This PR deprecats FastCGI deployment and improves WSGI commands

**Deprecation:**
**Make sure ``bin/omero config set omero.web.application_server`` is empty.**
To test:
 - ``$ bin/omero web config nginx-development``
 - ``$ bin/omero web config nginx``
 - ``$ bin/omero web start ``
 - ``$ bin/omero web status ``

gives:``WARNING: FastCGI support is deprecated and will be removed in OMERO 5.2. Install gunicorn and update config.``

**Improvement:**
To test:
 - ``$ bin/omero web stop`` should show ``OMERO.web FASTCGI workers (PID ...) killed.`` assuming you continue.
 - set ``bin/omero config set omero.web.application_server wsgi-tcp``**
 - check if ``$ bin/omero web start -h`` shows new params

   ```
  --workers WORKERS                     The number of worker processes for handling requests.
  --worker-connections WORKER_CONNECTIONS
                                        The maximum number of simultaneous clients.
  --wsgi-args WSGI_ARGS                 Additional arguments. Check Gunicorn Documentation http://docs.gunicorn.org/en/latest/settings.htm
```
 - example: ``$ bin/omero web start --workers 10 --wsgi-args "--log-file $OMERO_PREFIX/var/log/gunicorn.log --reload"``
 - check if ``ps aux | grep gunicorn`` shows 11 processes run with custom parameters

   ```
user            19530   0.0  0.7  2496960  61056   ??  S     4:44pm   0:00.73 /usr/bin/python /usr/local/bin/gunicorn -D -p /OMERO/openmicroscopy/dist/var/django.pid --bind 127.0.0.1:4080 --workers 5 --worker-connections 1000 --threads 1 --max-requests 0 omeroweb.wsgi:application
   ```
 - ``$ bin/omero web stop`` should show ``OMERO.web WSGI workers (PID ...) killed.``

cc: @manics 


                