### PR TITLE
Time format follow up (dev_5_1)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -519,12 +519,11 @@ class ChannelAcquisitionComponent
             date = DateUtils.round(date, Calendar.SECOND);
             m = date.get(Calendar.MINUTE);
             s = date.get(Calendar.SECOND);
-            return m + " m " + s + " s";
-        } else if (tInS > 0.9) {
+            return m + " min " + s + " s";
+        } else if (tInS > 0.9) 
             return sFormat.format(tInS);
-        } else {
-            return msFormat.format((tInS * 1000));
-        }
+            
+        return msFormat.format(tInS * 1000);
     }
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -101,7 +101,10 @@ class ChannelAcquisitionComponent
 	private static final int	GENERAL = 0;
 	
 	/** Format used for displaying time in ms */
-	private static final DecimalFormat msFormat = new DecimalFormat("#ms");
+	private static final DecimalFormat msFormat = new DecimalFormat("# ms");
+	
+	/** Format used for displaying time in s */
+	private static final DecimalFormat sFormat = new DecimalFormat("0.0 s");
 	
 	/** Reference to the parent of this component. */
 	private AcquisitionDataUI					parent;
@@ -493,36 +496,32 @@ class ChannelAcquisitionComponent
      */
     private String getReadableTime(double tInS) {
         if (tInS == 0.0)
-            return "0s";
+            return "0 s";
 
         Calendar date = Calendar.getInstance();
         date = DateUtils.truncate(date, Calendar.YEAR);
         date.add(Calendar.MILLISECOND, (int) (tInS * 1000));
 
-        int d, h, m, s, ms;
+        int d, h, m, s;
 
         if (tInS > (23 * 60 * 60)) {
             date = DateUtils.round(date, Calendar.MINUTE);
             d = date.get(Calendar.DAY_OF_YEAR) - 1;
             h = date.get(Calendar.HOUR_OF_DAY);
             m = date.get(Calendar.MINUTE);
-            return d + "d " + (h > 0 ? h + "h " : "")
-                    + (m > 0 ? m + "min " : "");
+            return d + " d " + h + " h " + (m > 0 ? m + " min " : "");
         } else if (tInS > (59 * 60)) {
             date = DateUtils.round(date, Calendar.MINUTE);
             h = date.get(Calendar.HOUR_OF_DAY);
             m = date.get(Calendar.MINUTE);
-            return h + "h " + (m > 0 ? m + "min" : "");
+            return h + " h " + m + " min";
         } else if (tInS > 59) {
             date = DateUtils.round(date, Calendar.SECOND);
             m = date.get(Calendar.MINUTE);
             s = date.get(Calendar.SECOND);
-            return m + "m " + (s > 0 ? s + "s" : "");
+            return m + " m " + s + " s";
         } else if (tInS > 0.9) {
-            date = DateUtils.round(date, Calendar.MILLISECOND);
-            s = date.get(Calendar.SECOND);
-            ms = date.get(Calendar.MILLISECOND);
-            return s + "s " + (ms > 0 ? ms + "ms" : "");
+            return sFormat.format(tInS);
         } else {
             return msFormat.format((tInS * 1000));
         }


### PR DESCRIPTION
Follow-up PR for #4154 
Display seconds as fraction with one decimal place; added whitespace between value and unit; always display next lower unit even if the value is 0 (e. g. 1 min 0 s ; or 1 h 0 min )

Test: Check that the Insight timestamp format matches OMERO.Web, for example on trout user-2 Image 9532 
