### PR TITLE
restricting Django version

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -63,6 +63,9 @@ def config_required(func):
                 import django  # NOQA
             except:
                 self.ctx.die(681, "Django not installed!")
+            if django.VERSION < (1, 6) or django.VERSION >= (1, 9):
+                self.ctx.die(684, "Django version %s is not "
+                             "supported!" % django.get_version())
             try:
                 import omeroweb.settings as settings
                 kwargs['settings'] = settings

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -62,9 +62,9 @@ def config_required(func):
             try:
                 import django  # NOQA
             except:
-                self.ctx.die(681, "Django not installed!")
+                self.ctx.die(681, "ERROR: Django not installed!")
             if django.VERSION < (1, 6) or django.VERSION >= (1, 9):
-                self.ctx.die(684, "Django version %s is not "
+                self.ctx.err("ERROR: Django version %s is not "
                              "supported!" % django.get_version())
             try:
                 import omeroweb.settings as settings


### PR DESCRIPTION
This PR should help preventing people from deploying web with incorrect Django version. As we noticed over testing, people tend to ``pip install django``, that in few weeks will install 1.9. Currently web is only compatible with 1.6 and 1.8

```
$ dist/bin/omero web start
Django version '1.9b1' is not supported!

$ dist/bin/omero web config nginx
Django version 1.5.9 is not supported!

$ dist/bin/omero web config nginx
Django version 1.4.22 is not supported!
```