### PR TITLE
Right panel general panes

### DIFF
--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -107,11 +107,13 @@ Test Annotate
     ${pid}=                                     Create Project      robot test annotate
 
     # Comment Form
+    Click Element                               xpath=//h1[@data-name='comments']
     Input Text                                  comment     test add comment
     Submit Form                                 add_comment_form
     Wait Until Page Contains                    test add comment
 
     # Tags
+    Click Element                               xpath=//h1[@data-name='tags']
     Click Element                               launch_tags_form
     # Wait for tag panel being loded
     Wait Until Page Contains Element            xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
@@ -124,6 +126,7 @@ Test Annotate
     Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), testSeleniumTag${pid})]    ${WAIT}
 
     # Files
+    Click Element                               xpath=//h1[@data-name='attachments']
     Click Element                               choose_file_anns
     Wait Until Page Contains Element            id_files
     Click Element                               xpath=//select[@id='id_files']/option    # just pick first file

--- a/components/tests/ui/testcases/web/map_annotations_test.txt
+++ b/components/tests/ui/testcases/web/map_annotations_test.txt
@@ -13,8 +13,9 @@ Suite Teardown      Close all browsers
 Test Map Annotation
     [Documentation]     Tests creation of Map Annotation on New Project
 
-    ${projectId}=                       Create Project
+    ${projectId}=                       Create Project          TestMapAnnotation
     Wait Until Page Contains Element    css=div.mapAnnContainer
+    Click Element                       xpath=//h1[@data-name='keyvaluepairs']
     # No rows selected. Toolbar should allow 'Insert' only.
     Xpath Should Not Have Class   xpath=//ul[contains(@class, 'mapAnnToolbar')]//input[@title='Insert rows']  button-disabled
     Xpath Should Have Class       xpath=//ul[contains(@class, 'mapAnnToolbar')]//input[@title='Copy rows']    button-disabled
@@ -52,8 +53,9 @@ Test Map Annotation
     # Refresh to check saved data
     Go To                               ${WELCOME URL}?show=project-${projectId}
     Wait Until Page Contains Element    css=div.mapAnnContainer
-    Page Should Contain Element         xpath=//table[contains(@class, 'editableKeyValueTable')]//td[contains(text(), '${key}')]
-    Page Should Contain Element         xpath=//table[contains(@class, 'editableKeyValueTable')]//td[contains(text(), '${value}')]
+    Click Element                       xpath=//h1[@data-name='keyvaluepairs']
+    Wait Until Element Is Visible       xpath=//table[contains(@class, 'editableKeyValueTable')]//td[contains(text(), '${key}')]
+    Wait Until Element Is Visible       xpath=//table[contains(@class, 'editableKeyValueTable')]//td[contains(text(), '${value}')]
     # Table shouldn't now have 'Add Key' or 'Add Value' placeholders
     Xpath Should Match X Times          //table[contains(@class, 'editableKeyValueTable')]/tbody/tr    1
     Page Should Not Contain Element     xpath=//div[contains(@class, 'mapAnnContainer')]//td[contains(text(), 'Add Key')]

--- a/components/tests/ui/testcases/web/tagging_test.txt
+++ b/components/tests/ui/testcases/web/tagging_test.txt
@@ -21,6 +21,7 @@ Test Tag
     Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
 
     # Tag a single Project
+    Click Element                               xpath=//h1[@data-name='tags']
     Click Element                               launch_tags_form
     Wait Until Page Contains Element            id_tag
     Sleep                                       5                   # allow tags to load
@@ -30,6 +31,8 @@ Test Tag
     Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
     # Refresh, check and add another Tag, remove first one
     Go To                                       ${WELCOME URL}?show=project-${pId}
+    Wait Until Page Contains Element            xpath=//h1[@data-name='tags']
+    Click Element                               xpath=//h1[@data-name='tags']
     Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
     Click Element                               launch_tags_form
     Wait Until Page Contains Element            id_tag

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
@@ -309,7 +309,11 @@
                         // update summary
                         $("#ratingsAverage").text(data.average);
                         $("#ratingsCount").text(data.count);
-                        $("#ratingsSummary").show();
+                        if (data.count > 0) {
+                            $("#ratingsSummary").show();
+                        } else {
+                            $("#ratingsSummary").hide();
+                        }
                     });
                 }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -64,6 +64,13 @@
         </tr>
     </table>
 
