### PR TITLE
List empty tagsets when using omero tag list

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/tag.py
+++ b/components/tools/OmeroPy/src/omero/plugins/tag.py
@@ -350,7 +350,7 @@ JSON File Format:
                 from TagAnnotation ann where ann.id not in
                 (select distinct l.child.id from AnnotationAnnotationLink l
                     join l.parent as ts
-                    where ts.ns = 'openmicroscopy.org/omero/insight/tagset')
+                    where ts.ns = :ns)
                 and ann.ns is null
                 """
             if args.uid:
@@ -429,7 +429,7 @@ JSON File Format:
                 select a.id, a.description, a.textValue,
                 a.details.owner.id, a.details.owner.firstName,
                 a.details.owner.lastName
-                from Annotation a
+                from TagAnnotation a
                 where a.ns=:ns
                 """
 
@@ -472,9 +472,9 @@ JSON File Format:
 
         return lines
 
-    def generate_orphans(self, tags, orphans, args):
+    def generate_orphans(self, orphans, args):
         """
-        Given a dict of tags and a list of orphaned tags, return a list of
+        Given a list of orphaned tags, return a list of
         lines representing the orphan output.
         """
         lines = []
@@ -700,7 +700,7 @@ JSON File Format:
             tc = self.list_tags(args, tagset)
             lines.extend(self.generate_tagset(tc.tags, tc.mapping, args))
             if len(tc.orphans) > 0:
-                lines.extend(self.generate_orphans(tc.tags, tc.orphans, args))
+                lines.extend(self.generate_orphans(tc.orphans, args))
                 if len(tc.empties) > 0:
                     lines.append('')
             if len(tc.empties) > 0:


### PR DESCRIPTION
This PR adds to the fix in https://github.com/ximenesuk/openmicroscopy/commit/32e3434a7b8d46b2d446005fe71e5ed1669e17af which included empty tagsets in the `listsets` command to include empty tagsets in the `list` command as a separate section below the tree view.

To test create some tags and tagsets and have some of those tagsets empty. To create empty tagsets from the CLI you need to create populated tagsets and then remove the contents, e.g.
```
$ omero tag create --name "tag1"
TagAnnotation:437
$ omero tag create --name "tag2"
TagAnnotation:438
$ omero tag create --name "tag3"
TagAnnotation:439
$ omero tag createset --name "tagset1" --tag 437
TagAnnotation:440
$ omero tag createset --name "tagset-empty" --tag 438
TagAnnotation:441
$ omero delete TagAnnotation:438
omero.cmd.Delete2 TagAnnotation 438... ok
$ omero tag list
+- 440:'tagset1'
|\
| +- 437:'tag1'

Orphaned tags:
> 439:'tag3'

Empty tagsets:
> 441:'tagset-empty'
```
This should also work when using the `--tagset` and `--uid` options.

Two tests have been expanded to test for both orphaned tags and empty tagsets.

--rebased-to #4142