### PR TITLE
Fixing trailing slash (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -54,7 +54,7 @@ $(function() {
         //...while we load groups
         // Need to find which groups we can move selected objects to.
         // Object owner must be member of target group.
-        var url = webindex_url + "load_chgrp_groups?" + OME.get_tree_selection();
+        var url = webindex_url + "load_chgrp_groups/?" + OME.get_tree_selection();
         $.getJSON(url, function(data){
             data_owners = data.owners;  // save for later
             var ownernames = [];
@@ -98,7 +98,7 @@ $(function() {
         $.jstree._focused().save_selected();        // 'Cancel' will roll back to this
         var sel = OME.get_tree_selection(),
             selImages = (sel.indexOf('Image') > -1);
-        $.get(webindex_url + "fileset_check/chgrp?" + sel, function(html){
+        $.get(webindex_url + "fileset_check/chgrp/?" + sel, function(html){
             if($('div.split_fileset', html).length > 0) {
                 $(html).appendTo($chgrpform);
                 $('.chgrp_confirm_dialog .ui-dialog-buttonset button:nth-child(2) span').text("Move All");


### PR DESCRIPTION

This is the same as gh-4123 but rebased onto develop.

----

This fixes issue with Move to group dialog box. URLs were missing trailing slash and redirected. Redirection was blocked loading mixed active content.

```
GET https://trout.o.org/integration/webclient/fileset_check/chgrp?Project=191 301 MOVED PERMANENTLY
GET https://trout.o.org/integration/webclient/load_chgrp_groups?Project=191 301 MOVED PERMANENTLY
Blocked loading mixed active content "http://trout.o.org/integration/webclient/fileset_check/chgrp/?Project=..."
Blocked loading mixed active content "http://trout.o.org/integration/webclient/load_chgrp_groups/?Project=..."
```

URL:
```
url(r'^load_chgrp_groups/$',
        views.load_chgrp_groups,
        name="load_chgrp_groups"),  # Query E.g. ?Image=1,2&Dataset=3
```
They must be consistent. By default https://docs.djangoproject.com/en/1.6/ref/settings/#append-slash in True.

@will-moore if you want to use both you have to add:
```
(r'^load_chgrp_groups$', redirect_to, {'url': ...}),
```

cc: @sbesson @will-moore 



                