### PR TITLE
Parameterize DSL database types

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-types.properties
+++ b/components/dsl/resources/ome/dsl/psql-types.properties
@@ -1,0 +1,8 @@
+byte[]=bytea
+string[]=text[]
+string[][]=text[][]
+PositiveInteger=positive_int
+NonNegativeInteger=nonnegative_int
+float=double precision
+PositiveFloat=positive_float
+PercentFraction=percent_fraction


### PR DESCRIPTION
This moves the translation map used for converting OME model types to
database types into a resource file that can be specialized on a
per-database-profile basis.