### PR TITLE
Rnd settings

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -37,7 +37,6 @@ import javax.swing.Icon;
 import javax.swing.JComponent;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.dataBrowser.DataBrowserAgent;
 import org.openmicroscopy.shoola.agents.dataBrowser.IconManager;
 import org.openmicroscopy.shoola.agents.dataBrowser.ThumbnailProvider;
@@ -54,7 +53,7 @@ import org.openmicroscopy.shoola.agents.dataBrowser.visitor.FlushVisitor;
 import org.openmicroscopy.shoola.agents.dataBrowser.visitor.NodesFinder;
 import org.openmicroscopy.shoola.agents.dataBrowser.visitor.RegexFinder;
 import org.openmicroscopy.shoola.agents.dataBrowser.visitor.ResetNodesVisitor;
-import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
+import org.openmicroscopy.shoola.agents.events.hiviewer.LaunchViewer;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.agents.util.SelectionWizard;
@@ -1721,7 +1720,6 @@ class DataBrowserComponent
 		EventBus bus = DataBrowserAgent.getRegistry().getEventBus();
 		DataObject data = null;
 		Object uo = node.getHierarchyObject();
-		ViewImage event;
 		Object go;
 		ViewImageObject object;
 		if (uo instanceof ImageData) {
@@ -1738,7 +1736,7 @@ class DataBrowserComponent
 							img, LookupNames.IMAGE_J);
 					bus.post(evt);
 				} else {
-					bus.post(new ViewImage(ctx, object, null));
+					bus.post(new LaunchViewer(ctx, object));
 				}
 			} else {
 				if (internal)
@@ -1764,8 +1762,7 @@ class DataBrowserComponent
 						wellSample.getImage(), LookupNames.IMAGE_J);
 				bus.post(evt);
 			} else {
-				bus.post(new ViewImage(model.getSecurityContext(), object, 
-						null));
+				bus.post(new LaunchViewer(model.getSecurityContext(), object));
 			}
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/hiviewer/LaunchViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/hiviewer/LaunchViewer.java
@@ -1,0 +1,71 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.events.hiviewer;
+
+import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
+import org.openmicroscopy.shoola.env.event.RequestEvent;
+
+
+/**
+ * Event sent to
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.1
+ */
+public class LaunchViewer
+    extends RequestEvent
+{
+
+    /** The security context.*/
+    private SecurityContext ctx;
+
+    /** The data to open.*/
+    private ViewImageObject data;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param ctx The security context.
+     * @param data The data to open.
+     */
+    public LaunchViewer(SecurityContext ctx, ViewImageObject data)
+    {
+        this.ctx = ctx;
+        this.data = data;
+    }
+
+    /**
+     * Returns the security context.
+     *
+     * @return See above.
+     */
+    public SecurityContext getSecurityContext() { return ctx; }
+
+    /**
+     * Returns the data.
+     *
+     * @return See above.
+     */
+    public ViewImageObject getData() { return data; }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ResetRndSettings.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ResetRndSettings.java
@@ -1,0 +1,71 @@
+/*
+ * org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsSaved 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.events.iviewer;
+
+import org.openmicroscopy.shoola.env.event.RequestEvent;
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
+
+/** 
+ * Event posted when the rendering settings have been reset.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.2.0
+ */
+public class ResetRndSettings
+    extends RequestEvent
+{
+
+    /** The identifier of the image. */
+    private long imageID;
+
+    /** The save rendering settings. */
+    private RndProxyDef settings;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param imageID The identifier of the image.
+     * @param settings The rendering settings.
+     */
+    public ResetRndSettings(long imageID, RndProxyDef settings)
+    {
+        this.imageID = imageID;
+        this.settings = settings;
+    }
+
+    /**
+     * Returns the id of the image.
+     *
+     * @return See above.
+     */
+    public long getImageID() { return imageID; }
+
+    /**
+     * Returns the settings.
+     * 
+     * @return See above.
+     */
+    public RndProxyDef getSettings() { return settings; }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/RndSettingsChanged.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/RndSettingsChanged.java
@@ -1,0 +1,59 @@
+/*
+ * org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsSaved 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.events.iviewer;
+
+import org.openmicroscopy.shoola.env.event.RequestEvent;
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
+
+/** 
+ * Event posted when the rendering settings have been changed.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.2.0
+ */
+public class RndSettingsChanged
+    extends RequestEvent
+{
+
+    /** The identifier of the image. */
+    private long imageID;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param imageID The identifier of the image.
+     */
+    public RndSettingsChanged(long imageID)
+    {
+        this.imageID = imageID;
+    }
+
+    /**
+     * Returns the id of the image.
+     *
+     * @return See above.
+     */
+    public long getImageID() { return imageID; }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ViewImageObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ViewImageObject.java
@@ -90,6 +90,16 @@ public class ViewImageObject
     }
 
     /**
+     * Sets the user ID.
+     *
+     * @param selectedUserID The value to set.
+     */
+    public void setSelectedUser(long selectedUserID)
+    {
+        this.selectedUserID = selectedUserID;
+    }
+
+    /**
      * Sets the context of the node.
      * 
      * @param parent The parent of the image or <code>null</code>
@@ -133,7 +143,7 @@ public class ViewImageObject
      * @param selectedUserID The id of the user who set the
      *                       the rendering settings.
      */
-    public void setSettings(RndProxyDef	settings, long selectedUserID)
+    public void setSettings(RndProxyDef settings, long selectedUserID)
     {
         this.settings = settings;
         this.selectedUserID = selectedUserID;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ViewImageObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/iviewer/ViewImageObject.java
@@ -59,6 +59,9 @@ public class ViewImageObject
     /** The id of the image to view. Used when no <code>ImageData</code>set. */
     private long imageID;
 
+    /** The id of the selected rendering object.*/
+    private long rndDefID;
+
     /**
      * Creates a new instance.
      *
@@ -70,6 +73,7 @@ public class ViewImageObject
             throw new IllegalArgumentException("Image ID not valid.");
         this.imageID = imageID;
         selectedUserID = -1;
+        rndDefID = -1;
     }
 
     /**
@@ -87,17 +91,25 @@ public class ViewImageObject
         this.image = image;
         selectedUserID = -1;
         imageID = -1;
+        rndDefID = -1;
     }
 
     /**
-     * Sets the user ID.
+     * Sets the identifier of the rendering settings, this should only be used
+     * for settings used under "Users settings".
      *
-     * @param selectedUserID The value to set.
+     * @param rndDefID The value to set.
      */
-    public void setSelectedUser(long selectedUserID)
+    public void setSelectedRndDef(long rndDefID)
     {
-        this.selectedUserID = selectedUserID;
+        this.rndDefID = rndDefID;
     }
+
+    /**
+     * Returns the identifier of the rendering settings.
+     * @return See above.
+     */
+    public long getSelectedRndDef() { return rndDefID; }
 
     /**
      * Sets the context of the node.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -196,7 +196,7 @@ public class ImViewerAgent
 
         if (view != null) {
             view.activate(object.getSettings(), object.getSelectedUserID(),
-                    displayMode);
+                    displayMode, object.getSelectedRndDef());
             view.setContext(object.getParent(), object.getGrandParent());
         }
     }
@@ -441,7 +441,7 @@ public class ImViewerAgent
                         null, true);
                 if (view != null) {
                     view.activate(null, getUserDetails().getId(),
-                            displayMode);
+                            displayMode, -1);
                     JComponent src = evt.getSource();
                     if (src != null) src.setEnabled(true);
                 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -27,15 +27,16 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.JComponent;
+
 import ome.model.units.BigResult;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.events.FocusGainedEvent;
 import org.openmicroscopy.shoola.agents.events.iviewer.CopyRndSettings;
 import org.openmicroscopy.shoola.agents.events.iviewer.ImageViewport;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurementTool;
 import org.openmicroscopy.shoola.agents.events.iviewer.RendererUnloadedEvent;
+import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsChanged;
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsCopied;
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsSaved;
 import org.openmicroscopy.shoola.agents.events.iviewer.SaveRelatedData;
@@ -59,7 +60,9 @@ import org.openmicroscopy.shoola.env.data.events.ReloadRenderingEngine;
 import org.openmicroscopy.shoola.env.data.events.UserGroupSwitched;
 import org.openmicroscopy.shoola.env.data.events.ViewInPluginEvent;
 import org.openmicroscopy.shoola.env.data.util.AgentSaveInfo;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.event.EventBus;
@@ -350,6 +353,17 @@ public class ImViewerAgent
     }
 
     /**
+     * Handles the {@link RndSettingsChanged} event.
+     *
+     * @param evt The event to handle.
+     */
+    public void handleRndSettingsChangedEvent(RndSettingsChanged evt)
+    {
+        if (evt == null) return;
+        ImViewerFactory.rndSettingsChanged(evt.getImageID());
+    }
+    
+    /**
      * Indicates to bring up the window if a related window gained focus
      *
      * @param evt The event to handle.
@@ -603,6 +617,7 @@ public class ImViewerAgent
         bus.register(this, ChannelSavedEvent.class);
         bus.register(this, DisplayModeEvent.class);
         bus.register(this, RndSettingsCopied.class);
+        bus.register(this, RndSettingsChanged.class);
     }
 
     /**
@@ -673,6 +688,9 @@ public class ImViewerAgent
             handleDisplayModeEvent((DisplayModeEvent) e);
         else if (e instanceof RndSettingsCopied)
             handleRndSettingsCopied((RndSettingsCopied) e);
+        else if (e instanceof RndSettingsChanged) {
+            handleRndSettingsChangedEvent((RndSettingsChanged) e);
+        }
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ActivationAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ActivationAction.java
@@ -82,7 +82,8 @@ public class ActivationAction
      * Activates the model. 
      * @see java.awt.event.ActionListener#actionPerformed(ActionEvent)
      */
-    public void actionPerformed(ActionEvent e) { model.activate(null, -1,
-    		model.getDisplayMode()); }
-    
+    public void actionPerformed(ActionEvent e) {
+        model.activate(null, -1, model.getDisplayMode(), -1);
+    }
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
@@ -1269,7 +1269,6 @@ class ControlPane
     /** Resets the rendering settings. */
     void resetRndSettings()
     {
-        boolean gs = (model.getColorModel().equals(ImViewer.GREY_SCALE_MODEL));
         Iterator<ChannelButton> i = channelButtons.iterator();
         ChannelButton button;
         int index;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1319,4 +1319,5 @@ public interface ImViewer
      * @return See above
      */
     ImageAcquisitionData getImageAcquisitionData();
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -265,9 +265,12 @@ public interface ImViewer
 	 * 
 	 * @param settings The settings set by another user.
 	 * @param userID   The id of the user who set the settings.
-	 * @throws IllegalStateException If the current state is {@link #DISCARDED}.  
+	 * @param displayMode The mode used.
+	 * @param selectedSettingsID Settings used
+	 * @throws IllegalStateException If the current state is {@link #DISCARDED}.
 	 */
-	public void activate(RndProxyDef settings, long userID, int displayMode);
+	public void activate(RndProxyDef settings, long userID, int displayMode,
+	        long selectedSettingsID);
 
 	/**
 	 * Transitions the viewer to the {@link #DISCARDED} state.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -49,6 +50,7 @@ import org.openmicroscopy.shoola.agents.events.iviewer.ChannelSelection;
 import org.openmicroscopy.shoola.agents.events.iviewer.ImageRendered;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurePlane;
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurementTool;
+import org.openmicroscopy.shoola.agents.events.iviewer.ResetRndSettings;
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsCopied;
 import org.openmicroscopy.shoola.agents.events.iviewer.SaveRelatedData;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
@@ -70,13 +72,17 @@ import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.ProjectionParam;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.EventBus;
+
 import omero.log.LogMessage;
 import omero.log.Logger;
 import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.enums.UnitsLength;
+
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.rnd.data.Tile;
@@ -87,6 +93,7 @@ import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 import org.openmicroscopy.shoola.util.ui.drawingtools.canvas.DrawingCanvasView;
+
 import omero.gateway.model.ChannelData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
@@ -401,6 +408,10 @@ class ImViewerComponent
 					ImViewerAgent.getRegistry().getLogger().error(this, logMsg);
 				}
 			}
+			//post an event
+			ResetRndSettings evt = new ResetRndSettings(model.getImageID(),
+			        model.getOriginalDef());
+			ImViewerAgent.getRegistry().getEventBus().post(evt);
 			model.resetMappingSettings(model.getOriginalDef());
 		}
 		return true;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -642,11 +642,6 @@ class ImViewerComponent
 		switch (model.getState()) {
 			case NEW:
 				model.setAlternativeSettings(settings, userID);
-				/*
-				if (model.isImageLoaded())
-					model.fireRenderingControlLoading(model.getPixelsID());
-				else model.fireImageLoading();
-				*/
 				if (!model.isImageLoaded()) {
 					model.fireImageLoading();
 				} else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -634,11 +634,13 @@ class ImViewerComponent
 	
 	/** 
 	 * Implemented as specified by the {@link ImViewer} interface.
-	 * @see ImViewer#activate(RndProxyDef, long, int)
+	 * @see ImViewer#activate(RndProxyDef, long, int, long)
 	 */
-	public void activate(RndProxyDef settings, long userID, int displayMode)
+	public void activate(RndProxyDef settings, long userID, int displayMode,
+	        long selectedRndDefID)
 	{
 		model.setDisplayMode(displayMode);
+		model.setSelectedRndDef(selectedRndDefID);
 		switch (model.getState()) {
 			case NEW:
 				model.setAlternativeSettings(settings, userID);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -1020,8 +1020,6 @@ class ImViewerComponent
 			}
 			if (GREY_SCALE_MODEL.equals(model.getColorModel()))
 				setColorModel(ColorModelAction.RGB_MODEL);
-			//else 
-			//	renderXYPlane();
 		} catch (Exception e) {
 			Registry reg = ImViewerAgent.getRegistry();
 			LogMessage msg = new LogMessage();
@@ -3430,5 +3428,10 @@ class ImViewerComponent
      */
     public ImageAcquisitionData getImageAcquisitionData() {
         return this.acquisitionData;
+    }
+
+    void onSettingsChanged()
+    {
+        view.resetDefaults();
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerFactory.java
@@ -287,6 +287,23 @@ public class ImViewerFactory
 	}
 
 	/**
+	 * Indicates that rendering settings have been modified.
+	 * 
+	 * @param ImageID The Identifier of the pixels set.
+	 */
+	public static void rndSettingsChanged(long imageID)
+	{
+	    Iterator<ImViewer> v = singleton.viewers.iterator();
+	    ImViewerComponent comp;
+	    while (v.hasNext()) {
+	        comp = (ImViewerComponent) v.next();
+	        if (comp.getModel().getImageID() == imageID) {
+	            comp.onSettingsChanged();
+	        }
+	    }
+	}
+
+	/**
 	 * Stores the passed event in the correct viewer.
 	 * 
 	 * @param evt The event to store.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerFactory.java
@@ -100,7 +100,7 @@ public class ImViewerFactory
 	 * Adds all the {@link ImViewer} components that this factory is
 	 * currently tracking to the passed menu.
 	 * 
-	 * @param menu The menu to add the components to. 
+	 * @param menu The menu to add the components to.
 	 */
 	static void register(JMenu menu)
 	{ 
@@ -178,12 +178,12 @@ public class ImViewerFactory
 
 	/**
 	 * Returns a viewer to display the image corresponding to the specified id.
-	 * 
-	 * @param imageID  	The image to view.
-	 * @param bounds    The bounds of the component invoking the 
-	 *                  {@link ImViewer}.
-	 * @param separateWindow Pass <code>true</code> to open the viewer in a 
-	 * 						 separate window, <code>false</code> otherwise. 
+	 *
+	 * @param ctx The security context.
+	 * @param imageID The image to view.
+	 * @param bounds The bounds of the component invoking the {@link ImViewer}.
+	 * @param separateWindow Pass <code>true</code> to open the viewer in a
+	 *                       separate window, <code>false</code> otherwise.
 	 * @return See above.
 	 */
 	public static ImViewer getImageViewer(SecurityContext ctx,
@@ -196,7 +196,8 @@ public class ImViewerFactory
 	
 	/**
 	 * Returns the viewer if any, identified by the passed pixels ID.
-	 * 
+	 *
+	 * @param ctx The security context.
 	 * @param pixelsID The Identifier of the pixels set.
 	 * @return See above.
 	 */
@@ -213,7 +214,8 @@ public class ImViewerFactory
 
 	/**
 	 * Returns the viewer if any, identified by the passed image's ID.
-	 * 
+	 *
+	 * @param ctx The security context.
 	 * @param imageID The Identifier of the image.
 	 * @return See above.
 	 */
@@ -251,8 +253,8 @@ public class ImViewerFactory
 	/**
 	 * Copies the rendering settings.
 	 * 
-	 * @param image	The image to copy the rendering settings from.
-         * @param refRndDef 'Pending' rendering settings to copy (can be null)
+	 * @param image The image to copy the rendering settings from.
+	 * @param refRndDef 'Pending' rendering settings to copy (can be null)
 	 */
 	public static void copyRndSettings(ImageData image, RndProxyDef refRndDef)
 	{
@@ -289,7 +291,7 @@ public class ImViewerFactory
 	/**
 	 * Indicates that rendering settings have been modified.
 	 * 
-	 * @param ImageID The Identifier of the pixels set.
+	 * @param imageID The Identifier of the pixels set.
 	 */
 	public static void rndSettingsChanged(long imageID)
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -559,22 +559,22 @@ class ImViewerModel
 	/** Initializes the {@link #metadataViewer}. */
 	private void initializeMetadataViewer()
 	{
-		metadataViewer = MetadataViewerFactory.getViewer("",
-				MetadataViewer.RND_SPECIFIC, alternativeSettings);
-		metadataViewer.setRootObject(image, metadataViewer.getUserID(),
-				getSecurityContext());
-		
-		// there might already exist another MetadataViewer with modified
-		// rendering settings; if so copy it's original settings
-                MetadataViewer otherViewer = MetadataViewerFactory.getViewerFromId(
-                        ImageData.class.getName(), image.getId());
-                if (otherViewer != null) {
-                    Renderer otherRenderer = otherViewer.getRenderer();
-                    if (otherRenderer != null)
-                        originalDef = otherRenderer.getInitialRndSettings();
-                }
+	    metadataViewer = MetadataViewerFactory.getViewer("",
+	            MetadataViewer.RND_SPECIFIC, alternativeSettings);
+	    metadataViewer.setRootObject(image, metadataViewer.getUserID(),
+	            getSecurityContext());
+
+	    // there might already exist another MetadataViewer with modified
+	    // rendering settings; if so copy its original settings
+	    MetadataViewer otherViewer = MetadataViewerFactory.getViewerFromId(
+	            ImageData.class.getName(), image.getId());
+	    if (otherViewer != null) {
+	        Renderer otherRenderer = otherViewer.getRenderer();
+	        if (otherRenderer != null)
+	            originalDef = otherRenderer.getInitialRndSettings();
+	    }
 	}
-	
+
 	/**
    	 * Reloads the 'saved by' thumbnails of the the rendering panel
     	 */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -328,7 +328,10 @@ class ImViewerModel
     
     /** The unit used for the scale bar */
     private UnitsLength scaleBarUnit;
-    
+
+    /** The selected rendering settings in under "User Setting".*/
+    private long selectedRndDefID;
+
     /**
      * Returns the default resolution level.
      * 
@@ -560,7 +563,7 @@ class ImViewerModel
 	private void initializeMetadataViewer()
 	{
 	    metadataViewer = MetadataViewerFactory.getViewer("",
-	            MetadataViewer.RND_SPECIFIC, alternativeSettings);
+	            MetadataViewer.RND_SPECIFIC, alternativeSettings, selectedRndDefID);
 	    metadataViewer.setRootObject(image, metadataViewer.getUserID(),
 	            getSecurityContext());
 
@@ -646,6 +649,7 @@ class ImViewerModel
 		this.component = component;
 		browser = BrowserFactory.createBrowser(component,
 				ImViewerFactory.getPreferences());
+		selectedRndDefID = -1;
 	}
 	
 	/**
@@ -657,7 +661,7 @@ class ImViewerModel
 	}
 	
     /**
-     * Get the unit for the scalebar. 
+     * Get the unit for the scalebar.
      * Determined by assuming a 100px wide scalebar.
      * 
      * @return The unit used for the scalebar
@@ -1078,7 +1082,9 @@ class ImViewerModel
 			if (alternativeSettings != null && rnd != null)
 				rnd.resetSettings(alternativeSettings, false);
 			alternativeSettings = null;
-			if (rnd != null && originalDef == null) originalDef = rnd.getRndSettingsCopy();
+			if (rnd != null && originalDef == null) {
+			    originalDef = rnd.getRndSettingsCopy();
+			}
 		} catch (Exception e) {}
 	}
 	
@@ -3055,4 +3061,8 @@ class ImViewerModel
         browser.setInterpolation(interpolation);
     }
 
+    void setSelectedRndDef(long defID)
+    {
+        selectedRndDefID = defID;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -560,7 +560,7 @@ class ImViewerModel
 	private void initializeMetadataViewer()
 	{
 		metadataViewer = MetadataViewerFactory.getViewer("",
-				MetadataViewer.RND_SPECIFIC);
+				MetadataViewer.RND_SPECIFIC, alternativeSettings);
 		metadataViewer.setRootObject(image, metadataViewer.getUserID(),
 				getSecurityContext());
 		

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -75,6 +75,7 @@ import org.openmicroscopy.shoola.env.event.EventBus;
 import omero.log.LogMessage;
 import omero.log.Logger;
 
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.ui.RefWindow;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.filter.file.ExcelFilter;
@@ -776,6 +777,7 @@ class EditorControl
 				view.reloadScript();
 				break;
 			case VIEW_IMAGE:
+			    
 				Object refObject = view.getRefObject();
 				ImageData img = null;
 				if (refObject instanceof ImageData) {
@@ -785,6 +787,13 @@ class EditorControl
 		        }
 				if (img != null) {
 					ViewImageObject vio = new ViewImageObject(img);
+					if (model.getRenderer() != null) {
+					    RndProxyDef def = model.getRenderer().getSelectedDef();
+					    if (def != null) {
+					        vio.setSelectedRndDef(
+					                def.getData().getId().getValue());
+					    }
+					}
 					MetadataViewerAgent.getRegistry().getEventBus().post(
 						new ViewImage(model.getSecurityContext(), vio, null));
 				}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -790,8 +790,7 @@ class EditorControl
 					if (model.getRenderer() != null) {
 					    RndProxyDef def = model.getRenderer().getSelectedDef();
 					    if (def != null) {
-					        vio.setSelectedRndDef(
-					                def.getData().getId().getValue());
+					        vio.setSelectedRndDef(def.getDataID());
 					    }
 					}
 					MetadataViewerAgent.getRegistry().getEventBus().post(

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -3604,7 +3604,8 @@ class EditorModel
 			renderer.onSettingsApplied(rndControl);
 		} else {
 		    renderer = RendererFactory.createRenderer(getSecurityContext(),
-                    rndControl, getImage(), getRndIndex(), getXMLAnnotations());
+                    rndControl, getImage(), getRndIndex(), getXMLAnnotations(),
+                    parent.getAlternativeRenderingSettings());
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
@@ -795,7 +795,7 @@ public class DomainPane
      * @see ControlPane#getPaneIndex()
      */
     protected int getPaneIndex() { return ControlPane.DOMAIN_PANE_INDEX; }
-    
+
     /**
      * Resets the default rendering settings. 
      * @see ControlPane#resetDefaultRndSettings()
@@ -809,14 +809,24 @@ public class DomainPane
         resetBitResolution();
         int n = model.getMaxC();
         for (int i = 0; i < n; i++) {
-        	setChannelColor(i);
-		}
+            setChannelColor(i);
+        }
         resetGamma(model.getCurveCoefficient());
         setZSection(model.getDefaultZ());
         setTimepoint(model.getDefaultT());
         setGreyScale(model.isGreyScale());
     }
-    
+
+    /**
+     * Resets the settings.
+     *
+     * @param settings the value to set.
+     */
+    void resetViewedBy(RndProxyDef settings)
+    {
+        graphicsPane.resetViewedBy(settings);
+    }
+
     /**
      * Sets the enabled flag of the UI components.
      * @see ControlPane#onStateChange(boolean)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
@@ -1035,7 +1035,16 @@ public class DomainPane
 			cb.setText(data.getChannelLabeling());
 		}
     }
-    
+
+    /**
+     * Returns the selected rendering settings if any.
+     *
+     * @return See above.
+     */
+    RndProxyDef getSelectedDef()
+    {
+        return graphicsPane.getSelectedDef();
+    }
     /**
      * Depending on the source of the event. Sets the gamma value or
      * the bit resolution.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
@@ -133,7 +133,10 @@ class GraphicsPane
 
     /** The items shown in the 'saved by' taskpane */
     private List<ViewedByItem> viewedByItems;
-    
+
+    /** The selected item.*/
+    private RndProxyDef selectedDef;
+
     /**
      * Formats the specified value.
      * 
@@ -564,11 +567,12 @@ class GraphicsPane
     }
     
     /**
-     * Draws a border around the ViewedByItem whichs represents
+     * Draws a border around the ViewedByItem which represents
      * the given RndProxyDef
      * @param def The RndProxyDef to highlight
      */
     void highlight(RndProxyDef def) {
+        selectedDef = def;
         for(ViewedByItem item : viewedByItems) {
             if(item.getRndDef().getData().getId().getValue()==def.getData().getId().getValue()) {
                 ((JPanel)item.getParent()).setBorder(BorderFactory.createLineBorder(UIUtilities.STEELBLUE, 2));
@@ -578,7 +582,14 @@ class GraphicsPane
             }
         }
     }
-    
+
+    /**
+     * Returns the selected rendering settings if any.
+     *
+     * @return See above.
+     */
+    RndProxyDef getSelectedDef() { return selectedDef; }
+
     /**
      * Returns the slider used to set the codomain interval.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
@@ -584,8 +584,7 @@ class GraphicsPane
         selectedDef = def;
         for(ViewedByItem item : viewedByItems) {
             JPanel p = (JPanel) item.getParent();
-            if (item.getRndDef().getData().getId().getValue() ==
-                    def.getData().getId().getValue()) {
+            if (item.getRndDef().getDataID() == def.getDataID()) {
                 p.setBorder(BorderFactory.createLineBorder(
                         UIUtilities.STEELBLUE, 2));
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/GraphicsPane.java
@@ -516,6 +516,15 @@ class GraphicsPane
         repaint();
     }
 
+    /**
+     * Resets the display of the selected thumbanils under User Settings.
+     * @param activeRndDef The rendering setting which is currently used
+     */
+    void resetViewedBy(RndProxyDef activeRndDef)
+    {
+        displayViewedBy(viewedByItems, activeRndDef);
+    }
+
     /** 
      * Builds and lays out the images as seen by other experimenters.
      *  
@@ -528,10 +537,10 @@ class GraphicsPane
             viewedBy.removeAll();
             return;
         }
-         
+
         this.viewedByItems = results;
         Collections.sort(this.viewedByItems, new ViewedByItemComparator());
-        
+
         JPanel p = new JPanel();
         p.setLayout(new WrapLayout(WrapLayout.LEFT));
         p.setBackground(UIUtilities.BACKGROUND_COLOR);
@@ -540,15 +549,15 @@ class GraphicsPane
         while (i.hasNext()) {
             item = i.next();
             item.addPropertyChangeListener(this);
-            p.add(createViewedByPanel(item));       
+            p.add(createViewedByPanel(item));
         }
-        
-        if(activeRndDef!=null) {
+
+        if (activeRndDef != null) {
             highlight(activeRndDef);
         }
-        
+
         p.setSize(viewedBy.getSize());
-        
+
         viewedBy.removeAll();
         viewedBy.add(p, BorderLayout.CENTER);
         viewedBy.validate();
@@ -574,11 +583,14 @@ class GraphicsPane
     void highlight(RndProxyDef def) {
         selectedDef = def;
         for(ViewedByItem item : viewedByItems) {
-            if(item.getRndDef().getData().getId().getValue()==def.getData().getId().getValue()) {
-                ((JPanel)item.getParent()).setBorder(BorderFactory.createLineBorder(UIUtilities.STEELBLUE, 2));
+            JPanel p = (JPanel) item.getParent();
+            if (item.getRndDef().getData().getId().getValue() ==
+                    def.getData().getId().getValue()) {
+                p.setBorder(BorderFactory.createLineBorder(
+                        UIUtilities.STEELBLUE, 2));
             }
             else {
-                ((JPanel)item.getParent()).setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
+                p.setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
             }
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/PreviewControlBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/PreviewControlBar.java
@@ -5,7 +5,7 @@
  *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -23,21 +23,14 @@
 package org.openmicroscopy.shoola.agents.metadata.rnd;
 
 
-
-//Java imports
 import java.awt.FlowLayout;
 import javax.swing.AbstractButton;
 import javax.swing.Box;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
-import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 
-//Third-party libraries
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.agents.metadata.actions.ManageRndSettingsAction;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -804,5 +804,10 @@ public interface Renderer
      * Enables/Disables the paste action
      */
     void updatePasteAction();
-    
+
+    /**
+     * Returns the selected rendering settings under "User Settings".
+     * @return See above.
+     */
+    RndProxyDef getSelectedDef();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -845,19 +845,9 @@ class RendererComponent
      */
 	public void resetSettings()
 	{
-		try {
-		        model.makeHistorySnapshot();
-			model.resetDefaults();
-			view.resetDefaultRndSettings();
-			firePropertyChange(RENDER_PLANE_PROPERTY, 
-					Boolean.valueOf(false), Boolean.valueOf(true));
-			firePropertyChange(COLOR_MODEL_PROPERTY, Boolean.valueOf(false), 
-   		 			Boolean.valueOf(true));
-		} catch (Throwable e) {
-			handleException(e);
-		}
+		resetSettings(null, true);
 	}
-	
+
         /**
          * Implemented as specified by the {@link Renderer} interface.
          * 
@@ -906,13 +896,17 @@ class RendererComponent
 	public void resetSettings(RndProxyDef settings, boolean update)
 	{
 		try {
-		        model.makeHistorySnapshot();
-			model.resetSettings(settings);
+		    model.makeHistorySnapshot();
+		    if (settings != null) {
+		        model.resetSettings(settings);
+		    } else {
+		        model.resetDefaults();
+		    }
 			if (update) {
 				view.resetDefaultRndSettings();
 				firePropertyChange(RENDER_PLANE_PROPERTY, 
 						Boolean.valueOf(false), Boolean.valueOf(true));
-				firePropertyChange(COLOR_MODEL_PROPERTY, Boolean.valueOf(false), 
+				firePropertyChange(COLOR_MODEL_PROPERTY, Boolean.valueOf(false),
 	   		 			Boolean.valueOf(true));
 				controller.updatePasteAction();
 			}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -904,6 +904,10 @@ class RendererComponent
 		    }
 			if (update) {
 				view.resetDefaultRndSettings();
+				if (settings == null) {
+				    settings = model.getInitialRndSettings();
+				}
+				view.resetViewedBy(settings);
 				firePropertyChange(RENDER_PLANE_PROPERTY, 
 						Boolean.valueOf(false), Boolean.valueOf(true));
 				firePropertyChange(COLOR_MODEL_PROPERTY, Boolean.valueOf(false),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -34,6 +34,7 @@ import javax.swing.JFrame;
 import omero.romio.PlaneDef;
 
 import org.openmicroscopy.shoola.agents.events.iviewer.RendererUnloadedEvent;
+import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsChanged;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
@@ -602,12 +603,14 @@ class RendererComponent
 				}
 			}
 			view.setColorModelChanged();
-			//if (model.isGeneralIndex()) model.saveRndSettings();
 			firePropertyChange(COLOR_MODEL_PROPERTY, Boolean.valueOf(false), 
    		 			Boolean.valueOf(true));
 			if (update)
 				firePropertyChange(RENDER_PLANE_PROPERTY,
 						Boolean.valueOf(false), Boolean.valueOf(true));
+			RndSettingsChanged evt = new RndSettingsChanged(
+                    model.getRefImage().getId());
+            MetadataViewerAgent.getRegistry().getEventBus().post(evt);
 		} catch (Exception e) {
 			handleException(e);
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1262,6 +1262,10 @@ class RendererComponent
 					image, LookupNames.IMAGE_J));
 		} else {
 		    ViewImageObject vio = new ViewImageObject(image);
+		    RndProxyDef def = view.getSelectedDef();
+		    if (def != null) {
+		        vio.setSettings(def, def.getOwnerID());
+		    }
 			bus.post(new ViewImage(model.getSecurityContext(), vio, null));
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1346,10 +1346,19 @@ class RendererComponent
 	public ModuloInfo getModuloT() { return model.getModuloT(); }
 	
 	/**
-         * Implemented as specified by the {@link Renderer} interface.
-         * @see Renderer#updatePasteAction()
-         */
+	 * Implemented as specified by the {@link Renderer} interface.
+	 * @see Renderer#updatePasteAction()
+	 */
 	public void updatePasteAction() {
 	    controller.updatePasteAction();
+	}
+
+	/**
+	 * Implemented as specified by the {@link Renderer} interface.
+	 * @see Renderer#getSelectedDef()
+	 */
+	public RndProxyDef getSelectedDef()
+	{
+	    return  view.getSelectedDef();
 	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1262,10 +1262,6 @@ class RendererComponent
 					image, LookupNames.IMAGE_J));
 		} else {
 		    ViewImageObject vio = new ViewImageObject(image);
-		    RndProxyDef def = view.getSelectedDef();
-		    if (def != null) {
-		        vio.setSettings(def, def.getOwnerID());
-		    }
 			bus.post(new ViewImage(model.getSecurityContext(), vio, null));
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1264,7 +1264,7 @@ class RendererComponent
 		    ViewImageObject vio = new ViewImageObject(image);
 		    RndProxyDef def = view.getSelectedDef();
 		    if (def != null) {
-		        vio.setSettings(def, def.getOwnerID());
+		        vio.setSelectedRndDef(def.getData().getId().getValue());
 		    }
 			bus.post(new ViewImage(model.getSecurityContext(), vio, null));
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1260,8 +1260,12 @@ class RendererComponent
 			bus.post(new ViewInPluginEvent(model.getSecurityContext(),
 					image, LookupNames.IMAGE_J));
 		} else {
-			bus.post(new ViewImage(model.getSecurityContext(),
-					new ViewImageObject(image), null));
+		    ViewImageObject vio = new ViewImageObject(image);
+		    RndProxyDef def = view.getSelectedDef();
+		    if (def != null) {
+		        vio.setSettings(def, def.getOwnerID());
+		    }
+			bus.post(new ViewImage(model.getSecurityContext(), vio, null));
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -1264,7 +1264,7 @@ class RendererComponent
 		    ViewImageObject vio = new ViewImageObject(image);
 		    RndProxyDef def = view.getSelectedDef();
 		    if (def != null) {
-		        vio.setSelectedRndDef(def.getData().getId().getValue());
+		        vio.setSelectedRndDef(def.getDataID());
 		    }
 			bus.post(new ViewImage(model.getSecurityContext(), vio, null));
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererFactory.java
@@ -23,7 +23,10 @@ package org.openmicroscopy.shoola.agents.metadata.rnd;
 import java.util.Collection;
 
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
+
 import omero.gateway.model.ImageData;
 import omero.gateway.model.XMLAnnotationData;
 
@@ -49,13 +52,14 @@ public class RendererFactory
      * @param image The image the component is for.
      * @param rndIndex The index of the renderer.
      * @param modulo The modulo annotations if any.
+     * @param def The alternative rendering settings if any.
      * @return See above.
      */
     public static Renderer createRenderer(SecurityContext ctx,
     		RenderingControl rndControl, ImageData image, int rndIndex,
-    		Collection<XMLAnnotationData> modulo)
+    		Collection<XMLAnnotationData> modulo, RndProxyDef def)
     {
-        RendererModel model = new RendererModel(ctx, rndControl, rndIndex);
+        RendererModel model = new RendererModel(ctx, rndControl, rndIndex, def);
         model.setImage(image);
         model.setXMLAnnotations(modulo);
         RendererComponent rnd = new RendererComponent(model);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -176,6 +176,9 @@ class RendererModel
     /** Map hosting the extra dimension if available.*/
     private Map<Integer, ModuloInfo> modulo;
 
+    /** he alternative rendering settings if any.*/
+    private RndProxyDef def;
+
 	/**
 	 * Creates a new instance.
 	 *
@@ -183,9 +186,10 @@ class RendererModel
 	 * @param rndControl Reference to the component that controls the
 	 *                   rendering settings. Mustn't be <code>null</code>.
 	 * @param rndIndex The index associated to the renderer.
+	 * @param def The alternative rendering settings if any.
 	 */
 	RendererModel(SecurityContext ctx, RenderingControl rndControl,
-			int rndIndex)
+			int rndIndex, RndProxyDef def)
 	{
 		if (rndControl == null)
 			throw new NullPointerException("No rendering control.");
@@ -197,6 +201,7 @@ class RendererModel
 		globalMinChannels = null;
 		plane = new PlaneDef();
 		plane.slice = omero.romio.XY.value;
+		this.def = def;
 	}
 
 	/**
@@ -1137,6 +1142,13 @@ class RendererModel
 		if (rndControl == null) return null;
 		return rndControl.getRndSettingsCopy();
 	}
+
+	/**
+     * Returns the alternative rendering settings.
+     *
+     * @return See above.
+     */
+    RndProxyDef getAlternativeRndSettings() { return def; }
 
     /**
      * Returns the initial rendering settings.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -314,4 +314,14 @@ class RendererUI
         pane.onChannelUpdated();
     }
 
+    /**
+     * Returns the selected rendering settings if any.
+     *
+     * @return See above.
+     */
+    RndProxyDef getSelectedDef()
+    {
+        DomainPane pane = (DomainPane) controlPanes.get(DOMAIN);
+        return pane.getSelectedDef();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -192,6 +192,17 @@ class RendererUI
     }
 
     /**
+     * Resets the settings.
+     *
+     * @param settings the value to set.
+     */
+    void resetViewedBy(RndProxyDef settings)
+    {
+        DomainPane pane = (DomainPane) controlPanes.get(DOMAIN);
+        pane.resetViewedBy(settings);
+    }
+
+    /**
      * This is a method which is triggered from the {@link RendererControl} 
      * if the color model has changed.
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -289,7 +289,14 @@ class RendererUI
     {
         if (CollectionUtils.isEmpty(results)) return;
         DomainPane pane = (DomainPane) controlPanes.get(DOMAIN);
-        RndProxyDef activeDef = CollectionUtils.isEmpty(model.getRenderingControls()) ? null : model.getRenderingControls().get(0).getRndSettingsCopy();
+        RndProxyDef activeDef = null;
+        if (model.getAlternativeRndSettings() != null) {
+            activeDef = model.getAlternativeRndSettings();
+        } else {
+            if (CollectionUtils.isNotEmpty(model.getRenderingControls())) {
+                activeDef = model.getRenderingControls().get(0).getRndSettingsCopy();
+            }
+        }
         pane.displayViewedBy(results, activeDef);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -298,7 +298,17 @@ class RendererUI
         if (model.getAlternativeRndSettings() != null) {
             activeDef = model.getAlternativeRndSettings();
         } else {
-            if (CollectionUtils.isNotEmpty(model.getRenderingControls())) {
+            Iterator<ViewedByItem> i = results.iterator();
+            ViewedByItem item;
+            while (i.hasNext()) {
+                item = i.next();
+                if (item.isSelected()) {
+                    activeDef = item.getRndDef();
+                    item.setSelected(false);
+                }
+            }
+            if (activeDef == null && 
+                CollectionUtils.isNotEmpty(model.getRenderingControls())) {
                 activeDef = model.getRenderingControls().get(0).getRndSettingsCopy();
             }
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -23,8 +23,6 @@
 package org.openmicroscopy.shoola.agents.metadata.rnd;
 
 
-//Java imports
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -32,17 +30,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 
-//Third-party libraries
 import org.apache.commons.collections.CollectionUtils;
 
-//Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.agents.util.ViewedByItem;
-import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 
 /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -696,15 +696,22 @@ public interface MetadataViewer
 	ExperimenterData getCurrentUser();
 	
 	/**
-         * Applies the settings of a previous set image to
-         * the renderer (does not save them).
-         */
+	 * Applies the settings of a previous set image to
+	 * the renderer (does not save them).
+	 */
 	void applyCopiedRndSettings();
-	
-        /**
-         * Returns if there are copied rendering settings which could be pasted.
-         * 
-         * @return See above.
-         */
-        boolean hasRndSettingsCopied();
+
+	/**
+	 * Returns if there are copied rendering settings which could be pasted.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasRndSettingsCopied();
+
+	/**
+	 * Returns the alternative rendering settings.
+	 *
+	 * @return See above.
+	 */
+	RndProxyDef getAlternativeRenderingSettings();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -905,8 +905,11 @@ class MetadataViewerComponent
 	 */
 	public void onRndLoaded(boolean reload)
 	{
-		getRenderer().addPropertyChangeListener(controller);
-		firePropertyChange(RND_LOADED_PROPERTY, Boolean.valueOf(!reload), 
+	    Renderer rnd = getRenderer();
+	    if (rnd != null) {
+	        rnd.addPropertyChangeListener(controller);
+	    }
+		firePropertyChange(RND_LOADED_PROPERTY, Boolean.valueOf(!reload),
 				Boolean.valueOf(reload));
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -1322,23 +1322,31 @@ class MetadataViewerComponent
 	 * @see #toString()
 	 */
 	public String toString() { return model.getInstanceToSave(); }
-	
+
 	/**
-         * Implemented as specified by the {@link MetadataViewer} interface.
-         * @see MetadataViewer#hasRndSettingsCopied()
-         */
-        public boolean hasRndSettingsCopied() {
-            return model.hasRndSettingsCopied();
-        }
-	
+	 * Implemented as specified by the {@link MetadataViewer} interface.
+	 * @see MetadataViewer#hasRndSettingsCopied()
+	 */
+	public boolean hasRndSettingsCopied() {
+	    return model.hasRndSettingsCopied();
+	}
+
 	/**
-         * Implemented as specified by the {@link MetadataViewer} interface.
-         * @see MetadataViewer#applyCopiedRndSettings()
-         */
+	 * Implemented as specified by the {@link MetadataViewer} interface.
+	 * @see MetadataViewer#applyCopiedRndSettings()
+	 */
 	public void applyCopiedRndSettings() {
 	    if(getRenderer()==null)
 	        return;
-	    
+
 	    model.fireLoadRndSettings();
+	}
+
+	/**
+     * Implemented as specified by the {@link MetadataViewer} interface.
+     * @see MetadataViewer#getAlternativeRenderingSettings()
+     */
+	public RndProxyDef getAlternativeRenderingSettings() {
+	    return model.getAlternativeRenderingSettings();
 	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerFactory.java
@@ -76,7 +76,7 @@ public class MetadataViewerFactory
         if (CollectionUtils.isEmpty(data))
             throw new IllegalArgumentException("No data to edit");
         MetadataViewerModel model = new MetadataViewerModel(data, 
-                MetadataViewer.RND_GENERAL, null);
+                MetadataViewer.RND_GENERAL, null, -1);
         model.setDataType(type);
         return singleton.createViewer(model);
     }
@@ -89,7 +89,7 @@ public class MetadataViewerFactory
      */
     public static MetadataViewer getViewer(Object refObject)
     {
-        return getViewer(refObject, MetadataViewer.RND_GENERAL, null);
+        return getViewer(refObject, MetadataViewer.RND_GENERAL, null, -1);
     }
 
     /**
@@ -100,13 +100,14 @@ public class MetadataViewerFactory
      * 					{@link MetadataViewer#RND_GENERAL} or
      * 					{@link MetadataViewer#RND_SPECIFIC}.
      * @param def The alternative rendering settings if any.
+     * @param selectedViewedByDef The selected rendering settings.
      * @return See above.
      */
     public static MetadataViewer getViewer(Object refObject, int index,
-            RndProxyDef def)
+            RndProxyDef def, long selectedViewedByDef)
     {
         MetadataViewerModel model = new MetadataViewerModel(refObject, index,
-                def);
+                def, selectedViewedByDef);
         return singleton.createViewer(model);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerFactory.java
@@ -23,10 +23,13 @@ package org.openmicroscopy.shoola.agents.metadata.view;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
+
 import omero.model.NamedValue;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
@@ -70,10 +73,10 @@ public class MetadataViewerFactory
      */
     public static MetadataViewer getViewer(List<Object> data, Class type)
     {
-        if (data == null || data.size() == 0)
+        if (CollectionUtils.isEmpty(data))
             throw new IllegalArgumentException("No data to edit");
         MetadataViewerModel model = new MetadataViewerModel(data, 
-                MetadataViewer.RND_GENERAL);
+                MetadataViewer.RND_GENERAL, null);
         model.setDataType(type);
         return singleton.createViewer(model);
     }
@@ -86,7 +89,7 @@ public class MetadataViewerFactory
      */
     public static MetadataViewer getViewer(Object refObject)
     {
-        return getViewer(refObject, MetadataViewer.RND_GENERAL);
+        return getViewer(refObject, MetadataViewer.RND_GENERAL, null);
     }
 
     /**
@@ -96,11 +99,14 @@ public class MetadataViewerFactory
      * @param index 	One of the following constants: 
      * 					{@link MetadataViewer#RND_GENERAL} or
      * 					{@link MetadataViewer#RND_SPECIFIC}.
+     * @param def The alternative rendering settings if any.
      * @return See above.
      */
-    public static MetadataViewer getViewer(Object refObject, int index)
+    public static MetadataViewer getViewer(Object refObject, int index,
+            RndProxyDef def)
     {
-        MetadataViewerModel model = new MetadataViewerModel(refObject, index);
+        MetadataViewerModel model = new MetadataViewerModel(refObject, index,
+                def);
         return singleton.createViewer(model);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -155,7 +155,10 @@ class MetadataViewerModel
 	
 	/** The active loaders.*/
 	private Map<Integer, MetadataLoader> loaders;
-	
+
+	/** The alternative rendering settings.*/
+	private RndProxyDef def;
+
     /**
      * Creates a new context if <code>null</code>.
      *
@@ -216,11 +219,11 @@ class MetadataViewerModel
 	/**
 	 * Creates a new object and sets its state to {@link MetadataViewer#NEW}.
 	 * 
-	 * @param refObject	The reference object.
-	 * @param index		One of the rendering constants defined by the 
-	 * 					<code>MetadataViewer</code> I/F.
+	 * @param refObject The reference object.
+	 * @param index One of the rendering constants defined by the 
+	 *              <code>MetadataViewer</code> I/F.
 	 */
-	MetadataViewerModel(Object refObject, int index)
+	MetadataViewerModel(Object refObject, int index, RndProxyDef def)
 	{
 		state = MetadataViewer.NEW;
 		switch (index) {
@@ -231,6 +234,7 @@ class MetadataViewerModel
 			default:
 				this.index = MetadataViewer.RND_GENERAL;
 		}
+		this.def = def;
 		this.refObject = refObject;
 		loaderID = 0;
 		loaders = new HashMap<Integer, MetadataLoader>();
@@ -239,7 +243,7 @@ class MetadataViewerModel
 		singleMode = true;
 		userID = MetadataViewerAgent.getUserDetails().getId();
 	}
-	
+
 	/**
 	 * Called by the <code>MetadataViewer</code> after creation to allow this
 	 * object to store a back reference to the embedding component.
@@ -1134,7 +1138,7 @@ class MetadataViewerModel
      * 
      * @return See above
      */
-    public boolean hasRndSettingsCopied() {
+    boolean hasRndSettingsCopied() {
         Renderer rnd = component.getRenderer();
         ImageData img = getImage();
         
@@ -1146,5 +1150,14 @@ class MetadataViewerModel
                 || (copyRenderingSettingsFrom != null && img != null &&
                 copyRenderingSettingsFrom.getId() != img.getId());
     }
-    
+
+    /**
+     * Returns the alternative rendering settings.
+     *
+     * @return See above.
+     */
+    RndProxyDef getAlternativeRenderingSettings()
+    {
+        return def;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -159,6 +159,9 @@ class MetadataViewerModel
 	/** The alternative rendering settings.*/
 	private RndProxyDef def;
 
+	/** The selected rendering settings in "User Settings".*/
+	private long selectedViewedByDef;
+
     /**
      * Creates a new context if <code>null</code>.
      *
@@ -222,10 +225,14 @@ class MetadataViewerModel
 	 * @param refObject The reference object.
 	 * @param index One of the rendering constants defined by the 
 	 *              <code>MetadataViewer</code> I/F.
+	 * @param def The alternative settings if any.
+	 * @param selectedViewedByDef The selected viewed elements.
 	 */
-	MetadataViewerModel(Object refObject, int index, RndProxyDef def)
+	MetadataViewerModel(Object refObject, int index, RndProxyDef def,
+	        long selectedViewedByDef)
 	{
 		state = MetadataViewer.NEW;
+		this.selectedViewedByDef = selectedViewedByDef;
 		switch (index) {
 			case MetadataViewer.RND_GENERAL:
 			case MetadataViewer.RND_SPECIFIC:
@@ -243,6 +250,13 @@ class MetadataViewerModel
 		singleMode = true;
 		userID = MetadataViewerAgent.getUserDetails().getId();
 	}
+
+	/**
+	 * Returns the selected viewed by def.
+	 *
+	 * @return See above.
+	 */
+	long getSelectedViewedByDef() { return selectedViewedByDef; }
 
 	/**
 	 * Called by the <code>MetadataViewer</code> after creation to allow this

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
@@ -35,7 +35,9 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 
+import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsChanged;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
+import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.agents.util.ViewedByItem;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
@@ -255,6 +257,10 @@ class MetadataViewerUI
 				evt.getPropertyName())) {
 			model.applyRenderingSettings(
 					(RndProxyDef) evt.getNewValue());
+			//post an event
+			RndSettingsChanged e = new RndSettingsChanged(
+			        model.getImage().getId());
+			MetadataViewerAgent.getRegistry().getEventBus().post(e);
 		}
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -207,16 +208,24 @@ class MetadataViewerUI
             viewedByItems.clear();
     
             Map m = model.getViewedBy();
-            Iterator i = m.keySet().iterator();
+            Iterator i = m.entrySet().iterator();
             ViewedByItem item;
             ExperimenterData exp;
+            Entry e;
+            long id = model.getSelectedViewedByDef();
+            
+            RndProxyDef def;
             while (i.hasNext()) {
-                exp = (ExperimenterData) i.next();
+                e = (Entry) i.next();
+                exp = (ExperimenterData) e.getKey();
                 ImageData img = model.getImage();
                 if (img != null) {
+                    def = (RndProxyDef) e.getValue();
                     boolean isOwnerSetting = img.getOwner().getId() == exp.getId();
-                    item = new ViewedByItem(exp, (RndProxyDef) m.get(exp),
-                            isOwnerSetting);
+                    item = new ViewedByItem(exp, def, isOwnerSetting);
+                    if (def.getData().getId().getValue() == id) {
+                        item.setSelected(true);
+                    }
                     item.addPropertyChangeListener(ViewedByItem.VIEWED_BY_PROPERTY,
                             this);
                     viewedByItems.add(item);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -31,11 +31,11 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 
 import org.openmicroscopy.shoola.agents.events.hiviewer.DownloadEvent;
-
 import org.openmicroscopy.shoola.agents.events.importer.BrowseContainer;
 import org.openmicroscopy.shoola.agents.events.importer.ImportStatusEvent;
 import org.openmicroscopy.shoola.agents.events.importer.LoadImporter;
 import org.openmicroscopy.shoola.agents.events.iviewer.CopyRndSettings;
+import org.openmicroscopy.shoola.agents.events.iviewer.ResetRndSettings;
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsCopied;
 import org.openmicroscopy.shoola.agents.events.iviewer.ScriptDisplay;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewerCreated;
@@ -59,7 +59,9 @@ import org.openmicroscopy.shoola.env.data.events.ReconnectedEvent;
 import org.openmicroscopy.shoola.env.data.events.SaveEventRequest;
 import org.openmicroscopy.shoola.env.data.events.UserGroupSwitched;
 import org.openmicroscopy.shoola.env.data.util.AgentSaveInfo;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.event.EventBus;
@@ -520,6 +522,22 @@ public class TreeViewerAgent
         viewer.showMenu(TreeViewer.AVAILABLE_SCRIPTS_MENU, evt.getSource(),
                 evt.getLocation());
     }
+
+    /**
+     * Resets the rendering settings..
+     *
+     * @param evt The event to handle.
+     */
+    private void handleResetRndSettings(ResetRndSettings evt)
+    {
+        if (evt == null) return;
+        ExperimenterData exp = (ExperimenterData) registry.lookup(
+                LookupNames.CURRENT_USER_DETAILS);
+        if (exp == null) return;
+        TreeViewer viewer = TreeViewerFactory.getTreeViewer(exp);
+        viewer.resetRndSettings(evt.getImageID(), evt.getSettings());
+    }
+
     /**
      * Implemented as specified by {@link Agent}.
      * @see Agent#activate(boolean)
@@ -589,6 +607,7 @@ public class TreeViewerAgent
         bus.register(this, SaveEvent.class);
         bus.register(this, DownloadEvent.class);
         bus.register(this, ScriptDisplay.class);
+        bus.register(this, ResetRndSettings.class);
     }
 
     /**
@@ -657,6 +676,8 @@ public class TreeViewerAgent
             handleDownloadEvent((DownloadEvent) e);
         else if (e instanceof ScriptDisplay) {
             handleScriptDisplay((ScriptDisplay) e);
+        } else if (e instanceof ResetRndSettings) {
+            handleResetRndSettings((ResetRndSettings) e);
         }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/cmd/ViewCmd.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/cmd/ViewCmd.java
@@ -28,8 +28,11 @@ import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
@@ -105,6 +108,10 @@ public class ViewCmd
 		    Object uo = d.getUserObject();
 			EventBus bus = TreeViewerAgent.getRegistry().getEventBus();
 			ViewImageObject vo = new ViewImageObject((ImageData) uo);
+			RndProxyDef def = model.getSelectedViewedBy();
+			if (def != null) {
+			    vo.setSelectedRndDef(def.getDataID());
+			}
 			TreeImageDisplay p = d.getParentDisplay();
 			TreeImageDisplay gp = null;
 			DataObject po = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -28,10 +28,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.swing.JFrame;
 
 import org.openmicroscopy.shoola.agents.treeviewer.ImageChecker.ImageCheckerType;
-
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.util.DataObjectRegistration;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
@@ -43,9 +43,13 @@ import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 import org.openmicroscopy.shoola.env.data.model.ImageCheckerResult;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
+
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.ui.ActivityComponent;
 import org.openmicroscopy.shoola.util.ui.component.ObservableComponent;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
@@ -1187,4 +1191,12 @@ public interface TreeViewer
      * @return See above.
      */
     Collection<DataObject> getSelectedObjectsFromBrowser();
+    
+    /**
+     * Resets the rendering settings.
+     *
+     * @param imageID The image id.
+     * @param settings The settings to reset
+     */
+    void resetRndSettings(long imageID, RndProxyDef settings);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -1199,4 +1199,12 @@ public interface TreeViewer
      * @param settings The settings to reset
      */
     void resetRndSettings(long imageID, RndProxyDef settings);
+
+    /**
+     * Returns the rendering setting of the selected viewed by item if any.
+     *
+     * @return See above.
+     */
+    RndProxyDef getSelectedViewedBy();
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -60,6 +60,7 @@ import org.openmicroscopy.shoola.agents.events.treeviewer.CopyItems;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DeleteObjectEvent;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DisplayModeEvent;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
+import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerFactory;
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
@@ -4937,4 +4938,26 @@ class TreeViewerComponent
         }
         return null;
     }
+    
+    /**
+     * Implemented as specified by the {@link TreeViewer} interface.
+     * @see TreeViewer#resetRndSettings(long, RndProxyDef)
+     */
+   public void resetRndSettings(long imageID, RndProxyDef settings)
+   {
+       MetadataViewer viewer = model.getMetadataViewer();
+       if (viewer == null) return;
+       Object ho = viewer.getRefObject();
+       ImageData img = null;
+       if (ho instanceof ImageData) {
+           img = (ImageData) ho;
+       } else if (ho instanceof WellSampleData) {
+           img = ((WellSampleData) ho).getImage();
+       }
+       if (img == null || img.getId() != imageID) return;
+       Renderer rnd = viewer.getRenderer();
+       if (rnd != null) {
+           rnd.resetSettings(settings, true);
+       }
+   }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -4960,4 +4960,21 @@ class TreeViewerComponent
            rnd.resetSettings(settings, true);
        }
    }
+
+   public RndProxyDef getSelectedViewedBy()
+   {
+       MetadataViewer viewer = model.getMetadataViewer();
+       if (viewer == null) return null;
+       Object ho = viewer.getRefObject();
+       ImageData img = null;
+       if (ho instanceof ImageData) {
+           img = (ImageData) ho;
+       } else if (ho instanceof WellSampleData) {
+           img = ((WellSampleData) ho).getImage();
+       }
+       if (img == null) return null;
+       Renderer rnd = viewer.getRenderer();
+       if (rnd == null) return null;
+       return rnd.getSelectedDef();
+   }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2658,7 +2658,7 @@ class TreeViewerComponent
 			"paste. \n Please first copy settings.");
 			return;
 		}
-		if (ids == null || ids.size() == 0) {
+		if (CollectionUtils.isEmpty(ids)) {
 			UserNotifier un = TreeViewerAgent.getRegistry().getUserNotifier();
 			un.notifyInfo("Paste settings", "Please select the nodes \n" +
 			"you wish to apply the settings to.");

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
@@ -1574,4 +1574,5 @@ class TreeViewerModel
     {
         return TreeViewerAgent.getRegistry().getAdminService().isSecuritySystemGroup(id, key);
     }
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewedByItem.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewedByItem.java
@@ -66,6 +66,9 @@ public class ViewedByItem extends JLabel {
     /** The image with the rendering settings. */
     private BufferedImage image;
 
+    /** Flag indicating that the item should be selected by default.*/
+    private boolean selected;
+
     /**
      * Creates a new instance.
      * 
@@ -117,6 +120,24 @@ public class ViewedByItem extends JLabel {
 
         });
     }
+
+    /**
+     * Indicates that the element should be selected by default or not.
+     *
+     * @param selected The value to set.
+     */
+    public void setSelected(boolean selected)
+    {
+        this.selected = selected;
+    }
+
+    /**
+     * Returns <code>true</code> if the item is selected,
+     * <code>false</code> otherwise.
+     *
+     * @return See above.
+     */
+    public boolean isSelected() { return selected; }
 
     /**
      * Returns the experimenter the settings belong to.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
@@ -337,6 +337,16 @@ public class RndProxyDef
     }
 
     /**
+     * Returns the identifier of the settings.
+     *
+     * @return See above.
+     */
+    public long getDataID()
+    {
+        return data.getId().getValue();
+    }
+
+    /**
      * Returns the data hosted by this class.
      *
      * @return See above.


### PR DESCRIPTION
This PR fixes a synchronization issue reported on the following card: https://trello.com/c/4mDNygGv/38-follow-up

To test:
 1. Log as user-6. Select the read-write group
 * Add user-5 to the display. 
 * Select the first image in the ```archived dv``` dataset under user-5
 * Go to preview tab
 * The image has been rnd settings for both user-5 and user-6
 * Select user-5 settings.
 * Click ```Launch Full Viewer```
 * Display the rendering controls (click on the left icon in the toolbar to display it)
 * Check that the thumbnail under user settings corresponding to user-5 is selected in the main viewer (it was user-6 w/o this PR)
 * Close the viewer w/o saving the settings.
 * Check that the settings are reset in the preview and the original thumbnail under User settings is selected i.e. user-6

Repeat the same test but with the following variation on step 7
  * one test with ```Click on Full Viewer``` in the general pane.
 * one test with ```Right click on the selected image in the tree```
 * one test with ```Right click on the selected image in the central pane```

cc @dominikl 