### PR TITLE
Bugfix: Import As freezes

### DIFF
--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -204,6 +204,7 @@ class Connector
      * @param secureClient The entry point to server.
      * @param entryEncrypted The entry point to access the various services.
      * @param encrypted The entry point to access the various services.
+     * @param username The username if this is a derived connector
      * @param logger Reference to the logger.
      * @param elapseTime The time between network check.
      * @throws Exception Thrown if entry points cannot be initialized.
@@ -650,10 +651,11 @@ class Connector
             unsecureClient.__del__();
             this.pcs.firePropertyChange(Gateway.PROP_SESSION_CLOSED, null, id);
         }
-        if(username==null)
+        if (username == null)
             this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CLOSED, null, id);
         else
-            this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CLOSED, null, id+"_"+username);
+            this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CLOSED, null, id
+                    + "_" + username);
         closeDerived(networkup);
     }
 
@@ -913,7 +915,8 @@ class Connector
                 Connector.this.pcs.firePropertyChange(Gateway.PROP_SESSION_CREATED, null, client.getSessionId());
                 final Connector c = new Connector(context.copy(), client,
                         userSession, unsecureClient == null, userName, logger);
-                for(PropertyChangeListener l : Connector.this.pcs.getPropertyChangeListeners())
+                for (PropertyChangeListener l : Connector.this.pcs
+                        .getPropertyChangeListeners())
                     c.addPropertyChangeListener(l);
                 Connector.this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId()+"_"+userName);
                 logger.debug(this, "Created derived connector: " + userName);

--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -912,7 +912,7 @@ class Connector
                         .getUuid().getValue(), session.getUuid().getValue());
                 Connector.this.pcs.firePropertyChange(Gateway.PROP_SESSION_CREATED, null, client.getSessionId());
                 final Connector c = new Connector(context.copy(), client,
-                        userSession, unsecureClient == null, username, logger);
+                        userSession, unsecureClient == null, userName, logger);
                 for(PropertyChangeListener l : Connector.this.pcs.getPropertyChangeListeners())
                     c.addPropertyChangeListener(l);
                 Connector.this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId()+"_"+userName);

--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -184,7 +184,8 @@ class Connector
      * @param context The context hosting information about the user.
      * @param secureClient The entry point to server.
      * @param entryEncrypted The entry point to access the various services.
-     * @param encrypted The entry point to access the various services.
+     * @param encrypted Pass <code>false</code> to use an unencrypted connection
+     *                  for data transfers
      * @param logger Reference to the logger.
      * @param elapseTime The time between network check.
      * @throws Exception Thrown if entry points cannot be initialized.
@@ -203,7 +204,8 @@ class Connector
      * @param context The context hosting information about the user.
      * @param secureClient The entry point to server.
      * @param entryEncrypted The entry point to access the various services.
-     * @param encrypted The entry point to access the various services.
+     * @param encrypted Pass <code>false</code> to use an unencrypted connection
+     *                  for data transfers
      * @param username The username if this is a derived connector
      * @param logger Reference to the logger.
      * @param elapseTime The time between network check.

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -1019,7 +1019,8 @@ public class Gateway {
                 ctx.setServerInformation(cred.getServer());
                 connector = new Connector(ctx, client, entryEncrypted,
                         cred.isEncryption(), log);
-                for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                for (PropertyChangeListener l : this.pcs
+                        .getPropertyChangeListeners())
                     connector.addPropertyChangeListener(l);
                 this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId());
                 groupConnectorMap.put(ctx.getGroupID(), connector);
@@ -1032,7 +1033,8 @@ public class Gateway {
                     ctx.setCompression(cred.getCompression());
                     connector = new Connector(ctx, client, entryEncrypted,
                             cred.isEncryption(), log);
-                    for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                    for (PropertyChangeListener l : this.pcs
+                            .getPropertyChangeListeners())
                         connector.addPropertyChangeListener(l);
                     exp = getUserDetails(ctx, userName);
                     groupConnectorMap.put(ctx.getGroupID(), connector);
@@ -1470,7 +1472,8 @@ public class Gateway {
                         false));
             
             c = new Connector(ctx, client, prx, login.isEncryption(), log);
