### PR TITLE
5.2.0 history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -9,7 +9,7 @@ A full, production-ready release of OMERO 5.2.0; dropping support for Java
 and introducing new user features and many fixes and performance improvements:
 
 -  improved support for many file formats via Bio-Formats
--  faster import
+-  faster import for images with a large number of ROIs
 -  performance improvements for OMERO.web including faster data tree loading
 -  Java Web Start has been dropped, it is no longer possible to launch the
    desktop clients from the web

--- a/history.txt
+++ b/history.txt
@@ -13,23 +13,24 @@ and introducing new user features and many fixes and performance improvements:
 -  performance improvements for OMERO.web including faster data tree loading
 -  Java Web Start has been dropped, it is no longer possible to launch the
    desktop clients from the web
-  re-worked display of metadata and annotations in both UI clients
+-  re-worked display of metadata and annotations in both UI clients
 -  many bugs fixed
 
 Developer updates include:
 
-- the OMERO web framework no longer bundles a copy of the Django package, this 
+- the OMERO web framework no longer bundles a copy of the Django package, this
   dependency must be installed manually
 - updated jstree to 3.08 and now using json for all tree loading to
   substantially improve performance
 - removed FastCGI support, OMERO.web can be deployed using WSGI
 - configuration property :property:`omero.graphs.wrap` which allowed
   switching back to the old server code for moving and deleting data has now
-  been removed. You must migrate to using the new graph request operations
+  been removed. You should migrate to using the new graph request operations
+  before 5.3 when the old request operations will be removed
 - introduced new Java Gateway to facilitate the development of Java
   applications
-- aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz
-  server API to work with ROIs will need to be updated
+- aligned OMERO Rect with OME-XML schema for ROI. Clients using the
+  OMERO.blitz server API to work with ROIs will need to be updated
 
 
 5.1.4 (September 2015)

--- a/history.txt
+++ b/history.txt
@@ -4,27 +4,30 @@ OMERO version history
 5.2.0 (November 2015)
 ----------------------
 
-A full, production-ready release of OMERO 5.2.0; dropping support for Java 1.6;
-major upgrading of OMERO.web; re-working of the Java Gateway;
+A full, production-ready release of OMERO 5.2.0; dropping support for Java
+1.6; featuring major upgrading of OMERO.web; re-working of the Java Gateway;
 and introducing new user features and many fixes and performance improvements:
 
 -  improved support for many file formats via Bio-Formats
--  speed up import
--  no longer possible to launch Desktop clients using Java Web Start
--  updated jstree to 3.08 and use json for all tree loading to substantially
-   improve performances
--  re-worked display of metadata and annotation in both UI clients
+-  faster import
+-  Java Web Start has been dropped, it is no longer possible to launch the
+   desktop clients from the web
+-  updated jstree to 3.08 and now using json for all tree loading to
+   substantially improve performance
+-  re-worked display of metadata and annotations in both UI clients
 -  many bugs fixed
 
 Developer updates include:
 
-- OMERO.web is no longer bundled with a copy of the Django package
+- the OMERO web framework no longer bundles a copy of the Django package, this 
+  dependency must be installed manually
 - removed FastCGI support, OMERO.web can be deployed using WSGI
-- removed property allowing to switch back to old server code to delete or move
-  data. You must migrate to using the new request operations
-- introduced new Java Gateway to facilitate the development of Java applications
-- aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz server API
-  to work with ROIs will need to be updated
+- removed property allowing switching back to old server code to delete or
+  move data. You must migrate to using the new request operations
+- introduced new Java Gateway to facilitate the development of Java
+  applications
+- aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz
+  server API to work with ROIs will need to be updated
 
 
 5.1.4 (September 2015)

--- a/history.txt
+++ b/history.txt
@@ -9,17 +9,19 @@ major upgrading of OMERO.web; re-working of the Java Gateway;
 and introducing new user features and many fixes and performance improvements:
 
 -  improved support for many file formats via Bio-Formats
