### PR TITLE
Migrate checkwindows() call post configuration template writing

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -713,8 +713,6 @@ present, the user will enter a console""")
         self.check_access(config=config)
         self.checkice()
         self.check_node(args)
-        if self._isWindows():
-            self.checkwindows(args)
 
         if args.force_rewrite:
             self.rewrite(args, config, force=True)
@@ -725,6 +723,8 @@ present, the user will enter a console""")
         if not args.force_rewrite:
             self.rewrite(args, config)
 
+        if self._isWindows():
+            self.checkwindows(args)
         self.check_lock(config)
 
         self._initDir()


### PR DESCRIPTION
With the configuration template changes, deployment on Windows from a fresh server was not possible since the configuration files were not present initially. This commit migrates the Windows check function post configuration rewriting.

This PR fixes a Windows-specific bug introduced in https://github.com/openmicroscopy/openmicroscopy/pull/4093 (see https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-deploy-win2012/4/console) and should be tested via the Windows deployment in this CI job.