### PR TITLE
 improving wsgi configs for multiple servers deployment (rebased develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -294,10 +294,10 @@ class WebControl(BaseControl):
         try:
             d["FORCE_SCRIPT_NAME"] = settings.FORCE_SCRIPT_NAME.rstrip("/")
             prefix = re.sub(r'\W+', '', d["FORCE_SCRIPT_NAME"])
-            d["UPSTREAM_NAME"] = "omeroweb_%s" % prefix
+            d["PREFIX_NAME"] = "_%s" % prefix
         except:
             d["FORCE_SCRIPT_NAME"] = "/"
-            d["UPSTREAM_NAME"] = "omeroweb_server"
+            d["PREFIX_NAME"] = ""
 
         if server in ("apache", "apache-fcgi", "apache-wsgi"):
             try:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -14,6 +14,7 @@ from omero.cli import BaseControl, CLI
 import platform
 import sys
 import os
+import re
 from omero_ext.argparse import SUPPRESS
 
 HELP = "OMERO.web configuration/deployment tools"
@@ -292,8 +293,11 @@ class WebControl(BaseControl):
 
         try:
             d["FORCE_SCRIPT_NAME"] = settings.FORCE_SCRIPT_NAME.rstrip("/")
+            prefix = re.sub(r'\W+', '', d["FORCE_SCRIPT_NAME"])
+            d["UPSTREAM_NAME"] = "omeroweb_%s" % prefix
         except:
             d["FORCE_SCRIPT_NAME"] = "/"
+            d["UPSTREAM_NAME"] = "omeroweb_server"
 
         if server in ("apache", "apache-fcgi", "apache-wsgi"):
             try:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -226,7 +226,7 @@ class WebControl(BaseControl):
         if settings.APPLICATION_SERVER in settings.FASTCGI_TYPES:
             self.ctx.err(
                 "WARNING: FastCGI support is deprecated and will be removed"
-                " in OMERO 5.2. Install gunicorn and update config.")
+                " in OMERO 5.2. Install Gunicorn and update config.")
 
     def _assert_config_argtype(self, argtype, settings):
         mismatch = False

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf
@@ -56,9 +56,9 @@
 
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup omeroweb_test
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
@@ -56,9 +56,9 @@
 
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  WSGIDaemonProcess omeroweb_server processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup omeroweb_server
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf
@@ -56,9 +56,9 @@
 
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIDaemonProcess omeroweb_server processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
+  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
   
-  WSGIProcessGroup omeroweb_server
+  WSGIProcessGroup omeroweb
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream omeroweb_server {
+    upstream omeroweb_test {
         server 0.0.0.0:12345 fail_timeout=0;
     }
     
@@ -50,7 +50,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://omeroweb_server;
+            proxy_pass http://omeroweb_test;
         }
 
         location /test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development-withoptions.conf
