### PR TITLE
Django upgrade follow up

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -741,17 +741,6 @@ if not DEBUG:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
     LOGGING['loggers']['django']['level'] = 'INFO'
     LOGGING['loggers']['']['level'] = 'INFO'
 
-# TEMPLATE_DEBUG: A boolean that turns on/off template debug mode. If this is
-# True, the fancy error page will display a detailed report for any
-# TemplateSyntaxError. This report contains
-# the relevant snippet of the template, with the appropriate line highlighted.
-# Note that Django only displays fancy error pages if DEBUG is True,
-# alternatively error is handled by:
-#    handler404 = "omeroweb.feedback.views.handler404"
-#    handler500 = "omeroweb.feedback.views.handler500"
-TEMPLATE_DEBUG = DEBUG  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
-
-
 def report_settings(module):
     from django.views.debug import cleanse_setting
     custom_settings_mappings = getattr(module, 'CUSTOM_SETTINGS_MAPPINGS', {})
@@ -857,6 +846,44 @@ STATIC_ROOT = os.path.join(os.path.dirname(__file__),
 # from CUSTOM_SETTINGS_MAPPINGS
 # STATICFILES_DIRS += (("webapp/custom_static", path/to/statics),)  # noqa
 
+# TEMPLATES: A list containing the settings for all template engines
+# to be used with Django. Each item of the list is a dictionary containing
+# the options for an individual engine.
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': TEMPLATE_DIRS,
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': DEBUG,
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'omeroweb.custom_context_processor.url_suffix',
+            ],
+        },
+    },
+]
+
+# Django 1.6 only
+# TEMPLATE_DEBUG: A boolean that turns on/off template debug mode. If this is
+# True, the fancy error page will display a detailed report for any
+# TemplateSyntaxError. This report contains
+# the relevant snippet of the template, with the appropriate line highlighted.
+# Note that Django only displays fancy error pages if DEBUG is True,
+# alternatively error is handled by:
+#    handler404 = "omeroweb.feedback.views.handler404"
+#    handler500 = "omeroweb.feedback.views.handler500"
+TEMPLATE_DEBUG = DEBUG  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
+
+# Django 1.6 only
 # TEMPLATE_CONTEXT_PROCESSORS: A tuple of callables that are used to populate
 # the context in RequestContext. These callables take a request object as
 # their argument and return a dictionary of items to be merged into the

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -741,6 +741,7 @@ if not DEBUG:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
     LOGGING['loggers']['django']['level'] = 'INFO'
     LOGGING['loggers']['']['level'] = 'INFO'
 
+
 def report_settings(module):
     from django.views.debug import cleanse_setting
     custom_settings_mappings = getattr(module, 'CUSTOM_SETTINGS_MAPPINGS', {})
@@ -852,10 +853,10 @@ STATIC_ROOT = os.path.join(os.path.dirname(__file__),
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': TEMPLATE_DIRS,
+        'DIRS': TEMPLATE_DIRS,  # noqa
         'APP_DIRS': True,
         'OPTIONS': {
-            'debug': DEBUG,
+            'debug': DEBUG,  # noqa
             'context_processors': [
                 # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                 # list if you haven't customized them:

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -897,16 +897,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "omeroweb.custom_context_processor.url_suffix"
 )
 
-# TEMPLATE_LOADERS: A tuple of template loader classes, specified as strings.
-# Each Loader class knows how to import templates from a particular source.
-# Optionally, a tuple can be used instead of a string. The first item in the
-# tuple should be the Loader's module, subsequent items are passed to the
-# Loader during initialization.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
 # INSTALLED_APPS: A tuple of strings designating all applications that are
 # enabled in this Django installation. Each string should be a full Python
 # path to a Python package that contains a Django application, as created by

--- a/components/tools/OmeroWeb/omeroweb/webadmin/custom_forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/custom_forms.py
@@ -186,12 +186,13 @@ class GroupModelMultipleChoiceField(GroupModelChoiceField):
                             ' of the available choices.'),
     }
 
-    def __init__(self, queryset, cache_choices=False, required=True,
+    def __init__(self, queryset, required=True,
                  widget=SelectMultiple, label=None, initial=None,
                  help_text=None, *args, **kwargs):
         super(GroupModelMultipleChoiceField, self).__init__(
-            queryset, None, cache_choices, required, widget, label, initial,
-            help_text, *args, **kwargs)
+            queryset=queryset, empty_label=None, required=required,
+            widget=widget, label=label, initial=initial,
+            help_text=help_text, *args, **kwargs)
 
     def to_python(self, value):
         if self.required and not value:
