### PR TITLE
Refactor upgrade_check functionalities in the CLI admin plugin

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1161,7 +1161,7 @@ OMERO Diagnostics %s
 
         import logging
         logging.basicConfig()
-        check = self.run_upgrade_check("diagnostics", config)
+        check = self.run_upgrade_check(config, "diagnostics")
         if check.isUpgradeNeeded():
             self.ctx.out("")
 
@@ -1835,7 +1835,7 @@ OMERO Diagnostics %s
         2: an error occurred whilst checking
         """
 
-        uc = self.run_upgrade_check(CHECKUPGRADE_USERAGENT, config)
+        uc = self.run_upgrade_check(config, CHECKUPGRADE_USERAGENT)
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())
         if uc.isExceptionThrown():

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -35,8 +35,6 @@ from omero.cli import UserGroupControl
 from omero.plugins.prefs import \
     WriteableConfigControl, with_config, with_rw_config
 
-from omero.util.upgrade_check import UpgradeCheck
-
 from omero_ext import portalocker
 from omero_ext.which import whichall
 from omero_ext.argparse import FileType, SUPPRESS
@@ -1163,9 +1161,7 @@ OMERO Diagnostics %s
 
         import logging
         logging.basicConfig()
-        from omero.util.upgrade_check import UpgradeCheck
-        check = UpgradeCheck("diagnostics")
-        check.run()
+        check = self.run_upgrade_check("diagnostics", config)
         if check.isUpgradeNeeded():
             self.ctx.out("")
 
@@ -1839,13 +1835,7 @@ OMERO Diagnostics %s
         2: an error occurred whilst checking
         """
 
-        config = config.as_map()
-        upgrade_url = config.get("omero.upgrades.url", None)
-        if upgrade_url:
-            uc = UpgradeCheck(CHECKUPGRADE_USERAGENT, url=upgrade_url)
-        else:
-            uc = UpgradeCheck(CHECKUPGRADE_USERAGENT)
-        uc.run()
+        uc = self.run_upgrade_check(CHECKUPGRADE_USERAGENT, config)
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())
         if uc.isExceptionThrown():

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -103,6 +103,17 @@ class WriteableConfigControl(BaseControl):
         if not config.save_on_close:
             self.ctx.die(333, "Cannot modify %s" % config.filename)
 
+    def run_upgrade_check(self, config, agent):
+        from omero.util.upgrade_check import UpgradeCheck
+        properties = config.as_map()
+        upgrade_url = properties.get("omero.upgrades.url", None)
+        if upgrade_url:
+            uc = UpgradeCheck(agent, url=upgrade_url)
+        else:
+            uc = UpgradeCheck(agent)
+        uc.run()
+        return uc
+
 
 class PrefsControl(WriteableConfigControl):
 

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -24,6 +24,7 @@ from omero.cli import NonZeroReturnCode
 from omero.config import ConfigXml
 from omero.util import edit_path, get_omero_userdir
 from omero.util.decorators import wraps
+from omero.util.upgrade_check import UpgradeCheck
 from omero_ext import portalocker
 
 import omero.java
@@ -104,7 +105,6 @@ class WriteableConfigControl(BaseControl):
             self.ctx.die(333, "Cannot modify %s" % config.filename)
 
     def run_upgrade_check(self, config, agent):
-        from omero.util.upgrade_check import UpgradeCheck
         properties = config.as_map()
         upgrade_url = properties.get("omero.upgrades.url", None)
         if upgrade_url:

--- a/components/tools/OmeroPy/test/integration/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_admin.py
@@ -55,13 +55,13 @@ class TestAdmin(CLITest):
         self.cli.invoke(self.args, strict=True)
 
     def test_checkupgrade0(self, monkeypatch):
-        monkeypatch.setattr(omero.plugins.admin, "UpgradeCheck",
+        monkeypatch.setattr(omero.plugins.prefs, "UpgradeCheck",
                             createUpgradeCheckClass("999999999.0.0"))
         self.args.append("checkupgrade")
         self.go()
 
     def test_checkupgrade1(self, monkeypatch):
-        monkeypatch.setattr(omero.plugins.admin, "UpgradeCheck",
+        monkeypatch.setattr(omero.plugins.prefs, "UpgradeCheck",
                             createUpgradeCheckClass("0.0.0"))
         self.args.append("checkupgrade")
         with pytest.raises(NonZeroReturnCode) as exc:


### PR DESCRIPTION
This should allow both the diagnostics and the checkupgrade upgrade check call to share the same logic especially when retrieving the upgrade URL from the server configuration.

To test this PR, run `bin/omero admin diagnostics` and `bin/omero admin checkupgrade` from a server configured to use the staging registry URL and check both `OMERO.diagnostics` and `OMERO.test` agents are recorded in the staging registry DB.