### PR TITLE
Fix config creation

### DIFF
--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -140,7 +140,6 @@ class ConfigXml(object):
         if not self.read_only:
             try:
                 self.source = open(self.filename, "a+")  # Open file handle
-                self.lock = self._open_lock()  # Open file handle for lock
             except IOError:
                 self.logger.debug("open('%s', 'a+') failed" % self.filename)
                 if not os.path.isfile(self.filename):
@@ -153,6 +152,8 @@ class ConfigXml(object):
                 if val is not None:
                     raise Exception(
                         "Non-default OMERO_CONFIG on read-only: %s" % val)
+            else:
+                self.lock = self._open_lock()  # Open file handle for lock
 
         if self.source is None:
             self.lock = None

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -139,13 +139,12 @@ class ConfigXml(object):
         self.source = None
         if not self.read_only:
             try:
-                # Try to open the file for modification
-                # If this fails, then the file is readonly
                 self.source = open(self.filename, "a+")  # Open file handle
                 self.lock = self._open_lock()  # Open file handle for lock
             except IOError:
                 self.logger.debug("open('%s', 'a+') failed" % self.filename)
-
+                if not os.path.isfile(self.filename):
+                    raise
                 # Before we're forced to open read-only, we need to check
                 # that no other configuration has been requested because
                 # it will not be possible to modify the __ACTIVE__ setting

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import errno
 import pytest
 from omero.config import ConfigXml, xml
 from omero.util.temp_files import create_path
@@ -328,3 +329,11 @@ class TestConfig(object):
                 del os.environ["OMERO_CONFIG"]
             else:
                 os.environ["OMERO_CONFIG"] = old
+
+    def testCannotCreate(self):
+        d = create_path(folder=True)
+        d.chmod(0555)
+        filename = str(d / "config.xml")
+        with pytest.raises(IOError) as excinfo:
+            ConfigXml(filename).close()
+        assert excinfo.value.errno == errno.EACCES

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -337,3 +337,14 @@ class TestConfig(object):
         with pytest.raises(IOError) as excinfo:
             ConfigXml(filename).close()
         assert excinfo.value.errno == errno.EACCES
+
+    def testCannotCreateLock(self):
+        d = create_path(folder=True)
+        filename = str(d / "config.xml")
+        lock_filename = "%s.lock" % filename
+        with open(lock_filename, "w") as fo:
+            fo.write("dummy\n")
+        os.chmod(lock_filename, 0444)
+        with pytest.raises(IOError) as excinfo:
+            ConfigXml(filename).close()
+        assert excinfo.value.errno == errno.EACCES

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -348,3 +348,10 @@ class TestConfig(object):
         with pytest.raises(IOError) as excinfo:
             ConfigXml(filename).close()
         assert excinfo.value.errno == errno.EACCES
+
+    def testCannotRead(self):
+        p = create_path()
+        p.chmod(0)
+        with pytest.raises(IOError) as excinfo:
+            ConfigXml(str(p)).close()
+        assert excinfo.value.errno == errno.EACCES


### PR DESCRIPTION
This PR addresses two related issues in `ConfigXml.open_source` (from `omero/config.py`):

* The method assumes that the config file is read-only if it cannot be opened in `a+` mode, while in reality the `open` call can fail for several other reasons. In particular, if `etc/grid` exists but it's not writable, the exception is raised by the subsequent open-for-read attempt, and the final error message suggests that something is missing:
```
$ dist/bin/omero config set omero.data.dir /OMERO
[Errno 2] No such file or directory: '[...]/dist/etc/grid/config.xml'
```
This is addressed by the first commit. **To test:**
```
$ mkdir -p dist/etc/grid
$ rm -rf dist/etc/grid/*
$ chmod 555 dist/etc/grid
$ dist/bin/omero config set omero.data.dir /OMERO
[Errno 13] Permission denied: '[...]/dist/etc/grid/config.xml'
```

* Since both config file and lock file creation are checked for in the same try/except block, if only the latter fails (e.g., because it already exists but it's not writable), the following happens (with logging level set to DEBUG):
```
$ dist/bin/omero config set omero.data.dir /OMERO
[...]
DEBUG:ConfigXml:open('[...]/dist/etc/grid/config.xml', 'a+') failed
'ConfigXml' object has no attribute 'lock'
```
In the log, wrong info is given on which file could not be opened. Moreover, the error message reflects a subsequent unhandled exception. This is addressed in the second commit. **To test:**
```
$ mkdir -p dist/etc/grid
$ chmod 777 dist/etc/grid
$ rm -rf dist/etc/grid/*
$ touch dist/etc/grid/config.xml.lock
$ chmod 444 dist/etc/grid/config.xml.lock
$ dist/bin/omero config set omero.data.dir /OMERO
[Errno 13] Permission denied: '[...]/dist/etc/grid/config.xml.lock'
```
