### PR TITLE
fix typo in 5.0 to 5.1 SQL upgrade character encoding error

### DIFF
--- a/sql/psql/OMERO5.1DEV__18/OMERO5.1DEV__17.sql
+++ b/sql/psql/OMERO5.1DEV__18/OMERO5.1DEV__17.sql
@@ -403,7 +403,7 @@ create or replace function _fs_dir_delete() returns trigger AS $_fs_dir_delete$
             limit 1) then
 
                 -- CANCEL DELETE
-                RAISE EXCEPTION '%%', 'Directory('||OLD.id||')='||OLD.path||OLD.name||'/ is not empty!';
+                RAISE EXCEPTION '%', 'Directory('||OLD.id||')='||OLD.path||OLD.name||'/ is not empty!';
 
         end if;
         return OLD; -- proceed

--- a/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
+++ b/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
@@ -62,7 +62,7 @@ BEGIN
     END IF;
 
     IF char_encoding != 'UTF8' THEN
-        RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %%', char_encoding;
+        RAISE EXCEPTION 'OMERO database character encoding must be UTF8, not %', char_encoding;
     ELSE
         SET client_encoding = 'UTF8';
     END IF;

--- a/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
+++ b/sql/psql/OMERO5.1__1/OMERO5.0__0.sql
@@ -2226,7 +2226,7 @@ create or replace function _fs_dir_delete() returns trigger AS $_fs_dir_delete$
             limit 1) then
 
                 -- CANCEL DELETE
-                RAISE EXCEPTION '%%', 'Directory('||OLD.id||')='||OLD.path||OLD.name||'/ is not empty!';
+                RAISE EXCEPTION '%', 'Directory('||OLD.id||')='||OLD.path||OLD.name||'/ is not empty!';
 
         end if;
         return OLD; -- proceed


### PR DESCRIPTION
Accidentally used .vm file quoting syntax. Now with a wrong DB character encoding, upgrade from 5.0 should give an appropriate error message.

--no-rebase unless 5.1.5