### PR TITLE
Bump references to 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Also see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 Full developer documentation for OMERO is available from
-http://www.openmicroscopy.org/site/support/omero5.1/developers/
+http://www.openmicroscopy.org/site/support/omero5.2/developers/
 
 For general guidance on contributing to OME projects, see
 http://www.openmicroscopy.org/site/support/contributing/

--- a/components/blitz/README.txt
+++ b/components/blitz/README.txt
@@ -1,5 +1,5 @@
 OmeroBlitz
-http://www.openmicroscopy.org/site/support/omero5.1/developers/server-blitz.html
+http://www.openmicroscopy.org/site/support/omero5.2/developers/server-blitz.html
 ------------------------------------------------------------------------------
 
 The Blitz server is based on Ice (http://zeroc.com)
@@ -8,4 +8,4 @@ Contained in this directory are server implementation, code
 generation for the client implementation, and configuration
 for an IceGrid application.
 
-See also http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/grid.html
+See also http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/grid.html

--- a/components/blitz/resources/README.ice
+++ b/components/blitz/resources/README.ice
@@ -17,7 +17,7 @@
 // target to generate html under dist/docs/api/slice2html. The latest
 // copy of which is available here:
 //
-// http://downloads.openmicroscopy.org/latest/omero5.1/api/slice2html/
+// http://downloads.openmicroscopy.org/latest/omero5.2/api/slice2html/
 
 /**
 

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -129,7 +129,7 @@
 
   <!-- Stateless ome.api service-based
   ==============================================================================
-  See documentation at http://downloads.openmicroscopy.org/latest/omero5.1/api/package-summary.html
+  See documentation at http://downloads.openmicroscopy.org/latest/omero5.2/api/package-summary.html
   -->
 
 

--- a/components/blitz/resources/omero/API.ice
+++ b/components/blitz/resources/omero/API.ice
@@ -175,8 +175,8 @@ module omero {
              * Returns a reference to a back-end manager. The [omero::grid::SharedResources]
              * service provides look ups for various facilities offered by OMERO:
              * <ul>
-             *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/scripts/">OMERO.scripts</a>
-             *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Tables.html">OMERO.tables</a>
+             *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/scripts/">OMERO.scripts</a>
+             *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Tables.html">OMERO.tables</a>
              * </ul>
              * These facilities may or may not be available on first request.
              *

--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -162,7 +162,7 @@ module omero {
     };
 
     /**
-     * General namespaces for <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Modules/StructuredAnnotations.html">StructuredAnnotations</a>
+     * General namespaces for <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Modules/StructuredAnnotations.html">StructuredAnnotations</a>
      **/
     module namespaces {
         const string NSFSRENAME = "openmicroscopy.org/omero/fs/rename";

--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -19,7 +19,7 @@
  * implementation, for use by the server and via the
  * InteractiveProcessor wrapper by clients.
  *
- * See http://www.openmicroscopy.org/site/support/omero5.1/developers/scripts/
+ * See http://www.openmicroscopy.org/site/support/omero5.2/developers/scripts/
  */
 
 module omero {

--- a/components/blitz/resources/omero/Tables.ice
+++ b/components/blitz/resources/omero/Tables.ice
@@ -21,7 +21,7 @@
  * The Tables API is intended to provide a storage mechanism
  * for tabular data.
  *
- * See http://www.openmicroscopy.org/site/support/omero5.1/developers/Tables.html
+ * See http://www.openmicroscopy.org/site/support/omero5.2/developers/Tables.html
  */
 module omero {
 

--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IAdmin.html">IAdmin.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IAdmin.html">IAdmin.html</a>
          **/
         ["ami", "amd"] interface IAdmin extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IConfig.ice
+++ b/components/blitz/resources/omero/api/IConfig.ice
@@ -17,7 +17,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IConfig.html">IConfig.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IConfig.html">IConfig.html</a>
          **/
         ["ami", "amd"] interface IConfig extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IContainer.ice
+++ b/components/blitz/resources/omero/api/IContainer.ice
@@ -19,7 +19,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IContainer.html">IContainer.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IContainer.html">IContainer.html</a>
          **/
         ["ami", "amd"] interface IContainer extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/ILdap.ice
+++ b/components/blitz/resources/omero/api/ILdap.ice
@@ -16,7 +16,7 @@ module omero {
 
     module api {
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/ILdap.html">ILdap.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ILdap.html">ILdap.html</a>
          **/
         ["ami", "amd"] interface ILdap extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IMetadata.ice
+++ b/components/blitz/resources/omero/api/IMetadata.ice
@@ -18,7 +18,7 @@ module omero {
 
     module api {
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IMetadata.html">IMetadata.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IMetadata.html">IMetadata.html</a>
          **/
         ["ami", "amd"] interface IMetadata extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IPixels.ice
+++ b/components/blitz/resources/omero/api/IPixels.ice
@@ -16,7 +16,7 @@ module omero {
 
     module api {
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IPixels.html">IPixels.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IPixels.html">IPixels.html</a>
          **/
         ["ami", "amd"] interface IPixels extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IProjection.ice
+++ b/components/blitz/resources/omero/api/IProjection.ice
@@ -20,7 +20,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IProjection.html">IProjection.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IProjection.html">IProjection.html</a>
          **/
         ["ami", "amd"] interface IProjection extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IQuery.ice
+++ b/components/blitz/resources/omero/api/IQuery.ice
@@ -20,7 +20,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IQuery.html">IQuery.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IQuery.html">IQuery.html</a>
          **/
         ["ami", "amd"] interface IQuery extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IRenderingSettings.ice
+++ b/components/blitz/resources/omero/api/IRenderingSettings.ice
@@ -20,7 +20,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IRenderingSettings.html">IRenderingSettings.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IRenderingSettings.html">IRenderingSettings.html</a>
          **/
         ["ami", "amd"] interface IRenderingSettings extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IRepositoryInfo.ice
+++ b/components/blitz/resources/omero/api/IRepositoryInfo.ice
@@ -19,7 +19,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IRepositoryInfo.html">IRepositoryInfo.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IRepositoryInfo.html">IRepositoryInfo.html</a>
          **/
         ["ami", "amd"] interface IRepositoryInfo extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -48,7 +48,7 @@ module omero {
          *     proc.close(False)
          *
          * </pre>
-         * See <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/scripts/">OMERO.scripts</a> for more information.
+         * See <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/scripts/">OMERO.scripts</a> for more information.
          **/
         ["ami","amd"] interface IScript extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/ISession.ice
+++ b/components/blitz/resources/omero/api/ISession.ice
@@ -19,7 +19,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/ISession.html">ISession.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ISession.html">ISession.html</a>
          **/
         ["ami", "amd"] interface ISession extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IShare.ice
+++ b/components/blitz/resources/omero/api/IShare.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IShare.html">IShare.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IShare.html">IShare.html</a>
          **/
         ["ami", "amd"] interface IShare extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/ITypes.ice
+++ b/components/blitz/resources/omero/api/ITypes.ice
@@ -19,7 +19,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/ITypes.html">ITypes.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ITypes.html">ITypes.html</a>
          **/
         ["ami", "amd"] interface ITypes extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/IUpdate.ice
+++ b/components/blitz/resources/omero/api/IUpdate.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/IUpdate.html">IUpdate.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IUpdate.html">IUpdate.html</a>
          **/
         ["ami", "amd"] interface IUpdate extends ServiceInterface
             {

--- a/components/blitz/resources/omero/api/JobHandle.ice
+++ b/components/blitz/resources/omero/api/JobHandle.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/JobHandle.html">JobHandle.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/JobHandle.html">JobHandle.html</a>
          **/
         ["ami", "amd"] interface JobHandle extends StatefulServiceInterface
             {

--- a/components/blitz/resources/omero/api/RawFileStore.ice
+++ b/components/blitz/resources/omero/api/RawFileStore.ice
@@ -22,7 +22,7 @@ module omero {
          *
          * Note: methods on this service are protected by a "DOWNLOAD" restriction.
          *
-         * See also <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/RawFileStore.html">RawFileStore.html</a>
+         * See also <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/RawFileStore.html">RawFileStore.html</a>
          **/
         ["ami", "amd"] interface RawFileStore extends StatefulServiceInterface
             {

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -20,7 +20,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/omeis/providers/re/RenderingEngine.html">RenderingEngine.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/omeis/providers/re/RenderingEngine.html">RenderingEngine.html</a>
          **/
         ["ami", "amd"] interface RenderingEngine extends PyramidService
             {

--- a/components/blitz/resources/omero/api/Search.ice
+++ b/components/blitz/resources/omero/api/Search.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/Search.html">Search.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/Search.html">Search.html</a>
          **/
         ["ami", "amd"] interface Search extends StatefulServiceInterface
             {

--- a/components/blitz/resources/omero/api/ThumbnailStore.ice
+++ b/components/blitz/resources/omero/api/ThumbnailStore.ice
@@ -18,7 +18,7 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.1/api/ome/api/ThumbnailStore.html">ThumbnailStore.html</a>
+         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ThumbnailStore.html">ThumbnailStore.html</a>
          **/
         ["ami", "amd"] interface ThumbnailStore extends StatefulServiceInterface
             {

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -369,7 +369,7 @@ public class CommandLineImporter {
             + "  $ %s -s localhost -u username -w password -d 50 --debug ALL foo.tiff\n"
             + "\n"
             + "For additional information, see:\n"
-            + "http://www.openmicroscopy.org/site/support/omero5.1/users/cli/import.html\n"
+            + "http://www.openmicroscopy.org/site/support/omero5.2/users/cli/import.html\n"
             + "Report bugs to <ome-users@lists.openmicroscopy.org.uk>",
             APP_NAME, APP_NAME, APP_NAME, APP_NAME, APP_NAME, APP_NAME));
         System.exit(1);

--- a/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChgrpFacadeI.java
@@ -43,7 +43,7 @@ import omero.cmd.HandleI.Cancel;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChmodFacadeI.java
@@ -43,7 +43,7 @@ import omero.cmd.HandleI.Cancel;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.2
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/ChownFacadeI.java
@@ -43,7 +43,7 @@ import omero.cmd.HandleI.Cancel;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
+++ b/components/blitz/src/omero/cmd/graphs/DeleteFacadeI.java
@@ -45,7 +45,7 @@ import omero.cmd.HandleI.Cancel;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
+++ b/components/blitz/src/omero/cmd/graphs/IGraphModifyRequest.java
@@ -25,7 +25,7 @@ import omero.cmd.IRequest;
  * 
  * @since 5.0.0
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/insight/README.md
+++ b/components/insight/README.md
@@ -69,7 +69,7 @@
   Developing OMERO.insight
   ------------------------
 
-  See http://www.openmicroscopy.org/site/support/omero5.1/developers/index.html#insight
+  See http://www.openmicroscopy.org/site/support/omero5.2/developers/index.html#insight
 
 
 

--- a/components/server/src/ome/services/graphs/GraphOpts.java
+++ b/components/server/src/ome/services/graphs/GraphOpts.java
@@ -18,7 +18,7 @@ import ome.system.EventContext;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.2.1
  * @deprecated will be removed in OMERO 5.3, so use the
- * <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/ObjectGraphs.html">new graphs implementation</a>
+ * <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Server/ObjectGraphs.html">new graphs implementation</a>
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/components/server/src/ome/services/util/DBPatchCheck.java
+++ b/components/server/src/ome/services/util/DBPatchCheck.java
@@ -32,7 +32,7 @@ public class DBPatchCheck {
     }
 
     private final static String line = "***************************************************************************************\n";
-    private final static String see = "See http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-upgrade.html\n";
+    private final static String see = "See http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/server-upgrade.html\n";
     private final static String no_table = mk("Error connecting to database table dbpatch. You may need to bootstrap.\n");
     private final static String wrong_version = mk("DB version (%s) does not match omero.properties (%s). Please apply a db upgrade.\n");
 

--- a/components/tests/ui/README.md
+++ b/components/tests/ui/README.md
@@ -175,11 +175,11 @@ OMERO.web
 
 To run the tests locally, you will first need to start OMERO.web, please see
 
-http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/unix/install-web.html
+http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/unix/install-web.html
 
 or
 
-http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/windows/install-web.html
+http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/windows/install-web.html
 
 for more information.
 

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -133,7 +133,7 @@ Other help topics:
 %(topics)s
 
 For additional information, see:
-http://www.openmicroscopy.org/site/support/omero5.1/users/cli/index.html
+http://www.openmicroscopy.org/site/support/omero5.2/users/cli/index.html
 Report bugs to <ome-users@lists.openmicroscopy.org.uk>
 """
 

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -46,7 +46,7 @@ unlinks other users' annotations from data. The change to private will
 fail if different users' data is too closely related to be separated.
 
 More information is available at:
-http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/\
+http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/\
 server-permissions.html
         """
 

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -60,7 +60,7 @@ Examples:
   $ bin/omero import -- --debug=ERROR foo.tiff
 
 For additional information, see:
-http://www.openmicroscopy.org/site/support/omero5.1/users/cli/import.html
+http://www.openmicroscopy.org/site/support/omero5.2/users/cli/import.html
 Report bugs to <ome-users@lists.openmicroscopy.org.uk>
 """
 TESTHELP = """Run the Importer TestEngine suite (devs-only)"""

--- a/components/tools/OmeroWeb/README.rst
+++ b/components/tools/OmeroWeb/README.rst
@@ -70,5 +70,5 @@ Copyright
 .. _OMERO: http://openmicroscopy.org/
 .. _PIL: http://www.pythonware.com/products/pil/
 .. _Matplotlib: http://matplotlib.org/
-.. _Running and writing tests: http://www.openmicroscopy.org/site/support/omero5.1/developers/testing.html
+.. _Running and writing tests: http://www.openmicroscopy.org/site/support/omero5.2/developers/testing.html
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -143,7 +143,7 @@
 
     <p>
         Full details on various Permissions levels can be found on the 
-        <a href="http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-permissions.html" target="new">
+        <a href="http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/server-permissions.html" target="new">
             OMERO Permissions
         </a>
         page.

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form_owner.html
@@ -132,7 +132,7 @@
 
     <p>
         Full details on various Permissions levels can be found on the 
-        <a href="http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/server-permissions.html" target="new">
+        <a href="http://www.openmicroscopy.org/site/support/omero5.2/sysadmins/server-permissions.html" target="new">
             OMERO Permissions
         </a>
         page.

--- a/components/tools/bump_version.py
+++ b/components/tools/bump_version.py
@@ -23,17 +23,18 @@ def replace_file(input_path, pattern, version):
         infile.close()
 
 docs_pattern = r"(?P<baseurl>site/support/omero)(\d+(.\d+)?)"
+latest_pattern = r"(?P<baseurl>latest/omero)(\d+(.\d+)?)"
 extensions = ('.txt', '.md', '.java', '.ice', '.html', '.xml', '.py', '.rst')
 
 
 def bump_version(version):
     """Replace versions in documentation links"""
 
-    # Replace versions in components pom.xml
     for base, dirs, files in os.walk('.'):
         for file in files:
             if file.endswith(extensions):
                 replace_file(os.path.join(base, file), docs_pattern, version)
+                replace_file(os.path.join(base, file), latest_pattern, version)
 
 
 if __name__ == "__main__":

--- a/docs/overview.html
+++ b/docs/overview.html
@@ -25,12 +25,12 @@ have been added. For an overview or getting started guide, see the links below.<
 </div>
 <h2>Related Documentation</h2>
 <p>
-Further <a href="http://www.openmicroscopy.org/site/support/omero5.1/developers/index.html" target="_top">OMERO developer documentation</a> is available. You may find the following particularly useful:
+Further <a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/index.html" target="_top">OMERO developer documentation</a> is available. You may find the following particularly useful:
 <ul>
-  <li><a href="https://www.openmicroscopy.org/site/support/omero5.1/developers/GettingStarted/AdvancedClientDevelopment.html" target="_top">Developing OMERO clients</a></li>
-  <li><a href="https://www.openmicroscopy.org/site/support/omero5.1/developers/Server.html" target="_top">OMERO server overview</a></li>
-  <li><a href="https://www.openmicroscopy.org/site/support/omero5.1/developers/index.html#using-the-omero-api" target="_top">Using the OMERO API</a></li>
-  <li><a href="https://www.openmicroscopy.org/site/support/omero5.1/developers/Model.html" target="_top">OME-Remote Objects</a></li>
+  <li><a href="https://www.openmicroscopy.org/site/support/omero5.2/developers/GettingStarted/AdvancedClientDevelopment.html" target="_top">Developing OMERO clients</a></li>
+  <li><a href="https://www.openmicroscopy.org/site/support/omero5.2/developers/Server.html" target="_top">OMERO server overview</a></li>
+  <li><a href="https://www.openmicroscopy.org/site/support/omero5.2/developers/index.html#using-the-omero-api" target="_top">Using the OMERO API</a></li>
+  <li><a href="https://www.openmicroscopy.org/site/support/omero5.2/developers/Model.html" target="_top">OME-Remote Objects</a></li>
 </ul>
 
 There is also documentation on the <a href="https://www.openmicroscopy.org/site/support/ome-model/" target="_top">OME Data Model</a>.

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -73,7 +73,7 @@
            default if you are seeing "Protocol family unavailable"
            errors. To do that, use bin/omero config set Ice.IPv6 0
 
-           See https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/troubleshooting.html#server-fails-to-start
+           See https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/troubleshooting.html#server-fails-to-start
            for more information.
         -->
         <property name="Ice.IPv6" value="0"/>

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,3 +1,3 @@
 These examples are intended to complement the documentation available at
-http://www.openmicroscopy.org/site/support/omero5.1/developers/GettingStarted/AdvancedClientDevelopment.html.
+http://www.openmicroscopy.org/site/support/omero5.2/developers/GettingStarted/AdvancedClientDevelopment.html.
 Please refer there for further information.

--- a/examples/ScriptingService/Edit_Descriptions.py
+++ b/examples/ScriptingService/Edit_Descriptions.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         'Edit_Descriptions.py',
         ("Edits the descriptions of multiple Images, either specified via"
          " Image IDs or by the Dataset IDs.\nSee"
-         " http://www.openmicroscopy.org/site/support/omero5.1/developers/"
+         " http://www.openmicroscopy.org/site/support/omero5.2/developers/"
          "scripts/user-guide.html for the tutorial that uses this script."),
 
         scripts.String(


### PR DESCRIPTION
This PR updates the documentation and latest redirects references to use 5.2 instead of 5.1. The commits were produced  by running:

```
$ python components/tools/bump_version.py 5.2
```

Note that the latest 5.2 OMERO redirects do not exist yet and the documentation has not been re-promoted. The first release candidate might be a good occasion to have this into place if we want this PR to be properly tested /cc @hflynn @jburel 
