### PR TITLE
Immediately delete ROIs

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -644,8 +644,19 @@ class MeasurementViewerUI
 				}
 			}
 			model.deleteAllROIs(deobs);
+			
+            TreeMap<Long, ROI> rois = model.getROIComponent().getROIMap();
+            boolean allsaved = true;
+            for (ROI tmp : rois.values()) {
+                if (tmp.isClientSide()) {
+                    allsaved = false;
+                    break;
+                }
+            }
+            if (allsaved) {
+                model.notifyDataChanged(false);
+            }
 		} catch (Exception e) {
-		    e.printStackTrace();
 			handleROIException(e, DELETE_MSG);
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MessageBox.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/MessageBox.java
@@ -24,6 +24,7 @@ package org.openmicroscopy.shoola.util.ui;
 
 //Java imports
 import java.awt.Point;
+import java.awt.event.WindowEvent;
 
 import javax.swing.Icon;
 import javax.swing.JDialog;
@@ -179,6 +180,13 @@ public class MessageBox
      */
     public int showMsgBox(Point location)
     {
+        addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                MessageBox.this.option = CANCEL;
+            }
+        });
+        
     	setLocation(location);
     	setVisible(true);
     	return option;	
@@ -191,6 +199,13 @@ public class MessageBox
      */
     public int centerMsgBox()
     {
+        addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                MessageBox.this.option = CANCEL;
+            }
+        });
+        
     	UIUtilities.centerAndShow(this);
     	return option;	
     }


### PR DESCRIPTION
Bugfix for [Ticket 13037](trac.openmicroscopy.org/ome/ticket/13037), [Trello - Insight: Measurement tool follow up](https://trello.com/c/DMWzJr97/6-insight-measurement-tool-follow-up)

**Test**:
Open an image with several ROIs. Make sure, deleting *single* ROIs (via context menu), deleting *multiple* ROIs (via context menu) and deleting *all* ROIs (via toolbar menu) works like expected. After each step close the full viewer and reopen it again. In every case the ROIs should get deleted immediately, no confirmation dialog should pop up when closing the full viewer.

Note: There is still a little discrepancy between ROIs and other annotation. Deleting ROIs triggers an 'activity' whereas for example removing tags does not. Might tackle this in separate PR.

