### PR TITLE
Fix import target for omero import

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -562,19 +562,17 @@ class TestImport(CLITest):
         assert obj
 
     target_fixtures = [
-        ("Dataset", "test.fake", '-d'),
-        ("Screen",
+        ("Dataset", "Image", "test.fake", '-d'),
+        ("Screen", "Plate",
          "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake",
          "-r")]
 
-    @pytest.mark.parametrize("container,filename,arg", target_fixtures)
-    def testTargetInDifferentGroup(self, container, filename, arg,
+    @pytest.mark.parametrize("container,klass,filename,arg", target_fixtures)
+    def testTargetInDifferentGroup(self, container, klass, filename, arg,
                                    tmpdir, capfd):
         """
-        The workflow this test exercises is currently broken. Until
-        it is investigated and fixed the error is trapped early and
-        an exception is raised. The test is modified to test for this
-        fail case. See ticket 12781 (and 11539).
+        This now correctly tests the behaviour of the omero import
+        command when a valid target from a different group is supplied.
         """
         new_group = self.new_group(experimenters=[self.user])
         self.sf.getAdminService().getEventContext()  # Refresh
@@ -590,16 +588,15 @@ class TestImport(CLITest):
         self.args += [arg, '%s' % target.id.val]
 
         # Invoke CLI import command and retrieve stdout/stderr
-        with pytest.raises(NonZeroReturnCode):
-            self.cli.invoke(self.args, strict=True)
+        self.cli.invoke(self.args, strict=True)
 
-        # o, e = capfd.readouterr()
-        # obj = self.get_object(e, 'Image')
+        o, e = capfd.readouterr()
+        obj = self.get_object(e, klass)
 
-        # assert obj.details.id.val == new_group.id.val
+        assert obj.details.group.id.val == new_group.id.val
 
-    @pytest.mark.parametrize("container,filename,arg", target_fixtures)
-    def testUnknownTarget(self, container, filename, arg, tmpdir):
+    @pytest.mark.parametrize("container,klass,filename,arg", target_fixtures)
+    def testUnknownTarget(self, container, klass, filename, arg, tmpdir):
         target = eval("omero.model."+container+"I")()
         target.name = rstring('testUnknownTarget')
         target = self.update.saveAndReturnObject(target)


### PR DESCRIPTION
This is a partial potential fix for http://trac.openmicroscopy.org/ome/ticket/12781 However, it fixes the problem only in `omero import` and not in `importer-cli`. This is a relatively easy fix though it would mean the two command line importers diverging slightly and thus needing enhanced documentation. It may not be as comprehansive as it needs to be.

Questions:
 - are there any unintended consequences?
 - would it be worth adding this as a partial fix until something better was found?
 - could similar group switching logic be used in `importer-cli`? (It didn't look as promising.)
 - should the group switch be reverted after the import?
 - there is no logging from the plugins but should a `ctx.out` be used at some point to warn of the switch?

Testing:
 - The re-enabled test should pass, all the import tests with targets should pass.
 - For a user in several groups, create Datasets/Screens in those groups and try to import Images/Plates using the `-d`/`-r` options respectively across the different groups. Imports should succeed. 
