### PR TITLE
Have DropBox user log out after import

### DIFF
--- a/components/tools/OmeroFS/src/fsDropBoxMonitorClient.py
+++ b/components/tools/OmeroFS/src/fsDropBoxMonitorClient.py
@@ -693,8 +693,8 @@ class MonitorClientI(monitors.MonitorClient):
                 else:
                     self.log.error("%s not found !" % t)
                 self.log.error("***** end of output from importer-cli *****")
-                self.logoutUser(sess)
         finally:
+            self.logoutUser(sess)
             remove_path(t)
             remove_path(to)
 

--- a/components/tools/OmeroFS/src/fsDropBoxMonitorClient.py
+++ b/components/tools/OmeroFS/src/fsDropBoxMonitorClient.py
@@ -544,7 +544,7 @@ class MonitorClientI(monitors.MonitorClient):
 
     def loginUser(self, exName):
         """
-        Logs in in the given user and returns the session
+        Logs in the given user and returns the session
         """
 
         if not self.ctx.hasSession():


### PR DESCRIPTION
See https://trello.com/c/4dIYzO6H/13-dropbox-doesn-t-logout-user

To test use DropBox to import a file for a user, watch the `DropBox` log for the import completing and then try some (non-destructive!) cli action that requires log in. You should be prompted to log in rather than reconnecting to the session used by DropBox for the import.