@@ -368,12 +369,13 @@ class ExperimenterModelMultipleChoiceField(ExperimenterModelChoiceField):
                             ' of the available choices.'),
     }
 
-    def __init__(self, queryset, cache_choices=False, required=True,
+    def __init__(self, queryset, required=True,
                  widget=SelectMultiple, label=None, initial=None,
                  help_text=None, *args, **kwargs):
         super(ExperimenterModelMultipleChoiceField, self).__init__(
-            queryset, None, cache_choices, required, widget, label, initial,
-            help_text, *args, **kwargs)
+            queryset=queryset, empty_label=None, required=required,
+            widget=widget, label=label, initial=initial,
+            help_text=help_text, *args, **kwargs)
 
     def to_python(self, value):
         if self.required and not value:

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -23,6 +23,11 @@
 
 import logging
 
+try:
+    from collections import OrderedDict  # Python 2.7+ only
+except:
+    pass
+
 from django.conf import settings
 from django import forms
 from django.forms.widgets import Textarea
@@ -123,15 +128,25 @@ class ExperimenterForm(NonASCIIForm):
                 widget=forms.PasswordInput(attrs={'size': 30,
                                                   'autocomplete': 'off'}))
 
-            self.fields.keyOrder = [
+            fields_key_order = [
                 'omename', 'password', 'confirmation', 'first_name',
                 'middle_name', 'last_name', 'email', 'institution',
                 'administrator', 'active', 'default_group', 'other_groups']
         else:
-            self.fields.keyOrder = [
-                'omename', 'first_name', 'middle_name', 'last_name', 'email',
-                'institution', 'administrator', 'active', 'default_group',
-                'other_groups']
+            fields_key_order = [
+                'omename', 'first_name', 'middle_name', 'last_name',
+                'email', 'institution', 'administrator', 'active',
+                'default_group', 'other_groups']
+
+        # Django 1.8: Form.fields uses OrderedDict from the collections module.
+        # Django 1.6: Form.fields uses SortedDict for form.fields.keyOrder.
+        if hasattr(self.fields, 'keyOrder'):
+            self.fields.keyOrder = fields_key_order
+        else:
+            self.fields = OrderedDict(
+                (k, self.fields[k])
+                for k in fields_key_order)
+
         if experimenter_is_me_or_system:
             self.fields['omename'].widget.attrs['readonly'] = True
             self.fields['omename'].widget.attrs['title'] = \

--- a/components/tools/OmeroWeb/omeroweb/webclient/custom_forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/custom_forms.py
@@ -79,19 +79,15 @@ class UrlField(forms.Field):
 
 
 class MetadataQuerySetIterator(object):
-    def __init__(self, queryset, empty_label, cache_choices):
+    def __init__(self, queryset, empty_label):
         self.queryset = queryset
         self.empty_label = empty_label
-        self.cache_choices = cache_choices
 
     def __iter__(self):
         if self.empty_label is not None:
             yield (u"", self.empty_label)
         for obj in self.queryset:
             yield (obj.value, smart_unicode(obj.value))
-        # Clear the QuerySet cache if required.
-        # if not self.cache_choices:
-        #     self.queryset._result_cache = None
 
 
 class MetadataModelChoiceField(ModelChoiceField):
@@ -107,8 +103,7 @@ class MetadataModelChoiceField(ModelChoiceField):
         # *each* time _get_choices() is called (and, thus, each time
         # self.choices is accessed) so that we can ensure the QuerySet has not
         # been consumed.
-        return MetadataQuerySetIterator(self.queryset, self.empty_label,
-                                        self.cache_choices)
+        return MetadataQuerySetIterator(self.queryset, self.empty_label)
 
     def _set_choices(self, value):
         # This method is copied from ChoiceField._set_choices(). It's necessary
@@ -133,10 +128,9 @@ class MetadataModelChoiceField(ModelChoiceField):
 
 class AnnotationQuerySetIterator(object):
 
-    def __init__(self, queryset, empty_label, cache_choices):
+    def __init__(self, queryset, empty_label):
         self.queryset = queryset
         self.empty_label = empty_label
-        self.cache_choices = cache_choices
 
     def __iter__(self):
         if self.empty_label is not None:
@@ -169,9 +163,6 @@ class AnnotationQuerySetIterator(object):
                     textValue = "%s..." % textValue[:55]
             oid = obj.id
             yield (oid, smart_unicode(textValue))
-        # Clear the QuerySet cache if required.
-        # if not self.cache_choices:
-        #       self.queryset._result_cache = None
 
 
 class AnnotationModelChoiceField(ModelChoiceField):
@@ -187,8 +178,7 @@ class AnnotationModelChoiceField(ModelChoiceField):
         # *each* time _get_choices() is called (and, thus, each time
         # self.choices is accessed) so that we can ensure the QuerySet has not
         # been consumed.
-        return AnnotationQuerySetIterator(self.queryset, self.empty_label,
-                                          self.cache_choices)
+        return AnnotationQuerySetIterator(self.queryset, self.empty_label)
 
     def _set_choices(self, value):
         # This method is copied from ChoiceField._set_choices(). It's
@@ -219,12 +209,13 @@ class AnnotationModelMultipleChoiceField(AnnotationModelChoiceField):
         'invalid_choice': _(u'Select a valid choice. That choice is not one'
                             u' of the available choices.')}
 
