### PR TITLE
PORT number

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -417,7 +417,7 @@ class WebControl(BaseControl):
         import omeroweb.settings as settings
         self._fastcgi_deprecation(settings)  # to be removed in 5.2
 
-        link = ("%s:%s" % (settings.APPLICATION_SERVER_HOST,
+        link = ("%s:%d" % (settings.APPLICATION_SERVER_HOST,
                            settings.APPLICATION_SERVER_PORT))
         location = self._get_python_dir() / "omeroweb"
         deploy = getattr(settings, 'APPLICATION_SERVER')
@@ -469,7 +469,7 @@ using bin\omero web start on Windows with FastCGI.
 
         if deploy == settings.FASTCGITCP:
             cmd = "python manage.py runfcgi workdir=./"
-            cmd += " method=prefork host=%(host)s port=%(port)s"
+            cmd += " method=prefork host=%(host)s port=%(port)d"
             cmd += " pidfile=%(base)s/var/django.pid daemonize=true"
             cmd += " maxchildren=5 minspare=1 maxspare=5"
             cmd += " maxrequests=%(maxrequests)d"

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -379,7 +379,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          str,
          "Upstream application host"],
     "omero.web.application_server.port":
-        ["APPLICATION_SERVER_PORT", "4080", str, "Upstream application port"],
+        ["APPLICATION_SERVER_PORT", 4080, int, "Upstream application port"],
     "omero.web.application_server.max_requests":
         ["APPLICATION_SERVER_MAX_REQUESTS", 0, int,
          ("The maximum number ofrequests a worker will process before "


### PR DESCRIPTION
This PR for the following error and change APPLICATION_SERVER_PORT from string to number.

```
Starting OMERO.web... Traceback (most recent call last):
  File "/Users/ola/OMERO/openmicroscopy/dist/bin/omero", line 125, in <module>
    rv = omero.cli.argv()
  File "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omero/cli.py", line 1432, in argv
    cli.invoke(args[1:])
  File "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omero/cli.py", line 946, in invoke
    stop = self.onecmd(line, previous_args)
  File "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omero/cli.py", line 1023, in onecmd
    self.execute(line, previous_args)
  File "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omero/cli.py", line 1105, in execute
    args.func(args)
  File "/Users/ola/OMERO/openmicroscopy/dist/lib/python/omero/plugins/web.py", line 501, in start
    'wsgi_args': args.wsgi_args}).split()
TypeError: %d format: a number is required, not str
```

This was requested in https://github.com/openmicroscopy/openmicroscopy/pull/4056#discussion-diff-37514231

cc: @sbesson 