### PR TITLE
Web deploy

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -275,6 +275,7 @@ class WebControl(BaseControl):
         d = {
             "ROOT": self.ctx.dir,
             "OMEROWEBROOT": self._get_python_dir() / "omeroweb",
+            "STATIC_ROOT": settings.STATIC_ROOT,
             "STATIC_URL": settings.STATIC_URL.rstrip("/"),
             "NOW": str(datetime.now())}
 

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -136,17 +136,20 @@ class WebControl(BaseControl):
             group.add_argument(
                 "--no-wait", action="store_true",
                 help="Do not wait on expired sessions clean-up")
-            nginx_start_group = x.add_argument_group()
-            nginx_start_group.add_argument(
-                "--workers", type=int, default=5,
-                help="The number of worker processes for handling requests.")
-            nginx_start_group.add_argument(
-                "--worker-connections", type=int, default=1000,
-                help="The maximum number of simultaneous clients.")
-            nginx_start_group.add_argument(
-                "--wsgi-args", type=str, default="",
-                help=("Additional arguments. Check Gunicorn Documentation "
-                      "http://docs.gunicorn.org/en/latest/settings.html"))
+
+        start.add_argument(
+            "--workers", type=int, default=5,
+            help="NGINX only: the number of worker processes for handling "
+                 "requests.")
+        start.add_argument(
+            "--worker-connections", type=int, default=1000,
+            help="NGINX only: the maximum number of simultaneous clients.")
+        start.add_argument(
+            "--wsgi-args", type=str, default="",
+            help=("NGINX only: additional arguments. "
+                  "Check Gunicorn Documentation"
+                  "http://docs.gunicorn.org/en/latest/settings.html"))
+
         #
         # Advanced
         #

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache-withoptions.conf
@@ -62,7 +62,7 @@
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
-  <Directory /home/omero/OMERO.server/lib/python/omeroweb>
+  <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Order allow,deny
     Allow from all
   </Directory>

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache.conf
@@ -62,7 +62,7 @@
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
-  <Directory /home/omero/OMERO.server/lib/python/omeroweb>
+  <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Order allow,deny
     Allow from all
   </Directory>

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -67,6 +67,12 @@ class TestWeb(object):
                                 raising=False)
         return app_server
 
+    def add_static_root(self, static_root, monkeypatch):
+        if static_root:
+            monkeypatch.setattr(settings, 'STATIC_ROOT', static_root,
+                                raising=False)
+        return static_root
+
     def add_upstream_name(self, prefix, monkeypath):
         if prefix:
             name = "omeroweb_%s" % re.sub(r'\W+', '', prefix)
@@ -239,9 +245,13 @@ class TestWeb(object):
         ["nginx", 'wsgi-tcp'],
         ["nginx-development", 'wsgi-tcp'],
         ["apache", 'wsgi']])
-    def testFullTemplateDefaults(self, server_type, capsys, monkeypatch):
+    @pytest.mark.parametrize('static_root', [
+        '/home/omero/OMERO.server/lib/python/omeroweb/static'])
+    def testFullTemplateDefaults(self, server_type, static_root,
+                                 capsys, monkeypatch):
         app_server = server_type[-1]
         del server_type[-1]
+        self.add_static_root(static_root, monkeypatch)
         self.add_application_server(app_server, monkeypatch)
         self.args += ["config"] + server_type
         self.set_templates_dir(monkeypatch)
@@ -261,12 +271,16 @@ class TestWeb(object):
         ['nginx-development', '--http', '1234', '--max-body-size', '2m',
          'wsgi-tcp'],
         ['apache', '--http', '1234', 'wsgi']])
-    def testFullTemplateWithOptions(self, server_type, capsys, monkeypatch):
+    @pytest.mark.parametrize('static_root', [
+        '/home/omero/OMERO.server/lib/python/omeroweb/static'])
+    def testFullTemplateWithOptions(self, server_type, static_root,
+                                    capsys, monkeypatch):
         prefix = '/test'
         cgihost = '0.0.0.0'
         cgiport = '12345'
         app_server = server_type[-1]
         del server_type[-1]
