### PR TITLE
Don't zip and preserve original paths when downloading images (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
@@ -24,30 +24,22 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import javax.swing.Action;
 import javax.swing.JFrame;
-import javax.swing.filechooser.FileFilter;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
+
 import org.openmicroscopy.shoola.agents.dataBrowser.DataBrowserAgent;
 import org.openmicroscopy.shoola.agents.dataBrowser.IconManager;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageDisplay;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.agents.events.hiviewer.DownloadEvent;
 import org.openmicroscopy.shoola.env.event.EventBus;
-import org.openmicroscopy.shoola.util.filter.file.ZipFilter;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
-
 import pojos.DataObject;
-import pojos.FileAnnotationData;
 import pojos.ImageData;
 
 
@@ -123,49 +115,23 @@ public class DownloadAction
         
         JFrame f = DataBrowserAgent.getRegistry().getTaskBar().getFrame();
 
-        int type = FileChooser.SAVE;
-        
-        List<FileFilter> filters = new ArrayList<FileFilter>();
-        filters.add(new ZipFilter());
+        int type = FileChooser.FOLDER_CHOOSER;
 
-        final File file = UIUtilities.generateFileName(
-                UIUtilities.getDefaultFolder(), model.getBrowser()
-                        .getSelectedDataObjects().size() > 1 ? "Original_Files"
-                        : "Original_File", "zip");
-        
         FileChooser chooser = new FileChooser(f, type,
-                FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION,
-                filters, false);
-        try {
-            if (UIUtilities.getDefaultFolder() != null)
-                chooser.setCurrentDirectory(UIUtilities.getDefaultFolder());
-        } catch (Exception ex) {
-        }
-        
-        chooser.setSelectedFile(file);
-        chooser.setCheckOverride(true);
+                FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION);
+
         IconManager icons = IconManager.getInstance();
         chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
         chooser.setApproveButtonText(FileChooser.DOWNLOAD_TEXT);
