### PR TITLE
Python gateway & webclient delete improvements

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3826,7 +3826,13 @@ class _BlitzGateway (object):
         linked to others in the database
 
         :param obj:     Object to delete
-        :type obj:      IObject"""
+        :type obj:      IObject
+
+        ** Deprecated ** Use :meth:`deleteObject` or :meth:`deleteObjects`.
+        """
+        warnings.warn(
+            "Deprecated. Use deleteObject() or deleteObjects()",
+            DeprecationWarning)
 
         type = obj.__class__.__name__.rstrip('I')
         delete = Delete2(targetObjects={type: [obj.getId().val]})

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3843,7 +3843,8 @@ class _BlitzGateway (object):
         Delete a single object.
 
         :param obj:     Object to delete
-        :type obj:      IObject"""
+        :type obj:      IObject
+        """
 
         objType = obj.__class__.__name__.rstrip('I')
         self.deleteObjects(objType, [obj.id.val], wait=True)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7126,30 +7126,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         self._author = e.firstName.val + " " + e.lastName.val
         return self._author
 
-    def getDataset(self):
-        """
-        XXX: Deprecated since 4.3.2, use listParents(). (See #6660)
-        Gets the Dataset that image is in, or None.
-        Returns None if Image is in more than one Dataset.
-
-        :return:    Dataset
-        :rtype:     :class:`DatasetWrapper`
-        """
-
-        try:
-            q = """
-            select ds from Image i join i.datasetLinks dl join dl.parent ds
-            where i.id = %i
-            """ % self._obj.id.val
-            query = self._conn.getQueryService()
-            ds = query.findAllByQuery(q, None, self._conn.SERVICE_OPTS)
-            if ds and len(ds) == 1:
-                return DatasetWrapper(self._conn, ds[0])
-        except:  # pragma: no cover
-            logger.debug('on getDataset')
-            logger.debug(traceback.format_exc())
-            return None
-
     def getProject(self):
         """
         Gets the Project that image is in, or None.

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3832,6 +3832,16 @@ class _BlitzGateway (object):
         delete = Delete2(targetObjects={type: [obj.getId().val]})
         self.c.submit(delete, self.SERVICE_OPTS)
 
+    def deleteObject(self, obj):
+        """
+        Delete a single object.
+
+        :param obj:     Object to delete
+        :type obj:      IObject"""
+
+        objType = obj.__class__.__name__.rstrip('I')
+        self.deleteObjects(objType, [obj.id.val], wait=True)
+
     def deleteObjects(self, graph_spec, obj_ids, deleteAnns=False,
                       deleteChildren=False, dryRun=False, wait=False):
         """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
@@ -72,6 +72,29 @@ class TestDelete (object):
                "from CommentAnnotation where ns='%s'" % ns, None)]
         assert len(ids) == 0
 
+    def testDeleteObjectsWait(self, gatewaywrapper):
+        """ tests the call to deleteObjects using wait """
+        ns = 'testDeleteObjects-'+str(time.time())
+        gatewaywrapper.loginAsAuthor()
+        ids = self._prepareObjectsToDelete(gatewaywrapper.gateway, ns)
+        gatewaywrapper.gateway.deleteObjects('Annotation', ids, wait=True)
+        q = gatewaywrapper.gateway.getQueryService()
+        ids = [x.id.val for x in q.findAllByQuery(
+               "from CommentAnnotation where ns='%s'" % ns, None)]
+        assert len(ids) == 0
+
+    def testDeleteObjectsDryRun(self, gatewaywrapper):
+        """ tests the call to deleteObjects with dryRun using wait"""
+        ns = 'testDeleteObjects-'+str(time.time())
+        gatewaywrapper.loginAsAuthor()
+        ids = self._prepareObjectsToDelete(gatewaywrapper.gateway, ns)
+        gatewaywrapper.gateway.deleteObjects('Annotation', ids, dryRun=True,
+                                             wait=True)
+        q = gatewaywrapper.gateway.getQueryService()
+        foundIds = [x.id.val for x in q.findAllByQuery(
+            "from CommentAnnotation where ns='%s'" % ns, None)]
+        assert set(ids) == set(foundIds)
+
     def testDeleteAnnotatedFileAnnotation(self, gatewaywrapper):
         """ See trac:11939 """
         ns = 'testDeleteObjects-' + str(time.time())

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -544,9 +544,8 @@ class TestGetObject (object):
         image = author_testimg_tiny
         # This should return image wrapper
         pr = image.getProject()