+        self.add_static_root(static_root, monkeypatch)
         self.add_application_server(app_server, monkeypatch)
         self.add_prefix(prefix, monkeypatch)
         self.add_hostport(cgihost, cgiport, monkeypatch)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -816,7 +816,9 @@ except NameError:
                          string.digits,
                          string.punctuation)) for i in range(50)]
             )
-            with open(secret_path, 'w') as secret_file:
+            with os.fdopen(os.open(secret_path,
+                                   os.O_WRONLY | os.O_CREAT,
+                                   0600), 'w') as secret_file:
                 secret_file.write(secret_key)
         except IOError, e:
             raise IOError("Please create a %s file with random characters"

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -277,6 +277,14 @@ INTERNAL_SETTINGS_MAPPING = {
     "omero.web.allowed_hosts":
         ["ALLOWED_HOSTS", '["*"]', json.loads, None],
 
+    # Do not show WARNING (1_8.W001): The standalone TEMPLATE_* settings
+    # were deprecated in Django 1.8 and the TEMPLATES dictionary takes
+    # precedence. You must put the values of the following settings
+    # into your default TEMPLATES dict:
+    # TEMPLATE_DIRS, TEMPLATE_CONTEXT_PROCESSORS.
+    "omero.web.system_checks":
+        ["SILENCED_SYSTEM_CHECKS", '["1_8.W001"]', json.loads, None],
+
     # Internal email notification for omero.web.admins,
     # loaded from config.xml directly
     "omero.mail.from":

--- a/etc/templates/web/apache.conf.template
+++ b/etc/templates/web/apache.conf.template
@@ -62,13 +62,13 @@
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 
-  <Directory %(OMEROWEBROOT)s>
+  <Directory "%(OMEROWEBROOT)s">
     Order allow,deny
     Allow from all
   </Directory>
 
-  Alias %(STATIC_URL)s %(OMEROWEBROOT)s/static
-  <Directory "%(OMEROWEBROOT)s/static">
+  Alias %(STATIC_URL)s %(STATIC_ROOT)s
+  <Directory "%(STATIC_ROOT)s">
       Options -Indexes FollowSymLinks
       Order allow,deny
       Allow from all

--- a/etc/templates/web/nginx-development.conf.template
+++ b/etc/templates/web/nginx-development.conf.template
@@ -42,7 +42,7 @@ http {
 
         # weblitz django apps serve media from here
         location %(STATIC_URL)s {
-            alias %(OMEROWEBROOT)s/static;
+            alias %(STATIC_ROOT)s;
         }
 
         location @proxy_to_app%(PREFIX_NAME)s {

--- a/etc/templates/web/nginx.conf.template
+++ b/etc/templates/web/nginx.conf.template
@@ -17,7 +17,7 @@ server {
 
     # weblitz django apps serve media from here
     location %(STATIC_URL)s {
-        alias %(OMEROWEBROOT)s/static;
+        alias %(STATIC_ROOT)s;
     }
 
     location @proxy_to_app%(PREFIX_NAME)s {


### PR DESCRIPTION
This PR improve web plugin starting and stopping OMERO.web app

To test:
- start web twice, you should get error message saying already started.
- check if ``WARNINGS: ?: (1_8.W001) The standalone TEMPLATE_* settings...`` disappeared. When deploying with development server you will see ``System check identified no issues (1 silenced).``
- check if ``dist/var/django_secret_key`` file has correct permission (CHECK WINDOWS!):

    ```
-rw-------   1 omero  staff   50 24 Oct 14:58 django_secret_key
```
- run ``bin\omero web iis -h`` and check if you see only:

 ```
 usage: dist/bin/omero web iis [-h] [--remove] [--keep-sessions | --no-wait]
 ...
 ```
- run ``bin\omero web start|restart -h`` and check if you get 

 ```
 usage: dist/bin/omero web start [-h] [--keep-sessions | --no-wait]
                                [--workers WORKERS]
                                [--worker-connections WORKER_CONNECTIONS]
                                [--wsgi-args WSGI_ARGS]
 ...
  --workers WORKERS                     NGINX only: the number of worker processes for handling requests.
   --worker-connections WORKER_CONNECTIONS
                                        NGINX only: the maximum number of simultaneous clients.
   --wsgi-args WSGI_ARGS                 NGINX only: additional arguments. Check Gunicorn Documentationhttp://docs.gunicorn.org/en/latest/settings.html
 ```