+        chooser.setCheckOverride(true);
         chooser.addPropertyChangeListener(new PropertyChangeListener() {
-
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 FileChooser src = (FileChooser) evt.getSource();
-                File path = null;
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
-                    if (src.getChooserType() == FileChooser.FOLDER_CHOOSER) {
-                        path = new File((String) evt.getNewValue());
-                    } else {
-                        File[] files = (File[]) evt.getNewValue();
-                        if (files == null || files.length == 0) return;
-                        path = files[0];
-                    }
-                    if (path == null) {
-                        path = UIUtilities.getDefaultFolder();
-                    }
+                    String path = (String) evt.getNewValue();
                     EventBus bus = DataBrowserAgent.getRegistry().getEventBus();
-                    bus.post(new DownloadEvent(path, src.isOverride()));
+                    bus.post(new DownloadEvent(new File(path), src.isOverride()));
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -288,6 +288,17 @@ public interface Editor
 	 */
 	public void download(File file, boolean override);
 
+    /**
+     * Downloads the archived files, preserving the original folder structure
+     * 
+     * @param file
+     *            The folder where to download the content.
+     * @param override
+     *            Flag indicating to override the existing file if it exists,
+     *            <code>false</code> otherwise.
+     */
+    public void downloadOriginal(String path, boolean override);
+	
 	/**
 	 * Sets the parent of the root object. This will be taken into account
 	 * only if the root is a well sample.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -70,6 +70,7 @@ import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.data.util.Target;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 
@@ -638,6 +639,18 @@ class EditorComponent
 		if (file == null) return;
 		model.download(file, override);
 	}
+	
+    /**
+     * Implemented as specified by the {@link Editor} interface.
+     * 
+     * @see Editor#downloadOriginal(String, boolean)
+     */
+    public void downloadOriginal(String path, boolean override) {
+        if (CommonsLangUtils.isEmpty(path))
+            return;
+
+        model.downloadOriginal(path, override);
+    }
 
 	/** 
 	 * Implemented as specified by the {@link Editor} interface.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -73,7 +73,6 @@ import org.openmicroscopy.shoola.env.data.model.AnalysisParam;
 import org.openmicroscopy.shoola.env.data.model.FigureParam;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.Target;
-import org.openmicroscopy.shoola.env.data.util.TransformsParser;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.log.LogMessage;
 import org.openmicroscopy.shoola.env.log.Logger;
@@ -300,56 +299,31 @@ class EditorControl
 		//bus.post(new ViewImage(imageID, null));
 	}
 	
-	/** Brings up the folder chooser. */
-	private void download()
-	{
-	    JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
+    /** Brings up the folder chooser. */
+    private void download() {
+        JFrame f = MetadataViewerAgent.getRegistry().getTaskBar().getFrame();
 
-	    List<FileFilter> filters = new ArrayList<FileFilter>();
-        filters.add(new ZipFilter());
-        
-        int type = FileChooser.SAVE;
+        int type = FileChooser.FOLDER_CHOOSER;
 
-	    FileChooser chooser = new FileChooser(f, type,
-	            FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION,
-	            filters, false);
-        try {
-            if (UIUtilities.getDefaultFolder() != null)
-                chooser.setCurrentDirectory(UIUtilities.getDefaultFolder());
-        } catch (Exception ex) {
-        }
+        FileChooser chooser = new FileChooser(f, type,
+                FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION);
 
-        final File file = UIUtilities.generateFileName(
-                UIUtilities.getDefaultFolder(), view
-                        .getSelectedObjects().size() > 1 ? "Original_Files"
-                        : "Original_File", "zip");
-        
-	    IconManager icons = IconManager.getInstance();
-	    chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
-	    chooser.setApproveButtonText(FileChooser.DOWNLOAD_TEXT);
-	    chooser.setCheckOverride(true);
-	    chooser.setSelectedFile(file);
-	    chooser.addPropertyChangeListener(new PropertyChangeListener() {
+        IconManager icons = IconManager.getInstance();
+        chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
+        chooser.setApproveButtonText(FileChooser.DOWNLOAD_TEXT);
+        chooser.setCheckOverride(true);
+        chooser.addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 FileChooser src = (FileChooser) evt.getSource();
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
-                    File path = null;
-
-                    File[] files = (File[]) evt.getNewValue();
-                    if (files == null || files.length == 0)
-                        return;
-                    path = files[0];
-
-                    if (path == null) {
-                        path = file;
-                    }
-                    model.download(path, src.isOverride());
+                    String path = (String) evt.getNewValue();
+                    model.downloadOriginal(path, src.isOverride());
                 }
             }
-	    });
-	    chooser.centerDialog();
-	}
+        });
+        chooser.centerDialog();
+    }
 
 	/** Brings up the folder chooser to select where to save the files. 
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -3077,6 +3077,56 @@ class EditorModel
 	        downloadFiles(file, override);
 	    }
 	}
+	
+    /**
+     * Starts an asynchronous loading; preserving the original folder structure
+     * 
+     * @param path
+     *            The folder where to download the content.
+     * @param override
+     *            Flag indicating to override the existing file if it exists,
+     *            <code>false</code> otherwise.
+     */
+    void downloadOriginal(String path, boolean override) {
+        if (!(refObject instanceof ImageData))
+            return;
+
+        List<ImageData> images = new ArrayList<ImageData>();
+        List<DataObject> l = getSelectedObjects();
+        if (!CollectionUtils.isEmpty(l)) {
+            Iterator<DataObject> i = l.iterator();
+            DataObject o;
+            List<Long> filesetIds = new ArrayList<Long>();
+            long id;
+            ImageData image;
+            while (i.hasNext()) {
+                o = i.next();
+                if (isArchived(o)) {
+                    image = (ImageData) o;
+                    id = image.getFilesetId();
+                    if (id < 0)
+                        images.add(image);
+                    else if (!filesetIds.contains(id)) {
+                        images.add(image);
+                        filesetIds.add(id);
+                    }
+                }
+            }
+        }
+        if (!CollectionUtils.isEmpty(images)) {
+            DownloadArchivedActivityParam p;
+            UserNotifier un = MetadataViewerAgent.getRegistry()
+                    .getUserNotifier();
+            IconManager icons = IconManager.getInstance();
+            Icon icon = icons.getIcon(IconManager.DOWNLOAD_22);
+            SecurityContext ctx = getSecurityContext();
+            p = new DownloadArchivedActivityParam(new File(path), images, icon);
+            p.setOverride(override);
+            p.setZip(false);
+            p.setKeepOriginalPaths(true);
+            un.notifyActivity(ctx, p);
+        }
+    }
 
 	/** 
 	 * Starts an asynchronous call to retrieve disk space information. 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
@@ -28,7 +28,6 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -37,15 +36,12 @@ import javax.swing.JFrame;
 
 //Third-party libraries
 
-import javax.swing.filechooser.FileFilter;
-
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
 import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
-import org.openmicroscopy.shoola.util.filter.file.ZipFilter;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
 
@@ -153,61 +149,27 @@ public class DownloadAction
             return;
         
         JFrame f = TreeViewerAgent.getRegistry().getTaskBar().getFrame();
+        
+        int type = FileChooser.FOLDER_CHOOSER;
 
-        int type = FileChooser.SAVE;
-        List<FileFilter> filters = new ArrayList<FileFilter>();
-        filters.add(new ZipFilter());
-        boolean all = false;
-        
-        if(node.getUserObject() instanceof FileAnnotationData) {
-            type = FileChooser.FOLDER_CHOOSER;
-            filters = null;
-            all = true;
-        }
-        
         FileChooser chooser = new FileChooser(f, type,
-                FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION,
-                filters, all);
-        try {
-            if (UIUtilities.getDefaultFolder() != null)
-                chooser.setCurrentDirectory(UIUtilities.getDefaultFolder());
-        } catch (Exception ex) {
-        }
-        
-        if(type == FileChooser.SAVE) {
-            File file = UIUtilities.generateFileName(
-                    UIUtilities.getDefaultFolder(), browser
-                            .getSelectedDataObjects().size() > 1 ? "Original_Files"
-                            : "Original_File", "zip");
-            chooser.setSelectedFile(file);
-        }
-        
-        chooser.setCheckOverride(true);
+                FileChooser.DOWNLOAD_TEXT, FileChooser.DOWNLOAD_DESCRIPTION);
+
         IconManager icons = IconManager.getInstance();
         chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
         chooser.setApproveButtonText(FileChooser.DOWNLOAD_TEXT);
+        chooser.setCheckOverride(true);
         chooser.addPropertyChangeListener(new PropertyChangeListener() {
-
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 FileChooser src = (FileChooser) evt.getSource();
-                File path = null;
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
-                    if (src.getChooserType() == FileChooser.FOLDER_CHOOSER) {
-                        path = new File((String) evt.getNewValue());
-                    } else {
-                        File[] files = (File[]) evt.getNewValue();
-                        if (files == null || files.length == 0) return;
-                        path = files[0];
-                    }
-                    if (path == null) {
-                        path = UIUtilities.getDefaultFolder();
-                    }
-                    model.download(path, src.isOverride());
+                    String path = (String) evt.getNewValue();
+                    model.download(new File(path), src.isOverride());
                 }
             }
         });
-		chooser.centerDialog();
+        chooser.centerDialog();
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3673,6 +3673,8 @@ class TreeViewerComponent
             DownloadArchivedActivityParam p = new DownloadArchivedActivityParam(
                     folder, archived, icon);
             p.setOverride(override);
+            p.setZip(false);
+            p.setKeepOriginalPaths(true);
             un.notifyActivity(ctx, p);
 	    }
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -3740,7 +3740,7 @@ class OMEROGateway
 	{
 		return retrieveArchivedFiles(ctx, file, image, keepOriginalPaths);
 	}
-
+	
 	/**
 	 * Retrieves the archived files if any for the specified set of pixels.
 	 *
@@ -3825,25 +3825,37 @@ class OMEROGateway
 		folderPath = file.getAbsolutePath();
 		Iterator<Entry<OriginalFile, Fileset>> entries = values.entrySet().iterator();
 
+		Map<Fileset, String> filesetPaths = new HashMap<Fileset, String>();
+		
 		while (entries.hasNext()) {
 		    Entry<OriginalFile, Fileset> entry = entries.next();
 		    
 			of = entry.getKey();
 			Fileset set = entry.getValue();
-
+			String repoPath = set.getTemplatePrefix().getValue();
+			
             String path = null;
             if (keepOriginalPaths && set != null && set.sizeOfUsedFiles() > 1) {
                 // this will store multi file images within a subdirectory with
                 // the same name as the main image file
-                String repoPath = set.getTemplatePrefix().getValue();
-                path = folderPath.endsWith("/") ? folderPath : folderPath + "/";
-                String imgFilename = set.getFilesetEntry(0).getOriginalFile()
-                        .getName().getValue();
-                path += imgFilename + "/";
-                path = path + (of.getPath().getValue().replace(repoPath, ""));
+                path = filesetPaths.get(set);
+                if (path == null) {
+                    path = folderPath.endsWith("/") ? folderPath : folderPath + "/";
+                    String imgFilename = set.getFilesetEntry(0).getOriginalFile()
+                            .getName().getValue();
+                    path += imgFilename;
+                    path = generateUniquePathname(path);
+                    // path should now be in the form
+                    // DOWNLOAD_FOLDER/IMAGE_NAME[(N)]
+                    // where N is a consecutive number if the folder IMAGE_NAME
+                    // already exists
+                    filesetPaths.put(set, path);
+                }
+                path = path +"/"+ (of.getPath().getValue().replace(repoPath, ""));
                 // path should now be in the form
-                // [DOWNLOAD_FOLDER]/[IMAGE_NAME]/X/Y/Z
+                // DOWNLOAD_FOLDER/IMAGE_NAME[(N)]/X/Y/Z
                 // where X, Y, Z are image specific subdirectories
+                // for the single image/data files
                 File origPath = new File(path);
                 if (!origPath.exists())
                     origPath.mkdirs();
@@ -3902,6 +3914,32 @@ class OMEROGateway
 		return result;
 	}
 	
+    /**
+     * Checks if the given path already exists and if so, generates a new path
+     * name path(N), where N is a consecutive number
+     * 
+     * @param path
+     *            The path name to check
+     * @return A unique path name based on the given path or the path itself if
+     *         it doesn't exist yet
+     */
+    private String generateUniquePathname(String path) {
+
+        File tmp = new File(path);
+        if (tmp.isDirectory() && tmp.exists()) {
+            if (path.matches(".+\\(\\d+\\)")) {
+                int n = Integer.parseInt(path.substring(
+                        path.lastIndexOf('(') + 1, path.lastIndexOf(')')));
+                n++;
+                path = path.substring(0, path.lastIndexOf('(')) + "(" + n + ")";
+            } else {
+                path += "(1)";
+            }
+            return generateUniquePathname(path);
+        }
+        return path;
+    }
+
 	/**
 	 * Downloads a file previously uploaded to the server.
 	 *

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -3844,7 +3844,7 @@ class OMEROGateway
                     String imgFilename = set.getFilesetEntry(0).getOriginalFile()
                             .getName().getValue();
                     path += imgFilename;
-                    path = generateUniquePathname(path);
+                    path = generateUniquePathname(path, false);
                     // path should now be in the form
                     // DOWNLOAD_FOLDER/IMAGE_NAME[(N)]
                     // where N is a consecutive number if the folder IMAGE_NAME
@@ -3871,6 +3871,12 @@ class OMEROGateway
 				    f = new File(path, of.getName().getValue());
 				else
 				    f = file;
+				
+                if (f.exists()) {
+                    String newFileName = generateUniquePathname(f.getPath(),
+                            true);
+                    f = new File(newFileName);
+                }
 				
 				results.add(f);
 
@@ -3920,13 +3926,19 @@ class OMEROGateway
      * 
      * @param path
      *            The path name to check
+     * @param isFile
+     *            Pass <code>true</code> if the path name represents a file
      * @return A unique path name based on the given path or the path itself if
      *         it doesn't exist yet
      */
