### PR TITLE
fix AnnotationDeleteTest (rebased from develop)

### DIFF
--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -273,6 +273,9 @@ public class AnnotationDeleteTest extends AbstractServerTest {
      */
     @Test(dataProvider = "child option")
     public void testDeleteTargetSharedTag(Option option) throws Exception {
+        /* ensure a connection to the server */
+        newUserAndGroup("rwra--");
+
         /* create two tag sets */
         final List<TagAnnotation> tagsets = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= 2; i++) {


### PR DESCRIPTION
Make sure that the diff makes sense and that CI is green, including https://ci.openmicroscopy.org/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration.delete/AnnotationDeleteTest/.

--rebased-from #4171