### PR TITLE
Show image in well

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -349,8 +349,8 @@ class Show(object):
             if first_selected is not None:
                 for p in first_selected.getAncestry():
                     # If 'Well' is a parent, we have stared with Image.
-                    # We want to start again at 'Well' to _load_first_selected with
-                    # well, so we get 'acquisition' in ancestors.
+                    # We want to start again at 'Well' to _load_first_selected
+                    # with well, so we get 'acquisition' in ancestors.
                     if p.OMERO_CLASS == "Well":
                         self._initially_select = ['well.id-%s' % p.getId()]
                         return self._find_first_selected()

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -348,6 +348,9 @@ class Show(object):
             # Need to see if first item has parents
             if first_selected is not None:
                 for p in first_selected.getAncestry():
+                    # If 'Well' is a parent, we have stared with Image.
+                    # We want to start again at 'Well' to _load_first_selected with
+                    # well, so we get 'acquisition' in ancestors.
                     if p.OMERO_CLASS == "Well":
                         self._initially_select = ['well.id-%s' % p.getId()]
                         return self._find_first_selected()

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -348,6 +348,9 @@ class Show(object):
             # Need to see if first item has parents
             if first_selected is not None:
                 for p in first_selected.getAncestry():
+                    if p.OMERO_CLASS == "Well":
+                        self._initially_select = ['well.id-%s' % p.getId()]
+                        return self._find_first_selected()
                     if first_obj == "tag":
                         # Parents of tags must be tags (no OMERO_CLASS)
                         self._initially_open.insert(0, "tag-%s" % p.getId())


### PR DESCRIPTION
Fix for https://trello.com/c/XPrUXfTV/49-browse-spw-image-in-search-results-doesn-t-work
cc @manics.
Fixes show=?image-123 when the image is in a well - We browse to the well - Not necessarily the correct well-index (just first index).
This is the first fix I found for this that seems to work (maybe not the 'proper' fix, and no tests etc - in fact it's possible that 'show' tests may fail - haven't tried them yet).

