### PR TITLE
Fix broken link to the SpringFramework API in the Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -655,7 +655,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                         packages="ome.dynamic*:ome.rules*"/>
 
                 <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-                <link href="http://docs.spring.io/spring/docs/3.0.1.RELEASE/api/"/>
+                <link href="http://docs.spring.io/spring/docs/${versions.spring}/api/"/>
                 <link href="http://aopalliance.sourceforge.net/doc/"/>
 
             </javadoc>

--- a/build.xml
+++ b/build.xml
@@ -654,7 +654,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 <group title="I. Deprecated"
                         packages="ome.dynamic*:ome.rules*"/>
 
-                <link href="http://docs.oracle.com/javase/7/docs/api/"/>
+                <link href="http://docs.oracle.com/javase/8/docs/api/"/>
                 <link href="http://docs.spring.io/spring/docs/${versions.spring}/api/"/>
                 <link href="http://aopalliance.sourceforge.net/doc/"/>
 

--- a/build.xml
+++ b/build.xml
@@ -655,7 +655,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                         packages="ome.dynamic*:ome.rules*"/>
 
                 <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-                <link href="http://www.springframework.org/docs/api/"/>
+                <link href="http://docs.spring.io/spring/docs/3.0.1.RELEASE/api/"/>
                 <link href="http://aopalliance.sourceforge.net/doc/"/>
 
             </javadoc>

--- a/components/common/src/ome/system/UpgradeCheck.java
+++ b/components/common/src/ome/system/UpgradeCheck.java
@@ -77,7 +77,7 @@ public class UpgradeCheck implements Runnable {
         try {
             trustingContext = SSLContext.getInstance("SSL");
         } catch (NoSuchAlgorithmException e) {
-            // http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html#SSLContext
+            // http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext
         }
 
         try {


### PR DESCRIPTION
This should fix the remaining warning of https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-build/