### PR TITLE
Ticket 13030 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -29,7 +29,7 @@ from omero.util.decorators import timeit
 from omero.cmd import Chgrp2, Delete2, DoAll, SkipHead
 from omero.cmd.graphs import ChildOption
 from omero.api import Save
-from omero.gateway.utils import ServiceOptsDict, GatewayConfig
+from omero.gateway.utils import ServiceOptsDict, GatewayConfig, toBoolean
 import omero.scripts as scripts
 
 import Ice
@@ -1532,8 +1532,12 @@ class _BlitzGateway (object):
         """
         Returns default initial zoom level set on the server.
         """
-        return (self.getConfigService().getConfigValue(
-                "omero.client.viewer.initial_zoom_level") or 0)
+        try:
+            initzoom = (self.getConfigService().getConfigValue(
+                        "omero.client.viewer.initial_zoom_level") or 0)
+        except:
+            initzoom = None
+        return initzoom
 
     def getInterpolateSetting(self):
         """
@@ -1542,14 +1546,25 @@ class _BlitzGateway (object):
 
         :return:    String
         """
-        return (self.getConfigService().getConfigValue(
-                "omero.client.viewer.interpolate_pixels") or 'true')
+        try:
+            interpolate = (
+                toBoolean(self.getConfigService().getConfigValue(
+                    "omero.client.viewer.interpolate_pixels")) or True
+            )
+        except:
+            interpolate = False
+        return interpolate
 
     def getWebclientHost(self):
         """
         Returns default initial zoom level set on the server.
         """
-        return self.getConfigService().getConfigValue("omero.client.web.host")
+        try:
+            host = self.getConfigService() \
+                       .getConfigValue("omero.client.web.host")
+        except:
+            host = None
+        return host
 
     def isAnonymous(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1536,7 +1536,7 @@ class _BlitzGateway (object):
             initzoom = (self.getConfigService().getConfigValue(
                         "omero.client.viewer.initial_zoom_level") or 0)
         except:
-            initzoom = None
+            initzoom = 0
         return initzoom
 
     def getInterpolateSetting(self):
@@ -1552,7 +1552,7 @@ class _BlitzGateway (object):
                     "omero.client.viewer.interpolate_pixels")) or True
             )
         except:
-            interpolate = False
+            interpolate = True
         return interpolate
 
     def getWebclientHost(self):

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -37,7 +37,6 @@ from django.template import RequestContext
 from django.core.cache import cache
 
 from omeroweb.http import HttpJsonResponse
-from omero.gateway.utils import toBoolean
 
 from omeroweb.connector import Connector
 
@@ -259,7 +258,7 @@ class login_required(object):
             request.session['server_settings']['initial_zoom_level'] = \
                 conn.getInitialZoomLevel()
             request.session['server_settings']['interpolate_pixels'] = \
-                toBoolean(conn.getInterpolateSetting())
+                conn.getInterpolateSetting()
 
     def get_public_user_connector(self):
         """


### PR DESCRIPTION

This is the same as gh-4191 but rebased onto develop.

----

This should prevent python clients using OMERO.py gateway against older server where the following properties are not present.

To test:
 - go to trout/merge choose seabass and log in as non admin user
 - check if you were successfully logged in and there were no SecurityViolation exception thrown.
 - log out and log in to merge
 - check if interpolation is on in webviewer

cc: @sbesson @joshmoore @will-moore 

                