### PR TITLE
Matlab: add group support to create objects function (rebased onto develop)

### DIFF
--- a/components/tools/OmeroM/src/annotations/linkAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/linkAnnotation.m
@@ -50,7 +50,7 @@ end
 % Create object annotation link
 context = java.util.HashMap;
 group = parent.getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 
 link = objectType.annotationLink();
 link.setParent(parent)

--- a/components/tools/OmeroM/src/annotations/updateFileAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/updateFileAnnotation.m
@@ -56,7 +56,7 @@ context = java.util.HashMap;
 % Check if the Annotation exists on the server
 try
     group = fileAnnotation.getDetails().getGroup().getId().getValue();
-    context.put('omero.group', num2str(group));
+    context.put('omero.group', java.lang.String(num2str(group)));
     if isempty(ip.Results.group)
          index = length(varargin);
          varargin{index + 1} = 'group';

--- a/components/tools/OmeroM/src/io/createDataset.m
+++ b/components/tools/OmeroM/src/io/createDataset.m
@@ -17,8 +17,11 @@ function dataset = createDataset(session, name, varargin)
 %
 %   Examples:
 %
+%      % Create a new dataset in the context of the current session group
 %      dataset = createDataset(session, 'my-dataset');
+%      % Create a new dataset in the context of the specified group
 %      dataset = createDataset(session, 'my-dataset', 'group', groupId);
+%      % Create a new dataset and link it to the specified project
 %      dataset = createDataset(session, 'my-dataset', project);
 %      dataset = createDataset(session, 'my-dataset', projectId);
 %

--- a/components/tools/OmeroM/src/io/createDataset.m
+++ b/components/tools/OmeroM/src/io/createDataset.m
@@ -60,14 +60,9 @@ if ~isempty(ip.Results.project)
     else
         project = ip.Results.project;
     end
-    
+
+    % Determine group from the parent project
     groupId = project.getDetails().getGroup().getId().getValue();
-
-    % Create dataset object
-    dataset = omero.model.DatasetI();
-    dataset.setName(rstring(name));
-
-    % Create context for uploading
     if ~isempty(ip.Results.group)
         if ~isempty(groupId)
             assert(isequal(groupId, ip.Results.group),...
@@ -76,6 +71,11 @@ if ~isempty(ip.Results.project)
         groupId = ip.Results.group;
     end
 
+    % Create dataset object
+    dataset = omero.model.DatasetI();
+    dataset.setName(rstring(name));
+
+    % Create context for uploading
     context = ip.Results.context;
     context.put('omero.group', java.lang.String(num2str(groupId)));
 

--- a/components/tools/OmeroM/src/io/createDataset.m
+++ b/components/tools/OmeroM/src/io/createDataset.m
@@ -10,6 +10,9 @@ function dataset = createDataset(session, name, varargin)
 %   dataset = createDataset(session, name, projectId) also links the
 %   dataset to the project specified by the input identifier.
 %
+%   dataset = createDataset(..., 'group', groupId) specifies the group
+%   context in which the dataset should be created.
+%
 %   Examples:
 %
 %      dataset = createDataset(session, 'my-dataset');
@@ -18,7 +21,7 @@ function dataset = createDataset(session, name, varargin)
 %
 % See also: CREATEOBJECT, CREATEPROJECT
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -36,7 +39,7 @@ function dataset = createDataset(session, name, varargin)
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 % Delegate object creation
-dataset = createObject(session, 'dataset', name);
+dataset = createObject(session, 'dataset', name, varargin{:});
 
 % Check if optional project is passed
 isValidProject = @(x) isscalar(x) && ...

--- a/components/tools/OmeroM/src/io/createDataset.m
+++ b/components/tools/OmeroM/src/io/createDataset.m
@@ -18,6 +18,9 @@ function dataset = createDataset(session, name, varargin)
 %      dataset = createDataset(session, 'my-dataset');
 %      dataset = createDataset(session, 'my-dataset', project);
 %      dataset = createDataset(session, 'my-dataset', projectId);
+%      dataset = createDataset(session, 'my-dataset', 'group', groupId);
+%      dataset = createDataset(session, 'my-dataset', project, 'group', groupId);
+%      dataset = createDataset(session, 'my-dataset', projectId, 'group', groupId);
 %
 % See also: CREATEOBJECT, CREATEPROJECT
 
@@ -50,18 +53,18 @@ ip.addParamValue('group', [], @(x) isempty(x) || (isscalar(x) && isnumeric(x)));
 ip.parse(name, varargin{:});
 
 if ~isempty(ip.Results.project)
-    % Check project object
+    % Retrieve project identifier
     if isnumeric(ip.Results.project)
         projectId = ip.Results.project;
     else
         projectId = ip.Results.project.getId().getValue();
     end
     
-    %
+    % Create dataset object
     dataset = omero.model.DatasetI();
     dataset.setName(rstring(name));
 
-    % Create new object and upload onto the server
+    % Create context for uploading
     context = ip.Results.context;
     if ~isempty(ip.Results.group)
         context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
@@ -73,7 +76,7 @@ if ~isempty(ip.Results.project)
     link.setChild(dataset);
     link = session.getUpdateService().saveAndReturnObject(link, context);
     
-    % Retrieve fully loaded dataset
+    % Return the dataset
     dataset = link.getChild();
 else
     % Delegate object creation

--- a/components/tools/OmeroM/src/io/createObject.m
+++ b/components/tools/OmeroM/src/io/createObject.m
@@ -6,12 +6,13 @@ function newobject = createObject(session, type, name, varargin)
 %   the loaded object.
 %
 %   newobject = createObject(..., 'group', groupId) specifies the group
-%   context in which the
+%   context in which the object should be created.
 %
 %   Examples:
 %
-%      %
+%      % Create an image object in the context of the session group
 %      image = createObject(session, 'image', 'name');
+%      % Create an image object in the specified group
 %      image = createObject(session, 'image', 'name', 'group', groupId);
 %
 % See also: CREATEIMAGE, CREATEPROJECT, CREATEDATASET, CREATEPLATE,

--- a/components/tools/OmeroM/src/io/createObject.m
+++ b/components/tools/OmeroM/src/io/createObject.m
@@ -42,8 +42,8 @@ ip.addRequired('session');
 ip.addRequired('type', @(x) ischar(x) && ismember(x, objectNames));
 ip.addRequired('name', @ischar);
 ip.addParamValue('context', java.util.HashMap, @(x) isa(x, 'java.util.HashMap'));
-ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
-ip.parse(session, type, name);
+ip.addParamValue('group', [], @(x) isempty(x) || (isscalar(x) && isnumeric(x)));
+ip.parse(session, type, name, varargin{:});
 
 % Create new object and upload onto the server
 context = ip.Results.context;

--- a/components/tools/OmeroM/src/io/createObject.m
+++ b/components/tools/OmeroM/src/io/createObject.m
@@ -1,17 +1,23 @@
-function newobject = createObject(session, type, name)
+function newobject = createObject(session, type, name, varargin)
 % CREATEOBJECT Create a new object of input type and uploads it onto the OMERO server
 %
 %   newobject = createObject(session, type, name) create a new object of
 %   input type with the input name, uploads it onto the server and returns
 %   the loaded object.
 %
+%   newobject = createObject(..., 'group', groupId) specifies the group
+%   context in which the
+%
 %   Examples:
 %
-%      image = createObject(session, 'image', 'my-image')
+%      %
+%      image = createObject(session, 'image', 'name');
+%      image = createObject(session, 'image', 'name', 'group', groupId);
 %
-% See also: CREATEIMAGE, CREATEPROJECT, CREATEDATASET
+% See also: CREATEIMAGE, CREATEPROJECT, CREATEDATASET, CREATEPLATE,
+% CREATESCREEN
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -35,11 +41,18 @@ ip = inputParser;
 ip.addRequired('session');
 ip.addRequired('type', @(x) ischar(x) && ismember(x, objectNames));
 ip.addRequired('name', @ischar);
+ip.addParamValue('context', java.util.HashMap, @(x) isa(x, 'java.util.HashMap'));
+ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, type, name);
 
 % Create new object and upload onto the server
