### PR TITLE
ticket 12969

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
@@ -628,20 +628,20 @@ class WebGatewayCache (object):
             q = r.get('q', '')
             region = r.get('region', '')
             tile = r.get('tile', '')
-            rv = 'img_%s/%s/%s/%%s-c%s-m%s-q%s-r%s-t%s' % (
+            rv = 'img_%s/%s/%s/{0}-c%s-m%s-q%s-r%s-t%s' % (
                 client_base, pre, str(iid), c, m, q, region, tile)
             if p:
                 logger.debug('rv: {0} {1}'.format(rv, type(rv)))
                 logger.debug('p: {0} {1}'.format(str(p), type(p)))
                 logger.debug('t: {0} {1}'.format(str(t), type(t)))
                 pt = '%s-%s' % (p, str(t))
-                return rv % (pt)
+                return rv.format(pt)
             else:
                 logger.debug('rv: {0} {1}'.format(rv, type(rv)))
                 logger.debug('z: {0} {1}'.format(str(z), type(z)))
                 logger.debug('t: {0} {1}'.format(str(t), type(t)))
                 zt = '%sx%s' % (str(z), str(t))
-                return rv % (zt)
+                return rv.format(zt)
         else:
             return 'img_%s/%s/%s' % (client_base, pre, str(iid))
 


### PR DESCRIPTION
prevent throwing an exception if query_string is incorrect, see https://trac.openmicroscopy.org/ome/ticket/12969

to test:
 - log in as `user-1` to `trout/merge`
 - check if you see image https://trout.openmicroscopy.org/merge/webclient/render_image/8751/24/0/?c=1|119.5:1702.875$0000FF,2|141.05:458.4125$00FF00,3|363.65:818.2125$FF0000
 - then go to https://trout.openmicroscopy.org/merge/webclient/render_image/8751/24/0/?c=1%257C119.5:1702.875$0000FF,2%257C141.05:458.4125$00FF00,3%257C363.65:818.2125$FF0000 (this URL contains badly encoded ``|`` -> ``%257C``). You should see black image as channels in query_string are incorrect
 - to compare log as ``user-1`` to ``latest`` and using the same url https://trout.openmicroscopy.org/latest/webclient/render_image/8751/24/0/?c=1%257C119.5:1702.875$0000FF,2%257C141.05:458.4125$00FF00,3%257C363.65:818.2125$FF0000 you should get 500 saying ``TypeError: not enough arguments for format string``