+    <select id="annotationFilter" title="Filter by user" data-userId="{{ ome.user.id }}"
+            style="position:absolute; right:0; bottom:3px; width:80px">
+        <option value="all">Show all</option>
+        <option value="me">Show added by me</option>
+        <option value="others">Show added by others</option>
+    </select>
+
     {% if manager.openAstexViewerCompatible %}
         <button style="position: absolute; right:0; top:0" class="btn silver btn_text" href="#" onclick="return OME.openPopup('{% url 'open_astex_viewer' 'image_8bit' manager.image.id %}')"
                 title="Open with Open Astex Viewer">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -64,12 +64,14 @@
         </tr>
     </table>
 
-    <select id="annotationFilter" title="Filter by user" data-userId="{{ ome.user.id }}"
+    {% if not manager.tag %}
+    <select id="annotationFilter" title="Filter annotations by user" data-userId="{{ ome.user.id }}"
             style="position:absolute; right:0; bottom:3px; width:80px">
         <option value="all">Show all</option>
         <option value="me">Show added by me</option>
         <option value="others">Show added by others</option>
     </select>
+    {% endif %}
 
     {% if manager.openAstexViewerCompatible %}
         <button style="position: absolute; right:0; top:0" class="btn silver btn_text" href="#" onclick="return OME.openPopup('{% url 'open_astex_viewer' 'image_8bit' manager.image.id %}')"

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -258,7 +258,7 @@
 
             // Nothing selected - actions will apply to user's own table
             if ($selRows.length == 0) {
-                var canEdit = $('.editableKeyValueTable:visible').length > 0;
+                var canEdit = $('.editableKeyValueTable').length > 0;
                 enabled["Insert rows"] = canEdit;
                 enabled["Copy rows"] = false;
                 enabled["Paste rows"] = (canPaste && canEdit);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
@@ -54,11 +54,10 @@
                 };
                 $(".metadata_details").click(toggleInvalidRows);
 
