### PR TITLE
Bugfix: MapAnnotation Image link (rebased onto dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -161,7 +161,6 @@ import omero.grid.StringColumn;
 import omero.grid.TablePrx;
 import omero.grid.WellColumn;
 import omero.model.Annotation;
-import omero.model.AnnotationAnnotationLink;
 import omero.model.BooleanAnnotation;
 import omero.model.ChecksumAlgorithm;
 import omero.model.ChecksumAlgorithmI;
@@ -212,6 +211,7 @@ import omero.model.TagAnnotationI;
 import omero.model.TermAnnotation;
 import omero.model.Well;
 import omero.model.WellSample;
+import omero.model.WellSampleI;
 import omero.model.enums.ChecksumAlgorithmSHA1160;
 import omero.model.XmlAnnotation;
 import omero.sys.Parameters;
@@ -1055,23 +1055,31 @@ class OMEROGateway
 	{
 		String table = null;
 		if (Dataset.class.equals(klass) ||
+		        DatasetI.class.equals(klass) ||
 			DatasetData.class.equals(klass))
 			table = "DatasetAnnotationLink";
 		else if (Project.class.equals(klass) ||
+		        ProjectI.class.equals(klass) ||
 				ProjectData.class.equals(klass))
 			table = "ProjectAnnotationLink";
 		else if (Image.class.equals(klass) ||
-				ImageData.class.equals(klass)) table = "ImageAnnotationLink";
+		        ImageI.class.equals(klass) ||
+				ImageData.class.equals(klass)) 
+		    table = "ImageAnnotationLink";
 		else if (Screen.class.equals(klass) ||
+		        ScreenI.class.equals(klass) ||
 				ScreenData.class.equals(klass))
 			table = "ScreenAnnotationLink";
 		else if (Plate.class.equals(klass) ||
+		        PlateI.class.equals(klass) ||
 				PlateData.class.equals(klass))
 			table = "PlateAnnotationLink";
 		else if (PlateAcquisition.class.equals(klass) ||
+		        PlateAcquisitionI.class.equals(klass) ||
 				PlateAcquisitionData.class.equals(klass))
 			table = "PlateAcquisitionAnnotationLink";
 		else if (WellSample.class.equals(klass) ||
+		        WellSampleI.class.equals(klass) ||
 				WellSampleData.class.equals(klass))
 			table = "ScreenAnnotationLink";
 		else table = "AnnotationAnnotationLink";


### PR DESCRIPTION

This is the same as gh-4143 but rebased onto dev_5_1.

----

Found a bug will trying to reproduce [Ticket 12744](https://trac.openmicroscopy.org/ome/ticket/12744)

Test:
- Select an image.
- Add a MapAnnotation by entering a key, press tab, enter a value, but **don't** hit enter, instead navigate away by selecting another image (before: an exception was thrown at this point because Insight tried to save the ImageAnnotationLink twice)
- Go back to the image and make sure the key/value pair has been saved


                