### PR TITLE
Api link multiple

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -376,8 +376,8 @@
                     data: JSON.stringify(linkPayload),
                     dataType: 'json'
                 })
-                .done(function(){
-                    dd.resolve();
+                .done(function(data){
+                    dd.resolve(data);
                 });
 
                 // empty the payload, ready for sebsequent calls
@@ -413,8 +413,8 @@
                     data: JSON.stringify(unlinkPayload),
                     dataType: 'json'
                 })
-                .done(function(){
-                    dd.resolve();
+                .done(function(data){
+                    dd.resolve(data);
                 });
                 unlinkPayload = {};
             };

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -331,44 +331,103 @@
             }
         };
 
+
+        var linkNodeTimeout,
+            linkPayload = {};
+
+        var d = jQuery.Deferred();
+
+        function addDataToPayload(payload, node, parent) {
+
+            // Add data to payload...
+            var parent_id = parent.data.obj.id,
+                parent_type = parent.type,
+                child_id = node.data.obj.id,
+                child_type = node.type;
+            // payload is payload.parent_type.parent_id.child_type.child_id
+            if (!(parent_type in payload)) payload[parent_type] = {};
+            if (!(parent_id in payload[parent_type])) {
+                payload[parent_type][parent_id] = {};
+            }
+            if (!(child_type in payload[parent_type][parent_id])) {
+                payload[parent_type][parent_id][child_type] = [];
+            }
+            payload[parent_type][parent_id][child_type].push(child_id);
+        }
+
         function linkNode(inst, node, parent) {
 
-            var payload = {
-                'parent_id': parent.data.obj.id,
-                'parent_type': parent.type,
-                'child_id': node.data.obj.id,
-                'child_type': node.type
+            var doLink = function() {
+
+                var dd = d;
+                d = jQuery.Deferred();
+
+                console.log("Starting link....")
+                // Return a promise
+                $.ajax({
+                    url: "{% url 'api_link' %}",
+                    type: "POST",
+                    data: JSON.stringify(linkPayload),
+                    dataType: 'json'
+                })
+                .done(function(){
+                    dd.resolve();
+                });
+
+                linkPayload = {};
             };
             console.log('linkNode', payload);
 
-            // Return a promise
-            return $.ajax({
-                url: "{% url 'api_link' %}",
-                type: 'POST',
-                data: JSON.stringify(payload),
-                dataType: 'json'
-            });
+            addDataToPayload(linkPayload, node, parent)       
 
-        };
+            // if we're waiting on timeout, clear this and start new timeout
+            if (linkNodeTimeout) {
+                clearTimeout(linkNodeTimeout);
+            }
+            linkNodeTimeout = setTimeout(doLink, 20);
 
-        function unlinkNode(inst, node, parent, callback) {
-            var payload = {
-                'parent_id': parent.data.obj.id,
-                'parent_type': parent.type,
-                'child_id': node.data.obj.id,
-                'child_type': node.type
+            return d;
+
+        }
+
+
+        var unlinkNodeTimeout,
+            unlinkPayload = {};
+
+        var dUnlink = jQuery.Deferred();
+
+        function unlinkNode(inst, node, parent) {
+
+            var doUnlink = function() {
+
+                var dd = dUnlink;
+                dUnlink = jQuery.Deferred();
+
+                console.log("Starting link....")
+                // Return a promise
+                $.ajax({
+                    url: "{% url 'api_link' %}",
+                    type: "DELETE",
+                    data: JSON.stringify(unlinkPayload),
+                    dataType: 'json'
+                })
+                .done(function(){
+                    dd.resolve();
+                });
+
+                unlinkPayload = {};
             };
             console.log('unlink', payload);
 
-            // Return a promise
-            return $.ajax({
-                url: "{% url 'api_link' %}",
-                type: 'DELETE',
-                data: JSON.stringify(payload),
-                dataType: 'json'
-            });
+            addDataToPayload(unlinkPayload, node, parent)       
 
+            // if we're waiting on timeout, clear this and start new timeout
+            if (unlinkNodeTimeout) {
+                clearTimeout(unlinkNodeTimeout);
+            }
+            unlinkNodeTimeout = setTimeout(doUnlink, 20);
 
+            return d;
 
         };
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -371,7 +371,7 @@
 
                 // Do the call, and resolve the deferred when done
                 $.ajax({
-                    url: "{% url 'api_link' %}",
+                    url: "{% url 'api_links' %}",
                     type: "POST",
                     data: JSON.stringify(linkPayload),
                     dataType: 'json'
@@ -408,7 +408,7 @@
                 var dd = deferredUnlink;
                 deferredUnlink = jQuery.Deferred();
                 $.ajax({
-                    url: "{% url 'api_link' %}",
+                    url: "{% url 'api_links' %}",
                     type: "DELETE",
                     data: JSON.stringify(unlinkPayload),
                     dataType: 'json'

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -332,19 +332,15 @@
         };
 
 
-        var linkNodeTimeout,
-            linkPayload = {};
-
-        var d = jQuery.Deferred();
-
+        // Helper method used by linkNode and unlinkNode below.
+        // Simply adds parent_type, parent_id, child_type & child_id to payload object
+        // e.g. {"dataset":{"10":{"image":[1,2,3]}}}:
         function addDataToPayload(payload, node, parent) {
-
-            // Add data to payload...
             var parent_id = parent.data.obj.id,
                 parent_type = parent.type,
                 child_id = node.data.obj.id,
                 child_type = node.type;
-            // payload is payload.parent_type.parent_id.child_type.child_id
+            // payload is payload.parent_type.parent_id.child_type: [child_ids]
             if (!(parent_type in payload)) payload[parent_type] = {};
             if (!(parent_id in payload[parent_type])) {
                 payload[parent_type][parent_id] = {};
@@ -355,15 +351,25 @@
             payload[parent_type][parent_id][child_type].push(child_id);
         }
 
+        // linkNode and unlinkNode (below) use a 'debounce' timeout to collect
+        // many link or unlink calls into a single AJAX call.
+        // On each call to linkNode or unlinkNode, we add the data from node & parent
+        // to the payload that we submit. This is sent once the timeout expires.
+        // linkNode and unlinkNode both return a deferred promise that will be
+        // resolved when the AJAX call returns.
+        var linkNodeTimeout,
+            linkPayload = {},
+            deferredLink = jQuery.Deferred();
         function linkNode(inst, node, parent) {
 
+            // doLink is called on timeout to submit AJAX call
             var doLink = function() {
+                // we send a reference to the deferred...
+                var dd = deferredLink;
+                // ...and create a new deferred to handle subsequent calls to linkNode
+                deferredLink = jQuery.Deferred();
 
-                var dd = d;
-                d = jQuery.Deferred();
-
-                console.log("Starting link....")
-                // Return a promise
+                // Do the call, and resolve the deferred when done
                 $.ajax({
                     url: "{% url 'api_link' %}",
                     type: "POST",
@@ -374,37 +380,33 @@
                     dd.resolve();
                 });
 
+                // empty the payload, ready for sebsequent calls
                 linkPayload = {};
             };
-            console.log('linkNode', payload);
 
+            // build up an object with all the links we want to create
             addDataToPayload(linkPayload, node, parent)       
 
-            // if we're waiting on timeout, clear this and start new timeout
+            // if we're waiting on timeout, clear this...
             if (linkNodeTimeout) {
                 clearTimeout(linkNodeTimeout);
             }
-            linkNodeTimeout = setTimeout(doLink, 20);
+            // ...start new timeout
+            linkNodeTimeout = setTimeout(doLink, 10);
 
-            return d;
+            // return a promise (cannot call resolve() on it elsewhere)
+            return deferredLink.promise();
 
         }
 
-
+        // See docs above for linkNode (works the same as unlinkNode)
         var unlinkNodeTimeout,
-            unlinkPayload = {};
-
-        var dUnlink = jQuery.Deferred();
-
+            unlinkPayload = {},
+            deferredUnlink = jQuery.Deferred();
         function unlinkNode(inst, node, parent) {
-
             var doUnlink = function() {
-
-                var dd = dUnlink;
-                dUnlink = jQuery.Deferred();
-
-                console.log("Starting link....")
-                // Return a promise
+                var dd = deferredUnlink;
+                deferredUnlink = jQuery.Deferred();
                 $.ajax({
                     url: "{% url 'api_link' %}",
                     type: "DELETE",
@@ -414,21 +416,14 @@
                 .done(function(){
                     dd.resolve();
                 });
-
                 unlinkPayload = {};
             };
-            console.log('unlink', payload);
-
             addDataToPayload(unlinkPayload, node, parent)       
-
-            // if we're waiting on timeout, clear this and start new timeout
             if (unlinkNodeTimeout) {
                 clearTimeout(unlinkNodeTimeout);
             }
-            unlinkNodeTimeout = setTimeout(doUnlink, 20);
-
-            return d;
-
+            unlinkNodeTimeout = setTimeout(doUnlink, 10);
+            return deferredUnlink.promise();
         };
 
         // Remove duplicate nodes, normally as a result of copy_node

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -429,17 +429,20 @@
         // Remove duplicate nodes, normally as a result of copy_node
         // or move_node
         function removeDuplicate(inst, node, parentId) {
-            var parent = inst.get_node(parentId);
+            var parent = inst.get_node(parentId),
+                found = false;
             $.each(parent.children, function(index, childId) {
                 var child = inst.get_node(childId);
                 if (child.type === node.type &&
                     child.data.obj.id === node.data.obj.id &&
                     child.id != node.id) {
                     inst.delete_node(child);
+                    found = true;
                     // Break out of $.each
                     return false;
                 }
             });
+            return found;
         };
 
         // Stuff to do on load...
@@ -703,12 +706,16 @@
                     }
 
                     // Remove potential duplicate node
-                    removeDuplicate(inst, data.node, data.parent);
+                    var childExists = removeDuplicate(inst, data.node, data.parent);
 
                     // Persist
-                    $.when(linkNode(inst, data.node, inst.get_node(data.parent))).done(function() {
+                    if (!childExists) {
+                        $.when(linkNode(inst, data.node, inst.get_node(data.parent))).done(function() {
+                            update_thumbnails_panel(e, data);
+                        });
+                    } else {
                         update_thumbnails_panel(e, data);
-                    });
+                    }
 
                     // Update the child count
                     OME.updateNodeChildCount(inst, data.parent);
@@ -723,7 +730,7 @@
                     */
                     var inst = data.instance;
                     // Remove potential duplicate node
-                    removeDuplicate(inst, data.node, data.parent);
+                    var childExists = removeDuplicate(inst, data.node, data.parent);
 
                     // trigger ome remove
                     $("body").trigger('removed_node.jstree.ome', data.node.data.obj);
@@ -732,7 +739,7 @@
                     var linkPromise;
                     // If the move is orphaning an object, do not persist the link
                     if (data.parent.type !== 'experimenter' &&
-                        data.parent.type !== 'orphaned') {
+                        data.parent.type !== 'orphaned' && !childExists) {
                         linkPromise = linkNode(inst, data.node, inst.get_node(data.parent));
                     }
                     var unlinkPromise = unlinkNode(inst, data.node, inst.get_node(data.old_parent));

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -339,6 +339,7 @@
                 'child_id': node.data.obj.id,
                 'child_type': node.type
             };
+            console.log('linkNode', payload);
 
             // Return a promise
             return $.ajax({
@@ -357,6 +358,7 @@
                 'child_id': node.data.obj.id,
                 'child_type': node.type
             };
+            console.log('unlink', payload);
 
             // Return a promise
             return $.ajax({
@@ -631,7 +633,7 @@
                 })
                 .on('copy_node.jstree', function(e, data) {
                     /**
-                    * Fired when a node is copied
+                    * Fired when a node is copied and paste_rdef
                     * Updates the server, adding the new link
                     */
                     var inst = data.instance;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -51,7 +51,6 @@ $(document).ready(function() {
     // for 200ms)
     var loadThumbnailsPanelTimeout = false;
     var loadThumbnailsPanel = function(node, newPage, newField) {
-        console.log('loadThumbnailsPanel...');
         // Reset timeout if within 200ms of the last request
         if (loadThumbnailsPanelTimeout) {
             window.clearTimeout(loadThumbnailsPanelTimeout);
@@ -172,7 +171,6 @@ $(document).ready(function() {
     // This is called directly by various jstree plugins
     // E.g. omecut_plugin.js as well as the jstree in containers.html
     window.update_thumbnails_panel = function(event, data) {
-        console.log('update_thumbnails_panel...');
         var inst = $.jstree.reference('#dataTree');
 
         // Get the container that is currently rendered

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -51,6 +51,7 @@ $(document).ready(function() {
     // for 200ms)
     var loadThumbnailsPanelTimeout = false;
     var loadThumbnailsPanel = function(node, newPage, newField) {
+        console.log('loadThumbnailsPanel...');
         // Reset timeout if within 200ms of the last request
         if (loadThumbnailsPanelTimeout) {
             window.clearTimeout(loadThumbnailsPanelTimeout);
@@ -107,6 +108,7 @@ $(document).ready(function() {
                 $("div#content_details").html('<p class="loading_center">Loading... please wait. <img src ="{% static "webgateway/img/spinner_big.gif" %}"/></p>');
 
                 // Load html from url
+                console.log("loading", url);
                 $("div#content_details").load(url);
                 setThumbnailsPanel(nodeType, nodeId, inst.get_omepath(node), newPage, newField);
 
@@ -170,6 +172,7 @@ $(document).ready(function() {
     // This is called directly by various jstree plugins
     // E.g. omecut_plugin.js as well as the jstree in containers.html
     window.update_thumbnails_panel = function(event, data) {
+        console.log('update_thumbnails_panel...');
         var inst = $.jstree.reference('#dataTree');
 
         // Get the container that is currently rendered

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -333,8 +333,8 @@ urlpatterns = patterns(
     #     views.api_plate_acquisitions_detail),
 
     # POST to create link, DELETE to remove.
-    # parent_type, parent_id, child_type, child_id in request.body json
-    url(r'^api/link/$', views.api_link, name='api_link'),
+    # links in request.body json, e.g. {"dataset":{"10":{"image":[1,2,3]}}}
+    url(r'^api/links/$', views.api_links, name='api_links'),
 
     # url(r'^api/tags/$', views.api_tag_list, name='api_tags'),
     # url(r'^api/tags/(?P<pk>[0-9]+)/$', views.api_tag_detail),

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -924,13 +924,17 @@ def api_link(request, conn=None, **kwargs):
         for parent_id, children in parents.items():
             for child_type, child_ids in children.items():
                 if request.method == 'DELETE':
-                    linkType, linkIds = get_object_links(conn, parent_type, parent_id, child_type, child_ids)
+                    linkType, linkIds = get_object_links(conn, parent_type,
+                                                         parent_id,
+                                                         child_type,
+                                                         child_ids)
                     logger.info("api_link: Deleting %s links" % len(linkIds))
                     conn.deleteObjects(linkType, linkIds)
                 elif request.method == 'POST':
                     for child_id in child_ids:
                         parent_id = int(parent_id)
-                        link = get_link(parent_type, parent_id, child_type, child_id)
+                        link = get_link(parent_type, parent_id,
+                                        child_type, child_id)
                         if link and link != 'orphan':
                             linksToSave.append(link)
 
@@ -946,7 +950,8 @@ def api_link(request, conn=None, **kwargs):
             conn.saveArray(linksToSave)
             response['success'] = True
         except:
-            logger.info("api_link: Exception on saveArray with %s links" % len(linksToSave))
+            logger.info("api_link: Exception on saveArray with %s links"
+                        % len(linksToSave))
             # If this fails, e.g. ValidationException because link
             # already exists, try to save individual links
             for l in linksToSave:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -870,7 +870,7 @@ def get_object_links(conn, parent_type, parent_id, child_type, child_ids):
 
 
 @login_required()
-def api_link(request, conn=None, **kwargs):
+def api_links(request, conn=None, **kwargs):
     """ Creates or Deletes links between objects specified by a json
     blob in the request body.
     e.g. {"dataset":{"10":{"image":[1,2,3]}}}
@@ -878,7 +878,7 @@ def api_link(request, conn=None, **kwargs):
     (E.g. adding an image to a Dataset that already has that image).
     """
 
-    def get_link(parent_type, parent_id, child_type, child_id):
+    def create_link(parent_type, parent_id, child_type, child_id):
         # TODO Handle more types of link
         if parent_type == 'experimenter':
             if child_type == 'dataset' or child_type == 'plate':
@@ -944,14 +944,14 @@ def api_link(request, conn=None, **kwargs):
                                                                 child_ids)
                     # return remaining links in same format as json above
                     # e.g. {"dataset":{"10":{"image":[1,2,3]}}}
-                    if parent_type not in response:
-                        response[parent_type] = {}
                     for rl in remainingLinks:
                         pid = rl.parent.id.val
                         cid = rl.child.id.val
                         # Deleting links still in progress above - ignore these
                         if pid == int(parent_id):
                             continue
+                        if parent_type not in response:
+                            response[parent_type] = {}
                         if pid not in response[parent_type]:
                             response[parent_type][pid] = {child_type: []}
                         response[parent_type][pid][child_type].append(cid)
@@ -959,8 +959,8 @@ def api_link(request, conn=None, **kwargs):
                 elif request.method == 'POST':
                     for child_id in child_ids:
                         parent_id = int(parent_id)
-                        link = get_link(parent_type, parent_id,
-                                        child_type, child_id)
+                        link = create_link(parent_type, parent_id,
+                                           child_type, child_id)
                         if link and link != 'orphan':
                             linksToSave.append(link)
 

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -291,7 +291,7 @@ class TestCsrf(IWebTest):
                                          request_url,
                                          json.dumps(data),
                                          content_type="application/json")
-        # Response will contain any remaing links from image
+        # Response will contain remaining links from image (see test_links.py)
         response = json.loads(response.content)
         assert response == {"success": True}
 

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2014 Glencoe Software, Inc.
+# Copyright (C) 2014-2015 Glencoe Software, Inc.
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -269,13 +269,10 @@ class TestCsrf(IWebTest):
 
         img = self.image_with_channels()
 
-        # Move image
-        request_url = reverse("api_link")
+        # Link image to Dataset
+        request_url = reverse("api_links")
         data = {
-            'parent_type': 'dataset',
-            'parent_id': did,
-            'child_type': 'image',
-            'child_id': img.id.val
+            'dataset': {did: {'image': [img.id.val]}}
         }
 
         _post_response(self.django_client, request_url, data)
@@ -284,19 +281,19 @@ class TestCsrf(IWebTest):
                             json.dumps(data),
                             content_type="application/json")
 
-        # Delete image
-        request_url = reverse("api_link")
+        # Unlink image from Dataset
+        request_url = reverse("api_links")
         data = {
-            'parent_type': 'dataset',
-            'parent_id': did,
-            'child_type': 'image',
-            'child_id': img.id.val
+            'dataset': {did: {'image': [img.id.val]}}
         }
         _delete_response(self.django_client, request_url, data)
-        _csrf_delete_response(self.django_client,
-                              request_url,
-                              json.dumps(data),
-                              content_type="application/json")
+        response = _csrf_delete_response(self.django_client,
+                                         request_url,
+                                         json.dumps(data),
+                                         content_type="application/json")
+        # Response will contain any remaing links from image
+        response = json.loads(response.content)
+        assert response == {"success": True}
 
     def test_create_share(self):
 

--- a/components/tools/OmeroWeb/test/integration/test_links.py
+++ b/components/tools/OmeroWeb/test/integration/test_links.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests creation and deletion of links between e.g. Projects & Datasets etc.
+"""
+
+import omero
+
+from omero.rtypes import rstring
+from weblibrary import IWebTest
+from weblibrary import _csrf_post_response, _get_response
+# from weblibrary import _csrf_delete_response, _delete_response
+
+import json
+
+from django.core.urlresolvers import reverse
+
+import pytest
+
+
+class TestLinks(IWebTest):
+    """
+    Tests creation and deletion of links between
+    e.g. Projects & Datasets etc.
+    """
+
+    @pytest.fixture
+    def project(self):
+        """Returns a new OMERO Project with required fields set."""
+        project = omero.model.ProjectI()
+        project.name = rstring(self.uuid())
+        return self.update.saveAndReturnObject(project)
+
+    @pytest.fixture
+    def dataset(self):
+        """Returns a new OMERO Dataset with required fields set."""
+        dataset = omero.model.DatasetI()
+        dataset.name = rstring(self.uuid())
+        return self.update.saveAndReturnObject(dataset)
+
+    @pytest.fixture
+    def datasets(self):
+        """Returns a new OMERO Dataset with required fields set."""
+        dataset = omero.model.DatasetI()
+        dataset.name = rstring("A_%s" % self.uuid())
+        dataset2 = omero.model.DatasetI()
+        dataset2.name = rstring("B_%s" % self.uuid())
+        return self.update.saveAndReturnArray([dataset, dataset2])
+
+    def test_link_project_datasets(self, project, datasets):
+        # Link Project to Dataset
+        request_url = reverse("api_links")
+        pid = project.id.val
+        dids = [d.id.val for d in datasets]
+        data = {
+            'project': {pid: {'dataset': dids}}
+        }
+
+        json = _csrf_post_response_json(self.django_client, request_url, data)
+        assert json == {"success": True}
+
+        # Check links
+        request_url = reverse("api_datasets")
+        json = _get_response_json(self.django_client, request_url, {'id': pid})
+        # Expect a single Dataset with correct id
+        assert len(json['datasets']) == 2
+        assert json['datasets'][0]['id'] == dids[0]
+        assert json['datasets'][1]['id'] == dids[1]
+
+
+def _get_response_json(django_client, request_url, query_string):
+    rsp = _get_response(django_client, request_url,
+                        query_string, status_code=200)
+    return json.loads(rsp.content)
+
+
+def _csrf_post_response_json(django_client, request_url, data):
+    rsp = _csrf_post_response(django_client,
+                              request_url,
+                              json.dumps(data),
+                              content_type="application/json")
+    return json.loads(rsp.content)

--- a/components/tools/OmeroWeb/test/integration/test_links.py
+++ b/components/tools/OmeroWeb/test/integration/test_links.py
@@ -29,6 +29,7 @@ from weblibrary import _csrf_post_response, _get_response
 from weblibrary import _csrf_delete_response
 
 import json
+from time import sleep
 
 from django.core.urlresolvers import reverse
 
@@ -182,10 +183,17 @@ class TestLinks(IWebTest):
                             "screen": {str(sids[1]): {"plate": pids[:1]}}
                             }
 
-        # Check that link has been deleted, leaving 2nd plate under 1st screen
+        # Since the Delete is ansync - need to check repeatedly for deletion
+        # by counting plates under screen...
         plates_url = reverse("api_plates")
-        rsp = _get_response_json(self.django_client,
-                                 plates_url, {'id': sids[0]})
+        for i in range(10):
+            rsp = _get_response_json(self.django_client,
+                                     plates_url, {'id': sids[0]})
+            if len(rsp['plates']) == 1:
+                break
+            sleep(0.5)
+
+        # Check that link has been deleted, leaving 2nd plate under 1st screen
         assert len(rsp['plates']) == 1
         assert rsp['plates'][0]['id'] == pids[1]
 

--- a/components/tools/OmeroWeb/test/integration/test_links.py
+++ b/components/tools/OmeroWeb/test/integration/test_links.py
@@ -106,11 +106,13 @@ class TestLinks(IWebTest):
         # Check links
         request_url = reverse("api_images")
         # First Dataset has single image
-        json = _get_response_json(self.django_client, request_url, {'id': dids[0]})
+        json = _get_response_json(self.django_client,
+                                  request_url, {'id': dids[0]})
         assert len(json['images']) == 1
         assert json['images'][0]['id'] == iids[0]
         # Second Dataset has both images
-        json = _get_response_json(self.django_client, request_url, {'id': dids[1]})
+        json = _get_response_json(self.django_client,
+                                  request_url, {'id': dids[1]})
         assert len(json['images']) == 2
         assert json['images'][0]['id'] == iids[0]
         assert json['images'][1]['id'] == iids[1]


### PR DESCRIPTION
This improves performance of cut, copy & paste and drag 'n' drop actions in jsTree.
It makes a single AJAX call to create or delete multiple links for each action.
In each case, check that child counts are updated correctly and confirm the links have been created / deleted successfully by refreshing the tree.
Also check that the centre panel is correct and in sync with the tree.
Include cases where one or more of the children being moved is already contained in the destination parent.

Tests:
 - Drag and drop images, datasets & plates, moving from one parent to another in each case.
 - Copy and paste, as above.
 - Cut. Select a number of child nodes, some of which are also in other containers, others will become orphaned. Then Paste.
 
Any other actions you can think of?