### PR TITLE
Make sure the same pixelsize unit is used for all dimensions

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -710,28 +710,24 @@ public class PropertiesUI
     	String tooltip = "<html><body>";
     	if (dx != null && dx.doubleValue() > 0) {
     		value += nf.format(dx);
-    		tooltip += "X: "+x+"<br>";
+    		tooltip += "X: "+x.getValue()+" "+LengthI.lookupSymbol(x.getUnit())+"<br>";
     		label += "X";
     	}
     	if (dy != null && dy.doubleValue() > 0) {
     		if (value.length() == 0) value += nf.format(dy);
     		else value +="x"+nf.format(dy);;
-    		tooltip += "Y: "+y+"<br>";
+    		tooltip += "Y: "+y.getValue()+" "+LengthI.lookupSymbol(y.getUnit())+"<br>";
     		label += "Y";
     	}
     	if (dz != null && dz.doubleValue() > 0) {
     		if (value.length() == 0) value += nf.format(dz);
     		else value +="x"+nf.format(dz);
-    		tooltip += "Z: "+z+"<br>";
+    		tooltip += "Z: "+z.getValue()+" "+LengthI.lookupSymbol(z.getUnit())+"<br>";
     		label += "Z";
     	}
     	label += ") ";
-    	if (!number) {
-    		component.setForeground(AnnotationUI.WARNING);
-    		component.setToolTipText("Values stored in the file...");
-    	} else {
-    		component.setToolTipText(tooltip);
-    	}
+    	component.setToolTipText(tooltip);
+
     	if (value.length() == 0) return null;
     	component.setText(value);
     	if (unit == null) unit = UnitsLength.MICROMETER;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -679,7 +679,7 @@ public class PropertiesUI
 			number = false;
 		}
 		try {
-		    if(unit == null) {
+		    if (unit == null) {
 		        y = UIUtilities.transformSize(y);
 		        dy = y.getValue();
 		        unit = y.getUnit();
@@ -692,7 +692,7 @@ public class PropertiesUI
 			number = false;
 		}
 		try {
-		    if(unit == null) {
+		    if (unit == null) {
                 z = UIUtilities.transformSize(z);
                 dz = z.getValue();
                 unit = z.getUnit();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -670,25 +670,37 @@ public class PropertiesUI
     	Double dx = null, dy = null, dz = null;
     	boolean number = true;
     	NumberFormat nf = new DecimalFormat("0.00");
-    	String units = null;
+    	UnitsLength unit = null;
     	try {
     		x = UIUtilities.transformSize(x);
 			dx = x.getValue();
-			units = ((LengthI)x).getSymbol();
+			unit = x.getUnit();
 		} catch (Exception e) {
 			number = false;
 		}
 		try {
-			y = UIUtilities.transformSize(y);
-			dy = y.getValue();
-			if (units == null) units = ((LengthI)y).getSymbol();
+		    if(unit == null) {
+		        y = UIUtilities.transformSize(y);
+		        dy = y.getValue();
+		        unit = y.getUnit();
+		    }
+		    else {
+		        y = new LengthI(y, unit);
+		        dy = y.getValue();
+		    }
 		} catch (Exception e) {
 			number = false;
 		}
 		try {
-			z = UIUtilities.transformSize(z);
-			dz = z.getValue();
-			if (units == null) units = ((LengthI)z).getSymbol();
+		    if(unit == null) {
+                z = UIUtilities.transformSize(z);
+                dz = z.getValue();
+                unit = z.getUnit();
+            }
+            else {
+                z = new LengthI(z, unit);
+                dz = z.getValue();
+            }
 		} catch (Exception e) {
 			number = false;
 		}
@@ -722,8 +734,8 @@ public class PropertiesUI
     	}
     	if (value.length() == 0) return null;
     	component.setText(value);
-    	if (units == null) units = LengthI.lookupSymbol(UnitsLength.MICROMETER);
-    	label += "("+units+")";
+    	if (unit == null) unit = UnitsLength.MICROMETER;
+    	label += "("+LengthI.lookupSymbol(unit)+")";
     	return label+":";
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -598,7 +598,7 @@ public class EditorUtil
         Length y = (Length) details.get(PIXEL_SIZE_Y);
         Length z = (Length) details.get(PIXEL_SIZE_Z);
         Double dx = null, dy = null, dz = null;
-        NumberFormat nf = NumberFormat.getInstance();
+        NumberFormat nf = new DecimalFormat("0.00");
         
         try {
         	x = UIUtilities.transformSize(x);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -593,28 +593,41 @@ public class EditorUtil
      */
     private static String formatPixelsSize(Map details)
     {
-        String units = null;
+        UnitsLength unit = null;
         Length x = (Length) details.get(PIXEL_SIZE_X);
         Length y = (Length) details.get(PIXEL_SIZE_Y);
         Length z = (Length) details.get(PIXEL_SIZE_Z);
         Double dx = null, dy = null, dz = null;
         NumberFormat nf = NumberFormat.getInstance();
+        
         try {
         	x = UIUtilities.transformSize(x);
+        	unit = x.getUnit();
             dx = x.getValue();
-            units = ((LengthI)x).getSymbol();
         } catch (Exception e) {
         }
+        
         try {
-        	y = UIUtilities.transformSize(y);
-            dy = y.getValue();
-            if (units == null) units = ((LengthI)y).getSymbol();
+            if (unit == null) {
+                y = UIUtilities.transformSize(y);
+                dy = y.getValue();
+                unit = y.getUnit();
+            } else {
+                y = new LengthI(y, unit);
+                dy = y.getValue();
+            }
         } catch (Exception e) {
         }
+        
         try {
-        	z = UIUtilities.transformSize(z);
-            dz = z.getValue();
-            if (units == null) units = ((LengthI)z).getSymbol();
+            if (unit == null) {
+                z = UIUtilities.transformSize(z);
+                dz = z.getValue();
+                unit = z.getUnit();
+            } else {
+                z = new LengthI(z, unit);
+                dz = z.getValue();
+            }
         } catch (Exception e) {
         }
 
@@ -636,8 +649,8 @@ public class EditorUtil
         }
         label += ") ";
         if (value.length() == 0) return null;
-        if (units == null) units = LengthI.lookupSymbol(UnitsLength.MICROMETER);
-        return label+units+": </b>"+value;
+        if (unit == null) unit = UnitsLength.MICROMETER;
+        return label+LengthI.lookupSymbol(unit)+": </b>"+value;
     }
 
     /**


### PR DESCRIPTION
Bugfix: [Ticket 13034](http://trac.openmicroscopy.org/ome/ticket/13034)

Test: Check the pixelsizes for a few images (e.g. *.dv), especially the image mentioned in the ticket (nightshade image id: 4045578 ) Make sure the pixel size uses the same unit for all dimensions XYZ (it's shown in the tooltip when you hover over the pixelsize label), and make sure the values are correct (especially for Z dimension) by looking at the original meta data (unit can differ from the original meta data that's expected).

Note: The problem (wrong Z dimension unit) occured, when there was a two figure number for X, like in the example 66nm, but a three figure number for Z (200nm).

--no-rebase