### PR TITLE
fix small typo in web configuration message (rebased from dev_5_1)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -382,7 +382,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["APPLICATION_SERVER_PORT", 4080, int, "Upstream application port"],
     "omero.web.application_server.max_requests":
         ["APPLICATION_SERVER_MAX_REQUESTS", 0, int,
-         ("The maximum number ofrequests a worker will process before "
+         ("The maximum number of requests a worker will process before "
           "restarting.")],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",


### PR DESCRIPTION
Spotted in reviewing openmicroscopy/ome-documentation#1287.

--rebased-from #4210
cc: @sbesson