### PR TITLE
DnD autoscroll fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/DataObjectUpdater.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/DataObjectUpdater.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.treeviewer.DataObjectUpdater
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import omero.gateway.SecurityContext;
+import omero.gateway.model.DataObject;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 
@@ -173,8 +174,18 @@ public class DataObjectUpdater
      */
     public void handleResult(Object result)
     {
-        if (viewer.getState() == TreeViewer.DISCARDED) return;  //Async cancel.
-        viewer.onNodesMoved();
+        if (viewer.getState() == TreeViewer.DISCARDED)
+            return; // Async cancel.
+        DataObject target = null;
+        if (Map.class.isAssignableFrom(result.getClass())) {
+            Map m = (Map) result;
+            if (m.size() == 1) {
+                Object obj = m.keySet().iterator().next();
+                if (DataObject.class.isAssignableFrom(obj.getClass()))
+                    target = (DataObject) obj;
+            }
+        }
+        viewer.onNodesMoved(target);
     }
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -842,8 +842,10 @@ public interface TreeViewer
 	/** 
 	 * Refreshes the view when nodes have been <code>Cut/Paste</code> or
 	 * <code>Copy/Paste</code>. 
+	 * 
+	 * @param target The target node (can be <code>null</code>)
 	 */
-	public void onNodesMoved();
+	public void onNodesMoved(DataObject target);
 
 	/** Displays the tag wizard. */
 	public void showTagWizard();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3561,9 +3561,9 @@ class TreeViewerComponent
 	
 	/**
 	 * Implemented as specified by the {@link TreeViewer} interface.
-	 * @see TreeViewer#onNodesMoved()
+	 * @see TreeViewer#onNodesMoved(DataObject)
 	 */