-                
-                $('.can-collapse').click(function () {
+                // Setup toggling of panels
+                $('#metadata_tab .can-collapse').click(function () {
                   $(this).toggleClass('closed').next().slideToggle();
                 });
-
                 $('.can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
 
                 // Load Original Metadata...

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
@@ -54,11 +54,32 @@
                 };
                 $(".metadata_details").click(toggleInvalidRows);
 
-                // Setup toggling of panels
+
+                // Handle click on collapsible panes
                 $('#metadata_tab .can-collapse').click(function () {
-                  $(this).toggleClass('closed').next().slideToggle();
+                    $(this).toggleClass('closed').next().slideToggle();
+                    // remember which panes are expanded
+                    var open = [];
+                    $('#metadata_tab .can-collapse').each(function(){
+                        var $this = $(this);
+                        if (!$this.hasClass('closed') && $this.attr('data-name')) {
+                            open.push($this.attr('data-name'));
+                        }
+                    });
+                    $("#metadata_tab").data('open_panes', open);
                 });
-                $('.can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
+                // Expand any previously opened panes
+                var open_panes = $("#metadata_tab").data('open_panes');
+                if (open_panes === undefined) {
+                    open_panes = [];
+                }
+                open_panes.forEach(function(name) {
+                    // remove 'defclose' flag from open panes
+                    $('#metadata_tab .can-collapse[data-name="' + name + '"]').removeClass('defclose');
+                });
+                // Any panes that still have 'defclose' flag, we close
+                $('#metadata_tab .can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
+
 
                 // Load Original Metadata...
                 var origMetadataLoaded = false;
@@ -115,7 +136,9 @@
 			<div class="right_tab_inner">
 			
             {% if manager.companion_files %}
-            <h1 class="can-collapse defclose">{% trans "Companion Files" %}</h1>                
+            <h1 class="can-collapse defclose" data-name="companionfiles">
+                {% trans "Companion Files" %}
+            </h1>
                 <div>
                     {% for fileann in manager.companion_files %}
                     <p>
@@ -130,7 +153,9 @@
             
             {% if not share_id %}
             <!-- Original Metadata is loaded when tab expanded -->
-            <h1 class="can-collapse defclose load_original_metadata">{% trans "Original Metadata" %}</h1>
+            <h1 class="can-collapse defclose load_original_metadata" data-name="originalmetadata">
+                {% trans "Original Metadata" %}
+            </h1>
             <div id="orig_metadata">
             </div>
             <!-- hidden link provides url -->
@@ -145,7 +170,9 @@
 
             <!-- Microscope -->
             {% if form_objective or form_filters or form_detectors %}
-            <h1 class="can-collapse defclose">{% trans "Microscope" %}</h1>
+            <h1 class="can-collapse defclose" data-name="microscope">
+                {% trans "Microscope" %}
+            </h1>
             <div>
                 {% if form_microscope %}
                 <table class="metadata_details">
@@ -211,7 +238,9 @@
             
             <!-- Image -->
             {% if form_objective or form_environment or form_stageLabel %}
-            <h1 class="can-collapse defclose">{% trans "Image" %}</h1>
+            <h1 class="can-collapse defclose" data-name="image">
+                {% trans "Image" %}
+            </h1>
             <div><table class="metadata_details">
                 {% if form_objective %}
                 <tr><th><br/>{% trans "Objective" %}:</th><th colspan="2"></th></tr>
@@ -242,7 +271,7 @@
             
             <!-- Channels -->
             {% for ch in form_channels %}
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="channel{{forloop.counter}}">
                 {% if ch.color %}
                     <span style="padding:0 3px; color:#000; border:1px solid #000; background-color: #{{ ch.color }};">&nbsp&nbsp</span>
                 {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -542,6 +542,13 @@
                         $("#ratingsSummary").show();
                     });
                 }
+
+                // Set up collapsible panes
+                $('.can-collapse').click(function () {
+                  $(this).toggleClass('closed').next().slideToggle();
+                });
+
+                $('.can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
             });
             
     </script>
@@ -584,11 +591,10 @@
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
                   
-
-            <hr/><!-- Temporary Solution. Not the right way to add borders to elements! -->
-                  
-                  
-                  
+            <h1 class="can-collapse defclose">
+                Image Details
+            </h1>
+            <div> 
                   
             <!-- Image Description -->      
             {% with obj=manager.image %}
@@ -608,6 +614,8 @@
                 {% include "webclient/annotations/includes/core_metadata.html" %}
             {% endwith %}
 
+            </div>
+
 
             {% else %}
                 {% if manager.dataset %}
@@ -619,9 +627,12 @@
                     {% include "webclient/annotations/includes/name.html" %}
                 {% endwith %}
 
-                <hr/>
                 
                 <!-- Dataset Description -->
+                <h1 class="can-collapse defclose">
+                    Dataset Details
+                </h1>
+                <div> 
                 {% with obj=manager.dataset %}
                     {% include "webclient/annotations/includes/description.html" %}
                 {% endwith %}
@@ -632,6 +643,7 @@
                         <td id='creation_date'>{{ manager.dataset.getDate|date:"Y-m-d H:i:s" }}</td>
                     </tr>                    
                 </table>
+                </div>
                 {% else %}
                     {% if manager.project %}
 
@@ -642,9 +654,12 @@
                         {% include "webclient/annotations/includes/name.html" %}
                     {% endwith %}
 
-                    <hr/>
                     
                     <!--Project Description -->
+                    <h1 class="can-collapse defclose">
+                        Project Details
+                    </h1>
+                    <div>
                     {% with obj=manager.project %}
                         {% include "webclient/annotations/includes/description.html" %}
                     {% endwith %}
@@ -655,6 +670,7 @@
                             <td id='creation_date'>{{ manager.project.getDate|date:"Y-m-d H:i:s" }}</td>
                         </tr>
                     </table>
+                    </div>
                     {% endif %}
                 {% endif %}
             {% endif %}
@@ -682,16 +698,19 @@
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
 
-            <hr/>
             
             <!-- Image (in WellSample) Description -->
+            <h1 class="can-collapse defclose">
+                Well Details
+            </h1>
+            <div>
             {% with obj=image %}
                 {% include "webclient/annotations/includes/description.html" %}
             {% endwith %}
 
             <!-- Include table of core metadata, Owner, SizeX,Y,Z, Channels etc -->
             {% include "webclient/annotations/includes/core_metadata.html" %}
-
+            </div>
             {% endwith %}{# "image=manager.well.getWellSample.image" #}
 
             {% else %}
@@ -704,9 +723,12 @@
                     {% include "webclient/annotations/includes/name.html" %}
                 {% endwith %}
 
-                <hr/>
                 
                 <!-- Acquisition Description -->
+                <h1 class="can-collapse defclose">
+                    Run Details
+                </h1>
+                <div>
                 {% with obj=manager.acquisition %}
                     {% include "webclient/annotations/includes/description.html" %}
                 {% endwith %}
@@ -717,6 +739,8 @@
                         <td id='creation_date'>{{ manager.acquisition.getDate|date:"Y-m-d H:i:s" }}</td>
                     </tr>
                 </table>
+                </div>
+
                 {% else %}
                     {% if manager.plate %}
 
@@ -727,9 +751,12 @@
                         {% include "webclient/annotations/includes/name.html" %}
                     {% endwith %}
                     
-                    <hr/>
                     
                     <!-- Plate Description -->
+                    <h1 class="can-collapse defclose">
+                        Plate Details
+                    </h1>
+                    <div>
                     {% with obj=manager.plate %}
                         {% include "webclient/annotations/includes/description.html" %}
                     {% endwith %}
@@ -747,6 +774,7 @@
                         </tr>
                         {% endcomment %}-->
                     </table>
+                    </div>
                     {% else %}
                         {% if manager.screen %}
 
@@ -757,10 +785,13 @@
                             {% include "webclient/annotations/includes/name.html" %}
                         {% endwith %}
                             
-                        <hr/>   
                             
 
                         <!-- Screen Description -->
+                        <h1 class="can-collapse defclose">
+                            Plate Details
+                        </h1>
+                        <div>
                         {% with obj=manager.screen %}
                             {% include "webclient/annotations/includes/description.html" %}
                         {% endwith %}
@@ -775,19 +806,11 @@
                                 <td id='child_count'>{{ manager.screen.countChildren }} {% plural manager.screen.countChildren 'plate' 'plates' %}</td>
                             </tr>
                         </table>
+                        </div>
                         {% endif %}
                     {% endif %}
                 {% endif %}
             {% endif %}
-        
-        
-        
-            
-            
-            
-            <hr/><!-- Temporary Solution. Not the right way to add borders to elements! -->
-            
-            
             
             
             
@@ -796,7 +819,7 @@
         
     <!-- ANNOTATIONS -->
     <!--<h1>{% trans "Annotations" %}</h1>-->
-            <div>
+            <!-- <div>
                 <h2 style="float: left">
                     Annotations
                 </h2>
@@ -809,8 +832,11 @@
                 </select>
             </div>
             <div style="clear:both"></div>
-            <hr style="margin-top:0" />
+            <hr style="margin-top:0" /> -->
 
+            <h1 class="can-collapse defclose">
+                Rating
+            </h1>
             <div class="annotations_section">
 
             <!-- RATING -->
@@ -858,15 +884,12 @@
              </div>
             
             
-            <hr/><!-- Temporary Solution. Not the right way to add borders to elements! -->
-            
             
             <!-- TAGS -->               
+            <h1 class="can-collapse defclose">
+                Tags
+            </h1>
             <div class="annotations_section">
-                
-                <h2>{% trans "Tags" %}</h2>
-                
-                
                 
                 {% if manager.canAnnotate %}
                     <div>
@@ -884,13 +907,11 @@
             </div>
             
             
-            <hr/><!-- Temporary Solution. Not the right way to add borders to elements! -->
-            
-            
-            
             <!-- FILES -->
+            <h1 class="can-collapse defclose">
+                Attachments
+            </h1>
             <div class="annotations_section">
-                <h2>{% trans "Attachments" %}</h2>
 
                     {% if manager.canAnnotate %}
                         <a id="choose_file_anns" href="{% url 'annotate_file' %}?{{manager.obj_type}}={{ manager.obj_id }}&index={{ index }}" class="btn silver btn_add">
@@ -912,6 +933,7 @@
                     {% endif %}
                     <img id='fileann_spinner' src="{% static "webgateway/img/spinner.gif" %}" style="display:none"/>
 
+                <div style="clear:both"></div>
                 <!-- display existing file annotations -->
 
                     <ul id="fileanns_container" class="lnfiles">
@@ -931,9 +953,11 @@
             </div>
 
 
-            <hr/>
 
             <!-- MAP ANNOTATIONS -->
+            <h1 class="can-collapse defclose">
+                Key-Value Pairs
+            </h1>
             <div class="annotations_section">
 
                 {% include "webclient/annotations/mapannotations.html" %}
@@ -941,11 +965,11 @@
             </div>
 
 
-            <hr/><!-- Temporary Solution. Not the right way to add borders to elements! -->
-
-
             {% if manager.xml_annotations or manager.boolean_annotations or manager.double_annotations or manager.long_annotations or manager.term_annotations or manager.time_annotations %}
             <!-- CUSTOM ANNOTATIONS -->
+            <h1 class="can-collapse defclose">
+                Others
+            </h1>
             <div class="annotations_section">
                 <h2>{% trans "Others" %}:</h2>
                 
@@ -1009,12 +1033,14 @@
                         {% endfor %}
                     </table>
             </div>
-            <hr/>
             {% endif %}
 
             
             
             <!-- COMMENTS -->
+            <h1 class="can-collapse defclose">
+                Comments
+            </h1>
             <div class="annotations_section">
                 
                     {% if manager.canAnnotate %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -550,8 +550,8 @@
                     var open = [];
                     $('#metadata_general .can-collapse').each(function(){
                         var $this = $(this);
-                        if (!$this.hasClass('closed')) {
-                            open.push($(this).attr('data-name'));
+                        if (!$this.hasClass('closed') && $this.attr('data-name')) {
+                            open.push($this.attr('data-name'));
                         }
                     });
                     $("#metadata_general").data('open_panes', open);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -539,7 +539,11 @@
                         // update summary
                         $("#ratingsAverage").text(data.average);
                         $("#ratingsCount").text(data.count);
-                        $("#ratingsSummary").show();
+                        if (data.count > 0) {
+                            $("#ratingsSummary").show();
+                        } else {
+                            $("#ratingsSummary").hide();
+                        }
                     });
                 }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -970,6 +970,49 @@
              </div>
 
 
+            
+            <!-- COMMENTS -->
+            <h1 class="can-collapse defclose" data-name="comments">
+                Comments
+            </h1>
+            <div class="annotations_section">
+
+                    {% if manager.canAnnotate %}
+                    <form id="add_comment_form" action="{% url 'annotate_comment' %}" method="post">{% csrf_token %}
+                    <table>
+                        <tr class="hiddenField"><td>{{ form_comment.image }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.dataset }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.project }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.screen }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.plate }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.acquisition }}</td></tr>
+                        <tr class="hiddenField"><td>{{ form_comment.well }}</td></tr>
+                        <tr>
+                            <td>
+                                <div id="add_comment_wrapper" style="position: relative">
+                                    <label class="inline_label" for="id_comment">Add Comment:</label>
+                                    {{ form_comment.comment }}
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><input type="submit" value="{% trans 'Add Comment' %}" style="display:none" /></td>
+                        </tr>
+                    </table>
+                    </form>
+                    {% endif %}
+
+                    <div id="comments_container" class="lncomments">
+                        {% for tann in manager.text_annotations %}
+                            {% with added_by=tann.link.getDetails.getOwner.id %}
+                                {% include "webclient/annotations/comment.html" %}
+                            {% endwith %}
+                        {% endfor %}
+                    </div>
+            </div>
+            <div class="clear"></div>          
+            
+
 
             <!-- 'OTHER' ANNOTATIONS -->
             {% if manager.xml_annotations or manager.boolean_annotations or manager.double_annotations or manager.long_annotations or manager.term_annotations or manager.time_annotations %}