+-  speed up import
 -  no longer possible to launch Desktop clients using Java Web Start
 -  updated jstree to 3.08 and use json for all tree loading to substantially
    improve performances
 -  re-worked display of metadata and annotation in both UI clients
+-  many bugs fixed
 
 Developer updates include:
 
 - OMERO.web is no longer bundled with a copy of the Django package
 - removed FastCGI support, OMERO.web can be deployed using WSGI
 - removed property allowing to switch back to old server code to delete or move
-  data. You must migrate to using the new request operations.
+  data. You must migrate to using the new request operations
 - introduced new Java Gateway to facilitate the development of Java applications
 - aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz server API
   to work with ROIs will need to be updated

--- a/history.txt
+++ b/history.txt
@@ -23,8 +23,9 @@ Developer updates include:
 - updated jstree to 3.08 and now using json for all tree loading to
   substantially improve performance
 - removed FastCGI support, OMERO.web can be deployed using WSGI
-- removed property allowing switching back to old server code to delete or
-  move data. You must migrate to using the new request operations
+- configuration property :property:`omero.graphs.wrap` which allowed
+  switching back to the old server code for moving and deleting data has now
+  been removed. You must migrate to using the new graph request operations
 - introduced new Java Gateway to facilitate the development of Java
   applications
 - aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,30 @@
 OMERO version history
 =====================
 
+5.2.0 (November 2015)
+----------------------
+
+A full, production-ready release of OMERO 5.2.0; dropping support for Java 1.6;
+major upgrading of OMERO.web; re-working of the Java Gateway;
+and introducing new user features and many fixes and performance improvements:
+
+-  improved support for many file formats via Bio-Formats
+-  no longer possible to launch Desktop clients using Java Web Start
+-  updated jstree to 3.08 and use json for all tree loading to substantially
+   improve performances
+-  re-worked display of metadata and annotation in both UI clients
+
+Developer updates include:
+
+- OMERO.web is no longer bundled with a copy of the Django package
+- removed FastCGI support, OMERO.web can be deployed using WSGI
+- removed property allowing to switch back to old server code to delete or move
+  data. You must migrate to using the new request operations.
+- introduced new Java Gateway to facilitate the development of Java applications
+- aligned OME-XML schema for ROI and OMERO. Clients using the OMERO.blitz server API
+  to work with ROIs will need to be updated
+
+
 5.1.4 (September 2015)
 ----------------------
 

--- a/history.txt
+++ b/history.txt
@@ -13,7 +13,7 @@ and introducing new user features and many fixes and performance improvements:
 -  performance improvements for OMERO.web including faster data tree loading
 -  Java Web Start has been dropped, it is no longer possible to launch the
    desktop clients from the web
--  re-worked display of metadata and annotations in both UI clients
+-  reworked display of metadata and annotations in both UI clients
 -  many bugs fixed
 
 Developer updates include:

--- a/history.txt
+++ b/history.txt
@@ -10,17 +10,18 @@ and introducing new user features and many fixes and performance improvements:
 
 -  improved support for many file formats via Bio-Formats
 -  faster import
+-  performance improvements for OMERO.web including faster data tree loading
 -  Java Web Start has been dropped, it is no longer possible to launch the
    desktop clients from the web
--  updated jstree to 3.08 and now using json for all tree loading to
-   substantially improve performance
--  re-worked display of metadata and annotations in both UI clients
+  re-worked display of metadata and annotations in both UI clients
 -  many bugs fixed
 
 Developer updates include:
 
 - the OMERO web framework no longer bundles a copy of the Django package, this 
   dependency must be installed manually
+- updated jstree to 3.08 and now using json for all tree loading to
+  substantially improve performance
 - removed FastCGI support, OMERO.web can be deployed using WSGI
 - removed property allowing switching back to old server code to delete or
   move data. You must migrate to using the new request operations


### PR DESCRIPTION
Adds the version history for the 5.2.0. Will be staged on https://www.openmicroscopy.org/site/support/omero5.2-staging/users/history.html once the builds have run