### PR TITLE
Tweak dusty.css which is misselecting on some rules

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -559,7 +559,9 @@ button::-moz-focus-inner {
 			margin-bottom:5px;
 		}
 
-	.standard_form input[type=text], input[type=password], textarea {
+	.standard_form input[type=text],
+	.standard_form input[type=password],
+	.standard_form textarea {
 		width:70%;
 		border: solid 1px rgba(0,0,0,.2);
 		border-top: solid 1px rgba(0,0,0,.3);
@@ -574,8 +576,11 @@ button::-moz-focus-inner {
 		color:#333;
 		font-family:"HelveticaNeue-Medium", Helvetica, Arial, sans-serif
 	}
-			
-	.standard_form input[type=text]:focus, input[type=password]:focus, input[type=text]:active, input[type=password]:active {
+
+	.standard_form input[type=text]:focus,
+	.standard_form input[type=password]:focus,
+	.standard_form input[type=text]:active,
+	.standard_form input[type=password]:active {
 		border:solid 1px hsl(210,20%,50%);
 	}
 	
@@ -634,7 +639,8 @@ button::-moz-focus-inner {
 		
 	}
 			
-	.standard_form input[type="submit"]:active, input[type="submit"]:focus {
+	.standard_form input[type="submit"]:active,
+	.standard_form input[type="submit"]:focus {
 		background-image: -webkit-gradient(linear, left bottom, left top, from(hsl(210,40%,65%)), to(hsl(210,40%,60%)));
 		
 


### PR DESCRIPTION
I think these grouped rules (and by the looks of [dusty.css](https://github.com/dpwrussell/openmicroscopy/blob/dusty-overselection/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css), potentially a whole lot more) are meant to be selecting `.classname elementname` for each rule, or similar, but CSS selectors are not distributive. Instead only the first rule in the group has the `.classname` rule selector.

This is evident in a few places where this behaviour does not seem desirable. E.g. Edit the name of an image in the right panel, if you mousedown the `Save` and `Cancel` buttons, they have different behaviours. Also, when mousedown on `Save`, there is an unpleasant layout change which is much nicer to not have.

It is also very annoying to have overreaching CSS selectors from a plugins perspective because it is then necessary to restore the original behaviour in the plugins CSS.