-        ds = image.getDataset()
+        ds = image.getParent()
 
-        assert ds == image.getParent()
         assert image.listParents()[0] == image.getParent()
         assert ds == image.getParent(withlinks=True)[0]
         assert image.getParent(withlinks=True) == \

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -4,7 +4,7 @@
 """
    gateway tests - Testing the gateway.getObject() and deleteObjects() methods
 
-   Copyright 2013-2014 Glencoe Software, Inc. All rights reserved.
+   Copyright 2013-2015 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
    pytest fixtures used as defined in conftest.py:
@@ -157,8 +157,9 @@ class TestFindObject (object):
         find_ns = "omero.gateway.test.test_find_annotations"
         find_tag = gatewaywrapper.gateway.getObjects(
             "Annotation", attributes={"textValue": tag_value, "ns": find_ns})
-        for t in find_tag:
-            gatewaywrapper.gateway.deleteObjectDirect(t._obj)
+        ids = [t._obj.id.val for t in find_tag]
+        if ids:
+            gatewaywrapper.gateway.deleteObjects("Annotation", ids, wait=True)
 
         # create Tag
         tag = omero.gateway.TagAnnotationWrapper(gatewaywrapper.gateway)
@@ -265,16 +266,12 @@ class TestFindObject (object):
         assert timeId in [t.getId() for t in times]
 
         # delete what we created
-        # direct delete
-        gatewaywrapper.gateway.deleteObjectDirect(longAnn._obj)
+        gatewaywrapper.gateway.deleteObjects(
+            "Annotation", [longId, boolId, fileId, commId, tagId], wait=True)
         assert gatewaywrapper.gateway.getObject("Annotation", longId) is None
-        gatewaywrapper.gateway.deleteObjectDirect(boolAnn._obj)
         assert gatewaywrapper.gateway.getObject("Annotation", boolId) is None
-        gatewaywrapper.gateway.deleteObjectDirect(fileAnn._obj)
         assert gatewaywrapper.gateway.getObject("Annotation", fileId) is None
-        gatewaywrapper.gateway.deleteObjectDirect(commAnn._obj)
         assert gatewaywrapper.gateway.getObject("Annotation", commId) is None
-        gatewaywrapper.gateway.deleteObjectDirect(tag._obj)
         assert gatewaywrapper.gateway.getObject("Annotation", tagId) is None
 
 

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2012-2014 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2012-2015 University of Dundee & Open Microscopy Environment.
 # All rights reserved. Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify
@@ -195,7 +195,7 @@ class TestChgrp(lib.ITest):
 
         # Shouldn't be necessary to change group, but we're gonna
         owner_g.SERVICE_OPTS.setOmeroGroup("-1")
-        handle = owner_g.deleteObjects("/Image", [image.id.val])
+        handle = owner_g.deleteObjects("Image", [image.id.val])
         self.waitOnCmd(owner_g.c, handle)
 
     def testChgrpOneImageFilesetErr(self):

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -650,7 +650,7 @@ class TestRecursiveDelete(AbstractRepoTest):
         id = self.dir_map[self.dir_key]["id"]
 
         gateway = BlitzGateway(client_obj=self.client)
-        handle = gateway.deleteObjects("/OriginalFile", [id])
+        handle = gateway.deleteObjects("OriginalFile", [id])
         try:
             with pytest.raises(CmdError):
                 gateway._waitOnCmd(handle, failonerror=True)
@@ -688,7 +688,7 @@ class TestDeleteLog(AbstractRepoTest):
         finally:
             rfs.close()
 
-        handle = gateway.deleteObjects("/OriginalFile", [ofile.id.val])
+        handle = gateway.deleteObjects("OriginalFile", [ofile.id.val])
         try:
             gateway._waitOnCmd(handle)
         finally:

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1132,7 +1132,8 @@ class BaseContainer(BaseController):
                 if already_there:
                     if long(parent[1]) != long(destination[1]):
                         self.conn.deleteObjects(
-                            "ProjectDatasetLink", [up_pdl._obj.id.val])
+                            "ProjectDatasetLink", [up_pdl._obj.id.val],
+                            wait=True)
                 else:
                     new_pr = self.conn.getObject("Project", destination[1])
                     if parent[0] not in ('experimenter', 'orphaned'):
@@ -1149,7 +1150,8 @@ class BaseContainer(BaseController):
                     if p.parent.id.val == long(parent[1]):
                         up_pdl = p
                         self.conn.deleteObjects(
-                            "ProjectDatasetLink", [up_pdl._obj.id.val])
+                            "ProjectDatasetLink", [up_pdl._obj.id.val],
+                            wait=True)
             elif destination[0] == 'orphaned':
                 return ('Cannot move dataset to %s.' %
                         self.conn.getOrphanedContainerSettings()[1])
@@ -1174,7 +1176,8 @@ class BaseContainer(BaseController):
                     # delete link to not duplicate
                     if long(parent[1]) != long(destination[1]):
                         self.conn.deleteObjects(
-                            "DatasetImageLink", [up_dsl._obj.id.val])
+                            "DatasetImageLink", [up_dsl._obj.id.val],
+                            wait=True)
                 else:
                     # update link to new destination
                     new_ds = self.conn.getObject("Dataset", destination[1])
@@ -1199,7 +1202,8 @@ class BaseContainer(BaseController):
                         if dsls[0].parent.id.val == long(parent[1]):
                             up_dsl = dsls[0]
                             self.conn.deleteObjects(
-                                "DatasetImageLink", [up_dsl._obj.id.val])
+                                "DatasetImageLink", [up_dsl._obj.id.val],
+                                wait=True)
                     else:
                         return ('This image is linked in multiple places.'
                                 ' Please unlink the image first.')
@@ -1223,7 +1227,7 @@ class BaseContainer(BaseController):
                 if already_there:
                     if long(parent[1]) != long(destination[1]):
                         self.conn.deleteObjects(
-                            "ScreenPlateLink", [up_spl._obj.id.val])
+                            "ScreenPlateLink", [up_spl._obj.id.val], wait=True)
                 else:
                     new_sc = self.conn.getObject("Screen", destination[1])
                     if parent[0] not in ('experimenter', 'orphaned'):
@@ -1243,7 +1247,8 @@ class BaseContainer(BaseController):
                     for spl in spls:
                         if spl.parent.id.val == long(parent[1]):
                             self.conn.deleteObjects(
-                                "ScreenPlateLink", [spl._obj.id.val])
+                                "ScreenPlateLink", [spl._obj.id.val],
+                                wait=True)
                             break
             else:
                 return 'Destination not supported.'
@@ -1277,18 +1282,19 @@ class BaseContainer(BaseController):
                             tag_owner_id is None or
                             unwrap(al.details.owner.id) == tag_owner_id)):
                         self.conn.deleteObjects(
-                            "TagAnnotationLink", [al._obj.id.val])
+                            "TagAnnotationLink", [al._obj.id.val], wait=True)
             elif self.file:
                 for al in self.file.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
                         self.conn.deleteObjects(
-                            "FileAnnotationLink", [al._obj.id.val])
+                            "FileAnnotationLink", [al._obj.id.val], wait=True)
             elif self.comment:
                 # remove the comment from specified parent
                 for al in self.comment.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
                         self.conn.deleteObjects(
-                            "CommentAnnotationLink", [al._obj.id.val])
+                            "CommentAnnotationLink", [al._obj.id.val],
+                            wait=True)
                 # if comment is orphan, delete it directly
                 orphan = True
 
@@ -1308,26 +1314,30 @@ class BaseContainer(BaseController):
                         break
                 if orphan:
                     self.conn.deleteObjects(
-                        "CommentAnnotation", [self.comment._obj.id.val])
+                        "CommentAnnotation", [self.comment._obj.id.val],
+                        wait=True)
 
             elif self.dataset is not None:
                 if dtype == 'project':
                     for pdl in self.dataset.getParentLinks([parentId]):
                         if pdl is not None:
                             self.conn.deleteObjects(
-                                "ProjectDatasetLink", [pdl._obj.id.val])
+                                "ProjectDatasetLink", [pdl._obj.id.val],
+                                wait=True)
             elif self.plate is not None:
                 if dtype == 'screen':
                     for spl in self.plate.getParentLinks([parentId]):
                         if spl is not None:
                             self.conn.deleteObjects(
-                                "ScreenPlateLink", [spl._obj.id.val])
+                                "ScreenPlateLink", [spl._obj.id.val],
+                                wait=True)
             elif self.image is not None:
                 if dtype == 'dataset':
                     for dil in self.image.getParentLinks([parentId]):
                         if dil is not None:
                             self.conn.deleteObjects(
-                                "DatasetImageLink", [dil._obj.id.val])
+                                "DatasetImageLink", [dil._obj.id.val],
+                                wait=True)
             else:
                 raise AttributeError(
                     "Attribute not specified. Cannot be removed.")
@@ -1337,7 +1347,7 @@ class BaseContainer(BaseController):
             dil = self.dataset.getParentLinks('image', images)
             if dil is not None:
                 self.conn.deleteObjects(
-                    "DatasetImageLink", [dil._obj.id.val])
+                    "DatasetImageLink", [dil._obj.id.val], wait=True)
         else:
             raise AttributeError(
                 "Attribute not specified. Cannot be removed.")
@@ -1422,7 +1432,7 @@ class BaseContainer(BaseController):
             # gets every links for child
             dsls = self.conn.getDatasetImageLinks(source[1])
             dslIds = [dsl._obj.id.val for dsl in dsls]
-            self.conn.deleteObjects("DatasetImageLink", dslIds)
+            self.conn.deleteObjects("DatasetImageLink", dslIds, wait=True)
         else:
             im = self.conn.getObject("Image", source[1])
             ds = self.conn.getObject("Dataset", destination[1])

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1131,9 +1131,7 @@ class BaseContainer(BaseController):
                         up_pdl = pdl
                 if already_there:
                     if long(parent[1]) != long(destination[1]):
-                        self.conn.deleteObjects(
-                            "ProjectDatasetLink", [up_pdl._obj.id.val],
-                            wait=True)
+                        self.conn.deleteObject(up_pdl._obj)
                 else:
                     new_pr = self.conn.getObject("Project", destination[1])
                     if parent[0] not in ('experimenter', 'orphaned'):
@@ -1149,9 +1147,7 @@ class BaseContainer(BaseController):
                 for p in self.dataset.getParentLinks():
                     if p.parent.id.val == long(parent[1]):
                         up_pdl = p
-                        self.conn.deleteObjects(
-                            "ProjectDatasetLink", [up_pdl._obj.id.val],
-                            wait=True)
+                        self.conn.deleteObject(up_pdl._obj)
             elif destination[0] == 'orphaned':
                 return ('Cannot move dataset to %s.' %
                         self.conn.getOrphanedContainerSettings()[1])
@@ -1175,9 +1171,7 @@ class BaseContainer(BaseController):
                 if already_there:
                     # delete link to not duplicate
                     if long(parent[1]) != long(destination[1]):
-                        self.conn.deleteObjects(
-                            "DatasetImageLink", [up_dsl._obj.id.val],
-                            wait=True)
+                        self.conn.deleteObject(up_dsl._obj)
                 else:
                     # update link to new destination
                     new_ds = self.conn.getObject("Dataset", destination[1])
@@ -1201,9 +1195,7 @@ class BaseContainer(BaseController):
                         # gets old parent to delete
                         if dsls[0].parent.id.val == long(parent[1]):
                             up_dsl = dsls[0]
-                            self.conn.deleteObjects(
-                                "DatasetImageLink", [up_dsl._obj.id.val],
-                                wait=True)
+                            self.conn.deleteObject(up_dsl._obj)
                     else:
                         return ('This image is linked in multiple places.'
                                 ' Please unlink the image first.')
@@ -1226,8 +1218,7 @@ class BaseContainer(BaseController):
                         up_spl = spl
                 if already_there:
                     if long(parent[1]) != long(destination[1]):
-                        self.conn.deleteObjects(
-                            "ScreenPlateLink", [up_spl._obj.id.val], wait=True)
+                        self.conn.deleteObject(up_spl._obj)
                 else:
                     new_sc = self.conn.getObject("Screen", destination[1])
                     if parent[0] not in ('experimenter', 'orphaned'):
@@ -1246,9 +1237,7 @@ class BaseContainer(BaseController):
                     spls = list(self.plate.getParentLinks())
                     for spl in spls:
                         if spl.parent.id.val == long(parent[1]):
-                            self.conn.deleteObjects(
-                                "ScreenPlateLink", [spl._obj.id.val],
-                                wait=True)
+                            self.conn.deleteObject(spl._obj)
                             break
             else:
                 return 'Destination not supported.'
@@ -1281,20 +1270,16 @@ class BaseContainer(BaseController):
                     if (al is not None and al.canDelete() and (
                             tag_owner_id is None or
                             unwrap(al.details.owner.id) == tag_owner_id)):
-                        self.conn.deleteObjects(
-                            "TagAnnotationLink", [al._obj.id.val], wait=True)
+                        self.conn.deleteObject(al._obj)
             elif self.file:
                 for al in self.file.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
-                        self.conn.deleteObjects(
-                            "FileAnnotationLink", [al._obj.id.val], wait=True)
+                        self.conn.deleteObject(al._obj)
             elif self.comment:
                 # remove the comment from specified parent
                 for al in self.comment.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
-                        self.conn.deleteObjects(
-                            "CommentAnnotationLink", [al._obj.id.val],
-                            wait=True)
+                        self.conn.deleteObject(al._obj)
                 # if comment is orphan, delete it directly
                 orphan = True
 
@@ -1313,31 +1298,23 @@ class BaseContainer(BaseController):
                         orphan = False
                         break
                 if orphan:
-                    self.conn.deleteObjects(
-                        "CommentAnnotation", [self.comment._obj.id.val],
-                        wait=True)
+                    self.conn.deleteObject(self.comment._obj)
 
             elif self.dataset is not None:
                 if dtype == 'project':
                     for pdl in self.dataset.getParentLinks([parentId]):
                         if pdl is not None:
-                            self.conn.deleteObjects(
-                                "ProjectDatasetLink", [pdl._obj.id.val],
-                                wait=True)
+                            self.conn.deleteObject(pdl._obj)
             elif self.plate is not None:
                 if dtype == 'screen':
                     for spl in self.plate.getParentLinks([parentId]):
                         if spl is not None:
-                            self.conn.deleteObjects(
-                                "ScreenPlateLink", [spl._obj.id.val],
-                                wait=True)
+                            self.conn.deleteObject(spl._obj)
             elif self.image is not None:
                 if dtype == 'dataset':
                     for dil in self.image.getParentLinks([parentId]):
                         if dil is not None:
-                            self.conn.deleteObjects(
-                                "DatasetImageLink", [dil._obj.id.val],
-                                wait=True)
+                            self.conn.deleteObject(dil._obj)
             else:
                 raise AttributeError(
                     "Attribute not specified. Cannot be removed.")
@@ -1346,8 +1323,7 @@ class BaseContainer(BaseController):
         if self.dataset is not None:
             dil = self.dataset.getParentLinks('image', images)
             if dil is not None:
-                self.conn.deleteObjects(
-                    "DatasetImageLink", [dil._obj.id.val], wait=True)
+                self.conn.deleteObject(dil._obj)
         else:
             raise AttributeError(
                 "Attribute not specified. Cannot be removed.")

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -842,7 +842,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             self.deleteObjects(
                 "ExperimenterAnnotationLink", linkIds, wait=True)
             # No error handling?
-            self.deleteObjects("Annotation", [ann.id.val], wait=True)
+            self.deleteObject(ann)
 
     def cropExperimenterPhoto(self, box, oid=None):
         """