@@ -978,7 +1021,7 @@
             </h1>
             <div class="annotations_section">
                 <h2>{% trans "Others" %}:</h2>
-                
+
                     <!-- tool tips for each <td> is contained in child <span>, which are also hidden -->
                     <table id="custom_annotations">
                         {% for ann in manager.xml_annotations %}
@@ -991,7 +1034,7 @@
                             </td>
                         </tr>
                         {% endfor %}
-                        
+
                         {% for ann in manager.boolean_annotations %}
                         <tr data-added-by="{{ ann.link.getDetails.getOwner.id }}">
                             <th>Boolean:</th>
@@ -1041,49 +1084,6 @@
             </div>
             {% endif %}
 
-
-            
-            <!-- COMMENTS -->
-            <h1 class="can-collapse defclose" data-name="comments">
-                Comments
-            </h1>
-            <div class="annotations_section">
-                
-                    {% if manager.canAnnotate %}
-                    <form id="add_comment_form" action="{% url 'annotate_comment' %}" method="post">{% csrf_token %}
-                    <table>
-                        <tr class="hiddenField"><td>{{ form_comment.image }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.dataset }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.project }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.screen }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.plate }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.acquisition }}</td></tr>
-                        <tr class="hiddenField"><td>{{ form_comment.well }}</td></tr>
-                        <tr>
-                            <td>
-                                <div id="add_comment_wrapper" style="position: relative">
-                                    <label class="inline_label" for="id_comment">Add Comment:</label>
-                                    {{ form_comment.comment }}
-                                </div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><input type="submit" value="{% trans 'Add Comment' %}" style="display:none" /></td>
-                        </tr>
-                    </table>
-                    </form>
-                    {% endif %}                        
-                
-                    <div id="comments_container" class="lncomments">
-                        {% for tann in manager.text_annotations %}
-                            {% with added_by=tann.link.getDetails.getOwner.id %}
-                                {% include "webclient/annotations/comment.html" %}
-                            {% endwith %}
-                        {% endfor %}
-                    </div>
-            </div>
-            <div class="clear"></div>          
-            
         </div>
         {% endif %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -544,10 +544,9 @@
                 }
 
                 // Set up collapsible panes
