### PR TITLE
Don't try to convert to referenceframe

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -1446,38 +1446,18 @@ class ImViewerUI
 	            }
 	            toolTipText = "";
 	            toolTipText += "Stage coordinates: ";
+	            DecimalFormat format = new DecimalFormat("0.##");
                 if (!notSet.contains(EditorUtil.POSITION_X)) {
-                    if (details.get(EditorUtil.POSITION_X) instanceof BigResult) {
-                        toolTipText += "x=N/A ";
-                        ImViewerAgent.logBigResultExeption(this,
-                                details.get(EditorUtil.POSITION_X),
-                                EditorUtil.POSITION_X);
-                    } else {
-                        toolTipText += "x="
-                                + details.get(EditorUtil.POSITION_X) + " ";
-                    }
+                    Length l = (Length) details.get(EditorUtil.POSITION_X);
+                    toolTipText += "x="+format.format(l.getValue())+" "+l.getSymbol();
                 }
                 if (!notSet.contains(EditorUtil.POSITION_Y)) {
-                    if (details.get(EditorUtil.POSITION_Y) instanceof BigResult) {
-                        toolTipText += "y=N/A ";
-                        ImViewerAgent.logBigResultExeption(this,
-                                details.get(EditorUtil.POSITION_Y),
-                                EditorUtil.POSITION_Y);
-                    } else {
-                        toolTipText += "y="
-                                + details.get(EditorUtil.POSITION_Y) + " ";
-                    }
+                    Length l = (Length) details.get(EditorUtil.POSITION_Y);
+                    toolTipText += "y="+format.format(l.getValue())+" "+l.getSymbol();
                 }
                 if (!notSet.contains(EditorUtil.POSITION_Z)) {
-                    if (details.get(EditorUtil.POSITION_Z) instanceof BigResult) {
-                        toolTipText += "z=N/A ";
-                        ImViewerAgent.logBigResultExeption(this,
-                                details.get(EditorUtil.POSITION_Z),
-                                EditorUtil.POSITION_Z);
-                    } else {
-                        toolTipText += "z="
-                                + details.get(EditorUtil.POSITION_Z);
-                    }
+                    Length l = (Length) details.get(EditorUtil.POSITION_Z);
+                    toolTipText += "z="+format.format(l.getValue())+" "+l.getSymbol();
                 }
 	            tips.add(toolTipText);
 	            comp.setToolTipText(UIUtilities.formatToolTipText(tips));

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImageAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImageAcquisitionComponent.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
+
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -37,10 +38,12 @@ import javax.swing.JPanel;
 
 import org.openmicroscopy.shoola.agents.util.DataComponent;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.JLabelButton;
 import org.openmicroscopy.shoola.util.ui.NumericalTextField;
 import org.openmicroscopy.shoola.util.ui.OMETextArea;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import ome.formats.model.UnitsFactory;
 import omero.model.Length;
 import omero.model.LengthI;