-    private String generateUniquePathname(String path) {
-
+    private String generateUniquePathname(String path, boolean isFile) {
         File tmp = new File(path);
-        if (tmp.isDirectory() && tmp.exists()) {
+        if (tmp.exists()) {
+            String fileExt = null;
+            if (isFile && path.matches(".+\\..+")) {
+                fileExt = path.substring(path.lastIndexOf('.'), path.length());
+                path = path.substring(0, path.lastIndexOf('.'));
+            }
             if (path.matches(".+\\(\\d+\\)")) {
                 int n = Integer.parseInt(path.substring(
                         path.lastIndexOf('(') + 1, path.lastIndexOf(')')));
@@ -3935,7 +3947,9 @@ class OMEROGateway
             } else {
                 path += "(1)";
             }
-            return generateUniquePathname(path);
+            if (fileExt != null)
+                path += fileExt;
+            return generateUniquePathname(path, isFile);
         }
         return path;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.OmeroDataService
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -296,13 +296,15 @@ public interface OmeroDataService
 	 * @param ctx The security context.
 	 * @param location The location where to save the files.
 	 * @param imageID The ID of the image.
+	 * @param keepOriginalPath Pass <code>true</code> to preserve the original 
+	 *         path structure
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
 	public Map<Boolean, Object> getArchivedImage(SecurityContext ctx,
-			File location, long imageID)
+			File location, long imageID, boolean keepOriginalPath)
 		throws DSOutOfServiceException, DSAccessException;
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -497,16 +497,16 @@ class OmeroDataServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#getArchivedFiles(SecurityContext, File, long)
+	 * @see OmeroDataService#getArchivedFiles(SecurityContext, File, long, boolean)
 	 */
 	public Map<Boolean, Object> getArchivedImage(SecurityContext ctx,
-			File file, long imageID)
+			File file, long imageID, boolean keepOriginalPath)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		context.getLogger().debug(this, file.getAbsolutePath());
 		//Check the image is archived.
 		ImageData image = gateway.getImage(ctx, imageID, null);
-		return gateway.getArchivedFiles(ctx, file, image);
+		return gateway.getArchivedFiles(ctx, file, image, keepOriginalPath);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.model.DownloadArchivedActivityParam 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -64,6 +64,12 @@ public class DownloadArchivedActivityParam
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
 
+    /** Flag for zipping the downloaded images */
+    private boolean zip = false;
+    
+    /** Flag for preserving the original folder structure */
+    private boolean keepOriginalPaths = true;
+    
     /**
      * Creates a new instance.
      * 
@@ -116,5 +122,45 @@ public class DownloadArchivedActivityParam
      * @return See above.
      */
     public List<ImageData> getImages() { return images; }
+
+    /**
+     * Returns if the downloaded images should be zipped
+     * 
+     * @return See above
+     */
+    public boolean isZip() {
+        return zip;
+    }
+
+    /**
+     * Sets the zip flag
+     * 
+     * @param zip
+     *            Pass <code>true</code> if the downloaded images should be
+     *            zipped
+     */
+    public void setZip(boolean zip) {
+        this.zip = zip;
+    }
+
+    /**
+     * Returns if the original folder structure should be preserved
+     * 
+     * @return See above
+     */
+    public boolean isKeepOriginalPaths() {
+        return keepOriginalPaths;
+    }
+
+    /**
+     * Sets the keepOriginalPaths flag
+     * 
+     * @param keepOriginalPaths
+     *            Pass <code>true</code> to preserve the original folder
+     *            structure
+     */
+    public void setKeepOriginalPaths(boolean keepOriginalPaths) {
+        this.keepOriginalPaths = keepOriginalPaths;
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -308,11 +308,13 @@ public interface MetadataHandlerView
 	 * @param name The name of the image.
 	 * @param override Flag indicating to override the existing file if it
 	 *                 exists, <code>false</code> otherwise.
+	 * @param zip Pass <code>true</code> to create a zip file
+	 * @param keepOriginalPaths Pass <code>true</code> to preserve the original folder structure
 	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
-		File location, boolean override,
+		File location, boolean override, boolean zip, boolean keepOriginalPaths,
 		AgentEventListener observer);
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -245,15 +245,15 @@ class MetadataHandlerViewImpl
 
 	/**
 	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadOriginalImage(SecurityContext, List, File,
-	 * String, boolean, AgentEventListener)
+	 * @see MetadataHandlerView#loadArchivedImage(SecurityContext, List, File,
+	 * String, boolean, boolean, boolean AgentEventListener)
 	 */
 	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
-			File path, boolean override,
+			File path, boolean override, boolean zip, boolean keepOriginalPaths,
 			AgentEventListener observer)
 	{
 		BatchCallTree cmd = new ArchivedImageLoader(ctx, imageIDs, path,
-		        override);
+		        override, zip, keepOriginalPaths);
 		return cmd.exec(observer);
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
@@ -69,6 +69,12 @@ public class ArchivedImageLoader
     /**Flag indicating to override or not the existing file if it exists.*/
     private boolean override;
 
