### PR TITLE
Only analyze shapes of current active plane

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -58,7 +58,9 @@ import javax.swing.event.ChangeListener;
 import info.clearthought.layout.TableLayout;
 import org.jdesktop.swingx.JXBusyLabel;
 
+import org.openmicroscopy.shoola.agents.events.measurement.SelectPlane;
 import org.openmicroscopy.shoola.agents.imviewer.IconManager;
+import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ColorModelAction;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ColorPickerAction;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ViewerAction;
@@ -1943,7 +1945,7 @@ class ControlPane
                 controller.setZoomFactor(projectionRatioSlider.getValue());
             }
             if (object.equals(zSlider) || object.equals(tSlider))
-                setSelectedXYPlane(zSlider.getValue(), tSlider.getValue());
+                fireSelectPlaneRequest();
             else if (object.equals(lifetimeSlider)) {
                 controller.setSelectedXYPlane(model.getDefaultZ(),
                         model.getRealSelectedT(), lifetimeSlider.getValue());
@@ -1967,6 +1969,15 @@ class ControlPane
             controller.setProjectionRange(true);
     }
 
+    /**
+     * Fires a request to change the plane
+     */
+    private void fireSelectPlaneRequest() {
+        SelectPlane sp = new SelectPlane(model.getImage().getDefaultPixels()
+                .getId(), zSlider.getValue(), tSlider.getValue());
+        ImViewerAgent.getRegistry().getEventBus().post(sp);
+    }
+    
     /**
      * Reacts to wheels moved event related to the {@link #zSlider},
      * {@link #tSlider}, {@link #zSliderGrid} and {@link #zSliderGrid}.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/Analyser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/Analyser.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -79,10 +79,6 @@ public class Analyser
 			PixelsData pixels, Collection channels, List shapes)
 	{
 		super(viewer, ctx);
-		if (CollectionUtils.isEmpty(channels))
-			throw new IllegalArgumentException("No channels specified.");
-		if (CollectionUtils.isEmpty(shapes))
-			throw new IllegalArgumentException("No shapes specified.");
 		this.pixels = pixels;
 		this.channels = channels;
 		this.shapes = shapes;
@@ -94,7 +90,11 @@ public class Analyser
      */
     public void load()
     {
-    	handle = idView.analyseShapes(ctx, pixels, channels, shapes, this);
+        if (CollectionUtils.isNotEmpty(shapes)
+                && CollectionUtils.isNotEmpty(channels))
+            handle = idView.analyseShapes(ctx, pixels, channels, shapes, this);
+        else
+            viewer.setStatsShapes(null);
     }
     
     /**
@@ -129,9 +129,13 @@ public class Analyser
     
     /**
      * Cancels the data loading.
+     * 
      * @see MeasurementViewerLoader#cancel()
      */
