### PR TITLE
Improve web deploy

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -388,16 +388,36 @@ class WebControl(BaseControl):
     @config_required
     def clearsessions(self, args, settings):
         """Clean out expired sessions."""
-        self.ctx.out("Clearing expired sessions. This may take some time... ")
+        self.ctx.out("Clearing expired sessions. This may take some time... ",
+                     newline=False)
         location = self._get_python_dir() / "omeroweb"
         cmd = [sys.executable, "manage.py", "clearsessions"]
         if not args.no_wait:
             rv = self.ctx.call(cmd, cwd=location)
             if rv != 0:
+                self.ctx.out("[FAILED]")
                 self.ctx.die(607, "Failed to clear sessions.\n")
             self.ctx.out("[OK]")
         else:
             self.ctx.popen(cmd, cwd=location)
+
+    def _get_django_pid(self, pid_path):
+        """Get Django Process ID"""
+        pid = None
+        if pid_path.exists():
+            with open(pid_path, 'r') as pid_file:
+                pid = int(pid_file.read().strip())
+        return pid
+
+    def _check_pid(self, pid, pid_path):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            self.ctx.out("[ERROR] OMERO.web workers (PID %s) - no such "
+                         "process. Use `ps aux| grep %s` and kill stale "
+                         "processes by hand. " % (pid, pid_path))
+            return False
+        return True
 
     @config_required
     def start(self, args, settings):
@@ -411,13 +431,26 @@ class WebControl(BaseControl):
         deploy = getattr(settings, 'APPLICATION_SERVER')
 
         if deploy in (settings.WSGI,):
-            self.ctx.out("You are deploying OMERO.web using apache and"
+            self.ctx.die(609, "You are deploying OMERO.web using apache and"
                          " mod_wsgi. Generate apache config using"
                          " 'omero web config apache' and reload"
                          " web server.")
-            return 1
+            return False
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)
+
+        # 3216
+        pid_path = self.ctx.dir / "var" / "django.pid"
+        pid = self._get_django_pid(pid_path)
+        if pid:
+            if not self._check_pid(pid, pid_path):
+                pid_path.remove()
+                self.ctx.die(608, "Removed stale %s" % pid_path)
+            else:
+                self.ctx.die(606,
+                             "[FAILED] OMERO.web already started. "
+                             "%s exists (PID: %s)! Use 'web stop or restart'"
+                             " first." % (pid_path, str(pid)))
 
         cache_backend = getattr(settings, 'CACHE_BACKEND', None)
         if cache_backend is not None and cache_backend.startswith("file:///"):
@@ -427,30 +460,7 @@ class WebControl(BaseControl):
                 self.ctx.out("[FAILED]")
                 self.ctx.out("CACHE_BACKEND '%s' not writable or missing." %
                              getattr(settings, 'CACHE_BACKEND'))
-                return 1
-
-        # 3216
-        if deploy in (settings.WSGI,):
-            pid_path = self.ctx.dir / "var" / "django.pid"
-            pid_num = None
-
-            if pid_path.exists():
-                pid_txt = pid_path.text().strip()
-                try:
-                    pid_num = int(pid_txt)
-                except:
-                    pid_path.remove()
-                    self.ctx.err("Removed invalid %s: '%s'"
-                                 % (pid_path, pid_txt))
-
-            if pid_num is not None:
-                try:
-                    os.kill(pid_num, 0)
-                    self.ctx.die(606,
-                                 "%s exists! Use 'web stop' first" % pid_path)
-                except OSError:
-                    pid_path.remove()
-                    self.ctx.err("Removed stale %s" % pid_path)
+                return False
 
         if deploy == settings.WSGITCP:
             try:
@@ -498,59 +508,56 @@ class WebControl(BaseControl):
             cache_backend = ' (CACHE_BACKEND %s)' % cache_backend
         else:
             cache_backend = ''
-        rv = 0
-        if deploy in settings.WSGI_TYPES:
-            try:
-                f = open(self.ctx.dir / "var" / "django.pid", 'r')
-                pid = int(f.read())
-            except IOError:
-                self.ctx.out("[NOT STARTED]")
-                return rv
 
-            try:
-                os.kill(pid, 0)  # NULL signal
-                self.ctx.out("[RUNNING] (PID %d)%s" % (pid, cache_backend))
-            except:
-                self.ctx.out("[NOT STARTED]")
-                return rv
-        elif deploy in settings.DEVELOPMENT:
+        if deploy in (settings.WSGITCP,):
+            pid_path = self.ctx.dir / "var" / "django.pid"
+            pid = self._get_django_pid(pid_path)
+            if pid:
+                if not self._check_pid(pid, pid_path):
+                    self.ctx.err("[NOT STARTED]")
+                else:
+                    self.ctx.out("[RUNNING] (PID %d)%s" % (pid, cache_backend))
+            else:
+                self.ctx.err("[NOT STARTED]")
+        elif deploy in (settings.WSGI,):
+            self.ctx.err("You are deploying OMERO.web using apache and"
+                         " mod_wsgi. Cannot check status.")
+        elif deploy in (settings.DEVELOPMENT,):
             self.ctx.err(
                 "DEVELOPMENT: You will have to kill processes by hand!")
         else:
             self.ctx.err(
                 "Invalid APPLICATION_SERVER "
                 "(omero.web.application_server = '%s')!" % deploy)