@@ -1954,8 +1954,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 correct_dataset = False
                 for plink in i.getParentLinks():
                     if plink.parent.id != target_ds:
-                        self.deleteObjects(
-                            "DatasetImageLink", [plink._obj.id.val], wait=True)
+                        self.deleteObject(plink._obj)
                     else:
                         correct_dataset = True
                 if not correct_dataset:
@@ -2124,7 +2123,6 @@ class OmeroWebObjectWrapper (object):
             self.linkAnnotation(AnnotationWrapper(self._conn, ratingAnn))
 
         if ratingLink is not None:
-            linkType = ratingLink._obj.__class__.__name__.rstrip('I')
             ratingAnn = ratingLink.getChild()
             # if rating is only used by this object, we can update or delete
             if getLinkCount(ratingAnn.id) == 1:
@@ -2132,15 +2130,11 @@ class OmeroWebObjectWrapper (object):
                     ratingAnn.setLongValue(rlong(rating))
                     ratingAnn.save()
                 else:
-                    self._conn.deleteObjects(
-                        linkType, [ratingLink._obj.id.val],
-                        wait=True)
-                    self._conn.deleteObjects(
-                        "LongAnnotation", [ratingAnn._obj.id.val], wait=True)
+                    self._conn.deleteObject(ratingLink._obj)
+                    self._conn.deleteObject(ratingAnn._obj)
             # otherwise, unlink and create a new rating
             else:
-                self._conn.deleteObjects(
-                    linkType, [ratingLink._obj.id.val], wait=True)
+                self._conn.deleteObject(ratingLink._obj)
                 addRating(rating)
         else:
             addRating(rating)

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -838,8 +838,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             links = exp._getAnnotationLinks()
             # there should be only one ExperimenterAnnotationLink
             # but if there is more then one all of them should be deleted.
-            for l in links:
-                self.deleteObjectDirect(l)
+            linkIds = [l.id.val for l in links]
+            self.deleteObjects("ExperimenterAnnotationLink", linkIds)
             # No error handling?
             self.deleteObjects("/Annotation", [ann.id.val])
 
@@ -1953,7 +1953,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 correct_dataset = False
                 for plink in i.getParentLinks():
                     if plink.parent.id != target_ds:
-                        self.deleteObjectDirect(plink._obj)
+                        self.deleteObjects(
+                            "DatasetImageLink", [plink._obj.id.val])
                     else:
                         correct_dataset = True
                 if not correct_dataset:
@@ -2129,11 +2130,14 @@ class OmeroWebObjectWrapper (object):
                     ratingAnn.setLongValue(rlong(rating))
                     ratingAnn.save()
                 else:
-                    self._conn.deleteObjectDirect(ratingLink._obj)
-                    self._conn.deleteObjectDirect(ratingAnn._obj)
+                    self._conn.deleteObjects(
+                        "AnnotationLink", [ratingLink._obj.id.val])
+                    self._conn.deleteObjects(
+                        "Annotation", [ratingAnn._obj.id.val])
             # otherwise, unlink and create a new rating
             else:
-                self._conn.deleteObjectDirect(ratingLink._obj)
+                self._conn.deleteObjects(
+                    "AnnotationLink", [ratingLink._obj.id.val])
                 addRating(rating)
         else:
             addRating(rating)

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2124,6 +2124,7 @@ class OmeroWebObjectWrapper (object):
             self.linkAnnotation(AnnotationWrapper(self._conn, ratingAnn))
 
         if ratingLink is not None:
+            linkType = ratingLink._obj.__class__.__name__.rstrip('I')
             ratingAnn = ratingLink.getChild()
             # if rating is only used by this object, we can update or delete
             if getLinkCount(ratingAnn.id) == 1:
@@ -2132,13 +2133,14 @@ class OmeroWebObjectWrapper (object):
                     ratingAnn.save()
                 else:
                     self._conn.deleteObjects(
-                        "AnnotationLink", [ratingLink._obj.id.val], wait=True)
+                        linkType, [ratingLink._obj.id.val],
+                        wait=True)
                     self._conn.deleteObjects(
-                        "Annotation", [ratingAnn._obj.id.val], wait=True)
+                        "LongAnnotation", [ratingAnn._obj.id.val], wait=True)
             # otherwise, unlink and create a new rating
             else:
                 self._conn.deleteObjects(
-                    "AnnotationLink", [ratingLink._obj.id.val], wait=True)
+                    linkType, [ratingLink._obj.id.val], wait=True)
                 addRating(rating)
         else:
             addRating(rating)

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -839,9 +839,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             # there should be only one ExperimenterAnnotationLink
             # but if there is more then one all of them should be deleted.
             linkIds = [l.id.val for l in links]