+context = ip.Results.context;
+if ~isempty(ip.Results.group)
+    context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+
 newobject = objectTypes(strcmp(type, objectNames)).Iobject();
 newobject.setName(rstring(ip.Results.name));
-newobject = session.getUpdateService().saveAndReturnObject(newobject);
+newobject = session.getUpdateService().saveAndReturnObject(newobject, context);
 
 end

--- a/components/tools/OmeroM/src/io/createPlate.m
+++ b/components/tools/OmeroM/src/io/createPlate.m
@@ -9,7 +9,7 @@ function plate = createPlate(session, name, varargin)
 %
 %   plate = createPlate(session, name, screen) creates a plate and
 %   links it to the input screen. The group context is specified by the
-%    screen group.
+%   screen group.
 %
 %   plate = createPlate(session, name, screenId) creates a plate and
 %   links it to the screen specified by the input identifier. The group

--- a/components/tools/OmeroM/src/io/createPlate.m
+++ b/components/tools/OmeroM/src/io/createPlate.m
@@ -53,9 +53,8 @@ ip.addParamValue('context', java.util.HashMap, @(x) isa(x, 'java.util.HashMap'))
 ip.addParamValue('group', [], @(x) isempty(x) || (isscalar(x) && isnumeric(x)));
 ip.parse(name, varargin{:});
 
-
 if ~isempty(ip.Results.screen)
-    % Check screen validity
+    % Retrieve the screen identifier
     if isnumeric(ip.Results.screen)
         screenId = ip.Results.screen;
     else
@@ -66,19 +65,19 @@ if ~isempty(ip.Results.screen)
     plate = omero.model.PlateI();
     plate.setName(rstring(name));
 
-    % Create new object and upload onto the server
+    % Create context for uploading
     context = ip.Results.context;
     if ~isempty(ip.Results.group)
         context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
     end
-    
-    % Create project/dataset link
+
+    % Create screen/plate link
     link = omero.model.ScreenPlateLinkI();
     link.setParent(omero.model.ScreenI(screenId, false));
     link.setChild(plate);
     link = session.getUpdateService().saveAndReturnObject(link, context);
 
-    % Retrieve plate
+    % Return the plate
     plate = link.getChild();
 else
     % Delegate object creation

--- a/components/tools/OmeroM/src/io/createPlate.m
+++ b/components/tools/OmeroM/src/io/createPlate.m
@@ -43,33 +43,45 @@ function plate = createPlate(session, name, varargin)
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-% Delegate object creation
-plate = createObject(session, 'plate', name, varargin);
-
-% Check if optional project is passed
+% Input check
 isValidScreen = @(x) isscalar(x) && ...
     (isnumeric(x) || isa(x, 'omero.model.ScreenI'));
 ip = inputParser;
+ip.addRequired('name', @ischar);
 ip.addOptional('screen', [], isValidScreen);
-ip.parse(varargin{:});
+ip.addParamValue('context', java.util.HashMap, @(x) isa(x, 'java.util.HashMap'));
+ip.addParamValue('group', [], @(x) isempty(x) || (isscalar(x) && isnumeric(x)));
+ip.parse(name, varargin{:});
+
 
 if ~isempty(ip.Results.screen)
-    % Check project object
+    % Check screen validity
     if isnumeric(ip.Results.screen)
-        screen = getScreens(session, ip.Results.screen);
-        assert(~isempty(screen), 'Cannot find screen %g', ip.Results.screen);
+        screenId = ip.Results.screen;
     else
-        screen = ip.Results.screen;
+        screenId = ip.Results.screen.getId().getValue();
+    end
+
+    % Create plate object
+    plate = omero.model.PlateI();
+    plate.setName(rstring(name));
+
+    % Create new object and upload onto the server
+    context = ip.Results.context;
+    if ~isempty(ip.Results.group)
+        context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
     end
     
     % Create project/dataset link
     link = omero.model.ScreenPlateLinkI();
-    link.setParent(screen);
+    link.setParent(omero.model.ScreenI(screenId, false));
     link.setChild(plate);
-    session.getUpdateService().saveAndReturnObject(link);
-    
-    % Retrieve fully loaded plate
-    plate = getPlates(session, plate.getId().getValue());
-end
+    link = session.getUpdateService().saveAndReturnObject(link, context);
 
+    % Retrieve plate
+    plate = link.getChild();
+else
+    % Delegate object creation
+    plate = createObject(session, 'plate', name,...
+        'context', ip.Results.context, 'group', ip.Results.group);
 end

--- a/components/tools/OmeroM/src/io/createPlate.m
+++ b/components/tools/OmeroM/src/io/createPlate.m
@@ -10,15 +10,23 @@ function plate = createPlate(session, name, varargin)
 %   plate = createPlate(session, name, screenId) also links the plate to
 %   the screen specified by the input identifier.
 %
+%   plate = createPlate(..., 'group', groupId) specifies the group
+%   context in which the plate should be created.
+%
 %   Examples:
 %
+%      % Create a plate in the context of the current session group
 %      plate = createPlate(session, 'my-plate');
+%      % Create a plate in the context of the current session group and
+%      % links it to a screen
 %      plate = createPlate(session, 'my-plate', screen);
 %      plate = createPlate(session, 'my-plate', screenId);
+%      % Create a plate in the context of the specified group
+%      plate = createPlate(session, 'my-plate', 'group', groupId);
 %
 % See also: CREATEOBJECT, CREATESCREEN
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -36,7 +44,7 @@ function plate = createPlate(session, name, varargin)
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 % Delegate object creation
-plate = createObject(session, 'plate', name);
+plate = createObject(session, 'plate', name, varargin);
 
 % Check if optional project is passed
 isValidScreen = @(x) isscalar(x) && ...

--- a/components/tools/OmeroM/src/io/createProject.m
+++ b/components/tools/OmeroM/src/io/createProject.m
@@ -4,7 +4,7 @@ function project = createProject(session, name, varargin)
 %   project = createProject(session, name) creates a new project with the
 %   input name, uploads it onto the server and returns the loaded project.
 %
