### PR TITLE
Fix jsTree truncation

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/jquery.jstree.truncatetext_plugin.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/jquery.jstree.truncatetext_plugin.js
@@ -21,19 +21,14 @@
                     var left = offset ? offset.left : 36;
 
                     // Truncate where necessary
-                    var lp_width = $("#left_panel").width() - left - 75;  // margins
+                    var lp_width = $("#left_panel").width() - left - 65;  // margins
+                    var fullWidth = anchor.width(); // we start with full text from redraw_node() above
 
-                    if (anchor.textWidth(node.text) > lp_width) {
-                        // Optimize by calculating the estimated reduction required
-                        var letterWidth = anchor.textWidth('a');
-                        // +3 for the '...'
-                        var truncated = node.text.slice(3 + Math.floor((anchor.textWidth(node.text) - lp_width) / letterWidth));
-
-                        // If it's still too long, iterate until it isn't
-                        while (anchor.textWidth(truncated) > lp_width) {
-                            truncated = truncated.slice(1);
-                        }
-
+                    if (fullWidth > lp_width) {
+                        // Calculate the reduction required, +3 for the '...'
+                        var letterWidth = fullWidth / node.text.length;
+                        var truncated = node.text.slice(3 + Math.floor((fullWidth - lp_width) / letterWidth));
+                        // update the text
                         anchor.contents().filter(function(){
                             return this.nodeType == 3;
                         }).replaceWith(document.createTextNode('...' + truncated));

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -69,16 +69,6 @@ jQuery.fn.hide_if_empty = function() {
   return this;
 };
 
-// Function to enable measuring of a specific text element in jquery
-$.fn.textWidth = function(text, font) {
-    if (!$.fn.textWidth.fakeEl) $.fn.textWidth.fakeEl = $('<span>').appendTo(document.body);
-    var htmlText = text || this.val() || this.text();
-    htmlText = $.fn.textWidth.fakeEl.text(htmlText).html(); //encode to Html
-    htmlText = htmlText.replace(/\s/g, "&nbsp;"); //replace trailing and leading spaces
-    $.fn.textWidth.fakeEl.html(htmlText).css('font', font || this.css('font'));
-    return $.fn.textWidth.fakeEl.width();
-};
-
 // called from OME.tree_selection_changed() below
 OME.handle_tree_selection = function(data, event) {
 


### PR DESCRIPTION
Fixes the jsTree truncation issue in Firefox reported at https://github.com/openmicroscopy/openmicroscopy/pull/4242#issuecomment-150160802

To test, try the truncation of long image names (and P/D names) in Firefox, Chrome, Safari and IE (not tried IE yet).