-	public void onNodesMoved()
+	public void onNodesMoved(DataObject target)
 	{
 		if (model.getState() != SAVE) return;
 		model.setState(READY);
@@ -3574,7 +3574,7 @@ class TreeViewerComponent
 		DataBrowserFactory.discardAll();
 		
 		Browser browser = model.getSelectedBrowser();
-		browser.refreshTree(null, null);
+		browser.refreshTree(null, target);
 		model.getMetadataViewer().setRootObject(null, -1, null);
 		setStatus(false, "", true);
 		view.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
@@ -3588,12 +3588,12 @@ class TreeViewerComponent
 	{
 		if (model.getState() == DISCARDED) return;
 		if (deleted == null || deleted.size() == 0) {
-			onNodesMoved();
+			onNodesMoved(null);
 			return;
 		}
 		NotDeletedObjectDialog nd = new NotDeletedObjectDialog(view, deleted);
 		if (nd.centerAndShow() == NotDeletedObjectDialog.CLOSE)
-			onNodesMoved();
+			onNodesMoved(null);
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3587,7 +3587,7 @@ class TreeViewerComponent
 	public void onNodesDeleted(Collection<DataObject> deleted)
 	{
 		if (model.getState() == DISCARDED) return;
-		if (deleted == null || deleted.size() == 0) {
+		if (CollectionUtils.isEmpty(deleted)) {
 			onNodesMoved(null);
 			return;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
@@ -23,18 +23,15 @@ package org.openmicroscopy.shoola.agents.util.browser;
 import java.awt.Color;
 import java.awt.Font;
 import java.io.File;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
-
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
@@ -95,7 +92,7 @@ import omero.gateway.model.TagAnnotationData;
  * @since OME2.2
  */
 public abstract class TreeImageDisplay
-    extends DefaultMutableTreeNode implements Serializable
+    extends DefaultMutableTreeNode
 {
     
     /** Identifies the <code>plain</code> style constant. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeImageDisplay.java
@@ -23,15 +23,18 @@ package org.openmicroscopy.shoola.agents.util.browser;
 import java.awt.Color;
 import java.awt.Font;
 import java.io.File;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
@@ -92,7 +95,7 @@ import omero.gateway.model.TagAnnotationData;
  * @since OME2.2
  */
 public abstract class TreeImageDisplay
-    extends DefaultMutableTreeNode
+    extends DefaultMutableTreeNode implements Serializable
 {
     
     /** Identifies the <code>plain</code> style constant. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/DnDTree.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/DnDTree.java
@@ -165,44 +165,39 @@ public class DnDTree
     /** The data currently dragged */
     private List<TreeImageDisplay> toTransfer = new ArrayList<TreeImageDisplay>();
     
-	/** 
-	 * Sets the cursor depending on the selected node.
-	 * 
-	 * @param node The destination node.
-	 * @param transferable The object hosting the nodes to move.
-	 */
-	private void handleMouseOver(TreeImageDisplay node,
-			Transferable transferable)
-	{
-	    TreeImageDisplay parent = node;
+    /**
+     * Sets the cursor depending on the selected node.
+     * 
+     * @param node
+     *            The destination node.
+     * @param transferable
+     *            The object hosting the nodes to move.
+     */
+    private void handleMouseOver(TreeImageDisplay node,
+            Transferable transferable) {
+        TreeImageDisplay parent = node;
         if (node.isLeaf() && node instanceof TreeImageNode) {
             parent = (TreeImageDisplay) node.getParent();
         }
         Object ot = parent.getUserObject();
-        /*
-        if (ot instanceof GroupData && !administrator) {
-            setCursor(createCursor());
-            dropAllowed = false;
-            return;
-        }
-        */
-        if (!canLink(ot) &&
-                !(ot instanceof ExperimenterData || ot instanceof GroupData)) {
+        if (!canLink(ot)
+                && !(ot instanceof ExperimenterData || ot instanceof GroupData)) {
             dropAllowed = false;
             setCursor(createCursor());
             return;
         }
-        //Now check that the src and target are compatible.
+        // Now check that the src and target are compatible.
         try {
             List<TreeImageDisplay> nodes = new ArrayList<TreeImageDisplay>();
             nodes.addAll(toTransfer);
-            
-            if (nodes.size() == 0) return;
-            //Check the first node
+
+            if (nodes.size() == 0)
+                return;
+            // Check the first node
             TreeImageDisplay first = nodes.get(0);
             Object child = first.getUserObject();
-            if (ot instanceof GroupData && child instanceof ExperimenterData &&
-                !administrator) {
+            if (ot instanceof GroupData && child instanceof ExperimenterData
+                    && !administrator) {
                 setCursor(createCursor());
                 dropAllowed = false;
                 return;
@@ -210,7 +205,7 @@ public class DnDTree
             List<TreeImageDisplay> list = new ArrayList<TreeImageDisplay>();
             Iterator<TreeImageDisplay> i = nodes.iterator();
             TreeImageDisplay n;
-            
+
             Object os = null;
             int childCount = 0;
             while (i.hasNext()) {
@@ -221,27 +216,28 @@ public class DnDTree
                 } else {
                     if (EditorUtil.isTransferable(ot, os, userID)) {
                         if (ot instanceof GroupData) {
-                            if (os instanceof ExperimenterData &&
-                                    administrator) list.add(n);
+                            if (os instanceof ExperimenterData && administrator)
+                                list.add(n);
                             else {
-                                if (canLink(os)) list.add(n);
+                                if (canLink(os))
+                                    list.add(n);
                             }
                         } else {
-                            if (canLink(os)) 
+                            if (canLink(os))
                                 list.add(n);
                         }
                     }
                 }
             }
-            if (childCount == nodes.size() || list.size() == 0 ||
-                    (list.size() == 1 && parent == list.get(0))) {
+            if (childCount == nodes.size() || list.size() == 0
+                    || (list.size() == 1 && parent == list.get(0))) {
                 setCursor(createCursor());
                 dropAllowed = false;
             }
         } catch (Exception e) {
             dropAllowed = false;
         }
-	}
+    }
 	
 	/**
 	 * Returns <code>true</code> if the user currently logged in is the owner
@@ -269,15 +265,6 @@ public class DnDTree
 	 */
 	private Cursor getCursor(int action)
 	{
-		/*
-		switch (action) {
-			case DnDConstants.ACTION_COPY:
-				return DragSource.DefaultCopyDrop;
-			case DnDConstants.ACTION_MOVE:
-				default:
-				return DragSource.DefaultMoveDrop;
-		}
-		*/
 		return defaultCursor;
 	}
 	
@@ -543,7 +530,7 @@ public class DnDTree
         Point p = dtde.getLocation();
         SwingUtilities.convertPointToScreen(p, this);
 
-        if(lastPosition!=null) {
+        if (lastPosition != null) {
             if (Math.abs(p.x - lastPosition.x) > hysteresis
                     || Math.abs(p.y - lastPosition.y) > hysteresis) {
                 // no autoscroll
@@ -571,14 +558,13 @@ public class DnDTree
         repaint();
 	}
 	
-	/**
-	 * Drops the node and it to its destination.
-	 * {@link DropTargetListener#dragOver(DropTargetDragEvent)}
-	 */
-	public void drop(DropTargetDropEvent dtde)
-	{
-	    timer.stop();
-	    Point dropPoint = dtde.getLocation();
+    /**
+     * Drops the node and it to its destination.
+     * {@link DropTargetListener#dragOver(DropTargetDragEvent)}
+     */
+    public void drop(DropTargetDropEvent dtde) {
+        timer.stop();
+        Point dropPoint = dtde.getLocation();
         TreePath path = getPathForLocation(dropPoint.x, dropPoint.y);
         dropLocation = getRowForPath(path);
         setCursor(defaultCursor);
@@ -594,12 +580,12 @@ public class DnDTree
             return;
         }
         boolean dropped = false;
-        
+
         try {
             dtde.acceptDrop(DnDConstants.ACTION_MOVE);
             List<TreeImageDisplay> nodes = new ArrayList<TreeImageDisplay>();
             nodes.addAll(this.toTransfer);
-            
+
             if (nodes.size() == 0) {
                 dropped = true;
                 dtde.dropComplete(dropped);
@@ -607,20 +593,20 @@ public class DnDTree
                 return;
             }
             TreeImageDisplay parent = null;
-            DefaultMutableTreeNode dropNode =
-                (DefaultMutableTreeNode) path.getLastPathComponent();
-            //if (dropNode instanceof TreeImageDisplay) {
-                if (dropNode instanceof TreeImageDisplay)
-                    parent = (TreeImageDisplay) dropNode;
-                if (dropNode.isLeaf() && dropNode instanceof TreeImageNode) {
-                    parent = (TreeImageDisplay) dropNode.getParent();
-                }
-                int action = DnDConstants.ACTION_MOVE;
-                ObjectToTransfer transfer = new ObjectToTransfer(parent, nodes, 
-                        action);
-                firePropertyChange(DRAGGED_PROPERTY, null, transfer);
-                this.toTransfer.clear();
-            //}
+            DefaultMutableTreeNode dropNode = (DefaultMutableTreeNode) path
+                    .getLastPathComponent();
+            // if (dropNode instanceof TreeImageDisplay) {
+            if (dropNode instanceof TreeImageDisplay)
+                parent = (TreeImageDisplay) dropNode;
+            if (dropNode.isLeaf() && dropNode instanceof TreeImageNode) {
+                parent = (TreeImageDisplay) dropNode.getParent();
+            }
+            int action = DnDConstants.ACTION_MOVE;
+            ObjectToTransfer transfer = new ObjectToTransfer(parent, nodes,
+                    action);
+            firePropertyChange(DRAGGED_PROPERTY, null, transfer);
+            this.toTransfer.clear();
+            // }
             dropped = true;
         } catch (Exception e) {
             try {
@@ -631,7 +617,7 @@ public class DnDTree
         }
         dtde.dropComplete(dropped);
         repaint();
-	}
+    }
 	
 	/**
 	 * Starts dragging the node.
@@ -687,11 +673,6 @@ public class DnDTree
 	 */
 	public void dragDropEnd(DragSourceDropEvent dsde)
 	{
-		if (dsde.getDropSuccess() &&
-				dsde.getDropAction() == DnDConstants.ACTION_MOVE)
-		{
-			//pathSource = null;
-		}
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/TransferableNode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/TransferableNode.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.util.dnd.TransferableNode 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2011 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -30,12 +30,14 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 
+
 //Third-party libraries
 
 //Application-internal dependencies
 
 /** 
- * The object to transfer during the D&D.
+ * This is just a dummy Transferable, have to handle the transferable
+ * data our own, because of Windows DnD issues.
  *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
@@ -44,18 +46,14 @@ import java.io.IOException;
 class TransferableNode 
 	implements Transferable
 {
-	
-	/** The object to transfer.*/
-	private Object object;
-	
+
 	/**
 	 * Creates a new instance.
 	 * 
 	 * @param object The object to transfer.
 	 */
-	TransferableNode (Object object)
+	TransferableNode (String s)
 	{
-		this.object = object; 
 	}
 	
 	/**
@@ -65,7 +63,7 @@ class TransferableNode
 	public Object getTransferData(DataFlavor df)
 		throws UnsupportedFlavorException, IOException
 	{
-	    return object;
+	    return "";
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/TransferableNode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/dnd/TransferableNode.java
@@ -65,8 +65,7 @@ class TransferableNode
 	public Object getTransferData(DataFlavor df)
 		throws UnsupportedFlavorException, IOException
 	{
-		if (isDataFlavorSupported (df)) return object;
-		throw new UnsupportedFlavorException(df);
+	    return object;
 	}
 	
 	/**
@@ -75,7 +74,7 @@ class TransferableNode
 	 */
 	public boolean isDataFlavorSupported(DataFlavor df)
 	{
-		return (df.equals(DnDTree.localFlavor));
+	    return true;
 	}
 	
 	/**


### PR DESCRIPTION
Fixes [Ticket 12959](http://trac.openmicroscopy.org/ome/ticket/12959)

First Workaround:
Autoscrolling while performing drag&drop operations on trees is basically broken, due to various Java bugs which apparently don't get fixed. This PR adds a workaround, which is mainly based on a suggestion in this [stackoverflow post](http://stackoverflow.com/questions/29126758/how-can-i-implement-a-workaround-for-the-autoscroll-during-drag-and-drop-bug-on).
It still doesn't work as neat as is it should be, but at least it works. In order to activate autoscroll, you have to drag an item to the egde of the tree's visible area.

Second Workaround:
DnD on Windows didn't work at all, also several Java issues there (DataFlavor.javaJVMLocalObjectMimeType throws an exception on Windows; objects transfered via Transferables get messed up, ...). With this PR a simple String dummy DataFlavor is used, while the actual data for the DnD action is hold in the the DnDTree itself.

**How to test:** Perform a few drag&drop operations in the left hand side tree, on OSX, Windows and Linux (as the DnD seems to be very platform specific). Cover the case where the tree is quite large, so that your desired drop location is outside of the current visible area. Make sure DnD behaves as expected.

