### PR TITLE
Custom Wsgi app name

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -14,6 +14,7 @@ from omero.cli import BaseControl, CLI
 import platform
 import sys
 import os
+import re
 from omero_ext.argparse import SUPPRESS
 
 HELP = "OMERO.web configuration/deployment tools"
@@ -292,8 +293,11 @@ class WebControl(BaseControl):
 
         try:
             d["FORCE_SCRIPT_NAME"] = settings.FORCE_SCRIPT_NAME.rstrip("/")
+            prefix = re.sub(r'\W+', '', d["FORCE_SCRIPT_NAME"])
+            d["UPSTREAM_NAME"] = "omeroweb_%s" % prefix
         except:
             d["FORCE_SCRIPT_NAME"] = "/"
+            d["UPSTREAM_NAME"] = "omeroweb_server"
 
         if server in ("apache", "apache-fcgi", "apache-wsgi"):
             try:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -226,7 +226,7 @@ class WebControl(BaseControl):
         if settings.APPLICATION_SERVER in settings.FASTCGI_TYPES:
             self.ctx.err(
                 "WARNING: FastCGI support is deprecated and will be removed"
-                " in OMERO 5.2. Install gunicorn and update config.")
+                " in OMERO 5.2. Install Gunicorn and update config.")
 
     def _assert_config_argtype(self, argtype, settings):
         mismatch = False

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
@@ -56,9 +56,9 @@
 
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup omeroweb_test
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
@@ -56,9 +56,9 @@
 
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  WSGIDaemonProcess omeroweb_server processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup omeroweb_server
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream omeroweb_server {
+    upstream omeroweb_test {
         server 0.0.0.0:12345 fail_timeout=0;
     }
     
@@ -50,7 +50,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://omeroweb_server;
+            proxy_pass http://omeroweb_test;
         }
 
         location /test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
@@ -1,4 +1,4 @@
-upstream omeroweb_server {
+upstream omeroweb_test {
     server 0.0.0.0:12345 fail_timeout=0;
 }
 
@@ -25,7 +25,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://omeroweb_server;
+        proxy_pass http://omeroweb_test;
     }
 
     location /test {

--- a/etc/templates/apache-wsgi.conf.template
+++ b/etc/templates/apache-wsgi.conf.template
@@ -56,9 +56,9 @@
 
   DocumentRoot %(OMEROWEBROOT)s
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
+  WSGIDaemonProcess %(UPSTREAM_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup %(UPSTREAM_NAME)s
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 

--- a/etc/templates/nginx-wsgi-development.conf.template
+++ b/etc/templates/nginx-wsgi-development.conf.template
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream omeroweb_server {
+    upstream %(UPSTREAM_NAME)s {
         server %(FASTCGI_EXTERNAL)s fail_timeout=0;
     }
     
@@ -50,7 +50,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://omeroweb_server;
+            proxy_pass http://%(UPSTREAM_NAME)s;
         }
 
         location %(FORCE_SCRIPT_NAME)s {

--- a/etc/templates/nginx-wsgi.conf.template
+++ b/etc/templates/nginx-wsgi.conf.template
@@ -1,4 +1,4 @@
-upstream omeroweb_server {
+upstream %(UPSTREAM_NAME)s {
     server %(FASTCGI_EXTERNAL)s fail_timeout=0;
 }
 
@@ -25,7 +25,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://omeroweb_server;
+        proxy_pass http://%(UPSTREAM_NAME)s;
     }
 
     location %(FORCE_SCRIPT_NAME)s {


### PR DESCRIPTION
This PR customize wsgi application name based on prefix.

To test:
 - **NGINX config:**
  - no prefix:
   - ``omero config set omero.web.application_server wsgi-tcp``
   - ``omero web config nginx-wsgi``

     ```
     upstream omeroweb_server {
     ...
     location @proxy_to_app {
         ...
         proxy_pass http://omeroweb_server;
     ```

  - custom prefix ``/myprefix-123``:
   - ``omero config set omero.web.prefix '/myprefix-123'``
   -  should change ``omeroweb_server`` to ``omeroweb_myprefix123``
   *NOTE: all non alphanumeric characters will be removed from the prefix*

 - **APACHE config:**
  - no prefix:
   - ``omero config set omero.web.application_server wsgi``
   - ``omero web config apache-wsgi``

     ```
     <VirtualHost _default_:80>
     ...
      WSGIDaemonProcess omeroweb_server ...
      WSGIProcessGroup omeroweb_server
     ```

  - custom prefix ``/myprefix-123``:
   - ``omero config set omero.web.prefix '/myprefix123'``
   -  should change ``omeroweb_server`` to ``omeroweb_myprefix123``
   *NOTE: all non alphanumeric characters will be removed from the prefix*

cc: @sbesson 