### PR TITLE
Big image export

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -4278,13 +4278,25 @@ class EditorModel
 	    return objects;
 	}
 
-	/**
-	 * Returns <code>true</code> if the image is a large image,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isLargeImage() { return largeImage; }
+    /**
+     * Returns <code>true</code> if the image is a large image,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    boolean isLargeImage() {
+        try {
+            int maxPlaneW = Integer.parseInt((String) MetadataViewerAgent
+                    .getRegistry().lookup(LookupNames.MAX_PLANE_WIDTH));
+            int maxPlaneH = Integer.parseInt((String) MetadataViewerAgent
+                    .getRegistry().lookup(LookupNames.MAX_PLANE_HEIGHT));
+            return getPixels().getSizeX() * getPixels().getSizeY() > maxPlaneW
+                    * maxPlaneH;
+        } catch (Exception e) {
+        }
+
+        return largeImage;
+    }
 
 	/**
 	 * Indicates if the image is a big image or not.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -211,7 +211,7 @@ class ToolBar
         if (model.isMultiSelection()) b = false;
         else {
             b = model.getRefObject() instanceof ImageData &&
-                    !model.isLargeImage();
+                    !model.isLargeImage() && !model.isLargeImage();
         }
         exportAsOmeTiffItem.setEnabled(b);
         saveAsMenu.add(exportAsOmeTiffItem);
@@ -227,7 +227,7 @@ class ToolBar
         JMenuItem item;
         Object ho = model.getRefObject();
         boolean enabled = (ho instanceof ImageData ||
-                ho instanceof WellSampleData || ho instanceof DatasetData);
+                ho instanceof WellSampleData || ho instanceof DatasetData) && !model.isLargeImage();
         while (i.hasNext()) {
             e = i.next();
             item = new JMenuItem(icons.getIcon(

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -211,7 +211,7 @@ class ToolBar
         if (model.isMultiSelection()) b = false;
         else {
             b = model.getRefObject() instanceof ImageData &&
-                    !model.isLargeImage() && !model.isLargeImage();
+                    !model.isLargeImage();
         }
         exportAsOmeTiffItem.setEnabled(b);
         saveAsMenu.add(exportAsOmeTiffItem);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -361,4 +361,11 @@ public class LookupNames
     
     /** Lookup name for using pixel interpolation */
     public static final String INTERPOLATE = "omero.client.viewer.interpolate_pixels";
+    
+    /** Lookup name for the maximum plane width */
+    public static final String MAX_PLANE_WIDTH = "omero.pixeldata.max_plane_width";
+    
+    /** Lookup name for the maximum plane height */
+    public static final String MAX_PLANE_HEIGHT = "omero.pixeldata.max_plane_height";
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -48,6 +48,7 @@ import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
+import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
 import org.openmicroscopy.shoola.env.data.model.EnumerationObject;
@@ -115,6 +116,7 @@ import omero.ValidationException;
 import omero.rtypes;
 import omero.api.ExporterPrx;
 import omero.api.IAdminPrx;
+import omero.api.IConfigPrx;
 import omero.api.IContainerPrx;
 import omero.api.IMetadataPrx;
 import omero.api.IPixelsPrx;
@@ -1451,7 +1453,12 @@ class OMEROGateway
             throws DSOutOfServiceException, DSAccessException {
         if (isConnected()) {
             try {
-                return gw.getConfigService(new SecurityContext(-1)).getClientConfigValues();
+                IConfigPrx cs = gw.getConfigService(new SecurityContext(-1));
+                Map<String, String> result = new HashMap<String, String>();
+                result.putAll(cs.getClientConfigValues());
+                result.put(LookupNames.MAX_PLANE_HEIGHT, cs.getConfigValue(LookupNames.MAX_PLANE_HEIGHT));
+                result.put(LookupNames.MAX_PLANE_WIDTH, cs.getConfigValue(LookupNames.MAX_PLANE_WIDTH));
+                return result;
             } catch (Exception e) {
                 handleException(e, "Cannot access config service. ");
             }


### PR DESCRIPTION
Same as #4223 , just for Insight. Limits the "Exports as" actions to a small images.

Test:
- Check that the "Export as ..." menus are enabled for small images < 3k x 3k 
- Check that they are disabled for larger images.