### PR TITLE
Only analyze shapes of the current plane

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/Analyser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/Analyser.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,13 +25,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.measurement.view.MeasurementViewer;
 import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 import omero.log.LogMessage;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 
 import omero.gateway.model.PixelsData;
 
@@ -63,6 +63,9 @@ public class Analyser
 	/** Handle to the asynchronous call so that we can cancel it. */
     private CallHandle handle;
    
+    /** The plane to analyze the shapes for */
+    private Coord3D plane;
+    
     /**
      * Creates a new instance. 
      * 
@@ -74,9 +77,10 @@ public class Analyser
      * 					Mustn't be <code>null</code>.
      * @param shapes	Collection of shapes to analyze. 
      * 					Mustn't be <code>null</code>.
+     * @param plane     The plane to analyze the shapes for, can be <code>null</code>
      */
 	public Analyser(MeasurementViewer viewer, SecurityContext ctx,
-			PixelsData pixels, Collection channels, List shapes)
+			PixelsData pixels, Collection channels, List shapes, Coord3D plane)
 	{
 		super(viewer, ctx);
 		if (CollectionUtils.isEmpty(channels))
@@ -86,6 +90,7 @@ public class Analyser
 		this.pixels = pixels;
 		this.channels = channels;
 		this.shapes = shapes;
+		this.plane = plane;
 	}
 	
 	/**
@@ -94,7 +99,7 @@ public class Analyser
      */
     public void load()
     {
-    	handle = idView.analyseShapes(ctx, pixels, channels, shapes, this);
+    	handle = idView.analyseShapes(ctx, pixels, channels, shapes, plane, this);
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -674,10 +674,7 @@ public class GraphPane
 		Object src = evt.getSource();
 		if (src == zSlider || src == tSlider) {
 			formatPlane();
-			OneKnobSlider slider = (OneKnobSlider) src;
-			if (!slider.isDragging()) {
-				handleSliderReleased();
-			}
+			handleSliderReleased();
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -277,7 +277,7 @@ class IntensityView
 	/** The slider has changed value and the mouse button released. */
 	private void handleSliderReleased()
 	{
-		if (zSlider == null || tSlider == null || coord == null|| 
+		if (zSlider == null || tSlider == null || coord == null || 
                 state != State.READY)
 			return;
 		
@@ -1231,6 +1231,7 @@ class IntensityView
                 state = State.ANALYSING;
                 controller.analyseFigures(statsMissingFigures);
             }
+            channelSummaryTable.setVisible(false);
             clearMaps();
             return;
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -1355,10 +1355,7 @@ class IntensityView
 		Object src = evt.getSource();
 		if (src == zSlider || src == tSlider) {
 			formatPlane();
-			OneKnobSlider slider = (OneKnobSlider) src;
-			if (!slider.isDragging()) {
-				handleSliderReleased();
-			}
+			handleSliderReleased();
 		}
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -1227,10 +1227,10 @@ class IntensityView
 		}
 		
 		if (!hasData) {
-            if (!statsMissingFigures.isEmpty()) {
-                state = State.ANALYSING;
+            if (!statsMissingFigures.isEmpty()) 
                 controller.analyseFigures(statsMissingFigures);
-            }
+            else
+                state = State.READY;
             channelSummaryTable.setVisible(false);
             clearMaps();
             return;
@@ -1318,6 +1318,8 @@ class IntensityView
 	    }
 		zSlider.setEnabled(!analyse);
 		tSlider.setEnabled(!analyse);
+		if(!analyse)
+		    state = State.READY;
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
@@ -444,10 +444,19 @@ class MeasurementViewerControl
 	}
     
     /** Analyzes the selected figures. */
-	void analyseSelectedFigures()
+    void analyseSelectedFigures()
+    {
+        analyseFigures(model.getSelectedFigures());
+    }
+    
+    /** 
+     * Analyzes the selected figures. 
+     * @param figures The figures to analyse
+     */
+	void analyseFigures(Collection<Figure> figures)
 	{
-		Collection<Figure> figures = model.getSelectedFigures();
-		if (figures.size() != 1 && !view.inDataView()) return;
+		if (figures.size() != 1 && !view.inDataView()) 
+		    return;
 		Iterator<Figure> j = figures.iterator();
 		ROIFigure figure = null;
 		if (j.hasNext()) figure = (ROIFigure) j.next();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -1339,7 +1339,7 @@ class MeasurementViewerModel
             }
         }
 		currentLoader = new Analyser(component, getSecurityContext(), pixels,
-				activeChannels.keySet(), l);
+				activeChannels.keySet(), l, currentPlane);
 		currentLoader.load();
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -333,7 +333,7 @@ class MeasurementViewerUI
 		roiResults = new MeasurementResults(controller, model, this);
         if (showGraph) {
             graphPane = new GraphPane(this, controller, model);
-            intensityView = new IntensityView(this, model);
+            intensityView = new IntensityView(this, model, controller);
             intensityResultsView = new IntensityResultsView(this, model);
         }
 		calcWizard = new CalculationWizard(controller, model);
