### PR TITLE
Bugfix: Remove SPW attachments

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -2801,6 +2801,14 @@ class OMEROGateway
 					userID));
 			results.addAll(loadLinks(ctx, "ImageAnnotationLink", childID,
 					userID));
+			results.addAll(loadLinks(ctx, "ScreenAnnotationLink", childID,
+                    userID));
+			results.addAll(loadLinks(ctx, "PlateAnnotationLink", childID,
+                    userID));
+			results.addAll(loadLinks(ctx, "WellAnnotationLink", childID,
+                    userID));
+			results.addAll(loadLinks(ctx, "PlateAcquisitionAnnotationLink", childID,
+                    userID));
 			return results;
 		}
 		return loadLinks(ctx, getTableForLink(parentClass), childID, userID);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import ome.formats.model.UnitsFactory;
+import omero.model.PlateAnnotationLink;
 import ome.model.units.BigResult;
 import omero.cmd.OriginalMetadataRequest;
 import omero.cmd.Request;
@@ -61,14 +62,17 @@ import omero.model.ObjectiveSettings;
 import omero.model.ObjectiveSettingsI;
 import omero.model.OriginalFile;
 import omero.model.Pixels;
+import omero.model.PlateAcquisitionAnnotationLink;
 import omero.model.Pressure;
 import omero.model.ProjectAnnotationLink;
+import omero.model.ScreenAnnotationLink;
 import omero.model.StageLabel;
 import omero.model.StageLabelI;
 import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.model.Temperature;
 import omero.model.TermAnnotation;
+import omero.model.WellAnnotationLink;
 import omero.model.XmlAnnotation;
 import omero.sys.Parameters;
 import omero.sys.ParametersI;
@@ -2380,6 +2384,22 @@ class OmeroMetadataServiceImpl
 					nodes.add(PojoMapper.asDataObject(
 							((ImageAnnotationLink) o).getParent()));
 				}
+				else if (o instanceof PlateAnnotationLink) {
+                    nodes.add(PojoMapper.asDataObject(
+                            ((PlateAnnotationLink) o).getParent()));
+                }
+				else if (o instanceof ScreenAnnotationLink) {
+                    nodes.add(PojoMapper.asDataObject(
+                            ((ScreenAnnotationLink) o).getParent()));
+                }
+				else if (o instanceof WellAnnotationLink) {
+                    nodes.add(PojoMapper.asDataObject(
+                            ((WellAnnotationLink) o).getParent()));
+                }
+				else if (o instanceof PlateAcquisitionAnnotationLink) {
+                    nodes.add(PojoMapper.asDataObject(
+                            ((PlateAcquisitionAnnotationLink) o).getParent()));
+                }
 			}
 		}
 		return nodes;


### PR DESCRIPTION
Fix for [Ticket 13067 - BUG: Cannot remove file attachment](https://trac.openmicroscopy.org/ome/ticket/13067)

Nearly missed this ticket, sorry. It's not a regression for 5.2.0, this bug has always been there, but would be nice to still get it into 5.2.0. What do you think, @jburel @sbesson , exclude or not?

**Test**: Add file annotations to a screen, a plate and a plate run. Remove the file annotations again.