### PR TITLE
SPW deselection in tree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -102,10 +102,9 @@
             var syncTreeSelection = function(selected, idx, perms) {
                 // De-select 'Run' from tree, silent 'true' so we don't trigger clear of centre panel
                 var datatree = $.jstree.reference('#dataTree');
-                datatree.deselect_all(true);
-                // Update the buttons in the jstree
+                // Update the buttons in the jstree as if nothing selected.
                 if (buttonsShowHide) {
-                    buttonsShowHide(datatree.get_selected(true), datatree);
+                    buttonsShowHide([], datatree);
                 }
                 // Calls to ome.webclient.actions.js
                 OME.well_selection_changed(selected, idx, perms);


### PR DESCRIPTION
Fixes https://trello.com/c/eyNU6sWg/25-critical-loss-of-hierarchy-selection

To test:
 - Find / create a Plate with a Run and a Plate without Run (E.g. from Dataset to Plate script).
 - Browse in tree, then select a Well by clicking.
 - Parent Run / Plate should remain selected in tree, while right panel should show the selected well.
 - Try selecting multiple wells by dragging or shift-click. Should get same result.
 - In both cases, toolbar buttons in the tree should get disabled (except those for creating top-level P/D/S).
 - Clicking parent in the tree should re-enable toolbar buttons as before, and show parent in right panel again.