### PR TITLE
Roi count limit

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -209,6 +209,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.viewer.roi_limit">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.client.viewer.initial_zoom_level">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1532,8 +1532,8 @@ class _BlitzGateway (object):
 
     def getRoiLimitSetting(self):
         try:
-            roi_limit = (self.getConfigService().getConfigValue(
-                         "omero.client.viewer.roi_limit") or 100)
+            roi_limit = (int(self.getConfigService().getConfigValue(
+                             "omero.client.viewer.roi_limit")) or 100)
         except:
             roi_limit = 100
         return roi_limit

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1533,9 +1533,9 @@ class _BlitzGateway (object):
     def getRoiLimitSetting(self):
         try:
             roi_limit = (int(self.getConfigService().getConfigValue(
-                             "omero.client.viewer.roi_limit")) or 100)
+                             "omero.client.viewer.roi_limit")) or 2000)
         except:
-            roi_limit = 100
+            roi_limit = 2000
         return roi_limit
 
     def getInitialZoomLevel(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1530,6 +1530,14 @@ class _BlitzGateway (object):
                 int(c.getConfigValue('omero.pixeldata.max_plane_height')))
         return self._maxPlaneSize
 
+    def getRoiLimitSetting(self):
+        try:
+            roi_limit = (self.getConfigService().getConfigValue(
+                         "omero.client.viewer.roi_limit") or 100)
+        except:
+            roi_limit = 100
+        return roi_limit
+
     def getInitialZoomLevel(self):
         """
         Returns default initial zoom level set on the server.

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -258,6 +258,8 @@ class login_required(object):
                 conn.getDropdownMenuSettings()
             request.session['server_settings']['email'] = \
                 conn.getEmailSettings()
+            request.session['server_settings']['roi_limit'] = \
+                conn.getRoiLimitSetting()
             request.session['server_settings']['initial_zoom_level'] = \
                 conn.getInitialZoomLevel()
             request.session['server_settings']['interpolate_pixels'] = \

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -151,11 +151,11 @@ def imageMarshal(image, key=None, request=None):
 
     server_settings = request.session.get('server_settings', {})
 
-    init_zoom = server_settings.get('initial_zoom_level' , 0)
+    init_zoom = server_settings.get('initial_zoom_level', 0)
     if init_zoom < 0:
         init_zoom = levels + init_zoom
 
-    interpolate = server_settings.get('interpolate_pixels' , True)
+    interpolate = server_settings.get('interpolate_pixels', True)
 
     try:
         rv.update({

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -149,8 +149,8 @@ def imageMarshal(image, key=None, request=None):
         and image.getObjectiveSettings().getObjective().getNominalMagnification() \
         or None
 
-    server_settings = request.session.get('server_settings', {})
-
+    server_settings = request.session.get('server_settings',
+                                          {}) if request else {}
     init_zoom = server_settings.get('initial_zoom_level', 0)
     if init_zoom < 0:
         init_zoom = levels + init_zoom

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -149,17 +149,13 @@ def imageMarshal(image, key=None, request=None):
         and image.getObjectiveSettings().getObjective().getNominalMagnification() \
         or None
 
-    try:
-        init_zoom = request.session['server_settings']['initial_zoom_level']
-        if init_zoom < 0:
-            init_zoom = levels + init_zoom
-    except:
-        init_zoom = 0
+    server_settings = request.session.get('server_settings', {})
 
-    try:
-        interpolate = request.session['server_settings']['interpolate_pixels']
-    except:
-        interpolate = False
+    init_zoom = server_settings.get('initial_zoom_level' , 0)
+    if init_zoom < 0:
+        init_zoom = levels + init_zoom
+
+    interpolate = server_settings.get('interpolate_pixels' , True)
 
     try:
         rv.update({

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1047,7 +1047,7 @@
     viewport.bind('imageLoad', function() {
 
       // Enable 'Show ROIs' button
-    {% if roiCount > 0 and roiCount < roiLimit  %}
+    {% if roiCount > 0 and roiCount <= roiLimit  %}
         $("#show-rois-a").on("click", function () { show_rois(); return false; })
             .attr("href", "#").css("color", "");
     {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -963,9 +963,12 @@
 {% block roi_buttons %}
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
-                {% if roiCount > 0 and roiCount < roiLimit  %}
+                {% if roiCount > 0 %}
                   <!-- 'link is enabled on imageLoad callback -->
-                    <a id="show-rois-a" href="#" style="color:gray">Show ROIs</a> |
+                    <a id="show-rois-a" href="#" style="color:gray"
+                        {% if roiCount > roiLimit  %}
+                            title="Cannot display more then {{roiLimit}} ROIs"
+                        {% endif %}>Show ROIs</a> |
                     <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endif %}
           </div>
@@ -1044,9 +1047,10 @@
     viewport.bind('imageLoad', function() {
 
       // Enable 'Show ROIs' button
-      $("#show-rois-a").on("click", function () { show_rois(); return false; })
-        .attr("href", "#").css("color", "");
-
+    {% if roiCount > 0 and roiCount < roiLimit  %}
+        $("#show-rois-a").on("click", function () { show_rois(); return false; })
+            .attr("href", "#").css("color", "");
+    {% endif %}
       $.getJSON(viewport.viewport_server + "/getImgRDef/",
         function(data){
             if (data.rdef) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -967,7 +967,7 @@
                   <!-- 'link is enabled on imageLoad callback -->
                     <a id="show-rois-a" href="#" style="color:gray"
                         {% if roiCount > roiLimit  %}
-                            title="Cannot display more then {{roiLimit}} ROIs"
+                            title="Cannot display more than {{roiLimit}} ROIs"
                         {% endif %}>Show ROIs</a> |
                     <a id="hide-rois-a" style="color:gray">Hide</a>
                 {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -963,11 +963,11 @@
 {% block roi_buttons %}
           <div id="roi_controls">
                 <h1>ROI Count: {{ roiCount }}</h1>
-                {% ifnotequal roiCount 0 %}
+                {% if roiCount > 0 and roiCount < roiLimit  %}
                   <!-- 'link is enabled on imageLoad callback -->
                     <a id="show-rois-a" href="#" style="color:gray">Show ROIs</a> |
                     <a id="hide-rois-a" style="color:gray">Hide</a>
-                {% endifnotequal %}
+                {% endif %}
           </div>
 {% endblock roi_buttons %}
           <div class="odd row">

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1874,7 +1874,8 @@ def full_viewer(request, iid, conn=None, **kwargs):
     """
 
     rid = getImgDetailsFromReq(request)
