### PR TITLE
Tag multiple selection

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -579,6 +579,9 @@
                         if (selected.length > 0 && selected[0].type !== node.type) {
                             return false;
                         }
+                        if (selected.length > 0 && (node.type === 'tag' || node.type === 'tagset')) {
+                            return false;
+                        }
 
                         // Also disallow the selection if it is a multi-select and the new target
                         // is already selected


### PR DESCRIPTION
This fix multiple selection in a tag tree reported in http://trac.openmicroscopy.org/ome/ticket/13065

To test, go to tag tab and try to select multiple tags. You should be only allowed to select one.

cc: @jburel 