### PR TITLE
Configuration templates (part 2)

### DIFF
--- a/components/tools/OmeroM/build.xml
+++ b/components/tools/OmeroM/build.xml
@@ -53,6 +53,7 @@
         <fileset dir="${target.dir}"        includes="omeroVersion.m"/>
       </copy>
       <replace file="${target.dir}/matlab/ice.config" token="@omero.ports.prefix@@omero.ports.ssl@" value="4064"/>
+      <replace file="${target.dir}/matlab/ice.config" token="@Ice.Default.Host@" value="localhost"/>
       <zip destfile="target/${ivy.module}.zip">
         <zipfileset dir="${target.dir}/matlab" includes="**/*"/>
       </zip>

--- a/components/tools/OmeroM/build.xml
+++ b/components/tools/OmeroM/build.xml
@@ -47,13 +47,11 @@
       <copy file="${basedir}/src/omeroVersion.m" tofile="${target.dir}/matlab/omeroVersion.m"/>
       <replace file="${target.dir}/matlab/omeroVersion.m" token="@DEVBUILD@" value="${omero.version}"/>
       <copy todir="${target.dir}/matlab">
-        <fileset dir="${etc.dir}/templates" includes="ice.config"/>
+        <fileset dir="${etc.dir}" includes="ice.config"/>
         <fileset dir="${basedir}/src"       includes="**/*"/>
         <fileset dir="${target.dir}"        includes="libs/*"/>
         <fileset dir="${target.dir}"        includes="omeroVersion.m"/>
       </copy>
-      <replace file="${target.dir}/matlab/ice.config" token="@omero.ports.prefix@@omero.ports.ssl@" value="4064"/>
-      <replace file="${target.dir}/matlab/ice.config" token="@Ice.Default.Host@" value="localhost"/>
       <zip destfile="target/${ivy.module}.zip">
         <zipfileset dir="${target.dir}/matlab" includes="**/*"/>
       </zip>

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1011,6 +1011,7 @@ present, the user will enter a console""")
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
+            '@Ice.Default.Host@': config.get('Ice.Default.Host', '127.0.0.1')
             }
 
         def copy_template(input_file, output_dir):

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -37,7 +37,7 @@ from omero.plugins.prefs import \
 
 from omero_ext import portalocker
 from omero_ext.which import whichall
-from omero_ext.argparse import FileType
+from omero_ext.argparse import FileType, SUPPRESS
 from omero_version import ice_compatibility
 
 try:
@@ -320,24 +320,7 @@ dt_socket,address=8787,suspend=y" \\
             "--finish", action="store_true",
             help="Re-enables the background indexer after for indexing")
 
-        ports = Action(
-            "ports",
-            """Allows modifying the ports from a standard OMERO install (deprecated)
-
-To have multiple OMERO servers running on the same machine several ports
-must be modified from their defaults. Changing the ports on a running server
-will be prevented, use --skipcheck to override this.
-
-Examples:
-
-  # Set ports to registry:14061, tcp:14063, ssl:14064, web:14080
-  %(prog)s --prefix=1
-  # Set ports back to defaults: 4061, 4063, 4064, 4080
-  %(prog)s --prefix=1 --revert
-  # Set ports to: 4444, 5555, 6666, 7777
-  %(prog)s --registry=4444 --tcp=5555 --ssl=6666 --webserver=7777
-
-""").parser
+        ports = Action("ports", SUPPRESS).parser
         ports.add_argument(
             "--prefix",
             help="Adds a prefix to each port ON TOP OF any other settings")

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1034,6 +1034,8 @@ present, the user will enter a console""")
                 self._get_templates_dir() / "grid" / "*default.xml"):
             copy_template(xml_file, self._get_etc_dir() / "grid")
         ice_config = self._get_templates_dir() / "ice.config"
+        substitutions['@Ice.Default.Host@'] = config.get(
+            'Ice.Default.Host', 'localhost')
         copy_template(ice_config, self._get_etc_dir())
 
         return rv

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -4,7 +4,7 @@
     <echo>Entering ${basedir}...</echo>
 
     <property name="env.DESTDIR"    value="${up-two}/target/"/>
-    <property name="env.ICE_CONFIG" value="${basedir}/../../../etc/templates/ice.config"/>
+    <property name="env.ICE_CONFIG" value="${basedir}/../../../etc/ice.config"/>
     <property name="MARK" value="not (long_running or broken)"/>
 
     <defineVariables/>

