### PR TITLE
Use Unit objects in image viewer

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.Browser
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -30,6 +30,7 @@ import java.awt.image.BufferedImage;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
 import org.openmicroscopy.shoola.util.ui.component.ObservableComponent;
 
@@ -157,11 +158,12 @@ public interface Browser
     public void setUnitBar(boolean b);
 
     /**
-     * Sets the size of the unit bar in microns.
+     * Sets the size of the unit bar.
      * 
-     * @param size The size of the unit bar in microns.
+     * @param size The size of the unit bar.
+     * @param unit The unit
      */
-    public void setUnitBarSize(double size);
+    public void setUnitBarSize(double size, UnitsLength unit);
 
     /**
      * Returns <code>true</code> if the unit bar is displayed, 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.BrowserComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -32,6 +32,7 @@ import java.awt.image.BufferedImage;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ZoomAction;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
@@ -299,10 +300,10 @@ class BrowserComponent
      * Implemented as specified by the {@link Browser} interface.
      * @see Browser#setUnitBarSize(double)
      */
-    public void setUnitBarSize(double size)
+    public void setUnitBarSize(double size, UnitsLength unit)
     {
     	double oldUnit = model.getUnitInRefUnits();
-        model.setUnitBarSize(size);
+        model.setUnitBarSize(size, unit);
         
         Rectangle viewRect = view.getViewport().getBounds();
         if (viewRect.width >= model.getUnitBarSize()) {
@@ -320,7 +321,7 @@ class BrowserComponent
               		"the selected size: "+size +
               		"\ncannot be displayed on the image. " +
               		"Please select a new size.");
-              model.setUnitBarSize(oldUnit);
+              model.setUnitBarSize(oldUnit, unit);
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
@@ -298,7 +298,7 @@ class BrowserComponent
 
     /** 
      * Implemented as specified by the {@link Browser} interface.
-     * @see Browser#setUnitBarSize(double)
+     * @see Browser#setUnitBarSize(double, UnitsLength)
      */
     public void setUnitBarSize(double size, UnitsLength unit)
     {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -374,10 +374,10 @@ class BrowserModel
     }
     
     /**
-     * Calculates the size of the unit bar.
+     * Calculates the length of the unit bar.
      * 
      * @param ratio The ratio to multiple the value by.
-     * @return
+     * @return The unit bar length in pixels
      */
     private double getBarSizeInPx(double ratio)
     {
@@ -672,21 +672,23 @@ class BrowserModel
     }
     
     /**
-     * Returns the size of the unit bar.
+     * Returns the original (non-scaled) length of the unit bar in pixels
      * 
      * @return See above.
      */
-    double getOriginalUnitBarSize() { return getBarSizeInPx(1); }
+    double getOriginalUnitBarSize() {
+        return getBarSizeInPx(1);
+    }
     
     /**
-     * Returns the size of the unit bar.
+     * Returns the length of the unit bar in pixels
      * 
      * @return See above.
      */
     double getUnitBarSize() { return getBarSizeInPx(zoomFactor); }
   
     /**
-     * Returns the size of the unit bar for an image composing the grid.
+     * Returns the length of the unit bar (in pixels) for an image composing the grid.
      * 
      * @return See above.
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -44,8 +44,12 @@ import org.openmicroscopy.shoola.agents.imviewer.util.ImagePaintingFactory;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewerFactory;
 import org.openmicroscopy.shoola.agents.imviewer.view.ViewerPreferences;
+import ome.model.units.BigResult;
 import omero.log.LogMessage;
 import org.openmicroscopy.shoola.env.LookupNames;
+import omero.model.Length;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.env.rnd.data.Tile;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
@@ -110,9 +114,8 @@ class BrowserModel
      */
     private boolean         	unitBar;
     
-    /** The value of the unit bar in the units matching the size of the pixels
-     * e.g. microns, mm, etc. */
-    private double          	unitInRefUnits;
+    /** The length of the unit bar */
+    private Length          	unitBarLength;
     
     /** The default color of the unit bar. */
     private Color				unitBarColor;
@@ -376,13 +379,20 @@ class BrowserModel
      * @param ratio The ratio to multiple the value by.
      * @return
      */
-    private double getBarSize(double ratio)
+    private double getBarSizeInPx(double ratio)
     {
-    	double v = unitInRefUnits;
-        double t = UIUtilities.transformSize(getPixelsSizeX()).getValue();
-        if (t > 0) v = unitInRefUnits/t;
-        v *= ratio;
-        return v;
+        if(unitBarLength == null)
+            return 1;
+        
+        try {
+            double v = unitBarLength.getValue()
+                    / (new LengthI(getPixelsSizeX(), unitBarLength.getUnit()))
+                            .getValue();
+            v *= ratio;
+            return v;
+        } catch (BigResult e) {
+        }
+        return 1;
     }
     
     /** 
@@ -402,7 +412,6 @@ class BrowserModel
         ratio = ZoomGridAction.DEFAULT_ZOOM_FACTOR;
         gridRatio = ZoomGridAction.DEFAULT_ZOOM_FACTOR;
         init = true;
-        unitInRefUnits = UnitBarSizeAction.getDefaultValue(); // size microns.
         unitBarColor = ImagePaintingFactory.UNIT_BAR_COLOR;
         backgroundColor = ImagePaintingFactory.DEFAULT_BACKGROUND;
         gridImages = new ArrayList<BufferedImage>();
@@ -427,7 +436,9 @@ class BrowserModel
      * 
      * @param component The embedding component.
      */
-    void initialize(Browser component) { this.component = component; }
+    void initialize(Browser component) { 
+        this.component = component; 
+    }
     
     /** 
      * Returns <code>true</code> if the rendered image has been set,
@@ -595,11 +606,11 @@ class BrowserModel
     int getMaxT() { return parent.getRealT(); }
     
     /**
-     * The size in microns of a pixel along the X-axis.
+     * The size of a pixel along the X-axis.
      * 
      * @return See above.
      */
-    double getPixelsSizeX() { return parent.getPixelsSizeX(); }
+    Length getPixelsSizeX() { return parent.getPixelsSizeX(); }
     
     /**
      * Returns <code>true</code> if the unit bar is painted on top of 
@@ -617,47 +628,69 @@ class BrowserModel
      */
     void setUnitBar(boolean unitBar)
     {
-    	double v = UIUtilities.transformSize(parent.getPixelsSizeX()).getValue();
-    	if (v == 0 || v == 1) unitBar = false;
+        if (unitBar) {
+            int unitBarLenghtValue = UnitBarSizeAction.getDefaultValue();
+            // Guess the unit to use by assuming a 100px wide scalebar
+            Length tmp = new LengthI(getPixelsSizeX().getValue() * 100,
+                    getPixelsSizeX().getUnit());
+            tmp = UIUtilities.transformSize(tmp);
+            this.unitBarLength = new LengthI(unitBarLenghtValue, tmp.getUnit());
+        }
     	this.unitBar = unitBar;
     }
     
     /**
      * Sets the size of the unit bar.
      * 
-     * @param size The size of the unit bar.
+     * @param size
+     *            The size of the unit bar.
+     * @param unit The unit
      */
-    void setUnitBarSize(double size) { unitInRefUnits = size; }
+    void setUnitBarSize(double size, UnitsLength unit) {
+        if (unitBarLength != null) {
+            try {
+                LengthI tmp = new LengthI(size, unit);
+                tmp = new LengthI(tmp, unitBarLength.getUnit());
+                unitBarLength.setValue(tmp.getValue());
+            } catch (BigResult e) {
+            }
+        }
+        else {
+            unitBarLength = new LengthI(size, unit);
+        }
+    }
     
     /**
-     * Returns the unit used to determine the size of the unit bar.
-     * The unit depends on the size stored. The unit of reference in the
-     * OME model is in microns, but this is a transformed unit.
+     * Returns the unit used to determine the size of the unit bar. The unit
+     * depends on the size stored. The unit of reference in the OME model is in
+     * microns, but this is a transformed unit.
      * 
      * @return See above.
      */
-    double getUnitInRefUnits() { return unitInRefUnits; }
+    double getUnitInRefUnits() {
+        return unitBarLength != null ? unitBarLength.getValue() : 1;
+    }
     
     /**
      * Returns the size of the unit bar.
      * 
      * @return See above.
      */
-    double getOriginalUnitBarSize() { return getBarSize(1); }
+    double getOriginalUnitBarSize() { return getBarSizeInPx(1); }
     
     /**
      * Returns the size of the unit bar.
      * 
      * @return See above.
      */
-    double getUnitBarSize() { return getBarSize(zoomFactor); }
+    double getUnitBarSize() { return getBarSizeInPx(zoomFactor); }
   
     /**
      * Returns the size of the unit bar for an image composing the grid.
      * 
      * @return See above.
      */
-    double getGridBarSize() { return getBarSize(gridRatio); }
+    double getGridBarSize() { return getBarSizeInPx(gridRatio); }
     
     /**
      * Returns the unit bar value.
@@ -666,7 +699,15 @@ class BrowserModel
      */
     String getUnitBarValue()
     {
-    	return UIUtilities.twoDecimalPlaces(unitInRefUnits);
+    	return UIUtilities.twoDecimalPlaces(unitBarLength.getValue());
+    }
+    
+    /**
+     * Returns the unit of the scalebar 
+     * @return See above.
+     */
+    String getUnitBarUnit() {
+        return LengthI.lookupSymbol(unitBarLength.getUnit());
     }
     
     /**
@@ -791,19 +832,23 @@ class BrowserModel
 	int getMaxY() { return parent.getMaxY(); }
 
     /**
-     * Returns the size in microns of a pixel along the Y-axis.
+     * Returns the size of a pixel along the Y-axis.
      * 
      * @return See above.
      */
-	double getPixelsSizeY() { return parent.getPixelsSizeY(); }
+	Length getPixelsSizeY() { return parent.getPixelsSizeY(); }
 
     /**
-     * Returns the size in microns of a pixel along the Y-axis.
+     * Returns the size of a pixel along the Y-axis.
      * 
      * @return See above.
      */
-	double getPixelsSizeZ() { return parent.getPixelsSizeZ(); }
+	Length getPixelsSizeZ() { return parent.getPixelsSizeZ(); }
    
+	Length getUnitBarLength() {
+	    return unitBarLength;
+	}
+	
     /** 
      * Returns the number of column for the grid.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/ImageCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/ImageCanvas.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.ImageCanvas 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -122,8 +122,11 @@ class ImageCanvas
 		if (!model.isUnitBar()) return;
 
 		String value = model.getUnitBarValue();
-		if (value == null) return;
+		if (value == null) 
+		    return;
 
+		value += " "+model.getUnitBarUnit();
+		
 		int size = (int) (model.getUnitBarSize());
 		
 		// Position scalebar in the bottom left of the viewport or

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/UnitBarSizeDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/UnitBarSizeDialog.java
@@ -40,9 +40,10 @@ import javax.swing.JTextField;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
-import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 
 /** 
  * Sets the value of the scale bar.
@@ -69,6 +70,9 @@ public class UnitBarSizeDialog
     
     /** The label used to enter the value. */
     private JTextField label;
+    
+    /** The unit of the scalebar */
+    private UnitsLength unit;
     
     /** Fires a property change if the value entered is a valid number. */
     private void handleSelection()
@@ -109,7 +113,7 @@ public class UnitBarSizeDialog
         });
         JPanel p = new JPanel();
         p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
