### PR TITLE
ROI service

### DIFF
--- a/components/blitz/resources/omero/api/IRoi.ice
+++ b/components/blitz/resources/omero/api/IRoi.ice
@@ -16,7 +16,7 @@
 // -----------------------------
 // Histograms
 // Volumes, Velocities, Diffusions
-
+["deprecated:IROI is deprecated."]
 module omero {
 
     module api {
@@ -134,6 +134,7 @@ module omero {
                  * All Shapes are loaded, as is the Pixels and Image object.
                  * TODO: Annotations?
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 RoiResult findByRoi(long roiId, RoiOptions opts) throws omero::ServerError;
 
@@ -142,6 +143,7 @@ module omero {
                  *
                  * Loads Rois as findByRoi.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 RoiResult findByImage(long imageId, RoiOptions opts) throws omero::ServerError;
 
@@ -150,30 +152,35 @@ module omero {
                  *
                  * Loads Rois as findByRoi.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 RoiResult findByPlane(long imageId, int z, int t, RoiOptions opts) throws omero::ServerError;
 
                 /**
                  * Calculate the points contained within a given shape
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 ShapePoints getPoints(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate stats for all the shapes within the given Roi.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 RoiStats getRoiStats(long roiId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shape.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 ShapeStats getShapeStats(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shapes.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 ShapeStatsList getShapeStatsList(LongList shapeIdList) throws omero::ServerError;
 
@@ -188,6 +195,7 @@ module omero {
                  *
                  * @param opts, userId and groupId are respected based on the ownership of the annotation.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 AnnotationList getRoiMeasurements(long imageId, RoiOptions opts) throws omero::ServerError;
 
@@ -197,6 +205,7 @@ module omero {
                  *
                  * @param annotationId if -1, logic is identical to findByImage(imageId, opts)
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 RoiResult getMeasuredRois(long imageId, long annotationId, RoiOptions opts) throws omero::ServerError;
 
@@ -205,6 +214,7 @@ module omero {
                  * Logic is identical to getMeasuredRois, but Roi data will not be duplicated. (i.e.
                  * the objects are referentially identical)
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 LongRoiResultMap getMeasuredRoisMap(long imageId, LongList annotationIds, RoiOptions opts) throws omero::ServerError;
 
@@ -212,9 +222,11 @@ module omero {
                  * Returns the OMERO.tables service via the [omero::model::FileAnnotation] id returned
                  * by getImageMeasurements.
                  **/
+                ["deprecated:IROI is deprecated."]
                 idempotent
                 omero::grid::Table* getTable(long annotationId) throws omero::ServerError;
 
+                ["deprecated:IROI is deprecated."]
                 void uploadMask(long roiId, int z, int t, Ice::ByteSeq bytes) throws omero::ServerError;
 
             };


### PR DESCRIPTION
Deprecate methods in ROIService
I had to mark each method as deprecated in the slice so it is reflected in Java
There is maybe a more suitable way
cc @joshmoore 