### PR TITLE
t index formatting

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_acquisition.html
@@ -337,13 +337,13 @@
                 <div class="plane_info">
                 <table class="exposureTimeData"><tr>
                     <td>
-                        <div>t index </div>
+                        <div>t</div>
                         <div>Delta T</div>
                         <div style="white-space:nowrap;">Exposure</div>
                     </td>
                     {% for pi in ch.plane_info %}
                         <td>
-                            <div>t={{ pi.theT }} </div>
+                            <div>t={{ pi.theT|add:"1" }} </div>
                             <div>{{ pi.deltaT|timeformat }} </div>
                             <div>{{ pi.exposureTime|timeformat }}</div>
                         </td>


### PR DESCRIPTION
This is the equivalent on #4231 for Insight.
Removes the label "t index" to "t" and uses 1-based time indices.

To test, check that time stamps look same in web and Insight.

![screen shot 2015-10-19 at 12 40 26](https://cloud.githubusercontent.com/assets/900055/10576904/e36debb6-765e-11e5-9593-d236368961df.png)