-    public void cancel() { handle.cancel(); }
+    public void cancel() {
+        if (handle != null)
+            handle.cancel();
+    }
     
     /**
      * Feeds the result back to the viewer.
@@ -139,7 +143,8 @@ public class Analyser
      */
     public void handleResult(Object result)
     {
-    	if (viewer.getState() == MeasurementViewer.DISCARDED) return;
+    	if (viewer.getState() == MeasurementViewer.DISCARDED) 
+    	    return;
     	viewer.setStatsShapes((Map) result);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/MeasurementAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/MeasurementAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -31,6 +31,7 @@ import org.openmicroscopy.shoola.agents.events.iviewer.ImageRendered;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurePlane;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurementTool;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewerState;
+import org.openmicroscopy.shoola.agents.events.measurement.SelectPlane;
 import org.openmicroscopy.shoola.agents.events.metadata.ChannelSavedEvent;
 import org.openmicroscopy.shoola.agents.measurement.view.MeasurementViewer;
 import org.openmicroscopy.shoola.agents.measurement.view.MeasurementViewerFactory;
@@ -247,6 +248,20 @@ public class MeasurementAgent
     }
     
     /**
+     * Handles a SelectPlane request
+     * 
+     * @param evt
+     *            The event
+     */
+    private void handleSelectPlaneEvent(SelectPlane evt) {
+        MeasurementViewer viewer = MeasurementViewerFactory.getViewer(null,
+                evt.getPixelsID());
+        if (viewer != null) {
+            viewer.selectPlane(evt.getDefaultZ(), evt.getDefaultT());
+        }
+    }
+    
+    /**
      * Handles the {@link ActivityProcessEvent} event.
      * 
      * @param evt The event to handle.
@@ -332,6 +347,7 @@ public class MeasurementAgent
 		bus.register(this, ActivityProcessEvent.class);
 		bus.register(this, ReconnectedEvent.class);
 		bus.register(this, ChannelSavedEvent.class);
+		bus.register(this, SelectPlane.class);
 	}
 
     /**
@@ -393,6 +409,8 @@ public class MeasurementAgent
 			handleReconnectedEvent((ReconnectedEvent) e);
 		else if (e instanceof ChannelSavedEvent)
 			handleChannelSavedEvent((ChannelSavedEvent) e);
+		else if (e instanceof SelectPlane)
+            handleSelectPlaneEvent((SelectPlane) e);
 	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -572,48 +572,48 @@ public class GraphPane
 		this.ROIStats = model.getAnalysisResults();
 		if (ROIStats == null || ROIStats.size() == 0) {
 			buildHistogramNoSelection();
-			return;
 		}
-		shapeStatsList = new HashMap<Coord3D, Map<StatsType, Map>>();
-		pixelStats = new HashMap<Coord3D, Map<Integer, ROIShapeStatsSimple>>();
-		shapeMap = new HashMap<Coord3D, ROIShape>();
-		channelName = new ArrayList<String>();
-		channelColour = new ArrayList<Color>();
-		Entry entry;
-		Iterator i  = ROIStats.entrySet().iterator();
-        
-		Coord3D c3D;
-		Map<StatsType, Map> shapeStats;
-		Map<Integer, ROIShapeStatsSimple> data;
-		int t = model.getDefaultT();
-		int z = model.getDefaultZ();
-		boolean hasData = false;
-		int cT, cZ;
-		while (i.hasNext())
-		{
-			entry = (Entry) i.next();
-			shape = (ROIShape) entry.getKey();
-			
-			c3D = shape.getCoord3D();
-			cT = c3D.getTimePoint();
-			cZ = c3D.getZSection();
-			
-			if (cT == t && cZ == z) hasData = true;
-			
-			shapeMap.put(c3D, shape);
-			if (shape.getFigure() instanceof MeasureTextFigure)
-				return;
-			shapeStats = AnalysisStatsWrapper.convertStats(
-					(Map) entry.getValue());
-			if (shapeStats != null) {
-				shapeStatsList.put(c3D, shapeStats);
-				data = shapeStats.get(StatsType.PIXELDATA);
-				pixelStats.put(c3D, data);
-			}
-		}
-		if (!hasData) {
-			buildHistogramNoSelection();
-			return;
+		else {
+    		shapeStatsList = new HashMap<Coord3D, Map<StatsType, Map>>();
+    		pixelStats = new HashMap<Coord3D, Map<Integer, ROIShapeStatsSimple>>();
+    		shapeMap = new HashMap<Coord3D, ROIShape>();
+    		channelName = new ArrayList<String>();
+    		channelColour = new ArrayList<Color>();
+    		Entry entry;
+    		Iterator i  = ROIStats.entrySet().iterator();
+            
+    		Coord3D c3D;
+    		Map<StatsType, Map> shapeStats;
+    		Map<Integer, ROIShapeStatsSimple> data;
+    		int t = model.getDefaultT();
+    		int z = model.getDefaultZ();
+    		boolean hasData = false;
+    		int cT, cZ;
+    		while (i.hasNext())
+    		{
+    			entry = (Entry) i.next();
+    			shape = (ROIShape) entry.getKey();
+    			
+    			c3D = shape.getCoord3D();
+    			cT = c3D.getTimePoint();
+    			cZ = c3D.getZSection();
+    			
+    			if (cT == t && cZ == z) hasData = true;
+    			
+    			shapeMap.put(c3D, shape);
+    			if (shape.getFigure() instanceof MeasureTextFigure)
+    				return;
+    			shapeStats = AnalysisStatsWrapper.convertStats(
+    					(Map) entry.getValue());
+    			if (shapeStats != null) {
+    				shapeStatsList.put(c3D, shapeStats);
+    				data = shapeStats.get(StatsType.PIXELDATA);
+    				pixelStats.put(c3D, data);
+    			}
+    		}
+    		if (!hasData) {
+    			buildHistogramNoSelection();
+    		}
 		}
         
 		zSlider.setMaximum(maxZ);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -151,6 +151,12 @@ public class GraphPane
 	/** Button to save the graph as JPEG or PNG.*/
 	private JButton export;
 	
