### PR TITLE
Rename agent of SessionsBean.createSessionWithTimeouts()

### DIFF
--- a/components/server/src/ome/services/sessions/SessionBean.java
+++ b/components/server/src/ome/services/sessions/SessionBean.java
@@ -109,7 +109,7 @@ public class SessionBean implements ISession {
                 public Session call() throws Exception {
                     SessionManager.CreationRequest req = new SessionManager.CreationRequest();
                     req.principal = principal;
-                    req.agent = "createSession";
+                    req.agent = "OMERO.sudo";
                     req.groupsLed = groupsLed;
                     req.timeToIdle = timeToIdleMilliseconds;
                     req.timeToLive = timeToLiveMilliseconds;


### PR DESCRIPTION
See https://trello.com/c/azP0udku/37-rename-createsession-agent

Since this method uses a Principal object and is principally consumed as a way to sudo, the agent is renamed as OMERO.sudo.

To test this PR:
- create a connection from the CLI using `bin/omero login --sudo sudoer user@hostname:port`
- import an image for another user in Insight

In both cases, list the server-side sessions using `bin/omero sessions who` and check both sessions listed above are created with the `OMERO.sudo` agent.