### PR TITLE
Bugfix: 'Open with' external application

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.OpenObjectActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -117,19 +117,30 @@ public class OpenObjectActivity
 		    if (name != null) {
 		        name = name.toLowerCase();
 		        //Always use BF to open the file if Fiji or ImageJ
-		        if (name.contains("fiji") || name.contains("imagej")) {
-		            path = null;
-		            List<String> args = new ArrayList<String>();
-		            args.add("-eval");
-		            args.add("run('Bio-Formats Importer',"
-		                    + "'open=["+f.getAbsolutePath()+"]')");
-		            data.setCommandLineArguments(args);
-		        }
+                if (name.contains("fiji") || name.contains("imagej")) {
+                    path = null;
+                    List<String> args = new ArrayList<String>();
+                    args.add("-eval");
+                    args.add("run('Bio-Formats Importer'," + "'open=["
+                            + replaceWindowsPathSeparator(f.getAbsolutePath())
+                            + "]')");
+                    data.setCommandLineArguments(args);
+                }
 		    }
 		}
 		viewer.openApplication(parameters.getApplication(), path);
 		type.setText(DESCRIPTION_CREATED);
 	}
+	
+    /**
+     * Replaces the Windows backslash path separator with a slash
+     * 
+     * @param path The path
+     * @return See above
+     */
+    private String replaceWindowsPathSeparator(String path) {
+        return path.replaceAll("\\\\", "/");
+    }
 	
 	/**
 	 * Modifies the text of the component. 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectActivity.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectActivity.java
@@ -38,6 +38,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 import org.openmicroscopy.shoola.env.data.model.OpenActivityParam;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import omero.gateway.SecurityContext;
 
 /** 
@@ -122,7 +124,7 @@ public class OpenObjectActivity
                     List<String> args = new ArrayList<String>();
                     args.add("-eval");
                     args.add("run('Bio-Formats Importer'," + "'open=["
-                            + replaceWindowsPathSeparator(f.getAbsolutePath())
+                            + UIUtilities.replaceWindowsPathSeparator(f.getAbsolutePath())
                             + "]')");
                     data.setCommandLineArguments(args);
                 }
@@ -131,16 +133,6 @@ public class OpenObjectActivity
 		viewer.openApplication(parameters.getApplication(), path);
 		type.setText(DESCRIPTION_CREATED);
 	}
-	
-    /**
-     * Replaces the Windows backslash path separator with a slash
-     * 
-     * @param path The path
-     * @return See above
-     */
-    private String replaceWindowsPathSeparator(String path) {
-        return path.replaceAll("\\\\", "/");
-    }
 	
 	/**
 	 * Modifies the text of the component. 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -23,9 +23,13 @@ package org.openmicroscopy.shoola.env.ui;
 import java.io.File;
 
 import org.openmicroscopy.shoola.env.config.Registry;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 import org.openmicroscopy.shoola.util.filter.file.OMETIFFFilter;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.ImageData;
@@ -92,28 +96,19 @@ public class OpenObjectLoader
     		String name = image.getName();
     		name += image.getName();
     		name += "_"+image.getId();
-    		path += replaceNonWordCharacters(name)+"."+OMETIFFFilter.OME_TIFF;
+    		path += UIUtilities.replaceNonWordCharacters(name)+"."+OMETIFFFilter.OME_TIFF;
     		f = new File(path);
     		f.deleteOnExit();
     		handle = ivView.exportImageAsOMETiff(ctx, image.getId(), f, null,
     				this);
     	} else {
     		FileAnnotationData fa = (FileAnnotationData) object;
-    		path += replaceNonWordCharacters(fa.getFileName());
+    		path += UIUtilities.replaceNonWordCharacters(fa.getFileName());
     		f = new File(path);
     		f.deleteOnExit();
     		handle = mhView.loadFile(ctx, f, fa.getId(), 
     				FileLoader.FILE_ANNOTATION, this);
     	}
-    }
-    
-    /**
-     * Simply replaces all non word characters with underscores.
-     * @param name The original name
-     * @return See above.
-     */
-    private String replaceNonWordCharacters(String name) {
-        return name.replaceAll("\\W", "_");
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -89,21 +89,31 @@ public class OpenObjectLoader
     	File f;
     	if (object instanceof ImageData) {
     		ImageData image = (ImageData) object;
-    		path += image.getName();
-    		path += image.getId();
-    		path += "."+OMETIFFFilter.OME_TIFF;
+    		String name = image.getName();
+    		name += image.getName();
+    		name += "_"+image.getId();
+    		path += replaceNonWordCharacters(name)+"."+OMETIFFFilter.OME_TIFF;
     		f = new File(path);
     		f.deleteOnExit();
     		handle = ivView.exportImageAsOMETiff(ctx, image.getId(), f, null,
     				this);
     	} else {
     		FileAnnotationData fa = (FileAnnotationData) object;
-    		path += fa.getFileName();
+    		path += replaceNonWordCharacters(fa.getFileName());
     		f = new File(path);
     		f.deleteOnExit();
     		handle = mhView.loadFile(ctx, f, fa.getId(), 
     				FileLoader.FILE_ANNOTATION, this);
     	}
+    }
+    
+    /**
+     * Simply replaces all non word characters with underscores.
+     * @param name The original name
+     * @return See above.
+     */
+    private String replaceNonWordCharacters(String name) {
+        return name.replaceAll("\\W", "_");
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/UserNotifierImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/UserNotifierImpl.java
@@ -483,8 +483,16 @@ public class UserNotifierImpl implements UserNotifier, PropertyChangeListener {
 
 			logger.info(this, "Executing command & args: " + 
 					Arrays.toString(commandLineElements));
-
+			
 			ProcessBuilder builder = new ProcessBuilder(commandLineElements);
+			
+            if (commandLineElements[0].matches(".*Preview\\.app.*")) {
+                // workaround for OSX Preview.app; can't be called via full path 
+                // (will result in permissions exception)
+                builder = new ProcessBuilder("open", "-a", "Preview",
+                        commandLineElements[1]);
+            }
+			
 			builder.start();
 		} catch (Exception e) {
 			logger.error(this, e.getMessage());

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2916,4 +2916,23 @@ public class UIUtilities
         StringSelection strSel = new StringSelection(value);
         clipboard.setContents(strSel, null);
     }
+    
+    /**
+     * Replaces the Windows backslash path separator with a slash
+     * 
+     * @param path The path
+     * @return See above
+     */
+    public static String replaceWindowsPathSeparator(String path) {
+        return path.replaceAll("\\\\", "/");
+    }
+    
+    /**
+     * Simply replaces all non word characters with underscores.
+     * @param name The original name
+     * @return See above.
+     */
+    public static String replaceNonWordCharacters(String name) {
+        return name.replaceAll("\\W", "_");
+    }
 }


### PR DESCRIPTION
See [Ticket 13055](http://trac.openmicroscopy.org/ome/ticket/13055)

There were two issues:
- Open with ImageJ/Fiji always failed on Windows, because of the backslash path separator.
- Open with ImageJ/Fiji also failed on OSX with images which had spaces in the image name

With this PR non-word characters in the name for the temporary file for the 'open with' action are always replaced by underscores (to reduce the risk of complications with any external application) and the windows backslash is replaced by a slash before passing the path on to the ImageJ/Fiji bioformats importer.

**Test:**
- 'Open with' ImageJ and Fiji on OSX and Windows with an image which previously triggered the issue (white space(s) in image name).
- 'Open with' another application, e. g. Paint etc.; just to be sure this has not been broken.