-        p.add(new JLabel("Value (in "+EditorUtil.MICRONS_NO_BRACKET+"): "));
+        p.add(new JLabel("Value (in "+LengthI.lookupSymbol(unit)+"): "));
         p.add(label);
         getContentPane().add(UIUtilities.buildComponentPanel(p));
     }
@@ -118,10 +122,12 @@ public class UnitBarSizeDialog
      * Creates a new instance.
      * 
      * @param parent The window's parent.
+     * @param unit The unit of the scalebar
      */
-    public UnitBarSizeDialog(JFrame parent)
+    public UnitBarSizeDialog(JFrame parent, UnitsLength unit)
     {
         super(parent);
+        this.unit = unit;
         setProperties();
         buildGUI();
         pack();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -45,6 +45,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.ImageAcquisitionData;
 import omero.gateway.model.ImageData;
+import omero.model.Length;
 
 /** 
  * Defines the interface provided by the viewer component. 
@@ -471,25 +472,25 @@ public interface ImViewer
 	public int getDefaultT();
 
 	/**
-	 * Returns the size in microns of a pixel along the X-axis.
+	 * Returns the size of a pixel along the X-axis.
 	 * 
 	 * @return See above.
 	 */
-	public double getPixelsSizeX();
+	public Length getPixelsSizeX();
 
 	/**
-	 * Returns the size in microns of a pixel along the Y-axis.
+	 * Returns the size of a pixel along the Y-axis.
 	 * 
 	 * @return See above.
 	 */
-	public double getPixelsSizeY();
+	public Length getPixelsSizeY();
 
 	/**
-	 * Returns the size in microns of a pixel along the X-axis.
+	 * Returns the size of a pixel along the X-axis.
 	 * 
 	 * @return See above.
 	 */
-	public double getPixelsSizeZ();
+	public Length getPixelsSizeZ();
 
 	/**
 	 * Returns the title of the viewer.
@@ -1014,13 +1015,6 @@ public interface ImViewer
 
 	/** Loads all the datasets available. */
 	public void loadAllContainers();
-	
-	/**
-	 * Returns the unit in microns.
-	 * 
-	 * @return See above.
-	 */
-	public double getUnitInRefUnits();
 
 	/** Makes a movie. */
 	public void makeMovie();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -74,6 +74,9 @@ import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import omero.log.LogMessage;
 import omero.log.Logger;
+import omero.model.Length;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.rnd.data.Tile;
@@ -523,7 +526,9 @@ class ImViewerComponent
 	 */
 	ImViewerComponent(ImViewerModel model)
 	{
-		if (model == null) throw new NullPointerException("No model.");
+		if (model == null) 
+		    throw new NullPointerException("No model.");
+		
 		this.model = model;
 		controller = new ImViewerControl();
 		view = new ImViewerUI(model.getImageTitle());
@@ -1540,14 +1545,14 @@ class ImViewerComponent
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#getPixelsSizeX()
 	 */
-	public double getPixelsSizeX()
+	public Length getPixelsSizeX()
 	{
 		switch (model.getState()) {
 			case NEW:
 				throw new IllegalStateException(
 						"This method can't be invoked in the NEW state.");
 			case DISCARDED:
-				return -1;
+				return new LengthI(1, UnitsLength.PIXEL);
 		}
 		return model.getPixelsSizeX();
 	}
@@ -1556,14 +1561,14 @@ class ImViewerComponent
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#getPixelsSizeY()
 	 */
-	public double getPixelsSizeY()
+	public Length getPixelsSizeY()
 	{
 		switch (model.getState()) {
 			case NEW:
 				throw new IllegalStateException(
 						"This method can't be invoked in the NEW state.");
 			case DISCARDED:
-				return -1;
+			    return new LengthI(1, UnitsLength.PIXEL);
 		}
 		return model.getPixelsSizeY();
 	}
@@ -1572,14 +1577,14 @@ class ImViewerComponent
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#getPixelsSizeZ()
 	 */
-	public double getPixelsSizeZ()
+	public Length getPixelsSizeZ()
 	{
 		switch (model.getState()) {
 			case NEW:
 				throw new IllegalStateException(
 						"This method can't be invoked in the NEW state.");
 			case DISCARDED:
-				return -1;
+			    return new LengthI(1, UnitsLength.PIXEL);
 		}
 		return model.getPixelsSizeZ();
 	}
@@ -1668,8 +1673,9 @@ class ImViewerComponent
 	 */
 	public void setUnitBarSize(double size)
 	{
-		if (model.getState() == DISCARDED) return;
-		model.getBrowser().setUnitBarSize(size);
+		if (model.getState() == DISCARDED) 
+		    return;
+		model.getBrowser().setUnitBarSize(size, model.getScaleBarUnit());
 		controller.setPreferences();
 	}
 
@@ -1680,7 +1686,7 @@ class ImViewerComponent
 	public void showUnitBarSelection()
 	{
 		if (model.getState() == DISCARDED) return;
-		UnitBarSizeDialog d = new UnitBarSizeDialog(view);
+		UnitBarSizeDialog d = new UnitBarSizeDialog(view, model.getScaleBarUnit());
 		d.addPropertyChangeListener(controller);
 		UIUtilities.centerAndShow(d);
 	}
@@ -2803,12 +2809,6 @@ class ImViewerComponent
 
 	/** 
 	 * Implemented as specified by the {@link ImViewer} interface.
-	 * @see ImViewer#getUnitInRefUnits()
-	 */
-	public double getUnitInRefUnits() { return model.getUnitInRefUnits(); }
-
-	/** 
-	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#makeMovie()
 	 */
 	public void makeMovie()
@@ -2820,8 +2820,7 @@ class ImViewerComponent
 	/** Build the view.*/
 	private void buildView()
 	{
-		int index = UnitBarSizeAction.getDefaultIndex(
-				UIUtilities.transformSize(5*getPixelsSizeX()).getValue());
+		int index = UnitBarSizeAction.DEFAULT_UNIT_INDEX;
 		setUnitBarSize(UnitBarSizeAction.getValue(index));
 		view.setDefaultScaleBarMenu(index);
 		colorModel = model.getColorModel();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -324,7 +324,10 @@ class ImViewerModel
     private int planeSize;
 
     /** The units corresponding to the pixels size.*/
-    private String refUnit;
+    private UnitsLength refUnit;
+    
+    /** The unit used for the scale bar */
+    private UnitsLength scaleBarUnit;
     
     /**
      * Returns the default resolution level.
@@ -652,6 +655,25 @@ class ImViewerModel
 	boolean isRendererLoaded() {
 	    return metadataViewer.getRenderer() != null;
 	}
+	
+    /**
+     * Get the unit for the scalebar. 
+     * Determined by assuming a 100px wide scalebar.
+     * 
+     * @return The unit used for the scalebar
+     */
+    public UnitsLength getScaleBarUnit() {
+        if (scaleBarUnit == null) {
+            if (getPixelsSizeX() == null)
+                return UnitsLength.MICROMETER;
+            // Determine a reasonable unit by assuming a 100px wide scalebar
+            Length tmp = new LengthI(getPixelsSizeX().getValue() * 100,
+                    getPixelsSizeX().getUnit());
+            tmp = UIUtilities.transformSize(tmp);
+            this.scaleBarUnit = tmp.getUnit();
+        }
+        return scaleBarUnit;
+    }
 	
 	/**
 	 * Returns the current user's details.
@@ -1380,38 +1402,39 @@ class ImViewerModel
 	BufferedImage getGridImage() { return browser.getGridImage(); }
 
 	/**
-	 * Returns the size in microns of a pixel along the X-axis.
+	 * Returns the size of a pixel along the X-axis.
 	 * 
 	 * @return See above.
 	 */
-	double getPixelsSizeX()
+	Length getPixelsSizeX()
 	{
 		Renderer rnd = metadataViewer.getRenderer();
-		if (rnd == null) return -1;
+		if (rnd == null) 
+		    return new LengthI(1, UnitsLength.PIXEL);
 		return rnd.getPixelsSizeX(); 
 	}
 
 	/**
-	 * Returns the size in microns of a pixel along the Y-axis.
+	 * Returns the size of a pixel along the Y-axis.
 	 * 
 	 * @return See above.
 	 */
-	double getPixelsSizeY()
+	Length getPixelsSizeY()
 	{ 
 		Renderer rnd = metadataViewer.getRenderer();
-		if (rnd == null) return -1;
+		if (rnd == null) return new LengthI(1, UnitsLength.PIXEL);
 		return rnd.getPixelsSizeY();
 	}
 
 	/**
-	 * Returns the size in microns of a pixel along the Y-axis.
+	 * Returns the size of a pixel along the Y-axis.
 	 * 
 	 * @return See above.
 	 */
-	double getPixelsSizeZ()
+	Length getPixelsSizeZ()
 	{
 		Renderer rnd = metadataViewer.getRenderer();
-		if (rnd == null) return -1;
+		if (rnd == null) return new LengthI(1, UnitsLength.PIXEL);
 		return rnd.getPixelsSizeZ();
 	}
 
@@ -2947,18 +2970,14 @@ class ImViewerModel
      * 
      * @return See above.
      */
-	String getUnits()
+	UnitsLength getRefUnit()
 	{
 		if (refUnit != null) 
 			return refUnit;
 		
-		double size = getPixelsSizeX();
-		if (size < 0) 
-			return LengthI.lookupSymbol(UnitsLength.MICROMETER);
+		Length tmp = UIUtilities.transformSize(getPixelsSizeX());
+		refUnit = tmp.getUnit();
 		
-		Length tmp = new LengthI(size, UnitsLength.MICROMETER);
-		tmp = UIUtilities.transformSize(tmp);
-		refUnit = ((LengthI)tmp).getSymbol();
 		return refUnit;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -468,7 +468,7 @@ class ImViewerUI
 	 */
 	private JMenu createScaleBarLengthSubMenu(ViewerPreferences pref)
 	{
-		scaleBarMenu = new JMenu(SCALE_BAR_TEXT+model.getUnits()+")");
+		scaleBarMenu = new JMenu(SCALE_BAR_TEXT+LengthI.lookupSymbol(model.getScaleBarUnit())+")");
 		scaleBarGroup = new ButtonGroup();
 		if (pref != null && pref.getScaleBarIndex() > 0)
 			defaultIndex = pref.getScaleBarIndex();
@@ -558,7 +558,7 @@ class ImViewerUI
 				controller.getAction(ImViewerControl.UNIT_BAR));
 		unitBarItem.setSelected(model.isUnitBar());
 		unitBarItem.setAction(controller.getAction(ImViewerControl.UNIT_BAR));
-		scaleBarMenu.setText(SCALE_BAR_TEXT+model.getUnits()+")");
+		scaleBarMenu.setText(SCALE_BAR_TEXT+LengthI.lookupSymbol(model.getScaleBarUnit())+")");
 	}
 	
 	/**
@@ -1318,7 +1318,7 @@ class ImViewerUI
 	{
 		int n;
 		int max = model.getMaxZ();
-		double d = model.getPixelsSizeZ();
+		double d = model.getPixelsSizeZ().getValue();
 		String units;
 		Length o;
 		StringBuffer buffer = new StringBuffer();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import javax.swing.JComponent;
 
+import omero.model.Length;
 import omero.romio.PlaneDef;
 
 import org.openmicroscopy.shoola.agents.util.ViewedByItem;
@@ -420,24 +421,24 @@ public interface Renderer
     List<Integer> getActiveChannels();
 
     /**
-     * Returns the size in microns of a pixel along the X-axis.
+     * Returns the size of a pixel along the X-axis.
      * 
      * @return See above.
      */
-    double getPixelsSizeX();
+    Length getPixelsSizeX();
     /**
-     * Returns the size in microns of a pixel along the Y-axis.
+     * Returns the size of a pixel along the Y-axis.
      * 
      * @return See above.
      */
-    double getPixelsSizeY();
+    Length getPixelsSizeY();
 
     /**
-     * Returns the size in microns of a pixel along the Y-axis.
+     * Returns the size of a pixel along the Y-axis.
      * 
      * @return See above.
      */
-    double getPixelsSizeZ();
+    Length getPixelsSizeZ();
 
     /**
      * Returns a 3-dimensional array of boolean value, one per color band.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -48,6 +48,7 @@ import org.openmicroscopy.shoola.env.event.EventBus;
 
 import omero.log.LogMessage;
 import omero.log.Logger;
+import omero.model.Length;
 
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
@@ -769,19 +770,19 @@ class RendererComponent
      * Implemented as specified by the {@link Renderer} interface.
      * @see Renderer#getPixelsSizeX()
      */
-	public double getPixelsSizeX() { return model.getPixelsSizeX(); }
+	public Length getPixelsSizeX() { return model.getPixelsSizeX(); }
 
     /** 
      * Implemented as specified by the {@link Renderer} interface.
      * @see Renderer#getPixelsSizeY()
      */
-	public double getPixelsSizeY() { return model.getPixelsSizeY(); }
+	public Length getPixelsSizeY() { return model.getPixelsSizeY(); }
 
     /** 
      * Implemented as specified by the {@link Renderer} interface.
      * @see Renderer#getPixelsSizeZ()
      */
-	public double getPixelsSizeZ() { return model.getPixelsSizeZ(); }
+	public Length getPixelsSizeZ() { return model.getPixelsSizeZ(); }
 
     /** 
      * Implemented as specified by the {@link Renderer} interface.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -45,6 +45,9 @@ import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.RenderingServiceException;
 import omero.log.LogMessage;
+import omero.model.Length;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
@@ -1093,9 +1096,10 @@ class RendererModel
 	 *
 	 * @return See above.
 	 */
-	double getPixelsSizeY()
+	Length getPixelsSizeY()
 	{ 
-		if (rndControl == null) return -1;
+		if (rndControl == null) 
+		    return new LengthI(1, UnitsLength.PIXEL);
 		return rndControl.getPixelsPhysicalSizeY();
 	}
 
@@ -1104,9 +1108,10 @@ class RendererModel
 	 *
 	 * @return See above.
 	 */
-	double getPixelsSizeX()
+	Length getPixelsSizeX()
 	{
-		if (rndControl == null) return -1;
+		if (rndControl == null) 
+		    return new LengthI(1, UnitsLength.PIXEL);
 		return rndControl.getPixelsPhysicalSizeX();
 	}
 	
@@ -1115,9 +1120,10 @@ class RendererModel
 	 *
 	 * @return See above.
 	 */
-	double getPixelsSizeZ()
+	Length getPixelsSizeZ()
 	{
-		if (rndControl == null) return -1;
+		if (rndControl == null) 
+		    return new LengthI(1, UnitsLength.PIXEL);
 		return rndControl.getPixelsPhysicalSizeZ();
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Map;
 
+import omero.model.Length;
 import omero.romio.PlaneDef;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.RenderingServiceException;
@@ -158,25 +159,25 @@ public interface RenderingControl
     public int getPixelsDimensionsC();
     
     /**
-     * The size in microns of a pixel along the X-axis.
+     * The size of a pixel along the X-axis.
      * 
      * @return See above.
      */
-    public double getPixelsPhysicalSizeX();
+    public Length getPixelsPhysicalSizeX();
     
     /**
-     * The size in microns of a pixel along the Y-axis.
+     * The size of a pixel along the Y-axis.
      * 
      * @return See above.
      */
-    public double getPixelsPhysicalSizeY();
+    public Length getPixelsPhysicalSizeY();
     
     /**
-     * The size in microns of a pixel along the Z-axis.
+     * The size of a pixel along the Z-axis.
      * 
      * @return See above.
      */
-    public double getPixelsPhysicalSizeZ();
+    public Length getPixelsPhysicalSizeZ();
 
     /**
      * Specifies the model that dictates how transformed raw data has to be 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -39,9 +39,12 @@ import omero.LockTimeout;
 import omero.api.RenderingEnginePrx;
 import omero.api.ResolutionDescription;
 import omero.model.Family;
+import omero.model.Length;
+import omero.model.LengthI;
 import omero.model.Pixels;
 import omero.model.QuantumDef;
 import omero.model.RenderingModel;
+import omero.model.enums.UnitsLength;
 import omero.romio.PlaneDef;
 
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -1340,30 +1343,33 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getPixelsPhysicalSizeX()
      */
-    public double getPixelsPhysicalSizeX()
+    public Length getPixelsPhysicalSizeX()
     {
-        if (pixs.getPhysicalSizeX() == null) return 1;
-        return pixs.getPhysicalSizeX().getValue();
+        if (pixs.getPhysicalSizeX() == null) 
+            return new LengthI(1, UnitsLength.PIXEL);
+        return pixs.getPhysicalSizeX();
     }
 
     /** 
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getPixelsPhysicalSizeY()
      */
-    public double getPixelsPhysicalSizeY()
+    public Length getPixelsPhysicalSizeY()
     {
-        if (pixs.getPhysicalSizeY() == null) return 1;
-        return pixs.getPhysicalSizeY().getValue();
+        if (pixs.getPhysicalSizeY() == null) 
+            return new LengthI(1, UnitsLength.PIXEL);
+        return pixs.getPhysicalSizeY();
     }
 
     /** 
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getPixelsPhysicalSizeZ()
      */
-    public double getPixelsPhysicalSizeZ()
+    public Length getPixelsPhysicalSizeZ()
     {
-        if (pixs.getPhysicalSizeZ() == null) return 1;
-        return pixs.getPhysicalSizeZ().getValue();
+        if (pixs.getPhysicalSizeZ() == null) 
+            return new LengthI(1, UnitsLength.PIXEL);
+        return pixs.getPhysicalSizeZ();
     }
 
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.lensComponent.java
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,7 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.filechooser.FileFilter;
 
+import omero.model.Length;
 import org.openmicroscopy.shoola.util.filter.file.BMPFilter;
 import org.openmicroscopy.shoola.util.filter.file.CustomizedFileFilter;
 import org.openmicroscopy.shoola.util.filter.file.JPEGFilter;
@@ -320,7 +321,7 @@ public class LensComponent
 	 * @param x mapping in x axis.
 	 * @param y mapping in y axis.
 	 */
-	public void setXYPixelMicron(double  x, double y)
+	public void setXYPixelMicron(Length  x, Length y)
 	{
 		zoomWindow.setXYPixelMicron(x, y);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.ZoomWindow.java
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -35,6 +35,11 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLayeredPane;
 import javax.swing.JMenuBar;
+
+import ome.model.units.BigResult;
+import omero.model.Length;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 
 //Third-party libraries
 
@@ -146,9 +151,14 @@ class ZoomWindow
 	 * @param x mapping in x axis.
 	 * @param y mapping in y axis.
 	 */
-	void setXYPixelMicron(double x, double y) 
+	void setXYPixelMicron(Length x, Length y) 
 	{
-		statusPanel.setXYPixelMicron(x, y);
+	    try {
+            Length x1 = new LengthI(x, UnitsLength.MICROMETER);
+            Length y1 = new LengthI(y, UnitsLength.MICROMETER);
+            statusPanel.setXYPixelMicron(x1.getValue(), y1.getValue());
+        } catch (BigResult e) {
+        }
 		statusPanel.repaint();
 	}
 	


### PR DESCRIPTION
With this PR the Unit objects for pixel sizes will be used directly in the scope of the image viewer, instead of constraining everything to micrometers.

This fixes also the scalebar problem in [Ticket 13035](http://trac.openmicroscopy.org/ome/ticket/13035)

Test: Open some images which use nm as default unit, e. g. the image mentioned in the ticket (nightshade image id 4045578 ) and make sure the scalebar is drawn (and labelled) correctly.
Note: Even the pixel size is reported in nm (on the 'General' tab) the scalebar unit doesn't have to be in nm, it should be a reasonable unit.

--no-rebase