-                $('.can-collapse').click(function () {
+                $('#metadata_general .can-collapse').click(function () {
                   $(this).toggleClass('closed').next().slideToggle();
                 });
-
                 $('.can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
             });
             

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -591,7 +591,7 @@
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
                   
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse">
                 Image Details
             </h1>
             <div> 
@@ -629,7 +629,7 @@
 
                 
                 <!-- Dataset Description -->
-                <h1 class="can-collapse defclose">
+                <h1 class="can-collapse">
                     Dataset Details
                 </h1>
                 <div> 
@@ -656,7 +656,7 @@
 
                     
                     <!--Project Description -->
-                    <h1 class="can-collapse defclose">
+                    <h1 class="can-collapse">
                         Project Details
                     </h1>
                     <div>
@@ -700,7 +700,7 @@
 
             
             <!-- Image (in WellSample) Description -->
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse">
                 Well Details
             </h1>
             <div>
@@ -725,7 +725,7 @@
 
                 
                 <!-- Acquisition Description -->
-                <h1 class="can-collapse defclose">
+                <h1 class="can-collapse">
                     Run Details
                 </h1>
                 <div>
@@ -753,7 +753,7 @@
                     
                     
                     <!-- Plate Description -->
-                    <h1 class="can-collapse defclose">
+                    <h1 class="can-collapse">
                         Plate Details
                     </h1>
                     <div>
@@ -788,8 +788,8 @@
                             
 
                         <!-- Screen Description -->
-                        <h1 class="can-collapse defclose">
-                            Plate Details
+                        <h1 class="can-collapse">
+                            Screen Details
                         </h1>
                         <div>
                         {% with obj=manager.screen %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -543,10 +543,29 @@
                     });
                 }
 