--- a/etc/ice.config
+++ b/etc/ice.config
@@ -1,0 +1,162 @@
+#
+# OmeroBlitz example configuration file
+# -------------------------------------
+#
+# Configuration files are usable by all clients to modify
+# connection information for connecting to an OMERO.blitz
+# server by editing the environment parameter: ICE_CONFIG
+#
+# Rather than editing this file, it is also possible
+# to use a multiple file argument to Ice.Config, e.g.:
+#
+#   export ICE_CONFIG=etc/ice.config,etc/private.config
+#
+# where later configuration files take precedence. Finally,
+# some clients may also support passing options over the
+# command-line:
+#
+#   ./myClient --Ice.Config=etc/private.config --omero.pass=secret
+#
+# depending on whether or not the client passes command-line
+# arguments to the omero.client constructor.
+#
+# So in general, a configuration file is unnecessary since
+# all required parameters can be provided via omero.client
+# methods:
+#
+#   omero.client c = new omero.client("localhost", myPort)
+#   c.createSession(user, password)
+#
+# but can be useful none the less.
+
+
+# Properties, examples, and explanations
+# --------------------------------------
+
+# Ice.Default.Router is the main property for connecting to
+# a server. By default, omero uses a template value and
+# replaces @omero.host@ and @omero.port@ with the given
+# values. If a non-template string is provided, it will
+# be used directly.
+
+## Ice.Default.Router=OMERO.Glacier2/router:tcp -p @omero.port@ -h @omero.host@ (default)
+## Ice.Default.Router=OMERO.Glacier2/router:tcp -p 10000 -h host.example.com
+
+
+# Instead of defining the entire Ice.Default.Router property,
+# it is also an option to specify just omero.host which will
+# be inserted into a template Ice.Default.Router
+
+omero.host=localhost
+
+
+# If your blitz server runs on a non-standard port (not 4064)
+# then omero.port can also be set.
+
+omero.port=4064
+
+
+# Login information can also be provided via configuration
+# files, though storing passwords in config files can be
+# dangerous.
+
+omero.user=user
+omero.pass=SUPER_SECRET
+
+
+# If keep_alive > 0, then every keep_alive seconds a call
+# will be made on the current session to keep it alive.
+# If no session is present, this is a no-op. Calling the
+# client.enableKeepAlive() method will have the same effect as
+# setting this property.
+
+# omero.keep_alive=-1 (disabled by default)
+
+# All "omero.ClientCallback.*" properties configure the
+# object adapter in each omero.client instance used for
+# server callbacks. Any property beginning with
+# "omero.ClientCallback" which the Ice runtime does
+# not understand will issue a warning.
+
+# Other properties: Any prefix preferenced with "omero"
+# will be parsed by the omero.client objects in all available
+# languages.
+#
+# For example, the following is used in the test cases for
+# creating a root login.
+
+omero.rootpass=omero
+
+
+# By setting omero.dump to any non-empty property, all
+# the settings for the current communicator will be printed
+# on creation. Careful: This prints your password.
+
+## omero.dump=1
+
+
+#
+# Other Ice properties
+#
+#
+# Determines the batch size for sending
+# objects to the server. Too many can
+# result in MessageSizeMax errors.
+
+## omero.batch_size=2000
+
+# Determines the block size of byte arrays used for
+# uploading and downloading binary data.
+
+## omero.block_size=5000000
+
+
+# Determines the maximum size of any single message which
+# can be recieved from or sent to OMERO.blitz. This value
+# can be lowered to prevent memory exhaustion, but if an
+# overly large message is sent to the client, then an
+# exception will be thrown. If the client tries to send
+# too much information in one call to the server, the
+# server's setting for MessageSizeMax will determine
+# whether or not an exception is thrown.
+
+## Ice.MessageSizeMax=65536
+
+
+# Each Ice communicator maintains two thread pools.
+# One for outgoing connections ("Client") and one
+# for incoming connectiosn ("Server"). If a series
+# of calls uses all available threads but is still
+# waiting on a connection, all threads will block!
+
+## Ice.ThreadPool.Client.SizeMax=50
+## Ice.ThreadPool.Server.SizeMax=50
+
+## Ice.ThreadPool.Client.Size=1
+## Ice.ThreadPool.Server.Size=1
+
+
+# Length of time that an attempt to form a connection
+# will block before throwing Ice::ConnectTimeoutException.
+# This is primarily of importance during createSession()
+
+## Ice.Override.ConnectTimeout=5000
+
+# Garbage collection times (in secs) C++ only
+
+## Ice.GC.Interval=60
+
+# Logging: The Ice runtime has a number of logging statements
+# from trace to warning levels. See the appendix of the online
+# documentation for more choices.
+
+## Ice.Warn.Connections=0
+## Ice.Trace.GC=0
+
+# Security: By default, all OMERO clients prefer to use
+# use a secure connection. By setting the following
+# property, a secure connection is required and if one
+# is not available, Ice::NoEndpointException will be
+# thrown.
+
+## Ice.Override.Secure=1

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -49,7 +49,7 @@
     <node name="master">
       <server-instance template="Glacier2Template"
         client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
