### PR TITLE
OMERO.matlab: add group support (rebased onto dev_5_1)

### DIFF
--- a/components/tools/OmeroM/src/annotations/getAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getAnnotations.m
@@ -1,4 +1,4 @@
-function annotations = getAnnotations(session, ids, type)
+function annotations = getAnnotations(session, ids, type, varargin)
 % GETANNOTATIONS Retrieve annotations from a given type from the OMERO server
 %
 %   annotations = getAnnotations(session, ids, type) returns all the 
@@ -7,6 +7,8 @@ function annotations = getAnnotations(session, ids, type)
 %   Examples:
 %
 %      annotations = getAnnotations(session, ids, type);
+%      annotations = getAnnotations(session, ids, type, 'group', groupId);
+%        returns annoations from the input group specfied by groupId.
 %
 % See also: GETANNOTATIONTYPES, GETDOUBLEANNOTATIONS, GETCOMMENTANNOTATIONS,
 % GETFILEANNOTATIONS, GETLONGANNOTATIONS, GETTAGANNOTATIONS,
@@ -34,17 +36,26 @@ annotationTypes = getAnnotationTypes();
 annotationNames = {annotationTypes.name};
 ip = inputParser;
 ip.addRequired('session');
-ip.addRequired('ids', @(x) isvector(x) || isempty(x));
+ip.addRequired('ids', @(x) isvector(x) || ~isempty(x));
 ip.addRequired('type', @(x) ischar(x) && ismember(x, annotationNames));
-ip.parse(session, ids, type);
+ip.addParameter('group', [], @(x) isscalar(x) && isnumeric(x));
+ip.parse(session, ids, type, varargin{:});
+
 annotationType = annotationTypes(strcmp(type, annotationNames));
 
 % Create list of annotations identifiers to load
 ids = toJavaList(ip.Results.ids, 'java.lang.Long');
 
 % Create container service to load annotations
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+else
+    context.put('omero.group', '-1');
+end
 service = session.getMetadataService();
-annotationList = service.loadAnnotation(ids);
+annotationList = service.loadAnnotation(ids, context);
 
 % Filter annotation list by annotation class
 for i = annotationList.size - 1 : -1 : 0

--- a/components/tools/OmeroM/src/annotations/getCommentAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getCommentAnnotations.m
@@ -1,4 +1,4 @@
-function cas = getCommentAnnotations(session, ids)
+function cas = getCommentAnnotations(session, ids, varargin)
 % GETCOMMENTANNOTATIONS Retrieve comment annotations from the OMERO server
 %
 %   cas = getCommentAnnotations(session, ids) returns all the comment