-                // Set up collapsible panes
+                // Handle click on collapsible panes
                 $('#metadata_general .can-collapse').click(function () {
-                  $(this).toggleClass('closed').next().slideToggle();
+                    $(this).toggleClass('closed').next().slideToggle();
+                    // remember which panes are expanded
+                    var open = [];
+                    $('#metadata_general .can-collapse').each(function(){
+                        var $this = $(this);
+                        if (!$this.hasClass('closed')) {
+                            open.push($(this).attr('data-name'));
+                        }
+                    });
+                    $("#metadata_general").data('open_panes', open);
                 });
+                // Expand any previously opened panes
+                var open_panes = $("#metadata_general").data('open_panes');
+                if (open_panes === undefined) {
+                    open_panes = ["details"];     // by default, just 'details' is open
+                }
+                open_panes.forEach(function(name) {
+                    // remove 'defclose' flag from open panes
+                    $('#metadata_general .can-collapse[data-name="' + name + '"]').removeClass('defclose');
+                });
+                // Any panes that still have 'defclose' flag, we close
                 $('.can-collapse.defclose').removeClass('defclose').addClass('closed').next().hide();
             });
             
@@ -590,7 +609,7 @@
                 {% include "webclient/annotations/includes/name.html" %}
             {% endwith %}
                   
-            <h1 class="can-collapse">
+            <h1 class="can-collapse defclose" data-name="details">
                 Image Details
             </h1>
             <div> 
@@ -628,7 +647,7 @@
 
                 
                 <!-- Dataset Description -->
-                <h1 class="can-collapse">
+                <h1 class="can-collapse defclose" data-name="details">
                     Dataset Details
                 </h1>
                 <div> 
@@ -655,7 +674,7 @@
 
                     
                     <!--Project Description -->
-                    <h1 class="can-collapse">
+                    <h1 class="can-collapse defclose" data-name="details">
                         Project Details
                     </h1>
                     <div>
@@ -699,7 +718,7 @@
 
             
             <!-- Image (in WellSample) Description -->
-            <h1 class="can-collapse">
+            <h1 class="can-collapse defclose" data-name="details">
                 Well Details
             </h1>
             <div>
@@ -724,7 +743,7 @@
 
                 
                 <!-- Acquisition Description -->
-                <h1 class="can-collapse">
+                <h1 class="can-collapse defclose" data-name="details">
                     Run Details
                 </h1>
                 <div>
@@ -752,7 +771,7 @@
                     
                     
                     <!-- Plate Description -->
-                    <h1 class="can-collapse">
+                    <h1 class="can-collapse defclose" data-name="details">
                         Plate Details
                     </h1>
                     <div>
@@ -787,7 +806,7 @@
                             
 
                         <!-- Screen Description -->
-                        <h1 class="can-collapse">
+                        <h1 class="can-collapse defclose" data-name="details">
                             Screen Details
                         </h1>
                         <div>
