### PR TITLE
allowing generate config even gunicorn is not installed

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -408,8 +408,9 @@ class WebControl(BaseControl):
 
         if deploy in (settings.WSGI,):
             self.ctx.out("You are deploying OMERO.web using apache and"
-                         " mod_wsgi. Generate apache config "
-                         "bin/omero web config apache and reload web server.")
+                         " mod_wsgi. Generate apache config using"
+                         " 'omero web config apache' and reload"
+                         " web server.")
             return 1
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -87,13 +87,6 @@ def assert_config_argtype(func):
             if settings.APPLICATION_SERVER in ("development",):
                 mismatch = True
             if settings.APPLICATION_SERVER in (settings.WSGITCP,):
-                try:
-                    import gunicorn  # NOQA
-                except ImportError:
-                    self.ctx.die(690,
-                                 "ERROR: FastCGI support was removed in "
-                                 "OMERO 5.2. Install Gunicorn and update "
-                                 "config.")
                 if argtype not in ("nginx", "nginx-development",):
                     mismatch = True
             if (settings.APPLICATION_SERVER in (settings.WSGI,) and
@@ -415,7 +408,8 @@ class WebControl(BaseControl):
 
         if deploy in (settings.WSGI,):
             self.ctx.out("You are deploying OMERO.web using apache and"
-                         " mod_wsgi. Add config to Apache and reload.")
+                         " mod_wsgi. Generate apache config "
+                         "bin/omero web config apache and reload web server.")
             return 1
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)
@@ -454,6 +448,14 @@ class WebControl(BaseControl):
                     self.ctx.err("Removed stale %s" % pid_path)
 
         if deploy == settings.WSGITCP:
+            try:
+                import gunicorn  # NOQA
+            except ImportError:
+                self.ctx.err("[FAILED]")
+                self.ctx.die(690,
+                             "ERROR: FastCGI support was removed in "
+                             "OMERO 5.2. Install Gunicorn and update "
+                             "config.")
             try:
                 os.environ['SCRIPT_NAME'] = settings.FORCE_SCRIPT_NAME
             except:


### PR DESCRIPTION
@manics this should fix https://trello.com/c/07pqxE0t/100-omero-web-config-nginx-should-warn-but-not-fail

```
$ dist/bin/omero web config nginx
upstream omeroweb {
    server 127.0.0.1:4080 fail_timeout=0;
}
...

$ dist/bin/omero web config apache
ERROR: configuration mismatch. omero.web.application_server=wsgi-tcp cannot be used with 'omero web config apache'.

$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... 
[OK]
Starting OMERO.web... [FAILED]
ERROR: FastCGI support was removed in OMERO 5.2. Install Gunicorn and update config.

$ dist/bin/omero config set omero.web.application_server 'wsgi'
$ dist/bin/omero web config apache
###
# apache config for omero
...

$ dist/bin/omero web config nginx
ERROR: configuration mismatch. omero.web.application_server=wsgi cannot be used with 'omero web config nginx'.

$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... 
[OK]
You are deploying OMERO.web using apache and mod_wsgi. Generate apache config bin/omero web config apache and reload web server.

$ dist/bin/omero config set omero.web.application_server 'development'
$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/openmicroscopy/dist/lib/python/omeroweb/static', 618 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... 
[OK]
Starting OMERO.web... Performing system checks...

System check identified no issues (1 silenced).
October 29, 2015 - 10:33:20
Django version 1.8.5, using settings 'omeroweb.settings'
Starting development server at http://127.0.0.1:4080/
Quit the server with CONTROL-C.
```

**Note:** if Django is not installed you cannot generate config because it must import settings.