@@ -180,7 +183,7 @@ class ImageAcquisitionComponent
             label.setBackground(UIUtilities.BACKGROUND_COLOR);
             if (value instanceof String) {
             	area = UIUtilities.createComponent(OMETextArea.class, null);
-                if (value == null || value.equals("")) {
+                if (CommonsLangUtils.isBlank((String)value)) {
                 	value = AnnotationUI.DEFAULT_TEXT;
                 	set = false;
                 }
@@ -189,12 +192,15 @@ class ImageAcquisitionComponent
             } else if (value instanceof Length) {
                 Length l = (Length) value;
                 area = UIUtilities.createComponent(OMETextArea.class, null);
-                if (value == null || value.equals("")) {
+                if (value == null) {
                     value = AnnotationUI.DEFAULT_TEXT;
                     set = false;
+                    ((OMETextArea) area).setText((String) value);
                 }
-                DecimalFormat df = new DecimalFormat("0.##");
-                ((OMETextArea) area).setText(df.format(l.getValue())+" "+l.getSymbol());
+                else {
+                    DecimalFormat df = new DecimalFormat("0.##");
+                    ((OMETextArea) area).setText(df.format(l.getValue())+" "+l.getSymbol());
+                }
                 ((OMETextArea) area).setEditedColor(UIUtilities.EDITED_COLOR);
             } else {
             	area = UIUtilities.createComponent(NumericalTextField.class, 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImageAcquisitionComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ImageAcquisitionComponent.java
@@ -23,6 +23,7 @@ package org.openmicroscopy.shoola.agents.metadata.editor;
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.text.DecimalFormat;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.openmicroscopy.shoola.util.ui.NumericalTextField;
 import org.openmicroscopy.shoola.util.ui.OMETextArea;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import ome.formats.model.UnitsFactory;
+import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.PressureI;
 import omero.model.TemperatureI;
@@ -184,6 +186,16 @@ class ImageAcquisitionComponent
                 }
                 ((OMETextArea) area).setText((String) value);
            	 	((OMETextArea) area).setEditedColor(UIUtilities.EDITED_COLOR);
+            } else if (value instanceof Length) {
+                Length l = (Length) value;
+                area = UIUtilities.createComponent(OMETextArea.class, null);
+                if (value == null || value.equals("")) {
+                    value = AnnotationUI.DEFAULT_TEXT;
+                    set = false;
+                }
+                DecimalFormat df = new DecimalFormat("0.##");
+                ((OMETextArea) area).setText(df.format(l.getValue())+" "+l.getSymbol());
+                ((OMETextArea) area).setEditedColor(UIUtilities.EDITED_COLOR);
             } else {
             	area = UIUtilities.createComponent(NumericalTextField.class, 
             			null);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1663,40 +1663,27 @@ public class EditorUtil
         if (CommonsLangUtils.isBlank(s))
             notSet.add(NAME);
         details.put(NAME, s);
-        Length p;
-        double f;
+        
         try {
-            p = data.getPositionX(UnitsLength.REFERENCEFRAME);
-            f = 0;
-            if (p == null) {
+            Length l = data.getPositionX(null);
+            if (l == null)
                 notSet.add(POSITION_X);
-            } else
-                f = p.getValue();
-            details.put(POSITION_X, NF.format(f));
-        } catch (BigResult e) {
-            details.put(POSITION_X, e);
-        }
-
-        try {
-            p = data.getPositionY(UnitsLength.REFERENCEFRAME);
-            f = 0;
-            if (p == null) {
+            else
+                details.put(POSITION_X, l);
+            
+            l = data.getPositionY(null);
+            if (l == null)
                 notSet.add(POSITION_Y);
-            } else f = p.getValue();
-            details.put(POSITION_Y, NF.format(f));
-        } catch (BigResult e) {
-            details.put(POSITION_Y, e);
-        }
-       
-        try {
-            p = data.getPositionZ(UnitsLength.REFERENCEFRAME);
-            f = 0;
-            if (p == null) {
+            else
+                details.put(POSITION_Y, l);
+            
+            l = data.getPositionZ(null);
+            if (l == null)
                 notSet.add(POSITION_Z);
-            } else f = p.getValue();
-            details.put(POSITION_Z, NF.format(f));
-        } catch (BigResult e) {
-            details.put(POSITION_Z, e);
+            else
+                details.put(POSITION_Z, l);
+        } catch (BigResult e1) {
+            // can't be thrown when called with null argument
         }
 
         details.put(NOT_SET, notSet);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -1647,9 +1647,9 @@ public class EditorUtil
         details = new LinkedHashMap<String, Object>(4);
         List<String> notSet = new ArrayList<String>();
         details.put(NAME, "");
-        details.put(POSITION_X, Double.valueOf(0));
-        details.put(POSITION_Y, Double.valueOf(0));
-        details.put(POSITION_Z, Double.valueOf(0));
+        details.put(POSITION_X, new LengthI(0, UnitsLength.REFERENCEFRAME));
+        details.put(POSITION_Y, new LengthI(0, UnitsLength.REFERENCEFRAME));
+        details.put(POSITION_Z, new LengthI(0, UnitsLength.REFERENCEFRAME));
 
         if (data == null) {
             notSet.add(NAME);
@@ -2266,9 +2266,9 @@ public class EditorUtil
         details = new LinkedHashMap<String, Object>(4);
         details.put(DELTA_T, Double.valueOf(0));
         details.put(EXPOSURE_TIME, Double.valueOf(0));
-        details.put(POSITION_X, Double.valueOf(0));
-        details.put(POSITION_Y, Double.valueOf(0));
-        details.put(POSITION_Z, Double.valueOf(0));
+        details.put(POSITION_X, new LengthI(0, UnitsLength.REFERENCEFRAME));
+        details.put(POSITION_Y, new LengthI(0, UnitsLength.REFERENCEFRAME));
+        details.put(POSITION_Z, new LengthI(0, UnitsLength.REFERENCEFRAME));
         final List<String> notSet = new ArrayList<String>(5);
         notSet.add(DELTA_T);
         notSet.add(EXPOSURE_TIME);
@@ -2299,17 +2299,17 @@ public class EditorUtil
             Length o = plane.getPositionX();
             if (o != null) {
                 notSet.remove(POSITION_X);
-                details.put(POSITION_X, NF.format(o.getValue()));
+                details.put(POSITION_X, o);
             }
             o = plane.getPositionY();
             if (o != null) {
                 notSet.remove(POSITION_Y);
-                details.put(POSITION_Y, NF.format(o.getValue()));
+                details.put(POSITION_Y, o);
             }
             o = plane.getPositionZ();
             if (o != null) {
                 notSet.remove(POSITION_Z);
-                details.put(POSITION_Z, NF.format(o.getValue()));
+                details.put(POSITION_Z, o);
             }
         }
         return details;


### PR DESCRIPTION
Don't try to convert the unit for image acquisition position to reference frame, just display as it is.
Fixes [Ticket 13097](https://trac.openmicroscopy.org/ome/ticket/13097)

Test:
Display image acquisition metadata for an image which does not use reference frame as unit, e. g. eel, user-5,image id 26061 (or the images from the bug report, eel, user-5/read-write-1, Dataset name 16890)