@@ -35,7 +35,7 @@ http {
         client_max_body_size 2m;
 
         # maintenance page serve from here
-        location @maintenance {
+        location @maintenance_test {
             root /home/omero/OMERO.server/etc/templates/error;
             try_files $uri /maintainance.html =502;
         }
@@ -45,7 +45,7 @@ http {
             alias /home/omero/OMERO.server/lib/python/omeroweb/static;
         }
 
-        location @proxy_to_app {
+        location @proxy_to_app_test {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;
@@ -55,9 +55,9 @@ http {
 
         location /test {
 
-            error_page 502 @maintenance;
+            error_page 502 @maintenance_test;
             # checks for static file, if not found proxy to app
-            try_files $uri @proxy_to_app;
+            try_files $uri @proxy_to_app_test;
         }
 
     }

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-development.conf
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream omeroweb_server {
+    upstream omeroweb {
         server 127.0.0.1:4080 fail_timeout=0;
     }
     
@@ -50,7 +50,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://omeroweb_server;
+            proxy_pass http://omeroweb;
         }
 
         location / {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
@@ -10,7 +10,7 @@ server {
     client_max_body_size 2m;
 
     # maintenance page serve from here
-    location @maintenance {
+    location @maintenance_test {
         root /home/omero/OMERO.server/etc/templates/error;
         try_files $uri /maintainance.html =502;
     }
@@ -20,7 +20,7 @@ server {
         alias /home/omero/OMERO.server/lib/python/omeroweb/static;
     }
 
-    location @proxy_to_app {
+    location @proxy_to_app_test {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;
@@ -30,9 +30,9 @@ server {
 
     location /test {
 
-        error_page 502 @maintenance;
+        error_page 502 @maintenance_test;
         # checks for static file, if not found proxy to app
-        try_files $uri @proxy_to_app;
+        try_files $uri @proxy_to_app_test;
     }
 
 }

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf
@@ -1,4 +1,4 @@
-upstream omeroweb_server {
+upstream omeroweb_test {
     server 0.0.0.0:12345 fail_timeout=0;
 }
 
@@ -25,7 +25,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://omeroweb_server;
+        proxy_pass http://omeroweb_test;
     }
 
     location /test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi.conf
@@ -1,4 +1,4 @@
-upstream omeroweb_server {
+upstream omeroweb {
     server 127.0.0.1:4080 fail_timeout=0;
 }
 
@@ -25,7 +25,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://omeroweb_server;
+        proxy_pass http://omeroweb;
     }
 
     location / {

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -69,10 +69,10 @@ class TestWeb(object):
 
     def add_upstream_name(self, prefix, monkeypath):
         if prefix:
-            prefix = re.sub(r'\W+', '', prefix)
+            name = "omeroweb_%s" % re.sub(r'\W+', '', prefix)
         else:
-            prefix = "server"
-        return "omeroweb_%s" % prefix
+            name = "omeroweb"
+        return name
 
     def add_fastcgi_hostport(self, host, port, monkeypatch):
         if host:

--- a/etc/templates/apache-wsgi.conf.template
+++ b/etc/templates/apache-wsgi.conf.template
@@ -56,9 +56,9 @@
 
   DocumentRoot %(OMEROWEBROOT)s
 
-  WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
+  WSGIDaemonProcess %(UPSTREAM_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
   
-  WSGIProcessGroup omeroweb
+  WSGIProcessGroup %(UPSTREAM_NAME)s
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 

--- a/etc/templates/apache-wsgi.conf.template
+++ b/etc/templates/apache-wsgi.conf.template
@@ -56,9 +56,9 @@
 
   DocumentRoot %(OMEROWEBROOT)s
 
-  WSGIDaemonProcess %(UPSTREAM_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
+  WSGIDaemonProcess omeroweb%(PREFIX_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
   
-  WSGIProcessGroup %(UPSTREAM_NAME)s
+  WSGIProcessGroup omeroweb%(PREFIX_NAME)s
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 

--- a/etc/templates/nginx-wsgi-development.conf.template
+++ b/etc/templates/nginx-wsgi-development.conf.template
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream omeroweb_server {
+    upstream %(UPSTREAM_NAME)s {
         server %(FASTCGI_EXTERNAL)s fail_timeout=0;
     }
     
@@ -50,7 +50,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://omeroweb_server;
+            proxy_pass http://%(UPSTREAM_NAME)s;
         }
 
         location %(FORCE_SCRIPT_NAME)s {

--- a/etc/templates/nginx-wsgi-development.conf.template
+++ b/etc/templates/nginx-wsgi-development.conf.template
@@ -22,7 +22,7 @@ http {
 
     keepalive_timeout 65;
 
-    upstream %(UPSTREAM_NAME)s {
+    upstream omeroweb%(PREFIX_NAME)s {
         server %(FASTCGI_EXTERNAL)s fail_timeout=0;
     }
     
@@ -35,7 +35,7 @@ http {
         client_max_body_size %(MAX_BODY_SIZE)s;
 
         # maintenance page serve from here
-        location @maintenance {
+        location @maintenance%(PREFIX_NAME)s {
             root %(ROOT)s/etc/templates/error;
             try_files $uri /maintainance.html =502;
         }
@@ -45,19 +45,19 @@ http {
             alias %(OMEROWEBROOT)s/static;
         }
 
-        location @proxy_to_app {
+        location @proxy_to_app%(PREFIX_NAME)s {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;
 
-            proxy_pass http://%(UPSTREAM_NAME)s;
+            proxy_pass http://omeroweb%(PREFIX_NAME)s;
         }
 
         location %(FORCE_SCRIPT_NAME)s {
 
-            error_page 502 @maintenance;
+            error_page 502 @maintenance%(PREFIX_NAME)s;
             # checks for static file, if not found proxy to app
-            try_files $uri @proxy_to_app;
+            try_files $uri @proxy_to_app%(PREFIX_NAME)s;
         }
 
     }

--- a/etc/templates/nginx-wsgi.conf.template
+++ b/etc/templates/nginx-wsgi.conf.template
@@ -1,4 +1,4 @@
-upstream %(UPSTREAM_NAME)s {
+upstream omeroweb%(PREFIX_NAME)s {
     server %(FASTCGI_EXTERNAL)s fail_timeout=0;
 }
 
@@ -10,7 +10,7 @@ server {
     client_max_body_size %(MAX_BODY_SIZE)s;
 
     # maintenance page serve from here
-    location @maintenance {
+    location @maintenance%(PREFIX_NAME)s {
         root %(ROOT)s/etc/templates/error;
         try_files $uri /maintainance.html =502;
     }
@@ -20,19 +20,19 @@ server {
         alias %(OMEROWEBROOT)s/static;
     }
 
-    location @proxy_to_app {
+    location @proxy_to_app%(PREFIX_NAME)s {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://%(UPSTREAM_NAME)s;
+        proxy_pass http://omeroweb%(PREFIX_NAME)s;
     }
 
     location %(FORCE_SCRIPT_NAME)s {
 
-        error_page 502 @maintenance;
+        error_page 502 @maintenance%(PREFIX_NAME)s;
         # checks for static file, if not found proxy to app
-        try_files $uri @proxy_to_app;
+        try_files $uri @proxy_to_app%(PREFIX_NAME)s;
     }
 
 }

--- a/etc/templates/nginx-wsgi.conf.template
+++ b/etc/templates/nginx-wsgi.conf.template
@@ -1,4 +1,4 @@
-upstream omeroweb_server {
+upstream %(UPSTREAM_NAME)s {
     server %(FASTCGI_EXTERNAL)s fail_timeout=0;
 }
 
@@ -25,7 +25,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
 
-        proxy_pass http://omeroweb_server;
+        proxy_pass http://%(UPSTREAM_NAME)s;
     }
 
     location %(FORCE_SCRIPT_NAME)s {


### PR DESCRIPTION
This is the same as gh-4110 and gh-4132 but rebased onto develop.

----

This PR prevent from duplicates when deploying multiple omeroweb in one server. Reported in https://github.com/openmicroscopy/management_tools/pull/47/

To test:
*NOTE: all non alphanumeric characters will be removed from the prefix*
 - **NGINX config:**
   - no prefix:
     - ``omero config set omero.web.application_server wsgi-tcp``
     - ``omero web config nginx-wsgi``
     - check if it matches https://github.com/aleksandra-tarkowska/openmicroscopy/blob/wsgi_config_with_prefix/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi.conf
   - custom prefix ``/test`` try also with ASCII non alphanumeric characters:
     - ``omero config set omero.web.prefix '/test'``
     -  check if it matches https://github.com/aleksandra-tarkowska/openmicroscopy/blob/wsgi_config_with_prefix/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-wsgi-withoptions.conf

 - **APACHE config:**
   - no prefix:
     - ``omero config set omero.web.application_server wsgi``
     - ``omero web config apache-wsgi``
     - check if it matches https://github.com/aleksandra-tarkowska/openmicroscopy/blob/wsgi_config_with_prefix/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi.conf

   - custom prefix ``/test`` try also with ASCII non alphanumeric characters:
     - ``omero config set omero.web.prefix '/test'``
     -  check if it matches https://github.com/aleksandra-tarkowska/openmicroscopy/blob/wsgi_config_with_prefix/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-wsgi-withoptions.conf


cc: @sbesson 