+	/** Maximum Z value possible */
+	private int maxZ;
+	
+	/** Maximum T value possible */
+	private int maxT;
+	
 	/**
 	 * Implemented as specified by the I/F {@link TabPaneInterface}
 	 * @see TabPaneInterface#getIndex()
@@ -221,18 +227,22 @@ public class GraphPane
 	/** The slider has changed value and the mouse button released. */
 	private void handleSliderReleased()
 	{
-		if (zSlider == null || tSlider == null) return;
-		if (coord == null) return;
-		if (state == ANALYSING) return;
+		if (zSlider == null || tSlider == null)
+		    return;
+		if (coord == null) 
+		    return;
+		if (state == ANALYSING) 
+		    return;
 		Coord3D thisCoord = new Coord3D(zSlider.getValue()-1, 
 				tSlider.getValue()-1);
-		if (coord.equals(thisCoord)) return;
-		if (!pixelStats.containsKey(thisCoord)) return;
+		if (coord.equals(thisCoord)) 
+		    return;
 		state = ANALYSING;
 		buildGraphsAndDisplay();
 		formatPlane();
-		if (shape != null)
-			view.selectFigure(shape.getFigure());
+        if (shape != null)
+            view.selectFigure(shape.getFigure(), new Coord3D(
+                    zSlider.getValue() - 1, tSlider.getValue() - 1));
 		state = READY;
 	}
 
@@ -505,9 +515,11 @@ public class GraphPane
 	 * @param view Reference to the View. Mustn't be <code>null</code>.
 	 * @param controller Reference to the Control. Mustn't be <code>null</code>.
 	 * @param model Reference to the Model. Mustn't be <code>null</code>.
+	 * @param maxZ Number of Z planes
+	 * @param maxT Number of T planes
 	 */
 	GraphPane(MeasurementViewerUI view, MeasurementViewerControl controller,
-		MeasurementViewerModel model)
+		MeasurementViewerModel model, int maxZ, int maxT)
 	{
 		if (view == null)
 			throw new IllegalArgumentException("No view.");
@@ -518,6 +530,8 @@ public class GraphPane
 		this.model = model;
 		this.view = view;
 		this.controller = controller;
+		this.maxZ = maxZ;
+		this.maxT = maxT;
 		initComponents();
 		buildGUI();
 	}
@@ -567,11 +581,7 @@ public class GraphPane
 		channelColour = new ArrayList<Color>();
 		Entry entry;
 		Iterator i  = ROIStats.entrySet().iterator();
-		
-	
-		int minZ = Integer.MAX_VALUE, maxZ = Integer.MIN_VALUE;
-		int minT = Integer.MAX_VALUE, maxT = Integer.MIN_VALUE;
-		
+        
 		Coord3D c3D;
 		Map<StatsType, Map> shapeStats;
 		Map<Integer, ROIShapeStatsSimple> data;
@@ -587,11 +597,6 @@ public class GraphPane
 			c3D = shape.getCoord3D();
 			cT = c3D.getTimePoint();
 			cZ = c3D.getZSection();
-			
-			minT = Math.min(minT, cT);
-			maxT = Math.max(maxT, cT);
-			minZ = Math.min(minZ, cZ);
-			maxZ = Math.max(maxZ, cZ);
 			
 			if (cT == t && cZ == z) hasData = true;
 			
@@ -610,16 +615,13 @@ public class GraphPane
 			buildHistogramNoSelection();
 			return;
 		}
-		maxZ = maxZ+1;
-		minZ = minZ+1;
-		minT = minT+1;
-		maxT = maxT+1;
+        
 		zSlider.setMaximum(maxZ);
-		zSlider.setMinimum(minZ);
+		zSlider.setMinimum(1);
 		tSlider.setMaximum(maxT);