-    interpolate = request.session['server_settings']['interpolate_pixels']
+    server_settings = request.session.get('server_settings', {})
+    interpolate = server_settings.get('interpolate_pixels' , True)
 
     try:
         image = conn.getObject("Image", iid)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1876,6 +1876,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
     rid = getImgDetailsFromReq(request)
     server_settings = request.session.get('server_settings', {})
     interpolate = server_settings.get('interpolate_pixels' , True)
+    roiLimit = server_settings.get('roi_limit' , 100)
 
     try:
         image = conn.getObject("Image", iid)
@@ -1887,6 +1888,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
              'opts': rid,
              'interpolate': interpolate,
              'build_year': build_year,
+             'roiLimit': roiLimit,
              'roiCount': image.getROICount(),
              'viewport_server': kwargs.get(
                  # remove any trailing slash

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1876,7 +1876,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
     rid = getImgDetailsFromReq(request)
     server_settings = request.session.get('server_settings', {})
     interpolate = server_settings.get('interpolate_pixels', True)
-    roiLimit = server_settings.get('roi_limit', 100)
+    roiLimit = server_settings.get('roi_limit', 2000)
 
     try:
         image = conn.getObject("Image", iid)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1875,8 +1875,8 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
     rid = getImgDetailsFromReq(request)
     server_settings = request.session.get('server_settings', {})
-    interpolate = server_settings.get('interpolate_pixels' , True)
-    roiLimit = server_settings.get('roi_limit' , 100)
+    interpolate = server_settings.get('interpolate_pixels', True)
+    roiLimit = server_settings.get('roi_limit', 100)
 
     try:
         image = conn.getObject("Image", iid)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -844,7 +844,7 @@ omero.client.ui.menu.dropdown.everyone.enabled=true
 omero.client.viewer.interpolate_pixels=true
 
 # Client viewers roi limit.
-omero.client.viewer.roi_limit=100
+omero.client.viewer.roi_limit=2000
 
 #############################################
 ## Ice overrides

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -843,6 +843,9 @@ omero.client.ui.menu.dropdown.everyone.enabled=true
 # Client viewers interpolate pixels by default.
 omero.client.viewer.interpolate_pixels=true
 
+# Client viewers roi limit.
+omero.client.viewer.roi_limit=100
+
 #############################################
 ## Ice overrides
 ##


### PR DESCRIPTION
This PR prevents showing ROI button in a viewer if number of ROIs is bigger then limit.

To test:
 - add more then 10000 ROIs and check if `Show ROIs` in web is not visible
 - check image with less then 10000 ROIs if `Show ROIs` in web is visible
 - check image with no ROIs if `Show ROIs` in web is not visible

Test image with ~1500 http://eel/merge/webclient/?show=image-24083 user-1

Insight may do the same? cc @dominikl 