-%   project = createProject(..., 'group', groupId) specifies the group
+%   project = createProject(..., 'group, groupId) specifies the group
 %   context in which the project should be created.
 %
 %   Examples:

--- a/components/tools/OmeroM/src/io/createProject.m
+++ b/components/tools/OmeroM/src/io/createProject.m
@@ -1,16 +1,22 @@
-function project = createProject(session, name)
+function project = createProject(session, name, varargin)
 % CREATEPROJECT Create a new project and uploads it onto the OMERO server
 %
 %   project = createProject(session, name) creates a new project with the
 %   input name, uploads it onto the server and returns the loaded project.
 %
+%   project = createProject(..., 'group', groupId) specifies the group
+%   context in which the project should be created.
+%
 %   Examples:
 %
-%      project = createProject(session, name)
+%      % Creates a new project in the context of the current session group
+%      project = createProject(session, projectName);
+%      % Creates a new project in the context of the specified group
+%      project = createProject(session, projectName, 'group', groupId);
 %
 % See also: CREATEOBJECT, CREATEDATASET
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -28,6 +34,6 @@ function project = createProject(session, name)
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 % Delegate object creation
-project = createObject(session, 'project', name);
+project = createObject(session, 'project', name, varargin{:});
 
 end

--- a/components/tools/OmeroM/src/io/createProject.m
+++ b/components/tools/OmeroM/src/io/createProject.m
@@ -4,7 +4,7 @@ function project = createProject(session, name, varargin)
 %   project = createProject(session, name) creates a new project with the
 %   input name, uploads it onto the server and returns the loaded project.
 %
-%   project = createProject(..., 'group, groupId) specifies the group
+%   project = createProject(..., 'group', groupId) specifies the group
 %   context in which the project should be created.
 %
 %   Examples:

--- a/components/tools/OmeroM/src/io/createProject.m
+++ b/components/tools/OmeroM/src/io/createProject.m
@@ -4,14 +4,14 @@ function project = createProject(session, name, varargin)
 %   project = createProject(session, name) creates a new project with the
 %   input name, uploads it onto the server and returns the loaded project.
 %
-%   project = createProject(..., 'group', groupId) specifies the group
-%   context in which the project should be created.
+%   project = createProject(session, name, 'group', groupId) specifies the
+%   group context in which the project should be created.
 %
 %   Examples:
 %
-%      % Creates a new project in the context of the current session group
+%      % Create a new project in the context of the current session group
 %      project = createProject(session, projectName);
-%      % Creates a new project in the context of the specified group
+%      % Create a new project in the context of the specified group
 %      project = createProject(session, projectName, 'group', groupId);
 %
 % See also: CREATEOBJECT, CREATEDATASET

--- a/components/tools/OmeroM/src/io/createScreen.m
+++ b/components/tools/OmeroM/src/io/createScreen.m
@@ -9,9 +9,9 @@ function screen = createScreen(session, name, varargin)
 %
 %   Examples:
 %
-%      % Creates a new screen in the context of the current session group
+%      % Create a new screen in the context of the current session group
 %      screen = createScreen(session, 'my-screen')
-%      % Creates a new plate in the context of the specified group
+%      % Create a new plate in the context of the specified group
 %      screen = createScreen(session, 'my-screen', 'group', groupId)
 %
 % See also: CREATEOBJECT, CREATEPLATE

--- a/components/tools/OmeroM/src/io/createScreen.m
+++ b/components/tools/OmeroM/src/io/createScreen.m
@@ -1,16 +1,22 @@
-function screen = createScreen(session, name)
+function screen = createScreen(session, name, varargin)
 % CREATESCREEN Create a new screen and uploads it onto the OMERO server
 %
 %   screen = createScreen(session, name) creates a new screen with the
 %   input name, uploads it onto the server and returns the loaded screen.
 %
+%   screen = createScreen(..., 'group', groupId) specifies the group
+%   context in which the screen should be created.
+%
 %   Examples:
 %
+%      % Creates a new screen in the context of the current session group
 %      screen = createScreen(session, 'my-screen')
+%      % Creates a new plate in the context of the specified group
+%      screen = createScreen(session, 'my-screen', 'group', groupId)
 %
 % See also: CREATEOBJECT, CREATEPLATE
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroM/src/io/createScreen.m
+++ b/components/tools/OmeroM/src/io/createScreen.m
@@ -4,14 +4,14 @@ function screen = createScreen(session, name, varargin)
 %   screen = createScreen(session, name) creates a new screen with the
 %   input name, uploads it onto the server and returns the loaded screen.
 %
-%   screen = createScreen(..., 'group', groupId) specifies the group
-%   context in which the screen should be created.
+%   screen = createScreen(session, name, 'group', groupId) specifies the
+%   group context in which the screen should be created.
 %
 %   Examples:
 %
 %      % Create a new screen in the context of the current session group
 %      screen = createScreen(session, 'my-screen')
-%      % Create a new plate in the context of the specified group
+%      % Create a new screen in the context of the specified group
 %      screen = createScreen(session, 'my-screen', 'group', groupId)
 %
 % See also: CREATEOBJECT, CREATEPLATE

--- a/components/tools/OmeroM/src/io/createScreen.m
+++ b/components/tools/OmeroM/src/io/createScreen.m
@@ -34,6 +34,6 @@ function screen = createScreen(session, name, varargin)
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 % Delegate object creation
-screen = createObject(session, 'screen', name);
+screen = createObject(session, 'screen', name, varargin{:});
 
 end

--- a/examples/Training/matlab/ConnectToOMERO.m
+++ b/examples/Training/matlab/ConnectToOMERO.m
@@ -51,9 +51,9 @@ try
     t = omeroKeepAlive(client);
     stop(t);
     delete(t);
-    
+
     %% Admin service
-    % Retrieve  the identifier of the groups the user is member/owner of
+    % Retrieve the identifier of the groups the user is member/owner of
     user = adminService.getExperimenter(userId);
     groupIds1 = toMatlabList(adminService.getMemberOfGroupIds(user));
     groupIds2 = toMatlabList(adminService.getLeaderOfGroupIds(user));

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -70,9 +70,9 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the unloaded projects owned by the any user in the
+    % Retrieve all the unloaded projects owned by any user in the
     % context of the current session group
-    disp('Retrieving projects across by any user in the current group')
+    disp('Retrieving projects owned by any user in the current group')
     projects = getProjects(session, 'owner', -1);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
@@ -117,9 +117,9 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the unloaded datasets owned by the any user in the
+    % Retrieve all the unloaded datasets owned by any user in the
     % context of the current session group
-    disp('Retrieving datasets across by any user in the current group')
+    disp('Retrieving datasets owned by any user in the current group')
     datasets = getDatasets(session, 'owner', -1);
     fprintf(1, '  Found %g datasets\n', numel(datasets));
     for i = 1 : numel(datasets),
@@ -167,7 +167,7 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the images contained in a given dataset.
+    % Retrieve all the images contained in a given project.
     fprintf(1, 'Retrieving images contained in project %g\n', projectId);
     images3 = getImages(session, 'project', projectId);
     fprintf(1, '  Found %g images\n', numel(images3));
@@ -255,7 +255,7 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the pldates owned by the session user across all groups
+    % Retrieve all the plates owned by the session user across all groups
     disp('Retrieving plates owned by the session user across all groups')
     allPlatesAllGroups = getPlates(session, 'group', -1);
     fprintf(1, '  Found %g plates\n', numel(allPlatesAllGroups));

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -58,45 +58,48 @@ try
     %% P/D/I
     % Create a project/dataset/image
     disp('Creating projects');
-    p1 = createProject(session, 'project-1');
-    p2 = createProject(session, 'project-1', 'group', groupId);
-    print_object(p1);
-    print_object(p2);
+    project1 = createProject(session, 'project-1');
+    project2 = createProject(session, 'project-1', 'group', groupId);
+    print_object(project1);
+    print_object(project2);
     disp('Creating datasets linked to projects');
-    d1 = createDataset(session, 'dataset-1', p1);
-    d2 = createDataset(session, 'dataset-2', p1.getId().getValue());
-    d3 = createDataset(session, 'dataset-1', p2, 'group', groupId);
-    d4 = createDataset(session, 'dataset-1', p2.getId().getValue(), 'group', groupId);
-    print_object(d1);
-    print_object(d2);
-    print_object(d3);
-    print_object(d4);
+    projectId1 = project1.getId().getValue();
+    projectId2 = project2.getId().getValue();
+    dataset1 = createDataset(session, 'dataset-1', project1);
+    dataset2 = createDataset(session, 'dataset-2', projectId1);
+    dataset3 = createDataset(session, 'dataset-1', project2, 'group', groupId);
+    dataset4 = createDataset(session, 'dataset-1', projectId2, 'group', groupId);
+    print_object(dataset1);
+    print_object(dataset2);
+    print_object(dataset3);
+    print_object(dataset4);
     disp('Creating orphaned datasets');
-    od1 = createDataset(session, 'orphaned dataset-1');
-    od2 = createDataset(session, 'orphaned dataset-2', 'group', groupId);
-    print_object(od1)
-    print_object(od2)
+    dataset5 = createDataset(session, 'orphaned dataset-1');
+    dataset6 = createDataset(session, 'orphaned dataset-2', 'group', groupId);
+    print_object(dataset5)
+    print_object(dataset6)
 
     disp('Creating screens');
-    s1 = createScreen(session, 'screen-1');
-    s2 = createScreen(session, 'screen-1', 'group', groupId);
-    print_object(s1);
-    print_object(s2);
+    screen1 = createScreen(session, 'screen-1');
+    screen2 = createScreen(session, 'screen-1', 'group', groupId);
+    print_object(screen1);
+    print_object(screen2);
     disp('Creating plates linked to screens');
-    p1 = createPlate(session, 'plate-1', s1);
-    p2 = createPlate(session, 'plate-2', s1.getId().getValue());
-    p3 = createPlate(session, 'plate-1', s2, 'group', groupId);
-    p4 = createPlate(session, 'plate-2', s2.getId().getValue(), 'group', groupId);
-    print_object(p1);
-    print_object(p2);
-    print_object(p3);
-    print_object(p4);
+    screenId1 = screen1.getId().getValue();
+    screenId2 = screen2.getId().getValue();
+    plate1 = createPlate(session, 'plate-1', screen1);
+    plate2 = createPlate(session, 'plate-2', screenId1);
+    plate3 = createPlate(session, 'plate-1', screen2, 'group', groupId);
+    plate4 = createPlate(session, 'plate-2', screenId2, 'group', groupId);
+    print_object(plate1);
+    print_object(plate2);
+    print_object(plate3);
+    print_object(plate4);
     disp('Creating orphaned plates');
-    op1 = createDataset(session, 'orphaned plate-1');
-    op2 = createDataset(session, 'orphaned plate-2', 'group', groupId);
-    print_object(op1)
-    print_object(op2)
-    df
+    plate5 = createDataset(session, 'orphaned plate-1');
+    plate6 = createDataset(session, 'orphaned plate-2', 'group', groupId);
+    print_object(plate5)
+    print_object(plate6)
 
     %% File Annotation
     disp('File annotation');

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -40,13 +40,8 @@ try
     msg = 'Created session for user %s (id: %g) using group %s (id: %g)\n';
     fprintf(1, msg, char(eventContext.userName), eventContext.userId,...
         char(eventContext.groupName), eventContext.groupId);
-    
+
     % Information to edit
-    imageId = p.imageid;
-    datasetId = p.datasetid;
-    projectId = p.projectid;
-    plateId = p.plateid;
-    screenId = p.screenid;
     group2 = p.group2;
     groupId = session.getAdminService().lookupGroup('training_group-2').getId().getValue();
 
@@ -78,6 +73,8 @@ try
     dataset6 = createDataset(session, 'orphaned dataset-2', 'group', groupId);
     print_object(dataset5)
     print_object(dataset6)
+    datasetId1 = dataset1.getId().getValue();
+    datasetId2 = dataset2.getId().getValue();
 
     disp('Creating screens');
     screen1 = createScreen(session, 'screen-1');
@@ -100,6 +97,11 @@ try
     plate6 = createDataset(session, 'orphaned plate-2', 'group', groupId);
     print_object(plate5)
     print_object(plate6)
+    plateId1 = plate1.getId().getValue();
+
+    image1 = createObject(session, 'image', 'image-1');
+    image2 = createObject(session, 'image', 'image-1', 'group', groupId);
+    imageId1 = image1.getId().getValue();
 
     %% File Annotation
     disp('File annotation');
@@ -178,49 +180,48 @@ try
     fprintf(1, 'Reading content of updated file annotation %g: %s\n',...
         fileAnnotation2.getId().getValue(), readContent);
     delete(fileOutputPath);
-    
+
     % Project - Annotation link
     fa = omero.model.FileAnnotationI(fileAnnotation.getId().getValue(), false);
-    linkAnnotation(session, fa, 'project', projectId);
-    fprintf(1, 'Linked file annotation to project %g\n', projectId);
+    linkAnnotation(session, fa, 'project', projectId1);
+    fprintf(1, 'Linked file annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving file annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    fas = getProjectFileAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    fas = getProjectFileAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(fa, fas), 'WriteData: Could not find annotation');
-    
 
     % Dataset - Annotation link
-    linkAnnotation(session, fa, 'dataset', datasetId);
-    fprintf(1, 'Linked file annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, fa, 'dataset', datasetId1);
+    fprintf(1, 'Linked file annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving file annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    fas = getDatasetFileAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    fas = getDatasetFileAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(fa, fas), 'WriteData: Could not find annotation');
-    
+
     % Image - Annotation link
-    linkAnnotation(session, fa, 'image', imageId);
-    fprintf(1, 'Linked file annotation to image %g\n', imageId);
+    linkAnnotation(session, fa, 'image', imageId1);
+    fprintf(1, 'Linked file annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving file annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    fas = getImageFileAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    fas = getImageFileAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(fa, fas), 'WriteData: Could not find annotation');
-    
+
     % Plate - Annotation link
-    linkAnnotation(session, fa, 'plate', plateId);
-    fprintf(1, 'Linked file annotation to plate %g\n', plateId);
+    linkAnnotation(session, fa, 'plate', plateId1);
+    fprintf(1, 'Linked file annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving file annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    fas = getPlateFileAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    fas = getPlateFileAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(fa, fas), 'WriteData: Could not find annotation');
-    
+
     % Screen - Annotation link
-    linkAnnotation(session, fa, 'screen', screenId);
-    fprintf(1, 'Linked file annotation to screen %g\n', screenId);
+    linkAnnotation(session, fa, 'screen', screenId1);
+    fprintf(1, 'Linked file annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving file annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    fas = getScreenFileAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    fas = getScreenFileAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(fa, fas), 'WriteData: Could not find annotation');
-    
+
     %% Comment Annotation
     disp('Comment annotation');
     commentAnnotation = writeCommentAnnotation(session, 'comment',...
@@ -235,43 +236,43 @@ try
     
     % Project - Annotation link
     ca = omero.model.CommentAnnotationI(commentAnnotation.getId().getValue(), false);
-    linkAnnotation(session, ca, 'project', projectId);
-    fprintf(1, 'Linked comment annotation to project %g\n', projectId);
+    linkAnnotation(session, ca, 'project', projectId1);
+    fprintf(1, 'Linked comment annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving comment annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    cas = getProjectCommentAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    cas = getProjectCommentAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
     
     % Dataset - Annotation link
-    linkAnnotation(session, ca, 'dataset', datasetId);
-    fprintf(1, 'Linked comment annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, ca, 'dataset', datasetId1);
+    fprintf(1, 'Linked comment annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving comment annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    cas = getDatasetCommentAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    cas = getDatasetCommentAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
     
     % Image - Annotation link
-    linkAnnotation(session, ca, 'image', imageId);
-    fprintf(1, 'Linked comment annotation to image %g\n', imageId);
+    linkAnnotation(session, ca, 'image', imageId1);
+    fprintf(1, 'Linked comment annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving comment annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    cas = getImageCommentAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    cas = getImageCommentAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
     
     % Plate - Annotation link
-    linkAnnotation(session, ca, 'plate', plateId);
-    fprintf(1, 'Linked comment annotation to plate %g\n', plateId);
+    linkAnnotation(session, ca, 'plate', plateId1);
+    fprintf(1, 'Linked comment annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving comment annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    cas = getPlateCommentAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    cas = getPlateCommentAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
     
     % Screen - Annotation link
-    linkAnnotation(session, ca, 'screen', screenId);
-    fprintf(1, 'Linked comment annotation to screen %g\n', screenId);
+    linkAnnotation(session, ca, 'screen', screenId1);
+    fprintf(1, 'Linked comment annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving comment annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    cas = getScreenCommentAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    cas = getScreenCommentAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
     
     %% Double Annotation
@@ -288,43 +289,43 @@ try
     
     % Project - Annotation link
     da = omero.model.DoubleAnnotationI(doubleAnnotation.getId().getValue(), false);
-    linkAnnotation(session, da, 'project', projectId);
-    fprintf(1, 'Linked double annotation to project %g\n', projectId);
+    linkAnnotation(session, da, 'project', projectId1);
+    fprintf(1, 'Linked double annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving double annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    das = getProjectDoubleAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    das = getProjectDoubleAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
     
     % Dataset - Annotation link
-    linkAnnotation(session, da, 'dataset', datasetId);
-    fprintf(1, 'Linked double annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, da, 'dataset', datasetId1);
+    fprintf(1, 'Linked double annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving double annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    das = getDatasetDoubleAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    das = getDatasetDoubleAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
     
     % Image - Annotation link
-    linkAnnotation(session, da, 'image', imageId);
-    fprintf(1, 'Linked double annotation to image %g\n', imageId);
+    linkAnnotation(session, da, 'image', imageId1);
+    fprintf(1, 'Linked double annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving double annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    das = getImageDoubleAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    das = getImageDoubleAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
     
     % Plate - Annotation link
-    linkAnnotation(session, da, 'plate', plateId);
-    fprintf(1, 'Linked double annotation to plate %g\n', plateId);
+    linkAnnotation(session, da, 'plate', plateId1);
+    fprintf(1, 'Linked double annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving double annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    das = getPlateDoubleAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    das = getPlateDoubleAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
     
     % Screen - Annotation link
-    linkAnnotation(session, da, 'screen', screenId);
-    fprintf(1, 'Linked double annotation to screen %g\n', screenId);
+    linkAnnotation(session, da, 'screen', screenId1);
+    fprintf(1, 'Linked double annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving double annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    das = getScreenDoubleAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    das = getScreenDoubleAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
     
     %% Long Annotation
@@ -338,46 +339,46 @@ try
     annotation = getLongAnnotations(session,...
         longAnnotation.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
     la = omero.model.LongAnnotationI(longAnnotation.getId().getValue(), false);
-    linkAnnotation(session, la, 'project', projectId);
-    fprintf(1, 'Linked long annotation to project %g\n', projectId);
+    linkAnnotation(session, la, 'project', projectId1);
+    fprintf(1, 'Linked long annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving long annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    las = getProjectLongAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    las = getProjectLongAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(la, las), 'WriteData: Could not find annotation');
-    
+
     % Dataset - Annotation link
-    linkAnnotation(session, la, 'dataset', datasetId);
-    fprintf(1, 'Linked long annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, la, 'dataset', datasetId1);
+    fprintf(1, 'Linked long annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving long annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    las = getDatasetLongAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    las = getDatasetLongAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(la, las), 'WriteData: Could not find annotation');
-    
+
     % Image - Annotation link
-    linkAnnotation(session, la, 'image', imageId);
-    fprintf(1, 'Linked long annotation to image %g\n', imageId);
+    linkAnnotation(session, la, 'image', imageId1);
+    fprintf(1, 'Linked long annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving long annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    las = getImageLongAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    las = getImageLongAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(la, las), 'WriteData: Could not find annotation');
-    
+
     % Plate - Annotation link
-    linkAnnotation(session, la, 'plate', plateId);
-    fprintf(1, 'Linked long annotation to plate %g\n', plateId);
+    linkAnnotation(session, la, 'plate', plateId1);
+    fprintf(1, 'Linked long annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving long annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    las = getPlateLongAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    las = getPlateLongAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(la, las), 'WriteData: Could not find annotation');
-    
+
     % Screen - Annotation link
-    linkAnnotation(session, la, 'screen', screenId);
-    fprintf(1, 'Linked long annotation to screen %g\n', screenId);
+    linkAnnotation(session, la, 'screen', screenId1);
+    fprintf(1, 'Linked long annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving long annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    las = getScreenLongAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    las = getScreenLongAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(la, las), 'WriteData: Could not find annotation');
 
     %% Map Annotation
@@ -391,46 +392,46 @@ try
     annotation = getAnnotations(session,...
         mapAnnotation.getId().getValue(), 'map');
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
     ma = omero.model.MapAnnotationI(mapAnnotation.getId().getValue(), false);
-    linkAnnotation(session, ma, 'project', projectId);
-    fprintf(1, 'Linked map annotation to project %g\n', projectId);
+    linkAnnotation(session, ma, 'project', projectId1);
+    fprintf(1, 'Linked map annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving map annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    mas = getObjectAnnotations(session, 'map', 'project', projectId, 'include', ns);
+        projectId1, ns);
+    mas = getObjectAnnotations(session, 'map', 'project', projectId1, 'include', ns);
     assert(hasAnnotation(ma, mas), 'WriteData: Could not find annotation');
-    
+
     % Dataset - Annotation link
-    linkAnnotation(session, ma, 'dataset', datasetId);
-    fprintf(1, 'Linked map annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, ma, 'dataset', datasetId1);
+    fprintf(1, 'Linked map annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving map annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    mas = getObjectAnnotations(session, 'map', 'dataset', datasetId, 'include', ns);
+        datasetId1, ns);
+    mas = getObjectAnnotations(session, 'map', 'dataset', datasetId1, 'include', ns);
     assert(hasAnnotation(ma, mas), 'WriteData: Could not find annotation');
-    
+
     % Image - Annotation link
-    linkAnnotation(session, ma, 'image', imageId);
-    fprintf(1, 'Linked map annotation to image %g\n', imageId);
+    linkAnnotation(session, ma, 'image', imageId1);
+    fprintf(1, 'Linked map annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving map annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    mas = getObjectAnnotations(session, 'map', 'image', imageId, 'include', ns);
+        imageId1, ns);
+    mas = getObjectAnnotations(session, 'map', 'image', imageId1, 'include', ns);
     assert(hasAnnotation(ma, mas), 'WriteData: Could not find annotation');
-    
+
     % Plate - Annotation link
-    linkAnnotation(session, ma, 'plate', plateId);
-    fprintf(1, 'Linked map annotation to plate %g\n', plateId);
+    linkAnnotation(session, ma, 'plate', plateId1);
+    fprintf(1, 'Linked map annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving map annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    mas = getObjectAnnotations(session, 'map', 'plate', plateId, 'include', ns);
+        plateId1, ns);
+    mas = getObjectAnnotations(session, 'map', 'plate', plateId1, 'include', ns);
     assert(hasAnnotation(ma, mas), 'WriteData: Could not find annotation');
-    
+
     % Screen - Annotation link
-    linkAnnotation(session, ma, 'screen', screenId);
-    fprintf(1, 'Linked map annotation to screen %g\n', screenId);
+    linkAnnotation(session, ma, 'screen', screenId1);
+    fprintf(1, 'Linked map annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving map annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    mas = getObjectAnnotations(session, 'map', 'screen', screenId, 'include', ns);
+        screenId1, ns);
+    mas = getObjectAnnotations(session, 'map', 'screen', screenId1, 'include', ns);
     assert(hasAnnotation(ma, mas), 'WriteData: Could not find annotation');
 
     %% Tag Annotation
@@ -447,43 +448,43 @@ try
     
     % Project - Annotation link
     ta = omero.model.TagAnnotationI(tagAnnotation.getId().getValue(), false);
-    linkAnnotation(session, ta, 'project', projectId);
-    fprintf(1, 'Linked tag annotation to project %g\n', projectId);
+    linkAnnotation(session, ta, 'project', projectId1);
+    fprintf(1, 'Linked tag annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving tag annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    tas = getProjectTagAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    tas = getProjectTagAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Dataset - Annotation link
-    linkAnnotation(session, ta, 'dataset', datasetId);
-    fprintf(1, 'Linked tag annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, ta, 'dataset', datasetId1);
+    fprintf(1, 'Linked tag annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving tag annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    tas = getDatasetTagAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    tas = getDatasetTagAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Image - Annotation link
-    linkAnnotation(session, ta, 'image', imageId);
-    fprintf(1, 'Linked tag annotation to image %g\n', imageId);
+    linkAnnotation(session, ta, 'image', imageId1);
+    fprintf(1, 'Linked tag annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving tag annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    tas = getImageTagAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    tas = getImageTagAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Plate - Annotation link
-    linkAnnotation(session, ta, 'plate', plateId);
-    fprintf(1, 'Linked tag annotation to plate %g\n', plateId);
+    linkAnnotation(session, ta, 'plate', plateId1);
+    fprintf(1, 'Linked tag annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving tag annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    tas = getPlateTagAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    tas = getPlateTagAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Screen - Annotation link
-    linkAnnotation(session, ta, 'screen', screenId);
-    fprintf(1, 'Linked tag annotation to screen %g\n', screenId);
+    linkAnnotation(session, ta, 'screen', screenId1);
+    fprintf(1, 'Linked tag annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving tag annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    tas = getScreenTagAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    tas = getScreenTagAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     %% Timestamp Annotation
@@ -500,43 +501,43 @@ try
     
     % Project - Annotation link
     ta = omero.model.TimestampAnnotationI(timestampAnnotation.getId().getValue(), false);
-    linkAnnotation(session, ta, 'project', projectId);
-    fprintf(1, 'Linked timestamp annotation to project %g\n', projectId);
+    linkAnnotation(session, ta, 'project', projectId1);
+    fprintf(1, 'Linked timestamp annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving timestamp annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    tas = getProjectTimestampAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    tas = getProjectTimestampAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Dataset - Annotation link
-    linkAnnotation(session, ta, 'dataset', datasetId);
-    fprintf(1, 'Linked timestamp annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, ta, 'dataset', datasetId1);
+    fprintf(1, 'Linked timestamp annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving timestamp annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    tas = getDatasetTimestampAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    tas = getDatasetTimestampAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Image - Annotation link
-    linkAnnotation(session, ta, 'image', imageId);
-    fprintf(1, 'Linked timestamp annotation to image %g\n', imageId);
+    linkAnnotation(session, ta, 'image', imageId1);
+    fprintf(1, 'Linked timestamp annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving timestamp annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    tas = getImageTimestampAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    tas = getImageTimestampAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Plate - Annotation link
-    linkAnnotation(session, ta, 'plate', plateId);
-    fprintf(1, 'Linked timestamp annotation to plate %g\n', plateId);
+    linkAnnotation(session, ta, 'plate', plateId1);
+    fprintf(1, 'Linked timestamp annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving timestamp annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    tas = getPlateTimestampAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    tas = getPlateTimestampAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     % Screen - Annotation link
-    linkAnnotation(session, ta, 'screen', screenId);
-    fprintf(1, 'Linked timestamp annotation to screen %g\n', screenId);
+    linkAnnotation(session, ta, 'screen', screenId1);
+    fprintf(1, 'Linked timestamp annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving timestamp annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    tas = getScreenTimestampAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    tas = getScreenTimestampAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
     
     %% XML Annotation
@@ -553,43 +554,43 @@ try
     
     % Project - Annotation link
     xa = omero.model.XmlAnnotationI(xmlAnnotation.getId().getValue(), false);
-    linkAnnotation(session, xa, 'project', projectId);
-    fprintf(1, 'Linked XML annotation to project %g\n', projectId);
+    linkAnnotation(session, xa, 'project', projectId1);
+    fprintf(1, 'Linked XML annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving XML annotations attached to project %g with namespace %s\n',...
-        projectId, ns);
-    xas = getProjectXmlAnnotations(session, projectId, 'include', ns);
+        projectId1, ns);
+    xas = getProjectXmlAnnotations(session, projectId1, 'include', ns);
     assert(hasAnnotation(xa, xas), 'WriteData: Could not find annotation');
     
     % Dataset - Annotation link
-    linkAnnotation(session, xa, 'dataset', datasetId);
-    fprintf(1, 'Linked XML annotation to dataset %g\n', datasetId);
+    linkAnnotation(session, xa, 'dataset', datasetId1);
+    fprintf(1, 'Linked XML annotation to dataset %g\n', datasetId1);
     fprintf(1, 'Retrieving XML annotations attached to dataset %g with namespace %s\n',...
-        datasetId, ns);
-    xas = getDatasetXmlAnnotations(session, datasetId, 'include', ns);
+        datasetId1, ns);
+    xas = getDatasetXmlAnnotations(session, datasetId1, 'include', ns);
     assert(hasAnnotation(xa, xas), 'WriteData: Could not find annotation');
     
     % Image - Annotation link
-    linkAnnotation(session, xa, 'image', imageId);
-    fprintf(1, 'Linked XML annotation to image %g\n', imageId);
+    linkAnnotation(session, xa, 'image', imageId1);
+    fprintf(1, 'Linked XML annotation to image %g\n', imageId1);
     fprintf(1, 'Retrieving XML annotations attached to image %g with namespace %s\n',...
-        imageId, ns);
-    xas = getImageXmlAnnotations(session, imageId, 'include', ns);
+        imageId1, ns);
+    xas = getImageXmlAnnotations(session, imageId1, 'include', ns);
     assert(hasAnnotation(xa, xas), 'WriteData: Could not find annotation');
     
     % Plate - Annotation link
-    linkAnnotation(session, xa, 'plate', plateId);
-    fprintf(1, 'Linked XML annotation to plate %g\n', plateId);
+    linkAnnotation(session, xa, 'plate', plateId1);
+    fprintf(1, 'Linked XML annotation to plate %g\n', plateId1);
     fprintf(1, 'Retrieving XML annotations attached to plate %g with namespace %s\n',...
-        plateId, ns);
-    xas = getPlateXmlAnnotations(session, plateId, 'include', ns);
+        plateId1, ns);
+    xas = getPlateXmlAnnotations(session, plateId1, 'include', ns);
     assert(hasAnnotation(xa, xas), 'WriteData: Could not find annotation');
     
     % Screen - Annotation link
-    linkAnnotation(session, xa, 'screen', screenId);
-    fprintf(1, 'Linked XML annotation to screen %g\n', screenId);
+    linkAnnotation(session, xa, 'screen', screenId1);
+    fprintf(1, 'Linked XML annotation to screen %g\n', screenId1);
     fprintf(1, 'Retrieving XML annotations attached to screen %g with namespace %s\n',...
-        screenId, ns);
-    xas = getScreenXmlAnnotations(session, screenId, 'include', ns);
+        screenId1, ns);
+    xas = getScreenXmlAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(xa, xas), 'WriteData: Could not find annotation');
     
 catch err

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -50,6 +50,7 @@ try
         x.getDetails().getOwner().getId().getValue(),...
         x.getDetails().getGroup().getId().getValue());
 
+
     %% P/D/I
     % Create a project/dataset/image
     disp('Creating projects');
@@ -224,18 +225,26 @@ try
 
     %% Comment Annotation
     disp('Comment annotation');
-    commentAnnotation = writeCommentAnnotation(session, 'comment',...
+
+    disp('Creating comment annotations');
+    commentAnnotation1 = writeCommentAnnotation(session, 'comment',...
         'description', 'comment description', 'namespace', ns);
-    fprintf(1, 'Created comment annotation %g\n',...
-        commentAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving comment annotation %g\n',...
-        commentAnnotation.getId().getValue());
+    commentAnnotation2 = writeCommentAnnotation(session, 'comment',...
+        'description', 'comment description', 'namespace', ns, 'group', groupId);
+    print_long = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getTextValue().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_long(commentAnnotation1);
+    print_long(commentAnnotation2);
+
+    disp('Retrieving comment annotations');
     annotation = getCommentAnnotations(session,...
-        commentAnnotation.getId().getValue());
+        commentAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
-    ca = omero.model.CommentAnnotationI(commentAnnotation.getId().getValue(), false);
+    ca = omero.model.CommentAnnotationI(commentAnnotation1.getId().getValue(), false);
     linkAnnotation(session, ca, 'project', projectId1);
     fprintf(1, 'Linked comment annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving comment annotations attached to project %g with namespace %s\n',...
@@ -274,21 +283,29 @@ try
         screenId1, ns);
     cas = getScreenCommentAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ca, cas), 'WriteData: Could not find annotation');
-    
+
     %% Double Annotation
     disp('Double annotation');
-    doubleAnnotation = writeDoubleAnnotation(session, .5,...
+
+    disp('Creating double annotations');
+    doubleAnnotation1 = writeDoubleAnnotation(session, .5,...
         'description', 'double description', 'namespace', ns);
-    fprintf(1, 'Created double annotation %g\n',...
-        doubleAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving double annotation %g\n',...
-        doubleAnnotation.getId().getValue());
+    doubleAnnotation2 = writeDoubleAnnotation(session, .5,...
+        'description', 'double description', 'namespace', ns, 'group', groupId);
+    print_long = @(x) fprintf(1, '  %g (id: %d, owner: %d, group: %d)\n',...
+        x.getDoubleValue().getValue(), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_long(doubleAnnotation1);
+    print_long(doubleAnnotation2);
+
+    disp('Retrieving double annotations');
     annotation = getDoubleAnnotations(session,...
-        doubleAnnotation.getId().getValue());
+        doubleAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
-    da = omero.model.DoubleAnnotationI(doubleAnnotation.getId().getValue(), false);
+    da = omero.model.DoubleAnnotationI(doubleAnnotation1.getId().getValue(), false);
     linkAnnotation(session, da, 'project', projectId1);
     fprintf(1, 'Linked double annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving double annotations attached to project %g with namespace %s\n',...
@@ -327,21 +344,29 @@ try
         screenId1, ns);
     das = getScreenDoubleAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(da, das), 'WriteData: Could not find annotation');
-    
+
     %% Long Annotation
     disp('Long annotation');
-    longAnnotation = writeLongAnnotation(session, 1,...
+
+    disp('Creating long annotations');
+    longAnnotation1 = writeLongAnnotation(session, 1,...
         'description', 'long description', 'namespace', ns);
-    fprintf(1, 'Created long annotation %g\n',...
-        longAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving long annotation %g\n',...
-        longAnnotation.getId().getValue());
+    longAnnotation2 = writeLongAnnotation(session, 1,...
+        'description', 'long description', 'namespace', ns, 'group', groupId);
+    print_long = @(x) fprintf(1, '  %g (id: %d, owner: %d, group: %d)\n',...
+        char(x.getLongValue().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_long(longAnnotation1);
+    print_long(longAnnotation2);
+
+    disp('Retrieving long annotations');
     annotation = getLongAnnotations(session,...
-        longAnnotation.getId().getValue());
+        longAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
 
     % Project - Annotation link
-    la = omero.model.LongAnnotationI(longAnnotation.getId().getValue(), false);
+    la = omero.model.LongAnnotationI(longAnnotation1.getId().getValue(), false);
     linkAnnotation(session, la, 'project', projectId1);
     fprintf(1, 'Linked long annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving long annotations attached to project %g with namespace %s\n',...
@@ -383,18 +408,26 @@ try
 
     %% Map Annotation
     disp('Map annotation');
-    mapAnnotation = writeMapAnnotation(session, 'key', 'value',...
+
+    disp('Creating map annotations');
+    mapAnnotation1 = writeMapAnnotation(session, 'key', 'value',...
         'description', 'map description', 'namespace', ns);
-    fprintf(1, 'Created map annotation %g\n',...
-        mapAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving map annotation %g\n',...
-        mapAnnotation.getId().getValue());
+    mapAnnotation2 = writeMapAnnotation(session, 'key', 'value',...
+        'description', 'map description', 'namespace', ns, 'group', groupId);
+    print_map = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getMapValueAsMap), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_map(mapAnnotation1);
+    print_map(mapAnnotation2);
+
+    disp('Retrieving map annotations');
     annotation = getAnnotations(session,...
-        mapAnnotation.getId().getValue(), 'map');
+        mapAnnotation1.getId().getValue(), 'map');
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
 
     % Project - Annotation link
-    ma = omero.model.MapAnnotationI(mapAnnotation.getId().getValue(), false);
+    ma = omero.model.MapAnnotationI(mapAnnotation1.getId().getValue(), false);
     linkAnnotation(session, ma, 'project', projectId1);
     fprintf(1, 'Linked map annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving map annotations attached to project %g with namespace %s\n',...
@@ -436,18 +469,26 @@ try
 
     %% Tag Annotation
     disp('Tag annotation');
-    tagAnnotation = writeTagAnnotation(session, 'tag value',...
+
+    disp('Creating tag annotations');
+    tagAnnotation1 = writeTagAnnotation(session, 'tag value',...
         'description', 'tag description', 'namespace', ns);
-    fprintf(1, 'Created tag annotation %g\n',...
-        tagAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving tag annotation %g\n',...
-        tagAnnotation.getId().getValue());
+    tagAnnotation2 = writeTagAnnotation(session, 'tag value',...
+        'description', 'tag description', 'namespace', ns, 'group', groupId);
+    print_tag = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getTextValue().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_tag(tagAnnotation1);
+    print_tag(tagAnnotation2);
+
+    disp('Retrieving tag annotations');
     annotation = getTagAnnotations(session,...
-        tagAnnotation.getId().getValue());
+        tagAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
-    ta = omero.model.TagAnnotationI(tagAnnotation.getId().getValue(), false);
+    ta = omero.model.TagAnnotationI(tagAnnotation1.getId().getValue(), false);
     linkAnnotation(session, ta, 'project', projectId1);
     fprintf(1, 'Linked tag annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving tag annotations attached to project %g with namespace %s\n',...
@@ -486,21 +527,29 @@ try
         screenId1, ns);
     tas = getScreenTagAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
-    
+
     %% Timestamp Annotation
     disp('Timestamp annotation');
-    timestampAnnotation = writeTimestampAnnotation(session, now,...
+
+    disp('Creating timestamp annotations');
+    timestampAnnotation1 = writeTimestampAnnotation(session, now,...
         'description', 'timestamp description', 'namespace', ns);
-    fprintf(1, 'Created timestamp annotation %g\n',...
-        timestampAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving timestamp annotation %g\n',...
-        timestampAnnotation.getId().getValue());
+    timestampAnnotation2 = writeTimestampAnnotation(session, now,...
+        'description', 'timestamp description', 'namespace', ns, 'group', groupId);
+    print_ts = @(x) fprintf(1, '  %g (id: %d, owner: %d, group: %d)\n',...
+        x.getTimeValue().getValue(), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_ts(timestampAnnotation1);
+    print_ts(timestampAnnotation2);
+
+    disp('Retrieving timestamp annotations');
     annotation = getTimestampAnnotations(session,...
-        timestampAnnotation.getId().getValue());
+        timestampAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
-    ta = omero.model.TimestampAnnotationI(timestampAnnotation.getId().getValue(), false);
+    ta = omero.model.TimestampAnnotationI(timestampAnnotation1.getId().getValue(), false);
     linkAnnotation(session, ta, 'project', projectId1);
     fprintf(1, 'Linked timestamp annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving timestamp annotations attached to project %g with namespace %s\n',...
@@ -539,21 +588,29 @@ try
         screenId1, ns);
     tas = getScreenTimestampAnnotations(session, screenId1, 'include', ns);
     assert(hasAnnotation(ta, tas), 'WriteData: Could not find annotation');
-    
+
     %% XML Annotation
     disp('XML annotation');
-    xmlAnnotation = writeXmlAnnotation(session, 'xml value',...
+
+    disp('Creating XML annotations');
+    xmlAnnotation1 = writeXmlAnnotation(session, 'xml value',...
         'description', 'xml description', 'namespace', ns);
-    fprintf(1, 'Created XML annotation %g\n',...
-        xmlAnnotation.getId().getValue());
-    fprintf(1, 'Retrieving XML annotation %g\n',...
-        xmlAnnotation.getId().getValue());
+    xmlAnnotation2 = writeXmlAnnotation(session, 'xml value',...
+        'description', 'xml description', 'namespace', ns, 'group', groupId);
+    print_timestamp = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getTextValue().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+    print_timestamp(xmlAnnotation1);
+    print_timestamp(xmlAnnotation2);
+
+    disp('Retrieving XML annotations');
     annotation = getXmlAnnotations(session,...
-        xmlAnnotation.getId().getValue());
+        xmlAnnotation1.getId().getValue());
     assert(~isempty(annotation), 'WriteData: Could not find annotation');
-    
+
     % Project - Annotation link
-    xa = omero.model.XmlAnnotationI(xmlAnnotation.getId().getValue(), false);
+    xa = omero.model.XmlAnnotationI(xmlAnnotation1.getId().getValue(), false);
     linkAnnotation(session, xa, 'project', projectId1);
     fprintf(1, 'Linked XML annotation to project %g\n', projectId1);
     fprintf(1, 'Retrieving XML annotations attached to project %g with namespace %s\n',...

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -49,6 +49,55 @@ try
     screenId = p.screenid;
     group2 = p.group2;
     groupId = session.getAdminService().lookupGroup('training_group-2').getId().getValue();
+
+    print_object = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
+        char(x.getName().getValue()), x.getId().getValue(),...
+        x.getDetails().getOwner().getId().getValue(),...
+        x.getDetails().getGroup().getId().getValue());
+
+    %% P/D/I
+    % Create a project/dataset/image
+    disp('Creating projects');
+    p1 = createProject(session, 'project-1');
+    p2 = createProject(session, 'project-1', 'group', groupId);
+    print_object(p1);
+    print_object(p2);
+    disp('Creating datasets linked to projects');
+    d1 = createDataset(session, 'dataset-1', p1);
+    d2 = createDataset(session, 'dataset-2', p1.getId().getValue());
+    d3 = createDataset(session, 'dataset-1', p2, 'group', groupId);
+    d4 = createDataset(session, 'dataset-1', p2.getId().getValue(), 'group', groupId);
+    print_object(d1);
+    print_object(d2);
+    print_object(d3);
+    print_object(d4);
+    disp('Creating orphaned datasets');
+    od1 = createDataset(session, 'orphaned dataset-1');
+    od2 = createDataset(session, 'orphaned dataset-2', 'group', groupId);
+    print_object(od1)
+    print_object(od2)
+
+    disp('Creating screens');
+    s1 = createScreen(session, 'screen-1');
+    s2 = createScreen(session, 'screen-1', 'group', groupId);
+    print_object(s1);
+    print_object(s2);
+    disp('Creating plates linked to screens');
+    p1 = createPlate(session, 'plate-1', s1);
+    p2 = createPlate(session, 'plate-2', s1.getId().getValue());
+    p3 = createPlate(session, 'plate-1', s2, 'group', groupId);
+    p4 = createPlate(session, 'plate-2', s2.getId().getValue(), 'group', groupId);
+    print_object(p1);
+    print_object(p2);
+    print_object(p3);
+    print_object(p4);
+    disp('Creating orphaned plates');
+    op1 = createDataset(session, 'orphaned plate-1');
+    op2 = createDataset(session, 'orphaned plate-2', 'group', groupId);
+    print_object(op1)
+    print_object(op2)
+    df
+
     %% File Annotation
     disp('File annotation');
     % Create a local file
@@ -57,6 +106,7 @@ try
     fwrite(fid, fileContent);
     fclose(fid);
     
+
     % Create a file annotation
     fileAnnotation = writeFileAnnotation(session, filePath,...
         'mimetype', fileMimeType, 'description', fileDescription,...

--- a/examples/Training/matlab/WriteData.m
+++ b/examples/Training/matlab/WriteData.m
@@ -63,8 +63,8 @@ try
     projectId2 = project2.getId().getValue();
     dataset1 = createDataset(session, 'dataset-1', project1);
     dataset2 = createDataset(session, 'dataset-2', projectId1);
-    dataset3 = createDataset(session, 'dataset-1', project2, 'group', groupId);
-    dataset4 = createDataset(session, 'dataset-1', projectId2, 'group', groupId);
+    dataset3 = createDataset(session, 'dataset-1', project2);
+    dataset4 = createDataset(session, 'dataset-1', projectId2);
     print_object(dataset1);
     print_object(dataset2);
     print_object(dataset3);
@@ -87,8 +87,8 @@ try
     screenId2 = screen2.getId().getValue();
     plate1 = createPlate(session, 'plate-1', screen1);
     plate2 = createPlate(session, 'plate-2', screenId1);
-    plate3 = createPlate(session, 'plate-1', screen2, 'group', groupId);
-    plate4 = createPlate(session, 'plate-2', screenId2, 'group', groupId);
+    plate3 = createPlate(session, 'plate-1', screen2);
+    plate4 = createPlate(session, 'plate-2', screenId2);
     print_object(plate1);
     print_object(plate2);
     print_object(plate3);

--- a/examples/Training/matlab/mydata.txt
+++ b/examples/Training/matlab/mydata.txt
@@ -1,1 +1,0 @@
-file annotation current session group modified

--- a/examples/Training/matlab/mydata.txt
+++ b/examples/Training/matlab/mydata.txt
@@ -1,0 +1,1 @@
+file annotation current session group modified


### PR DESCRIPTION

This is the same as gh-4145 but rebased onto develop.

----

See https://trello.com/c/gSKqCAe2/49-omero-matlab-group-support

This PR:
- addresses some comments from https://github.com/openmicroscopy/openmicroscopy/pull/4136
- reviews the object creation functions `createXXX` and add group support to them
- improves the performance of the `createDataset/createPlate` function when linking to projects/screens by performing a single transaction instead of multiple
- extends the `WriteData` training example to cover the semantics of the `createXXX` functions and cover the annotation creation function with a group argument.

/cc @emilroz 

                