### PR TITLE
Selection browser

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
@@ -673,7 +673,7 @@ class BrowserModel
 		//Note: avoid caching b/c we don't know yet what we are going
 		//to do with updates
 	    ImageFinder finder = new ImageFinder();
-	    accept(finder, ImageDisplayVisitor.ALL_NODES);
+	    accept(finder, ImageDisplayVisitor.IMAGE_SET_ONLY);
 	    return new ArrayList<ImageNode>(finder.getVisibleImageNodes());
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
@@ -48,59 +48,59 @@ public class ImageFinder
 {
 
     /** Set of <code>ImageNode</code>s */
-    private Set<ImageDisplay>	imageNodes;
-    
+    private Set<ImageDisplay> imageNodes;
+
     /** Set of corresponding <code>DataObject</code>s */
-    private Set<DataObject>		images;
-    
+    private Set<DataObject> images;
+
     /** Set of <code>ImageNode</code>s */
-    private Set<ImageNode>		visibleImageNodes;
-    
+    private Set<ImageNode> visibleImageNodes;
+
     /** Set of corresponding visible <code>DataObject</code>s */
-    private Set<DataObject>		visibleImages;
-    
+    private Set<DataObject> visibleImages;
+
     /** Creates a new instance. */
     public ImageFinder()
     {
-    	 images = new HashSet<DataObject>();
-         imageNodes = new HashSet<ImageDisplay>();
-         visibleImages = new HashSet<DataObject>();
-         visibleImageNodes = new HashSet<ImageNode>();
+        images = new HashSet<DataObject>();
+        imageNodes = new HashSet<ImageDisplay>();
+        visibleImages = new HashSet<DataObject>();
+        visibleImageNodes = new HashSet<ImageNode>();
     }
-   
-    /** 
-     * Returns the set of {@link ImageNode}s displayed. 
-     * 
+
+    /**
+     * Returns the set of {@link ImageNode}s displayed.
+     *
      * @return See above.
      */
     public Set<ImageDisplay> getImageNodes() { return imageNodes; }
-    
+
     /** 
-     * Returns the set of corresponding <code>DataObject</code>s. 
-     * 
+     * Returns the set of corresponding <code>DataObject</code>s.
+     *
      * @return See above.
      */
     public Set<DataObject> getImages() { return images; }
-    
-    /** 
-     * Returns the set of {@link ImageNode}s displayed. 
-     * 
+
+    /**
+     * Returns the set of {@link ImageNode}s displayed.
+     *
      * @return See above.
      */
     public Set<ImageNode> getVisibleImageNodes()
     { 
-    	return visibleImageNodes; 
+        return visibleImageNodes;
     }
-    
-    /** 
-     * Returns the set of visible <code>DataObject</code>s. 
-     * 
+
+    /**
+     * Returns the set of visible <code>DataObject</code>s.
+     *
      * @return See above.
      */
     public Set<DataObject> getVisibleImages() { return visibleImages; }
-    
-    /** 
-     * Implemented as specified by {@link ImageDisplayVisitor}. 
+
+    /**
+     * Implemented as specified by {@link ImageDisplayVisitor}.
      * @see ImageDisplayVisitor#visit(ImageNode)
      */
     public void visit(ImageNode node)
@@ -109,13 +109,13 @@ public class ImageFinder
         visibleImageNodes.add(node);
         Object ho = node.getHierarchyObject();
         if (ho instanceof WellSampleData) {
-        	WellSampleData wsd = (WellSampleData) ho;
-        	ho = wsd.getImage();
+            WellSampleData wsd = (WellSampleData) ho;
+            ho = wsd.getImage();
         }
         if (ho instanceof ImageData) images.add((ImageData) ho);
     }
 
-    /** 
+    /**
      * Implemented as specified by {@link ImageDisplayVisitor}.
      * @see ImageDisplayVisitor#visit(ImageSet)
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/ImageFinder.java
@@ -116,42 +116,40 @@ public class ImageFinder
     }
 
     /** 
-     * Implemented as specified by {@link ImageDisplayVisitor}. 
+     * Implemented as specified by {@link ImageDisplayVisitor}.
      * @see ImageDisplayVisitor#visit(ImageSet)
      */
     public void visit(ImageSet node)
     {
-    	if (node == null) return;
-    	//if (node.containsImages()) {
-    		JComponent desktop = node.getInternalDesktop();
-    		Component[] comps = desktop.getComponents();
-    		if (comps != null) {
-    			Component c;
-    			ImageNode n;
-    			Object ho;
-    			WellSampleData wsd;
-    			for (int i = 0; i < comps.length; i++) {
-					c = comps[i];
-					if (c instanceof ImageNode) {
-						n = (ImageNode) c;
-						ho = n.getHierarchyObject();
-						if (ho instanceof WellSampleData) {
-				        	wsd = (WellSampleData) ho;
-				        	ho = wsd.getImage();
-				        } else if (ho instanceof ImageData) {
-							visibleImages.add((ImageData) ho);
-							visibleImageNodes.add(n);
-						} else if (ho instanceof FileData) {
-							visibleImages.add((FileData) ho);
-							visibleImageNodes.add(n);
-						} else if (ho instanceof ExperimenterData) {
-							visibleImages.add((ExperimenterData) ho);
-							visibleImageNodes.add(n);
-						}
-					}
-				}
-    		}
-    	//}
+        if (node == null) return;
+        JComponent desktop = node.getInternalDesktop();
+        Component[] comps = desktop.getComponents();
+        if (comps != null) {
+            Component c;
+            ImageNode n;
+            Object ho;
+            WellSampleData wsd;
+            for (int i = 0; i < comps.length; i++) {
+                c = comps[i];
+                if (c instanceof ImageNode) {
+                    n = (ImageNode) c;
+                    ho = n.getHierarchyObject();
+                    if (ho instanceof WellSampleData) {
+                        wsd = (WellSampleData) ho;
+                        ho = wsd.getImage();
+                    } else if (ho instanceof ImageData) {
+                        visibleImages.add((ImageData) ho);
+                        visibleImageNodes.add(n);
+                    } else if (ho instanceof FileData) {
+                        visibleImages.add((FileData) ho);
+                        visibleImageNodes.add(n);
+                    } else if (ho instanceof ExperimenterData) {
+                        visibleImages.add((ExperimenterData) ho);
+                        visibleImageNodes.add(n);
+                    }
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fix selection problem noticed by @mporter-gre 
Nodes not visible in central panel were still selected in tree
to test this PR:
 * log in as user-3
 * Browse dataset non-archivedv
 * in central panel, filter by name using for example R3D.
 * 6 images out of 9 should be displayed.
 * Select all 6 in the central panel
 * Check that  the image ```/home/hudson/for_import_to_howe/non-archived-imoprt-case/user-3/read-only-1/no_projects/non-archivedv/off_by_1_a.dv``` is not selected in the tree. It is not visible in the central panel.

cc @pwalczysko 