### PR TITLE
Fix ListAnnotation Annotation links when importing sample images (rebased onto develop)

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -4918,7 +4918,7 @@ public class OMEROMetadataStoreClient
     public void setListAnnotationAnnotationRef(String annotation,
             int listAnnotationIndex, int annotationRefIndex)
     {
-        LSID key = new LSID(Annotation.class, listAnnotationIndex);
+        LSID key = new LSID(ListAnnotation.class, listAnnotationIndex);
         addReference(key, new LSID(annotation));
     }
 


### PR DESCRIPTION

This is the same as gh-4174 but rebased onto develop.

----

See http://trac.openmicroscopy.org/ome/ticket/11252. 

OME samples containing list annotations with annotation references were previously failing at import
during the references post-processing step at import. With this commit, the image should be properly imported with all its annotations.

To test this PR, try to import the file mentioned in the ticket and check the import works and a new image is created. To be complete, use HQL queries to check the annotations objects are creted and properly linked in the database.

As a side, this import-side fix may expose deficiencies in our clients as we likely never properly handled list annotations. My development Web server crashed with the following stacktrace when I tried to open the image /cc @will-moore @pwalczysko 

```
...
  File "/opt/ome/openmicroscopy/dist/lib/python/omeroweb/webclient/views.py", line 1080, in load_metadata_details
    manager.annotationList()

  File "/opt/ome/openmicroscopy/dist/lib/python/omeroweb/webclient/controller/container.py", line 523, in annotationList
    annClass = ann._obj.__class__

AttributeError: 'NoneType' object has no attribute '_obj'
```

                