+    /** Flag for zipping the downloaded images */
+    private boolean zip = true;
+    
+    /** Flag for preserving the original folder structure */
+    private boolean keepOriginalPaths = false;
+    
     /**
      * Copies the specified file to the folder.
      * 
@@ -130,19 +136,25 @@ public class ArchivedImageLoader
                 OmeroDataService os = context.getDataService();
                 File tmpFolder = null;
                 try {
-                    tmpFolder = Files.createTempDir();
+                    if(zip)
+                        tmpFolder = Files.createTempDir();
+                    else
+                        tmpFolder = folder;
                     
                     List<File> files = new ArrayList<File>();
                     
                     for (Long imageID : imageIDs) {
                         Map<Boolean, Object> r = os.getArchivedImage(ctx,
-                                tmpFolder, imageID);
+                                tmpFolder, imageID, keepOriginalPaths);
                         files.addAll((List<File>) r.get(Boolean.TRUE));
                     }
                     
                     result = new HashMap<Boolean, List<File>>();
                     
-                    if (!CollectionUtils.isEmpty(files)) {
+                    if(CollectionUtils.isEmpty(files))
+                        return;
+                    
+                    if (zip) {
                         File f = IOUtil.zipDirectory(tmpFolder, false);
                         // rename the zip
                         String baseName = FilenameUtils
@@ -155,11 +167,14 @@ public class ArchivedImageLoader
                         f = copyFile(to, folder.getParentFile());
                         ((Map<Boolean, List<File>>)result).put(Boolean.TRUE, Arrays.asList(f));
                     }
+                    else {
+                        ((Map<Boolean, List<File>>)result).put(Boolean.TRUE, files);
+                    }
                     
                 } catch (Exception e) {
                     throw new Exception(e);
                 } finally {
-                    if (tmpFolder != null)
+                    if (zip && tmpFolder != null)
                         FileUtils.deleteDirectory(tmpFolder);
                 }
             }
@@ -196,6 +211,31 @@ public class ArchivedImageLoader
     	if (CollectionUtils.isEmpty(imageIDs))
     		 throw new IllegalArgumentException("No image IDs provided.");
     	this.override = override;
+        loadCall = makeBatchCall(ctx, imageIDs, folderPath);
+    }
+
+    /**
+     * Loads the archived images.
+     * If bad arguments are passed, we throw a runtime
+     * exception so to fail early and in the caller's thread.
+     * 
+     * @param ctx The security context.
+     * @param imageID The Id of the image.
+     * @param name The name of the image.
+     * @param folderPath The location where to download the archived image.
+     * @param override Flag indicating to override the existing file if it
+     *                 exists, <code>false</code> otherwise.
+     * @param zip Pass <code>true</code> to create a zip file
+     * @param keepOriginalPaths Pass <code>true</code> to preserve the original folder structure
+     */
+    public ArchivedImageLoader(SecurityContext ctx, List<Long> imageIDs,
+            File folderPath, boolean override, boolean zip, boolean keepOriginalPaths)
+    {
+        if (CollectionUtils.isEmpty(imageIDs))
+             throw new IllegalArgumentException("No image IDs provided.");
+        this.override = override;
+        this.zip = zip;
+        this.keepOriginalPaths = keepOriginalPaths;
         loadCall = makeBatchCall(ctx, imageIDs, folderPath);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -68,6 +68,12 @@ public class ArchivedLoader
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
 
+    /** Flag for zipping the downloaded images */
+    private boolean zip = false;
+    
+    /** Flag for preserving the original folder structure */
+    private boolean keepOriginalPaths = true;
+    
     /**
      * Notifies that an error occurred.
      * @see UserNotifierLoader#onException(String, Throwable)
@@ -90,11 +96,13 @@ public class ArchivedLoader
      * @param file The location where to download the image.
      * @param override Flag indicating to override the existing file if it
      *                 exists, <code>false</code> otherwise.
+     * @param zip Pass <code>true</code> to create a zip file
+     * @param keepOriginalPaths Pass <code>true</code> to preserve the original folder structure
      * @param activity The activity associated to this loader.
      */
 	public ArchivedLoader(UserNotifier viewer, Registry registry,
 			SecurityContext ctx, List<ImageData> images, File file,
-			boolean override, ActivityComponent activity)
+			boolean override, boolean zip, boolean keepOriginalPaths, ActivityComponent activity)
 	{
 		super(viewer, registry, ctx, activity);
 		if (images == null)
@@ -102,6 +110,8 @@ public class ArchivedLoader
 		this.images = images;
 		this.file = file;
 		this.override = override;
+		this.zip = zip;
+		this.keepOriginalPaths = keepOriginalPaths;
 	}
 
 	/**
@@ -115,7 +125,7 @@ public class ArchivedLoader
 	        imageIds.add(d.getId());
 	    
 	    handle = mhView.loadArchivedImage(ctx, imageIds, file,
-	            override, this);
+	            override, zip, keepOriginalPaths, this);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 //Application-internal dependencies
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.DownloadArchivedActivityParam;
 import org.openmicroscopy.shoola.env.data.util.SecurityContext;
@@ -102,7 +101,8 @@ public class DownloadArchivedActivity
 	{
 	    File f = parameters.getLocation();
 		loader = new ArchivedLoader(viewer, registry, ctx,
-		        parameters.getImages(), f, parameters.isOverride(), this);
+		        parameters.getImages(), f, parameters.isOverride(), parameters.isZip(), 
+		        parameters.isKeepOriginalPaths(), this);
 		return loader;
 	}
 

--- a/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
@@ -195,7 +195,7 @@ public class NullOmeroPojoService
      * @see OmeroDataService#getArchivedFiles(String, long)
      */
 	public Map getArchivedImage(SecurityContext ctx, File location,
-			long pixelsID) 
+			long pixelsID, boolean keepOriginalPath) 
 		throws DSOutOfServiceException, DSAccessException
 	{
 		return null;


### PR DESCRIPTION

This is the same as gh-4060 but rebased onto dev_5_1.

----

See Trello card [Download multiple files - preserve directories](https://trello.com/c/asMv2nvz/27-download-multiple-files-preserve-directories)

With this PR original files will be downloaded as they are (not zipped like before) and their original folder structure will be preserved. Test: Download some original files and make sure the folder structure is correct (see File Path info dialog, folder structure should match the path in the managed repository).


                