@@ -820,7 +839,7 @@
 
 
             <!-- TAGS -->               
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="tags">
                 Tags
             </h1>
             <div class="annotations_section">
@@ -843,7 +862,7 @@
 
 
             <!-- MAP ANNOTATIONS -->
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="keyvaluepairs">
                 Key-Value Pairs
             </h1>
             <div class="annotations_section">
@@ -855,7 +874,7 @@
 
 
             <!-- FILES -->
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="attachments">
                 Attachments
             </h1>
             <div class="annotations_section">
@@ -901,7 +920,7 @@
 
 
             <!-- RATING -->
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="ratings">
                 Ratings
             </h1>
             <div class="annotations_section">
@@ -950,7 +969,7 @@
 
             <!-- 'OTHER' ANNOTATIONS -->
             {% if manager.xml_annotations or manager.boolean_annotations or manager.double_annotations or manager.long_annotations or manager.term_annotations or manager.time_annotations %}
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="others">
                 Others
             </h1>
             <div class="annotations_section">
@@ -1021,7 +1040,7 @@
 
             
             <!-- COMMENTS -->
-            <h1 class="can-collapse defclose">
+            <h1 class="can-collapse defclose" data-name="comments">
                 Comments
             </h1>
             <div class="annotations_section">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -818,73 +818,8 @@
         
         
     <!-- ANNOTATIONS -->
-    <!--<h1>{% trans "Annotations" %}</h1>-->
-            <!-- <div>
-                <h2 style="float: left">
-                    Annotations
-                </h2>
 
-                <select id="annotationFilter" title="Filter by user" data-userId="{{ ome.user.id }}"
-                        style="float: right; width:80px">
-                    <option value="all">Show all</option>
-                    <option value="me">Show added by me</option>
-                    <option value="others">Show added by others</option>
-                </select>
-            </div>
-            <div style="clear:both"></div>
-            <hr style="margin-top:0" /> -->
 
-            <h1 class="can-collapse defclose">
-                Rating
-            </h1>
-            <div class="annotations_section">
-
-            <!-- RATING -->
-      
-                <h2>{% trans "Rating" %}</h2>
-
-                {% with ratings=manager.getGroupedRatings %}
-
-                {% if manager.canAnnotate %}
-                    <div>
-                        <a id="add_rating" href="#" class="btn silver btn_add"
-                            {% if ratings.myRating %}style="display: none"{% endif %}
-                        ><span></span></a>
-                    </div>
-                {% endif %}
-
-                <div style="clear:both"></div>
-
-                <ul id="rating_annotations" class="lnfiles">
-
-                    <li class="rating myRating" style="position: relative {% if not ratings.myRating %}; display:none{% endif %}">
-                        <a><img
-                        {% if ratings.myRating %}
-                        {% ifequal ratings.myRating 1 %} src="{% static "webclient/image/rating1.png" %}"{% endifequal %}
-                        {% ifequal ratings.myRating 2 %} src="{% static "webclient/image/rating2.png" %}"{% endifequal %}
-                        {% ifequal ratings.myRating 3 %} src="{% static "webclient/image/rating3.png" %}"{% endifequal %}
-                        {% ifequal ratings.myRating 4 %} src="{% static "webclient/image/rating4.png" %}"{% endifequal %}
-                        {% ifequal ratings.myRating 5 %} src="{% static "webclient/image/rating5.png" %}"{% endifequal %}
-
-                        {% else %}
-                            src="{% static "webclient/image/rating0.png" %}"
-                        {% endif %}
-                        />
-                        </a>
-                        <a href="#" class="removeRating removeTag" title="Delete rating">X</a>
-                    </li>
-                </ul>
-                <div id="ratingsSummary" {% if not ratings.average %}style="display:none"{% endif %}>
-                    (avg:
-                    <span id="ratingsAverage">{{ ratings.average }}</span>
-                    / <span id="ratingsCount">{{ ratings.count }}</span>
-                    votes)
-                </div>
-                {% endwith %}
-             </div>
-            
-            
-            
             <!-- TAGS -->               
             <h1 class="can-collapse defclose">
                 Tags
@@ -905,8 +840,21 @@
                 </div>
  
             </div>
-            
-            
+
+
+
+            <!-- MAP ANNOTATIONS -->
+            <h1 class="can-collapse defclose">
+                Key-Value Pairs
+            </h1>
+            <div class="annotations_section">
+
+                {% include "webclient/annotations/mapannotations.html" %}
+
+            </div>
+
+
+
             <!-- FILES -->
             <h1 class="can-collapse defclose">
                 Attachments