@@ -1341,8 +1341,10 @@ class MeasurementViewerUI
 	/** Builds the graphs and displays them in the results pane. */
 	void displayAnalysisResults()
 	{
-		if (inGraphView()) graphPane.displayAnalysisResults();
-		else if (inIntensityView()) intensityView.displayAnalysisResults();
+		if (inGraphView()) 
+		    graphPane.displayAnalysisResults();
+		else if (inIntensityView())
+		    intensityView.displayAnalysisResults();
 		else if (inIntensityResultsView())
 			intensityResultsView.displayAnalysisResults();
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
@@ -40,6 +40,7 @@ import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.rnd.data.Tile;
+import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.PixelsData;
@@ -127,11 +128,12 @@ public interface ImageDataView
      * 					Mustn't be <code>null</code>.
      * @param shapes	Collection of shapes to analyze. 
      * 					Mustn't be <code>null</code>.
+     * @param plane     The plane to analyze the shapes for, can be <code>null</code>
      * @param observer	Call-back handler.
      * @return See above.
      */
     public CallHandle analyseShapes(SecurityContext ctx, PixelsData pixels,
-    		Collection channels, List shapes, AgentEventListener observer);
+    		Collection channels, List shapes, Coord3D plane, AgentEventListener observer);
     
     /**
      * Retrieves all the rendering settings associated to a given set of pixels.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
@@ -64,6 +64,7 @@ import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.rnd.data.Tile;
+import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.PixelsData;
@@ -141,9 +142,9 @@ class ImageDataViewImpl
      * 									AgentEventListener)
      */
 	public CallHandle analyseShapes(SecurityContext ctx, PixelsData pixels,
-			Collection channels, List shapes, AgentEventListener observer)
+			Collection channels, List shapes, Coord3D plane, AgentEventListener observer)
 	{
-		BatchCallTree cmd = new Analyser(ctx, pixels, channels, shapes);
+		BatchCallTree cmd = new Analyser(ctx, pixels, channels, shapes, plane);
 		return cmd.exec(observer);
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/Analyser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/Analyser.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,13 +25,12 @@ import java.util.Iterator;
 import java.util.List;
 
 import omero.gateway.SecurityContext;
-import omero.gateway.rnd.DataSink;
 
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
-import org.openmicroscopy.shoola.env.rnd.PixelsServicesFactory;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIAnalyser;
 import org.openmicroscopy.shoola.util.roi.model.ROIShape;
+import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 
 import omero.gateway.model.PixelsData;
 
@@ -61,6 +60,9 @@ public class Analyser
     /** Loads the specified experimenter groups. */
     private BatchCall loadCall;
     
+    /** The plane to analyze the shapes for */
+    private Coord3D plane;
+    
     /**
      * Creates a {@link BatchCall} to analyze the specified shapes.
      * 
@@ -76,7 +78,7 @@ public class Analyser
             {
             	ROIAnalyser analyser = new ROIAnalyser(context.getGateway(), pixels);
             	try {
-            		result = analyser.analyze(ctx, shapes, channels);
+            		result = analyser.analyze(ctx, shapes, channels, plane);
 				} catch (Exception e) {
 				}
             }
@@ -105,9 +107,10 @@ public class Analyser
      * 					Mustn't be <code>null</code>.
      * @param shapes	Collection of shapes to analyze. 
      * 					Mustn't be <code>null</code>.
+     * @param plane     The plane to analyze the shapes for, can be <code>null</code>
      */
     public Analyser(SecurityContext ctx, PixelsData pixels, Collection channels,
-    		List shapes)
+    		List shapes, Coord3D plane)
     {
     	if (pixels == null) 
     		throw new IllegalArgumentException("No Pixels specified."); 
@@ -117,6 +120,7 @@ public class Analyser
 			throw new IllegalArgumentException("No shapes specified.");
 		this.pixels = pixels;
     	this.channels = channels;
+    	this.plane = plane;
     	Iterator i = shapes.iterator();
     	ROIShape[] data = new ROIShape[shapes.size()];
     	int index = 0;


### PR DESCRIPTION
Further improvement of the ROI analysis, see [Trello card](https://trello.com/c/3HccWkMv/40-roi-memory-issue)

With this PR only the shape of the current active plane is analyzed, not the full stack, which should speed up the analysis significantly for large ROIs which are populated through several planes.

Test: Create a large ROI (which covers a lot of pixels), populate it through the stack. Perform an analysis by switching to the Graph Pane. Move through the stack via the sliders. The newly selected plane should then get analyzed and the diagram updated automatically. Check that the results make sense. Ideally this should be tested with different kinds of images (single plane, multi-z, multi-t, multi-z/t).
Also have a look at the Intensity View.

--
Second attempt, with less code changes, hope this time I didn't break as much as before.