### PR TITLE
improve Server security Javadoc

### DIFF
--- a/components/server/src/ome/security/ACLVoter.java
+++ b/components/server/src/ome/security/ACLVoter.java
@@ -36,6 +36,8 @@ public interface ACLVoter {
      * test whether the given object can have its
      * {@link Details#getPermissions() Permissions} changed within the current
      * {@link EventContext security context}.
+     * @param iObject a model object
+     * @return if the object's permissions may be changed
      */
     boolean allowChmod(IObject iObject);
 
@@ -48,10 +50,11 @@ public interface ACLVoter {
      * 
      * The {@link SecuritySystem} implementors will usually call
      * {@link #throwLoadViolation(IObject)} if this method returns false.
-     * 
+
+     * @param session the Hibernate session to use for the query
      * @param klass
      *            a non-null class to test for loading
-     * @param d
+     * @param trustedDetails
      *            the non-null trusted details (usually from the db) for this
      *            instance
      * @param id
@@ -134,7 +137,7 @@ public interface ACLVoter {
      * @param iObject
      *            Non-null object which caused this violation
      * @throws SecurityViolation
-     * @see {@link ACLEventListener#onPostLoad(org.hibernate.event.PostLoadEvent)}
+     * @see ACLEventListener#onPostLoad(org.hibernate.event.PostLoadEvent)
      */
     void throwLoadViolation(IObject iObject) throws SecurityViolation;
 
@@ -145,7 +148,7 @@ public interface ACLVoter {
      * @param iObject
      *            Non-null object which caused this violation
      * @throws SecurityViolation
-     * @see {@link ACLEventListener#onPreInsert(org.hibernate.event.PreInsertEvent)}
+     * @see ACLEventListener#onPreInsert(org.hibernate.event.PreInsertEvent)
      */
     void throwCreationViolation(IObject iObject) throws SecurityViolation;
 
@@ -174,15 +177,16 @@ public interface ACLVoter {
     /**
      * Provide the active restrictions for this {@link IObject}.
      *
-     * See {@link ome.security.policy.PolicyService for further details.
-     * @param object
-     * @return
+     * See {@link ome.security.policy.PolicyService} for further details.
+     * @param object a model object
+     * @return the restrictions applying for the object
      */
     Set<String> restrictions(IObject object);
 
     /**
      * Gives the {@link ACLVoter} instance a chance to act on the {@link IObject}
      * <em>after</em> the transaction but before finishing the AOP stack.
+     * @param obj a model object
      */
     void postProcess(IObject obj);
 }

--- a/components/server/src/ome/security/ChmodStrategy.java
+++ b/components/server/src/ome/security/ChmodStrategy.java
@@ -49,7 +49,7 @@ public interface ChmodStrategy {
      * differ from the current settings. In any case,
      * this method is intended to return quickly.
      * Once the change takes place, it will be necessary
-     * to run {@link #check(IObject, String)} to
+     * to run {@link #check(IObject, Object)} to
      * guarantee that no invalid links are present.
      */
     void chmod(IObject obj, String permissions);

--- a/components/server/src/ome/security/SecureAction.java
+++ b/components/server/src/ome/security/SecureAction.java
@@ -10,7 +10,7 @@ package ome.security;
 import ome.model.IObject;
 
 /**
- * action for passing to {@link SecuritySystem#doAction(IObject, SecureAction)}.
+ * Action for passing to {@link SecuritySystem#doAction(SecureAction, IObject...)}.
  * 
  * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
@@ -18,8 +18,10 @@ import ome.model.IObject;
  */
 public interface SecureAction {
     /**
-     * executes with special privilegs within the {@link SecuritySystem}. These
-     * privileges will only be granted to the top-level objects.
+     * executes with special privileges within the {@link SecuritySystem}. These
+     * privileges will be granted only to the top-level objects.
+     * @param objs some model objects
+     * @return the updated objects
      */
     <T extends IObject> T updateObject(T... objs);
 }

--- a/components/server/src/ome/security/SecurityFilter.java
+++ b/components/server/src/ome/security/SecurityFilter.java
@@ -74,7 +74,7 @@ public interface SecurityFilter {
      * Enables this filter with the settings from this filter. The intent is
      * that after this call, no Hibernate queries will return any objects that
      * would fail a call to
-     * {@link #passesFilter(Details, Long, Long, boolean, boolean, boolean, List)}.
+     * {@link #passesFilter(Session, Details, EventContext)}.
      *
      * @param sess Non-null.
      * @param ec Non-null.

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -45,12 +45,13 @@ public interface SecuritySystem {
      * stores this {@link Principal} instance in the current thread context for
      * authenticating and authorizing all actions. This method does <em>not</em>
      * make any queries and is only a conduit for login information from the
-     * outer-most levels. Session bean implementations and other in-JVM clients
+     * outermost levels. Session bean implementations and other in-JVM clients
      * can fill the {@link Principal}. Note, however, a call must first be made
-     * to {@link #loadEventContext(boolean)} or
-     * {@link #setEventContext(EventContext)} for some calls to be made to the
+     * to {@link #loadEventContext(boolean)} for some calls to be made to the
      * {@link SecuritySystem}. In general, this means that execution must pass
      * through the {@link ome.security.basic.EventHandler}
+     *
+     * @param principal the new current principal
      */
     void login(Principal principal);
 
@@ -65,9 +66,9 @@ public interface SecuritySystem {
     /**
      * Calls {@link #getEventContext(boolean)} with a false as "refresh".
      * This is the previous, safer logic of the method since consumers
-     * are not expecting a long-method run.
-     * 
-     * @return
+     * are not expecting a long method run.
+     *
+     * @return the event context
      */
     EventContext getEventContext();
 
@@ -98,7 +99,9 @@ public interface SecuritySystem {
      * }
      * image.linkAnnotation(toSave);
      * etc.
-     * <pre>
+     * </pre>
+     * 
+     * @return the effective user ID
      */
     Long getEffectiveUID();
 
@@ -106,9 +109,10 @@ public interface SecuritySystem {
      * If refresh is false, returns the current {@link EventContext} stored
      * in the session. Otherwise, reloads the context to have the most
      * up-to-date information.
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/4011">Trac ticket #4011</a>
      *
-     * @see ticket:4011
-     * @return
+     * @param refresh if the event context should first be reloaded
+     * @return the event context
      */
     EventContext getEventContext(boolean refresh);
 
@@ -161,13 +165,13 @@ public interface SecuritySystem {
     boolean hasPrivilegedToken(IObject obj);
 
     /**
-     * Checks whether or not a {@link ome.sercurity.Policy} instance of matching
+     * Checks whether or not a {@link Policy} instance of matching
      * name has been registered, considers itself active, <em>and</em>
      * considers the passed context object to be restricted.
      * 
      * @param name A non-null unique name for a class of policies.
      * @param obj An instance which is to be checked against matching policies.
-     * @throws a {@link SecurityViolation} if the given {@link Policy} is
+     * @throws SecurityViolation if the given {@link Policy} is
      *      considered to be restricted.
      */
     void checkRestriction(String name, IObject obj) throws SecurityViolation;
@@ -239,7 +243,8 @@ public interface SecuritySystem {
      *      href="http://trac.openmicroscopy.org.uk/ome/ticket/1769>1769</a>
      * @see <a
      *      href="http://trac.openmicroscopy.org.uk/ome/ticket/9474>9474</a>
-     * @return
+     * @param details the details
+     * @return if the graph is critical
      */
     boolean isGraphCritical(Details details);
 
@@ -309,13 +314,18 @@ public interface SecuritySystem {
      * Note: the {@link ome.api.IUpdate} save methods should not be used, since
      * they also accept detached entities, which could pose security risks.
      * Instead load an entity from the database via {@link ome.api.IQuery},
-     * make changes, and save the changes with {@link ome.api.IUpdate#flush()}.
+     * make changes, and save the changes with {@link ome.api.IUpdate}.
+     *
+     * @param group the group to run the action as
+     * @param action the action to run
      */
     void runAsAdmin(ExperimenterGroup group, AdminAction action);
 
     /**
      * Calls {@link #runAsAdmin(ExperimenterGroup, AdminAction)} with a
      * null group.
+     *
+     * @param action the action to run
      */
     void runAsAdmin(AdminAction action);
 

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -171,7 +171,7 @@ public interface SecuritySystem {
      * 
      * @param name A non-null unique name for a class of policies.
      * @param obj An instance which is to be checked against matching policies.
-     * @throws SecurityViolation if the given {@link Policy} is
+     * @throws {@link SecurityViolation} if the given {@link Policy} is
      *      considered to be restricted.
      */
     void checkRestriction(String name, IObject obj) throws SecurityViolation;

--- a/components/server/src/ome/security/auth/AttributeNewUserGroupBean.java
+++ b/components/server/src/ome/security/auth/AttributeNewUserGroupBean.java
@@ -23,9 +23,10 @@ import org.springframework.ldap.core.LdapOperations;
  * Handles the "*_attribute" specifiers from etc/omero.properties.
  *
  * The values of the attribute equal to the string following ":*_attribute:" are
- * taken to be the names and/or DNs of {@link ExperimenterGroup} instances and
- * created if necessary. If {@link #filtered} is set to true, then the names/DNs
- * found must pass the assigned group filter.
+ * taken to be the names and/or DNs of {@link ome.model.meta.ExperimenterGroup}
+ * instances and created if necessary. If the constructor's {@code filtered}
+ * argument is set to {@code true}, then the names/DNs found must pass the
+ * assigned group filter.
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @see SecuritySystem

--- a/components/server/src/ome/security/auth/ConfigurablePasswordProvider.java
+++ b/components/server/src/ome/security/auth/ConfigurablePasswordProvider.java
@@ -58,8 +58,8 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
 
     /**
      * If true, this implementation should return a null on
-     * {@link #checkPassword(String, String)} if the user is unknown, otherwise
-     * a {@link Boolean#FALSE}. Default value: false
+     * {@link #checkPassword(String, String, boolean)} if the user is unknown,
+     * otherwise a {@link Boolean#FALSE}. Default value: false
      */
     protected final boolean ignoreUnknown;
 
@@ -76,7 +76,7 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
     /**
      * Call {@link #ConfigurablePasswordProvider(PasswordUtil, boolean)}
      * with "ignoreUnknown" equal to false.
-     * @param util
+     * @param util an instance of the password utility class
      */
     public ConfigurablePasswordProvider(PasswordUtil util) {
         this(util, false);
@@ -85,6 +85,9 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
     /**
      * Call {@link #ConfigurablePasswordProvider(PasswordUtil, boolean, boolean)}
      * with "salt" equal to false.
+     * @param util an instance of the password utility class
+     * @param ignoreUnknown if {@link #checkPassword(String, String, boolean)} should
+     * return {@code null} rather than {@link Boolean#FALSE} for unknown users
      */
     public ConfigurablePasswordProvider(PasswordUtil util, boolean ignoreUnknown) {
         this(util, ignoreUnknown, false);
@@ -124,8 +127,9 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
     }
 
     /**
-     * If {@link #ignoreUnknown} is true, returns null, since the base class
-     * knows no users. Otherwise, return {@link Boolean#FALSE} specifying that
+     * If this was constructed with the {@code ignoreUnknown} argument set to
+     * {@code true}, returns {@code null}, since the base class knows no users.
+     * Otherwise, returns {@link Boolean#FALSE} specifying that
      * authentication should fail.
      */
     public Boolean checkPassword(String user, String password, boolean readOnly) {
@@ -158,6 +162,9 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
      * Encodes the password as it would be encoded for a check by
      * {@link #comparePasswords(String, String)} salting the password
      * with the given userId if it's provided.
+     * @param userId a user ID (may be {@code null})
+     * @param newPassword a password
+     * @return the encoded password
      */
     public String encodeSaltedPassword(Long userId, String newPassword) {
         return encodePassword(userId, newPassword, salt, util);
@@ -179,8 +186,8 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
      * {@link #checkPassword(String, String, boolean)}.
      *
      * For this implementation, if the trusted password is null, return
-     * {@link Boolean.FALSE}. If the trusted password is empty (only
-     * whitespace), return {@link Boolean.TRUE}. Otherwise return the results of
+     * {@link Boolean#FALSE}. If the trusted password is empty (only
+     * whitespace), return {@link Boolean#TRUE}. Otherwise return the result of
      * {@link String#equals(Object)}.
      */
     public Boolean comparePasswords(String trusted, String provided) {
@@ -190,11 +197,16 @@ public abstract class ConfigurablePasswordProvider implements PasswordProvider,
     /**
      * Compares the password provided by the user (unhashed) against the given
      * trusted password. In general, if the trusted password is null, return
-     * {@link Boolean.FALSE}. If the trusted password is empty (only
-     * whitespace), return {@link Boolean.TRUE}. Otherwise return the results of
+     * {@link Boolean#FALSE}. If the trusted password is empty (only
+     * whitespace), return {@link Boolean#TRUE}. Otherwise return the results of
      * {@link String#equals(Object)}.
      *
-     * If {@link #legacyUtil} is non-null, and {@link #util} return
+     * If necessary, falls back to using a legacy password utility class if one was set by {@link #setLegacyUtil(PasswordUtil)}.
+
+     * @param userId a user ID
+     * @param trusted the user's trusted password
+     * @param provided the provided password
+     * @return if the provided password matches the trusted password (for which blank matches anything)
      */
     public Boolean comparePasswords(Long userId, String trusted, String provided) {
         if(comparePasswords(userId, trusted, provided, util)) {

--- a/components/server/src/ome/security/auth/LdapConfig.java
+++ b/components/server/src/ome/security/auth/LdapConfig.java
@@ -20,8 +20,7 @@ import org.springframework.ldap.filter.Filter;
 import org.springframework.ldap.filter.HardcodedFilter;
 
 /**
- * Static methods for dealing with LDAP (DN) and the "password" table. Used
- * primarily by {@link ome.security.JBossLoginModule}
+ * Static methods for dealing with LDAP (DN) and the "password" table.
  *
  * @author Aleksandra Tarkowska, A.Tarkowska at dundee.ac.uk
  * @see SecuritySystem
@@ -50,7 +49,8 @@ public class LdapConfig {
 
 
     /**
-     * Sets {@link #syncOnLogin} to false and {@link #base} to null.
+     * As {@link #LdapConfig(boolean, String, String, String, String, String, boolean, String)}
+     * setting {@code syncOnLogin} to false and {@code base} to {@code null}.
      */
     public LdapConfig(boolean enabled, String newUserGroup, String userFilter,
         String groupFilter, String userMapping, String groupMapping) {
@@ -59,7 +59,8 @@ public class LdapConfig {
     }
 
     /**
-     * Sets {@link #base} to null.
+     * As {@link #LdapConfig(boolean, String, String, String, String, String, boolean, String)}
+     * setting {@code base} to {@code null}.
      */
     public LdapConfig(boolean enabled, String newUserGroup, String userFilter,
         String groupFilter, String userMapping, String groupMapping, boolean syncOnLogin) {
@@ -68,7 +69,8 @@ public class LdapConfig {
     }
 
     /**
-     * Sets {@link #newUserGroupOwner} to null.
+     * As {@link #LdapConfig(boolean, String, String, String, String, String, boolean, String, String)}
+     * setting {@code newUserGroupOwner} to {@code null}.
      */
     public LdapConfig(boolean enabled, String newUserGroup, String userFilter,
         String groupFilter, String userMapping, String groupMapping, boolean syncOnLogin,
@@ -121,10 +123,10 @@ public class LdapConfig {
      * if the base is "ou=example" and the fullDNString is
      * "cn=myuser,ou=example", then the returned DN will be "cn=myuser".
      *
-     * Note: if {@link #base} is null, then this will throw an exception.
+     * Note: if constructor argument {@code base} was {@code null} then this will throw an exception.
      *
-     * @param full Not null.
-     * @return Never null.
+     * @param fullDNString the full distinguished name, not {@code null}
+     * @return the corresponding relative distinguished name, not {@code null}
      */
     public DistinguishedName relativeDN(String fullDNString) {
         DistinguishedName full = new DistinguishedName(fullDNString);

--- a/components/server/src/ome/security/auth/LdapPasswordProvider.java
+++ b/components/server/src/ome/security/auth/LdapPasswordProvider.java
@@ -19,7 +19,7 @@ import org.springframework.util.Assert;
 
 /**
  * LDAP {@link PasswordProvider} which can create users on
- * {@link #checkPassword(String, String) request} to synchronize with an LDAP
+ * {@link #checkPassword(String, String, boolean) request} to synchronize with an LDAP
  * directory. Assuming that a user exists in the configured LDAP store but not
  * in the database, then a new user will be created. Authentication, however,
  * always takes place against LDAP, and changing passwords is not allowed.
@@ -54,9 +54,9 @@ public class LdapPasswordProvider extends ConfigurablePasswordProvider {
     /**
      * Only returns if the user is already in the database and has a DN value in
      * the password table. Note: after a call to
-     * {@link #checkPassword(String, String)} with this same user value, this
-     * method might begin to return true due to a call to
-     * {@link LocalLdap#createUser(String, String)}.
+     * {@link #checkPassword(String, String, boolean)} with this same user value, this
+     * method might begin to return {@code true} due to a call to
+     * {@link LdapImpl#createUser(String, String)}.
      */
     @Override
     public boolean hasPassword(String user) {

--- a/components/server/src/ome/security/auth/NewUserGroupBean.java
+++ b/components/server/src/ome/security/auth/NewUserGroupBean.java
@@ -22,13 +22,6 @@ import org.springframework.ldap.core.LdapOperations;
  */
 public interface NewUserGroupBean {
 
-    /**
-     *
-     * @param config
-     * @param ldap
-     * @param provider
-     * @param userProperties
-     */
     List<Long> groups(String username,
             LdapConfig config, LdapOperations ldap, RoleProvider provider,
             AttributeSet attrSet);

--- a/components/server/src/ome/security/auth/PasswordProvider.java
+++ b/components/server/src/ome/security/auth/PasswordProvider.java
@@ -14,7 +14,7 @@ import ome.security.SecuritySystem;
 /**
  * Authentication interface responsible for checking and changing passwords. In
  * addition, a {@link PasswordProvider implementation} may claim to know nothing
- * for a particular user name. See {@link #checkPassword(String, String)} for
+ * for a particular user name. See {@link #checkPassword(String, String, boolean)} for
  * more information.
  * 
  * @author Josh Moore, josh at glencoesoftware.com
@@ -29,7 +29,7 @@ public interface PasswordProvider {
      * user name. In general, if this method returns false, then checkPassword
      * will return null or false for all possible passwords. However, some
      * providers (like the LDAP provider) may create a user to synchronize with
-     * some backend during a call to {@link #checkPassword(String, String)}.
+     * some backend during a call to {@link #checkPassword(String, String, boolean)}.
      * {@link #hasPassword(String)} will not do this. This is typically only of
      * importance during {@link #changePassword(String, String)} since a
      * provider which is not responsible for a password should not attempt to

--- a/components/server/src/ome/security/auth/PasswordUtil.java
+++ b/components/server/src/ome/security/auth/PasswordUtil.java
@@ -111,6 +111,7 @@ public class PasswordUtil {
      * {@link #preparePassword(String)} and prints the results on
      * {@link System#out}. This is used by the build system to define the
      * "@ROOTPASS@" placeholder in data.sql.
+     * @param args the command-line arguments
      */
     public static void main(String args[]) {
         if (args == null || args.length < 1 || args.length > 2) {
@@ -146,9 +147,11 @@ public class PasswordUtil {
     }
 
     /**
-     * Calls {@link #changeUserPasswordById(Long, String, boolean) with
+     * Calls {@link #changeUserPasswordById(Long, String, METHOD)} with
      * "false" as the value of the salt argument in order to provide backwards
      * compatibility.
+     * @param id the user ID
+     * @param password the password
      */
     public void changeUserPasswordById(Long id, String password) {
         changeUserPasswordById(id, password, METHOD.LEGACY);
@@ -160,6 +163,9 @@ public class PasswordUtil {
      * value to {@link SqlAction#setUserPassword(Long, String)}.
      * An {@link InternalException} is thrown if the modification is not
      * successful, which should only occur if the user has been deleted.
+     * @param id the user ID
+     * @param password the password
+     * @param meth how to encode the password
      */
     public void changeUserPasswordById(Long id, String password, METHOD meth) {
         String prepared = password;
@@ -218,10 +224,11 @@ public class PasswordUtil {
 
     /**
      * Creates an MD5 hash of the given clear text and base64 encodes it.
-     *
-     * @DEV.TODO This should almost certainly be configurable as to encoding,
-     *           algorithm, and possibly even the implementation in general.
+     * @param clearText the cleartext of the password
+     * @return the password hash
      */
+    // TODO This should almost certainly be configurable as to encoding,
+    // algorithm, and possibly even the implementation in general.
     public String passwordDigest(String clearText) {
         return passwordDigest(null, clearText, false);
     }
@@ -230,6 +237,9 @@ public class PasswordUtil {
      * Creates an MD5 hash of the given clear text and base64 encodes it.
      * If the provided userId argument is not null, then it will be used
      * as a salt value for the password.
+     * @param userId the user's ID, may be {@code null}
+     * @param clearText the cleartext of the password
+     * @return the password hash
      */
     public String saltedPasswordDigest(Long userId, String clearText) {
         return passwordDigest(userId, clearText, true);

--- a/components/server/src/ome/security/auth/PasswordUtility.java
+++ b/components/server/src/ome/security/auth/PasswordUtility.java
@@ -9,8 +9,7 @@ package ome.security.auth;
 
 /**
  * Extension interface to {@link PasswordProvider} for methods which may or may
- * not be available from a provider implementation. This interface is intended
- * to eventually take over for {@link ome.security.PasswordUtil}.
+ * not be available from a provider implementation.
  * 
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.0

--- a/components/server/src/ome/security/auth/RoleProvider.java
+++ b/components/server/src/ome/security/auth/RoleProvider.java
@@ -16,10 +16,10 @@ import ome.security.SecuritySystem;
  * Provides {@link Experimenter user} and {@link ExperimenterGroup group}
  * creation, deletion, and modification for use by services. All invocations are
  * assumed "trusted" (services are responsible for authorization, and will take
- * part in the currently Hibernate {@link org.hibernate.Session session}.
+ * part in the current Hibernate {@link org.hibernate.Session session}.
  * 
  * @author Josh Moore, josh at glencoesoftware.com
- * @See ome.api.IAdmin
+ * @see ome.api.IAdmin
  * @see SecuritySystem
  * @since 4.0
  */

--- a/components/server/src/ome/security/auth/SimpleRoleProvider.java
+++ b/components/server/src/ome/security/auth/SimpleRoleProvider.java
@@ -343,10 +343,6 @@ public class SimpleRoleProvider implements RoleProvider {
      * If the "user" group is the first element of the list of groups that this
      * user is a member of, then check if there's a second value which could be
      * used as the default instead.
-     *
-     * @param userId
-     * @param s
-     * @return
      */
     private ExperimenterGroup shouldBeDefault(Experimenter usr, Session s) {
         List<ExperimenterGroup> grps = usr.linkedExperimenterGroupList();

--- a/components/server/src/ome/security/auth/providers/LdapPasswordProvider431.java
+++ b/components/server/src/ome/security/auth/providers/LdapPasswordProvider431.java
@@ -21,7 +21,7 @@ import org.springframework.util.Assert;
 
 /**
  * LDAP {@link PasswordProvider} which can create users on
- * {@link #checkPassword(String, String) request} to synchronize with an LDAP
+ * {@link #checkPassword(String, String, boolean) request} to synchronize with an LDAP
  * directory. Assuming that a user exists in the configured LDAP store but not
  * in the database, then a new user will be created. Authentication, however,
  * always takes place against LDAP, and changing passwords is not allowed.
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
  * Note: deleted LDAP users will not be removed from OMERO, but will not be able
  * to login.
  *
- * Note: unlike {@link ome.security.auth.LdapPassProvider}, this implementation
+ * Note: unlike {@link ome.security.auth.LdapPasswordProvider}, this implementation
  * (the default LDAP password provider up until 4.3.2) does <em>not</em> check
  * the user_filter on every login, but only when a user does not exist. This means
  * that when using this implementation it is not possible to remove a user's login
@@ -63,9 +63,9 @@ public class LdapPasswordProvider431 extends ConfigurablePasswordProvider {
     /**
      * Only returns if the user is already in the database and has a DN value in
      * the password table. Note: after a call to
-     * {@link #checkPassword(String, String)} with this same user value, this
-     * method might begin to return true due to a call to
-     * {@link LocalLdap#createUser(String, String)}.
+     * {@link #checkPassword(String, String,boolean)} with this same user value, this
+     * method might begin to return {@code true} due to a call to
+     * {@link LdapImpl#createUser(String, String)}.
      */
     @Override
     public boolean hasPassword(String user) {

--- a/components/server/src/ome/security/basic/AbstractSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AbstractSecurityFilter.java
@@ -44,14 +44,14 @@ public abstract class AbstractSecurityFilter extends FilterDefinitionFactoryBean
     protected final Roles roles;
 
     /**
-     * default constructor which calls all the necessary setters for this
-     * {@link FactoryBean}. Also constructs the {@link #defaultFilterCondition }
+     * Default constructor which calls all the necessary setters for this
+     * {@link FactoryBean}. Also calls {@link #setDefaultFilterCondition(String)}.
      * This query clause must be kept in sync with
-     * {@link #passesFilter(Details, Long, Collection, Collection, boolean)}
+     * {@link #passesFilter(Session, Details, EventContext)}.
      *
-     * @see #passesFilter(Details, Long, Collection, Collection, boolean)
+     * @see #passesFilter(Session, Details, EventContext)
      * @see FilterDefinitionFactoryBean#setFilterName(String)
-     * @see FilterDefinitionFactoryBean#setParameterTypes(Properties)
+     * @see FilterDefinitionFactoryBean#setParameterTypes(java.util.Map)
      * @see FilterDefinitionFactoryBean#setDefaultFilterCondition(String)
      */
     public AbstractSecurityFilter() {

--- a/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
@@ -65,15 +65,17 @@ public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
     final SqlAction sql;
 
     /**
-     * default constructor which calls all the necessary setters for this
-     * {@link FactoryBean}. Also constructs the {@link #defaultFilterCondition }
+     * Default constructor which calls all the necessary setters for this
+     * {@link FactoryBean}. Also calls {@link #setDefaultFilterCondition(String)}.
      * This query clause must be kept in sync with
-     * {@link #passesFilter(Details, Long, Collection, Collection, boolean)}
+     * {@link #passesFilter(Session, Details, EventContext)}.
      *
-     * @see #passesFilter(Details, Long, Collection, Collection, boolean)
+     * @see #passesFilter(Session, Details, EventContext)
      * @see FilterDefinitionFactoryBean#setFilterName(String)
-     * @see FilterDefinitionFactoryBean#setParameterTypes(Properties)
+     * @see FilterDefinitionFactoryBean#setParameterTypes(java.util.Map)
      * @see FilterDefinitionFactoryBean#setDefaultFilterCondition(String)
+     *
+     * @param sql an SQL action instance
      */
     public AllGroupsSecurityFilter(SqlAction sql) {
         this(sql, new Roles());

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -108,7 +108,7 @@ public class BasicACLVoter implements ACLVoter {
 
     /**
      * delegates to SecurityFilter because that is where the logic is defined
-     * for the {@link #enableReadFilter(Object) read filter}
+     * for the {@link BasicSecuritySystem#enableReadFilter(Object) read filter}
      * 
      * Ignores the id for the moment.
      * 
@@ -418,11 +418,12 @@ public class BasicACLVoter implements ACLVoter {
     }
 
     /**
-     * @param iObject
-     * @param uid
-     * @return
-     * @DEV.TODO this is less problematic than linking.
+     * Check if the given object is owned by the given user.
+     * @param iObject a model object
+     * @param uid the ID of a user
+     * @return if the object is owned by the user, or is not yet persisted
      */
+    // TODO this is less problematic than linking
     private boolean objectBelongsToUser(IObject iObject, Long uid) {
         final Experimenter e = iObject.getDetails().getOwner();
         if (e == null) {

--- a/components/server/src/ome/security/basic/BasicEventContext.java
+++ b/components/server/src/ome/security/basic/BasicEventContext.java
@@ -82,12 +82,8 @@ public class BasicEventContext extends SimpleEventContext {
 
     /**
      * Copy-constructor to not have to allow the mutator {@link #copy(EventContext)}
-     * or {@link #copyContext(EventContext)} out of the {@link EventContext}
+     * or {@code copyContext(EventContext)} out of the {@link EventContext}
      * hierarchy.
-     *
-     * @param p
-     * @param stats
-     * @param ec
      */
     public BasicEventContext(Principal p, SessionStats stats, EventContext ec) {
         this(p, stats);
@@ -330,7 +326,9 @@ public class BasicEventContext extends SimpleEventContext {
     // =========================================================================
 
     /**
-     * Never returns {@link Permissions.DUMMY}.
+     * Never returns {@link Permissions#DUMMY}.
+     * @param group a group ID, may be {@code null}
+     * @return the group's permissions, may be {@code null}
      */
     public Permissions getPermissionsForGroup(Long group) {
         if (group == null || groupPermissionsMap == null) {
@@ -342,6 +340,9 @@ public class BasicEventContext extends SimpleEventContext {
     /**
      * Called during {@link BasicACLVoter#allowLoad(org.hibernate.Session, Class, ome.model.internal.Details, long)}
      * to track groups that will need resolving later.
+     * @param group a group ID, not {@code null}
+     * @param perms the group's permissions
+     * @return the group's previous permissions, or {@code null} if none are noted
      */
     public Permissions setPermissionsForGroup(Long group, Permissions perms) {
         if (perms == Permissions.DUMMY) {

--- a/components/server/src/ome/security/basic/BasicMethodSecurity.java
+++ b/components/server/src/ome/security/basic/BasicMethodSecurity.java
@@ -62,7 +62,7 @@ public class BasicMethodSecurity implements MethodSecurity {
     }
 
     /**
-     * See {@link MethodSecurity#checkMethod(Object, Method, Principal)}
+     * @see MethodSecurity#checkMethod(Object, Method, Principal, boolean)
      */
     public void checkMethod(Object o, Method m, Principal p, boolean hasPassword) {
         String[] allowedRoles = null;

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -113,6 +113,10 @@ public class BasicSecuritySystem implements SecuritySystem,
     /**
      * Simplified factory method which generates all the security primitives
      * internally. Primarily useful for generated testing instances.
+     * @param sm the session manager
+     * @param sf the session factory
+     * @param cache the session cache
+     * @return a configured security system
      */
     public static BasicSecuritySystem selfConfigure(SessionManager sm,
             ServiceFactory sf, SessionCache cache) {
@@ -133,6 +137,15 @@ public class BasicSecuritySystem implements SecuritySystem,
 
     /**
      * Main public constructor for this {@link SecuritySystem} implementation.
+     * @param interceptor the OMERO interceptor for Hibernate
+     * @param sysTypes the system types
+     * @param cd the current details
+     * @param sessionManager the session manager
+     * @param roles the OMERO roles
+     * @param sf the session factory
+     * @param tokenHolder the token holder
+     * @param filter the security filter
+     * @param policyService the policy service
      */
     public BasicSecuritySystem(OmeroInterceptor interceptor,
             SystemTypes sysTypes, CurrentDetails cd,
@@ -206,7 +219,7 @@ public class BasicSecuritySystem implements SecuritySystem,
      * entities silently removed from the return value. This filter does <em>
      * not</em>
      * apply to single value loads from the database. See
-     * {@link #allowLoad(Class, Details)} for more.
+     * {@link ome.security.ACLVoter#allowLoad(Session, Class, Details, long)} for more.
      * 
      * Note: this filter must be disabled on logout, otherwise the necessary
      * parameters (current user, current group, etc.) for building the filters
@@ -514,12 +527,12 @@ public class BasicSecuritySystem implements SecuritySystem,
     /**
      * 
      * It would be better to catch the
-     * {@link SecureAction#updateObject(IObject)} method in a try/finally block,
+     * {@link SecureAction#updateObject(IObject...)} method in a try/finally block,
      * but since flush can be so poorly controlled that's not possible. instead,
      * we use the one time token which is removed this Object is checked for
      * {@link #hasPrivilegedToken(IObject) privileges}.
      * 
-     * @param obj
+     * @param objs
      *            A managed (non-detached) entity. Not null.
      * @param action
      *            A code-block that will be given the entity argument with a
@@ -626,16 +639,14 @@ public class BasicSecuritySystem implements SecuritySystem,
     }
 
     /**
-     * See {@link TokenHolder#copyToken(IObject, IObject)
-
+     * @see TokenHolder#copyToken(IObject, IObject)
      */
     public void copyToken(IObject source, IObject copy) {
         tokenHolder.copyToken(source, copy);
     }
 
     /**
-     * See {@link TokenHolder#hasPrivilegedToken(IObject)
-
+     * @see TokenHolder#hasPrivilegedToken(IObject)
      */
     public boolean hasPrivilegedToken(IObject obj) {
         return tokenHolder.hasPrivilegedToken(obj);

--- a/components/server/src/ome/security/basic/BasicSecurityWiring.java
+++ b/components/server/src/ome/security/basic/BasicSecurityWiring.java
@@ -46,9 +46,8 @@ public final class BasicSecurityWiring extends HardWiredInterceptor {
 
     /**
      * Lookup name.
-     * 
-     * @DEV.TODO This should be replaced by a components concept
      */
+    // TODO This should be replaced by a components concept
     @Override
     public String getName() {
         return "securityWiring";

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -270,9 +270,7 @@ public class CurrentDetails implements PrincipalHolder {
     }
 
     /**
-     * Public view on the data contained here. Used to create the
-     * 
-     * @return
+     * @return the current event context
      */
     public EventContext getCurrentEventContext() {
         return current();
@@ -369,7 +367,7 @@ public class CurrentDetails implements PrincipalHolder {
      * The {@link Permissions} on the instance are calculated from the current
      * group as well as the user's umask.
      *
-     * @return
+     * @return details for the current security context
      * @see <a href="https://trac.openmicroscopy.org.uk/trac/omero/ticket:1434">ticket:1434</a>
      */
     public Details createDetails() {
@@ -422,6 +420,7 @@ public class CurrentDetails implements PrincipalHolder {
      * Checks the "groupPermissions" map in {@link BasicEventContext} which has
      * been filled up by calls to {@link BasicEventContext#setPermissionsForGroup(Long, Permissions)}
      * during {@link BasicACLVoter#allowLoad(org.hibernate.Session, Class, Details, long)}.
+     * @param session the Hibernate session
      */
     public void loadPermissions(org.hibernate.Session session) {
         current().loadPermissions(session);
@@ -484,6 +483,7 @@ public class CurrentDetails implements PrincipalHolder {
      * most likely only be closed once, so it doesn't make sense to keep them
      * around. The first caller of this method is responsible for closing all of
      * them.
+     * @return a new copy of the current cleanups
      */
     public Set<RegisterServiceCleanupMessage> emptyCleanups() {
         Set<RegisterServiceCleanupMessage> set = current().getServiceCleanups();

--- a/components/server/src/ome/security/basic/EventHandler.java
+++ b/components/server/src/ome/security/basic/EventHandler.java
@@ -34,7 +34,7 @@ import org.springframework.transaction.interceptor.TransactionAttributeSource;
 /**
  * method interceptor responsible for login and creation of Events. Calls are
  * made to the {@link BasicSecuritySystem} provided in the
- * {@link EventHandler#EventHandler(BasicSecuritySystem, HibernateTemplate)
+ * {@link EventHandler#EventHandler(SqlAction, BasicSecuritySystem, SessionFactory, TransactionAttributeSource, boolean)
  * constructor}.
  * 
  * After the method is {@link MethodInterceptor#invoke(MethodInvocation)
@@ -65,11 +65,11 @@ public class EventHandler implements MethodInterceptor, ApplicationListener<Cont
     /**
      * only public constructor, used for dependency injection. Requires an
      * active {@link HibernateTemplate} and {@link BasicSecuritySystem}.
-     * 
-     * @param securitySystem
-     *            Not null.
-     * @param template
-     *            Not null.
+     *
+     * @param sql the SQL action
+     * @param securitySystem the security system
+     * @param factory the Hibernate session factory
+     * @param txSource the Spring transaction attribute source
      */
     public EventHandler(SqlAction sql,
             BasicSecuritySystem securitySystem, SessionFactory factory,
@@ -89,9 +89,9 @@ public class EventHandler implements MethodInterceptor, ApplicationListener<Cont
     }
 
     /**
-     * If a {@link ContextMessage} is received, then we either need to add a
-     * {@link ContextMessage.Push} login to the stack or
-     * {@link ContextMessage.Pop} remove one.
+     * If a {@link ContextMessage} is received then we need to either add a
+     * {@link ome.services.messages.ContextMessage.Push} login to the stack or
+     * {@link ome.services.messages.ContextMessage.Pop} remove one.
      */
     @Override
     public void onApplicationEvent(ContextMessage msg) {

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -563,12 +563,12 @@ public class OmeroInterceptor implements Interceptor {
     }
 
     /**
-     * The default right need for a linkage is WRITE
+     * The default right need for a linkage is {@link Right#WRITE}.
      * If however, this is only an annotation or only a viewing,
      * then less permission is needed.
-     * @param changedClass
-     * @param linkedClass
-     * @return
+     * @param changedClass the changed class
+     * @param linkedClass the linked class
+     * @return the right that is needed
      */
     protected Right neededRight(final Class<?> changedClass,
             final Class<?> linkedClass) {
@@ -604,10 +604,7 @@ public class OmeroInterceptor implements Interceptor {
 
     /**
      * Like {@link #newTransientDetails(IObject)} but allows passing in a
-     * newDetails object with possibly pre-set values.
-     *
-     * @param obj
-     * @return
+     * newDetails object with possibly preset values.
      * @see #evaluateLinkages(IObject)
      */
     protected Details newTransientDetails(final IObject obj,
@@ -861,11 +858,10 @@ public class OmeroInterceptor implements Interceptor {
 
     /**
      * responsible for guaranteeing that external info is not modified by any
-     * users, including rot.
+     * users, including root.
      *
-     * @param locked
-     * @param privileged
-     * @param obj
+     * @param privileged if the user is privileged
+     * @param obj the model object
      * @param previousDetails
      *            details representing the known DB state
      * @param currentDetails

--- a/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
+++ b/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
@@ -49,14 +49,14 @@ public class OneGroupSecurityFilter extends AbstractSecurityFilter {
     static public final String current_group = "current_group";
 
     /**
-     * default constructor which calls all the necessary setters for this
-     * {@link FactoryBean}. Also constructs the {@link #defaultFilterCondition }
+     * Default constructor which calls all the necessary setters for this
+     * {@link FactoryBean}. Also calls {@link #setDefaultFilterCondition(String)}.
      * This query clause must be kept in sync with
-     * {@link #passesFilter(Details, Long, Collection, Collection, boolean)}
+     * {@link #passesFilter(Session, Details, EventContext)}.
      *
-     * @see #passesFilter(Details, Long, Collection, Collection, boolean)
+     * @see #passesFilter(Session, Details, EventContext)
      * @see FilterDefinitionFactoryBean#setFilterName(String)
-     * @see FilterDefinitionFactoryBean#setParameterTypes(Properties)
+     * @see FilterDefinitionFactoryBean#setParameterTypes(java.util.Map)
      * @see FilterDefinitionFactoryBean#setDefaultFilterCondition(String)
      */
     public OneGroupSecurityFilter() {

--- a/components/server/src/ome/security/basic/PrincipalHolder.java
+++ b/components/server/src/ome/security/basic/PrincipalHolder.java
@@ -21,30 +21,32 @@ public interface PrincipalHolder {
 
     /**
      * Get the number of active principal contexts.
+     * @return the number of active principals
      */
     public int size();
 
     /**
      * Get the last, i.e. currently active, principal.
-     * 
-     * @return
+     * @return the current principal
      */
     public Principal getLast();
 
     /**
      * Add a new principal context to the stack.
+     * @param principal the principal to add
      */
     public void login(Principal principal);
 
     /**
      * Allow logging in directly with an event context.
-     * @param bec
+     * @param bec the event context to use
      */
     public void login(BasicEventContext bec);
 
     /**
      * Pop the last created principal context and return the number of active
      * contexts remaining.
+     * @return the number of active principals after the logout
      */
     public int logout();
 }

--- a/components/server/src/ome/security/policy/BasePolicy.java
+++ b/components/server/src/ome/security/policy/BasePolicy.java
@@ -30,7 +30,6 @@ import ome.model.IObject;
  * Simple base class for {@link Policy} implementations which always returns
  * true for {@link #isRestricted(IObject)} and always fails on
  * {@link #checkRestriction(IObject)}.
- * @param <T>
  */
 public abstract class BasePolicy implements Policy {
 

--- a/components/server/src/ome/security/policy/Policy.java
+++ b/components/server/src/ome/security/policy/Policy.java
@@ -81,7 +81,7 @@ public interface Policy {
     boolean isRestricted(IObject obj);
 
     /**
-     * Like {@link #isRestricted(Policy)} but throws an appropriate
+     * Like {@link #isRestricted(IObject)} but throws an appropriate
      * {@link SecurityViolation} subclass if the restriction is active.
      */
     void checkRestriction(IObject obj) throws SecurityViolation;

--- a/components/server/src/ome/tools/RepositoryTask.java
+++ b/components/server/src/ome/tools/RepositoryTask.java
@@ -12,7 +12,7 @@ import ome.api.IRepositoryInfo;
 import ome.util.SqlAction;
 
 /**
- * Class implementation of various mechanised tasks, database queries, file I/O,
+ * Class implementation of various mechanized tasks, database queries, file I/O,
  * etc. This class is used by the public services provided by IRepositoryInfo
  * 
  * @since 3.0
@@ -22,9 +22,6 @@ public class RepositoryTask {
 
 	final private SqlAction sql;
 
-	/**
-	 * Constructor
-	 */
 	public RepositoryTask(SqlAction sql) {
 	    this.sql = sql;
 	}
@@ -58,23 +55,4 @@ public class RepositoryTask {
 	public List<Long> getThumbnailIds() {
 	    return sql.getDeletedIds("ome.model.display.Thumbnail");
 	}
-
-	/**
-	 * Private method used for testing only. Will be removed later.
-	 * 
-	 * @return
-	 */
-	public List<Long> getTestIds() {
-		ArrayList<Long> list = new ArrayList<Long>();
-		Long var1 = new Long(63);
-		Long var2 = new Long(2613);
-		Long var3 = new Long(3331);
-
-		list.add(var1);
-		list.add(var2);
-		list.add(var3);
-
-		return list;
-	}
-
 }

--- a/components/server/src/ome/tools/hibernate/ExtendedMetadata.java
+++ b/components/server/src/ome/tools/hibernate/ExtendedMetadata.java
@@ -54,11 +54,13 @@ public interface ExtendedMetadata {
 
     /**
      * Returns all the classes which implement {@link IAnnotated}
+     * @return the annotatable types
      */
     Set<Class<IAnnotated>> getAnnotatableTypes();
 
     /**
      * Returns all the classes which subclass {@link Annotation}
+     * @return the types of annotation
      */
     Set<Class<Annotation>> getAnnotationTypes();
 
@@ -80,6 +82,8 @@ public interface ExtendedMetadata {
      * Given the name of a database table or alternatively the simple class name
      * (non-fully qualified) of an IObject, this method returns the class which
      * Hibernate will map that table to.
+     * @param table a database table name, or simple class name of a model object
+     * @return the corresponding mapped class
      */
     Class<IObject> getHibernateClass(String table);
 
@@ -108,7 +112,8 @@ public interface ExtendedMetadata {
      * objects will be returned.
      *
      * @param klass Not null.
-     * @return
+     * @param onlyWithGroups if should omit checks that point to {@link IGlobal}s
+     * @return the lock candidates for checking
      */
     String[][] getLockCandidateChecks(Class<? extends IObject> klass, boolean onlyWithGroups);
 
@@ -120,7 +125,6 @@ public interface ExtendedMetadata {
      *            Non-null {@link Class subclass} of {@link IObject}
      * @return A non-null array of {@link String} queries which can be used to
      *         determine if an {@link IObject} instance can be unlocked.
-     * @see Permissions.Flag#LOCKED
      */
     String[][] getLockChecks(Class<? extends IObject> klass);
 
@@ -140,16 +144,11 @@ public interface ExtendedMetadata {
      * </pre>
      *
      * If the clause argument is null or empty it will be omitted.
-     *
-     * @param id
-     * @param lockChecks
-     * @param clause
-     * @return
      */
     Map<String, Long> countLocks(Session session, Long id, String[][] lockChecks, String clause);
 
     /**
-     * Walks both the {@link #locksHolder} and the {@link #lockedByHolder} data
+     * Walks the data on what locks what
      * for "from" argument to see if there is any direct relationship to the
      * "to" argument. If there is, the name will be returned. Otherwise, null.
      */
@@ -168,12 +167,6 @@ public interface ExtendedMetadata {
      * returns "child". getSQLJoin("Image", "I", "DatasetImageLink", "L"),
      * however, will always return "I.id = L.child" (though the order may be
      * reversed).
-     *
-     * @param fromType
-     * @param fromAlias
-     * @param toType
-     * @param toAlias
-     * @return
      */
     String getSQLJoin(String fromType, String fromAlias, String toType, String toAlias);
 
@@ -252,8 +245,8 @@ public static class Impl extends OnContextRefreshedEventListener implements Exte
     /**
      * Initializes the metadata needed by this instance.
      * 
-     * @param sessionFactory
-     * @see SessionFactory#getAllClassMetadata()
+     * @param sessionFactory the Hibernate session factory
+     * @see org.hibernate.SessionFactory#getAllClassMetadata()
      */
     public void setSessionFactory(SessionFactory sessionFactory) {
 
@@ -375,7 +368,7 @@ public static class Impl extends OnContextRefreshedEventListener implements Exte
     }
 
     /**
-     * Walks both the {@link #locksHolder} and the {@link #lockedByHolder} data
+     * Walks the data on what locks what
      * for "from" argument to see if there is any direct relationship to the
      * "to" argument. If there is, the name will be returned. Otherwise, null.
      */
@@ -428,7 +421,7 @@ public static class Impl extends OnContextRefreshedEventListener implements Exte
 
     /**
      * walks the {@link IObject} argument <em>non-</em>recursively and gathers
-     * all {@link IObject} instances which will be linkd to by the
+     * all {@link IObject} instances which will be linked to by the
      * creation or updating of the argument. (Previously this was called "locking"
      * since a flag was set on the object to mark it as linked, but this was 
      * removed in 4.2)
@@ -461,7 +454,6 @@ public static class Impl extends OnContextRefreshedEventListener implements Exte
      *            Non-null {@link Class subclass} of {@link IObject}
      * @return A non-null array of {@link String} queries which can be used to
      *         determine if an {@link IObject} instance can be unlocked.
-     * @see Permissions.Flag#LOCKED
      */
     public String[][] getLockChecks(Class<? extends IObject> klass) {
         if (klass == null) {
@@ -950,6 +942,7 @@ class Locks {
      * components) can possibly point to multiple instances. See
      * {@link #total()} for the final size and (2) some fields do not need to be
      * examined (Integers, e.g.). See {@link #include}
+     * @return how many fields this entity has
      */
     public int size() {
         return size;
@@ -958,6 +951,7 @@ class Locks {
     /**
      * as opposed to {@link #size()}, the returns the actual number of fields
      * that will need to be checked.
+     * @return how many fields must be checked for this entity
      */
     public int total() {
         return total;

--- a/components/server/src/ome/tools/hibernate/HibernateUtils.java
+++ b/components/server/src/ome/tools/hibernate/HibernateUtils.java
@@ -91,8 +91,8 @@ public abstract class HibernateUtils {
     }
 
     /**
-     * returns the id of the {@link ExperimenterGroup group} of this entity, or
-     * null if: (1) the object is null, (2) the {@link Details} is null, (3) the
+     * returns the id of the {@link ome.model.meta.ExperimenterGroup group} of this entity,
+     * or null if: (1) the object is null, (2) the {@link Details} is null, (3) the
      * group is null.
      * 
      * @param iobject
@@ -114,21 +114,6 @@ public abstract class HibernateUtils {
 
     /**
      * loads collections which have been filtered or nulled by the user
-     * 
-     * @param entity
-     *            IObject to have its collections reloaded
-     * @param id
-     *            persistent (db) id of this entity
-     * @param currentState
-     *            the possibly changed field data for this entity
-     * @param previousState
-     *            the field data as seen in the db
-     * @param propertyNames
-     *            field names
-     * @param types
-     *            Hibernate {@link Type} for each field
-     * @param detailsIndex
-     *            the index of the {@link Details} instance (perf opt)
      */
     public static void fixNulledOrFilteredCollections(IObject entity,
             IObject target, EntityPersister persister, SessionImplementor source) {
@@ -201,12 +186,9 @@ public abstract class HibernateUtils {
     }
 
     /**
-     * 
-     * @param newD
-     *            Not null.
-     * @param oldD
-     *            Not null.
-     * @return
+     * @param new_d the new details
+     * @param old_d the old details
+     * @return if the non-permissions fields are the same
      */
     public static boolean onlyPermissionsChanged(Details new_d, Details old_d) {
         if (idEqual(new_d.getOwner(), old_d.getOwner())
@@ -220,7 +202,7 @@ public abstract class HibernateUtils {
     }
 
     /**
-     * returns true under the following circumstatnces:
+     * returns true under the following circumstances:
      * <ul>
      * <li>both arguments are null, or</li>
      * <li>both arguments are identical (==), or</li>

--- a/components/server/src/ome/tools/hibernate/ListAsSQLArrayUserType.java
+++ b/components/server/src/ome/tools/hibernate/ListAsSQLArrayUserType.java
@@ -247,8 +247,6 @@ public abstract class ListAsSQLArrayUserType<T> implements UserType, Parameteriz
         private E[] theEnumValues;
 
         /**
-         * @param clazz
-         *            the class of the enum.
          * @param theEnumValues
          *            The values of enum (by invoking .values()).
          */
@@ -305,7 +303,6 @@ public abstract class ListAsSQLArrayUserType<T> implements UserType, Parameteriz
         return true;
     }
 
-    @SuppressWarnings("unused")
     public Object nullSafeGet(ResultSet resultSet, String[] names, Object owner)
             throws HibernateException, SQLException {
 
@@ -334,14 +331,13 @@ public abstract class ListAsSQLArrayUserType<T> implements UserType, Parameteriz
             return true;
         if (null == x || null == y)
             return false;
-        Class javaClass = returnedClass();
+        Class<?> javaClass = returnedClass();
         if (!javaClass.equals(x.getClass()) || !javaClass.equals(y.getClass()))
             return false;
 
         return x.equals(y);
     }
 
-    @SuppressWarnings("unused")
     public Object assemble(Serializable cached, Object owner)
             throws HibernateException {
         return cached;
@@ -351,7 +347,6 @@ public abstract class ListAsSQLArrayUserType<T> implements UserType, Parameteriz
         return (Serializable) value;
     }
 
-    @SuppressWarnings("unused")
     public Object replace(Object original, Object target, Object owner)
             throws HibernateException {
         return original;

--- a/components/server/src/ome/tools/hibernate/ProxyCleanupFilter.java
+++ b/components/server/src/ome/tools/hibernate/ProxyCleanupFilter.java
@@ -48,7 +48,7 @@ import org.hibernate.collection.AbstractPersistentCollection;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 1.0
- * @see ticket 8277
+ * @see <a href="http://trac.openmicroscopy.org/ome/ticket/8277">Trac ticket #8277</a>
  */
 public class ProxyCleanupFilter extends ContextFilter {
 
@@ -59,7 +59,7 @@ public class ProxyCleanupFilter extends ContextFilter {
     protected final CurrentDetails current;
 
     /**
-     * Passes null to {@link ProxyCleanupFilter#ProxyCleanupFilter(CurrentDetails)}
+     * Passes {@code null}s to {@link ProxyCleanupFilter#ProxyCleanupFilter(ACLVoter, CurrentDetails)}
      * such that all restricted objects will be unloaded.
      */
     public ProxyCleanupFilter() {
@@ -67,8 +67,10 @@ public class ProxyCleanupFilter extends ContextFilter {
     }
 
     /**
-     * Constructor take a {@link CurrentDetails} object in order to check
+     * Construct a proxy cleanup filter that checks
      * the security restrictions on certain objects.
+     * @param acl the ACL voter
+     * @param current the current thread's security context
      */
     public ProxyCleanupFilter(ACLVoter acl, CurrentDetails current) {
         this.acl = acl;

--- a/components/server/src/ome/tools/hibernate/QueryBuilder.java
+++ b/components/server/src/ome/tools/hibernate/QueryBuilder.java
@@ -97,9 +97,7 @@ public class QueryBuilder {
 
     /**
      * Whether {@link Session#createSQLQuery(String)} should be used or not during
-     * {@link #__query(Session, boolean)}
-     *
-     * @param sqlQuery
+     * {@link #query(Session)} and similar.
      */
     public QueryBuilder(boolean sqlQuery) {
         this.sqlQuery = sqlQuery;
@@ -112,9 +110,8 @@ public class QueryBuilder {
 
     /**
      * Obtain a unique alias to be used in the SQL.
-     * 
-     * @param prefix
-     *            Not null
+     * @param prefix the prefix for the alias
+     * @return a unique alias
      */
     public String unique_alias(String prefix) {
         StringBuilder sb = new StringBuilder(prefix.length() + 8);
@@ -161,12 +158,6 @@ public class QueryBuilder {
 
     }
 
-    /**
-     *
-     * @param type
-     * @param alias
-     * @return
-     */
     public QueryBuilder from(String type, String alias) {
         current = from;
         if (from.length() == 0) {
@@ -219,9 +210,6 @@ public class QueryBuilder {
     /**
      * Appends "and" plus your string unless this is the first where-spec in
      * which case it is simply appended.
-     * 
-     * @param str
-     * @return
      */
     public QueryBuilder and(String str) {
         return _where("and ", str);
@@ -231,9 +219,6 @@ public class QueryBuilder {
     /**
      * Appends "or" plus your string unless this is the first where-spec in
      * which case it is simply appended.
-     * 
-     * @param str
-     * @return
      */
     public QueryBuilder or(String str) {
         return _where("or ", str);
@@ -412,6 +397,7 @@ public class QueryBuilder {
     /**
      * Returns the current query as a String. As opposed to {@link #toString()},
      * this method should return parseable HQL.
+     * @return the current HQL query
      */
     public String queryString() {
         StringBuilder sb = new StringBuilder();
@@ -469,9 +455,9 @@ public class QueryBuilder {
 
     /**
      * Similar to how skipFrom and skipWhere were previously used, this sets
-     * the current builder to {@link #where} but without prefacing the
+     * the current builder to {@link #where()} but without prefacing the
      * "where " string. Instead, it adds a space so that further calls to
-     * {@link #where} also won't add it. This can be used to create a clause
+     * {@link #where()} also won't add it. This can be used to create a clause
      * that can later be combined via {@link #subselect(QueryBuilder)}.
      */
     public QueryBuilder whereClause() {

--- a/components/server/src/ome/tools/hibernate/SessionFactory.java
+++ b/components/server/src/ome/tools/hibernate/SessionFactory.java
@@ -72,7 +72,8 @@ public class SessionFactory implements MethodInterceptor {
     /**
      * Returns a session active for the current thread. The returned
      * instance will be wrapped with AOP to prevent certain usage.
-     * @see ticket:73
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/73">Trac ticket #73</a>
+     * @return a wrapped active Hibernate session
      */
     public Session getSession() {
 

--- a/components/server/src/ome/tools/hibernate/SessionHandler.java
+++ b/components/server/src/ome/tools/hibernate/SessionHandler.java
@@ -112,11 +112,9 @@ public class SessionHandler implements MethodInterceptor,
             + " constructor should be not null.";
 
     /**
-     * constructor taking a {@link DataSource} and a {@link SessionFactory}. A
-     * new {@link HibernateInterceptor} will be created.
-     * 
-     * @param dataSource
-     *            Not null.
+     * Constructor taking a {@link SessionFactory}.
+     * A new {@link HibernateInterceptor} will be created.
+     *
      * @param factory
      *            Not null.
      */

--- a/components/server/src/ome/tools/hibernate/UpdateFilter.java
+++ b/components/server/src/ome/tools/hibernate/UpdateFilter.java
@@ -45,12 +45,12 @@ public class UpdateFilter extends ContextFilter {
      * instead.
      * </p>
      * <p>
-     * The replacement is set by {@link MergeEventListener} and this is the
+     * The replacement is set by {@link ome.security.basic.MergeEventListener} and this is the
      * signal that that entity can be unloaded. Usually, this method is invoked
      * by {@link ome.logic.UpdateImpl}
      * </p>
      * 
-     * @see MergeEventListener
+     * @see ome.security.basic.MergeEventListener
      * @see ome.logic.UpdateImpl
      * @see IObject#unload()
      */
@@ -132,7 +132,7 @@ public class UpdateFilter extends ContextFilter {
 
     /**
      * Prevents CountPerOwner from being loaded unnecessarily.
-     * @see ticket:3978
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/3978">Trac ticket #3978</a>
      */
     @Override
     public Map filter(String fieldId, Map m) {


### PR DESCRIPTION
This PR should improve the Javadoc within `ome.security.*`. Building the Javadoc should not report warnings within those classes. It also improves  the Javadoc within `ome.tools.*` though `FileSystem` will still give warnings unless #4127 is merged in. Apart from that, within the server component it is probably now only `ome.services.*` that generates warnings.

--no-rebase