### PR TITLE
Right panel fileanns slow 13022 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4581,6 +4581,10 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
 
     OMERO_TYPE = FileAnnotationI
 
+    def __init__(self, *args, **kwargs):
+        super(FileAnnotationWrapper, self).__init__(*args, **kwargs)
+        self._file = None
+
     _attrs = ('file|OriginalFileWrapper',)
 
     def _getQueryString(self):
@@ -4600,6 +4604,16 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
     def setValue(self, val):
         """ Not implemented """
         pass
+
+    def getFile(self):
+        """
+        Returns an OriginalFileWrapper for the file.
+        Wrapper object will load the file if it isn't already loaded.
+        File is cached to prevent repeated loading of the file.
+        """
+        if self._file is None:
+            self._file = OriginalFileWrapper(self._conn, self._obj.file)
+        return self._file
 
     def setFile(self, originalfile):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -824,8 +824,9 @@ class BlitzObjectWrapper (object):
 
     def _loadAnnotationLinks(self):
         """
-        Loads the annotation links for the object (if not already loaded) and
-        saves them to the object
+        Loads the annotation links and annotations for the object
+        (if not already loaded) and saves them to the object.
+        Also loads file for file annotations.
         """
         # pragma: no cover
         if not hasattr(self._obj, 'isAnnotationLinksLoaded'):
@@ -839,6 +840,7 @@ class BlitzObjectWrapper (object):
                      "fetch l.details.owner join "
                      "fetch l.details.creationEvent "
                      "join fetch l.child as a join fetch a.details.owner "
+                     "left outer join fetch a.file "
                      "join fetch a.details.creationEvent where l.parent.id=%i"
                      % (self.OMERO_CLASS, self._oid))
             links = self._conn.getQueryService().findAllByQuery(

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -308,6 +308,35 @@ def testFileAnnotation(author_testimg_generated, gatewaywrapper):
     assert gateway.getObject("Annotation", annId) is None
 
 
+def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):
+    """ Tests speed of loading file annotations. See PR: 4176 """
+    tempFileName = "tempFile"
+    f = open(tempFileName, 'w')
+    fileText = "testFileAnnotationSpeed text"
+    f.write(fileText)
+    f.close()
+    ns = TESTANN_NS
+    image = author_testimg_generated
+
+    # use the same file to create many file annotations
+    for i in range(20):
+        fileAnn = gatewaywrapper.gateway.createFileAnnfromLocalFile(
+            tempFileName, mimetype='text/plain', ns=ns)
+        image.linkAnnotation(fileAnn)
+    os.remove(tempFileName)
+
+    now = time.time()
+    for ann in image.listAnnotations():
+        if ann._obj.__class__ == omero.model.FileAnnotationI:
+            # mimmic behaviour of templates which call multiple times
+            print ann.getId()
+            print ann.getFileName()
+            print ann.getFileName()
+            print ann.getFileSize()
+            print ann.getFileSize()
+    print time.time() - now
+
+
 def testFileAnnNonDefaultGroup(author_testimg_generated, gatewaywrapper):
     """ Test conn.createFileAnnfromLocalFile() respects SERVICE_OPTS """
     gatewaywrapper.loginAsAuthor()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -16,6 +16,7 @@
 import time
 import datetime
 import os
+from tempfile import NamedTemporaryFile
 
 import omero.gateway
 
@@ -310,20 +311,19 @@ def testFileAnnotation(author_testimg_generated, gatewaywrapper):
 
 def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):
     """ Tests speed of loading file annotations. See PR: 4176 """
-    tempFileName = "tempFile"
-    f = open(tempFileName, 'w')
-    fileText = "testFileAnnotationSpeed text"
-    f.write(fileText)
-    f.close()
-    ns = TESTANN_NS
-    image = author_testimg_generated
+    try:
+        f = NamedTemporaryFile()
+        f.write("testFileAnnotationSpeed text")
+        ns = TESTANN_NS
+        image = author_testimg_generated
 
-    # use the same file to create many file annotations
-    for i in range(20):
-        fileAnn = gatewaywrapper.gateway.createFileAnnfromLocalFile(
-            tempFileName, mimetype='text/plain', ns=ns)
-        image.linkAnnotation(fileAnn)
-    os.remove(tempFileName)
+        # use the same file to create many file annotations
+        for i in range(20):
+            fileAnn = gatewaywrapper.gateway.createFileAnnfromLocalFile(
+                f.name, mimetype='text/plain', ns=ns)
+            image.linkAnnotation(fileAnn)
+    finally:
+        f.close()
 
     now = time.time()
     for ann in image.listAnnotations():


### PR DESCRIPTION

This is the same as gh-4176 but rebased onto develop.

----

See http://trac.openmicroscopy.org/ome/ticket/13022

This fixes the slow loading of right panel "General" tab when the P/D/I has several file annotations.
Two factors were causing the poor performance:
 - Loading annotations didn't also load the files, so that ann.getFile() created a new ```OriginalFileWrapper``` with an unloaded file, causing the file to be loaded each time on the fly. Now, we include files when loading annotations.
 - Further poor performance was caused by not caching the file for the FileAnnotationWrapper, so that repeated calls to getName() or getFileSize() were loading the file each time. We now cache the file in ann.getFile()

To test:
 - Compare loading speed of right panel for P/D/I with lots of file annotations vv none. Should be about the same.

                