### PR TITLE
Bugfix: ROI tool z/t slider

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -601,10 +601,14 @@ public class GraphPane
 			cT = c3D.getTimePoint();
 			cZ = c3D.getZSection();
 			
-			minT = Math.min(minT, cT);
-			maxT = Math.max(maxT, cT);
-			minZ = Math.min(minZ, cZ);
-			maxZ = Math.max(maxZ, cZ);
+            if (cZ == z) {
+                minT = Math.min(minT, cT);
+                maxT = Math.max(maxT, cT);
+            }
+            if (cT == t) {
+                minZ = Math.min(minZ, cZ);
+                maxZ = Math.max(maxZ, cZ);
+            }
 			
 			shapeMap.put(c3D, shape);
 			if (shape.getFigure() instanceof MeasureTextFigure)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -1168,10 +1168,15 @@ class IntensityView
 			entry = (Entry) j.next();
 			shape = (ROIShape) entry.getKey();
 			c3D = shape.getCoord3D();
-			minT = Math.min(minT, c3D.getTimePoint());
-			maxT = Math.max(maxT, c3D.getTimePoint());
-			minZ = Math.min(minZ, c3D.getZSection());
-			maxZ = Math.max(maxZ, c3D.getZSection());
+			
+            if (c3D.getZSection() == cZ) {
+                minT = Math.min(minT, c3D.getTimePoint());
+                maxT = Math.max(maxT, c3D.getTimePoint());
+            }
+            if (c3D.getTimePoint() == cT) {
+                minZ = Math.min(minZ, c3D.getZSection());
+                maxZ = Math.max(maxZ, c3D.getZSection());
+            }
 			
 			shapeMap.put(c3D, shape);
 			if (shape.getFigure() instanceof MeasureTextFigure)


### PR DESCRIPTION
Bugfix: Unevenly propagated 4D ROIs sometimes caused unnecessary (and ineffective) Z/T sliders being displayed in Graph Pane and Intensity View.

See [Trello - Insight: Measurement tool follow up](https://trello.com/c/DMWzJr97/6-insight-measurement-tool-follow-up)

**Test:**
- Open measurement tool for a 4D multi-Z/T image
- Create an ROI and propagate it through several Z planes and through several T planes (but not for all Z planes!), so that you have something like on the screenshot below.

Check the Graph Pane and the Intensity View:
- Make sure, that the T slider is only displayed if the current Z plane has multiple timepoints
- Make sure, that the Z slider is only displayed if the current T plane has multiple Z planes. 

![screen shot 2015-10-27 at 09 56 21](https://cloud.githubusercontent.com/assets/6575139/10754850/5daa85c2-7c92-11e5-9aa8-de82eac8e824.png)