-            for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+            for (PropertyChangeListener l : this.pcs
+                    .getPropertyChangeListeners())
                 c.addPropertyChangeListener(l);
             this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId());
             groupConnectorMap.put(ctx.getGroupID(), c);

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -67,7 +67,6 @@ import omero.gateway.cache.CacheService;
 import omero.gateway.exception.ConnectionStatus;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.facility.Facility;
-import omero.gateway.util.GatewayMonitor;
 import omero.gateway.util.NetworkChecker;
 import omero.grid.ProcessCallbackI;
 import omero.grid.ScriptProcessPrx;

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -20,6 +20,8 @@
  */
 package omero.gateway;
 
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,6 +67,7 @@ import omero.gateway.cache.CacheService;
 import omero.gateway.exception.ConnectionStatus;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.facility.Facility;
+import omero.gateway.util.GatewayMonitor;
 import omero.gateway.util.NetworkChecker;
 import omero.grid.ProcessCallbackI;
 import omero.grid.ScriptProcessPrx;
@@ -89,7 +92,43 @@ import com.google.common.collect.Multimaps;
  */
 
 public class Gateway {
-
+    
+    /** Property to indicate that a {@link Connector} has been created */
+    public static final String PROP_CONNECTOR_CREATED = "PROP_CONNECTOR_CREATED";
+    
+    /** Property to indicate that a {@link Connector} has been closed */
+    public static final String PROP_CONNECTOR_CLOSED = "PROP_CONNECTOR_CLOSED";
+    
+    /** Property to indicate that a session has been created */
+    public static final String PROP_SESSION_CREATED = "PROP_SESSION_CREATED";
+    
+    /** Property to indicate that a session has been closed */
+    public static final String PROP_SESSION_CLOSED = "PROP_SESSION_CLOSED";
+    
+    /** Property to indicate that a {@link Facility} has been created */
+    public static final String PROP_FACILITY_CREATED = "PROP_FACILITY_CREATED";
+    
+    /** Property to indicate that an import store has been created */
+    public static final String PROP_IMPORTSTORE_CREATED = "PROP_IMPORTSTORE_CREATED";
+    
+    /** Property to indicate that an import store has been closed */
+    public static final String PROP_IMPORTSTORE_CLOSED = "PROP_IMPORTSTORE_CLOSED";
+    
+    /** Property to indicate that a rendering engine has been created */
+    public static final String PROP_RENDERINGENGINE_CREATED = "PROP_RENDERINGENGINE_CREATED";
+    
+    /** Property to indicate that a rendering engine has been closed */
+    public static final String PROP_RENDERINGENGINE_CLOSED = "PROP_RENDERINGENGINE_CLOSED";
+    
+    /** Property to indicate that a stateful service has been created */
+    public static final String PROP_STATEFUL_SERVICE_CREATED = "PROP_SERVICE_CREATED";
+    
+    /** Property to indicate that a stateful service has been closed */
+    public static final String PROP_STATEFUL_SERVICE_CLOSED = "PROP_SERVICE_CLOSED";
+    
+    /** Property to indicate that a stateless service has been created */
+    public static final String PROP_STATELESS_SERVICE_CREATED = "PROP_STATELESS_SERVICE_CREATED";
+    
     /** Reference to a {@link Logger} */
     private Logger log;
 
@@ -119,6 +158,9 @@ public class Gateway {
     /** Optional reference to a {@link CacheService} */
     private CacheService cacheService;
 
+    /** The PropertyChangeSupport */
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    
     /**
      * Creates a new Gateway instance
      * @param log A {@link Logger}
@@ -308,13 +350,40 @@ public class Gateway {
     // General public methods
 
     /**
+     * Adds a {@link PropertyChangeListener}
+     * @param listener The listener
+     */
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * Removes a {@link PropertyChangeListener}
+     * @param listener The listener
+     */
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.removePropertyChangeListener(listener);
+    }
+    
+    /**
+     * Get the {@link PropertyChangeListener}s
+     * @return See above
+     */
+    public PropertyChangeListener[] getPropertyChangeListeners() {
+        return this.pcs.getPropertyChangeListeners();
+    }
+    
+    /**
      * Executes the commands.
-     *
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
      * @param commands
      *            The commands to execute.
      * @param target
      *            The target context is any.
      * @return See above.
+     * @throws Throwable 
      */
     public CmdCallbackI submit(SecurityContext ctx, List<Request> commands,
             SecurityContext target) throws Throwable {
@@ -417,7 +486,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public SharedResourcesPrx getSharedResources(SecurityContext ctx)
@@ -434,7 +503,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IRenderingSettingsPrx getRenderingSettingsService(SecurityContext ctx)
@@ -451,7 +520,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IRepositoryInfoPrx getRepositoryService(SecurityContext ctx)
@@ -468,7 +537,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IScriptPrx getScriptService(SecurityContext ctx)
@@ -485,7 +554,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IContainerPrx getPojosService(SecurityContext ctx)
@@ -502,7 +571,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IQueryPrx getQueryService(SecurityContext ctx)
@@ -519,7 +588,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IUpdatePrx getUpdateService(SecurityContext ctx)
@@ -532,8 +601,9 @@ public class Gateway {
      * 
      * @param ctx
      *            The {@link SecurityContext}
+     * @param userName The username
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IUpdatePrx getUpdateService(SecurityContext ctx, String userName)
@@ -558,7 +628,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IMetadataPrx getMetadataService(SecurityContext ctx)
@@ -575,7 +645,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IRoiPrx getROIService(SecurityContext ctx)
@@ -592,7 +662,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IConfigPrx getConfigService(SecurityContext ctx)
@@ -609,7 +679,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public ThumbnailStorePrx getThumbnailService(SecurityContext ctx)
@@ -626,7 +696,8 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws @throws Throwable Thrown if the service cannot be initialized.
+     * @throws DSOutOfServiceException 
+     *          Thrown if the service cannot be initialized.
      */
     public ExporterPrx getExporterService(SecurityContext ctx)
             throws DSOutOfServiceException {
@@ -642,7 +713,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws @throws Throwable Thrown if the service cannot be initialized.
+     * @throws DSOutOfServiceException Thrown if the service cannot be initialized.
      */
     public RawFileStorePrx getRawFileService(SecurityContext ctx)
             throws DSOutOfServiceException {
@@ -658,7 +729,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public RawPixelsStorePrx getPixelsStore(SecurityContext ctx)
@@ -675,7 +746,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IPixelsPrx getPixelsService(SecurityContext ctx)
@@ -692,7 +763,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public SearchPrx getSearchService(SecurityContext ctx)
@@ -709,7 +780,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IProjectionPrx getProjectionService(SecurityContext ctx)
@@ -726,7 +797,7 @@ public class Gateway {
      * @param ctx
      *            The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IAdminPrx getAdminService(SecurityContext ctx)
@@ -746,7 +817,7 @@ public class Gateway {
      *            Pass <code>true</code> to have a secure admin service,
      *            <code>false</code> otherwise.
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public IAdminPrx getAdminService(SecurityContext ctx, boolean secure)
@@ -759,9 +830,9 @@ public class Gateway {
 
     /**
      * Creates or recycles the import store.
-     * 
+     * @param ctx The {@link SecurityContext}
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public OMEROMetadataStoreClient getImportStore(SecurityContext ctx)
@@ -771,9 +842,10 @@ public class Gateway {
 
     /**
      * Creates or recycles the import store.
-     * 
+     * @param ctx The {@link SecurityContext}
+     * @param userName The username
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
      *             Thrown if the service cannot be initialized.
      */
     public OMEROMetadataStoreClient getImportStore(SecurityContext ctx,
@@ -794,9 +866,12 @@ public class Gateway {
 
     /**
      * Returns the {@link RenderingEnginePrx Rendering service}.
-     * 
+     * @param ctx  The {@link SecurityContext}
+     * @param pixelsID The pixels ID
      * @return See above.
-     * @throws Throwable
+     * @throws DSOutOfServiceException
+     *             Thrown if the service cannot be initialized.
+     * @throws ServerError 
      *             Thrown if the service cannot be initialized.
      */
     public RenderingEnginePrx getRenderingService(SecurityContext ctx,
@@ -847,17 +922,21 @@ public class Gateway {
             secureClient.setAgent(c.getApplicationName());
             ServiceFactoryPrx entryEncrypted;
             boolean session = true;
+            ServiceFactoryPrx guestSession = null;
             try {
                 // Check if it is a session first
-                ServiceFactoryPrx guestSession = secureClient.createSession(
+                guestSession = secureClient.createSession(
                         "guest", "guest");
+                this.pcs.firePropertyChange(PROP_SESSION_CREATED, null, secureClient.getSessionId());
                 guestSession.getSessionService().getSession(
                         c.getUser().getUsername());
             } catch (Exception e) {
                 // thrown if it is not a session or session has experied.
                 session = false;
             } finally {
+                String id = secureClient.getSessionId();
                 secureClient.closeSession();
+                this.pcs.firePropertyChange(PROP_SESSION_CLOSED, null, id);
             }
             if (session) {
                 entryEncrypted = secureClient.joinSession(c.getUser()
@@ -866,6 +945,7 @@ public class Gateway {
                 entryEncrypted = secureClient.createSession(c.getUser()
                         .getUsername(), c.getUser().getPassword());
             }
+            this.pcs.firePropertyChange(PROP_SESSION_CREATED, null, secureClient.getSessionId());
             serverVersion = entryEncrypted.getConfigService().getVersion();
 
             if (c.isCheckNetwork()) {
@@ -939,6 +1019,9 @@ public class Gateway {
                 ctx.setServerInformation(cred.getServer());
                 connector = new Connector(ctx, client, entryEncrypted,
                         cred.isEncryption(), log);
+                for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                    connector.addPropertyChangeListener(l);
+                this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId());
                 groupConnectorMap.put(ctx.getGroupID(), connector);
                 if (defaultID == cred.getGroupID())
                     return exp;
@@ -949,6 +1032,8 @@ public class Gateway {
                     ctx.setCompression(cred.getCompression());
                     connector = new Connector(ctx, client, entryEncrypted,
                             cred.isEncryption(), log);
+                    for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                        connector.addPropertyChangeListener(l);
                     exp = getUserDetails(ctx, userName);
                     groupConnectorMap.put(ctx.getGroupID(), connector);
                 } catch (Exception e) {
@@ -965,6 +1050,9 @@ public class Gateway {
             ctx.setCompression(cred.getCompression());
             connector = new Connector(ctx, client, entryEncrypted,
                     cred.isEncryption(), log);
+            for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                connector.addPropertyChangeListener(l);
+            this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId());
             groupConnectorMap.put(ctx.getGroupID(), connector);
             return exp;
         } catch (Throwable e) {
@@ -1070,6 +1158,7 @@ public class Gateway {
      * @param useCachedValue
      *            Uses the result of the last check instead of really performing
      *            the test if the last check is not older than 5 sec
+     * @return See above
      * @throws Exception
      */
     public boolean isNetworkUp(boolean useCachedValue) {
@@ -1221,6 +1310,7 @@ public class Gateway {
      *            whether or not to throw a {@link DSOutOfServiceException} if
      *            no {@link Connector} is available by the end of the execution.
      * @return See above.
+     * @throws DSOutOfServiceException 
      */
     public Connector getConnector(SecurityContext ctx, boolean recreate,
             boolean permitNull) throws DSOutOfServiceException {
@@ -1380,6 +1470,9 @@ public class Gateway {
                         false));
             
             c = new Connector(ctx, client, prx, login.isEncryption(), log);
+            for(PropertyChangeListener l : this.pcs.getPropertyChangeListeners())
+                c.addPropertyChangeListener(l);
+            this.pcs.firePropertyChange(Gateway.PROP_CONNECTOR_CREATED, null, client.getSessionId());
             groupConnectorMap.put(ctx.getGroupID(), c);
         } catch (Throwable e) {
             if (!permitNull) {

--- a/components/blitz/src/omero/gateway/SecurityContext.java
+++ b/components/blitz/src/omero/gateway/SecurityContext.java
@@ -113,18 +113,33 @@ public class SecurityContext {
         return groupID;
     }
 
+    /**
+     * @return The {@link ServerInformation} 
+     */
     public ServerInformation getServerInformation() {
         return serverInformation;
     }
 
+    /**
+     * Sets the {@link ServerInformation} 
+     * @param serverInformation The {@link ServerInformation} 
+     */
     public void setServerInformation(ServerInformation serverInformation) {
         this.serverInformation = serverInformation;
     }
 
+    /**
+     * Get the compression level
+     * @return See above.
+     */
     public float getCompression() {
         return compression;
     }
 
+    /**
+     * Set the compression level
+     * @param compression
+     */
     public void setCompression(float compression) {
         this.compression = compression;
     }

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -201,6 +201,7 @@ public class BrowseFacility extends Facility {
      *            The type of object to retrieve.
      * @param id
      *            The object's id.
+     * @param allGroups Pass <code>true</code> to look for all groups
      * @return The last version of the object.
      * @throws DSOutOfServiceException
      *             If the connection is broken, or logged in
@@ -1007,6 +1008,7 @@ public class BrowseFacility extends Facility {
      *            The {@link SecurityContext}
      * @param ownerId
      *            The id of the user
+     * @param ids The image ids
      * @return A collection of {@link ImageData}s
      */
     public Collection<ImageData> getImages(SecurityContext ctx, long ownerId,

--- a/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
+++ b/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
@@ -78,6 +78,7 @@ public class DataManagerFacility extends Facility {
      *            The security context.
      * @param object
      *            The object to delete.
+     * @return The {@link Response} handle
      * @throws DSOutOfServiceException
      *             If the connection is broken, or logged in
      * @throws DSAccessException
@@ -96,6 +97,7 @@ public class DataManagerFacility extends Facility {
      *            The security context.
      * @param objects
      *            The objects to delete.
+     * @return The {@link Response} handle
      * @throws DSOutOfServiceException
      *             If the connection is broken, or logged in
      * @throws DSAccessException
@@ -313,6 +315,7 @@ public class DataManagerFacility extends Facility {
      *            The objects to update.
      * @param options
      *            Options to update the data.
+     * @param userName The username
      * @return The updated object.
      * @throws DSOutOfServiceException
      *             If the connection is broken, or logged in

--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -102,9 +102,11 @@ public abstract class Facility {
                         "Created new " + type.getSimpleName());
                 Facility facility = type.getDeclaredConstructor(Gateway.class).newInstance(
                         gateway);
-                for(PropertyChangeListener l : gateway.getPropertyChangeListeners()) {
+                for (PropertyChangeListener l : gateway
+                        .getPropertyChangeListeners()) {
                     facility.addPropertyChangeListener(l);
-                    facility.pcs.firePropertyChange(Gateway.PROP_FACILITY_CREATED, null, type.getName());
+                    facility.pcs.firePropertyChange(
+                            Gateway.PROP_FACILITY_CREATED, null, type.getName());
                 }
                 return facility;
             }

--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -335,12 +335,9 @@ public class ROIFacility extends Facility {
             Map<ROICoordinate, ShapeData> clientCoordMap;
             Roi serverRoi;
             Iterator<List<ShapeData>> shapeIterator;
-            Iterator<ROICoordinate> serverIterator;
             Map<ROICoordinate, Shape>serverCoordMap;
             Shape s;
             ROICoordinate coord;
-            long id;
-            RoiResult tempResults;
             int shapeIndex;
 
             Collection<ROIData> updated = new ArrayList<ROIData>();
@@ -399,7 +396,6 @@ public class ROIFacility extends Facility {
                 Iterator si = serverCoordMap.entrySet().iterator();
                 Entry entry;
                 List<ROICoordinate> removed = new ArrayList<ROICoordinate>();
-                List<IObject> toDelete = new ArrayList<IObject>();
                 while (si.hasNext()) {
                     entry = (Entry) si.next();
                     coord = (ROICoordinate) entry.getKey();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -612,7 +612,7 @@ public class DataServicesFactory
         try {
             // Load the omero client properties from the server
             List agents = (List) registry.lookup(LookupNames.AGENTS);
-            Map<String, String> props = omeroGateway.getOmeroClientProperties();
+            Map<String, String> props = omeroGateway.getOmeroClientProperties(exp.getGroupId());
             for (String key : props.keySet()) {
                 if (registry.lookup(key) == null)
                     registry.bind(key, props.get(key));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/GatewayMonitor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/GatewayMonitor.java
@@ -1,0 +1,25 @@
+package org.openmicroscopy.shoola.env.data;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import omero.gateway.Gateway;
+
+/**
+ * A simple {@link PropertyChangeListener} to monitor what happens in
+ * the {@link Gateway}
+ */
+public class GatewayMonitor implements PropertyChangeListener {
+
+    /** Simple format to display timestamps */
+    private static final DateFormat df = new SimpleDateFormat("hh:mm ss.SSS");
+    
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        System.out.println(df.format(new Date())+" - "+evt);
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/GatewayMonitor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/GatewayMonitor.java
@@ -1,3 +1,24 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
 package org.openmicroscopy.shoola.env.data;
 
 import java.beans.PropertyChangeEvent;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1442,16 +1442,16 @@ class OMEROGateway
 	
     /**
      * Get the omero client properties from the server
-     * 
+     * @param The groupId for the {@link SecurityContext}
      * @return See above.
      * @throws DSAccessException
      * @throws DSOutOfServiceException
      */
-    Map<String, String> getOmeroClientProperties()
+    Map<String, String> getOmeroClientProperties(long groupId)
             throws DSOutOfServiceException, DSAccessException {
         if (isConnected()) {
             try {
-                return gw.getConfigService(new SecurityContext(-1)).getClientConfigValues();
+                return gw.getConfigService(new SecurityContext(groupId)).getClientConfigValues();
             } catch (Exception e) {
                 handleException(e, "Cannot access config service. ");
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -338,12 +338,7 @@ class OmeroDataServiceImpl
 			if (links.size() > 0)
 				gateway.createObjects(ctx, links);
 		}
-		try {
-			gateway.shutDownDerivedConnector(ctx);
-		} catch (Exception e) {
-			context.getLogger().info(this, "Cannot shut down the connectors.");
-		}
-
+		
 		return PojoMapper.asDataObject(created);
 	}
 


### PR DESCRIPTION
Fixes [Ticket 12929](https://trac.openmicroscopy.org/ome/ticket/12929)
Problem: After an object has been saved the connector was shutdown. This could lead to an abortion of a parallel running import job. This PR removes the connector shutdown, because it's actually not necessary at that point anyway.

**Test**:
Follow the workflow which previously triggered this bug, which is:
- Log in as a group owner or administrator
- *Start*  (not just add to the queue) a long running import job for another user
- Now start another import for the user you're logged in with, but import into a particular dataset which you have to create first on the import dialog (this caused the crash)
- Make sure the imports are passing like expected.

Note: The actual bugfix is just commit 979098b . The first commits add PropertyChangeSupport to the Gateway, i. e. one can add a PropertyChangeListener to the Gateway for debugging purposes, which makes it much easier to monitor what's going on in the Gateway. Any objections on this?

/cc @jburel 