### PR TITLE
Temporarily bump MessageSizeMax to 250mb

### DIFF
--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -43,10 +43,12 @@ module omero {
     const int GLACIER2PORT = 4064;
 
     /**
-     * Default Ice.MessageSizeMax (65536kb). Not strictly necessary, but helps to
+     * Default Ice.MessageSizeMax (250mb). Not strictly necessary, but helps to
      * curb memory issues. Must be set before communicator initialization.
+     *
+     * Temporarily set to 250MB
      **/
-    const int MESSAGESIZEMAX = 65536;
+    const int MESSAGESIZEMAX = 250000;
 
     /**
      * Determines the batch size for sending

--- a/etc/grid/templates.xml
+++ b/etc/grid/templates.xml
@@ -25,7 +25,7 @@
     </properties>
 
     <properties id="Basics">
-      <property name="Ice.MessageSizeMax" value="65536"/> <!-- 64 MB -->
+      <property name="Ice.MessageSizeMax" value="250000"/> <!-- 64 MB -->
       <property name="Ice.CacheMessageBuffers" value="0"/>
       <property name="Ice.Override.ConnectTimeout" value="5000"/>
     </properties>


### PR DESCRIPTION
Import of the condensation screens failed with

```
==> Summary
63171 files uploaded, 0 filesets created, 0 images imported, 0 errors in 2:47:28.118
2015-09-10 15:20:46,922 10354261   [1-thread-1] ERROR  me.formats.importer.util.ClientKeepAlive - Exception while executing ping(), logging Connector out:
java.lang.RuntimeException: Ice.CommunicatorDestroyedException
        at ome.formats.OMEROMetadataStoreClient.ping(OMEROMetadataStoreClient.java:763) ~[blitz.jar:na]
```

```
-! 09/10/15 15:20:14.841 OMERO.Glacier2: warning: dispatch exception: OutgoingAsync.cpp:720: Ice::UnknownLocalException:
   unknown local exception:
   Ice::MemoryLimitException
   Ice.MemoryLimitException
       reason = "requested 67108865 bytes, maximum allowed is 67108864 bytes (see Ice.MessageSizeMax)"
```