### PR TITLE
Use warnings.simplefilter("always") to catch deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-nginx.txt; fi
     - export PATH=$PATH:$HOME/.local/bin
     - scc travis-merge
-    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
+    - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 
 # retries the build due to:

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -428,7 +428,7 @@ class ConfigXml(object):
         default = self.default()
         props = self.properties(default)
         to_remove = []
-        for p in props.getchildren():
+        for p in props:
             if p.get("name") == key:
                 to_remove.append(p)
         for x in to_remove:

--- a/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sessions.py
@@ -22,6 +22,7 @@
 from omero.cli import CLI
 from omero.plugins.sessions import SessionsControl
 import pytest
+import warnings
 
 
 class TestSessions(object):
@@ -94,6 +95,7 @@ class TestSessions(object):
             setattr(args, session_args, tmpdir / session_args)
 
         if environment.get('OMERO_SESSION_DIR') or session_args:
+            warnings.simplefilter("always")
             pytest.deprecated_call(self.cli.controls['sessions'].store, args)
 
         store = self.cli.controls['sessions'].store(args)

--- a/components/tools/OmeroPy/test/unit/test_util.py
+++ b/components/tools/OmeroPy/test/unit/test_util.py
@@ -25,6 +25,7 @@ Test of various things under omero.util
 """
 
 import pytest
+import warnings
 from path import path
 
 from omero.util.text import CSVStyle, PlainStyle, TableBuilder
@@ -183,6 +184,7 @@ class TestTempFileManager(object):
                 monkeypatch.delenv(var, raising=False)
 
         if environment.get('OMERO_TEMPDIR'):
+            warnings.simplefilter("always")
             pytest.deprecated_call(manager.tmpdir)
 
         if environment.get('OMERO_TMPDIR'):


### PR DESCRIPTION
Also remove cap on pytest version on the develop branch.

This should allow us to track the latest pytest releases. Additionally this PR can be rebased onto `metadata` to fix the OMERO-unit failures.