### PR TITLE
Restrict size for export as jpg/png/tif

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -161,6 +161,9 @@ class EditorModel
 	
 	/** The index of the default channel. */
 	static final int	DEFAULT_CHANNEL = 0;
+	
+	/** The default size limit for exporting images, if no server side value is provided */
+	private static final int DOWNLOAD_MAX_SIZE = 144000000;
 
 	/** Enum to distinguish between different kind of 
 	 * {@link MapAnnotationData}, see {@link #getMapAnnotations(MapAnnotationType)}
@@ -4286,6 +4289,46 @@ class EditorModel
 	 */
 	boolean isLargeImage() { return largeImage; }
 
+    /**
+     * Checks if the image doesn't exceed the maximum download size for being
+     * exported as JPG, PNG or TIF
+     * 
+     * @return See above.
+     */
+    boolean isExportable() {
+        ImageData img = null;
+        if (refObject instanceof ImageData) {
+            img = (ImageData) refObject;
+        } else if (refObject instanceof WellSampleData) {
+            img = ((WellSampleData) refObject).getImage();
+        }
+
+        if (img == null)
+            return false;
+
+        PixelsData data = img.getDefaultPixels();
+        int n = data.getSizeX() * data.getSizeY();
+        return n <= getMaxDownloadSizeForExport();
+    }
+	
+    /**
+     * Get the maximum size for images being exported as jpg, png or tif.
+     * 
+     * @return See above.
+     */
+    private int getMaxDownloadSizeForExport() {
+        String tmp = (String) MetadataViewerAgent.getRegistry().lookup(
+                LookupNames.DOWNLOAD_MAX_SIZE);
+        if (tmp == null)
+            return DOWNLOAD_MAX_SIZE;
+
+        try {
+            return Integer.parseInt(tmp);
+        } catch (NumberFormatException e) {
+            return DOWNLOAD_MAX_SIZE;
+        }
+    }
+    
 	/**
 	 * Indicates if the image is a big image or not.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -211,7 +211,7 @@ class ToolBar
         if (model.isMultiSelection()) b = false;
         else {
             b = model.getRefObject() instanceof ImageData &&
-                    !model.isLargeImage();
+                    !model.isLargeImage() && model.isExportable();
         }
         exportAsOmeTiffItem.setEnabled(b);
         saveAsMenu.add(exportAsOmeTiffItem);
@@ -227,7 +227,7 @@ class ToolBar
         JMenuItem item;
         Object ho = model.getRefObject();
         boolean enabled = (ho instanceof ImageData ||
-                ho instanceof WellSampleData || ho instanceof DatasetData);
+                ho instanceof WellSampleData || ho instanceof DatasetData) && model.isExportable();
         while (i.hasNext()) {
             e = i.next();
             item = new JMenuItem(icons.getIcon(

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -361,4 +361,7 @@ public class LookupNames
     
     /** Lookup name for using pixel interpolation */
     public static final String INTERPOLATE = "omero.client.viewer.interpolate_pixels";
+    
+    /** Lookup name for download size restriction */
+    public static final String DOWNLOAD_MAX_SIZE = "omero.client.download_as_max_size";
 }


### PR DESCRIPTION
Same as #4172 , just for Insight. Limits the "Exports as JPG/PNG/TIF" actions to a certain maximum image size.

Test: 
- Check that the "Export as ..." menus are enabled for images < 12k x 12k (that's the default limit if nothing else has been set).
- Check that they are disabled for larger images.
- Set a custom limit, e. g. 1k x 1k `./omero config set omero.client.download_as_max_size 1000000` (followed by `./omero admin restart` ) and perform above mentioned checks again.

