### PR TITLE
Formatting timestamps (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -263,11 +263,11 @@ def timeformat(value):
         return u'%d\u00A0\u00B5s' % (round(value * 1000 * 1000))
     elif value < 1:
         return u'%d\u00A0ms' % (round(value * 1000))
-    elif value < 60:
+    elif round(value) < 60:
         # Round and format seconds to one decimal place
         value = round(value * 10) / 10
         return u'%0.1f\u00A0s' % value
-    elif value < 60 * 60:
+    elif round(value) < 60 * 60:
         value = round(value)        # Avoids '1min 60s'
         return u'%d\u00A0min\u00A0%d\u00A0s' % (value / 60, value % 60)
     else:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -256,7 +256,7 @@ def timeformat(value):
             value = Decimal(force_unicode(float(value)))
         except (ValueError, InvalidOperation, TypeError, UnicodeEncodeError):
             return u'%s s' % str(value)
-    # String formatting shows integer values for all, so we round() for accuracy
+    # Formatting shows integer values for all, so we round() for accuracy
     if value == 0:
         return u'%d\u00A0s' % value
     if value < Decimal("0.001"):
@@ -270,4 +270,5 @@ def timeformat(value):
         return u'%d\u00A0min\u00A0%d\u00A0s' % (value / 60, value % 60)
     else:
         value = round(value)        # Avoids '1h 60min'
-        return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600, round((value % 3600)/60))
+        return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600,
+                                                round((value % 3600)/60))

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -264,7 +264,9 @@ def timeformat(value):
     elif value < 1:
         return u'%d\u00A0ms' % (round(value * 1000))
     elif value < 60:
-        return u'%d\u00A0s' % (round(value))
+        # Round and format seconds to one decimal place
+        value = round(value * 10) / 10
+        return u'%0.1f\u00A0s' % value
     elif value < 60 * 60:
         value = round(value)        # Avoids '1min 60s'
         return u'%d\u00A0min\u00A0%d\u00A0s' % (value / 60, value % 60)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -258,7 +258,7 @@ def timeformat(value):
             return u'%s s' % str(value)
     if value == 0:
         return u'%d\u00A0s' % value
-    if value < 1.0 / 1000:
+    if value < Decimal("0.001"):
         return u'%d\u00A0\u00B5s' % (value * 1000 * 1000)
     elif value < 1:
         return u'%d\u00A0ms' % (value * 1000)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -256,15 +256,18 @@ def timeformat(value):
             value = Decimal(force_unicode(float(value)))
         except (ValueError, InvalidOperation, TypeError, UnicodeEncodeError):
             return u'%s s' % str(value)
+    # String formatting shows integer values for all, so we round() for accuracy
     if value == 0:
         return u'%d\u00A0s' % value
     if value < Decimal("0.001"):
-        return u'%d\u00A0\u00B5s' % (value * 1000 * 1000)
+        return u'%d\u00A0\u00B5s' % (round(value * 1000 * 1000))
     elif value < 1:
-        return u'%d\u00A0ms' % (value * 1000)
+        return u'%d\u00A0ms' % (round(value * 1000))
     elif value < 60:
-        return u'%d\u00A0s' % value
+        return u'%d\u00A0s' % (round(value))
     elif value < 60 * 60:
+        value = round(value)        # Avoids '1min 60s'
         return u'%d\u00A0min\u00A0%d\u00A0s' % (value / 60, value % 60)
     else:
+        value = round(value)        # Avoids '1h 60min'
         return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600, round((value % 3600)/60))

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -267,4 +267,4 @@ def timeformat(value):
     elif value < 60 * 60:
         return u'%d\u00A0min\u00A0%d\u00A0s' % (value / 60, value % 60)
     else:
-        return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600, value % 3600)
+        return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600, round((value % 3600)/60))


### PR DESCRIPTION

This is the same as gh-4131 but rebased onto develop.

----

This fixes a bug in python 2.6 when comparing Decimal with floats and also other bugs in the calculation of times for formatting.
https://trac.openmicroscopy.org/ome/ticket/13016

To test, user trout (python 2.6).
 - Find Image 24551 (user-3), which has timepoints every 5 minutes.
 - Look at Delta T times, Under POL channel on Acquisition tab.
 - Should see human readable time values.
 - Check that with timestamps over an hour, that minutes are shown correctly (don't go over 59!)
 - We also round() the numbers before truncating to integers for display, but the only way to see the original values is to download the log file.

Before:
![screen shot 2015-09-04 at 10 51 10](https://cloud.githubusercontent.com/assets/900055/9681059/19f0bbda-52f3-11e5-9aee-8acb67018fdb.png)

After:
![screen shot 2015-09-04 at 11 11 06](https://cloud.githubusercontent.com/assets/900055/9681416/b7afec9a-52f5-11e5-82c7-1af03a377129.png)



                