### PR TITLE
Don't reload image after dis/enabling interpolation

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserBICanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserBICanvas.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.BrowserBICanvas 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -70,7 +70,7 @@ class BrowserBICanvas
     {
         super.paintComponent(g);
     	Graphics2D g2D = (Graphics2D) g;
-        ImagePaintingFactory.setGraphicRenderingSettings(g2D);
+        ImagePaintingFactory.setGraphicRenderingSettings(g2D, model.isInterpolation());
         if (model.isBigImage()) {
         	g2D.setColor(BACKGROUND);
         	g2D.drawRect(0, 0, getWidth()-1, getHeight()-1);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.BrowserComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -135,6 +135,13 @@ class BrowserComponent
         if (!hasImage) {
         	view.locateScrollBars();
         }
+        paintImage();
+    }
+    
+    /**
+     * (Re)paints the image
+     */
+    private void paintImage() {
         view.paintMainImage();
         viewSplitImages();
     }
@@ -665,6 +672,7 @@ class BrowserComponent
          */
         public void setInterpolation(boolean interpolation) {
             model.setInterpolation(interpolation);
+            paintImage();
         }
 	    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1299,30 +1299,30 @@ public interface ImViewer
     /**
      * Reloads the 'saved by' thumbnails of the the rendering panel
      */
-    public void reloadRenderingThumbs();
+    void reloadRenderingThumbs();
     
     /**
      * Returns if interpolation is enabled or not
      * @return See above.
      */
-    public boolean isInterpolation();
+    boolean isInterpolation();
 
     /**
      * En-/Disables interpolation
      * 
      * @param interpolation
      */
-    public void setInterpolation(boolean interpolation);
+    void setInterpolation(boolean interpolation);
     
     /**
      * Set the {@link ImageAcquisitionData}
      * @param data The {@link ImageAcquisitionData}
      */
-    public void setImageAcquisitionData(ImageAcquisitionData data);
+    void setImageAcquisitionData(ImageAcquisitionData data);
     
     /**
      * Get the {@link ImageAcquisitionData}
      * @return See above
      */
-    public ImageAcquisitionData getImageAcquisitionData();
+    ImageAcquisitionData getImageAcquisitionData();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3406,7 +3406,6 @@ class ImViewerComponent
      */
     public void setInterpolation(boolean interpolation) {
         model.setInterpolation(interpolation);
-        refresh();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -1159,20 +1159,22 @@ class ImViewerControl
 	 */
 	public void componentMoved(ComponentEvent e) {}
 	
-	/**
-	 * Returns if interpolation is enabled or not
-	 * @return
-	 */
-        public boolean isInterpolation() {
-            return model.isInterpolation();
-        }
-    
-        /**
-         * En-/Disables interpolation
-         * @param interpolation
-         */
-        public void setInterpolation(boolean interpolation) {
-            model.setInterpolation(interpolation);
-            ImViewerFactory.setInterpolation(interpolation);
-        }
+    /**
+     * Returns if interpolation is enabled or not
+     * 
+     * @return
+     */
+    boolean isInterpolation() {
+        return model.isInterpolation();
+    }
+
+    /**
+     * En-/Disables interpolation
+     * 
+     * @param interpolation
+     */
+    void setInterpolation(boolean interpolation) {
+        model.setInterpolation(interpolation);
+        ImViewerFactory.setInterpolation(interpolation);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -3024,7 +3024,7 @@ class ImViewerModel
      * Returns if interpolation is enabled or not
      * @return
      */
-    public boolean isInterpolation() {
+    boolean isInterpolation() {
         return browser.isInterpolation();
     }
 
@@ -3032,7 +3032,7 @@ class ImViewerModel
      * En-/Disables interpolation
      * @param interpolation
      */
-    public void setInterpolation(boolean interpolation) {
+    void setInterpolation(boolean interpolation) {
         browser.setInterpolation(interpolation);
     }
 


### PR DESCRIPTION
Fixes [Ticket 13052](https://trac.openmicroscopy.org/ome/ticket/13052)

Test: 
- Check that toggling the interpolation option still works (open a very small image and zoom in to the maximum in order to see an effect). 
- Check that toggling the interpolation option *does not* request the image from the server again (open a big, tiled image; if the image is reloaded you should see the tiles gradually building up again; this should *not* happen when the interpolation option is changed).
