### PR TITLE
ROI tool OutOfMemory (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
@@ -23,7 +23,6 @@
 package org.openmicroscopy.shoola.agents.measurement.util.model;
 
 //Java imports
-import java.awt.Point;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -33,7 +32,6 @@ import java.util.TreeMap;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.rnd.roi.AbstractROIShapeStats;
-import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStats;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -60,8 +58,7 @@ public class AnalysisStatsWrapper
 		MEAN,
 		STDDEV,
 		PIXELDATA,
-		SUM,
-		PIXEL_PLANEPOINT2D
+		SUM
 	};
 
 	/**
@@ -73,21 +70,20 @@ public class AnalysisStatsWrapper
 	public static Map<StatsType, Map> convertStats(Map shapeStats)
 	{
 		if (shapeStats == null || shapeStats.size() == 0) return null;
-		AbstractROIShapeStats stats;
+		ROIShapeStatsSimple stats;
 		Map<Integer, Double> channelMin = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelSum = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelMax = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelMean = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelStdDev = new TreeMap<Integer, Double>();
-		Map<Integer, double[]> channelData = new TreeMap<Integer, double[]>();
-		double[] pixels;
+		Map<Integer, ROIShapeStatsSimple> channelData = new TreeMap<Integer,ROIShapeStatsSimple>();
 		
 		int channel;
 		Iterator channelIterator = shapeStats.keySet().iterator();
 		while (channelIterator.hasNext())
 		{
 			channel = (Integer) channelIterator.next();
-			stats = (AbstractROIShapeStats) shapeStats.get(channel);
+			stats = (ROIShapeStatsSimple) shapeStats.get(channel);
 			channelSum.put(channel, stats.getSum());
 			channelMin.put(channel, stats.getMin());
 			channelMax.put(channel, stats.getMax());
@@ -95,22 +91,7 @@ public class AnalysisStatsWrapper
 					stats.getMean()));
 			channelStdDev.put(channel, UIUtilities.roundTwoDecimals(
 					stats.getStandardDeviation()));
-			
-            if (stats instanceof ROIShapeStatsSimple)
-                pixels = ((ROIShapeStatsSimple) stats).getPixelsValue();
-            else {
-                Map<Point, Double> pixelsMap = ((ROIShapeStats) stats)
-                        .getPixelsValue();
-                Iterator<Double> pixelIterator = pixelsMap.values().iterator();
-                pixels = new double[pixelsMap.size()];
-                int cnt = 0;
-                while (pixelIterator.hasNext()) {
-                    pixels[cnt] = pixelIterator.next();
-                    cnt++;
-                }
-            }
-			
-			channelData.put(channel, pixels);
+			channelData.put(channel,  (ROIShapeStatsSimple) stats);
 		}
 		Map<StatsType, Map> 
 			statsMap = new HashMap<StatsType, Map>(StatsType.values().length);
@@ -120,8 +101,6 @@ public class AnalysisStatsWrapper
 		statsMap.put(StatsType.MEAN, channelMean);
 		statsMap.put(StatsType.STDDEV, channelStdDev);
 		statsMap.put(StatsType.PIXELDATA, channelData);
-		statsMap.put(StatsType.PIXEL_PLANEPOINT2D, channelData);
-		//shapeStats.clear();
 		return statsMap;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
@@ -31,7 +31,6 @@ import java.util.TreeMap;
 //Third-party libraries
 
 //Application-internal dependencies
-import org.openmicroscopy.shoola.env.rnd.roi.AbstractROIShapeStats;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -76,7 +75,7 @@ public class AnalysisStatsWrapper
 		Map<Integer, Double> channelMax = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelMean = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelStdDev = new TreeMap<Integer, Double>();
-		Map<Integer, ROIShapeStatsSimple> channelData = new TreeMap<Integer,ROIShapeStatsSimple>();
+		Map<Integer, ROIShapeStatsSimple> channelData = new TreeMap<Integer, ROIShapeStatsSimple>();
 		
 		int channel;
 		Iterator channelIterator = shapeStats.keySet().iterator();
@@ -91,7 +90,7 @@ public class AnalysisStatsWrapper
 					stats.getMean()));
 			channelStdDev.put(channel, UIUtilities.roundTwoDecimals(
 					stats.getStandardDeviation()));
-			channelData.put(channel,  (ROIShapeStatsSimple) stats);
+			channelData.put(channel, (ROIShapeStatsSimple) stats);
 		}
 		Map<StatsType, Map> 
 			statsMap = new HashMap<StatsType, Map>(StatsType.values().length);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
@@ -23,6 +23,7 @@
 package org.openmicroscopy.shoola.agents.measurement.util.model;
 
 //Java imports
+import java.awt.Point;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -31,7 +32,9 @@ import java.util.TreeMap;
 //Third-party libraries
 
 //Application-internal dependencies
+import org.openmicroscopy.shoola.env.rnd.roi.AbstractROIShapeStats;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStats;
+import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /** 
@@ -70,7 +73,7 @@ public class AnalysisStatsWrapper
 	public static Map<StatsType, Map> convertStats(Map shapeStats)
 	{
 		if (shapeStats == null || shapeStats.size() == 0) return null;
-		ROIShapeStats stats;
+		AbstractROIShapeStats stats;
 		Map<Integer, Double> channelMin = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelSum = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelMax = new TreeMap<Integer, Double>();
@@ -84,7 +87,7 @@ public class AnalysisStatsWrapper
 		while (channelIterator.hasNext())
 		{
 			channel = (Integer) channelIterator.next();
-			stats = (ROIShapeStats) shapeStats.get(channel);
+			stats = (AbstractROIShapeStats) shapeStats.get(channel);
 			channelSum.put(channel, stats.getSum());
 			channelMin.put(channel, stats.getMin());
 			channelMax.put(channel, stats.getMax());
@@ -92,7 +95,20 @@ public class AnalysisStatsWrapper
 					stats.getMean()));
 			channelStdDev.put(channel, UIUtilities.roundTwoDecimals(
 					stats.getStandardDeviation()));
-			pixels = stats.getPixelsValue();
+			
+            if (stats instanceof ROIShapeStatsSimple)
+                pixels = ((ROIShapeStatsSimple) stats).getPixelsValue();
+            else {
+                Map<Point, Double> pixelsMap = ((ROIShapeStats) stats)
+                        .getPixelsValue();
+                Iterator<Double> pixelIterator = pixelsMap.values().iterator();
+                pixels = new double[pixelsMap.size()];
+                int cnt = 0;
+                while (pixelIterator.hasNext()) {
+                    pixels[cnt] = pixelIterator.next();
+                    cnt++;
+                }
+            }
 			
 			channelData.put(channel, pixels);
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnalysisStatsWrapper.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.util.AnalysisStatsWrapper 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,6 @@
 package org.openmicroscopy.shoola.agents.measurement.util.model;
 
 //Java imports
-import java.awt.Point;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -78,13 +77,8 @@ public class AnalysisStatsWrapper
 		Map<Integer, Double> channelMean = new TreeMap<Integer, Double>();
 		Map<Integer, Double> channelStdDev = new TreeMap<Integer, Double>();
 		Map<Integer, double[]> channelData = new TreeMap<Integer, double[]>();
-		Map<Integer, Map<Point, Double>> channelPixel = 
-			new TreeMap<Integer, Map<Point, Double>>();
-		Iterator<Double> 	pixelIterator;
-		Map<Point, Double> pixels;
+		double[] pixels;
 		
-		double[] pixelData;
-		int cnt;
 		int channel;
 		Iterator channelIterator = shapeStats.keySet().iterator();
 		while (channelIterator.hasNext())
@@ -99,19 +93,8 @@ public class AnalysisStatsWrapper
 			channelStdDev.put(channel, UIUtilities.roundTwoDecimals(
 					stats.getStandardDeviation()));
 			pixels = stats.getPixelsValue();
-				
-			channelPixel.put(channel, pixels);
-			pixelIterator = pixels.values().iterator();
-			pixelData = new double[pixels.size()];
-			cnt = 0;
-			while (pixelIterator.hasNext())
-			{
-				pixelData[cnt] = pixelIterator.next();
-				cnt++;
-			}
 			
-			channelData.put(channel, pixelData);
-			//pixels.clear();
+			channelData.put(channel, pixels);
 		}
 		Map<StatsType, Map> 
 			statsMap = new HashMap<StatsType, Map>(StatsType.values().length);
@@ -121,7 +104,7 @@ public class AnalysisStatsWrapper
 		statsMap.put(StatsType.MEAN, channelMean);
 		statsMap.put(StatsType.STDDEV, channelStdDev);
 		statsMap.put(StatsType.PIXELDATA, channelData);
-		statsMap.put(StatsType.PIXEL_PLANEPOINT2D, channelPixel);
+		statsMap.put(StatsType.PIXEL_PLANEPOINT2D, channelData);
 		//shapeStats.clear();
 		return statsMap;
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -57,7 +57,7 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
-import omero.log.Logger;
+import org.openmicroscopy.shoola.env.log.Logger;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -57,7 +57,8 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
-import org.openmicroscopy.shoola.env.log.Logger;
+import omero.log.Logger;
+import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure;
@@ -124,7 +125,7 @@ public class GraphPane
 	private Map<Coord3D, Map<StatsType, Map>> shapeStatsList;
 	
 	/** Map of the pixel intensity values to coordinates. */
