### PR TITLE
Add `omero admin checkupgrade`

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -54,6 +54,8 @@ except ImportError:
 
 DEFAULT_WAIT = 300
 
+CHECKUPGRADE_USERAGENT = "test"
+
 HELP = """Administrative tools including starting/stopping OMERO.
 
 Environment variables:
@@ -1794,12 +1796,11 @@ OMERO Diagnostics %s
         """
 
         config = config.as_map()
-        agent = 'server'
         upgrade_url = config.get("omero.upgrades.url", None)
         if upgrade_url:
-            uc = UpgradeCheck(agent, url=upgrade_url)
+            uc = UpgradeCheck(CHECKUPGRADE_USERAGENT, url=upgrade_url)
         else:
-            uc = UpgradeCheck(agent)
+            uc = UpgradeCheck(CHECKUPGRADE_USERAGENT)
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1794,9 +1794,12 @@ OMERO Diagnostics %s
         """
 
         config = config.as_map()
-        upgrade_url = config.get(
-            "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
-        uc = UpgradeCheck('server', url=upgrade_url)
+        agent = 'server'
+        upgrade_url = config.get("omero.upgrades.url", None)
+        if upgrade_url:
+            uc = UpgradeCheck(agent, url=upgrade_url)
+        else:
+            uc = UpgradeCheck(agent)
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1794,7 +1794,7 @@ OMERO Diagnostics %s
         """
 
         config = config.as_map()
-        url = config.get(
+        upgrade_url = config.get(
             "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
         uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1795,7 +1795,7 @@ OMERO Diagnostics %s
 
         config = config.as_map()
         url = config.get(
-            "omero.ugprades.url", "http://upgrade.openmicroscopy.org.uk")
+            "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
         uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()
         if uc.isUpgradeNeeded():

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1791,8 +1791,10 @@ OMERO Diagnostics %s
     @with_config
     def checkupgrade(self, args, config):
         """
-        Checks whether a server upgrade is available,
-        exits with return code 1 if yes
+        Checks whether a server upgrade is available, exits with return code
+        0: this is the latest version
+        1: an upgrade is available
+        2: an error occurred whilst checking
         """
 
         config = config.as_map()
@@ -1804,6 +1806,8 @@ OMERO Diagnostics %s
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())
+        if uc.isExceptionThrown():
+            self.ctx.die(2, uc.getExceptionThrown())
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -35,6 +35,8 @@ from omero.cli import UserGroupControl
 from omero.plugins.prefs import \
     WriteableConfigControl, with_config, with_rw_config
 
+from omero.util.upgrade_check import UpgradeCheck
+
 from omero_ext import portalocker
 from omero_ext.which import whichall
 from omero_ext.argparse import FileType
@@ -396,6 +398,9 @@ location.
         Action("checkice", "Run simple check of the Ice installation")
 
         Action("events", "Print event log (Windows-only)")
+
+        Action(
+            "checkupgrade", "Check whether a server upgrade is available")
 
         self.actions["ice"].add_argument(
             "argument", nargs="*",
@@ -1780,6 +1785,17 @@ OMERO Diagnostics %s
     def _get_data_dir(self, config):
         config = config.as_map()
         return config.get("omero.data.dir", "/OMERO")
+
+    def checkupgrade(self, args):
+        """
+        Checks whether a server upgrade is available,
+        exits with return code 1 if yes
+        """
+        uc = UpgradeCheck('server')
+        uc.run()
+        if uc.isUpgradeNeeded():
+            self.ctx.die(1, uc.getUpgradeUrl())
+
 
 try:
     register("admin", AdminControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1786,12 +1786,17 @@ OMERO Diagnostics %s
         config = config.as_map()
         return config.get("omero.data.dir", "/OMERO")
 
-    def checkupgrade(self, args):
+    @with_config
+    def checkupgrade(self, args, config):
         """
         Checks whether a server upgrade is available,
         exits with return code 1 if yes
         """
-        uc = UpgradeCheck('server')
+
+        config = config.as_map()
+        url = config.get(
+            "omero.ugprades.url", "http://upgrade.openmicroscopy.org.uk")
+        uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())

--- a/components/tools/OmeroPy/test/integration/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_admin.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import pytest
+
+from test.integration.clitest.cli import CLITest
+import omero.plugins.admin
+from omero.cli import NonZeroReturnCode
+from path import path
+from omero.util.upgrade_check import UpgradeCheck
+
+
+def createUpgradeCheckClass(version):
+    class MockUpgradeCheck(UpgradeCheck):
+        def __init__(self, agent, url=None):
+            if url:
+                super(MockUpgradeCheck, self).__init__(
+                    agent, url, version=version)
+            else:
+                super(MockUpgradeCheck, self).__init__(agent, version=version)
+
+    return MockUpgradeCheck
+
+
+class TestAdmin(CLITest):
+
+    def setup_method(self, method):
+        super(TestAdmin, self).setup_method(method)
+        self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
+        # omero needs the etc/grid directory
+        self.cli.dir = (path(__file__).dirname()
+                        / ".." / ".." / ".." / ".." / ".." / ".." / "dist")
+        self.args += ["admin"]
+
+    def go(self):
+        self.cli.invoke(self.args, strict=True)
+        return self.cli.get("tx.state")
+
+    def test_checkupgrade0(self, monkeypatch):
+        monkeypatch.setattr(omero.plugins.admin, "UpgradeCheck",
+                            createUpgradeCheckClass("999999999.0.0"))
+        self.args.append("checkupgrade")
+        self.go()
+
+    def test_checkupgrade1(self, monkeypatch):
+        monkeypatch.setattr(omero.plugins.admin, "UpgradeCheck",
+                            createUpgradeCheckClass("0.0.0"))
+        self.args.append("checkupgrade")
+        with pytest.raises(NonZeroReturnCode) as exc:
+            self.go()
+        assert exc.value.rv == 1

--- a/components/tools/OmeroPy/test/integration/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_admin.py
@@ -53,7 +53,6 @@ class TestAdmin(CLITest):
 
     def go(self):
         self.cli.invoke(self.args, strict=True)
-        return self.cli.get("tx.state")
 
     def test_checkupgrade0(self, monkeypatch):
         monkeypatch.setattr(omero.plugins.admin, "UpgradeCheck",


### PR DESCRIPTION
Add `omero admin checkupgrade`

This allows scripts to automatically determine whether an updated server is available. Sets exit code 1 if so. To test.... you'll have to override the current server version somehow, or trust the integration test.

If you want to be thorough check an invalid `omero.upgrades.url` sets an exit code that's not 0 or 1.

~~TODO. Since this is going in to 5.2 should we set a specific agent to distinguish upgrade checks from server startups. e.g. `OMERO.status`, `OMERO.upgrade`, ... ?~~