### PR TITLE
trac 13018: disabling inactive share access

### DIFF
--- a/components/blitz/src/ome/services/blitz/fire/PermissionsVerifierI.java
+++ b/components/blitz/src/ome/services/blitz/fire/PermissionsVerifierI.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import ome.api.IQuery;
+import ome.conditions.SecurityViolation;
 import ome.conditions.SessionException;
 import ome.model.meta.Experimenter;
 import ome.services.sessions.SessionManager;
@@ -166,6 +167,9 @@ public class PermissionsVerifierI extends _PermissionsVerifierDisp {
                 return false;
             }
 
+        } catch (SecurityViolation sv) {
+            reason.value = sv.getMessage();
+            return false;
         } catch (Throwable t) {
             reason.value = "Internal error. Please contact your administrator:\n"
                     + t.getMessage();

--- a/components/server/src/ome/security/sharing/SharingACLVoter.java
+++ b/components/server/src/ome/security/sharing/SharingACLVoter.java
@@ -19,6 +19,7 @@ import ome.security.SystemTypes;
 import ome.security.basic.CurrentDetails;
 import ome.security.basic.TokenHolder;
 import ome.services.sharing.ShareStore;
+import ome.services.sharing.data.ShareData;
 
 import org.hibernate.Session;
 import org.slf4j.Logger;
@@ -73,7 +74,11 @@ public class SharingACLVoter implements ACLVoter {
             return true;
         }
         long sessionID = cd.getCurrentEventContext().getCurrentShareId();
-        return store.contains(sessionID, klass, id);
+        ShareData data = store.get(sessionID);
+        if (data.enabled) {
+            return store.contains(sessionID, klass, id);
+        }
+        return false;
     }
 
     public void throwLoadViolation(IObject iObject) throws SecurityViolation {

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -544,8 +544,10 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
 
             if (Boolean.FALSE.equals(active)) {
                throw new SecurityViolation(prefix + " is inactive");
-            } else if (started.getTime() + timeToLive > System.currentTimeMillis()) {
-                throw new SecurityViolation(prefix + " has expired");
+            } else if ((System.currentTimeMillis() - started.getTime()) > timeToLive) {
+                String msg = String.format("%s has expired: %s, timeToLive=%s",
+                        prefix, started, timeToLive);
+                throw new SecurityViolation(msg);
             }
         }
     }

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -519,9 +519,36 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
 
     public Session find(String uuid) {
         SessionContext sessionContext = cache.getSessionContext(uuid);
+        checkIfShare(sessionContext);
         return (sessionContext == null) ? null : sessionContext.getSession();
     }
 
+    private void checkIfShare(SessionContext sessionContext) {
+        if (sessionContext.getSession() instanceof Share) {
+            final Long id = sessionContext.getSession().getId();
+            final String uuid = sessionContext.getSession().getUuid();
+            final String prefix = String.format("Share:%s (%s)", id, uuid);
+
+            List<Object[]> rv = executeProjection(
+                    "select s.active, s.timeToLive, s.started from Share s where s.id = :id",
+                    new Parameters().addId(sessionContext.getSession().getId()));
+
+            if (rv.size() != 1) {
+                throw new RuntimeException(prefix + " could not be found!");
+            }
+
+            Object[] items = rv.get(0);
+            Boolean active = (Boolean) items[0];
+            Long timeToLive = (Long) items[1];
+            Timestamp started = (Timestamp) items[2];
+
+            if (Boolean.FALSE.equals(active)) {
+               throw new SecurityViolation(prefix + " is inactive");
+            } else if (started.getTime() + timeToLive > System.currentTimeMillis()) {
+                throw new SecurityViolation(prefix + " has expired");
+            }
+        }
+    }
     private final static String findBy1 =
         "select s.id, s.uuid from Session s " +
         "join s.owner o where " +

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -1028,11 +1028,12 @@ class TestIShare(lib.ITest):
         self.assert_expiration(expiration, o_share.getShare(sid))
         time.sleep(0.5)
 
-        with pytest.raises(Glacier2.PermissionDeniedException):
-            self.new_client(session=s.uuid)
         # Forced closing
         o_session = owner.sf.getSessionService()
         o_session.closeSession(o_share.getShare(sid))
+
+        with pytest.raises(Glacier2.PermissionDeniedException):
+            self.new_client(session=s.uuid)
 
     # Helpers
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -983,6 +983,23 @@ class TestIShare(lib.ITest):
         finally:
             user_client.__del__()
 
