### PR TITLE
Fix update of thumbnails on rdef 'Save' and 'Save to All'

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -180,7 +180,9 @@ $(document).ready(function() {
         var newParentId = parentNode.type + "-" + parentNode.data.obj.id;
         if (parentId === newParentId
                 && event.type !== "load_node"
-                && event.type !== "delete_node") {
+                && event.type !== "delete_node"
+                && event.type !== "refreshThumb"
+                && event.type !== "refreshThumbnails") {
 
             highlightSelectedThumbs(selected);
 


### PR DESCRIPTION
Fixes update of thumbnails on rendering settings 'Save' and 'Save to All'.

To test:
 - Save rendering settings on an image in Preview panel - thumbnail should update.
 - "Save All" should update all thumbnails.
 - Also check that right-click Rendering Settings options update thumbnails as expected.