### PR TITLE
Custom server error deprecation

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -32,6 +32,7 @@ import sys
 import datetime
 import traceback
 import logging
+import warnings
 
 from django.conf import settings
 from django.template import loader as template_loader
@@ -141,6 +142,9 @@ def custom_server_error(request, error500):
     Templates: `500.html`
     Context: ErrorForm
     """
+    warnings.warn(
+        "Deprecated handler. Will be removed in 5.2",
+        DeprecationWarning)
     form = ErrorForm(initial={'error': error500})
     context = {'form': form}
     t = template_loader.get_template('500.html')

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -134,6 +134,19 @@ def send_comment(request):
     return HttpResponse(t.render(c))
 
 
+def custom_server_error(request, error500):
+    """
+    Custom 500 error handler.
+
+    Templates: `500.html`
+    Context: ErrorForm
+    """
+    form = ErrorForm(initial={'error': error500})
+    context = {'form': form}
+    t = template_loader.get_template('500.html')
+    c = RequestContext(request, context)
+    return HttpResponse(t.render(c))
+
 ##############################################################################
 # handlers
 


### PR DESCRIPTION
See https://trello.com/c/ra7UKuEJ/50-resurrect-5-1-web-method

This PR restores a handler removed in https://github.com/openmicroscopy/openmicroscopy/pull/4090 and deprecates it (removed in 5.2 via #4108).

--no-rebase