### PR TITLE
Roi count limit

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/metadata/ROICountLoaded.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/metadata/ROICountLoaded.java
@@ -1,0 +1,72 @@
+/*
+ * org.openmicroscopy.shoola.agents.events.FocusGainedEvent 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.events.metadata;
+
+import org.openmicroscopy.shoola.env.event.AgentEvent;
+
+/**
+ * Event indicating that the ROI count for a specific image has been loaded.
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ROICountLoaded extends AgentEvent {
+
+    /** The image id */
+    private long imageId = -1;
+
+    /** The number of ROIs the image has */
+    private int roiCount = -1;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param imageId
+     *            The image id
+     * @param roiCount
+     *            The number of ROIs the image has
+     */
+    public ROICountLoaded(long imageId, int roiCount) {
+        this.imageId = imageId;
+        this.roiCount = roiCount;
+    }
+
+    /**
+     * Get the number of ROIs the image has
+     * 
+     * @return See above
+     */
+    public int getRoiCount() {
+        return roiCount;
+    }
+
+    /**
+     * Get the image id
+     * 
+     * @return See above
+     */
+    public long getImageId() {
+        return imageId;
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -46,6 +46,7 @@ import org.openmicroscopy.shoola.agents.events.measurement.MeasurementToolLoaded
 import org.openmicroscopy.shoola.agents.events.measurement.SelectChannel;
 import org.openmicroscopy.shoola.agents.events.measurement.SelectPlane;
 import org.openmicroscopy.shoola.agents.events.metadata.ChannelSavedEvent;
+import org.openmicroscopy.shoola.agents.events.metadata.ROICountLoaded;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DeleteObjectEvent;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DisplayModeEvent;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
@@ -535,6 +536,17 @@ public class ImViewerAgent
         displayMode = evt.getDisplayMode();
         ImViewerFactory.setDisplayMode(displayMode);
     }
