### PR TITLE
chgrp 'not included' warning

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -128,9 +128,10 @@ $(function() {
         var dryRunUrl = webindex_url + "chgrpDryRun/",
             data = $.extend({}, targetObjects, {'group_id': groupId});
         // Show message and start dry-run
-        var msg = "<p><img alt='Loading' src='" + static_url + "/../webgateway/img/spinner.gif'> " +
+        var msg = "<p style='margin-bottom:0'><img alt='Loading' src='" + static_url + "/../webgateway/img/spinner.gif'> " +
                   "Checking which linked objects will be moved...</p>";
         var $dryRunSpinner = $(msg).appendTo($group_chooser);
+        $group_chooser.append('<hr>');
         $.post(dryRunUrl, data, function(jobId){
             // keep polling for dry-run completion...
             var getDryRun = function() {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -26,6 +26,9 @@ $(function() {
         data_owners,
         chgrp_type,
         target_type,
+        // gets populated with selected objects and possibly also
+        // Filesets IDs if filesets would be split.
+        dryRunTargetObjects,
         $chgrpform = $("#chgrp-form"),
         $group_chooser,
         $move_group_tree,
@@ -98,20 +101,98 @@ $(function() {
         $.jstree._focused().save_selected();        // 'Cancel' will roll back to this
         var sel = OME.get_tree_selection(),
             selImages = (sel.indexOf('Image') > -1);
+            dtype = sel.split('=')[0];
+        var ids = sel.split('=')[1];
+        dryRunTargetObjects = {};
+        dryRunTargetObjects[dtype] = ids;
         $.get(webindex_url + "fileset_check/chgrp/?" + sel, function(html){
             if($('div.split_fileset', html).length > 0) {
                 $(html).appendTo($chgrpform);
                 $('.chgrp_confirm_dialog .ui-dialog-buttonset button:nth-child(2) span').text("Move All");
-                var filesetId = $('input[name="fileset"]', html).val();     // TODO - handle > 1 filesetId
+                var filesetIds = [];
+                $('input[name="fileset"]', html).each(function(){
+                    filesetIds.push($(this).val());
+                });
                 if (selImages) {
-                    OME.select_fileset_images(filesetId);
+                    OME.select_fileset_images(filesetIds);
                 }
+                dryRunTargetObjects['Fileset'] = filesetIds.join(",");
             } else {
                 $group_chooser.show();
             }
         });
     };
 
+    // We do a chgrp 'dryRun' to check for loss of annotations etc.
+    var dryRun = function(targetObjects, groupId) {
+        var dryRunUrl = webindex_url + "chgrpDryRun/",
+            data = $.extend({}, targetObjects, {'group_id': groupId});
+        // Show message and start dry-run
+        var msg = "<p><img alt='Loading' src='" + static_url + "/../webgateway/img/spinner.gif'> " +
+                  "Checking which linked objects will be moved...</p>";
+        var $dryRunSpinner = $(msg).appendTo($group_chooser);
+        $.post(dryRunUrl, data, function(jobId){
+            // keep polling for dry-run completion...
+            var getDryRun = function() {
+                var url = webindex_url + "activities_json/",
+                    data = {'jobId': jobId};
+                $.get(url, data, function(dryRunData) {
+                    console.log(dryRunData);
+                    // TODO: handle error
+                    if (dryRunData.finished) {
+                        if (dryRunData.error) {
+                            alert(dryRunData.error);
+                            return;
+                        }
+                        var html = "<b style='font-weight: bold'>Move:</b> ",
+                            move = [], count,
+                            unlink = [], unlinked;
+                        ["Projects", "Datasets", "Screens",
+                         "Plates", "Wells", "Images"].forEach(function(otype){
+                            if (otype in dryRunData.includedDetails) {
+                                count = dryRunData.includedDetails[otype].length;
+                                if (count === 1) otype = otype.slice(0, -1);  // remove s
+                                move.push(count + " " + otype);
+                            }
+                        });
+                        html += move.join(", ");
+
+                        ["Datasets", "Plates", "Images", "Tags", "Files"].forEach(function(otype){
+                            if (otype in dryRunData.unlinkedDetails) {
+                                unlinked = dryRunData.unlinkedDetails[otype];
+                                count = unlinked.length;
+                                if (count === 1) otype = otype.slice(0, -1);  // remove s
+                                var namesList = [], names;
+                                unlinked.forEach(function(u){
+                                    namesList.push(u.name);
+                                });
+                                names = namesList.join(", ");
+                                names = " <i title='" + namesList.join("\n") + "'>(" + names.slice(0, 40) + (names.length > 40 ? "..." : "") + ")</i>";
+                                unlink.push(count + " " + otype + names);
+                            }
+                        });
+                        if (dryRunData.unlinkedDetails.Comments > 0) {
+                            count = dryRunData.unlinkedDetails.Comments;
+                            unlink.push(count + " Comment" + (count > 1 ? "s" : ""));
+                        }
+                        if (dryRunData.unlinkedDetails.Others > 0) {
+                            count = dryRunData.unlinkedDetails.Others;
+                            unlink.push(count + " Other" + (count > 1 ? "s" : ""));
+                        }
+                        if (unlink.length > 0) {
+                            html += "<br><b style='font-weight: bold'>Not included:</b> " + unlink.join(", ");
+                        }
+                        $dryRunSpinner.html(html);
+                    } else {
+                        // try again...
+                        console.log("AGAIN...");
+                        setTimeout(getDryRun, 200);
+                    }
+                });
+            };
+            getDryRun();
+        });
+    };
 
     // Called from "New..." button, simply add input to form (and hide tree)
     var newContainer = function newContainer() {
@@ -182,12 +263,16 @@ $(function() {
                 $newbtn.show();
             });
         }
+
+        // Now we know target group, can do dry-run to check lost annotations etc...
+        dryRun(dryRunTargetObjects, gid);
     });
 
 
     // After we edit the chgrp dialog to handle Filesets, we need to clean-up
     var resetChgrpForm = function() {
-        $('.chgrp_confirm_dialog .ui-dialog-buttonset button:nth-child(2) span').text("OK");
+        $('span', $okbtn).text("OK");
+        // $okbtn.prop('disabled', 'disabled');
         $newbtn.hide();
         $("#move_group_tree").show();
         $("#chgrp_split_filesets").remove();
@@ -198,8 +283,8 @@ $(function() {
         dialogClass: 'chgrp_confirm_dialog',
         autoOpen: false,
         resizable: true,
-        height: 310,
-        width:420,
+        height: 350,
+        width:520,
         modal: true,
         buttons: {
             "New...": function() {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -169,6 +169,7 @@ $(function() {
                             if (otype in dryRunData.unlinkedDetails) {
                                 unlinked = dryRunData.unlinkedDetails[otype];
                                 count = unlinked.length;
+                                if (count === 0) return;
                                 if (count === 1) otype = otype.slice(0, -1);  // remove s
                                 var namesList = [], names;
                                 unlinked.forEach(function(u){

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -137,11 +137,19 @@ $(function() {
                 var url = webindex_url + "activities_json/",
                     data = {'jobId': jobId};
                 $.get(url, data, function(dryRunData) {
-                    console.log(dryRunData);
-                    // TODO: handle error
                     if (dryRunData.finished) {
+                        // Handle chgrp errors by showing message...
                         if (dryRunData.error) {
-                            alert(dryRunData.error);
+                            var errHtml = "<img style='vertical-align: middle; position:relative; top:-3px' src='" +
+                                static_url + "/../webgateway/img/failed.png'> ";
+                            // In messages, replace Image[123] with link to image
+                            var getLinkHtml = function(imageId) {
+                                var id = imageId.replace("Image[", "").replace("]", "");
+                                return "<a href='" + webindex_url + "?show=image-" + id + "'>" + imageId + "</a>";
+                            };
+                            errHtml += dryRunData.error.replace(/Image\[([0-9]*)\]/g, getLinkHtml);
+                            $dryRunSpinner.html(errHtml);
+                            $okbtn.hide();
                             return;
                         }
                         var html = "<b style='font-weight: bold'>Move:</b> ",
@@ -185,7 +193,6 @@ $(function() {
                         $dryRunSpinner.html(html);
                     } else {
                         // try again...
-                        console.log("AGAIN...");
                         setTimeout(getDryRun, 200);
                     }
                 });
@@ -272,7 +279,7 @@ $(function() {
     // After we edit the chgrp dialog to handle Filesets, we need to clean-up
     var resetChgrpForm = function() {
         $('span', $okbtn).text("OK");
-        // $okbtn.prop('disabled', 'disabled');
+        $okbtn.show();
         $newbtn.hide();
         $("#move_group_tree").show();
         $("#chgrp_split_filesets").remove();

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -161,8 +161,8 @@ $(function() {
                             unlink = [], unlinked;
                         ["Projects", "Datasets", "Screens",
                          "Plates", "Wells", "Images"].forEach(function(otype){
-                            if (otype in dryRunData.includedDetails) {
-                                count = dryRunData.includedDetails[otype].length;
+                            if (otype in dryRunData.includedObjects) {
+                                count = dryRunData.includedObjects[otype].length;
                                 if (count === 1) otype = otype.slice(0, -1);  // remove s
                                 move.push(count + " " + otype);
                             }

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -140,6 +140,9 @@ $(function() {
                     if (dryRunData.finished) {
                         // Handle chgrp errors by showing message...
                         if (dryRunData.error) {
+                            var errMsg = dryRunData.error;
+                            // More assertive error message
+                            errMsg = errMsg.replace("may not move", "Cannot move");
                             var errHtml = "<img style='vertical-align: middle; position:relative; top:-3px' src='" +
                                 static_url + "/../webgateway/img/failed.png'> ";
                             // In messages, replace Image[123] with link to image
@@ -147,7 +150,7 @@ $(function() {
                                 var id = imageId.replace("Image[", "").replace("]", "");
                                 return "<a href='" + webindex_url + "?show=image-" + id + "'>" + imageId + "</a>";
                             };
-                            errHtml += dryRunData.error.replace(/Image\[([0-9]*)\]/g, getLinkHtml);
+                            errHtml += errMsg.replace(/Image\[([0-9]*)\]/g, getLinkHtml);
                             $dryRunSpinner.html(errHtml);
                             $okbtn.hide();
                             return;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -107,10 +107,12 @@ OME.field_selection_changed = function(field) {
 };
 
 // select all images from the specified fileset (if currently visible)
-OME.select_fileset_images = function(filesetId) {
+OME.select_fileset_images = function(filesetIds) {
     var datatree = $.jstree._focused();
-    $("#dataTree li[data-fileset="+filesetId+"]").each(function(){
-        datatree.select_node(this);
+    filesetIds.forEach(function(fsId){
+        $("#dataTree li[data-fileset="+fsId+"]").each(function(){
+            datatree.select_node(this);
+        });
     });
 };
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/chgrp_target_tree.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/chgrp_target_tree.html
@@ -25,47 +25,48 @@
 
 <link rel="stylesheet" href="{% static "3rdparty/jquery.jstree-1.0-rc3/themes/default/style.css" %}" type="text/css" media="screen"/>
 
-{% if manager.containers.projects or manager.containers.datasets %}
+
 <h1>Choose target {{ target_type|capfirst }} in new Group:</h1>
 
 <div id="hierarchyTree" class="jstree jstree-default">
     <ul>
-    <!-- projects and datasets -->
-{% if show_projects %}
-    {% for d in manager.containers.projects %}
-        <li id='project-{{ d.id }}' rel="project" class="jstree-last jstree-leaf jstree-closed">
-            <ins class="jstree-icon" style="height:10px">
-                {% if d.countChildren_cached %}<img src="{% static 'webgateway/img/folder_closed.png' %}" />{% endif %}
-            </ins>
-            <a hre="#">
-                <img src="{% static "webclient/image/folder16.png" %}"/>
-                {{ d.name|truncatebefor:"35" }}
-                {% if d.countChildren_cached %}
-                    <span class="children_count">{{ d.countChildren_cached}}</span>
-                {% endif %}
-            </a>
-        {% ifequal target_type 'dataset' %}
-            <ul>
-            {% for c in d.listChildren %}
-                <li id='dataset-{{ c.id }}' rel="dataset" class="clear jstree-last jstree-open jstree-leaf">
-                    <ins class="jstree-icon" style="height:10px"></ins>
-                    <a hre="#">
-                        <img src="{% static "webclient/image/folder_image16.png" %}"/>
-                        {{ c.name|truncatebefor:"35" }}
-                        {% if c.countChildren_cached %}
-                            <span class="children_count">{{ c.countChildren_cached }}</span>
-                        {% endif %}
-                    </a>
-                </li>
-            {% endfor %}
-            </ul>
-        {% endifequal %}
-        </li>
-    {% endfor %}
+    {% ifequal target_type 'project' %}
+        {% if not manager.containers.projects %}<li>[No Projects in Group]</li>{% endif %}
+        {% for d in manager.containers.projects %}
+            <li id='project-{{ d.id }}' rel="project" class="jstree-last jstree-leaf jstree-closed">
+                <ins class="jstree-icon" style="height:10px">
+                    {% if d.countChildren_cached %}<img src="{% static 'webgateway/img/folder_closed.png' %}" />{% endif %}
+                </ins>
+                <a hre="#">
+                    <img src="{% static "webclient/image/folder16.png" %}"/>
+                    {{ d.name|truncatebefor:"35" }}
+                    {% if d.countChildren_cached %}
+                        <span class="children_count">{{ d.countChildren_cached}}</span>
+                    {% endif %}
+                </a>
+            {% ifequal target_type 'dataset' %}
+                <ul>
+                {% for c in d.listChildren %}
+                    <li id='dataset-{{ c.id }}' rel="dataset" class="clear jstree-last jstree-open jstree-leaf">
+                        <ins class="jstree-icon" style="height:10px"></ins>
+                        <a hre="#">
+                            <img src="{% static "webclient/image/folder_image16.png" %}"/>
+                            {{ c.name|truncatebefor:"35" }}
+                            {% if c.countChildren_cached %}
+                                <span class="children_count">{{ c.countChildren_cached }}</span>
+                            {% endif %}
+                        </a>
+                    </li>
+                {% endfor %}
+                </ul>
+            {% endifequal %}
+            </li>
+        {% endfor %}
+    {% endifequal %}
 
     <!-- Orphaned datasets (if target=='dataset') -->
     {% ifequal target_type 'dataset' %}
-        
+        {% if not manager.containers.datasets %}<li>[No Datasets in Group]</li>{% endif %}
         {% for c in manager.containers.datasets %}
             <li id='dataset-{{ c.id }}' rel="dataset" class="clear jstree-last">
                 <ins class="jstree-icon" style="height:10px"></ins>
@@ -79,9 +80,10 @@
             </li>
         {% endfor %}
     {% endifequal %}
-{% endif %}
+
     <!-- Screens (if target=='screen') -->
     {% ifequal target_type 'screen' %}
+        {% if not manager.containers.screens %}<li>[No Screens in Group]</li>{% endif %}
         {% for c in manager.containers.screens %}
             <li id='screen-{{ c.id }}' rel="screen" class="clear jstree-last">
                 <ins class="jstree-icon" style="height:10px"></ins>
@@ -96,7 +98,4 @@
         {% endfor %}
     {% endifequal %}
     </ul>
-{% else %}
-<h1>No Projects</h1>
-{% endif %}
 </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -196,6 +196,10 @@ urlpatterns = patterns(
         views.fileset_check,
         name="fileset_check"),
 
+    # chgrp dry run - 'group_id', obj-types and ids in POST data.
+    # E.g. Dataset=1,2,3 & Fileset=4. Multiple datatypes in one chgrp.
+    url(r'^chgrpDryRun/$', views.chgrpDryRun, name="chgrpDryRun"),
+
     # Popup for downloading original archived files for images
     url(r'^download_placeholder/$', views.download_placeholder,
         name="download_placeholder"),

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -718,11 +718,9 @@ def load_chgrp_target(request, group_id, target_type, conn=None, **kwargs):
     manager.listContainerHierarchy(owner)
     template = 'webclient/data/chgrp_target_tree.html'
 
-    show_projects = target_type in ('project', 'dataset')
     context = {
         'manager': manager,
         'target_type': target_type,
-        'show_projects': show_projects,
         'template': template}
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -39,7 +39,7 @@ import omero.scripts
 
 from omero.rtypes import rbool, rint, rstring, rlong, rlist, rtime, unwrap
 from omero.model import ExperimenterI, ExperimenterGroupI
-from omero.cmd import Chmod
+from omero.cmd import Chmod, Chgrp2, DoAll
 
 from omero.gateway import AnnotationWrapper
 from omero.gateway import OmeroGatewaySafeCallWrapper
@@ -202,6 +202,25 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 self.getConfigService().getConfigValue(
                     "omero.client.ui.menu.dropdown.everyone")
         return dropdown_menu
+
+    def chgrpDryRun(self, targetObjects, group_id):
+        """
+        Submits a 'dryRun' chgrp to test for links that would be broken.
+        Returns a handle.
+
+        :param targetObjects:   Dict of dtype: [ids]. E.g. {'Dataset': [1,2]}
+        :param group_id:        The group to move the data to.
+        """
+
+        chgrp = Chgrp2(targetObjects=targetObjects, groupId=group_id)
+        chgrp.dryRun = True
+
+        da = DoAll()
+        da.requests = [chgrp]
+
+        ctx = self.SERVICE_OPTS.copy()
+        prx = self.c.sf.submit(da, ctx)
+        return prx
 
     ##############################################
     #   IAdmin                                  ##

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -423,7 +423,7 @@ def chgrpMarshal(conn, rsp):
                     query, params, conn.SERVICE_OPTS)
                 for lnk in links:
                     child = lnk.child
-                    if child.id.val not in includedDetails[ch]:
+                    if ch not in includedDetails or child.id.val not in includedDetails[ch]:
                         name = unwrap(child.getName())
                         # Put objects in a dictionary to avoid duplicates
                         if ch not in objects:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -423,7 +423,8 @@ def chgrpMarshal(conn, rsp):
                     query, params, conn.SERVICE_OPTS)
                 for lnk in links:
                     child = lnk.child
-                    if ch not in includedDetails or child.id.val not in includedDetails[ch]:
+                    if (ch not in includedDetails or
+                            child.id.val not in includedDetails[ch]):
                         name = unwrap(child.getName())
                         # Put objects in a dictionary to avoid duplicates
                         if ch not in objects:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -333,7 +333,8 @@ def chgrpMarshal(conn, rsp):
     if isinstance(rsp, omero.cmd.ERR):
         rsp_params = ", ".join(["%s: %s" % (k, v) for k, v in
                                rsp.parameters.items()])
-        rv['error'] = "%s %s" % (rsp.name, rsp_params)
+        rv['error'] = rsp.message
+        rv['report'] = "%s %s" % (rsp.name, rsp_params)
     else:
         included = rsp.responses[0].includedObjects
         deleted = rsp.responses[0].deletedObjects

--- a/components/tools/OmeroWeb/test/integration/test_chgrp.py
+++ b/components/tools/OmeroWeb/test/integration/test_chgrp.py
@@ -155,8 +155,8 @@ class TestChgrp(IWebTest):
                     'Datasets': [{'id': dataset.id.val,
                                   'name': dataset.name.val}],
                     'Comments': 0, 'Others': 0}
-        assert 'includedDetails' in rsp
-        assert rsp['includedDetails'] == {'Projects': [projectId]}
+        assert 'includedObjects' in rsp
+        assert rsp['includedObjects'] == {'Projects': [projectId]}
         assert 'unlinkedDetails' in rsp
         assert rsp['unlinkedDetails'] == unlinked
 
@@ -166,7 +166,9 @@ class TestChgrp(IWebTest):
             "Project": "%s,%s" % (projectId, projectId2)
         }
         rsp = doDryRun(data)
-        assert rsp['includedDetails'] == {'Projects': [projectId, projectId2],
+        pids = [projectId, projectId2]
+        pids.sort()
+        assert rsp['includedObjects'] == {'Projects': pids,
                                           'Datasets': [dataset.id.val],
                                           'Images': [image.id.val]}
         assert rsp['unlinkedDetails'] == {'Files': [], 'Tags': [],

--- a/components/tools/OmeroWeb/test/integration/test_chgrp.py
+++ b/components/tools/OmeroWeb/test/integration/test_chgrp.py
@@ -21,7 +21,7 @@
 Tests chgrp functionality of views.py
 """
 
-from omero.model import ProjectI, DatasetI
+from omero.model import ProjectI, DatasetI, TagAnnotationI
 from omero.rtypes import rstring
 from omero.gateway import BlitzGateway
 
@@ -74,6 +74,29 @@ class TestChgrp(IWebTest):
         project.name = rstring(self.uuid())
         return self.update.saveAndReturnObject(project)
 
+    @pytest.fixture
+    def projects_dataset_image_tag(self):
+        """
+        Returns 2 new OMERO Projects, linked Dataset and linked Image populated
+        by an L{test.integration.library.ITest} instance with required fields
+        set. Also a Tag linked to both Projects.
+        """
+        project1 = ProjectI()
+        project1.name = rstring(self.uuid())
+        project2 = ProjectI()
+        project2.name = rstring(self.uuid())
+        dataset = DatasetI()
+        dataset.name = rstring(self.uuid())
+        image = self.new_image(name=self.uuid())
+        dataset.linkImage(image)
+        project1.linkDataset(dataset)
+        project2.linkDataset(dataset)
+        tag = TagAnnotationI()
+        tag.textValue = rstring("ChgrpTag")
+        project1.linkAnnotation(tag)
+        project2.linkAnnotation(tag)
+        return self.update.saveAndReturnArray([project1, project2])
+
     @pytest.mark.parametrize("credentials", ['user', 'admin'])
     def test_load_chgrp_groups(self, project, credentials):
         """
@@ -90,6 +113,64 @@ class TestChgrp(IWebTest):
         assert 'groups' in data
         assert len(data['groups']) == 1
         assert data['groups'][0]['id'] == self.group2.id.val
+
+    @pytest.mark.parametrize("credentials", ['user'])  # TODO - add 'admin'
+    def test_chgrp_dry_run(self, projects_dataset_image_tag, credentials):
+        """
+        Performs a chgrp POST, polls the activities json till done,
+        then checks that Dataset has moved to new group and has new
+        Project as parent.
+        """
+
+        def doDryRun(data):
+            request_url = reverse('chgrpDryRun')
+            rsp = _csrf_post_response(django_client, request_url, data)
+            jobId = rsp.content
+            # Keep polling activities until dry-run job completed
+            activities_url = reverse('activities_json')
+            data = {'jobId': jobId}
+            rsp = _get_response_json(django_client, activities_url, data)
+            while rsp['finished'] is not True:
+                time.sleep(0.5)
+                rsp = _get_response_json(django_client, activities_url, data)
+            return rsp
+
+        django_client = self.get_django_client(credentials)
+        pdit = projects_dataset_image_tag
+        projectId = pdit[0].id.val
+        projectId2 = pdit[1].id.val
+        dataset, = pdit[0].linkedDatasetList()
+        image, = dataset.linkedImageList()
+        tag, = pdit[0].linkedAnnotationList()
+
+        # If we try to move single Project, Dataset, Tag remain
+        data = {
+            "group_id": self.group2.id.val,
+            "Project": projectId
+        }
+        rsp = doDryRun(data)
+        unlinked = {'Files': [],
+                    'Tags': [{'id': tag.id.val,
+                              'name': 'ChgrpTag'}],
+                    'Datasets': [{'id': dataset.id.val,
+                                  'name': dataset.name.val}],
+                    'Comments': 0, 'Others': 0}
+        assert 'includedDetails' in rsp
+        assert rsp['includedDetails'] == {'Projects': [projectId]}
+        assert 'unlinkedDetails' in rsp
+        assert rsp['unlinkedDetails'] == unlinked
+
+        # If we try to move both Projects all data moves
+        data = {
+            "group_id": self.group2.id.val,
+            "Project": "%s,%s" % (projectId, projectId2)
+        }
+        rsp = doDryRun(data)
+        assert rsp['includedDetails'] == {'Projects': [projectId, projectId2],
+                                          'Datasets': [dataset.id.val],
+                                          'Images': [image.id.val]}
+        assert rsp['unlinkedDetails'] == {'Files': [], 'Tags': [],
+                                          'Comments': 0, 'Others': 0}
 
     @pytest.mark.parametrize("credentials", ['user', 'admin'])
     def test_chgrp_new_container(self, dataset, credentials):


### PR DESCRIPTION
See: http://trac.openmicroscopy.org/ome/ticket/12965
Webclient warns when you will lose lined annotations or child objects during chgrp.

Test setup:
 - Add a bunch of annotations to P/D/I S/P/W - including some which ARE expected to chgrp with the data (Comments, MapAnnotations etc) and some of which are NOT expected to chgrp with the data, e.g. Tags, Multi-linked Files, Comments.
 - Also put some images in multiple Datasets (so that when you chgrp one Dataset, some images will be left behind).
 - Also, perform an image projection or Images_From_ROIs script or Channel_Offsets script so that some images will give an error on chgrp.
 - Also, find a Multi-Image Fileset.

 To test, try chgrp with different selections of your P/D/I S/PW data and you should be warned if:
 - You try to move a P/D/S that will not include some child data (E.g. if images in multiple Datasets - you will get a message showing the number of Images, and a tool-tip of all their names) - see screenshot.
 - Your chgrp will lose annotations from the Data - warning will name the tags and files and will simply number the Comments and any Others.
 - Trying to split a MIF, you will see the existing warning and have the "Move All" button. The warning of lost annotations etc should apply to ALL the images in the Fileset (not just the ones you chose to move).
 - If you try to move an image that has been projected etc, you should see a warning with suitable links to the images in question and the "OK" button will be hidden.

![screen shot 2015-09-14 at 17 13 45](https://cloud.githubusercontent.com/assets/900055/9855079/27f66b3a-5b04-11e5-9aab-cfdbe2018adb.png)

![screen shot 2015-09-15 at 10 42 06](https://cloud.githubusercontent.com/assets/900055/9876976/e23b59a8-5bb1-11e5-9940-f8e901a4c61e.png)