-    def __init__(self, queryset, cache_choices=False, required=True,
+    def __init__(self, queryset, required=True,
                  widget=SelectMultiple, label=None, initial=None,
                  help_text=None, *args, **kwargs):
         super(AnnotationModelMultipleChoiceField, self).__init__(
-            queryset,  None, cache_choices, required, widget, label, initial,
-            help_text, *args, **kwargs)
+            queryset=queryset, empty_label=None, required=required,
+            widget=widget, label=label, initial=initial,
+            help_text=help_text, *args, **kwargs)
 
     def clean(self, value):
         if self.required and not value:
@@ -254,10 +245,9 @@ class AnnotationModelMultipleChoiceField(AnnotationModelChoiceField):
 
 # Object queryset iterator for group form
 class ObjectQuerySetIterator(object):
-    def __init__(self, queryset, empty_label, cache_choices):
+    def __init__(self, queryset, empty_label):
         self.queryset = queryset
         self.empty_label = empty_label
-        self.cache_choices = cache_choices
 
     def __iter__(self):
         if self.empty_label is not None:
@@ -267,9 +257,6 @@ class ObjectQuerySetIterator(object):
                 yield (obj.id.val, smart_unicode(obj.id.val))
             else:
                 yield (obj.id, smart_unicode(obj.id))
-        # Clear the QuerySet cache if required.
-        # if not self.cache_choices:
-        #     self.queryset._result_cache = None
 
 
 class ObjectModelChoiceField(ModelChoiceField):
@@ -285,8 +272,7 @@ class ObjectModelChoiceField(ModelChoiceField):
         # *each* time _get_choices() is called (and, thus, each time
         # self.choices is accessed) so that we can ensure the QuerySet has not
         # been consumed.
-        return ObjectQuerySetIterator(self.queryset, self.empty_label,
-                                      self.cache_choices)
+        return ObjectQuerySetIterator(self.queryset, self.empty_label)
 
     def _set_choices(self, value):
         # This method is copied from ChoiceField._set_choices(). It's
@@ -322,12 +308,13 @@ class ObjectModelMultipleChoiceField(ObjectModelChoiceField):
                             u' of the available choices.'),
     }
 
-    def __init__(self, queryset, cache_choices=False, required=True,
+    def __init__(self, queryset, required=True,
                  widget=SelectMultiple, label=None, initial=None,
                  help_text=None, *args, **kwargs):
         super(ObjectModelMultipleChoiceField, self).__init__(
-            queryset, None, cache_choices, required, widget, label, initial,
-            help_text, *args, **kwargs)
+            queryset=queryset, empty_label=None, required=required,
+            widget=widget, label=label, initial=initial,
+            help_text=help_text, *args, **kwargs)
 
     def clean(self, value):
         if self.required and not value:


### PR DESCRIPTION
This is #4236 follow up PR. It fixes:
 - adds TEMPLATES settings introduced in 1.8, see https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/
 - removes deprecated cache_choice (never used), see https://docs.djangoproject.com/en/1.8/releases/1.8/#cache-choices-option-of-modelchoicefield-and-modelmultiplechoicefield
 - resolve experimenter form password order issue reported in https://trac.openmicroscopy.org/ome/ticket/13063 //cc: @pwalczysko 

Testing servers: cowfish/integration and eel/merge

To test:
 - check on both servers if experimenter form fields are in the right order, see https://github.com/openmicroscopy/openmicroscopy/pull/4236#issuecomment-147668137
 - test annotation forms (comment, tag, etc.)
