### PR TITLE
fix small typo in web configuration message

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -382,7 +382,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["APPLICATION_SERVER_PORT", 4080, int, "Upstream application port"],
     "omero.web.application_server.max_requests":
         ["APPLICATION_SERVER_MAX_REQUESTS", 0, int,
-         ("The maximum number ofrequests a worker will process before "
+         ("The maximum number of requests a worker will process before "
           "restarting.")],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",


### PR DESCRIPTION
Spotted in reviewing https://github.com/openmicroscopy/ome-documentation/pull/1287.

--rebased-to #4211
cc: @sbesson