-            self.deleteObjects("ExperimenterAnnotationLink", linkIds)
+            self.deleteObjects(
+                "ExperimenterAnnotationLink", linkIds, wait=True)
             # No error handling?
-            self.deleteObjects("Annotation", [ann.id.val])
+            self.deleteObjects("Annotation", [ann.id.val], wait=True)
 
     def cropExperimenterPhoto(self, box, oid=None):
         """
@@ -1954,7 +1955,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 for plink in i.getParentLinks():
                     if plink.parent.id != target_ds:
                         self.deleteObjects(
-                            "DatasetImageLink", [plink._obj.id.val])
+                            "DatasetImageLink", [plink._obj.id.val], wait=True)
                     else:
                         correct_dataset = True
                 if not correct_dataset:
@@ -2131,13 +2132,13 @@ class OmeroWebObjectWrapper (object):
                     ratingAnn.save()
                 else:
                     self._conn.deleteObjects(
-                        "AnnotationLink", [ratingLink._obj.id.val])
+                        "AnnotationLink", [ratingLink._obj.id.val], wait=True)
                     self._conn.deleteObjects(
-                        "Annotation", [ratingAnn._obj.id.val])
+                        "Annotation", [ratingAnn._obj.id.val], wait=True)
             # otherwise, unlink and create a new rating
             else:
                 self._conn.deleteObjects(
-                    "AnnotationLink", [ratingLink._obj.id.val])
+                    "AnnotationLink", [ratingLink._obj.id.val], wait=True)
                 addRating(rating)
         else:
             addRating(rating)

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -841,7 +841,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             linkIds = [l.id.val for l in links]
             self.deleteObjects("ExperimenterAnnotationLink", linkIds)
             # No error handling?
-            self.deleteObjects("/Annotation", [ann.id.val])
+            self.deleteObjects("Annotation", [ann.id.val])
 
     def cropExperimenterPhoto(self, box, oid=None):
         """


### PR DESCRIPTION
This PR addresses the various items in https://trello.com/c/WMnOBpC6/31-improve-deleteobjects-deprecate-deleteobjectdirect-inpython-gateway both RFEs and deprecation of `deleteObjectDirect`.

Tests, both `OmeroPy` and `OmeroWeb` should pass.

Web functionality to be tested is that which deletes and unlinks P/D/I, S/P and Annotations. I.e quite wide-ranging, but concentrating on unlinking and deleting all types of annotations would be useful.
  