-        return rv
+        return 0
 
     @config_required
     def stop(self, args, settings):
         self.ctx.out("Stopping OMERO.web... ", newline=False)
         deploy = getattr(settings, 'APPLICATION_SERVER')
-        if deploy in settings.WSGI_TYPES:
-            pid = 'Unknown'
+        if deploy in (settings.WSGITCP,):
             pid_path = self.ctx.dir / "var" / "django.pid"
-            pid_text = "Unknown"
-            if pid_path.exists():
-                pid_text = pid_path.text().strip()
-            try:
+            pid = self._get_django_pid(pid_path)
+            if pid:
                 try:
-                    pid = int(pid_text)
-                    import signal
-                    os.kill(pid, 0)  # NULL signal
-                except:
-                    self.ctx.out("[FAILED]")
-                    self.ctx.out(
-                        "OMERO.web %s workers (PID %s) not started?"
-                        % (deploy.replace("-tcp", "").upper(), pid_text))
+                    if self._check_pid(pid, pid_path):
+                        import signal
+                        os.kill(pid, signal.SIGTERM)  # kill whole group
+                        self.ctx.out("[OK]")
+                        self.ctx.out("OMERO.web %s workers (PID %d) killed." %
+                                     (deploy.replace("-tcp", "").upper(), pid))
+                finally:
+                    if pid_path.exists():
+                        pid_path.remove()
+                        self.ctx.out("Removed stale %s" % pid_path)
                     return True
-                os.kill(pid, signal.SIGTERM)  # kill whole group
-                self.ctx.out("[OK]")
-                self.ctx.out("OMERO.web %s workers (PID %d) killed." %
-                             (deploy.replace("-tcp", "").upper(), pid))
+            else:
+                self.ctx.out("[NOT STARTED]")
                 return True
-            finally:
-                if pid_path.exists():
-                    pid_path.remove()
+        elif deploy in (settings.WSGI,):
+            self.ctx.err("You are deploying OMERO.web using apache and"
+                         " mod_wsgi. Cannot check status.")
+            return False
         elif deploy in settings.DEVELOPMENT:
             self.ctx.err(
                 "DEVELOPMENT: You will have to kill processes by hand!")

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -435,7 +435,6 @@ class WebControl(BaseControl):
                          " mod_wsgi. Generate apache config using"
                          " 'omero web config apache' and reload"
                          " web server.")
-            return False
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)
 
@@ -482,7 +481,7 @@ class WebControl(BaseControl):
             cmd += " --max-requests %(maxrequests)d"
             cmd += " %(wsgi_args)s"
             cmd += " omeroweb.wsgi:application"
