### PR TITLE
allowing generate config even gunicorn is not installed

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -90,8 +90,7 @@ def assert_config_argtype(func):
                 try:
                     import gunicorn  # NOQA
                 except ImportError:
-                    self.ctx.die(690,
-                                 "ERROR: FastCGI support was removed in "
+                    self.ctx.err("ERROR: FastCGI support was removed in "
                                  "OMERO 5.2. Install Gunicorn and update "
                                  "config.")
                 if argtype not in ("nginx", "nginx-development",):


### PR DESCRIPTION
@manics this should fix https://trello.com/c/07pqxE0t/100-omero-web-config-nginx-should-warn-but-not-fail