### PR TITLE
ticket 13018

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -145,7 +145,10 @@ class login_required(object):
         share = conn.getShare(share_id)
         try:
             if share.getOwner().id != conn.getUserId():
-                return self.get_share_connection(request, conn, share_id)
+                if share.active and not share.isExpired():
+                    return self.get_share_connection(request, conn, share_id)
+                logger.debug('Share is unavailable.')
+                return None
         except:
             logger.error('Error retrieving share connection.', exc_info=True)
             return None

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -143,6 +143,11 @@
                                             return !obj.hasClass('isDisabled');
                                         }
                                     },
+                                    "toggle_node" : function(obj){
+                                        if (!obj.hasClass('isOwned')) {
+                                            return !obj.hasClass('isDisabled');
+                                        }
+                                    },
                                     "create_node" : false,
                                     "start_drag" : false,
                                     "move_node" : false,


### PR DESCRIPTION
This PR fixes access to image when share is inactive or expired.

To test:
 - log in as ``user-1`` and share image with ``user-5``
 - log in as ``user-5`` check if image is visible in the viewer, copy the image URL ``http://host/webclient/img_detail/IMAGE_ID/``
 - log in back to ``user-1`` and deactivate share (uncheck enable in share edit form)
 - log in back to ``user-5`` and check if share is greyed out, you should also not being able to click on it. Go to the URL ``http://host/webclient/img_detail/IMAGE_ID/``, you should get 404
 - as it is impossible to create expired share check if image in ``share 17754`` (owned by ``user-1``) is not visible by ``user-5``

cc: @will-moore 