-            django = (cmd % {
+            runserver = (cmd % {
                 'base': self.ctx.dir,
                 'host': settings.APPLICATION_SERVER_HOST,
                 'port': settings.APPLICATION_SERVER_PORT,
@@ -490,11 +489,11 @@ class WebControl(BaseControl):
                 'workers': args.workers,
                 'worker_conn': args.worker_connections,
                 'wsgi_args': args.wsgi_args}).split()
-            rv = self.ctx.popen(args=django, cwd=location)  # popen
+            rv = self.ctx.popen(args=runserver, cwd=location)  # popen
         else:
-            django = [sys.executable, "manage.py", "runserver", link,
-                      "--noreload", "--nothreading"]
-            rv = self.ctx.call(django, cwd=location)
+            runserver = [sys.executable, "manage.py", "runserver", link,
+                         "--noreload", "--nothreading"]
+            rv = self.ctx.call(runserver, cwd=location)
         self.ctx.out("[OK]")
         return rv
 

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -409,13 +409,16 @@ class WebControl(BaseControl):
                 pid = int(pid_file.read().strip())
         return pid
 
+    def _get_django_pid_path(self):
+        return self.ctx.dir / "var" / "django.pid"
+
     def _check_pid(self, pid, pid_path):
         try:
             os.kill(pid, 0)
         except OSError:
-            self.ctx.out("[ERROR] OMERO.web workers (PID %s) - no such "
-                         "process. Use `ps aux| grep %s` and kill stale "
-                         "processes by hand. " % (pid, pid_path))
+            self.ctx.err("[ERROR] OMERO.web workers (PID %s) - no such "
+                         "process. Use `ps aux | grep %s` and kill stale "
+                         "processes by hand." % (pid, pid_path))
             return False
         return True
 
@@ -439,7 +442,7 @@ class WebControl(BaseControl):
             self.ctx.out("Starting OMERO.web... ", newline=False)
 
         # 3216
-        pid_path = self.ctx.dir / "var" / "django.pid"
+        pid_path = self._get_django_pid_path()
         pid = self._get_django_pid(pid_path)
         if pid:
             if not self._check_pid(pid, pid_path):
@@ -509,7 +512,7 @@ class WebControl(BaseControl):
             cache_backend = ''
 
         if deploy in (settings.WSGITCP,):
-            pid_path = self.ctx.dir / "var" / "django.pid"
+            pid_path = self._get_django_pid_path()
             pid = self._get_django_pid(pid_path)
             if pid:
                 if not self._check_pid(pid, pid_path):
@@ -535,7 +538,7 @@ class WebControl(BaseControl):
         self.ctx.out("Stopping OMERO.web... ", newline=False)
         deploy = getattr(settings, 'APPLICATION_SERVER')
         if deploy in (settings.WSGITCP,):
-            pid_path = self.ctx.dir / "var" / "django.pid"
+            pid_path = self._get_django_pid_path()
             pid = self._get_django_pid(pid_path)
             if pid:
                 try:


### PR DESCRIPTION
Test nginx (no webserver needed)
```
$ dist/bin/omero web restart
Stopping OMERO.web... [NOT STARTED]
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... [OK]
```

Open localhost:4080 (you won't see statics)

```
$ dist/bin/omero web status
OMERO.web status... [RUNNING] (PID 7272)

$ cat dist/var/django.pid 
7272

$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... [FAILED] OMERO.web already started. /Users/ola/OMERO/openmicroscopy/dist/var/django.pid exists (PID: 7272)! Use 'web stop or restart' first.

$ dist/bin/omero web status
OMERO.web status... [RUNNING] (PID 7272)

$ cat dist/var/django.pid 
7272

$ dist/bin/omero web stop
Stopping OMERO.web... [OK]
OMERO.web WSGI workers (PID 7272) killed.
Removed stale /Users/ola/OMERO/openmicroscopy/dist/var/django.pid

$ dist/bin/omero web status
OMERO.web status... [NOT STARTED]

$ dist/bin/omero web stop
Stopping OMERO.web... [NOT STARTED]
```

test bad behavior, wait few sec between steps to make s

```
$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... [OK]
```

LOG IN TO WEB localhost:4080 (you won't see statics)

```
$ dist/bin/omero web status
OMERO.web status... [RUNNING] (PID 7439)

$ cat dist/var/django.pid 
7439

$ rm -f dist/var/django.pid

$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... [OK]
```

By that time it is unknown that there are any stale processes running
REFRESH WEB

```
$ cat dist/var/django.pid 
7484 <- PID will be different

$ dist/bin/omero web status
OMERO.web status... [ERROR] OMERO.web workers (PID 7484) - no such process. Use `ps aux| grep /Users/ola/OMERO/openmicroscopy/dist/var/django.pid` and kill stale processes by hand. 
[NOT STARTED]
```

```
$ dist/bin/omero web stop
Stopping OMERO.web... [ERROR] OMERO.web workers (PID 7484) - no such process. Use `ps aux| grep /Users/ola/OMERO/openmicroscopy/dist/var/django.pid` and kill stale processes by hand. 
Removed stale /Users/ola/OMERO/openmicroscopy/dist/var/django.pid
```
If you run restart instead you will get the same error:

```
$ dist/bin/omero web restart
Stopping OMERO.web... [NOT STARTED]
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... [OK]

```

```
 $ dist/bin/omero web status
OMERO.web status... [ERROR] OMERO.web workers (PID 3319) - no such process. Use `ps aux| grep /Users/ola/OMERO/openmicroscopy/dist/var/django.pid` and kill stale processes by hand. 
```
-----------------------

Test apache  (no webserver needed)

```
$ dist/bin/omero config set omero.web.application_server wsgi
$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
You are deploying OMERO.web using apache and mod_wsgi. Add config to Apache and reload.

$ ps aux| grep /Users/ola/OMERO/openmicroscopy/dist/var/django.pid
ola             7636   0.0  0.0  2432768    648 s000  R+   10:59am   0:00.00 grep /Users/ola/OMERO/openmicroscopy/dist/var/django.pid

$ dist/bin/omero web status
OMERO.web status... You are deploying OMERO.web using apache and mod_wsgi. Cannot check status.

$ dist/bin/omero web stop
Stopping OMERO.web... You are deploying OMERO.web using apache and mod_wsgi. Cannot check status.
```