### PR TITLE
Rnd copy/paste

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -335,9 +335,10 @@ public class ImViewerAgent
             if (view != null ) {
                 if (view.getPixelsID() != id) {
                     view.pasteRenderingSettings();
+                    view.saveRndSettings(true);
                 }
                 view.reloadRenderingThumbs();
-            }     
+            }
         }
     }
     /**


### PR DESCRIPTION
Fix another out of synch issue
to test: 
Select image in centre pane.
Copy settings.
Open another image in full viewer.
Go back to main window - leaving Full Viewer open.
Select open image and click on Preview tab.
Paste settings and save using Preview pane buttons.
Preview pane updates as expected, Full Viewer updates as expected and Save button on both Preview and Full Viewer are disabled as expected.
Repeat but paste settings using right-click Paste and Save in centre pane or data tree.
Preview pane updates as expected and Save button in Preview is disabled as expected.
In Full Viewer image updates as expected, The  Save button should now become disabled (was enabled w/o this PR).

cc @dominikl  @gusferguson 