### PR TITLE
Bugfix: MapAnnotation Image link

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -171,6 +171,7 @@ import omero.model.FilesetEntry;
 import omero.model.GroupExperimenterMap;
 import omero.model.IObject;
 import omero.model.Image;
+import omero.model.ImageI;
 import omero.model.Instrument;
 import omero.model.LabelI;
 import omero.model.Laser;
@@ -186,6 +187,7 @@ import omero.model.PixelsType;
 import omero.model.Plate;
 import omero.model.PlateAcquisition;
 import omero.model.PlateAcquisitionI;
+import omero.model.PlateI;
 import omero.model.PointI;
 import omero.model.PolygonI;
 import omero.model.PolylineI;
@@ -199,6 +201,7 @@ import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.model.Well;
 import omero.model.WellSample;
+import omero.model.WellSampleI;
 import omero.model.enums.ChecksumAlgorithmSHA1160;
 import omero.sys.Parameters;
 import omero.sys.ParametersI;
@@ -951,23 +954,31 @@ class OMEROGateway
 	{
 		String table = null;
 		if (Dataset.class.equals(klass) ||
+		        DatasetI.class.equals(klass) ||
 			DatasetData.class.equals(klass))
 			table = "DatasetAnnotationLink";
 		else if (Project.class.equals(klass) ||
+		        ProjectI.class.equals(klass) ||
 				ProjectData.class.equals(klass))
 			table = "ProjectAnnotationLink";
 		else if (Image.class.equals(klass) ||
-				ImageData.class.equals(klass)) table = "ImageAnnotationLink";
+		        ImageI.class.equals(klass) ||
+				ImageData.class.equals(klass)) 
+		    table = "ImageAnnotationLink";
 		else if (Screen.class.equals(klass) ||
+		        ScreenI.class.equals(klass) ||
 				ScreenData.class.equals(klass))
 			table = "ScreenAnnotationLink";
 		else if (Plate.class.equals(klass) ||
+		        PlateI.class.equals(klass) ||
 				PlateData.class.equals(klass))
 			table = "PlateAnnotationLink";
 		else if (PlateAcquisition.class.equals(klass) ||
+		        PlateAcquisitionI.class.equals(klass) ||
 				PlateAcquisitionData.class.equals(klass))
 			table = "PlateAcquisitionAnnotationLink";
 		else if (WellSample.class.equals(klass) ||
+		        WellSampleI.class.equals(klass) ||
 				WellSampleData.class.equals(klass))
 			table = "ScreenAnnotationLink";
 		else if (RectangleData.class.equals(klass) || RectI.class.equals(klass) ||


### PR DESCRIPTION
Found a bug will trying to reproduce [Ticket 12744](https://trac.openmicroscopy.org/ome/ticket/12744)

Test:
- Select an image.
- Add a MapAnnotation by entering a key, press tab, enter a value, but **don't** hit enter, instead navigate away by selecting another image (before: an exception was thrown at this point because Insight tried to save the ImageAnnotationLink twice)
- Go back to the image and make sure the key/value pair has been saved