+    def test13018(self):
+        owner = self.new_client()
+        member, mobj = self.new_client_and_user()
+
+        createTestImage(owner.sf)
+        image = owner.sf.getQueryService().findAll("Image", None)[0]
+
+        o_share = owner.sf.getShareService()
+        sid = o_share.createShare("", None, [image], [mobj], [], True)
+
+        m_share = member.sf.getShareService()
+        m_share.activate(sid)
+
+        o_share.setActive(sid, False)
+        with pytest.raises(omero.ValidationException):
+            m_share.activate(sid)
+
     # Helpers
 
     def assert_access(self, client, sid, success=True):

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -1011,9 +1011,7 @@ class TestIShare(lib.ITest):
         # test inactive share, if member has no access to the image
         s = o_share.getShare(sid)
         m_conn = self.new_client(session=s.uuid)
-        with pytest.raises(omero.SecurityViolation):
-            m_conn.sf.getQueryService().find("Image", image.id.val)
-        m_conn.__del__()
+        assert not m_conn.sf.getQueryService().find("Image", image.id.val)
 
         # activate again
         o_share.setActive(sid, True)

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -1018,6 +1018,10 @@ class TestIShare(lib.ITest):
         # activate again
         o_share.setActive(sid, True)
 
+        # test that the image is now loadable again.
+        t_conn = self.new_client(session=s.uuid)
+        t_conn.sf.getQueryService().find("Image", image.id.val)
+
         # test expired share, if member has no access to the image
         expiration = long(time.time() * 1000) + 500
         o_share.setExpiration(sid, rtime(expiration))

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -984,6 +984,9 @@ class TestIShare(lib.ITest):
             user_client.__del__()
 
     def test13018(self):
+        """
+        Test that share can't be activated when inactive
+        """
         owner = self.new_client()
         member, mobj = self.new_client_and_user()
 
@@ -999,6 +1002,10 @@ class TestIShare(lib.ITest):
         o_share.setActive(sid, False)
         with pytest.raises(omero.ValidationException):
             m_share.activate(sid)
+
+        with pytest.raises(omero.ValidationException):
+            obj = omero.model.ShareI(sid, False)
+            member.sf.setSecurityContext(obj)
 
     # Helpers
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -13,6 +13,8 @@ import time
 import library as lib
 import pytest
 import omero
+import Glacier2
+
 from omero.rtypes import rtime, rlong, rlist
 from omero.gateway import BlitzGateway
 
@@ -1010,8 +1012,8 @@ class TestIShare(lib.ITest):
 
         # test inactive share, if member has no access to the image
         s = o_share.getShare(sid)
-        m_conn = self.new_client(session=s.uuid)
-        assert not m_conn.sf.getQueryService().find("Image", image.id.val)
+        with pytest.raises(Glacier2.PermissionDeniedException):
+            self.new_client(session=s.uuid)
 
         # activate again
         o_share.setActive(sid, True)
@@ -1021,14 +1023,11 @@ class TestIShare(lib.ITest):
         o_share.setExpiration(sid, rtime(expiration))
         self.assert_expiration(expiration, o_share.getShare(sid))
 
-        m_conn = self.new_client(session=s.uuid)
+        with pytest.raises(Glacier2.PermissionDeniedException):
+            self.new_client(session=s.uuid)
         # Forced closing
         o_session = owner.sf.getSessionService()
         o_session.closeSession(o_share.getShare(sid))
-
-        with pytest.raises(omero.SecurityViolation):
-            m_conn.sf.getQueryService().find("Image", image.id.val)
-        m_conn.__del__()
 
     # Helpers
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -1019,9 +1019,10 @@ class TestIShare(lib.ITest):
         o_share.setActive(sid, True)
 
         # test expired share, if member has no access to the image
-        expiration = long(time.time() * 1000) + 86400
+        expiration = long(time.time() * 1000) + 500
         o_share.setExpiration(sid, rtime(expiration))
         self.assert_expiration(expiration, o_share.getShare(sid))
+        time.sleep(0.5)
 
         with pytest.raises(Glacier2.PermissionDeniedException):
             self.new_client(session=s.uuid)


### PR DESCRIPTION
When using `joinSession` on an inactive share, throw PermissionDenied:

```
        CannotCreateSessionException Raised if the session
E       PermissionDeniedException: exception ::Glacier2::PermissionDeniedException
E       {
E           reason = Share:1489 (497c947c-8e57-4e9a-9886-f3f87e6016a6) is inactive
E       }

```

See: https://trac.openmicroscopy.org/ome/ticket/13018#comment:4