-        server-endpoints="tcp -h 127.0.0.1"/>
+        server-endpoints="tcp -h @Ice.Default.Host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>
       <server-instance template="DropBoxTemplate"/>

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -455,7 +455,7 @@
          </adapter>
          <properties>
             <properties refid="Profile"/>
-            <property name="IcePatch2.Admin.Endpoints" value="tcp -h 127.0.0.1"/>
+            <property name="IcePatch2.Admin.Endpoints" value="tcp -h @Ice.Default.Host@"/>
             <property name="IcePatch2.Admin.RegisterProcess" value="1"/>
             <property name="IcePatch2.InstanceName" value="${instance-name}"/>
             <property name="IcePatch2.Directory" value="${directory}"/>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -58,7 +58,7 @@
     <node name="master">
       <server-instance template="Glacier2Template"
         client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
-        server-endpoints="tcp -h 127.0.0.1"/>
+        server-endpoints="tcp -h @Ice.Default.Host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>
       <server-instance template="DropBoxTemplate"/>

--- a/etc/templates/ice.config
+++ b/etc/templates/ice.config
@@ -47,7 +47,7 @@
 # it is also an option to specify just omero.host which will
 # be inserted into a template Ice.Default.Router
 
-omero.host=localhost
+omero.host=@Ice.Default.Host@
 
 
 # If your blitz server runs on a non-standard port (not 4064)

--- a/etc/templates/internal.cfg
+++ b/etc/templates/internal.cfg
@@ -2,7 +2,7 @@
 # OMERO Internal Lookup Configuration
 # Copyright 2007 Glencoe Software, Inc.  All Rights Reserved.
 #
-Ice.Default.Locator=IceGrid/Locator:tcp -h 127.0.0.1 -p @omero.ports.prefix@@omero.ports.registry@
+Ice.Default.Locator=IceGrid/Locator:tcp -h @Ice.Default.Host@ -p @omero.ports.prefix@@omero.ports.registry@
 IceGridAdmin.Username=root
 IceGridAdmin.Password=ome
 

--- a/etc/templates/master.cfg
+++ b/etc/templates/master.cfg
@@ -7,21 +7,21 @@
 ########################################################
 # Registry properties
 ########################################################
-IceGrid.Registry.Client.Endpoints=tcp -h 127.0.0.1 -p @omero.ports.prefix@@omero.ports.registry@
-IceGrid.Registry.Server.Endpoints=tcp -h 127.0.0.1
-IceGrid.Registry.Internal.Endpoints=tcp -h 127.0.0.1
+IceGrid.Registry.Client.Endpoints=tcp -h @Ice.Default.Host@ -p @omero.ports.prefix@@omero.ports.registry@
+IceGrid.Registry.Server.Endpoints=tcp -h @Ice.Default.Host@
+IceGrid.Registry.Internal.Endpoints=tcp -h @Ice.Default.Host@
 IceGrid.Registry.Data=var/registry
 IceGrid.Registry.DynamicRegistration=0
 IceGrid.Registry.AdminPermissionsVerifier=IceGrid/NullPermissionsVerifier
 #IceGrid.Registry.DefaultTemplates=etc/grid/templates.xml
-#IceGrid.Registry.SessionManager.Endpoints=tcp -h 127.0.0.1
+#IceGrid.Registry.SessionManager.Endpoints=tcp -h @Ice.Default.Host@
 #IceGrid.Registry.AdminCryptPasswords=etc/passwd
 
 ########################################################
 # Node properties
 ########################################################
 IceGrid.Node.CollocateRegistry=1
-IceGrid.Node.Endpoints=tcp -h 127.0.0.1
+IceGrid.Node.Endpoints=tcp -h @Ice.Default.Host@
 IceGrid.Node.Name=master
 IceGrid.Node.Data=var/master
 #IceGrid.Node.Output=var/log


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/openmicroscopy/pull/4093, this PR:

- implements the substitutions of `@Ice.Default.Host@` for the configuration templates
- suppresses the help of `admin ports` 
- moves the Web templates to a subdirectory for clarity. The `web config` subcommand and the unit tests are updated accordingly

The CI servers will test the deployment of the servers on a non-default `Ice.Default.Host`. This PR should also be tested locally with `Ice.Default.Host` unset. Additionally, the Web configuration generation should be tested to make sure nothing was broken by the templates migration.