-	private Map<Coord3D, Map<Integer, double[]>> pixelStats;
+	private Map<Coord3D, Map<Integer, ROIShapeStatsSimple>> pixelStats;
 	
 	/** Map of the coordinates to a shape. */
 	private Map<Coord3D, ROIShape> shapeMap;
@@ -386,7 +387,7 @@ public class GraphPane
 	private void buildGraphsAndDisplay()
 	{
 		coord = new Coord3D(zSlider.getValue()-1, tSlider.getValue()-1);
-		Map<Integer, double[]> data = pixelStats.get(coord);
+		Map<Integer, ROIShapeStatsSimple> data = pixelStats.get(coord);
 		if (data == null) return;
 		shape = shapeMap.get(coord);
 		double[][] dataXY;
@@ -416,7 +417,7 @@ public class GraphPane
 				if (UIUtilities.isSameColors(c, Color.white, false))
 					c = DEFAULT_COLOR;
 				channelColour.add(c);
-				values = data.get(channel);
+				values = data.get(channel).getValues();
 				if (values != null && values.length != 0) {
 					channelData.add(values);
 					
@@ -566,7 +567,7 @@ public class GraphPane
 			return;
 		}
 		shapeStatsList = new HashMap<Coord3D, Map<StatsType, Map>>();
-		pixelStats = new HashMap<Coord3D, Map<Integer, double[]>>();
+		pixelStats = new HashMap<Coord3D, Map<Integer, ROIShapeStatsSimple>>();
 		shapeMap = new HashMap<Coord3D, ROIShape>();
 		channelName = new ArrayList<String>();
 		channelColour = new ArrayList<Color>();
@@ -579,7 +580,7 @@ public class GraphPane
 		
 		Coord3D c3D;
 		Map<StatsType, Map> shapeStats;
-		Map<Integer, double[]> data;
+		Map<Integer, ROIShapeStatsSimple> data;
 		int t = model.getDefaultT();
 		int z = model.getDefaultZ();
 		boolean hasData = false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -89,7 +89,8 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
 import org.openmicroscopy.shoola.env.config.Registry;
-import org.openmicroscopy.shoola.env.log.Logger;
+import omero.log.Logger;
+import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import pojos.ChannelData;
 
@@ -229,7 +230,7 @@ class IntensityView
 	private TreeMap<Coord3D, Map<StatsType, Map>> shapeStatsList;
 
 	/** Map of the pixel intensity values to coordinates. */
-	private TreeMap<Coord3D, Map<Integer, Map<Point, Double>>> pixelStats;
+	private TreeMap<Coord3D, Map<Integer, ROIShapeStatsSimple>> pixelStats;
 	
 	/** Map of the minimum channel intensity values to coordinates. */
 	private TreeMap<Coord3D, Map<Integer, Double>> minStats;
@@ -541,9 +542,9 @@ class IntensityView
 		selectedChannelName = string;
 		int channel = nameMap.get(string);
 		if (channel < 0) return;
-		Map<Point, Double> pixels = pixelStats.get(coord).get(channel);
+		ROIShapeStatsSimple pixels = pixelStats.get(coord).get(channel);
 		if (pixels == null) return;
-		Iterator<Point> pixelIterator = pixels.keySet().iterator();
+		Iterator<Point> pixelIterator = pixels.getPoints().iterator();
 		double minX, maxX, minY, maxY;
 		if (!pixelIterator.hasNext()) return;
 		Point point = pixelIterator.next();
@@ -563,21 +564,16 @@ class IntensityView
 		sizeX = (int) (maxX-minX)+1;
 		sizeY = (int) ((maxY-minY)+1);
 		Double[][] data = new Double[sizeX][sizeY];
-		Iterator<Entry<Point, Double>> i = pixels.entrySet().iterator();
 		int x, y;
-		Double value;
-		Entry<Point, Double> entry;
-		while (i.hasNext())
+		for(int i=0; i<pixels.getPointsCount(); i++)
 		{
-			entry = i.next();
-			point = entry.getKey();
+			point = pixels.getPoints().get(i);
 			x = (int) (point.getX()-minX);
 			y = (int) (point.getY()-minY);
-			if (x >= sizeX || y >= sizeY) continue;
+			if (x >= sizeX || y >= sizeY) 
+			    continue;
 			
-			if (pixels.containsKey(point)) value = entry.getValue();
-			else value = 0.0;
-			data[x][y] = value;
+			data[x][y] = pixels.getValues()[i];;
 		}
 		tableModel = new IntensityModel(data);
 		intensityDialog.setModel(tableModel);
@@ -1184,7 +1180,7 @@ class IntensityView
 		clearMaps();
 		shapeStatsList = new TreeMap<Coord3D, Map<StatsType, Map>>(new Coord3D());
 		pixelStats = 
-			new TreeMap<Coord3D, Map<Integer, Map<Point, Double>>>(new Coord3D());
+			new TreeMap<Coord3D, Map<Integer, ROIShapeStatsSimple>>(new Coord3D());
 		shapeMap = new TreeMap<Coord3D, ROIShape>(new Coord3D());
 		minStats = new TreeMap<Coord3D, Map<Integer, Double>>(new Coord3D());
 		maxStats = new TreeMap<Coord3D, Map<Integer, Double>>(new Coord3D());
@@ -1232,7 +1228,7 @@ class IntensityView
 				meanStats.put(c3D, shapeStats.get(StatsType.MEAN));
 				sumStats.put(c3D, shapeStats.get(StatsType.SUM));
 				stdDevStats.put(c3D, shapeStats.get(StatsType.STDDEV));
-				pixelStats.put(c3D, shapeStats.get(StatsType.PIXEL_PLANEPOINT2D));
+				pixelStats.put(c3D, shapeStats.get(StatsType.PIXELDATA));
 			}
 			
 			

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -89,7 +89,7 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
 import org.openmicroscopy.shoola.env.config.Registry;