@@ -953,20 +901,56 @@
             </div>
 
 
-
-            <!-- MAP ANNOTATIONS -->
+            <!-- RATING -->
             <h1 class="can-collapse defclose">
-                Key-Value Pairs
+                Ratings
             </h1>
             <div class="annotations_section">
 
-                {% include "webclient/annotations/mapannotations.html" %}
+                {% with ratings=manager.getGroupedRatings %}
 
-            </div>
+                {% if manager.canAnnotate %}
+                    <div>
+                        <a id="add_rating" href="#" class="btn silver btn_add"
+                            {% if ratings.myRating %}style="display: none"{% endif %}
+                        ><span></span></a>
+                    </div>
+                {% endif %}
+
+                <div style="clear:both"></div>
+
+                <ul id="rating_annotations" class="lnfiles">
+
+                    <li class="rating myRating" style="position: relative {% if not ratings.myRating %}; display:none{% endif %}">
+                        <a><img
+                        {% if ratings.myRating %}
+                        {% ifequal ratings.myRating 1 %} src="{% static "webclient/image/rating1.png" %}"{% endifequal %}
+                        {% ifequal ratings.myRating 2 %} src="{% static "webclient/image/rating2.png" %}"{% endifequal %}
+                        {% ifequal ratings.myRating 3 %} src="{% static "webclient/image/rating3.png" %}"{% endifequal %}
+                        {% ifequal ratings.myRating 4 %} src="{% static "webclient/image/rating4.png" %}"{% endifequal %}
+                        {% ifequal ratings.myRating 5 %} src="{% static "webclient/image/rating5.png" %}"{% endifequal %}
+
+                        {% else %}
+                            src="{% static "webclient/image/rating0.png" %}"
+                        {% endif %}
+                        />
+                        </a>
+                        <a href="#" class="removeRating removeTag" title="Delete rating">X</a>
+                    </li>
+                </ul>
+                <div id="ratingsSummary" {% if not ratings.average %}style="display:none"{% endif %}>
+                    (avg:
+                    <span id="ratingsAverage">{{ ratings.average }}</span>
+                    / <span id="ratingsCount">{{ ratings.count }}</span>
+                    votes)
+                </div>
+                {% endwith %}
+             </div>
 
 
+
+            <!-- 'OTHER' ANNOTATIONS -->
             {% if manager.xml_annotations or manager.boolean_annotations or manager.double_annotations or manager.long_annotations or manager.term_annotations or manager.time_annotations %}
-            <!-- CUSTOM ANNOTATIONS -->
             <h1 class="can-collapse defclose">
                 Others
             </h1>
@@ -1035,7 +1019,7 @@
             </div>
             {% endif %}
 
-            
+
             
             <!-- COMMENTS -->
             <h1 class="can-collapse defclose">


### PR DESCRIPTION
This is the first part of the right panel update from https://docs.google.com/document/d/1C__ZB0uyX3295Fop-k-fcQIL53NaKrZcuZ3N0OBDMb0/edit#

In this PR we simply split the main "General" tab content into separate collapsible panes.
We don't yet change how data is loaded or provide annotation counts in the pane headers.

To test:
 - Browse P/D/I S/P/W and check that panel looks OK and tabs expand when clicked and contain correct data (maybe compare with viewing same data in Insight)
 - Filter Annotations by user and check this still works as expected

Some differences with mock-ups:
 - I've kept ```Image ID``` and ```Owner``` above each other, with the "Show All" selector to the right. I think this looks neater than having them on the same row. @gusferguson Do you think the "Show All" selector really needs a label, or will a tooltip be sufficient? I think a label might just be unnecessary clutter.
 - The mockups sometimes use plural E.g. "Tags" and "Attachments" and sometimes not "Rating" and "Other". It probably makes sense to always use the plural "Ratings" and "Others"?
 - I think that "Others" should go after "Ratings" since "Others" is really 'Anything not listed above'. Also, Rating is likely to be a smaller tab than Others, so expanding Rating will not make Others fly off the screen but Others (when expanded) could be big enough to make Rating disappear (I think this is the reason we have Comments last).

I think we should maybe have "Image Details" open by default?
This would minimise the change for users, is a small amount of key info and is never too big to hide other tabs (just means that we have less empty space when panel first loads).

Future PRs will handle:
 - Remembering which panel you had open
 - Adding Annotation counts to panel headers
 - Loading data only for open tabs

![screen shot 2015-10-13 at 12 18 42](https://cloud.githubusercontent.com/assets/900055/10453532/d39de65a-71a4-11e5-85f7-d9d002b2f3ce.png)

