### PR TITLE
Show own 'INACTIVE' shares in lighter color

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -261,7 +261,7 @@
                                                 'disabled'  : !this.isOwned && ( !this.active || this.expired )
                                             },
                                             'li_attr': {
-                                                // 'class': 'share',
+                                                'class': this.active ? "" : "inactive",
                                                 'data-id': value.id
                                             }
                                         };
@@ -281,7 +281,7 @@
                                                 'disabled'  : !this.isOwned && ( !this.active || this.expired )
                                             },
                                             'li_attr': {
-                                                // 'class': 'discussion',
+                                                'class': this.active ? "" : "inactive",
                                                 'data-id': value.id
                                             }
                                         };

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
@@ -600,6 +600,9 @@
   height: 18px;
   line-height: 18px;
 }
+.jstree-default-ome .inactive .jstree-icon {
+  opacity: 0.5;
+}
 .jstree-default-ome .jstree-icon:empty {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
Fixes Row 28 of this morning's testing report:
To test, disable one of your shares and check (after refreshing tree) that the share in tree is a lighter colour icon.

![screen shot 2015-10-26 at 16 16 49](https://cloud.githubusercontent.com/assets/900055/10734905/6a5bfebc-7bfd-11e5-8923-ac5347ecf754.png)