### PR TITLE
Rename 'Public' tab to 'Shares'

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/container_tags.html
@@ -732,7 +732,7 @@
     <ul id="left_panel_tab_list" class="ui-tabs-nav">
         <li id="explore_tab" class="ui-state-default"><a href="{% url 'load_template' 'userdata' %}" class="ui-tabs-anchor" title="Explore">{% trans "Explore" %}</a></li>
         <li id="tags_tab" class="ui-state-default ui-tabs-active"><a class="ui-tabs-anchor">{% trans "Tags" %}</a></li>
-        <li id="public_tab" class="ui-state-default"><a href="{% url 'load_template' 'public' %}" class="ui-tabs-anchor">{% trans "Public" %}</a></li>
+        <li id="public_tab" class="ui-state-default"><a href="{% url 'load_template' 'public' %}" class="ui-tabs-anchor">{% trans "Shares" %}</a></li>
     </ul>
     
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -1847,7 +1847,7 @@
 			
 	        <li id="explore_tab" class="ui-state-default ui-tabs-active"><a class="ui-tabs-anchor" title="Explore">{% trans "Explore" %}</a></li>
 	        <li id="tags_tab" class="ui-state-default"><a href="{% url 'load_template' 'usertags' %}" class="ui-tabs-anchor">{% trans "Tags" %}</a></li>
-	        <li id="public_tab" class="ui-state-default"><a href="{% url 'load_template' 'public' %}" class="ui-tabs-anchor">{% trans "Public" %}</a></li>
+	        <li id="public_tab" class="ui-state-default"><a href="{% url 'load_template' 'public' %}" class="ui-tabs-anchor">{% trans "Shares" %}</a></li>
        
 	    </ul>
 		

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -461,7 +461,7 @@
     <ul id="left_panel_tab_list" class="ui-tabs-nav">
         <li id="explore_tab" class="ui-state-default"><a href="{% url 'load_template' 'userdata' %}" class="ui-tabs-anchor" title="Explore">{% trans "Explore" %}</a></li>
         <li id="tags_tab" class="ui-state-default"><a href="{% url 'load_template' 'usertags' %}" class="ui-tabs-anchor">{% trans "Tags" %}</a></li>
-        <li id="public_tab" class="ui-state-default ui-tabs-active"><a class="ui-tabs-anchor">{% trans "Public" %}</a></li>
+        <li id="public_tab" class="ui-state-default ui-tabs-active"><a class="ui-tabs-anchor">{% trans "Shares" %}</a></li>
     </ul>
 
     <div id="Public">


### PR DESCRIPTION
As suggested in testing, this renames the "Public" tab to "Shares", which makes more sense since the data under that tab is in no way "Public". This is also more consistent with E.g. "Tags" tab containing Tags and "Shares" tab containing Shares.

@gusferguson @aleksandra-tarkowska Does this make sense to you?
@gusferguson If we go ahead with this fix and it requires changes to a lot of screenshots, I'm happy to help update screenshots in Photoshop (should be quite quick to patch the label change).