@@ -36,4 +36,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return comment annotations
-cas = getAnnotations(session, ids, 'comment');
+cas = getAnnotations(session, ids, 'comment', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getDoubleAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getDoubleAnnotations.m
@@ -1,4 +1,4 @@
-function das = getDoubleAnnotations(session, ids)
+function das = getDoubleAnnotations(session, ids, varargin)
 % GETDOUBLEANNOTATIONS Retrieve double annotations from the OMERO server
 %
 %   das = getDoubleAnnotations(session, ids) returns all the double
@@ -36,4 +36,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return double annotations
-das = getAnnotations(session, ids, 'double');
+das = getAnnotations(session, ids, 'double', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getFileAnnotationContent.m
+++ b/components/tools/OmeroM/src/annotations/getFileAnnotationContent.m
@@ -38,7 +38,11 @@ isLoadedFA = @(x) isa(x, 'omero.model.FileAnnotationI') && x.isLoaded();
 ip = inputParser;
 ip.addRequired('fileAnnotation', @(x) isLoadedFA(x) || isscalar(x));
 ip.addRequired('path', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(fileAnnotation, path);
+
+context = java.util.HashMap;
+context.put('omero.group', '-1');
 
 if ~isa(fileAnnotation, 'omero.model.FileAnnotationI'),
     % Load the file annotation from the server
@@ -53,7 +57,7 @@ store = session.createRawFileStore();
 
 % Set file annotation id
 file = fileAnnotation.getFile();
-store.setFileId(file.getId().getValue());
+store.setFileId(file.getId().getValue(), context);
 
 % Read data and cast into int8
 fid = fopen(path, 'w');

--- a/components/tools/OmeroM/src/annotations/getFileAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getFileAnnotations.m
@@ -1,4 +1,4 @@
-function fas = getFileAnnotations(session, ids)
+function fas = getFileAnnotations(session, ids, varargin)
 % GETFILEANNOTATIONS Retrieve file annotations from the OMERO server
 %
 %   fas = getFileAnnotations(session, ids) returns all the file
@@ -36,4 +36,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return file annotations
-fas = getAnnotations(session, ids, 'file');
+fas = getAnnotations(session, ids, 'file', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getLongAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getLongAnnotations.m
@@ -1,4 +1,4 @@
-function las = getLongAnnotations(session, ids)
+function las = getLongAnnotations(session, ids, varargin)
 % GETTAGANNOTATIONS Retrieve long annotations from the OMERO server
 %
 %   las = getLongAnnotations(session, ids) returns all the long annotations
@@ -35,4 +35,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return long annotations
-las = getAnnotations(session, ids, 'long');
+las = getAnnotations(session, ids, 'long', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getTagAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getTagAnnotations.m
@@ -1,4 +1,4 @@
-function tas = getTagAnnotations(session, ids)
+function tas = getTagAnnotations(session, ids, varargin)
 % GETTAGANNOTATIONS Retrieve tag annotations from the OMERO server
 %
 %   tas = getTagAnnotations(session, ids) returns all the tag annotations
@@ -35,4 +35,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return tag annotations
-tas = getAnnotations(session, ids, 'tag');
+tas = getAnnotations(session, ids, 'tag', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getTimestampAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getTimestampAnnotations.m
@@ -1,4 +1,4 @@
-function tas = getTimestampAnnotations(session, ids)
+function tas = getTimestampAnnotations(session, ids, varargin)
 % GETTIMESTAMPANNOTATIONS Retrieve timestamp annotations from the OMERO server
 %
 %   tas = getTimestampAnnotations(session, ids) returns all the timestamp 
@@ -36,4 +36,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return tag annotations
-tas = getAnnotations(session, ids, 'timestamp');
+tas = getAnnotations(session, ids, 'timestamp', varargin{:});

--- a/components/tools/OmeroM/src/annotations/getXmlAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getXmlAnnotations.m
@@ -1,4 +1,4 @@
-function xas = getXmlAnnotations(session, ids)
+function xas = getXmlAnnotations(session, ids, varargin)
 % GETXMLANNOTATIONS Retrieve XML annotations from the OMERO server
 %
 %   xas = getXmlAnnotations(session, ids) returns all the XML
@@ -36,4 +36,4 @@ ip.addRequired('ids', @(x) isvector(x) || isempty(x));
 ip.parse(ids);
 
 % Return XML annotations
-xas = getAnnotations(session, ids, 'xml');
+xas = getAnnotations(session, ids, 'xml', varargin{:});

--- a/components/tools/OmeroM/src/annotations/linkAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/linkAnnotation.m
@@ -48,7 +48,11 @@ else
 end
 
 % Create object annotation link
+context = java.util.HashMap;
+group = parent.getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
+
 link = objectType.annotationLink();
 link.setParent(parent)
 link.setChild(annotation);
-link = session.getUpdateService().saveAndReturnObject(link);
+link = session.getUpdateService().saveAndReturnObject(link, context);

--- a/components/tools/OmeroM/src/annotations/updateFileAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/updateFileAnnotation.m
@@ -57,6 +57,11 @@ context = java.util.HashMap;
 try
     group = fileAnnotation.getDetails().getGroup().getId().getValue();
     context.put('omero.group', num2str(group));
+    if isempty(ip.Results.group)
+         index = length(varargin);
+         varargin{index + 1} = 'group';
+         varargin{index + 2} = group;
+    end
 catch
 end
 % In case the FileAnnotation does not yet exist on the server:
@@ -82,4 +87,5 @@ if ~isempty(ip.Results.description) || ~isempty(ip.Results.namespace),
 end
 
 % Update the original file with the new content
-updateOriginalFile(session, fileAnnotation.getFile(), filePath, varargin);
+updateOriginalFile(...
+    session, fileAnnotation.getFile(), filePath, varargin{:});

--- a/components/tools/OmeroM/src/annotations/updateOriginalFile.m
+++ b/components/tools/OmeroM/src/annotations/updateOriginalFile.m
@@ -37,6 +37,7 @@ ip.addRequired('session');
 ip.addRequired('originalFile', @(x) isa(x, 'omero.model.OriginalFile'));
 ip.addRequired('filePath', @(x) exist(x, 'file') == 2);
 ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
+ip.KeepUnmatched = true;
 ip.parse(session, originalFile, filePath, varargin{:});
 
 % Read file absolute path and properties
@@ -75,7 +76,7 @@ hasher = checksumProviderFactory.getProvider(sha1);
 
 % Initialize the service to load the raw data
 rawFileStore = session.createRawFileStore();
-rawFileStore.setFileId(originalFile.getId().getValue());
+rawFileStore.setFileId(originalFile.getId().getValue(), context);
 
 %code for large files as well.
 lengthvec=262144;

--- a/components/tools/OmeroM/src/annotations/updateOriginalFile.m
+++ b/components/tools/OmeroM/src/annotations/updateOriginalFile.m
@@ -1,4 +1,5 @@
-function originalFile = updateOriginalFile(session, originalFile, filePath)
+function originalFile = updateOriginalFile(...
+    session, originalFile, filePath, varargin)
 % UPDATEORIGINALFILE Update a file on the OMERO server with new content
 %
 %    originalFile = updateOriginalFile(session, originalFile, filePath)
@@ -35,7 +36,8 @@ ip = inputParser;
 ip.addRequired('session');
 ip.addRequired('originalFile', @(x) isa(x, 'omero.model.OriginalFile'));
 ip.addRequired('filePath', @(x) exist(x, 'file') == 2);
-ip.parse(session, originalFile, filePath);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
+ip.parse(session, originalFile, filePath, varargin{:});
 
 % Read file absolute path and properties
 [~, f] = fileattrib(filePath);
@@ -49,8 +51,22 @@ originalFile.setPath(rstring(path));
 originalFile.setSize(rlong(fileLength));
 
 % Update the originalFile object
+context = java.util.HashMap;
+% This method is used to update OriginalFiles that may or may yet NOT exist
+% on the server, hence:
+% Check if the Annotation exists on the server
+try
+    group = fileAnnotation.getDetails().getGroup().getId().getValue();
+    context.put('omero.group', num2str(group));
+catch
+end
+% If exists only client side accept omero.group parameter
+if ~context.containsKey('omero.group') && ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
 updateService = session.getUpdateService();
-originalFile = updateService.saveAndReturnObject(originalFile);
+originalFile = updateService.saveAndReturnObject(originalFile, context);
 
 % Initialize provider to compute client-side checksum
 checksumProviderFactory = ome.util.checksum.ChecksumProviderFactoryImpl;
@@ -93,7 +109,7 @@ end
 rawFileStore.truncate(fileLength);
 
 % Save and close the service
-originalFile = rawFileStore.save();
+originalFile = rawFileStore.save(context);
 rawFileStore.close();
 
 % Compare checksums of file client-side verus server-side

--- a/components/tools/OmeroM/src/annotations/writeCommentAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeCommentAnnotation.m
@@ -10,6 +10,9 @@ function ca = writeCommentAnnotation(session, comment, varargin)
 %    ca = writeCommentAnnotation(session, comment, 'namespace', namespace)
 %    also sets the namespace of the comment annotation.
 %
+%    ca = writeCommentAnnotation(session, comment, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        ca = writeCommentAnnotation(session, comment)

--- a/components/tools/OmeroM/src/annotations/writeDoubleAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeDoubleAnnotation.m
@@ -10,6 +10,9 @@ function da = writeDoubleAnnotation(session, value, varargin)
 %    da = writeDoubleAnnotation(session, value, 'namespace', namespace)
 %    also sets the namespace of the annotation.
 %
+%    da = writeDoubleAnnotation(session, value, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        da = writeDoubleAnnotation(session, value)
@@ -44,6 +47,7 @@ ip.addRequired('session');
 ip.addRequired('value', @isscalar);
 ip.addParamValue('description', '', @ischar);
 ip.addParamValue('namespace', '', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, value, varargin{:});
 
 % Create double annotation
@@ -59,4 +63,9 @@ if ~isempty(ip.Results.namespace),
 end
 
 % Upload and return the annotation
-da = session.getUpdateService().saveAndReturnObject(da);
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+da = session.getUpdateService().saveAndReturnObject(da, context);

--- a/components/tools/OmeroM/src/annotations/writeLongAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeLongAnnotation.m
@@ -10,6 +10,9 @@ function la = writeLongAnnotation(session, value, varargin)
 %    la = writeLongAnnotation(session, value, 'namespace', namespace)
 %    also sets the namespace of the annotation.
 %
+%    la = writeLongAnnotation(session, value, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        la = writeLongAnnotation(session, value)
@@ -44,6 +47,7 @@ ip.addRequired('session');
 ip.addRequired('value', @isscalar);
 ip.addParamValue('description', '', @ischar);
 ip.addParamValue('namespace', '', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, value, varargin{:});
 
 % Create double annotation
@@ -59,4 +63,9 @@ if ~isempty(ip.Results.namespace),
 end
 
 % Upload and return the annotation
-la = session.getUpdateService().saveAndReturnObject(la);
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+la = session.getUpdateService().saveAndReturnObject(la, context);

--- a/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
@@ -12,6 +12,9 @@ function ma = writeMapAnnotation(session, keys, values, varargin)
 %    ma = writeMapAnnotation(session, keys, values, 'namespace', namespace)
 %    also sets the namespace of the map annotation.
 %
+%    ma = writeMapAnnotation(session, keys, values, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        map = writeMapAnnotation(session, 'key', 'value');
@@ -47,6 +50,7 @@ ip.addRequired('keys', @(x) ischar(x) || iscellstr(x));
 ip.addRequired('values', @(x) ischar(x) || iscellstr(x));
 ip.addParamValue('namespace', '', @ischar);
 ip.addParamValue('description', '', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, keys, values, varargin{:});
 
 % Convert keys and values into cell arrays
@@ -74,4 +78,9 @@ if ~isempty(ip.Results.namespace),
 end
 
 % Save the map annotation
-ma = session.getUpdateService().saveAndReturnObject(ma);
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+ma = session.getUpdateService().saveAndReturnObject(ma, context);

--- a/components/tools/OmeroM/src/annotations/writeTagAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeTagAnnotation.m
@@ -10,6 +10,9 @@ function ta = writeTagAnnotation(session, tag, varargin)
 %    ta = writeTagAnnotation(session, tag, 'namespace', namespace)
 %    also sets the namespace of the tag annotation.
 %
+%    ta = writeTagAnnotation(session, tag, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        ta = writeTagAnnotation(session, tag)

--- a/components/tools/OmeroM/src/annotations/writeTextAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeTextAnnotation.m
@@ -10,6 +10,9 @@ function ann = writeTextAnnotation(session, type, text, varargin)
 %    ann = writeTextAnnotation(session, type, text, 'namespace', namespace)
 %    also sets the namespace of the annotation.
 %
+%    ann = writeTextAnnotation(session, type, text, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        ann = writeTextAnnotation(session, type, text)
@@ -48,6 +51,7 @@ ip.addRequired('type', @(x) ischar(x) && ismember(x, annotationNames));
 ip.addRequired('text', @ischar);
 ip.addParamValue('description', '', @ischar);
 ip.addParamValue('namespace', '', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, type, text, varargin{:});
 
 % Create text annotation of input type
@@ -63,4 +67,9 @@ if ~isempty(ip.Results.namespace),
 end
 
 % Upload and return the annotation
-ann = session.getUpdateService().saveAndReturnObject(ann);
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+ann = session.getUpdateService().saveAndReturnObject(ann, context);

--- a/components/tools/OmeroM/src/annotations/writeTimestampAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeTimestampAnnotation.m
@@ -10,6 +10,9 @@ function ta = writeTimestampAnnotation(session, value, varargin)
 %    ta = writeTimestampAnnotation(session, value, 'namespace', namespace)
 %    also sets the namespace of the annotation.
 %
+%    ta = writeTimestampAnnotation(session, value, 'group', groupid)
+%    sets the group.
+%
 %    Examples:
 %
 %        ta = writeTimestampAnnotation(session, value)
@@ -45,6 +48,7 @@ ip.addRequired('session');
 ip.addRequired('value', @isscalar);
 ip.addParamValue('description', '', @ischar);
 ip.addParamValue('namespace', '', @ischar);
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, value, varargin{:});
 
 % Create double annotation
@@ -62,4 +66,9 @@ if ~isempty(ip.Results.namespace),
 end
 
 % Upload and return the annotation
-ta = session.getUpdateService().saveAndReturnObject(ta);
+context = java.util.HashMap;
+if ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+ta = session.getUpdateService().saveAndReturnObject(ta, context);

--- a/components/tools/OmeroM/src/annotations/writeXmlAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeXmlAnnotation.m
@@ -10,6 +10,9 @@ function xa = writeXmlAnnotation(session, xml, varargin)
 %    xa = writeXmlAnnotation(session, xml, 'namespace', namespace) also
 %    sets the namespace of the XML annotation.
 %
+%    xa = writeXmlAnnotation(session, xml, 'group', groupid) also
+%    sets the group.
+%
 %    Examples:
 %
 %        xa = writeXmlAnnotation(session, xml)

--- a/components/tools/OmeroM/src/image/exportImageAsOMETIFF.m
+++ b/components/tools/OmeroM/src/image/exportImageAsOMETIFF.m
@@ -51,8 +51,10 @@ end
 store = session.createExporter;
 
 % Set the image identifier
+context = java.util.HashMap;
+context.put('omero.group', '-1');
 store.addImage(imageID);
-size = store.generateTiff();
+size = store.generateTiff(context);
 
 % Open image file in write access
 fid = fopen(imagePath, 'w');

--- a/components/tools/OmeroM/src/image/getPlaneInfo.m
+++ b/components/tools/OmeroM/src/image/getPlaneInfo.m
@@ -93,5 +93,8 @@ if (ip.Results.c >= 0)
 end
 
 % Retrieve plane info
-planeInfo = session.getQueryService().findAllByQuery(query.toString, params);
+context = java.util.HashMap;
+context.put('omero.group', '-1');
+planeInfo = session.getQueryService().findAllByQuery(...
+    query.toString, params, context);
 planeInfo = toMatlabList(planeInfo);

--- a/components/tools/OmeroM/src/image/getRawPixelsStore.m
+++ b/components/tools/OmeroM/src/image/getRawPixelsStore.m
@@ -47,5 +47,8 @@ end
 pixels = image.getPrimaryPixels();
 
 % Create container service to load raw pixels
+context = java.util.HashMap;
+group = image.getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 store = session.createRawPixelsStore();
-store.setPixelsId(pixels.getId().getValue(), false);
+store.setPixelsId(pixels.getId().getValue(), false, context);

--- a/components/tools/OmeroM/src/image/getThumbnail.m
+++ b/components/tools/OmeroM/src/image/getThumbnail.m
@@ -63,11 +63,14 @@ if isnumeric(image),
 end
 
 % Create store to retrieve thumbnails and set pixels Id
+context = java.util.HashMap;
+group = image.getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 store = session.createThumbnailStore();
-store.setPixelsId(image.getPrimaryPixels().getId().getValue());
+store.setPixelsId(image.getPrimaryPixels().getId().getValue(), context);
 
 % Retrieve cache thumbnail
-byteArray = store.getThumbnail(width, height);
+byteArray = store.getThumbnail(width, height, context);
 store.close();
 
 % Convert byteArray into Matlab image

--- a/components/tools/OmeroM/src/image/getThumbnailByLongestSide.m
+++ b/components/tools/OmeroM/src/image/getThumbnailByLongestSide.m
@@ -61,11 +61,14 @@ if isnumeric(image),
 end
 
 % Create store to retrieve thumbnails and set pixels Id
+context = java.util.HashMap;
+group = image.getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 store = session.createThumbnailStore();
-store.setPixelsId(image.getPrimaryPixels().getId().getValue());
+store.setPixelsId(image.getPrimaryPixels().getId().getValue(), context);
 
 % Retrieve thumbnail set
-byteArray = store.getThumbnailByLongestSide(size);
+byteArray = store.getThumbnailByLongestSide(size, context);
 store.close();
 
 % Convert byteArray into Matlab image

--- a/components/tools/OmeroM/src/image/getThumbnailByLongestSideSet.m
+++ b/components/tools/OmeroM/src/image/getThumbnailByLongestSideSet.m
@@ -69,10 +69,13 @@ pixelsIds = arrayfun(@(x) x.getPrimaryPixels().getId().getValue(), images);
 nPixels = numel(pixelsIds);
 
 % Create container service to load the thumbnails
+context = java.util.HashMap;
+group = images(1).getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 store = session.createThumbnailStore();
 pixelsRange = 1 : min(nPixels, MAX_RETRIEVAL);
 thumbnailMap = store.getThumbnailByLongestSideSet(size,...
-    toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'));
+    toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'), context);
 store.close();
 
 % Load remaining pixels by series of MAX_RETRIEVAL thumbnails
@@ -82,7 +85,7 @@ if nPixels > MAX_RETRIEVAL
         pixelsRange = i * MAX_RETRIEVAL + 1 : min(nPixels, (i + 1) * MAX_RETRIEVAL);
         store = session.createThumbnailStore();
         thumbnailMap.putAll(store.getThumbnailByLongestSideSet(size,...
-            toJavaList(pixelsIds(pixelsRange), 'java.lang.Long')));
+            toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'), context));
         store.close();
     end
 end

--- a/components/tools/OmeroM/src/image/getThumbnailSet.m
+++ b/components/tools/OmeroM/src/image/getThumbnailSet.m
@@ -71,10 +71,13 @@ pixelsIds = arrayfun(@(x) x.getPrimaryPixels().getId().getValue(), images);
 nPixels = numel(pixelsIds);
 
 % Create container service to load the thumbnails
+context = java.util.HashMap;
+group = images(1).getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 store = session.createThumbnailStore();
 pixelsRange = 1 : min(nPixels, MAX_RETRIEVAL);
 thumbnailMap = store.getThumbnailSet(width, height,...
-    toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'));
+    toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'), context);
 store.close();
 
 % Load remaining pixels by series of MAX_RETRIEVAL thumbnails
@@ -84,7 +87,7 @@ if nPixels > MAX_RETRIEVAL
         pixelsRange = i * MAX_RETRIEVAL + 1 : min(nPixels, (i + 1) * MAX_RETRIEVAL);
         store = session.createThumbnailStore();
         thumbnailMap.putAll(store.getThumbnailSet(width, height,...
-            toJavaList(pixelsIds(pixelsRange), 'java.lang.Long')));
+            toJavaList(pixelsIds(pixelsRange), 'java.lang.Long'), context));
         store.close();
     end
 end

--- a/components/tools/OmeroM/src/image/loadChannels.m
+++ b/components/tools/OmeroM/src/image/loadChannels.m
@@ -46,6 +46,10 @@ end
 pixels = image.getPrimaryPixels();
 
 % Retrieve channels
+context = java.util.HashMap;
+group = image.getDetails().getGroup().getId().getValue();
+context.put('omero.group', num2str(group));
 pixelsService = session.getPixelsService();
-pixels = pixelsService.retrievePixDescription(pixels.getId.getValue);
+pixels = pixelsService.retrievePixDescription(...
+    pixels.getId.getValue, context);
 channels = toMatlabList(pixels.copyChannels);

--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -73,6 +73,6 @@ parameters = omero.sys.ParametersI();
 if ip.Results.loaded, parameters.leaves(); end
 
 % Delegate unmatched arguments check to getObjects function
-unmatchedArgs =[fieldnames(ip.Unmatched)' struct2cell(ip.Unmatched)'];
+unmatchedArgs =[fieldnames(ip.Unmatched)'; struct2cell(ip.Unmatched)'];
 datasets = getObjects(session, 'dataset', ip.Results.ids, parameters,...
     unmatchedArgs{:});

--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -18,17 +18,28 @@ function datasets = getDatasets(session, varargin)
 %   datasets = getDatasets(session, 'owner', owner) returns all the
 %   datasets owned by the input owner in the context of the session group.
 %
+%   datasets = getDatasets(session, 'group', groupId) returns all the
+%   datasets owned by the session owner in the context of the input group.
+%   A value of -1 for groupId means datasets are returned for all groups.
+%
 %   datasets = getDatasets(session, ids, 'owner', owner) returns all the
 %   datasets identified by the input ids owned by the input user in the
 %   context of the session group.
+%
+%   datasets = getDatasets(session, ids, 'group', groupId) returns all the
+%   datasets identified by the input ids owned by the session owner in the
+%   context of the input group. A value of -1 for groupId means datasets
+%   are returned for all groups.
 %
 %   Examples:
 %
 %      datasets = getDatasets(session);
 %      datasets = getDatasets(session, 'owner', ownerId);
+%      datasets = getDatasets(session, 'group', -1);
 %      datasets = getDatasets(session, ids);
 %      datasets = getDatasets(session, ids, false);
-%      datasets = getDatasets(session, ids, false, 'owner', ownerId);
+%      datasets = getDatasets(session, ids, 'owner', ownerId);
+%      datasets = getDatasets(session, ids, 'group', -1);
 %
 % See also: GETOBJECTS, GETPROJECTS, GETIMAGES
 

--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -5,12 +5,10 @@ function datasets = getDatasets(session, varargin)
 %   session user in the context of the session group.
 %
 %   datasets = getDatasets(session, ids) returns all the datasets
-%   identified by the input ids across all groups.
+%   identified by the input ids independently of the owner across all groups.
 %
-%   datasets = getDatasets(session, ids, loaded) returns all the datasets
-%   identified by the input ids in the context of the session group. If
-%   loaded is true, the images attached to the datasets are also loaded.
-%   Default: false.
+%   datasets = getDatasets(..., loaded) also loads the images attached to the
+%   datasets if loaded is true. Default: false.
 %
 %   datasets = getDatasets(..., 'owner', owner) specifies the owner of the
 %   datasets. A value of -1 implies datasets are returned independently of
@@ -23,10 +21,11 @@ function datasets = getDatasets(session, varargin)
 %   Examples:
 %
 %      datasets = getDatasets(session);
+%      datasets = getDatasets(session, true);
 %      datasets = getDatasets(session, 'owner', ownerId);
 %      datasets = getDatasets(session, 'group', groupId);
 %      datasets = getDatasets(session, ids);
-%      datasets = getDatasets(session, ids, false);
+%      datasets = getDatasets(session, ids, true);
 %      datasets = getDatasets(session, ids, 'owner', ownerId);
 %      datasets = getDatasets(session, ids, 'group', groupId);
 %

--- a/components/tools/OmeroM/src/io/getDatasets.m
+++ b/components/tools/OmeroM/src/io/getDatasets.m
@@ -2,44 +2,33 @@ function datasets = getDatasets(session, varargin)
 % GETDATASETS Retrieve dataset objects from the OMERO server
 %
 %   datasets = getDatasets(session) returns all the datasets owned by the
-%   session user in the context of the session group. By default,
-%   getDatasets loads all the images attached to the datasets. This may
-%   have consequences in terms of loading time depending on the number of
-%   images in the datasets.
+%   session user in the context of the session group.
 %
 %   datasets = getDatasets(session, ids) returns all the datasets
-%   identified by the input ids in the context of the session group.
+%   identified by the input ids across all groups.
 %
 %   datasets = getDatasets(session, ids, loaded) returns all the datasets
 %   identified by the input ids in the context of the session group. If
-%   loaded is False, the images attached to the datasets are not loaded.
+%   loaded is true, the images attached to the datasets are also loaded.
 %   Default: false.
 %
-%   datasets = getDatasets(session, 'owner', owner) returns all the
-%   datasets owned by the input owner in the context of the session group.
+%   datasets = getDatasets(..., 'owner', owner) specifies the owner of the
+%   datasets. A value of -1 implies datasets are returned independently of
+%   the owner.
 %
-%   datasets = getDatasets(session, 'group', groupId) returns all the
-%   datasets owned by the session owner in the context of the input group.
-%   A value of -1 for groupId means datasets are returned for all groups.
-%
-%   datasets = getDatasets(session, ids, 'owner', owner) returns all the
-%   datasets identified by the input ids owned by the input user in the
-%   context of the session group.
-%
-%   datasets = getDatasets(session, ids, 'group', groupId) returns all the
-%   datasets identified by the input ids owned by the session owner in the
-%   context of the input group. A value of -1 for groupId means datasets
-%   are returned for all groups.
+%   datasets = getDatasets(..., 'group', groupId) specifies the group
+%   context for the datasets. A value of -1 means datasets are returned
+%   across groups.
 %
 %   Examples:
 %
 %      datasets = getDatasets(session);
 %      datasets = getDatasets(session, 'owner', ownerId);
-%      datasets = getDatasets(session, 'group', -1);
+%      datasets = getDatasets(session, 'group', groupId);
 %      datasets = getDatasets(session, ids);
 %      datasets = getDatasets(session, ids, false);
 %      datasets = getDatasets(session, ids, 'owner', ownerId);
-%      datasets = getDatasets(session, ids, 'group', -1);
+%      datasets = getDatasets(session, ids, 'group', groupId);
 %
 % See also: GETOBJECTS, GETPROJECTS, GETIMAGES
 

--- a/components/tools/OmeroM/src/io/getImages.m
+++ b/components/tools/OmeroM/src/io/getImages.m
@@ -10,9 +10,18 @@ function images = getImages(session, varargin)
 %   images = getImages(session, 'owner', ownerId) returns all the images
 %   owned by the input owner in the context of the session group.
 %
+%   images = getImages(session, 'group', ownerId) returns all the images
+%   owned by the session owner in the context of the input group. A value
+%   of -1 for groupId means images are returned for all groups.
+%
 %   images = getImages(session, ids, 'owner', ownerId) returns all the
 %   images identified by the input ids and owned by the input owner in the
 %   context of the session group.
+%
+%   images = getImages(session, ids, 'group', groupId) returns all the
+%   images identified by the input ids owned by the session owner in the
+%   context of the input group. A value of -1 for groupId means images
+%   are returned for all groups.
 %
 %   images = getImages(session, 'project', projectIds) returns all the
 %   images contained in the projects identified by the input ids in the
@@ -21,13 +30,16 @@ function images = getImages(session, varargin)
 %   images = getImages(session, 'dataset', datasetIds) returns all the
 %   images contained in the datasets identified by the input ids in the
 %   context of the session group.
+
 %
 %   Examples:
 %
 %      images = getImages(session);
 %      images = getImages(session, 'owner', ownerId);
+%      images = getImages(session, 'group', -1);
 %      images = getImages(session, ids);
 %      images = getImages(session, ids, 'owner', ownerId);
+%      images = getImages(session, ids, 'group', -1);
 %      images = getImages(session, 'project', projectIds);
 %      images = getImages(session, 'dataset', projectIds);
 %

--- a/components/tools/OmeroM/src/io/getImages.m
+++ b/components/tools/OmeroM/src/io/getImages.m
@@ -16,13 +16,10 @@ function images = getImages(session, varargin)
 %   across groups.
 %
 %   images = getImages(session, 'project', projectIds) returns all the
-%   images contained in the projects identified by the input ids in the
-%   context of the session group.
+%   images contained in the projects identified by the input ids.
 %
 %   images = getImages(session, 'dataset', datasetIds) returns all the
-%   images contained in the datasets identified by the input ids in the
-%   context of the session group.
-
+%   images contained in the datasets identified by the input ids.
 %
 %   Examples:
 %

--- a/components/tools/OmeroM/src/io/getImages.m
+++ b/components/tools/OmeroM/src/io/getImages.m
@@ -7,21 +7,13 @@ function images = getImages(session, varargin)
 %   images = getImages(session, ids) returns all the images identified by
 %   the input ids in the context of the session group.
 %
-%   images = getImages(session, 'owner', ownerId) returns all the images
-%   owned by the input owner in the context of the session group.
+%   images = getImages(..., 'owner', owner) specifies the owner of the
+%   images. A value of -1 implies images are returned independently of
+%   the owner.
 %
-%   images = getImages(session, 'group', ownerId) returns all the images
-%   owned by the session owner in the context of the input group. A value
-%   of -1 for groupId means images are returned for all groups.
-%
-%   images = getImages(session, ids, 'owner', ownerId) returns all the
-%   images identified by the input ids and owned by the input owner in the
-%   context of the session group.
-%
-%   images = getImages(session, ids, 'group', groupId) returns all the
-%   images identified by the input ids owned by the session owner in the
-%   context of the input group. A value of -1 for groupId means images
-%   are returned for all groups.
+%   images = getImages(..., 'group', groupId) specifies the group
+%   context for the images. A value of -1 means images are returned
+%   across groups.
 %
 %   images = getImages(session, 'project', projectIds) returns all the
 %   images contained in the projects identified by the input ids in the
@@ -36,16 +28,16 @@ function images = getImages(session, varargin)
 %
 %      images = getImages(session);
 %      images = getImages(session, 'owner', ownerId);
-%      images = getImages(session, 'group', -1);
+%      images = getImages(session, 'group', groupId)
 %      images = getImages(session, ids);
 %      images = getImages(session, ids, 'owner', ownerId);
-%      images = getImages(session, ids, 'group', -1);
+%      images = getImages(session, ids, 'group', groupId);
 %      images = getImages(session, 'project', projectIds);
 %      images = getImages(session, 'dataset', projectIds);
 %
 % See also: GETOBJECTS, GETPROJECTS, GETDATASETS, GETPLATES
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -74,26 +66,31 @@ ip.parse(session, varargin{:});
 
 if isempty(ip.Results.project) && isempty(ip.Results.dataset)
     % Check optional input parameters
+    parameters = omero.sys.ParametersI();
+    defaultContext = java.util.HashMap;
     if isempty(ip.Results.ids)
         % If no input id, return the objects owned by the session user by default
         defaultOwner = session.getAdminService().getEventContext().userId;
+        parameters.exp(rlong(defaultOwner));
     else
         % If ids are specified, return the objects owned by any user by default
-        defaultOwner = -1;
+        parameters.exp(rlong(-1));
+        defaultContext.put('omero.group', '-1');
     end
-    ip.addParamValue('owner', defaultOwner, @(x) isscalar(x) && isnumeric(x));
-    ip.addParamValue('map', java.util.HashMap, @(x) isa(x, 'java.util.HashMap'));
+    ip.addParamValue('owner', [], @(x) isscalar(x) && isnumeric(x));
+    ip.addParamValue('context', defaultContext, @(x) isa(x, 'java.util.HashMap'));
     ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
     ip.KeepUnmatched = false;
     ip.parse(session, varargin{:});
 
     % Add the owner user id to the loading parameters
-    parameters = omero.sys.ParametersI();
-    parameters.exp(rlong(ip.Results.owner));
-    
-    m = ip.Results.map;
+    if ~isempty(ip.Results.owner)
+        parameters.exp(rlong(ip.Results.owner));
+    end
+
+    context = ip.Results.context;
     if ~isempty(ip.Results.group)
-        m.put('omero.group', java.lang.String(num2str(ip.Results.group)));
+        context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
     end
 
     % Create container service to load objects
@@ -101,11 +98,11 @@ if isempty(ip.Results.project) && isempty(ip.Results.dataset)
     
     if isempty(ip.Results.ids),
         % Load all images belonging to current session user
-        imageList = proxy.getUserImages(parameters, m);
+        imageList = proxy.getUserImages(parameters, context);
     else
         % Load all images specified by input ids
         ids = toJavaList(ip.Results.ids, 'java.lang.Long');
-        imageList = proxy.getImages('omero.model.Image', ids, parameters, m);
+        imageList = proxy.getImages('omero.model.Image', ids, parameters, context);
     end
     
     % Convert java.util.ArrayList into Matlab arrays

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -18,14 +18,24 @@ function [objects, orphans] = getObjects(session, type, ids, varargin)
 %   the objects of the specified type, identified by the input ids, owned
 %   by the input owner in the context of the session group.
 %
+%   objects = getObjects(session, type, ids, 'group', groupId) returns all
+%   the objects of the specified type, identified by the input ids, owned
+%   by the input owner in the context of the input group. A value of -1 for
+%   groupId means objects are returned for all groups.
+%
 %   [objects, orphans] = getObjects(session, type, [],...) returns all the
 %   orphans in addition to all the queried objects.
 %
 %   Examples:
 %
+%      % Retrieve objects by type and ids
 %      objects = getObjects(session, type, ids);
+%      % Retrieve objects with a custom set of parameters
 %      objects = getObjects(session, type, ids, parameters);
+%      % Retrieve objects owned by a given user
 %      objects = getObjects(session, type, ids, 'owner', ownerId);
+%      % Retrieve objects owned by the session user across all groups
+%      objects = getObjects(session, type, ids, 'group', -1);
 %      objects = getObjects(session, type, ids, parameters, 'owner', ownerId);
 %      [objects, orphans] = getObjects(session, type, [])
 %
@@ -75,6 +85,7 @@ else
     defaultOwner = -1;
 end
 ip.addParamValue('owner', defaultOwner, @(x) isscalar(x) && isnumeric(x));
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(varargin{:});
 
 % Use getImages function if retrieving images
@@ -92,7 +103,13 @@ ids = toJavaList(ids, 'java.lang.Long');
 
 % Create container service to load objects
 proxy = session.getContainerService();
-objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters);
+if ~isempty(ip.Results.group)
+    m=java.util.HashMap;
+    m.put('omero.group', java.lang.String(num2str(ip.Results.group)));
+    objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters, m);
+else
+    objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters);
+end
 
 % If orphans are loaded split the lists into two: objects and orphans
 orphanList = java.util.ArrayList();

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -5,7 +5,7 @@ function [objects, orphans] = getObjects(session, type, ids, varargin)
 %   specified type, identified by the input ids.
 %   If ids is an empty array, only the objects belonging to the session
 %   owner in the context of the current group are returned. If ids is non
-%   empty, all objects are returned independently of the owner.
+%   empty, all objects are returned independently of the owner or the group.
 %
 %   objects = getObjects(session, type, ids, parameters) returns all the
 %   objects of the specified type, identified by the input ids, owned by

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -74,7 +74,8 @@ assert(~strcmp(objectType.class, 'omero.model.PlateAcquisition'),...
 defaultParameters = omero.sys.ParametersI();
 defaultContext = java.util.HashMap;
 if isempty(ids),
-    % If no input id, return the objects owned by the session user in the    % current context
+    % If no input id, return the objects owned by the session user in the
+    % current context
     defaultOwner = session.getAdminService().getEventContext().userId;
 else
     % If ids are specified, return the objects owned by any user across

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -85,6 +85,8 @@ else
     defaultOwner = -1;
 end
 ip.addParamValue('owner', defaultOwner, @(x) isscalar(x) && isnumeric(x));
+ip.addParamValue('map', java.util.HashMap,...
+    @(x) isa(x, 'java.util.HashMap'));
 ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(varargin{:});
 
@@ -103,13 +105,11 @@ ids = toJavaList(ids, 'java.lang.Long');
 
 % Create container service to load objects
 proxy = session.getContainerService();
+m = ip.Results.map;
 if ~isempty(ip.Results.group)
-    m=java.util.HashMap;
     m.put('omero.group', java.lang.String(num2str(ip.Results.group)));
-    objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters, m);
-else
-    objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters);
 end
+objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters, m);
 
 % If orphans are loaded split the lists into two: objects and orphans
 orphanList = java.util.ArrayList();

--- a/components/tools/OmeroM/src/io/getPlates.m
+++ b/components/tools/OmeroM/src/io/getPlates.m
@@ -7,34 +7,26 @@ function plates = getPlates(session, varargin)
 %   plates = getPlates(session, ids) returns all the plates identified by
 %   the input ids in the context of the session group.
 %
-%   plates = getPlates(session, 'owner', ownerId) returns all the plates
-%   owned by the input owner in the context of the session group.
+%   plates = getPlates(..., 'owner', owner) specifies the owner of the
+%   plates. A value of -1 implies plates are returned independently of
+%   the owner.
 %
-%   plates = getPlates(session, 'group', groupId) returns all the plates
-%   owned by the session owner in the context of the input group. A value
-%   of -1 for groupId means plates are returned for all groups.
-%
-%   plates = getPlates(session, ids, 'owner', ownerId) returns all the
-%   plates identified by the input ids owned by the input owner in the
-%   context of the session group.
-%
-%   plates = getPlates(session, ids, 'group', groupId) returns all the
-%   platest identified by the input ids  owned by the session owner in the
-%   context of the input group. A value of -1 for groupId means plates
-%   are returned for all groups.
+%   plates = getPlates(..., 'group', groupId) specifies the group
+%   context for the plates. A value of -1 means plates are returned
+%   across groups.
 %
 %   Examples:
 %
 %      plates = getPlates(session);
 %      plates = getPlates(session, 'owner', ownerId);
-%      plates = getPlates(session, 'group', -1);
+%      plates = getPlates(session, 'group', groupId);
 %      plates = getPlates(session, ids);
 %      plates = getPlates(session, ids, 'owner', ownerId);
-%      plates = getPlates(session, ids, 'group', -1);
+%      plates = getPlates(session, ids, 'group', groupId);
 %
 % See also: GETOBJECTS, GETSCREENS, GETIMAGES
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroM/src/io/getPlates.m
+++ b/components/tools/OmeroM/src/io/getPlates.m
@@ -5,7 +5,7 @@ function plates = getPlates(session, varargin)
 %   session user in the context of the session group.
 %
 %   plates = getPlates(session, ids) returns all the plates identified by
-%   the input ids in the context of the session group.
+%   the input ids independently of the owner across groups.
 %
 %   plates = getPlates(..., 'owner', owner) specifies the owner of the
 %   plates. A value of -1 implies plates are returned independently of

--- a/components/tools/OmeroM/src/io/getPlates.m
+++ b/components/tools/OmeroM/src/io/getPlates.m
@@ -58,5 +58,5 @@ ip.KeepUnmatched = true;
 ip.parse(varargin{:});
 
 % Delegate unmatched arguments check to getObjects function
-unmatchedArgs =[fieldnames(ip.Unmatched)' struct2cell(ip.Unmatched)'];
+unmatchedArgs =[fieldnames(ip.Unmatched)'; struct2cell(ip.Unmatched)'];
 plates = getObjects(session, 'plate', ip.Results.ids, unmatchedArgs{:});

--- a/components/tools/OmeroM/src/io/getPlates.m
+++ b/components/tools/OmeroM/src/io/getPlates.m
@@ -10,16 +10,27 @@ function plates = getPlates(session, varargin)
 %   plates = getPlates(session, 'owner', ownerId) returns all the plates
 %   owned by the input owner in the context of the session group.
 %
+%   plates = getPlates(session, 'group', groupId) returns all the plates
+%   owned by the session owner in the context of the input group. A value
+%   of -1 for groupId means plates are returned for all groups.
+%
 %   plates = getPlates(session, ids, 'owner', ownerId) returns all the
 %   plates identified by the input ids owned by the input owner in the
 %   context of the session group.
+%
+%   plates = getPlates(session, ids, 'group', groupId) returns all the
+%   platest identified by the input ids  owned by the session owner in the
+%   context of the input group. A value of -1 for groupId means plates
+%   are returned for all groups.
 %
 %   Examples:
 %
 %      plates = getPlates(session);
 %      plates = getPlates(session, 'owner', ownerId);
+%      plates = getPlates(session, 'group', -1);
 %      plates = getPlates(session, ids);
 %      plates = getPlates(session, ids, 'owner', ownerId);
+%      plates = getPlates(session, ids, 'group', -1);
 %
 % See also: GETOBJECTS, GETSCREENS, GETIMAGES
 

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -2,8 +2,7 @@ function [projects, datasets] = getProjects(session, varargin)
 % GETPROJECTS Retrieve project objects from the server
 %
 %   projects = getProjects(session) returns all the projects owned by the
-%   session user in the context of the session group. By default,
-%   getProjects loads the entire projects/datasets/images graph. This may
+%   session user in the context of the session group. This may
 %   have consequences in terms of loading time depending on the images
 %   contained in the projects' datasets.
 %
@@ -15,21 +14,13 @@ function [projects, datasets] = getProjects(session, varargin)
 %   loaded is false, the images attached to the  datasets are not loaded.
 %   Default: false.
 %
-%   projects = getProjects(session, 'owner', ownerId) returns all the
-%   projects owned by the input owner in the context of the session group.
+%   projects = getProjects(..., 'owner', owner) specifies the owner of the
+%   projects. A value of -1 implies projects are returned independently of
+%   the owner.
 %
-%   projects = getProjects(session, 'group', groupId) returns all the
-%   projects owned by the session owner in the context of the input group.
-%   A value of -1 for groupId means projects are returned for all groups.
-%
-%   projects = getProjects(session, ids, 'owner', ownerId) returns all the
-%   projects identified by the input ids owned by the input owner in the
-%   context of the session group.
-%
-%   projects = getProjects(session, ids, 'group', groupId) returns all the
-%   projects identified by the input ids owned by the session owner in the
-%   context of the input group. A value of -1 for groupId means projects
-%   are returned for all groups.
+%   projects = getProjects(..., 'group', groupId) specifies the group
+%   context for the projects. A value of -1 means projects are returned
+%   across groups.
 %
 %   [projects, datasets] = getProjects(session, [],...) returns all the
 %   orphaned datasets in addition to all the projects.
@@ -41,10 +32,10 @@ function [projects, datasets] = getProjects(session, varargin)
 %      projects = getProjects(session, 'group', groupId);
 %      projects = getProjects(session, ids);
 %      projects = getProjects(session, ids, 'owner', ownerId);
-%      projects = getProjects(session, ids, 'group', -1);
+%      projects = getProjects(session, ids, 'group', groupId);
 %      projects = getProjects(session, ids, true);
 %      projects = getProjects(session, ids, true, 'owner', ownerId);
-%      projects = getProjects(session, ids, true, 'group', -1);
+%      projects = getProjects(session, ids, true, 'group', groupId);
 %      [projects, datasets] = getProjects(session, [], false);
 %
 %

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -18,9 +18,18 @@ function [projects, datasets] = getProjects(session, varargin)
 %   projects = getProjects(session, 'owner', ownerId) returns all the
 %   projects owned by the input owner in the context of the session group.
 %
+%   projects = getProjects(session, 'group', groupId) returns all the
+%   projects owned by the session owner in the context of the input group.
+%   A value of -1 for groupId means projects are returned for all groups.
+%
 %   projects = getProjects(session, ids, 'owner', ownerId) returns all the
 %   projects identified by the input ids owned by the input owner in the
 %   context of the session group.
+%
+%   projects = getProjects(session, ids, 'group', groupId) returns all the
+%   projects identified by the input ids owned by the session owner in the
+%   context of the input group. A value of -1 for groupId means projects
+%   are returned for all groups.
 %
 %   [projects, datasets] = getProjects(session, [],...) returns all the
 %   orphaned datasets in addition to all the projects.
@@ -29,10 +38,13 @@ function [projects, datasets] = getProjects(session, varargin)
 %
 %      projects = getProjects(session);
 %      projects = getProjects(session, 'owner', ownerId);
+%      projects = getProjects(session, 'group', groupId);
 %      projects = getProjects(session, ids);
 %      projects = getProjects(session, ids, 'owner', ownerId);
-%      projects = getProjects(session, ids, false);
-%      projects = getProjects(session, ids, false, 'owner', ownerId);
+%      projects = getProjects(session, ids, 'group', -1);
+%      projects = getProjects(session, ids, true);
+%      projects = getProjects(session, ids, true, 'owner', ownerId);
+%      projects = getProjects(session, ids, true, 'group', -1);
 %      [projects, datasets] = getProjects(session, [], false);
 %
 %

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -82,6 +82,6 @@ if ip.Results.loaded, parameters.leaves(); end
 if nargout > 1, parameters.orphan(); end
 
 % Delegate unmatched arguments check to getObjects function
-unmatchedArgs =[fieldnames(ip.Unmatched)' struct2cell(ip.Unmatched)'];
+unmatchedArgs =[fieldnames(ip.Unmatched)'; struct2cell(ip.Unmatched)'];
 [projects, datasets] = getObjects(session, 'project', ip.Results.ids,...
     parameters, unmatchedArgs{:});

--- a/components/tools/OmeroM/src/io/getProjects.m
+++ b/components/tools/OmeroM/src/io/getProjects.m
@@ -2,17 +2,13 @@ function [projects, datasets] = getProjects(session, varargin)
 % GETPROJECTS Retrieve project objects from the server
 %
 %   projects = getProjects(session) returns all the projects owned by the
-%   session user in the context of the session group. This may
-%   have consequences in terms of loading time depending on the images
-%   contained in the projects' datasets.
+%   session user in the context of the session group.
 %
 %   projects = getProjects(session, ids) returns all the projects
-%   identified by the input ids in the context of the session group.
+%   identified by the input ids independently of the owner across groups.
 %
-%   projects = getProjects(session, ids, loaded) returns all the projects
-%   identified by the input ids in the context of the session group. If
-%   loaded is false, the images attached to the  datasets are not loaded.
-%   Default: false.
+%   projects = getProjects(..., loaded) also loads the images attached to the
+%   datasets if loaded is true,  Default: false.
 %
 %   projects = getProjects(..., 'owner', owner) specifies the owner of the
 %   projects. A value of -1 implies projects are returned independently of

--- a/components/tools/OmeroM/src/io/getScreens.m
+++ b/components/tools/OmeroM/src/io/getScreens.m
@@ -8,7 +8,7 @@ function [screens, plates] = getScreens(session, varargin)
 %   screens to load and plates attached to them.
 %
 %   screens = getScreens(session, ids) returns all the screens identified
-%   by the input ids in the context of the session group.
+%   by the input ids independently of the owner across groups.
 %
 %   screens = getScreens(..., 'owner', owner) specifies the owner of the
 %   screens. A value of -1 implies screens are returned independently of

--- a/components/tools/OmeroM/src/io/getScreens.m
+++ b/components/tools/OmeroM/src/io/getScreens.m
@@ -10,21 +10,13 @@ function [screens, plates] = getScreens(session, varargin)
 %   screens = getScreens(session, ids) returns all the screens identified
 %   by the input ids in the context of the session group.
 %
-%   screens = getScreens(session, 'owner', owner) returns all the screens
-%   owned by the input owner in the context of the session group.
+%   screens = getScreens(..., 'owner', owner) specifies the owner of the
+%   screens. A value of -1 implies screens are returned independently of
+%   the owner.
 %
-%   screens = getScreens(session, 'group', groupId) returns all the screens
-%   owned by the session owner in the context of the input group. A value
-%   of -1 for groupId means screens are returned for all groups.
-%
-%   screens = getScreens(session, ids, 'owner', owner) returns all the
-%   screens identified by the input ids owned by the input user in the
-%   context of the session group.
-%
-%   screens = getScreens(session, ids, 'group', groupId) returns all the
-%   screens identified by the input ids owned by the session owner in the
-%   context of the input group. A value of -1 for groupId means screens
-%   are returned for all groups.
+%   screens = getScreens(..., 'group', groupId) specifies the group
+%   context for the screens. A value of -1 means screens are returned
+%   across groups.
 %
 %   [screens, plates] = getScreens(session, [],...) returns all the
 %   orphaned platest in addition to all the projects.
@@ -33,15 +25,15 @@ function [screens, plates] = getScreens(session, varargin)
 %
 %      screens = getScreens(session);
 %      screens = getScreens(session, 'owner', ownerId);
-%      screens = getScreens(session, 'group', -1);
+%      screens = getScreens(session, 'group', groupId);
 %      screens = getScreens(session, ids);
 %      screens = getScreens(session, ids, 'owner', ownerId);
-%      screens = getScreens(session, ids, 'group', -1);
+%      screens = getScreens(session, ids, 'group', groupId);
 %      [screens, plates] = getScreens(session, []);
 %
 % See also: GETOBJECTS, GETPLATES, GETIMAGES
 
-% Copyright (C) 2013-2014 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroM/src/io/getScreens.m
+++ b/components/tools/OmeroM/src/io/getScreens.m
@@ -13,9 +13,18 @@ function [screens, plates] = getScreens(session, varargin)
 %   screens = getScreens(session, 'owner', owner) returns all the screens
 %   owned by the input owner in the context of the session group.
 %
+%   screens = getScreens(session, 'group', groupId) returns all the screens
+%   owned by the session owner in the context of the input group. A value
+%   of -1 for groupId means screens are returned for all groups.
+%
 %   screens = getScreens(session, ids, 'owner', owner) returns all the
 %   screens identified by the input ids owned by the input user in the
 %   context of the session group.
+%
+%   screens = getScreens(session, ids, 'group', groupId) returns all the
+%   screens identified by the input ids owned by the session owner in the
+%   context of the input group. A value of -1 for groupId means screens
+%   are returned for all groups.
 %
 %   [screens, plates] = getScreens(session, [],...) returns all the
 %   orphaned platest in addition to all the projects.
@@ -24,8 +33,10 @@ function [screens, plates] = getScreens(session, varargin)
 %
 %      screens = getScreens(session);
 %      screens = getScreens(session, 'owner', ownerId);
+%      screens = getScreens(session, 'group', -1);
 %      screens = getScreens(session, ids);
 %      screens = getScreens(session, ids, 'owner', ownerId);
+%      screens = getScreens(session, ids, 'group', -1);
 %      [screens, plates] = getScreens(session, []);
 %
 % See also: GETOBJECTS, GETPLATES, GETIMAGES

--- a/components/tools/OmeroM/src/io/getScreens.m
+++ b/components/tools/OmeroM/src/io/getScreens.m
@@ -70,6 +70,6 @@ parameters = omero.sys.ParametersI();
 if nargout > 1, parameters.orphan(); end
 
 % Delegate unmatched arguments check to getObjects function
-unmatchedArgs =[fieldnames(ip.Unmatched)' struct2cell(ip.Unmatched)'];
+unmatchedArgs =[fieldnames(ip.Unmatched)'; struct2cell(ip.Unmatched)'];
 [screens, plates] = getObjects(session, 'screen', ip.Results.ids,...
     parameters, unmatchedArgs{:});

--- a/components/tools/OmeroM/src/io/getScreens.m
+++ b/components/tools/OmeroM/src/io/getScreens.m
@@ -19,7 +19,7 @@ function [screens, plates] = getScreens(session, varargin)
 %   across groups.
 %
 %   [screens, plates] = getScreens(session, [],...) returns all the
-%   orphaned platest in addition to all the projects.
+%   orphaned plates in addition to all the projects.
 %
 %   Examples:
 %

--- a/examples/Training/matlab/ConnectToOMERO.m
+++ b/examples/Training/matlab/ConnectToOMERO.m
@@ -1,4 +1,4 @@
-% Copyright (C) 2011-2014 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2011-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -53,19 +53,27 @@ try
     delete(t);
     
     %% Admin service
-    % List groups the user is member of
+    % Retrieve  the identifier of the groups the user is member/owner of
     user = adminService.getExperimenter(userId);
-    groupIds = toMatlabList(adminService.getMemberOfGroupIds(user), 'double');
+    groupIds1 = toMatlabList(adminService.getMemberOfGroupIds(user));
+    groupIds2 = toMatlabList(adminService.getLeaderOfGroupIds(user));
     
-    % Switch between groups the user is member of
-    for groupId = groupIds'
+    % List all groups the user is member of
+    disp('Group membership');
+    for groupId = groupIds1'
         group = adminService.getGroup(groupId);
-        fprintf(1, 'Switching to group %s (id: %g)\n',...
-            char(group.getName().getValue()), groupId);
-        session.setSecurityContext(group);
-        
-        % Check the current group has been switched
-        assert(groupId == adminService.getEventContext().groupId);
+        fprintf(1, ' Group %s (id: %g, type: %s)\n',...
+            char(group.getName().getValue()), groupId,...
+            char(group.getDetails().getPermissions()));
+    end
+    
+    % List all groups the user is owner of
+    disp('Group ownership');
+    for groupId = groupIds2'
+        group = adminService.getGroup(groupId);
+        fprintf(1, ' Group %s (id: %g, type: %s)\n',...
+            char(group.getName().getValue()), groupId,...
+            char(group.getDetails().getPermissions()));
     end
     
     %% Unencrypted session

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -72,7 +72,7 @@ try
 
     % Retrieve all the unloaded projects owned by the session owner across
     % groups
-    disp('Retrieving projects across owned by any user in the current group')
+    disp('Retrieving projects across by any user in the current group')
     projects = getProjects(session, 'owner', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
@@ -159,7 +159,7 @@ try
 
     % Retrieve all the images contained in a given dataset.
     fprintf(1, 'Retrieving images contained in project %g\n', projectId);
-    images3 = getImages(session, 'dataset', projectId);
+    images3 = getImages(session, 'project', projectId);
     fprintf(1, '  Found %g images\n', numel(images3));
     for i = 1 : numel(images3),
         print_object(images3(i));
@@ -197,9 +197,9 @@ try
     % There is no explicit method in the gateway exposed to retrieve screening data
     % (to learn about the model go to ScreenPlateWell) but you can use the ContainerService to
     % load the data, you can use the method `findAllByQuery`.
-    
+
     % load Screen and plate owned by the user currently logged in
-    disp('Retrieving all screens and orphaned plates owner by the session user')
+    disp('Retrieving all screens and orphaned plates owned by the session user')
     [screens, orphanedPlates] = getScreens(session);
     fprintf(1, '  Found %g screens\n', numel(screens));
     for i = 1 : numel(screens),
@@ -236,8 +236,7 @@ try
     fprintf(1, '\n');
 
     %% Plates
-    % Retrieve all the unloaded datasets owned by the session owner.
-    % If the datasets contain images, the images will not be loaded.
+    % Retrieve all the plates owned by the session user.
     disp('Listing plates owned by the session user');
     allPlates = getPlates(session);
     fprintf(1, '  Found %g plates\n', numel(allPlates));
@@ -246,11 +245,10 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the unloaded datasets owned by the session owner across
-    % all groups
+    % Retrieve all the pldates owned by the session user across all groups
     disp('Retrieving plates owned by the session user across all groups')
     allPlatesAllGroups = getPlates(session, 'group', -1);
-    fprintf(1, '  Found %g datasets\n', numel(allPlatesAllGroups));
+    fprintf(1, '  Found %g platest\n', numel(allPlatesAllGroups));
     for i = 1 : numel(allPlatesAllGroups),
         print_object(allPlatesAllGroups(i));
     end

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -65,8 +65,8 @@ try
     projects = getProjects(session, 'group', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
     fprintf(1, '\n');
-    
-    % Retrieve a project specified by an input identifier
+
+    % Retrieve a loaded project specified by an input identifier
     % If the dataset contains images, the images will be loaded
     fprintf(1, 'Reading project %g with loaded images\n', projectId);
     project = getProjects(session, projectId, true);
@@ -93,7 +93,7 @@ try
     allDatasetsAllGroups = getDatasets(session, 'group', -1);
     fprintf(1, '  Found %g datasets\n\n', numel(allDatasetsAllGroups));
 
-    % Retrieve a dataset specified by an input identifier
+    % Retrieve a loaded dataset specified by an input identifier
     % If the dataset contains images, the images will be loaded
     fprintf(1, 'Retrieving dataset %g with loaded images\n', datasetId);
     dataset = getDatasets(session, datasetId, true);
@@ -190,18 +190,30 @@ try
     fprintf(1, '  Found %g screens\n\n', numel(allScreensAllGroups));
 
     %% Plates
+    % Retrieve all the unloaded datasets owned by the session owner.
+    % If the datasets contain images, the images will not be loaded.
+    disp('Listing plates owned by the session user');
+    allPlates = getPlates(session);
+    fprintf(1, '  Found %g plates\n\n', numel(allPlates));
+
+    % Retrieve all the unloaded datasets owned by the session owner across
+    % all groups
+    disp('Retrieving plates owned by the session user across all groups')
+    allPlatesAllGroups = getPlates(session, 'group', -1);
+    fprintf(1, '  Found %g datasets\n\n', numel(allPlatesAllGroups));
+
     % Retrieve Wells within a Plate, see ScreenPlateWell.
-    
+
     % Given a plate ID, load the wells.
     % You will have to use the findAllByQuery method.
     fprintf(1, 'Listing wells for plate: %g\n ', plateId);
     wells = session.getQueryService().findAllByQuery(['select well from Well as well left outer join fetch well.plate as pt left outer join fetch well.wellSamples as ws left outer join fetch ws.plateAcquisition as pa left outer join fetch ws.image as img left outer join fetch img.pixels as pix left outer join fetch pix.pixelsType as pt where well.plate.id =  ', num2str(plateId)], []);
     wells = toMatlabList(wells);
-    fprintf(1, 'Found %g wells\n ', numel(wells));
+    fprintf(1, '  Found %g wells\n ', numel(wells));
     
     for i = 1:numel(wells),
         wellSamples = toMatlabList(wells(i).copyWellSamples());
-        fprintf(1, 'Well %g - Found %g well samples\n ', i, numel(wellSamples));
+        fprintf(1, '  Well %g - Found %g well samples\n ', i, numel(wellSamples));
         for j = 1:numel(wellSamples),
             pa = wellSamples(j).getPlateAcquisition();
         end

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -248,7 +248,7 @@ try
     % Retrieve all the pldates owned by the session user across all groups
     disp('Retrieving plates owned by the session user across all groups')
     allPlatesAllGroups = getPlates(session, 'group', -1);
-    fprintf(1, '  Found %g platest\n', numel(allPlatesAllGroups));
+    fprintf(1, '  Found %g plates\n', numel(allPlatesAllGroups));
     for i = 1 : numel(allPlatesAllGroups),
         print_object(allPlatesAllGroups(i));
     end

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -31,12 +31,12 @@ try
     datasetId = p.datasetid;
     imageId = p.imageid;
     plateId = p.plateid;
-
+    
     print_object = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
         char(x.getName().getValue()), x.getId().getValue(),...
         x.getDetails().getOwner().getId().getValue(),...
         x.getDetails().getGroup().getId().getValue());
-
+    
     %% Projects
     % Retrieve all the projects and orphaned datasets owned by session
     % owner in the current context
@@ -59,7 +59,7 @@ try
         print_object(orphanedDatasets(j));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the unloaded projects owned by the session owner across
     % groups
     disp('Retrieving projects owned by the session user across groups')
@@ -69,9 +69,9 @@ try
         print_object(projects(i));
     end
     fprintf(1, '\n');
-
-    % Retrieve all the unloaded projects owned by the session owner across
-    % groups
+    
+    % Retrieve all the unloaded projects owned by the any user in the
+    % context of the current session group
     disp('Retrieving projects across by any user in the current group')
     projects = getProjects(session, 'owner', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
@@ -79,7 +79,7 @@ try
         print_object(projects(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve a loaded project specified by an input identifier
     % If the dataset contains images, the images will be loaded
     fprintf(1, 'Reading project %g with loaded images\n', projectId);
@@ -95,7 +95,7 @@ try
         end
     end
     fprintf(1, '\n');
-
+    
     %% Datasets
     % Retrieve all the unloaded datasets owned by the session owner.
     % If the datasets contain images, the images will not be loaded.
@@ -106,7 +106,7 @@ try
         print_object(allDatasets(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the unloaded datasets owned by the session owner across
     % all groups
     disp('Retrieving dataset owned by the session user across all groups')
@@ -116,7 +116,17 @@ try
         print_object(allDatasetsAllGroups(i));
     end
     fprintf(1, '\n');
-
+    
+    % Retrieve all the unloaded datasets owned by the any user in the
+    % context of the current session group
+    disp('Retrieving datasets across by any user in the current group')
+    datasets = getDatasets(session, 'owner', -1);
+    fprintf(1, '  Found %g datasets\n', numel(datasets));
+    for i = 1 : numel(datasets),
+        print_object(datasets(i));
+    end
+    fprintf(1, '\n');
+    
     % Retrieve a loaded dataset specified by an input identifier
     % If the dataset contains images, the images will be loaded
     fprintf(1, 'Retrieving dataset %g with loaded images\n', datasetId);
@@ -128,7 +138,7 @@ try
         print_object(images(i));
     end
     fprintf(1, '\n');
-
+    
     %% Images
     % Retrieve all the images owned by the session user.
     disp('Retrieving images owned by the session user in the current group')
@@ -138,7 +148,7 @@ try
         print_object(allImages(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the images owned by the session user across all groups
     disp('Retrieving images owned by the session user across groups')
     allImagesAllGroups = getImages(session, 'group', -1);
@@ -147,7 +157,7 @@ try
         print_object(allImagesAllGroups(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the images contained in a given dataset.
     fprintf(1, 'Retrieving images contained in dataset %g\n', datasetId);
     images2 = getImages(session, 'dataset', datasetId);
@@ -156,7 +166,7 @@ try
         print_object(images2(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the images contained in a given dataset.
     fprintf(1, 'Retrieving images contained in project %g\n', projectId);
     images3 = getImages(session, 'project', projectId);
@@ -165,7 +175,7 @@ try
         print_object(images3(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve an image if the identifier is known.
     fprintf(1, 'Retrieving image: %g\n', imageId);
     image = getImages(session, imageId);
@@ -197,7 +207,7 @@ try
     % There is no explicit method in the gateway exposed to retrieve screening data
     % (to learn about the model go to ScreenPlateWell) but you can use the ContainerService to
     % load the data, you can use the method `findAllByQuery`.
-
+    
     % load Screen and plate owned by the user currently logged in
     disp('Retrieving all screens and orphaned plates owned by the session user')
     [screens, orphanedPlates] = getScreens(session);
@@ -225,7 +235,7 @@ try
         end
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the images owned by the session user across all groups
     disp('Retrieving all screens owned by the session user across all groups')
     allScreensAllGroups = getScreens(session, 'group', -1);
@@ -234,7 +244,7 @@ try
         print_object(allScreensAllGroups(i));
     end
     fprintf(1, '\n');
-
+    
     %% Plates
     % Retrieve all the plates owned by the session user.
     disp('Listing plates owned by the session user');
@@ -244,7 +254,7 @@ try
         print_object(allPlates(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve all the pldates owned by the session user across all groups
     disp('Retrieving plates owned by the session user across all groups')
     allPlatesAllGroups = getPlates(session, 'group', -1);
@@ -253,9 +263,9 @@ try
         print_object(allPlatesAllGroups(i));
     end
     fprintf(1, '\n');
-
+    
     % Retrieve Wells within a Plate, see ScreenPlateWell.
-
+    
     % Given a plate ID, load the wells.
     % You will have to use the findAllByQuery method.
     fprintf(1, 'Listing wells for plate: %g\n ', plateId);

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -31,39 +31,63 @@ try
     datasetId = p.datasetid;
     imageId = p.imageid;
     plateId = p.plateid;
-    
+
     %% Projects
     % Retrieve all the projects and orphaned datasets owned by session
-    % owner.
+    % owner in the current context
     % If a project contains datasets, the datasets will automatically be
     % loaded but the images contained in the datasets are not loaded.
-    disp('Retrieving projects and orphaned datasets owned by the session user');
+    disp(['Retrieving projects and orphaned datasets owned'...
+          'by the session user in the current group']);
     [projects, orphanedDatasets] = getProjects(session);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
         datasets = toMatlabList(projects(i).linkedDatasetList);
-        fprintf(1, '  Project %g: %s (%g) - %g datasets\n', i,...
+        fprintf(1, '  %s (id: %g)\n',...
             char(projects(i).getName().getValue()),...
-            projects(i).getId().getValue(), numel(datasets));
+            projects(i).getId().getValue());
         for j = 1 : numel(datasets),
-            fprintf(1, '    Dataset %g: %s (%d)\n',...
-                j, char(datasets(j).getName().getValue()),...
+            fprintf(1, '    %s (id: %d)\n',...
+                char(datasets(j).getName().getValue()),...
                 datasets(j).getId().getValue());
         end
     end
     fprintf(1, '  Found %g orphaned datasets\n', numel(orphanedDatasets));
     for j = 1 : numel(orphanedDatasets),
-        fprintf(1, '  Orphaned dataset %g: %s (%d)\n',...
-            j, char(orphanedDatasets(j).getName().getValue()),...
+        fprintf(1, '    %s (id: %d)\n',...
+            char(orphanedDatasets(j).getName().getValue()),...
             orphanedDatasets(j).getId().getValue());
     end
     fprintf(1, '\n');
-    
+
     % Retrieve all the unloaded projects owned by the session owner across
-    % all groups
-    disp('Retrieving projects owned by the session user across all groups')
+    % groups
+    disp('Retrieving projects across owned by the session user all groups')
     projects = getProjects(session, 'group', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
+    for i = 1 : numel(projects),
+        details = projects(i).getDetails();
+        fprintf(1, '    %s (id: %d, owner: %d, group: %d)\n',...
+            char(projects(i).getName().getValue()),...
+            projects(i).getId().getValue(),...
+            details.getOwner().getId().getValue(),...
+            details.getGroup().getId().getValue());
+    end
+    fprintf(1, '\n');
+
+        % Retrieve all the unloaded projects owned by the session owner across
+    % groups
+    disp('Retrieving projects across owned by any user in the current group')
+    projects = getProjects(session, 'owner', -1);
+    fprintf(1, '  Found %g projects\n', numel(projects));
+    for i = 1 : numel(projects),
+        details = projects(i).getDetails();
+        fprintf(1, '    %s (id: %d, owner: %d, group: %d)\n',...
+            char(projects(i).getName().getValue()),...
+            projects(i).getId().getValue(),...
+            details.getOwner().getId().getValue(),...
+            details.getGroup().getId().getValue());
+    end
     fprintf(1, '\n');
 
     % Retrieve a loaded project specified by an input identifier
@@ -74,7 +98,7 @@ try
     datasets = toMatlabList(project.linkedDatasetList);
     for j = 1 : numel(datasets),
         images = toMatlabList(datasets(j).linkedImageList);
-        fprintf(1, '  Dataset %g: %s (%d) - %g datasets\n',...
+        fprintf(1, '  Dataset %g: %s (id: %d) - %g image(s)\n',...
             j, char(datasets(j).getName().getValue()),...
             datasets(j).getId().getValue(), numel(images));
     end

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -32,61 +32,51 @@ try
     imageId = p.imageid;
     plateId = p.plateid;
 
+    print_object = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getName().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+
     %% Projects
     % Retrieve all the projects and orphaned datasets owned by session
     % owner in the current context
     % If a project contains datasets, the datasets will automatically be
     % loaded but the images contained in the datasets are not loaded.
-    disp(['Retrieving projects and orphaned datasets owned'...
-          'by the session user in the current group']);
+    disp(['Retrieving projects and orphaned datasets owned '...
+        'by the session user in the current group']);
     [projects, orphanedDatasets] = getProjects(session);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
+        print_object(projects(i));
         datasets = toMatlabList(projects(i).linkedDatasetList);
-        fprintf(1, '  %s (id: %g)\n',...
-            char(projects(i).getName().getValue()),...
-            projects(i).getId().getValue());
         for j = 1 : numel(datasets),
-            fprintf(1, '    %s (id: %d)\n',...
-                char(datasets(j).getName().getValue()),...
-                datasets(j).getId().getValue());
+            fprintf(1, '  ');
+            print_object(datasets(j));
         end
     end
     fprintf(1, '  Found %g orphaned datasets\n', numel(orphanedDatasets));
     for j = 1 : numel(orphanedDatasets),
-        fprintf(1, '    %s (id: %d)\n',...
-            char(orphanedDatasets(j).getName().getValue()),...
-            orphanedDatasets(j).getId().getValue());
+        print_object(orphanedDatasets(j));
     end
     fprintf(1, '\n');
 
     % Retrieve all the unloaded projects owned by the session owner across
     % groups
-    disp('Retrieving projects across owned by the session user all groups')
+    disp('Retrieving projects owned by the session user across groups')
     projects = getProjects(session, 'group', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
-        details = projects(i).getDetails();
-        fprintf(1, '    %s (id: %d, owner: %d, group: %d)\n',...
-            char(projects(i).getName().getValue()),...
-            projects(i).getId().getValue(),...
-            details.getOwner().getId().getValue(),...
-            details.getGroup().getId().getValue());
+        print_object(projects(i));
     end
     fprintf(1, '\n');
 
-        % Retrieve all the unloaded projects owned by the session owner across
+    % Retrieve all the unloaded projects owned by the session owner across
     % groups
     disp('Retrieving projects across owned by any user in the current group')
     projects = getProjects(session, 'owner', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
-        details = projects(i).getDetails();
-        fprintf(1, '    %s (id: %d, owner: %d, group: %d)\n',...
-            char(projects(i).getName().getValue()),...
-            projects(i).getId().getValue(),...
-            details.getOwner().getId().getValue(),...
-            details.getGroup().getId().getValue());
+        print_object(projects(i));
     end
     fprintf(1, '\n');
 
@@ -96,11 +86,13 @@ try
     project = getProjects(session, projectId, true);
     assert(~isempty(project), 'OMERO:ReadData', 'Project Id not valid');
     datasets = toMatlabList(project.linkedDatasetList);
-    for j = 1 : numel(datasets),
-        images = toMatlabList(datasets(j).linkedImageList);
-        fprintf(1, '  Dataset %g: %s (id: %d) - %g image(s)\n',...
-            j, char(datasets(j).getName().getValue()),...
-            datasets(j).getId().getValue(), numel(images));
+    for i = 1 : numel(datasets),
+        print_object(datasets(i));
+        images = toMatlabList(datasets(i).linkedImageList);
+        for j = 1 : numel(images)
+            fprintf(1, '  ');
+            print_object(images(j));
+        end
     end
     fprintf(1, '\n');
 
@@ -109,13 +101,21 @@ try
     % If the datasets contain images, the images will not be loaded.
     disp('Listing datasets owned by the session user');
     allDatasets = getDatasets(session);
-    fprintf(1, '  Found %g datasets\n\n', numel(allDatasets));
+    fprintf(1, '  Found %g datasets\n', numel(allDatasets));
+    for i = 1 : numel(allDatasets),
+        print_object(allDatasets(i));
+    end
+    fprintf(1, '\n');
 
     % Retrieve all the unloaded datasets owned by the session owner across
     % all groups
     disp('Retrieving dataset owned by the session user across all groups')
     allDatasetsAllGroups = getDatasets(session, 'group', -1);
-    fprintf(1, '  Found %g datasets\n\n', numel(allDatasetsAllGroups));
+    fprintf(1, '  Found %g datasets\n', numel(allDatasetsAllGroups));
+    for i = 1 : numel(allDatasetsAllGroups),
+        print_object(allDatasetsAllGroups(i));
+    end
+    fprintf(1, '\n');
 
     % Retrieve a loaded dataset specified by an input identifier
     % If the dataset contains images, the images will be loaded
@@ -123,31 +123,49 @@ try
     dataset = getDatasets(session, datasetId, true);
     assert(~isempty(dataset), 'OMERO:ReadData', 'Dataset Id not valid');
     images = toMatlabList(dataset.linkedImageList); % The images in the dataset.
-    fprintf(1, '  Found %g images\n\n', numel(images));
+    fprintf(1, '  Found %g images\n', numel(images));
+    for i = 1 : numel(images),
+        print_object(images(i));
+    end
+    fprintf(1, '\n');
 
     %% Images
     % Retrieve all the images owned by the session user.
-    disp('Retrieving images owned by the session user')
+    disp('Retrieving images owned by the session user in the current group')
     allImages = getImages(session);
-    fprintf(1, ' Found %g images\n\n', numel(allImages));
+    fprintf(1, ' Found %g images\n', numel(allImages));
+    for i = 1 : numel(allImages),
+        print_object(allImages(i));
+    end
+    fprintf(1, '\n');
 
     % Retrieve all the images owned by the session user across all groups
-    disp('Retrieving images owned by the session user')
+    disp('Retrieving images owned by the session user across groups')
     allImagesAllGroups = getImages(session, 'group', -1);
-    fprintf(1, '  Found %g images\n\n', numel(allImagesAllGroups));
-    
+    fprintf(1, '  Found %g images\n', numel(allImagesAllGroups));
+    for i = 1 : numel(allImagesAllGroups),
+        print_object(allImagesAllGroups(i));
+    end
+    fprintf(1, '\n');
+
     % Retrieve all the images contained in a given dataset.
     fprintf(1, 'Retrieving images contained in dataset %g\n', datasetId);
     images2 = getImages(session, 'dataset', datasetId);
     fprintf(1, '  Found %g images\n', numel(images2));
+    for i = 1 : numel(images2),
+        print_object(images2(i));
+    end
     fprintf(1, '\n');
 
     % Retrieve all the images contained in a given dataset.
     fprintf(1, 'Retrieving images contained in project %g\n', projectId);
     images3 = getImages(session, 'dataset', projectId);
     fprintf(1, '  Found %g images\n', numel(images3));
+    for i = 1 : numel(images3),
+        print_object(images3(i));
+    end
     fprintf(1, '\n');
-    
+
     % Retrieve an image if the identifier is known.
     fprintf(1, 'Retrieving image: %g\n', imageId);
     image = getImages(session, imageId);
@@ -185,46 +203,58 @@ try
     [screens, orphanedPlates] = getScreens(session);
     fprintf(1, '  Found %g screens\n', numel(screens));
     for i = 1 : numel(screens),
+        print_object(screens(i));
         plates = toMatlabList(screens(i).linkedPlateList);
-        fprintf(1, '  Screen %g: %s (%g) - %g plates\n', i,...
-            char(screens(i).getName().getValue()),...
-            screens(i).getId().getValue(), numel(plates));
         for j = 1 : numel(plates),
+            fprintf(1, '  ');
+            print_object(plates(j));
             plateAcquisitions = toMatlabList(plates(j).copyPlateAcquisitions());
-            fprintf(1, '    Plate %g: %s (%d) - %g plate runs\n',...
-                i, j, char(plates(j).getName().getValue()),...
-                plates(j).getId().getValue(), numel(plateAcquisitions));
             for k = 1 : numel(plateAcquisitions),
-                pa = plateAcquisitions(k);
+                fprintf(1, '    ');
+                print_object(plateAcquisitions(k));
             end
         end
     end
     fprintf(1, '  Found %g orphaned plates\n', numel(orphanedPlates));
     for i = 1 : numel(orphanedPlates),
+        print_object(orphanedPlates(i));
         plateAcquisitions = toMatlabList(orphanedPlates(i).copyPlateAcquisitions());
-        fprintf(1, '  Orphaned plate %g: %s (%g) - %g plate runs\n', i,...
-            char(orphanedPlates(i).getName().getValue()),...
-            orphanedPlates(i).getId().getValue(), numel(plateAcquisitions));
+        for j = 1 : numel(plateAcquisitions),
+            fprintf(1, '  ');
+            print_object(plateAcquisitions(j));
+        end
     end
     fprintf(1, '\n');
-    
+
     % Retrieve all the images owned by the session user across all groups
     disp('Retrieving all screens owned by the session user across all groups')
     allScreensAllGroups = getScreens(session, 'group', -1);
-    fprintf(1, '  Found %g screens\n\n', numel(allScreensAllGroups));
+    fprintf(1, '  Found %g screens\n', numel(allScreensAllGroups));
+    for i = 1 : numel(allScreensAllGroups),
+        print_object(allScreensAllGroups(i));
+    end
+    fprintf(1, '\n');
 
     %% Plates
     % Retrieve all the unloaded datasets owned by the session owner.
     % If the datasets contain images, the images will not be loaded.
     disp('Listing plates owned by the session user');
     allPlates = getPlates(session);
-    fprintf(1, '  Found %g plates\n\n', numel(allPlates));
+    fprintf(1, '  Found %g plates\n', numel(allPlates));
+    for i = 1 : numel(allPlates),
+        print_object(allPlates(i));
+    end
+    fprintf(1, '\n');
 
     % Retrieve all the unloaded datasets owned by the session owner across
     % all groups
     disp('Retrieving plates owned by the session user across all groups')
     allPlatesAllGroups = getPlates(session, 'group', -1);
-    fprintf(1, '  Found %g datasets\n\n', numel(allPlatesAllGroups));
+    fprintf(1, '  Found %g datasets\n', numel(allPlatesAllGroups));
+    for i = 1 : numel(allPlatesAllGroups),
+        print_object(allPlatesAllGroups(i));
+    end
+    fprintf(1, '\n');
 
     % Retrieve Wells within a Plate, see ScreenPlateWell.
 

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -48,7 +48,7 @@ try
     plateId = p.plateid;
     screenId = p.screenid;
     group2 = p.group2;
-    groupId = a.lookupGroup('training_group-2').getId().getValue();
+    groupId = session.getAdminService().lookupGroup('training_group-2').getId().getValue();
     %% File Annotation
     disp('File annotation');
     % Create a local file

--- a/examples/Training/matlab/parseOmeroProperties.m
+++ b/examples/Training/matlab/parseOmeroProperties.m
@@ -22,6 +22,7 @@ props.hostname = char(omeroProperties.get('omero.host'));
 props.username = char(omeroProperties.get('omero.user'));
 props.password = char(omeroProperties.get('omero.pass'));
 props.port = str2double(omeroProperties.get('omero.port'));
+props.group2 = str2double(omeroProperties.get('omero.group2'));
 props.imageid = str2double(omeroProperties.get('omero.imageid'));
 props.datasetid = str2double(omeroProperties.get('omero.datasetid'));
 props.plateid = str2double(omeroProperties.get('omero.plateid'));

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -69,7 +69,7 @@ plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Logout
 bin/omero logout
 
-# Create data owned by another user in the second group
+# Create data owned by another user in the same group
 bin/omero login $USER_NAME_2@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME
 bin/omero obj new Project name='Project 0'
 bin/omero obj new Dataset name='Dataset 0'

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -11,6 +11,7 @@ ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
 GROUP_NAME=${GROUP_NAME:-training_group}
 GROUP_NAME_2=${GROUP_NAME_2:-training_group-2}
 USER_NAME=${USER_NAME:-training_user}
+USER_NAME_2=${USER_NAME_2:-training_user-2}
 USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-training_ice.config}
 
@@ -19,6 +20,7 @@ bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
 bin/omero group add $GROUP_NAME --ignore-existing
 bin/omero group add $GROUP_NAME_2 --ignore-existing
 bin/omero user add $USER_NAME $USER_NAME $USER_NAME $GROUP_NAME $GROUP_NAME_2 --ignore-existing -P $USER_PASSWORD
+bin/omero user add $USER_NAME_2 $USER_NAME_2 $USER_NAME_2 $GROUP_NAME $GROUP_NAME_2 --ignore-existing -P $USER_PASSWORD
 bin/omero logout
 
 # Create fake files
@@ -67,8 +69,8 @@ plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Logout
 bin/omero logout
 
-# Create data under the second group
-bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME_2
+# Create data owned by another user in the second group
+bin/omero login $USER_NAME_2@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME_2
 bin/omero obj new Project name='Project 0'
 bin/omero obj new Dataset name='Dataset 0'
 bin/omero import test.fake --debug ERROR

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -70,12 +70,21 @@ plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 bin/omero logout
 
 # Create data owned by another user in the second group
-bin/omero login $USER_NAME_2@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME_2
+bin/omero login $USER_NAME_2@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME
 bin/omero obj new Project name='Project 0'
 bin/omero obj new Dataset name='Dataset 0'
 bin/omero import test.fake --debug ERROR
 bin/omero obj new Screen name='Screen'
 bin/omero obj new Plate name='Plate'
+
+# Create data owned by the same user in the second group
+bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME_2
+bin/omero obj new Project name='Project 0'
+bin/omero obj new Dataset name='Dataset 0'
+bin/omero import test.fake --debug ERROR
+bin/omero obj new Screen name='Screen'
+bin/omero obj new Plate name='Plate'
+
 # Logout
 bin/omero logout
 

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -9,6 +9,7 @@ HOSTNAME=${HOSTNAME:-localhost}
 PORT=${PORT:-4064}
 ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
 GROUP_NAME=${GROUP_NAME:-training_group}
+GROUP_NAME_2=${GROUP_NAME_2:-training_group-2}
 USER_NAME=${USER_NAME:-training_user}
 USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-training_ice.config}
@@ -16,14 +17,15 @@ CONFIG_FILENAME=${CONFIG_FILENAME:-training_ice.config}
 # Create training user and group
 bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
 bin/omero group add $GROUP_NAME --ignore-existing
-bin/omero user add $USER_NAME $USER_NAME $USER_NAME $GROUP_NAME --ignore-existing -P $USER_PASSWORD
+bin/omero group add $GROUP_NAME_2 --ignore-existing
+bin/omero user add $USER_NAME $USER_NAME $USER_NAME $GROUP_NAME $GROUP_NAME_2 --ignore-existing -P $USER_PASSWORD
 bin/omero logout
 
 # Create fake files
 touch test.fake
 
 # Create training user and group
-bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD
+bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME
 nProjects=1
 nDatasets=2
 echo "Creating projects and datasets"
@@ -62,6 +64,16 @@ touch "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake"
 bin/omero import -r $screen "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake" > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 
+# Logout
+bin/omero logout
+
+# Create data under the second group
+bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD -g $GROUP_NAME_2
+bin/omero obj new Project name='Project 0'
+bin/omero obj new Dataset name='Dataset 0'
+bin/omero import test.fake --debug ERROR
+bin/omero obj new Screen name='Screen'
+bin/omero obj new Plate name='Plate'
 # Logout
 bin/omero logout
 

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -17,8 +17,8 @@ CONFIG_FILENAME=${CONFIG_FILENAME:-training_ice.config}
 
 # Create training user and group
 bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
-bin/omero group add $GROUP_NAME --ignore-existing
-bin/omero group add $GROUP_NAME_2 --ignore-existing
+bin/omero group add $GROUP_NAME --type read-only --ignore-existing
+bin/omero group add $GROUP_NAME_2 --type read-only --ignore-existing
 bin/omero user add $USER_NAME $USER_NAME $USER_NAME $GROUP_NAME $GROUP_NAME_2 --ignore-existing -P $USER_PASSWORD
 bin/omero user add $USER_NAME_2 $USER_NAME_2 $USER_NAME_2 $GROUP_NAME $GROUP_NAME_2 --ignore-existing -P $USER_PASSWORD
 bin/omero logout

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -99,6 +99,7 @@ echo "omero.datasetid=${dataset##*:}" >> "$CONFIG_FILENAME"
 echo "omero.imageid=${imageid}" >> "$CONFIG_FILENAME"
 echo "omero.plateid=${plateid}" >> "$CONFIG_FILENAME"
 echo "omero.screenid=${screen##*:}" >> "$CONFIG_FILENAME"
+echo "omero.group2=$GROUP_NAME_2" >> "$CONFIG_FILENAME"
 
 # Remove fake file
 rm *.fake


### PR DESCRIPTION

This is the same as gh-3839 but rebased onto dev_5_1.

----

Following separate discussions with @dpwrussell and @chris-allan, this PR starts adding cross-group support to OMERO.matlab. While `AdminService.setSecurityContext()` can be used to achieve this, it has the downside of potentially changing the default group of the current user. The proper way to do cross-group operations is to pass a map to ice with `omero.group` set.

Most of the relevant functions in OMERO.matlab now support a `group` parameter/key value allowing to specify the `id` of the group (or `-1` for cross-group queries).

The signature of the getter methods with an explicit identifer is modified to be cross-group and cross-owner by default (BREAKING change). To restore the previous current behavior (current session owner, current group), the `owner` and `group` parameter/key values can be passed explicitly

```
getProjects(session, projectIds); % returns all projects of identifier ids
getProjects(session, projectIds, 'owner', ownerId, 'group', 'groupId`); % returns all projects of identifier ids owned by user ownerId in group groupId
```

Most writing functions are also modified to support a group argument.

                