### PR TITLE
OMERO.matlab: always cast the group to a java.lang.String

### DIFF
--- a/components/tools/OmeroM/src/annotations/updateOriginalFile.m
+++ b/components/tools/OmeroM/src/annotations/updateOriginalFile.m
@@ -58,7 +58,7 @@ context = java.util.HashMap;
 % Check if the Annotation exists on the server
 try
     group = fileAnnotation.getDetails().getGroup().getId().getValue();
-    context.put('omero.group', num2str(group));
+    context.put('omero.group', java.lang.String(num2str(group)));
 catch
 end
 % If exists only client side accept omero.group parameter

--- a/components/tools/OmeroM/src/image/getRawPixelsStore.m
+++ b/components/tools/OmeroM/src/image/getRawPixelsStore.m
@@ -49,6 +49,6 @@ pixels = image.getPrimaryPixels();
 % Create container service to load raw pixels
 context = java.util.HashMap;
 group = image.getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 store = session.createRawPixelsStore();
 store.setPixelsId(pixels.getId().getValue(), false, context);

--- a/components/tools/OmeroM/src/image/getThumbnail.m
+++ b/components/tools/OmeroM/src/image/getThumbnail.m
@@ -65,7 +65,7 @@ end
 % Create store to retrieve thumbnails and set pixels Id
 context = java.util.HashMap;
 group = image.getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 store = session.createThumbnailStore();
 store.setPixelsId(image.getPrimaryPixels().getId().getValue(), context);
 

--- a/components/tools/OmeroM/src/image/getThumbnailByLongestSide.m
+++ b/components/tools/OmeroM/src/image/getThumbnailByLongestSide.m
@@ -63,7 +63,7 @@ end
 % Create store to retrieve thumbnails and set pixels Id
 context = java.util.HashMap;
 group = image.getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 store = session.createThumbnailStore();
 store.setPixelsId(image.getPrimaryPixels().getId().getValue(), context);
 

