### PR TITLE
improve Blitz Javadoc

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -74,7 +74,7 @@ import Ice.Current;
  * OmeroCpp omero::client class.
  *
  * In order to more closely map the destructors in Python and C++, this class
- * keeps a {@link #CLIENTS collection} of {@link omero.client} instances, which
+ * keeps a collection of {@link omero.client} instances, which
  * are destroyed on program termination.
  *
  * Typical usage: <code>
@@ -83,7 +83,7 @@ import Ice.Current;
  *   omero.client client = new omero.client(host, port); // Defines "omero.host" and "omero.port"
  *</code>
  *
- * More more information, see <a
+ * For more information, see <a
  * href="http://trac.openmicroscopy.org.uk/ome/wiki/ClientDesign">
  * http://trac.openmicroscopy.org.uk/ome/wiki/ClientDesign </a>
  *
@@ -213,6 +213,7 @@ public class client {
     /**
      * Creates an {@link Ice.Communicator} from a {@link Ice.InitializationData}
      * instance. Cannot be null.
+     * @param id the Ice initialization data
      */
     public client(Ice.InitializationData id) {
         insecure = false;
@@ -221,7 +222,8 @@ public class client {
 
     /**
      * Creates an {@link Ice.Communicator} pointing at the given server using
-     * the {@link #DEFAULT_PORT}.
+     * the {@link ome.system.Server#DEFAULT_PORT}.
+     * @param host the server host name
      */
     public client(String host) {
         this(defaultRouter(host, omero.constants.GLACIER2PORT.value));
@@ -230,6 +232,8 @@ public class client {
     /**
      * Creates an {@link Ice.Communicator} pointing at the given server with the
      * non-standard port.
+     * @param host the server host name
+     * @param port the server port number
      */
     public client(String host, int port) {
         this(defaultRouter(host, port));
@@ -238,6 +242,7 @@ public class client {
     /**
      * Calls {@link #client(String[], Ice.InitializationData)} with a new
      * {@link Ice.InitializationData}
+     * @param args command-line arguments
      */
     public client(String[] args) {
         this(args, new Ice.InitializationData());
@@ -247,6 +252,8 @@ public class client {
      * Creates an {@link Ice.Communicator} from command-line arguments. These
      * are parsed via Ice.Properties.parseIceCommandLineOptions(args) and
      * Ice.Properties.parseCommandLineOptions("omero", args)
+     * @param args command-line arguments
+     * @param id the Ice initialization data
      */
     public client(String[] args, Ice.InitializationData id) {
         insecure = false;
@@ -260,6 +267,7 @@ public class client {
 
     /**
      * Creates an {@link Ice.Communicator} from multiple files.
+     * @param files files from which to load properties
      */
     public client(File... files) {
         insecure = false;
@@ -276,6 +284,7 @@ public class client {
      * {@link String} representation of each member is added to the
      * {@link Ice.Properties} under the {@link String} representation of the
      * key.
+     * @param p properties
      */
     public client(Map p) {
         this(p, true);
@@ -419,9 +428,11 @@ public class client {
     }
 
     /**
-     * Sets the {@link #fastShutdown} flag. By setting this
+     * Sets the {@code fastShutdown} flag. By setting this
      * to true, you will prevent proper clean up. This should
      * only be used in the case of network loss (or similar).
+     * @param fastShutdown if shutdown should be fast
+     * @return the previous value of this property
      */
     public boolean setFastShutdown(boolean fastShutdown) {
         return this.fastShutdown.getAndSet(fastShutdown);
@@ -430,8 +441,9 @@ public class client {
     /**
      * Sets the {@link omero.model.Session#getUserAgent() user agent} string for
      * this client. Every session creation will be passed this argument. Finding
-     * open sesssions with the same agent can be done via
+     * open sessions with the same agent can be done via
      * {@link omero.api.ISessionPrx#getMyOpenAgentSessions(String)}.
+     * @param agent the user agent for sessions
      */
     public void setAgent(String agent) {
         __agent = agent;
@@ -440,8 +452,9 @@ public class client {
     /**
      * Sets the {@link omero.model.Session#getUserIP() user ip} string for
      * this client. Every session creation will be passed this argument. Finding
-     * open sesssions with the same agent can be done via
-     * {@link omero.api.ISessionPrx#getMyOpenIPSessions(String)}.
+     * open sessions with the same agent can be done via
+     * {@link omero.api.ISessionPrx#getMyOpenAgentSessions(String)}.
+     * @param ip the user IP address
      */
     public void setIP(String ip) {
         __ip = ip;
@@ -451,6 +464,7 @@ public class client {
      * Specifies whether or not this client was created via a call to
      * {@link #createClient(boolean)} with a boolean of false. If insecure, then
      * all remote calls will use the insecure connection defined by the server.
+     * @return if the client's remote calls are secure
      */
     public boolean isSecure() {
         return !insecure;
@@ -507,6 +521,7 @@ public class client {
     /**
      * Returns the {@link Ice.Communicator} for this instance or throws an
      * exception if null.
+     * @return this client's {@link Ice.Communicator}
      */
     public Ice.Communicator getCommunicator() {
         Ice.Communicator ic = __ic;
@@ -529,6 +544,7 @@ public class client {
      * Returns the current active session or throws an exception if none has
      * been {@link #createSession(String, String) created} since the last
      * {@link #closeSession()}
+     * @return the current active session
      */
     public ServiceFactoryPrx getSession() {
         ServiceFactoryPrx sf = __sf;
@@ -542,6 +558,7 @@ public class client {
      * Returns the UUID for the current session without making a remote call.
      * Uses {@link #getSession()} internally and will throw an exception if
      * no session is active.
+     * @return the current session's UUID
      */
     public String getSessionId() {
         return getSession().ice_getIdentity().name;
@@ -550,6 +567,7 @@ public class client {
     /**
      * Returns the category which should be used for all callbacks
      * passed to the server.
+     * @return the category for callbacks
      */
     public String getCategory() {
         return getRouter(getCommunicator()).getCategoryForClient();
@@ -557,7 +575,8 @@ public class client {
 
     /**
      * @see #getSession()
-     * @deprecated
+     * @return the current active session
+     * @deprecated use {@link #getSession()} instead, to be removed in 5.3
      */
     @Deprecated
     public ServiceFactoryPrx getServiceFactory() {
@@ -567,6 +586,7 @@ public class client {
     /**
      * Returns the {@link Ice.ImplicitContext} which defines what properties
      * will be sent on every method invocation.
+     * @return the {@link Ice.ImplicitContext}
      */
     public Ice.ImplicitContext getImplicitContext() {
         return getCommunicator().getImplicitContext();
@@ -574,6 +594,7 @@ public class client {
 
     /**
      * Returns the {@link Ice.Properties active properties} for this instance.
+     * @return the active properties
      */
     public Ice.Properties getProperties() {
             return getCommunicator().getProperties();
@@ -581,6 +602,8 @@ public class client {
 
     /**
      * Returns the property value for this key or the empty string if none.
+     * @param key a property key
+     * @return the key's value or the empty string if none
      */
     public String getProperty(String key) {
         return getProperties().getProperty(key);
@@ -589,6 +612,7 @@ public class client {
     /**
      * Returns all properties which are prefixed with "omero." or "Ice."
      * using the Properties from {@link #getProperties()}.
+     * @return the "omero." and "Ice." properties
      */
     public Map<String, String> getPropertyMap() {
         return getPropertyMap(getProperties());
@@ -596,6 +620,8 @@ public class client {
 
     /**
      * Returns all properties which are prefixed with "omero." or "Ice."
+     * @param properties some Ice properties
+     * @return the "omero." and "Ice." properties
      */
     public Map<String, String> getPropertyMap(Ice.Properties properties) {
         Map<String, String> rv = new HashMap<String, String>();
@@ -608,8 +634,9 @@ public class client {
     }
 
     /**
-     * Returns the user configured setting for "omero.block_size"
+     * Returns the user-configured setting for "omero.block_size"
      * or {@link omero.constants.DEFAULTBLOCKSIZE} if none is set.
+     * @return the block size (in bytes)
      */
     public int getDefaultBlockSize() {
         try {
@@ -625,9 +652,6 @@ public class client {
     /**
      * Uses the given session uuid as name and password to rejoin a running
      * session.
-     *
-     * @throws PermissionDeniedException
-     * @throws CannotCreateSessionException
      */
     public ServiceFactoryPrx joinSession(String session)
             throws CannotCreateSessionException, PermissionDeniedException,
@@ -646,15 +670,9 @@ public class client {
 
     /**
      * Performs the actual logic of logging in, which is done via the
-     * {@link #getRouter()}. Disallows an extant {@link ServiceFactoryPrx}, and
-     * tries to re-create a null {@link Ice.Communicator}. A null or empty
+     * {@link #getRouter(Ice.Communicator)}. Disallows an extant {@link ServiceFactoryPrx}
+     * and tries to re-create a null {@link Ice.Communicator}. A null or empty
      * username will throw an exception, but an empty password is allowed.
-     *
-     * @param username
-     * @param password
-     * @return
-     * @throws CannotCreateSessionException
-     * @throws PermissionDeniedException
      */
     public ServiceFactoryPrx createSession(String username, String password)
             throws CannotCreateSessionException, PermissionDeniedException,
@@ -773,6 +791,8 @@ public class client {
      * Acquires the {@link Ice.Communicator#getDefaultRouter default router},
      * and throws an exception if it is not of type {Glacier2.RouterPrx}. Also
      * sets the {@link Ice.ImplicitContext} on the router proxy.
+     * @param comm the Ice communicator
+     * @return the communicator's router
      */
     public static Glacier2.RouterPrx getRouter(Ice.Communicator comm) {
         Ice.RouterPrx prx = comm.getDefaultRouter();
@@ -795,8 +815,7 @@ public class client {
     /**
      * Resets the "omero.keep_alive" property on the current
      * {@link Ice.Communicator} which is used on initialization to determine the
-     * time-period between {@link Resources.Entry#check() checks}. If no
-     * {@link #__resources} is available currently, one is also created.
+     * time-period between {@link omero.util.Resources.Entry#check() checks}.
      */
     public void enableKeepAlive(int seconds) {
 
@@ -982,6 +1001,8 @@ public class client {
 
     /**
      * Calculates the local sha1 for a file.
+     * @param file a local file
+     * @return the file's SHA-1 hexadecimal digest
      */
     public String sha1(File file) {
         ChecksumProviderFactory cpf = new ChecksumProviderFactoryImpl();
@@ -1006,7 +1027,6 @@ public class client {
      *            Can be null.
      * @param blockSize
      *            Can be null.
-     * @throws IOException
      */
     public OriginalFile upload(File file, OriginalFile fileObject, Integer blockSize) throws ServerError, IOException {
         ServiceFactoryPrx sf = getSession();

--- a/components/blitz/src/omero/cmd/CallContext.java
+++ b/components/blitz/src/omero/cmd/CallContext.java
@@ -23,7 +23,7 @@ import omero.SecurityViolation;
  * allows users to dynamically change, for example, the
  * call group without modifying the whole session.
  *
- * @see ticket:3529
+ * @see <a href="http://trac.openmicroscopy.org/ome/ticket/3529">Trac ticket #3529</a>
  */
 public class CallContext implements MethodInterceptor {
 

--- a/components/blitz/src/omero/cmd/HandleI.java
+++ b/components/blitz/src/omero/cmd/HandleI.java
@@ -132,8 +132,9 @@ public class HandleI implements _HandleOperations, IHandle,
     //
 
     /**
-     * Create a {@link HandleI} in the {@link State#CREATED} state with the
-     * given cancel timeout in milliseconds.
+     * Create a {@link HandleI} (at {@code CREATED} in the state diagram)
+     * with the given cancel timeout in milliseconds.
+     * @param cancelTimeoutMs the cancel timeout (in milliseconds)
      */
     public HandleI(int cancelTimeoutMs) {
         this.cancelTimeoutMs = cancelTimeoutMs;
@@ -175,8 +176,8 @@ public class HandleI implements _HandleOperations, IHandle,
 
     /**
      * Calls the proper notification on all callbacks based on the current
-     * {@link #state}. If the {@link State} is anything other than
-     * {@link State#CANCELLED} or {@link State#FINISHED} then
+     * position in the state diagram. If that is anything other than
+     * {@code CANCELLED} or {@code FINISHED} then
      * {@link CmdCallbackPrx#step(int, int)} is called.
      */
     public void notifyCallbacks() {
@@ -341,7 +342,7 @@ public class HandleI implements _HandleOperations, IHandle,
 
     /**
      *
-     * NB: only executes if {@link #state} is {@link State#CREATED}.
+     * NB: Executes only if at {@code CREATED} in the state diagram.
      */
     public void run() {
 
@@ -482,7 +483,7 @@ public class HandleI implements _HandleOperations, IHandle,
     }
 
     /**
-     * Signals that {@link HandleI#run()} has noticed that {@link HandleI#state}
+     * Signals that {@link HandleI#run()} has noticed that the state diagram
      * wants a cancellation or that the {@link Request} implementation wishes to
      * stop execution.
      */

--- a/components/blitz/src/omero/cmd/Helper.java
+++ b/components/blitz/src/omero/cmd/Helper.java
@@ -89,8 +89,9 @@ public class Helper {
     /**
      * Run {@link IRequest#init(Helper)} on a sub-command by creating a new
      * Helper instance.
-     * @param ireq
-     * @param substatus
+     * @param req the request
+     * @param substatus its status for its new helper
+     * @return the new helper
      */
     public Helper subhelper(Request req, Status substatus) {
         return new Helper(req, substatus, sql, session, sf);
@@ -129,10 +130,8 @@ public class Helper {
     /**
      * Set the response if there is not currently run, in which case true
      * is returned. Otherwise, false.
-     *
-     * @param rsp
-     *            Can be null.
-     * @return
+     * @param rsp the response
+     * @return if the setting was successful
      */
     public boolean setResponseIfNull(Response rsp) {
         return this.rsp.compareAndSet(null, rsp);
@@ -200,6 +199,8 @@ public class Helper {
     /**
      * Converts pairs of values from the varargs list into a map. Any leftover
      * value will be ignored.
+     * @param paramList a list of parameters
+     * @return a map with entries constructed from consecutive pairs of the parameters
      */
     public Map<String, String> params(final String... paramList) {
         Map<String, String> params = new HashMap<String, String>();
@@ -213,12 +214,8 @@ public class Helper {
     }
 
     /**
-     * Calls {@link #fail(ERR, String, Map)} with the output of
+     * Calls {@link #fail(ERR, Throwable, String, Map)} with the output of
      * {@link #params(String...)}.
-     *
-     * @param err
-     * @param name
-     * @param paramList
      */
     public void fail(ERR err, Throwable t, final String name, final String... paramList) {
         fail(err, t, name, params(paramList));
@@ -227,10 +224,6 @@ public class Helper {
     /**
      * Sets the status.flags and the ERR properties appropriately and also
      * stores the message and stacktrace of the throwable in the parameters.
-     *
-     * @param err
-     * @param name
-     * @param params
      */
     public void fail(ERR err, Throwable t, final String name,
             final Map<String, String> params) {
@@ -260,15 +253,10 @@ public class Helper {
     }
 
     /**
-     * Calls {@link #cancel(ERR, Throwable, String, Map<String, String>)} with
+     * Calls {@link #cancel(ERR, Throwable, String, Map)} with
      * the output of {@link #params(String...)}.
      *
      * See the statement about the return value.
-     *
-     * @param err
-     * @param t
-     * @param name
-     * @param paramList
      */
     public Cancel cancel(ERR err, Throwable t, final String name,
             final String... paramList) {
@@ -276,7 +264,7 @@ public class Helper {
     }
 
     /**
-     * Like {@link #fail(ERR, String, String...)} throws a
+     * Like {@link #fail(ERR, Throwable, String, String...)} throws a
      * {@link Cancel} exception.
      *
      * A {@link Cancel} is thrown, even though one is also specified as the
@@ -288,11 +276,6 @@ public class Helper {
      * </pre>
      * since omitting the "throw" within the catch clauses forces one to enter
      * a number of "return null; // Never reached" lines.
-     *
-     * @param err
-     * @param t
-     * @param name
-     * @param params
      */
     public Cancel cancel(ERR err, Throwable t, final String name,
             final Map<String, String> params) {
@@ -315,10 +298,8 @@ public class Helper {
      *         return null;
      *     }
      * </pre>
-     *
-     * @param i
-     * @param step
-     * @return
+     * @param i the expected step number
+     * @param step the actual step number
      */
     public void assertStep(int i, int step) {
         if (step != i) {
@@ -331,6 +312,7 @@ public class Helper {
     /**
      * Checks the given steps against the number of times that this method
      * has been called on this instance and then increments the call count.
+     * @param step the new step number
      */
     public void assertStep(int step) {
         assertStep(this.assertSteps, step);
@@ -340,6 +322,7 @@ public class Helper {
     /**
      * Checks the given steps against the number of times that this method
      * has been called on this instance and then increments the call count.
+     * @param step the step number for the new response
      */
     public void assertResponse(int step) {
         assertStep(this.assertResponses, step);
@@ -348,6 +331,8 @@ public class Helper {
 
     /**
      * Returns true if this is the last step for the given request.
+     * @param step the step number
+     * @return if the given step is the last
      */
     public boolean isLast(int step) {
         return step == (status.steps - 1);
@@ -356,6 +341,7 @@ public class Helper {
     /**
      * Provides an {@link EventContext} instance without reloading the session,
      * via {@link LocalAdmin#getEventContextQuiet()}.
+     * @return the event context
      */
     public EventContext getEventContext() {
         final LocalAdmin admin = (LocalAdmin) sf.getAdminService();

--- a/components/blitz/src/omero/cmd/IRequest.java
+++ b/components/blitz/src/omero/cmd/IRequest.java
@@ -36,6 +36,8 @@ public interface IRequest {
      * implementations will require "omero.group":"-1" for example and will
      * hard-code that value. Others may permit users to pass in the desired
      * values which will be merged into the static {@link Map} as desired.
+     *
+     * @return the call context for this request
      */
     Map<String, String> getCallContext();
 
@@ -43,11 +45,14 @@ public interface IRequest {
      * Method called within the transaction boundaries before any processing occurs.
      * 
      * Implementations must properly initialize the "step" field of the
-     * {@link Status} object by calling {@link Helper#setSteps(int). This count
+     * {@link Status} object by calling {@link Helper#setSteps(int)}. This count
      * will define how many times the {@link #step(int)} method will be called.
      * 
      * The {@link Helper} instance passed in contains those resources needed by
      * IRequests to interact with data and should be stored for later use.
+     *
+     * @param helper the helper for this request
+     * @throws Cancel if this request is cancelled
      */
     void init(Helper helper) throws Cancel;
 
@@ -58,10 +63,10 @@ public interface IRequest {
      * current thread and transaction. After processing and detachment from
      * the transaction, the object will be passed to
      * {@link #buildResponse(int, Object)} for conversion and storage.
-     * 
-     * @param i
-     * @return
-     * @throws Cancel
+     *
+     * @param step the step number
+     * @return an object to be used in building the response
+     * @throws Cancel if this request is cancelled
      */
     Object step(int step) throws Cancel;
 
@@ -70,6 +75,7 @@ public interface IRequest {
      * occurred. A thrown {@link Cancel} will still rollback the current
      * transaction.
      *
+     * @throws Cancel if this request is cancelled
      * @since 5.0.0
      */
     void finish() throws Cancel;
@@ -77,9 +83,9 @@ public interface IRequest {
     /**
      * Post-transaction chance to map from the return value of
      * {@link #step(int)} to a {@link omero.cmd.Response} object.
-     * 
-     * @param i
-     * @param object
+     *
+     * @param step the step number
+     * @param object an object to be used in building the response
      */
     void buildResponse(int step, Object object);
 
@@ -88,6 +94,8 @@ public interface IRequest {
      * by synchronization where necessary, and should never raise an exception.
      * It is also guaranteed to be called so that any state cleanup that is
      * necessary can take place here.
+     *
+     * @return the response to this request
      */
     Response getResponse();
 

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -53,7 +53,7 @@ import omero.cmd.mail.SendEmailRequestI;
  * register all its {@link Ice.ObjectFactory} instances with the
  * {@link Ice.Communicator}.
  *
- * @see ticket:6340
+ * @see <a href="http://trac.openmicroscopy.org/ome/ticket/6340">Trac ticket #6340</a>
  */
 public class RequestObjectFactoryRegistry extends
         omero.util.ObjectFactoryRegistry implements ApplicationContextAware {

--- a/components/blitz/src/omero/cmd/SessionI.java
+++ b/components/blitz/src/omero/cmd/SessionI.java
@@ -341,7 +341,7 @@ public class SessionI implements _SessionOperations {
 
     /**
      * Called if this isn't a kill-everything event.
-     * @see ticket 9330
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/9330">Trac ticket #9330</a>
      */
     public void cleanupSelf() {
         if (log.isInfoEnabled()) {
@@ -352,8 +352,8 @@ public class SessionI implements _SessionOperations {
 
     /**
      * Performs the actual cleanup operation on all the resources shared between
-     * this and other {@link ServiceFactoryI} instances in the same
-     * {@link Session}. Since {@link #destroy()} is called regardless by the
+     * this and other {@link ome.services.blitz.impl.ServiceFactoryI} instances in the
+     * same {@link Session}. Since {@link #destroy(Current)} is called regardless by the
      * router, even when a client has just died, we have this internal method
      * for handling the actual closing of resources.
      *
@@ -364,7 +364,7 @@ public class SessionI implements _SessionOperations {
      * the entire instance, then we should still close down the stateless
      * services for this instance as well as remove ourselves from the adapter.
      *
-     * @see ticket 9330
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/9330">Trac ticket #9330</a>
      */
     public void doDestroy() {
 
@@ -378,7 +378,7 @@ public class SessionI implements _SessionOperations {
      * Use {@link #cleanServants(boolean, String, ServantHolder, Ice.ObjectAdapter)}
      * to clean up.
      *
-     * @param all
+     * @param all if stateful sessions should be shut down such that other clients cannot reattach (the servant is cleaned up)
      */
     public void cleanServants(boolean all) {
         cleanServants(all, clientId, holder, adapter);
@@ -390,7 +390,7 @@ public class SessionI implements _SessionOperations {
      * processed. Otherwise, only servants that a) belong to this clientId and
      * b) are not stateful (since stateful services may be used by other clients).
      *
-     * @param all
+     * @param all if stateful sessions should be shut down such that other clients cannot reattach (the servant is cleaned up)
      * @param clientId Only used if all is false.
      * @param holder {@link ServantHolder} to be cleaned.
      * @param adapter from which the servants should be removed.
@@ -492,8 +492,8 @@ public class SessionI implements _SessionOperations {
     }
 
     /**
-     * Creates a proxy according to the {@link ServantDefinition} for the given
-     * name. Injects the {@link #helper} instance for this session so that all
+     * Creates a proxy according to the servant definition for the given
+     * name. Injects the instance for this session so that all
      * services are linked to a single session.
      *
      * Creates an ome.api.* service (mostly managed by Spring), wraps it with
@@ -532,10 +532,10 @@ public class SessionI implements _SessionOperations {
 
     /**
      * Apply proper AOP and call setters for any known injection properties.
-     * @param servant
-     * @throws ServerError
+     * @param servant the servant
+     * @throws ServerError if the configuration or tying failed
      */
-    public void configureServant(Ice. Object servant) throws ServerError {
+    public void configureServant(Ice.Object servant) throws ServerError {
         // Now setup the servant
         // ---------------------------------------------------------------------
         internalServantConfig(servant);
@@ -626,10 +626,10 @@ public class SessionI implements _SessionOperations {
 
     /**
      * Reverts all the additions made by
-     * {@link #registerServant(ServantInterface, Ice.Current, Ice.Identity)}
+     * {@link #registerServant(Ice.Identity, Ice.Object)}
      *
      * Now called by {@link ome.services.blitz.fire.SessionManagerI} in response
-     * to an {@link UnregisterServantMessage}
+     * to an {@link ome.services.blitz.util.UnregisterServantMessage}.
      */
     public static void unregisterServant(Ice.Identity id, Ice.ObjectAdapter adapter,
         ServantHolder holder) {
@@ -678,7 +678,7 @@ public class SessionI implements _SessionOperations {
     }
 
     /**
-     * Definition of session ids: "session-<CLIENTID>/<UUID>"
+     * Definition of session ids: {@code "session-<CLIENTID>/<UUID>"}
      */
     public static Ice.Identity sessionId(String clientId, String uuid) {
         Ice.Identity id = new Ice.Identity();
@@ -690,8 +690,6 @@ public class SessionI implements _SessionOperations {
     /**
      * Returns the {@link Ice.Identity} for this instance as defined by
      * {@link #sessionId(String, String)}
-     *
-     * @return
      */
     public Ice.Identity sessionId() {
         return sessionId(clientId, principal.getName());

--- a/components/blitz/src/omero/cmd/basic/DoAllI.java
+++ b/components/blitz/src/omero/cmd/basic/DoAllI.java
@@ -181,9 +181,9 @@ public class DoAllI extends DoAll implements IRequest {
      * If login is true, then {@link X#login()} and {@link X#logout} will be
      * called as appropriate.
      *
-     * @param step
-     * @param login
-     * @return
+     * @param step the overall step number
+     * @param login if {@link X#login()} and {@link X#logout} should be called
+     * @return the current substep information
      */
     private X substep(final int step, final boolean login) {
         X x = null;

--- a/components/blitz/src/omero/cmd/fs/OriginalMetadataRequestI.java
+++ b/components/blitz/src/omero/cmd/fs/OriginalMetadataRequestI.java
@@ -262,8 +262,6 @@ public class OriginalMetadataRequestI extends OriginalMetadataRequest implements
     /**
      * Read the given INI-style file and populate the maps with the properties from the corresponding sections.
      * @param file the file to read
-     * @param global the map in which to put the global metadata properties
-     * @param series the map in which to put the series metadata properties
      */
     protected void parseOriginalMetadataTxt(File file) {
         final Pattern section = Pattern.compile("\\s*\\[\\s*(.+?)\\s*\\]\\s*");

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphTraversalProcessor.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphTraversalProcessor.java
@@ -30,7 +30,7 @@ import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphTraversal;
 
 /**
- * Useful methods for {@link GraphTraversal.Processor} instances to share.
+ * Useful methods for {@link ome.services.graphs.GraphTraversal.Processor} instances to share.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -60,7 +60,7 @@ import omero.cmd.IRequest;
 import omero.cmd.Response;
 
 /**
- * Request to move model objects to a different experiment group, reimplementing {@link ChgrpI}.
+ * Request to move model objects to a different experiment group, replacing version 5.0's {@code ChgrpI}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -66,7 +66,7 @@ import omero.cmd.IRequest;
 import omero.cmd.Response;
 
 /**
- * Request to change the permissions on model objects, reimplementing {@link ChmodI}.
+ * Request to change the permissions on model objects, replacing version 5.0's {@code ChmodI}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.2
  */

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -62,7 +62,7 @@ import omero.cmd.IRequest;
 import omero.cmd.Response;
 
 /**
- * Request to give model objects to a different experimenter, reimplementing {@link ChownI}.
+ * Request to give model objects to a different experimenter, replacing version 5.0's {@code ChownI}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -56,7 +56,7 @@ import omero.cmd.IRequest;
 import omero.cmd.Response;
 
 /**
- * Request to delete model objects, reimplementing {@link DeleteI}.
+ * Request to delete model objects, replacing version 5.0's {@code DeleteI}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */

--- a/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
+++ b/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
@@ -20,7 +20,7 @@ package omero.cmd.graphs;
 import omero.cmd.IRequest;
 
 /**
- * Extension of {@link IRequest} to allow copying {@link GraphModify} objects
+ * Extension of {@link IRequest} to allow copying {@link omero.cmd.GraphModify} objects
  * during pre-processing.
  * 
  * @since 5.0.0

--- a/components/blitz/src/omero/grid/ParamsHelper.java
+++ b/components/blitz/src/omero/grid/ParamsHelper.java
@@ -65,7 +65,7 @@ public class ParamsHelper {
      * @param id
      *            script id.
      * @return the job.
-     * @throws ServerError
+     * @throws ServerError if the job could not be built for the script
      */
     public ParseJobI buildParseJob(final long id) throws ServerError {
         final OriginalFileI file = new OriginalFileI(id, false);
@@ -79,12 +79,12 @@ public class ParamsHelper {
     /**
      * Get the script params for the file.
      *
-     * @param file
-     *            the original file.
+     * @param id
+     *            the ID of the script
      * @param __current
-     *            cirrent
+     *            regarding the method invocation
      * @return jobparams of the script.
-     * @throws ServerError
+     * @throws ServerError if the params could not be retrieved or created
      */
     public JobParams getOrCreateParams(final long id, Current __current)
             throws ServerError {
@@ -249,8 +249,8 @@ public class ParamsHelper {
      * Interface added in order to allow ParamHelper instances to use methods
      * from SharedResourcesI. The build does not allow for a dependency between
      * the two.
-     * @DEV.TODO refactor
      */
+    // TODO refactor
     public interface Acquirer {
         public InteractiveProcessorPrx acquireProcessor(final Job submittedJob,
                 int seconds, final Current current) throws ServerError;

--- a/components/blitz/src/omero/grid/ProcessCallbackI.java
+++ b/components/blitz/src/omero/grid/ProcessCallbackI.java
@@ -81,10 +81,6 @@ public class ProcessCallbackI extends _ProcessCallbackDisp {
      * Should only be used if the default logic of the process methods is kept
      * in place. If "q.put" does not get called, this method will always
      * block for the given milliseconds.
-     *
-     * @param ms
-     * @return
-     * @throws InterruptedException
      */
     public Action block(long ms) throws InterruptedException {
         if (poll) {

--- a/components/blitz/src/omero/model/SmartShape.java
+++ b/components/blitz/src/omero/model/SmartShape.java
@@ -46,7 +46,7 @@ public interface SmartShape {
          * 
          * in all the implementations of {@link SmartShape#asPoints()}.
          * 
-         * @param points
+         * @param points the points
          * @return false if iterating through the points list and dereferencing
          *         the cx and cy fields would cause a
          *         {@link NullPointerException}
@@ -242,28 +242,27 @@ public interface SmartShape {
     /**
      * Calls the {@link PointCallback} with all of the x/y coordinates which are
      * within the shape.
+     * @param action the callback to call
      */
     void areaPoints(PointCallback action);
 
     /**
-     * Converst the current {@link SmartShape} to a {@link java.awt.Shape}. This
+     * Converts the current {@link SmartShape} to a {@link java.awt.Shape}. This
      * is useful for determining paths and included points.
-     * 
-     * @return
+     * @return the AWT shape
      */
     java.awt.Shape asAwtShape();
 
     /**
      * Provides some, possibly lossy, bounding polygon of this
      * {@link SmartShape} via points.
-     * 
-     * @return
+     * @return the bounding polygon
      */
     List<Point> asPoints();
 
     /**
-     * Initializes this shape with completely random data. This is useful for 
-     * @param random
+     * Initializes this shape with completely random data.
+     * @param random a random number generator
      */
     void randomize(Random random);
 

--- a/components/blitz/src/omero/rtypes.java
+++ b/components/blitz/src/omero/rtypes.java
@@ -91,8 +91,8 @@ public abstract class rtypes {
      * Limitation: All map keys will be converted to strings!
      *
      * Calls {@link #wrap(Object, Map)} with a new cache argument.
-     * @param value
-     * @return
+     * @param value the value to wrap
+     * @return the wrapped value
      */
     public static omero.RType wrap(final Object value) {
         if (value == null) {
@@ -107,7 +107,9 @@ public abstract class rtypes {
      * Limitation: All map keys will be converted to strings!
      *
      * The cache argument is used to prevent cycles.
-     * @param value
+     * @param value the value to wrap
+     * @param cache a cache of wrapped values (to be expanded by misses)
+     * @return the wrapped value
      * @throws omero.ClientError if all else fails.
      */
     public static omero.RType wrap(final Object value, final Map<Object, RType> cache) {
@@ -157,9 +159,9 @@ public abstract class rtypes {
      * Descends into data structures unwrapping all RType objects as it goes.
      * Limitation: RArrays are turned into {@link List} instances!
      *
-     * Calls {@link #unwrap(Object, Map)} with a new cache argument.
-     * @param value
-     * @return
+     * Calls {@link #unwrap(RType, Map)} with a new cache argument.
+     * @param value the wrapped value
+     * @return the value unwrapped
      */
     public static Object unwrap(final RType value) {
         if (value == null) {
@@ -174,7 +176,9 @@ public abstract class rtypes {
      * Limitation: RArrays are turned into {@link List} instances!
      *
      * The cache argument is used to prevent cycles.
-     * @param value
+     * @param value the wrapped value
+     * @param cache a cache of unwrapped values (to be expanded by misses)
+     * @return the value unwrapped
      */
     public static Object unwrap(final RType value, final Map<RType, Object> cache) {
         if (cache.containsKey(value)) {
@@ -1036,18 +1040,12 @@ public abstract class rtypes {
         /**
          * Specifies the type that can be expected from the
          * {@link #convert(IceMapper)} method.
-         * 
-         * @return
          */
         public Class<?> type();
 
         /**
          * Convert the "val" field on the given RType instance to an ome.model.*
          * representation.
-         * 
-         * @param mapper
-         * @return
-         * @throws ApiUsageException
          */
         public Object convert(IceMapper mapper) throws ApiUsageException;
 

--- a/components/blitz/src/omero/sys/ParametersI.java
+++ b/components/blitz/src/omero/sys/ParametersI.java
@@ -33,7 +33,7 @@ public class ParametersI extends omero.sys.Parameters {
 
     /**
      * Default constructor creates the {@link #map} instance to prevent later
-     * {@link NullPointerExceptions}. To save memory, it is possible to pass
+     * {@link NullPointerException}s. To save memory, it is possible to pass
      * null to {@link ParametersI#ParametersI(Map)}.
      */
     public ParametersI() {
@@ -41,10 +41,11 @@ public class ParametersI extends omero.sys.Parameters {
     }
 
     /**
-     * Uses (and does not copy) the given {@link Map<String, RType>} as the
+     * Uses (and does not copy) the given {@code Map<String, RType>} as the
      * named parameter store in this instance. Be careful if either null is
      * passed or if this instance is being used in a multi-threaded environment.
      * No synchronization takes place.
+     * @param map the named parameter store to use
      */
     public ParametersI(Map<String, RType> map) {
         this.map = map;
@@ -55,6 +56,7 @@ public class ParametersI extends omero.sys.Parameters {
 
     /**
      * Nulls both the {@link Filter#limit} and {@link Filter#offset} values.
+     * @return this instance, for method chaining
      */
     public Parameters noPage() {
         if (this.theFilter != null) {
@@ -68,6 +70,9 @@ public class ParametersI extends omero.sys.Parameters {
      * Sets both the {@link Filter#limit} and {@link Filter#offset} values by
      * wrapping the arguments in {@link RInt} and passing the values to
      * {@link #page(RInt, RInt)}
+     * @param offset the offset (to start from)
+     * @param limit the limit (maximum to return)
+     * @return this instance, for method chaining
      */
     public ParametersI page(int offset, int limit) {
         return this.page(rint(offset), rint(limit));
@@ -76,6 +81,9 @@ public class ParametersI extends omero.sys.Parameters {
     /**
      * Creates a {@link Filter} if necessary and sets both {@link Filter#limit}
      * and {@link Filter#offset}.
+     * @param offset the offset (to start from)
+     * @param limit the limit (maximum to return)
+     * @return this instance, for method chaining
      */
     public ParametersI page(RInt offset, RInt limit) {
         if (this.theFilter == null) {
@@ -501,6 +509,7 @@ public class ParametersI extends omero.sys.Parameters {
      * Pre-4.0, pojoOptions.map() was a common idiom for passing the {@link Map
      * <String, RType} into methods, to keep those uses valid, the
      * {@link #map()} method is defined.
+     * @deprecated use {@link #map()} instead, to be removed in 5.3
      */
     @Deprecated
     public ParametersI map() {

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -342,7 +342,7 @@ public class IceMapper extends ome.util.ModelMapper implements
 
     /**
      * Convert the given Object via the set {@link ReturnMapping}. Throws a
-     * {@link NullPointException} if no mapping is set.
+     * {@link NullPointerException} if no mapping is set.
      */
     public Object mapReturnValue(Object value) throws Ice.UserException {
         return mapping.mapReturnValue(this, value);
@@ -502,9 +502,9 @@ public class IceMapper extends ome.util.ModelMapper implements
      * implement {@link omero.rtypes.Conversion} otherwise ApiUsageException
      * will be thrown.
      * 
-     * @param rt
-     * @return
-     * @throws omero.ApiUsageException
+     * @param rt the wrapped value
+     * @return the value unwrapped
+     * @throws omero.ApiUsageException if the given value is not wrapped
      */
     public Object fromRType(RType rt) throws omero.ApiUsageException {
 
@@ -802,9 +802,6 @@ public class IceMapper extends ome.util.ModelMapper implements
     /**
      * Overrides the findCollection logic of {@link ModelMapper}, since all
      * {@link Collection}s should be {@link List}s in Ice.
-     * 
-     * Originally necessitated by the Map<Long, Set<IObject>> return value of
-     * {@link IContainer#findAnnotations(Class, Set, Set, Map)}
      */
     @Override
     public Collection findCollection(Collection source) {
@@ -885,12 +882,12 @@ public class IceMapper extends ome.util.ModelMapper implements
     /**
      * Copied from {@link ModelMapper#findCollection(Collection)} This could be
      * unified in that a method findCollection(Collection, Map) was added with
-     * {@link ModelMapper} calling findCollection(source,model2target) and
-     * {@link #reverseCollection(Collection)} calling
-     * findCollection(source,target2model).
+     * {@link ModelMapper} calling {@code findCollection(source, model2target)}
+     * and {@code reverseCollection(Collection)} calling
+     * {@code findCollection(source,target2model)}.
      * 
-     * @param collection
-     * @return
+     * @param source the wrapped {@link Collection}
+     * @return the {@link Collection} unwrapped
      */
     public Collection reverse(Collection source) { // FIXME throws
         // omero.ApiUsageException {
@@ -903,10 +900,7 @@ public class IceMapper extends ome.util.ModelMapper implements
      * {@link ArrayList}s will be returned. The need for this arose from the
      * decision to have no {@link Set}s in the Ice Java mapping.
      * 
-     * @param source
-     * @param targetType
-     * @return
-     * @see ticket:684
+     * @see <a href="http://trac.openmicroscopy.org/ome/ticket/684">Trac ticket #684</a>
      */
     public Collection reverse(Collection source, Class targetType) { // FIXME
         // throws
@@ -946,11 +940,6 @@ public class IceMapper extends ome.util.ModelMapper implements
     /**
      * Supports the separate case of reversing for arrays. See
      * {@link #reverse(Collection, Class)} and {@link #map(Filterable[])}.
-     * 
-     * @param list
-     * @param type
-     * @return
-     * @throws omero.ServerError
      */
     public Object[] reverseArray(List list, Class type)
             throws omero.ServerError {
@@ -1007,9 +996,7 @@ public class IceMapper extends ome.util.ModelMapper implements
     }
 
     /**
-     * Copied from {@link ReverseModelMapper#map(ModelBased)}
-     * 
-     * @param source
+     * Copied from {@link ReverseModelMapper}.
      */
     public Filterable reverse(ModelBased source) {
 
@@ -1239,10 +1226,6 @@ public class IceMapper extends ome.util.ModelMapper implements
      * wraps any non-ServerError returned by
      * {@link #handleException(Throwable, OmeroContext)} in an
      * {@link InternalException}.
-     *
-     * @param t
-     * @param ctx
-     * @return
      */
     public ServerError handleServerError(Throwable t, OmeroContext ctx) {
         Ice.UserException ue = handleException(t, ctx);

--- a/components/blitz/src/omero/util/ObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/util/ObjectFactoryRegistry.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * register all its {@link Ice.ObjectFactory} instances with the
  * {@link Ice.Communicator}.
  *
- * @see ticket:6340
+ * @see <a href="http://trac.openmicroscopy.org/ome/ticket/6340">Trac ticket #6340</a>
  */
 public abstract class ObjectFactoryRegistry {
 

--- a/components/blitz/src/omero/util/RPSTileLoop.java
+++ b/components/blitz/src/omero/util/RPSTileLoop.java
@@ -76,7 +76,6 @@ public class RPSTileLoop extends TileLoop {
      * Iterates over every tile in a given pixel based on the
      * over arching dimensions and a requested maximum tile width and height.
      * @param iteration Invoker to call for each tile.
-     * @param pixel Pixel instance
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
      * <code>x + tileWidth > sizeX</code>.

--- a/components/blitz/src/omero/util/Resources.java
+++ b/components/blitz/src/omero/util/Resources.java
@@ -23,8 +23,7 @@ import java.util.logging.Logger;
  * 
  * Note: this class uses java.util.logging (JUL) rather than commons-logging
  * since it may be used on the client-side. Any use server-side will have logs
- * forwarded to log4j via slf4j as described in
- * {@link ome.services.blitz.Entry#configureLogging()}
+ * forwarded to log4j via slf4j.
  */
 public class Resources {
 
@@ -66,18 +65,13 @@ public class Resources {
     }
 
     /**
-     * As {@link Resources#Resources(int, ExecutorService)} but uses a
+     * As {@link Resources#Resources(int, ScheduledExecutorService)} but uses a
      * {@link Executors#newSingleThreadExecutor()}.
      */
     public Resources(int sleeptimeSeconds) {
         this(sleeptimeSeconds, Executors.newSingleThreadScheduledExecutor());
     }
 
-    /**
-     * 
-     * @param sleeptimeSeconds
-     * @param service
-     */
     public Resources(int sleeptimeSeconds, ScheduledExecutorService service) {
         this.sleeptime = sleeptimeSeconds;
         this.service = service;

--- a/components/blitz/src/omero/util/ServantHolder.java
+++ b/components/blitz/src/omero/util/ServantHolder.java
@@ -98,8 +98,7 @@ public class ServantHolder {
     /**
      * Constructs an {@link Ice.Identity} from the current session
      * and from the given {@link String} which for
-     * stateless services are defined by the instance fields {@link #adminKey},
-     * {@link #configKey}, etc. and for stateful services are UUIDs.
+     * stateful services are defined by UUIDs.
      */
     public Ice.Identity getIdentity(String idName) {
         Ice.Identity id = new Ice.Identity();
@@ -126,8 +125,7 @@ public class ServantHolder {
 
     /**
      * Acquires the given lock or if necessary creates a new one.
-     *
-     * @param key
+     * @param key the lock's key
      */
     public void acquireLock(String key) {
         try {
@@ -140,6 +138,7 @@ public class ServantHolder {
     /**
      * Releases the given lock if found, otherwise throws an
      * {@link ome.conditions.InternalException}
+     * @param key the lock's key
      */
     public void releaseLock(String key) {
         final Lock lock = locks.getIfPresent(key);

--- a/components/blitz/src/omero/util/TempFileManager.java
+++ b/components/blitz/src/omero/util/TempFileManager.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Creates temporary files and folders and makes a best effort to remove them on
  * exit (or sooner). Typically only a single instance of this class will exist
- * (static {@link #manager} constant)
+ * (held in a private static field).
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.1
@@ -94,10 +94,11 @@ public class TempFileManager {
     }
 
     /**
-     * Initializes a {@link TempFileManager} instance with a {@link userDir}
-     * containing the given prefix value. Also adds a
+     * Initializes a {@link TempFileManager} instance with the user's
+     * temporary directory containing the given prefix value. Also adds a
      * {@link Runtime#addShutdownHook(Thread) shutdown hook} to call
      * {@link #cleanup()} on exit.
+     * @param prefix the prefix for the user's temporary directory
      */
     public TempFileManager(String prefix) {
         File tmp = tmpdir();
@@ -171,7 +172,7 @@ public class TempFileManager {
     }
 
     /**
-     * Releases {@link #lock} and deletes {@link #dir}. The lock is released
+     * Releases the lock and deletes the top-level temporary directory. The lock is released
      * first since on some platforms like Windows the lock file cannot be
      * deleted even by the owner of the lock.
      */
@@ -312,9 +313,9 @@ public class TempFileManager {
 
     /**
      * Uses {@link File#createTempFile(String, String, File)} to create
-     * temporary files and folders under {@link #dir}. For folders, first a
-     * temporary file is created, then deleted, and finally a directory
-     * produced.
+     * temporary files and folders under the top-level temporary directory.
+     * For folders, first a temporary file is created, then deleted,
+     * and finally a directory produced.
      */
     public File createPath(String prefix, String suffix, boolean folder)
             throws IOException {
@@ -330,8 +331,9 @@ public class TempFileManager {
     }
 
     /**
-     * If the given file is under {@link #dir}, then it is deleted whether file
-     * or folder. Otherwise a {@link RuntimeException} is thrown.
+     * If the given file is under the top-level temporary directory
+     * then it is deleted whether file or folder.
+     * Otherwise a {@link RuntimeException} is thrown.
      */
     public void removePath(File file) throws IOException {
         String f = file.getAbsolutePath();
@@ -353,7 +355,7 @@ public class TempFileManager {
     }
 
     /**
-     * Deletes {@link #dir}
+     * Deletes the top-level temporary directory.
      */
     protected void cleanTempDir() throws IOException {
         log.debug("Removing tree: " + dir.getAbsolutePath());
@@ -407,7 +409,7 @@ public class TempFileManager {
     }
 
     /**
-     * Calls {@link #createPath(String, String, boolean)} on {@link #manager}
+     * Calls {@link #createPath(String, String, boolean)}
      * with defaults of "omero", ".tmp", and false.
      */
     public static File create_path() throws IOException {
@@ -415,7 +417,7 @@ public class TempFileManager {
     }
 
     /**
-     * Calls {@link #createPath(String, String, boolean)} on {@link #manager}
+     * Calls {@link #createPath(String, String, boolean)}
      * with defaults of ".tmp", and false.
      */
     public static File create_path(String prefix) throws IOException {
@@ -423,7 +425,7 @@ public class TempFileManager {
     }
 
     /**
-     * Calls {@link #createPath(String, String, boolean)} on {@link #manager}
+     * Calls {@link #createPath(String, String, boolean)}
      * with ".tmp", and false arguments.
      */
     public static File create_path(String prefix, String suffix)
@@ -432,7 +434,7 @@ public class TempFileManager {
     }
 
     /**
-     * Calls {@link #createPath(String, String, boolean)} on {@link #manager}.
+     * Calls {@link #createPath(String, String, boolean)}.
      */
     public static File create_path(String prefix, String suffix, boolean folder)
             throws IOException {
@@ -440,22 +442,22 @@ public class TempFileManager {
     }
 
     /**
-     * Calls {@link #removePath(File)} on {@link #manager}.
+     * Calls {@link #removePath(File)}.
      */
     public static void remove_path(File file) throws IOException {
         manager.removePath(file);
     }
 
     /**
-     * Calls {@link #getTempDir()} on {@link #manager}.
+     * Calls {@link #getTempDir()}.
      */
     public static void gettempdir() {
         manager.getTempDir();
     }
 
     /**
-     * Command-line interface to the global {@link TempFileManager} instance (
-     * {@link #manger}). Valid arguments: "--debug", "clean", "dir", and for
+     * Command-line interface to the global {@link TempFileManager} instance.
+     * Valid arguments: "--debug", "clean", "dir", and for
      * testing, "lock"
      */
     public static void main(String[] _args) throws IOException {

--- a/components/blitz/src/omero/util/TileLoop.java
+++ b/components/blitz/src/omero/util/TileLoop.java
@@ -14,15 +14,21 @@ public abstract class TileLoop {
 
     /**
      * Subclasses must provide a fresh instance of {@link TileData}.
-     * The instance will be closed after the run of forEachTile.
+     * The instance will be closed after the run of
+     * {@link #forEachTile(int, int, int, int, int, int, int, TileLoopIteration)}.
+     * @return the new instance
      */
     public abstract TileData createData();
 
     /**
      * Iterates over every tile in a given pixel based on the
      * over arching dimensions and a requested maximum tile width and height.
+     * @param sizeX the size of the plane's X dimension
+     * @param sizeY the size of the plane's Y dimension
+     * @param sizeZ the size of the plane's Z dimension
+     * @param sizeC the size of the plane's C dimension
+     * @param sizeT the size of the plane's T dimension
      * @param iteration Invoker to call for each tile.
-     * @param pixel Pixel instance
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
      * <code>x + tileWidth > sizeX</code>.

--- a/components/blitz/src/omero/util/TileLoopIteration.java
+++ b/components/blitz/src/omero/util/TileLoopIteration.java
@@ -15,8 +15,7 @@ public interface TileLoopIteration
 {
     /**
     * Invoke a single loop iteration.
-    * @param rps An active {@link omero.api.RawPixelsStorePrx}. This instance
-    *            is created and will be closed by the calling method.
+    * @param data the tile access strategy
     * @param z Z section counter of the loop.
     * @param c Channel counter of the loop.
     * @param t Timepoint counter of the loop.

--- a/components/blitz/src/org/hibernate/stat/ConcurrentStatisticsImpl.java
+++ b/components/blitz/src/org/hibernate/stat/ConcurrentStatisticsImpl.java
@@ -39,7 +39,7 @@ import com.google.common.cache.CacheBuilder;
 
 /**
  * Implementation of {@link Statistics}, as well as {@link StatisticsImplementor}, based on the
- * {@link java.util.concurrent} package introduced in Java 5.
+ * {@code java.util.concurrent} package introduced in Java 5.
  *
  * @author Alex Snaps
  */


### PR DESCRIPTION
This PR should improve Blitz's Javadoc which should now report warnings from only,

* `ome.services.*`
* `omero.gateway.*`
* `pojos.*`

--no-rebase