-		tSlider.setMinimum(minT);
-		zSlider.setVisible(maxZ != minZ);
-		tSlider.setVisible(maxT != minT);
+		tSlider.setMinimum(1);
+		zSlider.setVisible(maxZ > 1);
+		tSlider.setVisible(maxT > 1);
 		tSlider.setValue(model.getCurrentView().getTimePoint()+1);
 		zSlider.setValue(model.getCurrentView().getZSection()+1);
 		formatPlane();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -647,9 +647,8 @@ public class GraphPane
 	public void stateChanged(ChangeEvent evt) {
 		Object src = evt.getSource();
 		if (src == zSlider || src == tSlider) {
-			formatPlane();
 			OneKnobSlider slider = (OneKnobSlider) src;
-			if (!slider.isDragging()) {
+			if (!slider.isDragging() && !slider.getValueIsAdjusting()) {
 				handleSliderReleased();
 			}
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -1164,8 +1164,11 @@ class IntensityView
 		if (state == State.ANALYSING)
 			return;
 		this.ROIStats = model.getAnalysisResults();
-		if (ROIStats == null || ROIStats.size() == 0) 
+		if (ROIStats == null || ROIStats.size() == 0) {
+		    clearMaps();
+		    onFigureRemoved();
 			return;
+		}
 		state = State.ANALYSING;
 		clearMaps();
 		shapeStatsList = new TreeMap<Coord3D, Map<StatsType, Map>>(new Coord3D());
@@ -1300,10 +1303,11 @@ class IntensityView
 			channelSelection.setEnabled(row);
 			saveButton.setEnabled(row);
 		} else {
-			boolean size = channelSelection.getModel().getSize() > 0;
-			channelSelection.setEnabled(size);
-			showIntensityTable.setEnabled(size);
-			saveButton.setEnabled(size);
+            boolean enabled = channelSelection.getModel().getSize() > 0
+                    && (ROIStats != null && ROIStats.size() > 0);
+            channelSelection.setEnabled(enabled);
+            showIntensityTable.setEnabled(enabled);
+            saveButton.setEnabled(enabled);
 		}
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -405,4 +405,14 @@ public interface MeasurementViewer
 
     /** Notifies that the annotations have been saved. Reloads.*/
     public void onAnnotationSaved();
+    
+    /**
+     * Changes the current plane
+     * 
+     * @param z
+     *            The Z plane
+     * @param t
+     *            The T plane
+     */
+    public void selectPlane(int z, int t);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1316,5 +1316,16 @@ class MeasurementViewerComponent
             nodes.add(shape.getData());
         }
         model.fireLoadROIAnnotations(nodes);
+    }
+    
+    /**
+     * Implemented as specified by the {@link MeasurementViewer} interface.
+     * 
+     * @see MeasurementViewer#selectPlane(int, int)
+     */
+    public void selectPlane(int z, int t) {
+        model.setPlane(z, t);
+        if(view.isShowing() && view.inDataView())
+            controller.analyseSelectedFigures();
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -406,7 +406,6 @@ class MeasurementViewerComponent
 			    model.setMagnification(magnification);
 			    view.onMagnificationChanged();
 			}
-			if (!model.isBigImage()) return;
 		}
 		model.setPlane(defaultZ, defaultT);
 		Drawing drawing = model.getDrawing();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -684,7 +684,9 @@ class MeasurementViewerModel
 	 *
 	 * @return See above.
 	 */
-	Coord3D getCurrentView() { return currentPlane; }
+	Coord3D getCurrentView() { 
+	    return currentPlane; 
+	    }
 
 	/**
 	 * Returns <code>true</code> if the size in microns can be displayed, this
@@ -1316,7 +1318,8 @@ class MeasurementViewerModel
 	 */
 	void fireAnalyzeShape(List<ROIShape> shapeList)
 	{
-	    if (CollectionUtils.isEmpty(shapeList)) return;
+	    if (CollectionUtils.isEmpty(shapeList)) 
+	        return;
 		state = MeasurementViewer.ANALYSE_SHAPE;
 		if (currentLoader != null) currentLoader.cancel();
 		List<ROIShape> l = new ArrayList<ROIShape>(shapeList.size());
@@ -1327,6 +1330,10 @@ class MeasurementViewerModel
             shape = i.next();
             z = shape.getZ();
             t = shape.getT();
+            // only analyze the shape of the current active plane
+            if (currentPlane.getZSection() != z
+                    || currentPlane.getTimePoint() != t)
+                continue;
             if (z >= 0 && t >= 0) {
                 l.add(shape);
             } else if (z == -1 && t >= 0) {


### PR DESCRIPTION
Further improvement of the ROI analysis, see [Trello card](https://trello.com/c/3HccWkMv/40-roi-memory-issue)

With this PR only the shape of the current active plane is analyzed, not the full stack, which should speed up the analysis significantly for large ROIs which are populated through several planes.

Test: Create a large ROI (which covers a lot of pixels), populate it through the stack. Perform an analysis by switching to the Graph Pane. Move through the stack via the sliders. The newly selected plane should then get analyzed and the diagram updated automatically. Check that the results make sense. Ideally this should be tested with different kinds of images (single plane, multi-z, multi-t, multi-z/t).