--- a/components/tools/OmeroM/src/image/getThumbnailByLongestSideSet.m
+++ b/components/tools/OmeroM/src/image/getThumbnailByLongestSideSet.m
@@ -71,7 +71,7 @@ nPixels = numel(pixelsIds);
 % Create container service to load the thumbnails
 context = java.util.HashMap;
 group = images(1).getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 store = session.createThumbnailStore();
 pixelsRange = 1 : min(nPixels, MAX_RETRIEVAL);
 thumbnailMap = store.getThumbnailByLongestSideSet(size,...

--- a/components/tools/OmeroM/src/image/getThumbnailSet.m
+++ b/components/tools/OmeroM/src/image/getThumbnailSet.m
@@ -73,7 +73,7 @@ nPixels = numel(pixelsIds);
 % Create container service to load the thumbnails
 context = java.util.HashMap;
 group = images(1).getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 store = session.createThumbnailStore();
 pixelsRange = 1 : min(nPixels, MAX_RETRIEVAL);
 thumbnailMap = store.getThumbnailSet(width, height,...

--- a/components/tools/OmeroM/src/image/loadChannels.m
+++ b/components/tools/OmeroM/src/image/loadChannels.m
@@ -48,7 +48,7 @@ pixels = image.getPrimaryPixels();
 % Retrieve channels
 context = java.util.HashMap;
 group = image.getDetails().getGroup().getId().getValue();
-context.put('omero.group', num2str(group));
+context.put('omero.group', java.lang.String(num2str(group)));
 pixelsService = session.getPixelsService();
 pixels = pixelsService.retrievePixDescription(...
     pixels.getId.getValue, context);

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -109,7 +109,7 @@ ids = toJavaList(ids, 'java.lang.Long');
 proxy = session.getContainerService();
 context = ip.Results.context;
 if ~isempty(ip.Results.group)
-    context.put('omero.group', num2str(ip.Results.group));
+    context.put('omero.group', java.lang.String(num2str(ip.Results.group)));
 end
 objectList = proxy.loadContainerHierarchy(objectType.class, ids, parameters, context);
 

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -31,7 +31,7 @@ try
     datasetId = p.datasetid;
     imageId = p.imageid;
     plateId = p.plateid;
-    group2 = p.group2
+    groupId = eventContext.groupId;
 
     print_object = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
         char(x.getName().getValue()), x.getId().getValue(),...
@@ -83,8 +83,8 @@ try
 
     % Retrieve all the unloaded projects owned by the session user in the
     % context of the specified group
-    disp('Retrieving projects owned by the session user in a different group')
-    projects = getProjects(session, 'group', group2);
+    disp('Retrieving projects owned by the session user in a specified group')
+    projects = getProjects(session, 'group', groupId);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
         print_object(projects(i));
@@ -140,8 +140,8 @@ try
 
     % Retrieve all the unloaded datasets owned by the session user in the
     % context of the specified group
-    disp('Retrieving datasets owned by the session user in a different group')
-    datasets = getDatasets(session, 'group', group2);
+    disp('Retrieving datasets owned by the session user in a specified group')
+    datasets = getDatasets(session, 'group', groupId);
     fprintf(1, '  Found %g datasets\n', numel(datasets));
     for i = 1 : numel(datasets),
         print_object(datasets(i));
@@ -181,8 +181,8 @@ try
 
     % Retrieve all the images owned by the session user in the
     % context of the specified group
-    disp('Retrieving images owned by the session user in a different group')
-    images = getImages(session, 'group', group2);
+    disp('Retrieving images owned by the session user in a specified group')
+    images = getImages(session, 'group', groupId);
     fprintf(1, '  Found %g images\n', numel(images));
     for i = 1 : numel(images),
         print_object(images(i));
@@ -278,18 +278,8 @@ try
 
     % Retrieve all the screens owned by the session user in the
     % context of the specified group
-    disp('Retrieving screens owned by the session user in a different group')
-    screens = getScreens(session, 'group', group2);
-    fprintf(1, '  Found %g screens\n', numel(screens));
-    for i = 1 : numel(screens),
-        print_object(screens(i));
-    end
-    fprintf(1, '\n');
-
-    % Retrieve all the screens owned by the session user in the
-    % context of the specified group
-    disp('Retrieving screens owned by the session user in a different group')
-    screens = getScreens(session, 'group', group2);
+    disp('Retrieving screens owned by the session user in a specified group')
+    screens = getScreens(session, 'group', groupId);
     fprintf(1, '  Found %g screens\n', numel(screens));
     for i = 1 : numel(screens),
         print_object(screens(i));
@@ -308,8 +298,8 @@ try
 
     % Retrieve all the plates owned by the session user in the
     % context of the specified group
-    disp('Retrieving plates owned by the session user in a different group')
-    plates = getPlates(session, 'group', group2);
+    disp('Retrieving plates owned by the session user in a specified group')
+    plates = getPlates(session, 'group', groupId);
     fprintf(1, '  Found %g plates\n', numel(plates));
     for i = 1 : numel(plates),
         print_object(plates(i));

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -290,7 +290,7 @@ try
     % context of the specified group
     disp('Retrieving screens owned by the session user in a different group')
     screens = getScreens(session, 'group', group2);
-    fprintf(1, '  Found %g plates\n', numel(screens));
+    fprintf(1, '  Found %g screens\n', numel(screens));
     for i = 1 : numel(screens),
         print_object(screens(i));
     end

--- a/examples/Training/matlab/ReadData.m
+++ b/examples/Training/matlab/ReadData.m
@@ -31,6 +31,7 @@ try
     datasetId = p.datasetid;
     imageId = p.imageid;
     plateId = p.plateid;
+    group2 = p.group2
 
     print_object = @(x) fprintf(1, '  %s (id: %d, owner: %d, group: %d)\n',...
         char(x.getName().getValue()), x.getId().getValue(),...
@@ -74,6 +75,16 @@ try
     % context of the current session group
     disp('Retrieving projects owned by any user in the current group')
     projects = getProjects(session, 'owner', -1);
+    fprintf(1, '  Found %g projects\n', numel(projects));
+    for i = 1 : numel(projects),
+        print_object(projects(i));
+    end
+    fprintf(1, '\n');
+
+    % Retrieve all the unloaded projects owned by the session user in the
+    % context of the specified group
+    disp('Retrieving projects owned by the session user in a different group')
+    projects = getProjects(session, 'group', group2);
     fprintf(1, '  Found %g projects\n', numel(projects));
     for i = 1 : numel(projects),
         print_object(projects(i));
@@ -127,6 +138,16 @@ try
     end
     fprintf(1, '\n');
 
+    % Retrieve all the unloaded datasets owned by the session user in the
+    % context of the specified group
+    disp('Retrieving datasets owned by the session user in a different group')
+    datasets = getDatasets(session, 'group', group2);
+    fprintf(1, '  Found %g datasets\n', numel(datasets));
+    for i = 1 : numel(datasets),
+        print_object(datasets(i));
+    end
+    fprintf(1, '\n');
+
     % Retrieve a loaded dataset specified by an input identifier
     % If the dataset contains images, the images will be loaded
     fprintf(1, 'Retrieving dataset %g with loaded images\n', datasetId);
@@ -155,6 +176,16 @@ try
     fprintf(1, '  Found %g images\n', numel(allImagesAllGroups));
     for i = 1 : numel(allImagesAllGroups),
         print_object(allImagesAllGroups(i));
+    end
+    fprintf(1, '\n');
+
+    % Retrieve all the images owned by the session user in the
+    % context of the specified group
+    disp('Retrieving images owned by the session user in a different group')
+    images = getImages(session, 'group', group2);
+    fprintf(1, '  Found %g images\n', numel(images));
+    for i = 1 : numel(images),
+        print_object(images(i));
     end
     fprintf(1, '\n');
 
@@ -236,12 +267,32 @@ try
     end
     fprintf(1, '\n');
 
-    % Retrieve all the images owned by the session user across all groups
+    % Retrieve all the screens owned by the session user across all groups
     disp('Retrieving all screens owned by the session user across all groups')
     allScreensAllGroups = getScreens(session, 'group', -1);
     fprintf(1, '  Found %g screens\n', numel(allScreensAllGroups));
     for i = 1 : numel(allScreensAllGroups),
         print_object(allScreensAllGroups(i));
+    end
+    fprintf(1, '\n');
+
+    % Retrieve all the screens owned by the session user in the
+    % context of the specified group
+    disp('Retrieving screens owned by the session user in a different group')
+    screens = getScreens(session, 'group', group2);
+    fprintf(1, '  Found %g screens\n', numel(screens));
+    for i = 1 : numel(screens),
+        print_object(screens(i));
+    end
+    fprintf(1, '\n');
+
+    % Retrieve all the screens owned by the session user in the
+    % context of the specified group
+    disp('Retrieving screens owned by the session user in a different group')
+    screens = getScreens(session, 'group', group2);
+    fprintf(1, '  Found %g plates\n', numel(screens));
+    for i = 1 : numel(screens),
+        print_object(screens(i));
     end
     fprintf(1, '\n');
 
@@ -252,6 +303,16 @@ try
     fprintf(1, '  Found %g plates\n', numel(allPlates));
     for i = 1 : numel(allPlates),
         print_object(allPlates(i));
+    end
+    fprintf(1, '\n');
+
+    % Retrieve all the plates owned by the session user in the
+    % context of the specified group
+    disp('Retrieving plates owned by the session user in a different group')
+    plates = getPlates(session, 'group', group2);
+    fprintf(1, '  Found %g plates\n', numel(plates));
+    for i = 1 : numel(plates),
+        print_object(plates(i));
     end
     fprintf(1, '\n');
 


### PR DESCRIPTION
This PR fixes a bug encountered while working on MultiMOT with the new multi-group functionality included in OMERO.matlab 5.1.4.

When retrieving objects in a different group than the session group, the method call resulted in exceptions of type `java.lang.Character cannot be cast to java.lang.String`. This exception was not thrown when passing `-1` as the group.
This PR reviews all usages of the group context in OMERO.matlab and unconditionally casts the `groupId` as a `java.lang.String`. The training examples are updated to also read object in a specified group. /cc @emilroz 