+    
+    /**
+     * Handles the ROI count loaded event
+     * @param e The event
+     */
+    private void handleROICountLoaded(ROICountLoaded e) {
+        ImViewer viewer = ImViewerFactory.getImageViewerFromImage(null, e.getImageId());
+        if (viewer != null) {
+            viewer.onROICountLoaded(e.getRoiCount());
+        }
+    }
 
     /**
      * Checks if the passed image is actually opened in the viewer.
@@ -603,6 +615,7 @@ public class ImViewerAgent
         bus.register(this, ChannelSavedEvent.class);
         bus.register(this, DisplayModeEvent.class);
         bus.register(this, RndSettingsCopied.class);
+        bus.register(this, ROICountLoaded.class);
     }
 
     /**
@@ -673,6 +686,8 @@ public class ImViewerAgent
             handleDisplayModeEvent((DisplayModeEvent) e);
         else if (e instanceof RndSettingsCopied)
             handleRndSettingsCopied((RndSettingsCopied) e);
+        else if (e instanceof ROICountLoaded)
+            handleROICountLoaded((ROICountLoaded) e);
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ROICountLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ROICountLoader.java
@@ -1,0 +1,143 @@
+/*
+ * org.openmicroscopy.shoola.agents.metadata.EditorLoader 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2014-2015 University of Dundee. All rights reserved.
+ *
+ *
+ * 	This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.imviewer;
+
+import java.util.Collection;
+
+import omero.gateway.SecurityContext;
+import omero.gateway.model.ROIResult;
+import omero.log.LogMessage;
+
+import org.openmicroscopy.shoola.agents.events.metadata.ROICountLoaded;
+import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
+import org.openmicroscopy.shoola.env.config.Registry;
+import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
+import org.openmicroscopy.shoola.env.data.views.CallHandle;
+import org.openmicroscopy.shoola.env.data.views.ImageDataView;
+
+/**
+ * An async. loader which load the number of ROIs for the certain image
+ *
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ROICountLoader extends ImageDataLoader {
+    /** Reference to the registry */
+    private final Registry registry;
+
+    /** Reference to the ImageDataView */
+    private final ImageDataView imView;
+
+    /** The id of the image the ROIs are related to. */
+    private long imageID;
+
+    /** The id of the user. */
+    private long userID;
+
+    /** Handle to the asynchronous call so that we can cancel it. */
+    private CallHandle handle;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param viewer
+     *            Reference to the viewer
+     * @param ctx
+     *            The SecurityContext
+     * @param loaderID
+     *            The loader ID
+     * @param imageId
+     *            The image id to load the ROIs for
+     * @param userID
+     *            The user id
+     */
+    public ROICountLoader(ImViewer viewer, SecurityContext ctx, int loaderID,
+            long imageId, long userID) {
+        super(viewer, ctx, loaderID);
+        this.imageID = imageId;
+        this.userID = userID;
+
+        registry = ImViewerAgent.getRegistry();
+        imView = (ImageDataView) registry
+                .getDataServicesView(ImageDataView.class);
+    }
+
+    /**
+     * Handles a null result
+     */
+    public void handleNullResult() {
+        LogMessage msg = new LogMessage();
+        msg.print("No data returned.");
+        registry.getLogger().error(this, msg);
+    }
+
+    /** Handles the cancellation */
+    public void handleCancellation() {
+        String info = "The data retrieval has been cancelled.";
+        registry.getLogger().info(this, info);
+    }
+
+    /**
+     * Handles exceptions
+     * 
+     * @see DSCallAdapter#handleException(Throwable)
+     */
+    public void handleException(Throwable exc) {
+        String s = "Data Retrieval Failure: ";
+        LogMessage msg = new LogMessage();
+        msg.print(s);
+        msg.print(exc);
+        registry.getLogger().error(this, msg);
+        registry.getUserNotifier()
+                .notifyError("Data Retrieval Failure", s, exc);
+    }
+
+    /** Fires an asynchronous data loading. */
+    public void load() {
+        handle = imView.loadROIFromServer(ctx, imageID, userID, this);
+    }
+
+    /** Cancels any ongoing data loading. */
+    public void cancel() {
+        handle.cancel();
+    }
+
+    @Override
+    /**
+     * Updates the toolbar
+     */
+    public void handleResult(Object result) {
+        int n = 0;
+
+        Collection c = (Collection) result;
+        for (Object obj : c) {
+            if (obj instanceof ROIResult) {
+                n += ((ROIResult) obj).getROIs().size();
+            }
+        }
+
+        ROICountLoaded evt = new ROICountLoaded(imageID, n);
+        registry.getEventBus().post(evt);
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ROIToolAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ROIToolAction.java
@@ -68,6 +68,9 @@ public class ROIToolAction
     /** Flag indicating the component has been pressed.*/
     private boolean pressed;
 
+    /** Flag to disable the action by all means */
+    private boolean forceDisable = false;
+    
     /**
      * Sets the enabled flag depending on the selected tab.
      * @see ViewerAction#onTabSelection()
@@ -77,7 +80,7 @@ public class ROIToolAction
         if (ImViewerAgent.isRunAsPlugin()) {
             setEnabled(false);
         } else {
-            setEnabled(model.getSelectedIndex() != ImViewer.PROJECTION_INDEX);
+            setEnabled(model.getSelectedIndex() != ImViewer.PROJECTION_INDEX && !forceDisable);
         }
     }
 
@@ -93,6 +96,17 @@ public class ROIToolAction
         else setEnabled(false);
     }
 
+    /**
+     * Forces the action to stay disabled
+     * 
+     * @param b
+     *            Pass <code>true</code> to make sure the action will be
+     *            disabled
+     */
+    public void forceDisable(boolean b) {
+        this.forceDisable = b;
+    }
+    
     /**
      * Creates a new instance.
      *

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1319,4 +1319,10 @@ public interface ImViewer
      * @return See above
      */
     ImageAcquisitionData getImageAcquisitionData();
+    
+    /**
+     * Handles the ROI count
+     * @param roiCount The number of ROIs the current image has
+     */
+    void onROICountLoaded(int roiCount);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -57,6 +57,7 @@ import org.openmicroscopy.shoola.agents.imviewer.MeasurementsLoader;
 import org.openmicroscopy.shoola.agents.imviewer.OverlaysRenderer;
 import org.openmicroscopy.shoola.agents.imviewer.PlaneInfoLoader;
 import org.openmicroscopy.shoola.agents.imviewer.ProjectionSaver;
+import org.openmicroscopy.shoola.agents.imviewer.ROICountLoader;
 import org.openmicroscopy.shoola.agents.imviewer.RenderingSettingsCreator;
 import org.openmicroscopy.shoola.agents.imviewer.RenderingSettingsLoader;
 import org.openmicroscopy.shoola.agents.imviewer.TileLoader;
@@ -2784,6 +2785,16 @@ class ImViewerModel
     	Iterator<Tile> i = tiles.values().iterator();
 		while (i.hasNext())
 			i.next().setImage(null);
+    }
+    
+    /**
+     * Initiates an asynchronous call to load the number of ROIs for the current
+     * image
+     */
+    void fireROICountLoading() {
+        ROICountLoader l = new ROICountLoader(component, ctx, -1, image.getId(),
+                getUserDetails().getId());
+        l.load();
     }
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -2490,8 +2490,6 @@ class ImViewerUI
 	 */
 	void setMeasurementLaunchingStatus(boolean b)
 	{ 
-		Action a = controller.getAction(ImViewerControl.MEASUREMENT_TOOL);
-		a.setEnabled(!b);
 		toolBar.setMeasurementLaunchingStatus(b);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -28,9 +28,9 @@ import java.util.List;
 import ome.model.units.BigResult;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsCopied;
 import org.openmicroscopy.shoola.agents.events.metadata.ChannelSavedEvent;
+import org.openmicroscopy.shoola.agents.events.metadata.ROICountLoaded;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DisplayModeEvent;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerFactory;
@@ -338,6 +338,17 @@ public class MetadataViewerAgent
     }
     
     /**
+     * Handles a {@link ROICountLoaded} event, i. e. passes the number
+     * of ROIs on to the respective viewer for the image
+     */
+    private void handleROICountLoaded(ROICountLoaded e) {
+        MetadataViewer viewer = MetadataViewerFactory.getViewerFromId(
+                ImageData.class.getName(), e.getImageId());
+        if(viewer!=null) 
+            viewer.updateROICount(e.getRoiCount());
+    }
+    
+    /**
      * Updates the view when the mode is changed.
      * 
      * @param evt The event to handle.
@@ -383,6 +394,7 @@ public class MetadataViewerAgent
         bus.register(this, RndSettingsCopied.class);
         bus.register(this, CopyRndSettings.class);
         bus.register(this, RndSettingsPasted.class);
+        bus.register(this, ROICountLoaded.class);
     }
 
     /**
@@ -431,6 +443,8 @@ public class MetadataViewerAgent
                    	 handleCopyRndSettings((CopyRndSettings) e);
 		else if (e instanceof RndSettingsPasted) 
                     	handleRndSettingsPasted((RndSettingsPasted) e);
+		else if (e instanceof ROICountLoaded) 
+            handleROICountLoaded((ROICountLoaded) e);
 	}
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -564,4 +564,11 @@ public interface Editor
      */
     public Collection<FileAnnotationData> getSelectedFileAnnotations();
     
