### PR TITLE
Removed seemingly unused TagWrapper class that changed interface

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2551,15 +2551,6 @@ class WellWrapper(OmeroWebObjectWrapper, omero.gateway.WellWrapper):
 omero.gateway.WellWrapper = WellWrapper
 
 
-class TagWrapper(OmeroWebObjectWrapper, omero.gateway.TagAnnotationWrapper):
-    """
-    omero_model_TagAnnotationI class wrapper overwrite
-    omero.gateway.TagAnnotationWrapper and extends OmeroWebObjectWrapper.
-    """
-
-omero.gateway.TagAnnotationWrapper = TagWrapper
-
-
 class PlateAcquisitionWrapper(OmeroWebObjectWrapper,
                               omero.gateway.PlateAcquisitionWrapper):
 


### PR DESCRIPTION
I'm not sure what this was added for, but I don't think it does anything and it changes the interface. I know it's not exactly a public API, but seems like it would be good not to change it if possible.

I noticed because it broke webtagging.