### PR TITLE
test Security Violation

### DIFF
--- a/components/tools/OmeroJava/test/integration/PojosServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/PojosServiceTest.java
@@ -2166,7 +2166,7 @@ public class PojosServiceTest extends AbstractServerTest {
     }
 
     /**
-     * Test to load container hierarchy with project containing an dataset
+     * Test to load container hierarchy with screen containing a plate
      * owned by another member of the group.
      *
      * @throws Exception
@@ -2176,6 +2176,8 @@ public class PojosServiceTest extends AbstractServerTest {
     public void testLoadContainerHierarchyScreenWithOtherMembersPlate()
             throws Exception {
         // first create a Screen
+        String perms = "rwrw--";
+        EventContext ctx = newUserAndGroup(perms, true);
         Screen p = (Screen) iUpdate.saveAndReturnObject(mmFactory
                 .simpleScreenData().asIObject());
 


### PR DESCRIPTION
Create group with correct permissions.
The permission level of the group was not correctly set.
To test:
Check that the Java tests are greeen