### PR TITLE
Thumbnail scrolling & selection

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -386,11 +386,11 @@ $(function() {
 
             // Update the central panel in case chgrp removes an icon
             $.each(removalClosure, function(index, node) {
+                inst.delete_node(node);
                 var e = {'type': 'delete_node'};
                 var data = {'node': node,
                             'old_parent': inst.get_parent(node)};
                 update_thumbnails_panel(e, data);
-                inst.delete_node(node);
             });
 
             function markChildless(ids, dtype) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -549,13 +549,6 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
                 dataType: "json",
                 type: "POST",
                 success: function(r){
-                    // Update the central panel in case delete removes an icon
-                    $.each(selected, function(index, node) {
-                        var e = {'type': 'delete_node'};
-                        var data = {'node': node,
-                                    'old_parent': firstParent};
-                        update_thumbnails_panel(e, data);
-                    });
 
                     datatree.delete_node(selected);
 
@@ -569,6 +562,14 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
                         //TODO Make use of server calculated update like chgrp?
                         updateParentRemoveNode(datatree, node, firstParent);
                         removeDuplicateNodes(datatree, node);
+                    });
+
+                    // Update the central panel in case delete has removed an icon
+                    $.each(selected, function(index, node) {
+                        var e = {'type': 'delete_node'};
+                        var data = {'node': node,
+                                    'old_parent': firstParent};
+                        update_thumbnails_panel(e, data);
                     });
 
                     OME.refreshActivities();

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -108,24 +108,6 @@ $(document).ready(function() {
             handleClickSelection(event);
         });
 
-        // plugin to handle drag-select of images (share is single-select only)
-        if (parentNode.type !== "share") {
-            $("#icon_table").selectable({
-                filter: 'li.row',
-                distance: 2,
-                stop: function() {
-                    // Make the same selection in the jstree etc
-                    syncTreeSelection();
-                },
-                start: function() {
-                    // Remove any fileset selection markings
-                    $("#dataIcons li.row:visible")
-                        .removeClass("fs-selected")
-                        .removeClass("lastSelected");
-                }
-            });
-        }
-
         $("#filtersearch label").inFieldLabels();
 
         $("#thumb_size_slider").slider({
@@ -282,6 +264,11 @@ $(document).ready(function() {
         // init the elementsorter plugin
         setupSorting();
 
+        // plugin to handle drag-select of images (share is single-select only)
+        if (parentNode.type !== "share") {
+            setupSelectable();
+        }
+
         return;
     }
 
@@ -290,6 +277,23 @@ $(document).ready(function() {
 
     var getRandom = function() {
         return (Math.random() + "").slice(2);
+    }
+
+    var setupSelectable = function() {
+        $("#dataIcons").selectable({
+            filter: 'li.row',
+            distance: 2,
+            stop: function() {
+                // Make the same selection in the jstree etc
+                syncTreeSelection();
+            },
+            start: function() {
+                // Remove any fileset selection markings
+                $("#dataIcons li.row:visible")
+                    .removeClass("fs-selected")
+                    .removeClass("lastSelected");
+            }
+        });
     }
 
     var setupSorting = function() {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -60,6 +60,7 @@ $(document).ready(function() {
     var li_styles = [];
     var aspect_ratios = [];
     var iconSize = 65;
+    var parentId;       // E.g. dataset-1
 
     var dateFormatOptions = {
         weekday: "short", year: "numeric", month: "short",
@@ -141,11 +142,15 @@ $(document).ready(function() {
 
         if (selected.length === 0) {
             $("#content_details").html("");
+            parentId = undefined;
+            clearThumbnailsPanel();
             return;
         }
         var dtype = selected[0].type;
         if (selected.length > 1 && dtype !== "image") {
             $("#content_details").html("");
+            parentId = undefined;
+            clearThumbnailsPanel();
             return;
         }
 
@@ -157,22 +162,35 @@ $(document).ready(function() {
         } else if (dtype === "image") {
             parentNode = inst.get_node(inst.get_parent(selected[0]));
         } else if (dtype === "plate" || dtype === "acquisition") {
+            parentId = undefined;
             load_spw(event, data);
             return;
         // All other types have blank centre panel
         } else {
+            parentId = undefined;
             clearThumbnailsPanel();
             return;
         }
-
-        // clear html and stored data before adding back html
-        clearThumbnailsPanel();
 
         if (!parentNode) {
             // need this for pagination etc
             parentNode = inst.get_node(data.node);
         }
 
+        var newParentId = parentNode.type + "-" + parentNode.data.obj.id;
+        if (parentId === newParentId
+                && event.type !== "load_node"
+                && event.type !== "delete_node") {
+
+            highlightSelectedThumbs(selected);
+
+            return;
+        }
+
+        parentId = newParentId;
+
+        // clear html and stored data before adding back html
+        clearThumbnailsPanel();
 
         imgNodes = [];
         parentNode.children.forEach(function(ch){
@@ -274,6 +292,24 @@ $(document).ready(function() {
 
     // Update thumbnails when we switch between plugins
     $('#center_panel_chooser').on('center_plugin_changed.ome', update_thumbnails_panel);
+
+    // Use selected nodes from tree to indicate thumbnails
+    var highlightSelectedThumbs = function(selected) {
+        $("#dataIcons li.row").removeClass("ui-selected").removeClass("fs-selected");
+        var selFileSets = [];
+        selected.forEach(function(node){
+            if (node.type == "image") {
+                $("#image_icon-" + node.data.obj.id).addClass("ui-selected");
+            }
+            var fsId = node.data.obj.filesetId;
+            if (fsId) {
+                selFileSets.push(fsId);
+            }
+        });
+        selFileSets.forEach(function(fsId){
+            $("#dataIcons li[data-fileset='" + fsId + "']").addClass("fs-selected");
+        });
+    }
 
     var getRandom = function() {
         return (Math.random() + "").slice(2);


### PR DESCRIPTION
This fixes a number of bugs reported at today's testing. To test:

 - Row 26 In Firefox & IE, browse a Dataset with many thumbnails (so that a scrollbar is shown to their right), select some thumbnails (drag select thumbs or select in tree). Then drag the scrollbar to scroll the thumbnails. Selection shouldn't change (shouldn't see drag-select region as you drag).
 - Rows 21 & 22 - In a large Dataset (200 images) changes in selection in jsTree should be instantly updated in centre panel. No delay.
 - Row 25: Selection changes in jsTree should not scroll centre panel. E.g scroll to bottom of thumbnail panel, select a thumbnail. Then in jsTree, select next thumbnail. Thumb panel shouldn't scroll.

Other fixes:
 - Filter images by text in filter field. Then change selection of images (same dataset) in the jsTree. Filter should not be cleared.
 - Select a Run that has a number of siblings. Then select 2 or more siblings (centre panel clears) then select just 1 Run again, centre panel should load Plate again.
 - Select a Run, then de-select in jsTree with Cmd-click (nothing selected & centre panel clears) then re-select Run again, centre panel should load Plate again.