### PR TITLE
Roi text background

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.util.roi.drawingtools.figures.BezierTextFigure 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -22,8 +22,6 @@
  */
 package org.openmicroscopy.shoola.util.ui.drawingtools.figures;
 
-
-//Java imports
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -36,7 +34,6 @@ import java.awt.geom.Rectangle2D;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 
-//Third-party libraries
 import org.jhotdraw.draw.AttributeKeys;
 import org.jhotdraw.draw.BezierFigure;
 import org.jhotdraw.draw.TextHolderFigure;
@@ -44,8 +41,6 @@ import org.jhotdraw.draw.Tool;
 import org.jhotdraw.geom.BezierPath;
 import org.jhotdraw.geom.Insets2D;
 
-//Application-internal dependencies
-import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.drawingtools.attributes.DrawingAttributes;
 import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
 
@@ -178,7 +173,7 @@ public class BezierTextFigure
 				layout.draw(g, (float) x, (float) y);
 				y += layout.getDescent()+layout.getLeading();
 			}
-		}	
+		}
 	}
 
 	/** 
@@ -349,5 +344,3 @@ public class BezierTextFigure
 	}
 
 }
-
-

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
@@ -169,16 +169,7 @@ public class BezierTextFigure
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
 			// draw
-			g.setColor(UIUtilities.TOOLTIP_COLOR);
-			g.fillRect((int) x-1, (int) textBounds.getY(),
-					(int) textBounds.getWidth()+2,
-					(int) textBounds.getHeight()+1);
 			g.setColor(FigureUtil.TEXT_COLOR);
-			/*
-			g.drawRect((int) x-1, (int) textBounds.getY(),
-					(int) textBounds.getWidth()+2,
-					(int) textBounds.getHeight()+1);
-					*/
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/BezierTextFigure.java
@@ -1,7 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.roi.drawingtools.figures.BezierTextFigure 
- *
-  *------------------------------------------------------------------------------
+ *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
@@ -52,9 +50,6 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class BezierTextFigure
@@ -164,7 +159,10 @@ public class BezierTextFigure
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
 			// draw
-			g.setColor(FigureUtil.TEXT_COLOR);
+			Color c = AttributeKeys.STROKE_COLOR.get(this);
+			if (c != null) {
+			    g.setColor(c);
+			}
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/EllipseTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/EllipseTextFigure.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.drawingtools.figures.EllipseTextFigure 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
@@ -60,9 +58,6 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.TransformedDrawi
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class EllipseTextFigure
@@ -265,6 +260,10 @@ public class EllipseTextFigure
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
 			// draw
+			Color c = AttributeKeys.STROKE_COLOR.get(this);
+			if (c != null) {
+			    g.setColor(c);
+			}
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {
@@ -273,7 +272,7 @@ public class EllipseTextFigure
 				layout.draw(g, (float) x, (float) y);
 				y += layout.getDescent()+layout.getLeading();
 			}
-		}	
+		}
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/LineConnectionTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/LineConnectionTextFigure.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.drawingtools.figures.LineConnectionTextFigure 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
@@ -51,9 +49,6 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class LineConnectionTextFigure 
@@ -148,6 +143,10 @@ public class LineConnectionTextFigure
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
 			// draw
+			Color c = AttributeKeys.STROKE_COLOR.get(this);
+			if (c != null) {
+			    g.setColor(c);
+			}
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/LineTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/LineTextFigure.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.drawingtools.figures.LineTextFigure 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
@@ -51,8 +49,7 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
- * @version 3.0 <small> (<b>Internal version:</b> $Revision: $Date: $)
- *          </small>
+ * @version 3.0
  * @since OME3.0
  */
 public class LineTextFigure 
@@ -156,6 +153,10 @@ public class LineTextFigure
 			AttributedCharacterIterator i = styledText.getIterator();
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
+			Color c = AttributeKeys.STROKE_COLOR.get(this);
+			if (c != null) {
+			    g.setColor(c);
+			}
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/PointTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/PointTextFigure.java
@@ -1,7 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.ui.drawingtools.figures.PointTextFigure 
- *
-  *------------------------------------------------------------------------------
+ *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
@@ -52,9 +50,6 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class PointTextFigure
@@ -143,6 +138,10 @@ public class PointTextFigure
 				AttributedCharacterIterator i = styledText.getIterator();
 				LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
+				Color c = AttributeKeys.STROKE_COLOR.get(this);
+				if (c != null) {
+				    g.setColor(c);
+				}
 				int w = (int) width;
 				TextLayout layout;
 				while (measurer.getPosition() < text.length()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/RectangleTextFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/RectangleTextFigure.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.drawingtools.figures.RectangleTextFigure 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
@@ -53,8 +51,7 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.texttools.DrawingTextTool;
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
- * @version 3.0 <small> (<b>Internal version:</b> $Revision: $Date: $)
- *          </small>
+ * @version 3.0
  * @since OME3.0
  */
 public class RectangleTextFigure 
@@ -227,6 +224,10 @@ public class RectangleTextFigure
 			LineBreakMeasurer measurer = new LineBreakMeasurer(i, frc);
 
 			// draw
+            Color c = AttributeKeys.STROKE_COLOR.get(this);
+            if (c != null) {
+                g.setColor(c);
+            }
 			int w = (int) width;
 			TextLayout layout;
 			while (measurer.getPosition() < text.length()) {


### PR DESCRIPTION
Remove the "yellow" background when displaying comment on some rois.
 
To test:
 * Draw a polygon or polyline
 * Add a comment
 * Make sure that no "yellow" rectangle is displayed.

cc @bramalingam 