### PR TITLE
OMEROMetadataStoreClient: speed up import for many LSIDs

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -249,6 +249,9 @@ public class OMEROMetadataStoreClient
     private Map<LSID, List<LSID>> referenceCache =
         new HashMap<LSID, List<LSID>>();
 
+    private Map<LSID, Set<LSID>> referenceCacheCheck =
+        new HashMap<LSID, Set<LSID>>();
+
     /** Our authoritative LSID container cache. */
     private Map<Class<? extends IObject>, Map<String, IObjectContainer>>
         authoritativeContainerCache =
@@ -1189,6 +1192,7 @@ public class OMEROMetadataStoreClient
             containerCache =
                 new TreeMap<LSID, IObjectContainer>(new OMEXMLModelComparator());
             referenceCache = new HashMap<LSID, List<LSID>>();
+            referenceCacheCheck = new HashMap<LSID, Set<LSID>>();
             referenceStringCache = null;
             imageChannelGlobalMinMax = null;
             userSpecifiedAnnotations = null;
@@ -1440,7 +1444,7 @@ public class OMEROMetadataStoreClient
      */
     public Map<LSID, List<LSID>> getReferenceCache()
     {
-        return referenceCache;
+        return Collections.unmodifiableMap(referenceCache);
     }
 
     /* (non-Javadoc)
@@ -1481,17 +1485,23 @@ public class OMEROMetadataStoreClient
     public void addReference(LSID source, LSID target)
     {
         List<LSID> targets = null;
+        Set<LSID> targetsCheck = null;
         if (referenceCache.containsKey(source))
         {
             targets = referenceCache.get(source);
+            targetsCheck = referenceCacheCheck.get(source);
         }
         else
         {
             targets = new ArrayList<LSID>();
+            targetsCheck = new HashSet<LSID>();
             referenceCache.put(source, targets);
+            referenceCacheCheck.put(source, targetsCheck);
         }
-        if (!targets.contains(target))
+        // Adding to a list is VERY slow.
+        if (!targetsCheck.contains(target))
         {
+            targetsCheck.add(target);
             targets.add(target);
         }
     }

--- a/components/model/test/ome/util/utests/LSIDEquivilenceTest.java
+++ b/components/model/test/ome/util/utests/LSIDEquivilenceTest.java
@@ -8,9 +8,13 @@ package ome.util.utests;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import junit.framework.TestCase;
 import ome.model.acquisition.DetectorSettings;
 import ome.model.acquisition.FilterSet;
 import ome.model.acquisition.ObjectiveSettings;
@@ -18,8 +22,10 @@ import ome.model.core.Image;
 import ome.model.core.LogicalChannel;
 import ome.model.screen.Plate;
 import ome.util.LSID;
-import junit.framework.TestCase;
 
+import org.testng.annotations.Test;
+
+@Test
 public class LSIDEquivilenceTest extends TestCase
 {
 	public void testStringHashMapContainsKey()
@@ -145,5 +151,40 @@ public class LSIDEquivilenceTest extends TestCase
         assertEquals(a, b);
         assertEquals(a.getJavaClass(), b.getJavaClass());
         assertEquals(a.getIndexes()[0], b.getIndexes()[0]);
+    }
+
+    public void testBigListsWithSet()
+    {
+        Set<LSID> set = new HashSet<LSID>();
+        for (int i = 0; i < 100000; i++)
+        {
+            set.add(new LSID(Plate.class, i));
+        }
+    }
+
+    public void testBigListsWithSetAndList()
+    {
+        Set<LSID> found = new HashSet<LSID>();
+        List<LSID> list = new ArrayList<LSID>();
+        for (int i = 0; i < 100000; i++)
+        {
+            LSID lsid = new LSID(Plate.class, i);
+            if (!found.contains(lsid)) {
+                found.add(lsid);
+                list.add(lsid);
+            }
+        }
+    }
+
+    public void testBigListsWithLinkedHashSet()
+    {
+        LinkedHashSet<LSID> set = new LinkedHashSet<LSID>();
+        for (int i = 0; i < 100000; i++)
+        {
+            LSID lsid = new LSID(Plate.class, i);
+            if (!set.contains(lsid)) {
+                set.add(lsid);
+            }
+        }
     }
 }


### PR DESCRIPTION
The check of List.contains(LSID) was extremely time expensive.
This code could use a further refactoring but that will mean
changing public methods. Instead, here we simply maintain a
map of checks which can be used to speed up the parsing.

cc: @chris-allan @jburel @mtbc 