### PR TITLE
Copy bftools to bin/ with omero (rebased onto metadata)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -731,7 +731,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
     Top-level helpers (shared helpers are in components/antlib/resources)
     =====================================================================
     -->
-    <target name="build-dist" depends="init,copy-licenses,copy-history,copy-etc,copy-sql,copy-server,copy-client,update-version,create-workdirs"
+    <target name="build-dist" depends="init,copy-licenses,copy-history,copy-etc,copy-sql,copy-bftools,copy-server,copy-client,update-version,create-workdirs"
         description="Copy all components to dist/; called at the end of build-* targets"/>
 
     <target name="copy-licenses" depends="init">
@@ -762,6 +762,16 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 <fileset dir="${omero.home}">
                     <include name="sql/**"/>
                 </fileset>
+            </copy>
+    </target>
+
+    <target name="copy-bftools" depends="init">
+            <copy todir="${dist.dir}/bin">
+                <fileset dir="${bioformats.comp}/tools"/>
+            </copy>
+            <chmod dir="${dist.dir}/bin" perm="a+x" includes="*"/>
+            <copy todir="${dist.dir}/bin">
+                <fileset file="${bioformats.comp}/artifacts/bioformats_package.jar"/>
             </copy>
     </target>
 


### PR DESCRIPTION

This is the same as gh-3380 but rebased onto metadata.

----

Briefly discussed with @melissalinkert this PR. In order to clean off of another branch and have a proper discussion, I'm opening as a standalone PR. The goal of this would be to allow testing of the the BF jars built with OMERO by running the standard bftools scripts under bin. E.g.:
```
$ cd dist
$ bin/omero version
5.1.0-m3-ice35-SNAPSHOT
$ touch a.fake
$ bin/bfconvert a.fake a.ome.tiff
a.fake
FakeReader initializing a.fake
[Simulated data] -> a.ome.tiff [OME-TIFF]
        Converted 1/1 planes (100%)
[done]
1.018s elapsed (22.0+496.0ms per plane, 424ms overhead)
```

Originally I had intended to write a wrapper plugin (`bin/omero bf` or similar) but this is a likely much simpler fix.

                