-import omero.log.Logger;
+import org.openmicroscopy.shoola.env.log.Logger;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import pojos.ChannelData;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/AbstractROIShapeStats.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/AbstractROIShapeStats.java
@@ -1,0 +1,192 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.rnd.roi;
+
+//Java imports
+
+/**
+ *
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @since 5.1
+ */
+
+public abstract class AbstractROIShapeStats implements PointIteratorObserver {
+
+    /** The minimum value within the 2D-selection. */
+    protected double min = Double.MAX_VALUE;
+    
+    /** The maximum value within the 2D-selection. */
+    protected double max = Double.MIN_VALUE;
+    
+    /** The sum of all values within the 2D-selection. */
+    protected double sum;
+    
+    /** The sum of the squares of all values within the 2D selection. */
+    protected double sumOfSquares;
+    
+    /** The mean value within the 2D-selection. */
+    protected double mean;
+    
+    /** The standard deviation within the 2D-selection. */
+    protected double standardDeviation;
+    
+    /** The number of points contained within the 2D-selection. */
+    protected int pointsCount;
+
+    public AbstractROIShapeStats() {
+        super();
+    }
+
+    /**
+     * Sets the minimum value.
+     * 
+     * @param min
+     *            The value to set.
+     */
+    protected void setMin(double min) {
+        this.min = min;
+    }
+
+    /**
+     * Sets the maximum value.
+     * 
+     * @param max
+     *            The value to set.
+     */
+    protected void setMax(double max) {
+        this.max = max;
+    }
+
+    /**
+     * Adds the passed value to the sum.
+     * 
+     * @param value
+     *            The value to add.
+     */
+    protected void addToSum(double value) {
+        this.sum += value;
+    }
+
+    /**
+     * Adds the passed value to the sum of squares.
+     * 
+     * @param value
+     *            The value to add.
+     */
+    protected void addToSumOfSquares(double value) {
+        this.sumOfSquares += value * value;
+    }
+
+    /**
+     * Sets the mean value.
+     * 
+     * @param mean
+     *            The value to set.
+     */
+    protected void setMean(double mean) {
+        this.mean = mean;
+    }
+
+    /**
+     * Sets the number of points counted.
+     * 
+     * @param pointsCount
+     *            The value to set.
+     */
+    protected void setPointsCount(int pointsCount) {
+        this.pointsCount = pointsCount;
+    }
+
+    /**
+     * Returns the sum of squares.
+     * 
+     * @return See above.
+     */
+    protected double getSumOfSquares() {
+        return sumOfSquares;
+    }
+
+    /**
+     * Sets the standard deviation.
+     * 
+     * @param standardDeviation
+     *            The value to set.
+     */
+    protected void setStandardDeviation(double standardDeviation) {
+        this.standardDeviation = standardDeviation;
+    }
+
+    /**
+     * Returns the minimum value within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public double getMin() {
+        return min;
+    }
+
+    /**
+     * Returns the maximum value within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public double getMax() {
+        return max;
+    }
+
+    /**
+     * Returns the mean value within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public double getMean() {
+        return mean;
+    }
+
+    /**
+     * Returns the standard deviation within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public double getStandardDeviation() {
+        return standardDeviation;
+    }
+
+    /**
+     * Returns the sum of all values within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public double getSum() {
+        return sum;
+    }
+
+    /**
+     * Returns the number of points contained within the 2D-selection.
+     * 
+     * @return See above.
+     */
+    public int getPointsCount() {
+        return pointsCount;
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIAnalyser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIAnalyser.java
@@ -129,12 +129,12 @@ public class ROIAnalyser
      * @param channels Collection of selected channels.
      * @return A map whose keys are the {@link ROIShape} objects specified
      *         and whose values are a map (keys: channel index, value
-     *         the corresponding {@link ROIShapeStats} objects computed by
+     *         the corresponding {@link AbstractROIShapeStats} objects computed by
      *         this method).
      * @throws DataSourceException  If an error occurs while retrieving plane
      *                              data from the pixels source.
      */
-    public Map<ROIShape, Map<Integer, ROIShapeStats>> analyze(
+    public Map<ROIShape, Map<Integer, AbstractROIShapeStats>> analyze(
             SecurityContext ctx, ROIShape[] shapes,
             Collection<Integer> channels)
     throws DataSourceException
@@ -144,10 +144,10 @@ public class ROIAnalyser
             throw new IllegalArgumentException("No shapes defined.");
         if (CollectionUtils.isEmpty(channels))
             throw new IllegalArgumentException("No channels defined.");
-        Map<ROIShape, Map<Integer, ROIShapeStats>>
-        r = new HashMap<ROIShape, Map<Integer, ROIShapeStats>>();
-        ROIShapeStats computer;
-        Map<Integer, ROIShapeStats> stats;
+        Map<ROIShape, Map<Integer, AbstractROIShapeStats>>
+        r = new HashMap<ROIShape, Map<Integer, AbstractROIShapeStats>>();
+        AbstractROIShapeStats computer;
+        Map<Integer, AbstractROIShapeStats> stats;
         Iterator<Integer> j;
         int n = channels.size();
         Integer w;
@@ -157,7 +157,7 @@ public class ROIAnalyser
             shape = shapes[i];
             close = i == shapes.length-1;
             if (checkPlane(shape.getZ(), shape.getT())) {
-                stats = new HashMap<Integer, ROIShapeStats>(n);
+                stats = new HashMap<Integer, AbstractROIShapeStats>(n);
                 j = channels.iterator();
                 List<Point> points = shape.getFigure().getPoints();
                 int count = 0;
@@ -165,7 +165,7 @@ public class ROIAnalyser
                 while (j.hasNext()) {
                     w = j.next();
                     if (checkChannel(w.intValue())) {
-                        computer =  new ROIShapeStats();
+                        computer =  new ROIShapeStatsSimple();
                         runner.register(computer);
                         if (close) {
                             last = count == channels.size()-1;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIAnalyser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIAnalyser.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.rnd.roi.ROIAnalyser 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStats.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStats.java
@@ -25,6 +25,8 @@ package org.openmicroscopy.shoola.env.rnd.roi;
 
 //Java imports
 import java.awt.Point;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 //Third-party libraries
 
@@ -43,152 +45,26 @@ import java.awt.Point;
  * @version 3.0
  * @since OME3.0
  */
-public class ROIShapeStats
-    implements PointIteratorObserver
+public class ROIShapeStats extends AbstractROIShapeStats
 {
 
     //NOTE: fields have package visibility so they can easily be accessed
     //during the computation.  However, we only supply getters to outside
     //clients b/c these fields are read-only after the computation is done.
 
-    /** The minimum value within the 2D-selection. */
-    private double min = Double.MAX_VALUE;
-
-    /** The maximum value within the 2D-selection. */
-    private double max = Double.MIN_VALUE;
-
-    /** The sum of all values within the 2D-selection. */
-    private double sum;
-
-    /** The sum of the squares of all values within the 2D selection. */
-    private double sumOfSquares;  //Only useful during computation, hence no getter.
-
-    /** The mean value within the 2D-selection. */
-    private double mean;
-
-    /** The standard deviation within the 2D-selection. */
-    private  double standardDeviation;
-
-    /** The number of points contained within the 2D-selection. */
-    private int pointsCount;
-
     /** 
-     * Array holding the pixels values.
+     * Map whose keys are the point on the plane and the values are 
+     * the corresponding pixels value.
      */
-    private double[] pixelsValue;
-    
-    /**
-     * Index pointing to the next unassigned field in the pixelsValue array
-     */
-    private int index;
+    private Map<Point, Double> pixelsValue;
 
     /**
-     * Sets the minimum value.
-     * 
-     * @param min The value to set.
-     */
-    void setMin(double min) { this.min = min; }
-
-    /**
-     * Sets the maximum value.
-     * 
-     * @param max The value to set.
-     */
-    void setMax(double max) { this.max = max; }
-
-    /**
-     * Adds the passed value to the sum.
-     * 
-     * @param value The value to add.
-     */
-    void addToSum(double value) { this.sum += value; }
-
-    /**
-     * Adds the passed value to the sum of squares.
-     * 
-     * @param value The value to add.
-     */
-    void addToSumOfSquares(double value) { this.sumOfSquares += value*value; }
-
-    /**
-     * Sets the mean value.
-     * 
-     * @param mean The value to set.
-     */
-    void setMean(double mean) { this.mean = mean; }
-
-    /**
-     * Sets the number of points counted.
-     * 
-     * @param pointsCount The value to set.
-     */
-    void setPointsCount(int pointsCount) { this.pointsCount = pointsCount; }
-
-    /**
-     * Returns the sum of squares.
+     * Returns the map storing the pixel coordinates and the corresponding 
+     * pixel value.
      * 
      * @return See above.
      */
-    double getSumOfSquares() { return sumOfSquares; }
-
-    /**
-     * Sets the standard deviation.
-     * 
-     * @param standardDeviation The value to set.
-     */
-    void setStandardDeviation(double standardDeviation)
-    {
-        this.standardDeviation = standardDeviation;
-    }
-
-    /**
-     * Returns the minimum value within the 2D-selection.
-     * 
-     * @return See above.
-     */
-    public double getMin() { return min; }
-
-    /**
-     * Returns the maximum value within the 2D-selection.
-     * 
-     * @return See above.
-     */
-    public double getMax() { return max; }
-
-    /**
-     * Returns the mean value within the 2D-selection.
-     * 
-     * @return See above.
-     */
-    public double getMean() { return mean; }
-
-    /**
-     * Returns the standard deviation within the 2D-selection.
-     * 
-     * @return See above.
-     */
-    public double getStandardDeviation() { return standardDeviation; }
-
-    /**
-     * Returns the sum of all values within the 2D-selection.
-     * 
-     * @return See above.
-     */
-    public double getSum() { return sum; }
-
-    /** 
-     * Returns the number of points contained within the 2D-selection. 
-     * 
-     * @return See above.
-     */
-    public int getPointsCount() { return pointsCount; }
-
-    /**
-     * Returns the pixel values.
-     * 
-     * @return See above.
-     */
-    public double[] getPixelsValue() { return pixelsValue; }
+    public Map<Point, Double> getPixelsValue() { return pixelsValue; }
 
     /** 
      * Calculates the mean and standard deviation for the current 
@@ -219,17 +95,16 @@ public class ROIShapeStats
         max = Math.max(pixelValue,max);
         sum += pixelValue;
         sumOfSquares += pixelValue*pixelValue;
-        pixelsValue[index++] = pixelValue;
+        pixelsValue.put(loc, new Double(pixelValue));
     }
 
     /**
-     * Creates a new array to store the pixel values. 
+     * Creates a new map to store the pixel values. 
      * @see PointIteratorObserver#onStartPlane(int, int, int, int)
      */
     public void onStartPlane(int z, int w, int t, int pointsCount)
     {
-        pixelsValue = new double[pointsCount];
-        index = 0;
+        pixelsValue = new LinkedHashMap<Point, Double>(pointsCount);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStats.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStats.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStats 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,8 +25,6 @@ package org.openmicroscopy.shoola.env.rnd.roi;
 
 //Java imports
 import java.awt.Point;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 //Third-party libraries
 
@@ -75,10 +73,14 @@ public class ROIShapeStats
     private int pointsCount;
 
     /** 
-     * Map whose keys are the point on the plane and the values are 
-     * the corresponding pixels value.
+     * Array holding the pixels values.
      */
-    private Map<Point, Double> pixelsValue;
+    private double[] pixelsValue;
+    
+    /**
+     * Index pointing to the next unassigned field in the pixelsValue array
+     */
+    private int index;
 
     /**
      * Sets the minimum value.
@@ -182,12 +184,11 @@ public class ROIShapeStats
     public int getPointsCount() { return pointsCount; }
 
     /**
-     * Returns the map storing the pixel coordinates and the corresponding 
-     * pixel value.
+     * Returns the pixel values.
      * 
      * @return See above.
      */
-    public Map<Point, Double> getPixelsValue() { return pixelsValue; }
+    public double[] getPixelsValue() { return pixelsValue; }
 
     /** 
      * Calculates the mean and standard deviation for the current 
@@ -218,16 +219,17 @@ public class ROIShapeStats
         max = Math.max(pixelValue,max);
         sum += pixelValue;
         sumOfSquares += pixelValue*pixelValue;
-        pixelsValue.put(loc, new Double(pixelValue));
+        pixelsValue[index++] = pixelValue;
     }
 
     /**
-     * Creates a new map to store the pixel values. 
+     * Creates a new array to store the pixel values. 
      * @see PointIteratorObserver#onStartPlane(int, int, int, int)
      */
     public void onStartPlane(int z, int w, int t, int pointsCount)
     {
-        pixelsValue = new LinkedHashMap<Point, Double>(pointsCount);
+        pixelsValue = new double[pointsCount];
+        index = 0;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStatsSimple.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStatsSimple.java
@@ -1,0 +1,122 @@
+/*
+ * org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStats 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.rnd.roi;
+
+//Java imports
+import java.awt.Point;
+
+//Third-party libraries
+
+//Application-internal dependencies
+
+/**
+ * Stores the results of some basic statistic analysis run on a given
+ * 2D-selection within an XY-plane. Some of the fields are also used as
+ * accumulators during the computation.
+ *
+ *
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ROIShapeStatsSimple extends AbstractROIShapeStats {
+    /**
+     * Array holding the pixels values.
+     */
+    private double[] pixelsValue;
+
+    /**
+     * Index pointing to the next unassigned field in the pixelsValue array
+     */
+    private int index;
+
+    /**
+     * Returns the pixel values.
+     * 
+     * @return See above.
+     */
+    public double[] getPixelsValue() {
+        return pixelsValue;
+    }
+
+    /**
+     * Calculates the mean and standard deviation for the current
+     * {@link ROIShapeStatsSimple}.
+     * 
+     * @see PointIteratorObserver#onEndPlane(int, int, int, int)
+     */
+    public void onEndPlane(int z, int c, int t, int pointsCount) {
+        if (pointsCount <= 0)
+            return;
+        mean = sum / pointsCount;
+        this.pointsCount = pointsCount;
+        if (0 < pointsCount - 1) {
+            double sigmaSquare = (sumOfSquares - sum * sum / pointsCount)
+                    / (pointsCount - 1);
+            if (sigmaSquare > 0)
+                standardDeviation = Math.sqrt(sigmaSquare);
+        }
+    }
+
+    /**
+     * Updates the min, max, and sum values of the current
+     * {@link ROIShapeStatsSimple}.
+     * 
+     * @see PointIteratorObserver#update(double, int, int, int, Point)
+     */
+    public void update(double pixelValue, int z, int w, int t, Point loc) {
+        min = Math.min(pixelValue, min);
+        max = Math.max(pixelValue, max);
+        sum += pixelValue;
+        sumOfSquares += pixelValue * pixelValue;
+        pixelsValue[index++] = pixelValue;
+    }
+
+    /**
+     * Creates a new array to store the pixel values.
+     * 
+     * @see PointIteratorObserver#onStartPlane(int, int, int, int)
+     */
+    public void onStartPlane(int z, int w, int t, int pointsCount) {
+        pixelsValue = new double[pointsCount];
+        index = 0;
+    }
+
+    /**
+     * Required by {@link PointIteratorObserver} interface, but no-operation
+     * implementation in our case.
+     * 
+     * @see PointIteratorObserver#iterationStarted()
+     */
+    public void iterationStarted() {
+    }
+
+    /**
+     * Required by {@link PointIteratorObserver} interface, but no-operation
+     * implementation in our case.
+     * 
+     * @see PointIteratorObserver#iterationFinished()
+     */
+    public void iterationFinished() {
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStatsSimple.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIShapeStatsSimple.java
@@ -24,6 +24,8 @@ package org.openmicroscopy.shoola.env.rnd.roi;
 
 //Java imports
 import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
 
 //Third-party libraries
 
@@ -34,33 +36,61 @@ import java.awt.Point;
  * 2D-selection within an XY-plane. Some of the fields are also used as
  * accumulators during the computation.
  *
+ * (A less memory consuming implementation of {@link AbstractROIShapeStats} than
+ * {@link ROIShapeStats} )
  *
  * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 public class ROIShapeStatsSimple extends AbstractROIShapeStats {
-    /**
-     * Array holding the pixels values.
-     */
-    private double[] pixelsValue;
 
     /**
-     * Index pointing to the next unassigned field in the pixelsValue array
+     * The {@link List} of {@link Point}s
      */
-    private int index;
+    private List<Point> points;
 
     /**
-     * Returns the pixel values.
+     * The corresponding values
+     */
+    private double values[];
+
+    /**
+     * Get the {@link Point}s in the order they have been added.
      * 
      * @return See above.
      */
-    public double[] getPixelsValue() {
-        return pixelsValue;
+    public List<Point> getPoints() {
+        return points;
+    }
+
+    /**
+     * Get the values in the order they have been added.
+     * 
+     * @return See above.
+     */
+    public double[] getValues() {
+        return values;
+    }
+
+    /**
+     * Get the value for a certain {@link Point} (Note: Not very efficient, if
+     * you know the index better use {@link #getValues()}[index] )
+     * 
+     * @param p
+     *            The {@link Point} to get the value for
+     * @return See above.
+     */
+    public double getValue(Point p) {
+        int i = points.indexOf(p);
+        if (i == -1)
+            return Double.NaN;
+        else
+            return values[i];
     }
 
     /**
      * Calculates the mean and standard deviation for the current
-     * {@link ROIShapeStatsSimple}.
+     * {@link ROIShapeStats}.
      * 
      * @see PointIteratorObserver#onEndPlane(int, int, int, int)
      */
@@ -78,8 +108,8 @@ public class ROIShapeStatsSimple extends AbstractROIShapeStats {
     }
 
     /**
-     * Updates the min, max, and sum values of the current
-     * {@link ROIShapeStatsSimple}.
+     * Updates the min, max, and sum values of the current {@link ROIShapeStats}
+     * .
      * 
      * @see PointIteratorObserver#update(double, int, int, int, Point)
      */
@@ -88,17 +118,18 @@ public class ROIShapeStatsSimple extends AbstractROIShapeStats {
         max = Math.max(pixelValue, max);
         sum += pixelValue;
         sumOfSquares += pixelValue * pixelValue;
-        pixelsValue[index++] = pixelValue;
+        values[points.size()] = pixelValue;
+        points.add(loc);
     }
 
     /**
-     * Creates a new array to store the pixel values.
+     * Creates a new map to store the pixel values.
      * 
      * @see PointIteratorObserver#onStartPlane(int, int, int, int)
      */
     public void onStartPlane(int z, int w, int t, int pointsCount) {
-        pixelsValue = new double[pointsCount];
-        index = 0;
+        points = new ArrayList<Point>();
+        values = new double[pointsCount];
     }
 
     /**
@@ -118,5 +149,4 @@ public class ROIShapeStatsSimple extends AbstractROIShapeStats {
      */
     public void iterationFinished() {
     }
-
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIStats.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/ROIStats.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.rnd.roi.ROIStats 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -114,7 +114,7 @@ public class ROIStats
      *          2D-selection in the specified plane. If no selection was
      *          made in that plane, then <code>null</code> is returned instead.
      */
-    public ROIShapeStats getPlaneStats(int z, int w, int t)
+    public AbstractROIShapeStats getPlaneStats(int z, int w, int t)
     {
         Integer index = linearize(z, w, t);
         return arrayMap.get(index);
@@ -150,7 +150,7 @@ public class ROIStats
     public void update(double pixelValue, int z, int w, int t, Point loc)
     {
         Integer index = linearize(z, w, t);
-        ROIShapeStats planeStats = arrayMap.get(index);
+        AbstractROIShapeStats planeStats = arrayMap.get(index);
         //planeStats can't be null, see onStartPlane().
         if (pixelValue < planeStats.getMin())
             planeStats.setMin(pixelValue);
@@ -168,7 +168,7 @@ public class ROIStats
     public void onEndPlane(int z, int w, int t, int pointsCount)
     {
         Integer index = linearize(z, w, t);
-        ROIShapeStats ps = arrayMap.get(index);
+        AbstractROIShapeStats ps = arrayMap.get(index);
         //planeStats can't be null, see onStartPlane().
         if (0 < pointsCount) {
             ps.setMean(ps.getSum()/pointsCount);


### PR DESCRIPTION

This is the same as gh-4083 but rebased onto dev_5_1.

----

See [Ticket 12995](https://trac.openmicroscopy.org/ome/ticket/12995)

For analyzing ROI shapes a LinkedHashMap was used, which consumed a lot of memory. This PR replaces it with a double array and a list of points. It also removes some unnecessary duplications of data structures which in total significantly reduces the memory usage.

Test: Analyze some ROIs: Make sure the histogram plots and intensity values are still calculated correctly. Analyze a rectangular ROI same size or bigger as the one mentioned in ticket (250x280px) on a multi channel image, make sure Insight doesn't crash and it doesn't take several minutes for the graphs to appear.



                