### PR TITLE
Use unidata Maven repository for edu.ucar dependencies

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -67,7 +67,8 @@
            root="http://artifacts.openmicroscopy.org/artifactory/simple/${simple.repository}/"/>
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
-          m2compatible="true" root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
+          m2compatible="true"
+          root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
       <ibiblio name="unidata.releases" cache="maven"
               usepoms="true" useMavenMetadata="true"

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -69,6 +69,11 @@
           usepoms="true" useMavenMetadata="true"
           m2compatible="true" root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
+      <ibiblio name="unidata.releases" cache="maven"
+              usepoms="true" useMavenMetadata="true"
+              m2compatible="true" root=" http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"/>
+
+
       <url name="com.springsource.repository.bundles.release" cache="maven">
         <ivy pattern="http://repository.springsource.com/ivy/bundles/release/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]" />
         <artifact pattern="http://repository.springsource.com/ivy/bundles/release/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]" />
@@ -92,6 +97,12 @@
     <chain name="ome-resolver" returnFirst="true">
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
+    </chain>
+
+    <!-- Resolver for Unidata dependencies-->
+    <chain name="unidata-resolver" returnFirst="true">
+        <resolver ref="user-maven"/>
+        <resolver ref="unidata.releases"/>
     </chain>
 
     <!-- Spring resolver which has as its first resolver the location
@@ -123,6 +134,9 @@
 
 
   <modules>
+    <module organisation="edu.ucar" name="grib" resolver="ome-resolver"/>
+    <module organisation="edu.ucar" name="bufr" resolver="ome-resolver"/>
+    <module organisation="edu.ucar" resolver="unidata-resolver"/>
     <module organisation="omero" name="omejava" resolver="omero-resolver" />
     <module organisation="omero" name="*-test" resolver="test-resolver" matcher="glob"/>
     <module organisation="org.springframework" resolver="spring-resolver"/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -71,8 +71,9 @@
           root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
       <ibiblio name="unidata.releases" cache="maven"
-              usepoms="true" useMavenMetadata="true"
-              m2compatible="true" root=" http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"/>
+          usepoms="true" useMavenMetadata="true"
+          m2compatible="true"
+          root="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"/>
 
 
       <url name="com.springsource.repository.bundles.release" cache="maven">


### PR DESCRIPTION
This PR registers a new Maven repository for downloading edu.ucar dependencies like netcdf instead of defaulting to the ome.external repository. bufr and grib are still consumed from the OME artifactory since their version is not available via Unidata Maven repository.

To test this PR:
- from a clean Maven cache or minimally after running `rm -rf ~/.m2/repository/edu/ucar/`, run the default build command
- check the NetCDF dependency is properly retrieved from the Unidata artifactory (i.e. the build passes)
- under `dist/share/server/dependencies.html` check `netcdf 4.3.19` is included
- as a bonus check there is no more `joda-time` version evication with joda-time 2.2 being the only dependency (https://trello.com/c/YJJ4OAd4/64-fix-joda-time-version-mismatch)

This PR is a prerequisite for bumping NetCDF version Bio-Formats side (https://github.com/openmicroscopy/bioformats/pull/1980). Once merged, the `edu/ucar` Maven repositories will need to be cleaned CI-side to make sure 5.1.4 has the proper dependency report.