### PR TITLE
Cap pytest to 2.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - pip install --user scc pytest
     - export PATH=$PATH:$HOME/.local/bin
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
 # retries the build due to:


### PR DESCRIPTION
As it looks like pytest 2.8.0 is causing some issues with our usage of `pytest.deprecated_call()` in Python unit tests, this commit is forcing an earlier version of pytest to be installed on Travis rather than downloading the latest.

To test this PR, check Travis is green. Note this PR is mostly targeted at keeping our PR validation via Travis ongoing. The reason of the regression should likely be investigated as a follow-up.

/cc @ximenesuk @aleksandra-tarkowska @will-moore @jburel 