+    /**
+     * Updates the number of ROIs
+     * 
+     * @param roiCount
+     *            The number of ROIs
+     */
+    public void updateROICount(int roiCount);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -1243,4 +1243,12 @@ class EditorComponent
     public Collection<FileAnnotationData> getSelectedFileAnnotations() {
         return view.getSelectedFileAnnotations();
     }
+    
+    /** 
+     * Implemented as specified by the {@link Editor} interface.
+     * @see Editor#updateROICount(int)
+     */
+    public void updateROICount(int roiCount) {
+        view.updateROICount(roiCount);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -1095,4 +1095,8 @@ class EditorUI
 	public Collection<FileAnnotationData> getSelectedFileAnnotations() { 
 	    return generalPane.getSelectedFileAnnotations();
 	}
+	
+	public void updateROICount(int roiCount) {
+        generalPane.updateROICount(roiCount);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -556,4 +556,14 @@ class GeneralPaneUI
 	public Collection<FileAnnotationData> getSelectedFileAnnotations() {
 	    return annotationUI.getSelectedFileAnnotations();
 	}
+	
+	/**
+     * Updates the number of ROIs
+     * 
+     * @param roiCount
+     *            The number of ROIs
+     */
+	public void updateROICount(int roiCount) {
+	    propertiesUI.updateROICount(roiCount);
+	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -234,6 +234,9 @@ public class PropertiesUI
 	/** The label showing the ROI count */
 	private JLabel roiCountLabel;
 	
+	/** The number of ROIs */
+	private int roiCount = -1;
+	
 	/** Builds and lays out the components displaying the channel information.*/
 	private void buildChannelsPane()
 	{
@@ -869,9 +872,11 @@ public class PropertiesUI
         content.add(label, c);
         c.gridx++;
         roiCountLabel = UIUtilities.createComponent(null);
-        roiCountLabel.setText("...");
+        if (this.roiCount < 0)
+            roiCountLabel.setText("...");
+        else
+            roiCountLabel.setText("" + this.roiCount);
         content.add(roiCountLabel, c);
-        loadROICount(image);
         
         return content;
     }
@@ -1613,20 +1618,14 @@ public class PropertiesUI
 	 */
 	public void changedUpdate(DocumentEvent e) {}
         
-        /** 
-         * Starts an asyc. call to load the number of ROIs
-         */
-        void loadROICount(ImageData image) {
-            ExperimenterData exp = MetadataViewerAgent.getUserDetails();
-            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId(), exp.getId());
-            l.load();
-        }
-        
-        /**
-         * Updates label showing the ROI count
-         * @param n Number of ROIs of the current image
-         */
-        public void updateROICount(int n) {
-            roiCountLabel.setText(""+n);
-        }
+    /**
+     * Updates label showing the ROI count
+     * 
+     * @param n
+     *            Number of ROIs of the current image
+     */
+    public void updateROICount(int n) {
+        this.roiCount = n;
+        roiCountLabel.setText("" + n);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -701,10 +701,18 @@ public interface MetadataViewer
          */
 	void applyCopiedRndSettings();
 	
-        /**
-         * Returns if there are copied rendering settings which could be pasted.
-         * 
-         * @return See above.
-         */
-        boolean hasRndSettingsCopied();
+    /**
+     * Returns if there are copied rendering settings which could be pasted.
+     * 
+     * @return See above.
+     */
+    boolean hasRndSettingsCopied();
+
+    /**
+     * Updates the number of ROIs
+     * 
+     * @param roiCount
+     *            The number of ROIs
+     */
+    public void updateROICount(int roiCount);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -421,6 +421,7 @@ class MetadataViewerComponent
 		model.setRootObject(root, ctx);
 		if (model.isSingleMode()) {
 			model.fireStructuredDataLoading(root);
+			model.fireROICountLoading();
 			fireStateChange();
 		}
 		view.setRootObject();
@@ -439,6 +440,7 @@ class MetadataViewerComponent
 	{
 		if (model.isSingleMode()) {
 			model.fireStructuredDataLoading(model.getRefObject());
+			model.fireROICountLoading();
 		} else {
 			model.setRelatedNodes(model.getRelatedNodes());
 		}
@@ -1340,5 +1342,13 @@ class MetadataViewerComponent
 	        return;
 	    
 	    model.fireLoadRndSettings();
+	}
+
+	/**
+     * Implemented as specified by the {@link MetadataViewer} interface.
+     * @see MetadataViewer#updateROICount(int)
+     */
+	public void updateROICount(int roiCount) {
+	    model.getEditor().updateROICount(roiCount);
 	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.Map.Entry;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.metadata.AdminEditor;
 import org.openmicroscopy.shoola.agents.metadata.DataBatchSaver;
 import org.openmicroscopy.shoola.agents.metadata.DataSaver;
@@ -42,6 +41,7 @@ import org.openmicroscopy.shoola.agents.metadata.GroupEditor;
 import org.openmicroscopy.shoola.agents.metadata.MetadataLoader;
 import org.openmicroscopy.shoola.agents.metadata.ContainersLoader;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
+import org.openmicroscopy.shoola.agents.metadata.ROICountLoader;
 import org.openmicroscopy.shoola.agents.metadata.RenderingSettingsLoader;
 import org.openmicroscopy.shoola.agents.metadata.StructuredDataLoader;
 import org.openmicroscopy.shoola.agents.metadata.ThumbnailLoader;
@@ -440,8 +440,26 @@ class MetadataViewerModel
 					ctx, Arrays.asList((DataObject) node), loaderID);
 			loaders.put(loaderID, loader);
 			loader.load();
+			
 			state = MetadataViewer.LOADING_METADATA;
 		}
+	}
+	
+    /**
+     * Starts an asynchronous call to load the number of ROIs
+     */
+	void fireROICountLoading() {
+	    ImageData image = null;
+        if (refObject instanceof ImageData) 
+            image = (ImageData) refObject;
+        else if (refObject instanceof WellSampleData)
+            image = ((WellSampleData) refObject).getImage();
+        if (image == null)
+            return;
+        
+	    ROICountLoader loader = new ROICountLoader(component, ctx, ++loaderID, image.getId(), getUserID());
+	    loaders.put(loaderID, loader);
+	    loader.load();
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -361,4 +361,7 @@ public class LookupNames
     
     /** Lookup name for using pixel interpolation */
     public static final String INTERPOLATE = "omero.client.viewer.interpolate_pixels";
+
+    /** Lookup name for measurement tool ROIs limit */
+    public static final String ROI_COUNT_LIMIT = "omero.client.viewer.roi_limit";
 }


### PR DESCRIPTION
Same as #4249 just for Insight. Limits the availability of the measurement tool to a certain number of ROIs (default: disabled if > 100 ROIs).

Testing: See above mentioned PR (except the measurement tool should be enabled in Insight, if there are no ROIs)