### PR TITLE
Another formatting issue

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -533,7 +533,7 @@ class ChannelAcquisitionComponent
 		PlaneInfo info;
 		Map<String, Object> details;
 		List<String> notSet;
-		names[0] = "t index";
+		names[0] = "t";
 		values[0][i] = "Delta T";
 		values[1][i] = "Exposure";
 		i++;
@@ -564,7 +564,7 @@ class ChannelAcquisitionComponent
 			}
 			else
 				values[1][i] = "--";
-			names[i] = "t="+(i-1);
+			names[i] = "t="+i;
 			i++;
 		}
 		if (i > 1) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -510,12 +510,11 @@ class ChannelAcquisitionComponent
             date = DateUtils.round(date, Calendar.SECOND);
             m = date.get(Calendar.MINUTE);
             s = date.get(Calendar.SECOND);
-            return m + " m " + s + " s";
-        } else if (tInS > 0.9) {
+            return m + " min " + s + " s";
+        } else if (tInS > 0.9) 
             return sFormat.format(tInS);
-        } else {
-            return msFormat.format((tInS * 1000));
-        }
+            
+        return msFormat.format(tInS * 1000);
     }
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelAcquisitionComponent.java
@@ -92,7 +92,10 @@ class ChannelAcquisitionComponent
 	private static final int	GENERAL = 0;
 	
 	/** Format used for displaying time in ms */
-	private static final DecimalFormat msFormat = new DecimalFormat("#ms");
+	private static final DecimalFormat msFormat = new DecimalFormat("# ms");
+	
+	/** Format used for displaying time in s */
+	private static final DecimalFormat sFormat = new DecimalFormat("0.0 s");
 	
 	/** Reference to the parent of this component. */
 	private AcquisitionDataUI					parent;
@@ -484,36 +487,32 @@ class ChannelAcquisitionComponent
      */
     private String getReadableTime(double tInS) {
         if (tInS == 0.0)
-            return "0s";
+            return "0 s";
 
         Calendar date = Calendar.getInstance();
         date = DateUtils.truncate(date, Calendar.YEAR);
         date.add(Calendar.MILLISECOND, (int) (tInS * 1000));
 
-        int d, h, m, s, ms;
+        int d, h, m, s;
 
         if (tInS > (23 * 60 * 60)) {
             date = DateUtils.round(date, Calendar.MINUTE);
             d = date.get(Calendar.DAY_OF_YEAR) - 1;
             h = date.get(Calendar.HOUR_OF_DAY);
             m = date.get(Calendar.MINUTE);
-            return d + "d " + (h > 0 ? h + "h " : "")
-                    + (m > 0 ? m + "min " : "");
+            return d + " d " + h + " h " + (m > 0 ? m + " min " : "");
         } else if (tInS > (59 * 60)) {
             date = DateUtils.round(date, Calendar.MINUTE);
             h = date.get(Calendar.HOUR_OF_DAY);
             m = date.get(Calendar.MINUTE);
-            return h + "h " + (m > 0 ? m + "min" : "");
+            return h + " h " + m + " min";
         } else if (tInS > 59) {
             date = DateUtils.round(date, Calendar.SECOND);
             m = date.get(Calendar.MINUTE);
             s = date.get(Calendar.SECOND);
-            return m + "m " + (s > 0 ? s + "s" : "");
+            return m + " m " + s + " s";
         } else if (tInS > 0.9) {
-            date = DateUtils.round(date, Calendar.MILLISECOND);
-            s = date.get(Calendar.SECOND);
-            ms = date.get(Calendar.MILLISECOND);
-            return s + "s " + (ms > 0 ? ms + "ms" : "");
+            return sFormat.format(tInS);
         } else {
             return msFormat.format((tInS * 1000));
         }


### PR DESCRIPTION
Follow up PR for #4199 

Changes the term "t index" to simply "t", and start count for t from 1 (instead of 0), see 'Exposure Time' table in channel acquisition metadata.

![screen shot 2015-10-01 at 08 34 02](https://cloud.githubusercontent.com/assets/6575139/10215191/3ed2daf8-6817-11e5-9e58-dd7513de933a.png)


(only the last commit is relevant for this PR, the other two are part for the previously mentioned PR)