### PR TITLE
Metadata panel followup 1

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -425,6 +425,7 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
     @Override
     void onRelatedNodesSet() {
         addButton.setEnabled(model.canAddAnnotationLink());
+        refreshUI();
     }
     
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -538,11 +538,7 @@ class EditorControl
 	public void propertyChange(PropertyChangeEvent evt)
 	{
 		String name = evt.getPropertyName();
-		if (SAVE_PROPERTY.equals(name) || 
-				DataComponent.DATA_MODIFIED_PROPERTY.equals(name) ||
-				PreviewPanel.PREVIEW_EDITED_PROPERTY.equals(name)) {
-			view.setDataToSave(view.hasDataToSave());
-		} else if (MetadataViewer.SAVE_DATA_PROPERTY.equals(name)) {
+		if (MetadataViewer.SAVE_DATA_PROPERTY.equals(name)) {
 			Boolean b = (Boolean) evt.getNewValue();
 			view.saveData(b.booleanValue());
 		} else if (MetadataViewer.CLEAR_SAVE_DATA_PROPERTY.equals(name) ||

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2548,8 +2548,46 @@ class EditorModel
 	Collection<TextualAnnotationData> getTextualAnnotations()
 	{
 		StructuredDataResults data = parent.getStructuredData();
-		if (data == null) return null;
+		if (data == null) 
+		    return null;
+		
 		return data.getTextualAnnotations();
+	}
+	
+	/**
+	 * Get the comments of all selected objects
+	 * @return See above
+	 */
+	Collection<TextualAnnotationData> getAllTextualAnnotations() {
+	    Map<DataObject, StructuredDataResults> 
+        r = parent.getAllStructuredData();
+        if (r == null) 
+            return new ArrayList<TextualAnnotationData>();
+        
+        Entry<DataObject, StructuredDataResults> e;
+        Iterator<Entry<DataObject, StructuredDataResults>>
+        i = r.entrySet().iterator();
+
+        Collection<TextualAnnotationData> others;
+        List<TextualAnnotationData> results = new ArrayList<TextualAnnotationData>();
+        List<Long> ids = new ArrayList<Long>();
+        Iterator<TextualAnnotationData> k;
+        TextualAnnotationData other;
+        while (i.hasNext()) {
+            e = i.next();
+            others = e.getValue().getTextualAnnotations();
+            if (others != null) {
+                k = others.iterator();
+                while (k.hasNext()) {
+                    other = k.next();
+                    if (!ids.contains(other.getId())) {
+                        results.add(other);
+                        ids.add(other.getId());
+                    }
+                }
+            }
+        }
+        return results;
 	}
 	
 	/**
@@ -2559,9 +2597,10 @@ class EditorModel
 	 */
 	List getTextualAnnotationsByDate()
 	{
-		if (textualAnnotationsByDate != null)
-			return textualAnnotationsByDate;
-		textualAnnotationsByDate = (List) getTextualAnnotations();
+//		if (textualAnnotationsByDate != null)
+//			return textualAnnotationsByDate;
+		textualAnnotationsByDate = (List) 
+		        getAllTextualAnnotations();
 		sortAnnotationByDate(textualAnnotationsByDate);
 		return textualAnnotationsByDate;
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -258,7 +258,6 @@ class EditorUI
     {
     	Object uo = model.getRefObject();
     	remove(component);
-    	setDataToSave(false);
     	if (uo instanceof ExperimenterData)  {
     		toolBar.buildUI();
     		userUI.buildUI();
@@ -326,11 +325,9 @@ class EditorUI
 	{
 		Object uo = model.getRefObject();
 		tabPane.setComponentAt(RND_INDEX, dummyPanel);
-		setDataToSave(false);
 		toolBar.buildUI();
 		tabPane.setToolTipTextAt(RND_INDEX, RENDERER_DESCRIPTION);
 		if (!(uo instanceof DataObject)) {
-			setDataToSave(false);
 			toolBar.setStatus(false);
 			toolBar.buildUI();
 			remove(component);
@@ -376,7 +373,6 @@ class EditorUI
 	void saveData(boolean async)
 	{
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-		toolBar.setDataToSave(false);
 		if (model.getRefObject() instanceof ExperimenterData) {
 			Object exp = userUI.getExperimenterToSave();
 			model.fireAdminSaving(exp, async);
@@ -385,7 +381,6 @@ class EditorUI
 			AdminObject o = groupUI.getAdminObject();
 			if (o == null) {
 				setCursor(Cursor.getDefaultCursor());
-				toolBar.setDataToSave(true);
 				return;
 			}
 			model.fireAdminSaving(o, async);
@@ -406,14 +401,6 @@ class EditorUI
     	generalPane.setChannelData();
     	acquisitionPane.setChannelData();
     }
-    
-    /**
-     * Enables the saving controls depending on the passed value.
-     * 
-     * @param b Pass <code>true</code> to save the data,
-     * 			<code>false</code> otherwise.
-     */
-    void setDataToSave(boolean b) { toolBar.setDataToSave(b); }
     
     /**
 	 * Returns <code>true</code> if data to save, <code>false</code>
@@ -523,7 +510,6 @@ class EditorUI
 	private void removeLinks(int level, Collection l)
 	{
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-		toolBar.setDataToSave(false);
 		Iterator<AnnotationData> i = l.iterator();
 		AnnotationData o;
 		List<Object> toRemove = new ArrayList<Object>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -489,8 +489,6 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
             public void tableChanged(TableModelEvent e) {
                 refreshButtonStates();
                 MapTableModel m = (MapTableModel) t.getModel();
-                if (m.isDirty())
-                    view.setDataToSave(true);
                 if (m.isEmpty() && m.getMap().getId() >= 0) {
                     view.deleteAnnotation(m.getMap());
                     view.saveData(true);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1025,7 +1025,7 @@ public class PropertiesUI
 		k = well.getColumn()+1;
 		String columnText = "";
 		if (columnIndex == PlateData.ASCENDING_LETTER)
-			columnText = UIUtilities.LETTERS.get(k+1);
+			columnText = UIUtilities.LETTERS.get(k);
 		else if (columnIndex == PlateData.ASCENDING_NUMBER)
 			columnText = ""+k;
 		String value = rowText+"-"+columnText;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -96,21 +96,9 @@ class ToolBar
 	/** The text associated to the export as OME-TIFF action. */
 	private static final String EXPORT_AS_OME_TIFF_TOOLTIP = 
 		"Export the image as OME-TIFF.";
-	
-	/** Button to save the annotations. */
-	private JButton			saveButton;
 
 	/** Button to download the original image. */
 	private JButton			downloadButton;
-
-	/** Button to load the rendering control for the primary select. */
-	private JButton			rndButton;
-	
-	/** Button to refresh the selected tab. */
-	private JButton			refreshButton;
-
-	/** Button to bring up the analysis list. */
-	private JButton			analysisButton;
 	
 	/** Button to bring up the publishing list. */
 	private JButton			publishingButton;
@@ -171,9 +159,7 @@ class ToolBar
     {
     	if (MetadataViewerAgent.isBinaryAvailable()) return;
     	downloadButton.setEnabled(false); 
-    	rndButton.setEnabled(false);
     	publishingButton.setEnabled(false);
-		analysisButton.setEnabled(false);
     }
     
     /** Creates or recycles the save as menu. */
@@ -272,12 +258,6 @@ class ToolBar
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		IconManager icons = IconManager.getInstance();
-		saveButton = new JButton(icons.getIcon(IconManager.SAVE));
-		saveButton.setToolTipText("Save changes back to the server.");
-		saveButton.addActionListener(controller);
-		saveButton.setActionCommand(""+EditorControl.SAVE);
-		saveButton.setEnabled(false);
-		saveButton.setBackground(UIUtilities.BACKGROUND_COLOR);
 		
 		downloadButton = new JButton(icons.getIcon(IconManager.DOWNLOAD));
 		downloadButton.setToolTipText("Download the Archived File(s).");
@@ -285,20 +265,6 @@ class ToolBar
 		downloadButton.setActionCommand(""+EditorControl.DOWNLOAD);
 		//downloadButton.setEnabled(false);
 		downloadButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-		
-		rndButton = new JButton(icons.getIcon(IconManager.RENDERER));
-		rndButton.setToolTipText("Rendering control for the first selected " +
-				"image.");
-		rndButton.addActionListener(controller);
-		rndButton.setActionCommand(""+EditorControl.RENDERER);
-		rndButton.setEnabled(false);
-		rndButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-		
-		refreshButton = new JButton(icons.getIcon(IconManager.REFRESH));
-		refreshButton.setToolTipText("Refresh.");
-		refreshButton.addActionListener(controller);
-		refreshButton.setActionCommand(""+EditorControl.REFRESH);
-		refreshButton.setBackground(UIUtilities.BACKGROUND_COLOR);
 		
 		publishingButton = new JButton(icons.getIcon(IconManager.PUBLISHING));
 		publishingButton.setToolTipText("Display the publishing options.");
@@ -316,22 +282,7 @@ class ToolBar
 						MetadataViewer.PUBLISHING_OPTION);
 			}
 		});
-		analysisButton = new JButton(icons.getIcon(IconManager.ANALYSIS));
-		analysisButton.setToolTipText("Display the analysis options.");
-		analysisButton.setEnabled(false);
-		analysisButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-		analysisButton.addMouseListener(new MouseAdapter() {
-			
-			/**
-			 * Launches the dialog when the user releases the mouse.
-			 * MouseAdapter#mouseReleased(MouseEvent)
-			 */
-			public void mouseReleased(MouseEvent e)
-			{
-				launchOptions((Component) e.getSource(), e.getPoint(), 
-						MetadataViewer.ANALYSIS_OPTION);
-			}
-		});
+
 		scriptsButton = new JButton(icons.getIcon(IconManager.ANALYSIS_RUN));
 		scriptsButton.setToolTipText("Display the available scripts.");
 		scriptsButton.setEnabled(false);
@@ -430,14 +381,10 @@ class ToolBar
 		UIUtilities.unifiedButtonLookAndFeel(pathButton);
 		UIUtilities.unifiedButtonLookAndFeel(locationButton);
 		UIUtilities.unifiedButtonLookAndFeel(saveAsButton);
-		UIUtilities.unifiedButtonLookAndFeel(saveButton);
 		UIUtilities.unifiedButtonLookAndFeel(downloadButton);
-		UIUtilities.unifiedButtonLookAndFeel(rndButton);
-		UIUtilities.unifiedButtonLookAndFeel(refreshButton);
 		UIUtilities.unifiedButtonLookAndFeel(exportAsOmeTiffButton);
 		UIUtilities.unifiedButtonLookAndFeel(publishingButton);
 		UIUtilities.unifiedButtonLookAndFeel(uploadScriptButton);
-		UIUtilities.unifiedButtonLookAndFeel(analysisButton);
 		UIUtilities.unifiedButtonLookAndFeel(scriptsButton);
 		
 		Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH, 
@@ -463,8 +410,6 @@ class ToolBar
     	
         bar.add(viewButton);
         bar.add(Box.createHorizontalGlue());
-    	bar.add(saveButton);
-    	bar.add(Box.createHorizontalStrut(5));
         bar.add(publishingButton);
         bar.add(Box.createHorizontalStrut(5));
         bar.add(locationButton);
@@ -599,14 +544,6 @@ class ToolBar
     	initComponents();
     	buildGUI();
     }
-
-    /**
-     * Enables the {@link #saveButton} depending on the passed value.
-     * 
-     * @param b Pass <code>true</code> to save the data,
-     * 			<code>false</code> otherwise. 
-     */
-    void setDataToSave(boolean b) { saveButton.setEnabled(b); }
     
     /**
      * Sets to <code>true</code> if loading data, to <code>false</code>
@@ -626,14 +563,10 @@ class ToolBar
     {
     	saveAsMenu = null;
     	Object refObject = model.getRefObject();
-    	rndButton.setEnabled(false);
 		downloadButton.setEnabled(false);
 		if (pathButton != null) pathButton.setEnabled(false);
     	if ((refObject instanceof ImageData) || 
     			(refObject instanceof WellSampleData)) {
-    		rndButton.setEnabled(!model.isRendererLoaded());
-    		if (model.isNumerousChannel())
-    			rndButton.setEnabled(false);
     		if (refObject instanceof ImageData) {
     			downloadButton.setEnabled(model.isArchived());
     		}
@@ -653,7 +586,6 @@ class ToolBar
         Object ref = model.getRefObject();
         if (ref instanceof ExperimenterData || ref instanceof GroupData) {
             publishingButton.setEnabled(false);
-            analysisButton.setEnabled(false);
             scriptsButton.setEnabled(false);
             return;
         }
@@ -673,7 +605,6 @@ class ToolBar
         }
 
         publishingButton.setEnabled(true);
-        analysisButton.setEnabled(true);
         scriptsButton.setEnabled(true);
         if (publishingDialog != null)
             publishingDialog.setRootObject();


### PR DESCRIPTION
See [Trello - insight: Right-hand panel follow up](https://trello.com/c/74yV81oZ/9-insight-right-hand-panel-follow-up)
- Removes the "Save" button from the metadata panel (changes are saved anyway, no need for the button anymore); *Test*: Make sure the button is gone; add/edit some data, make sure its stored automatically.
- Fixes "Comments" for multiselection, [Ticket 13083](https://trac.openmicroscopy.org/ome/ticket/13083); *Test*: Select multiple dataobjects and add a comment; make sure the comment is added to all objects. Select multiple dataobjects with different comments; make sure you see all comments of all selected objects.
- Fixes [Small bug in Dataset_To_Plate.py](https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7920). Problem wasn't caused by python script, just the name of wells from plates generated by datasets was wrongly displayed in Insight (off by one). *Test*: Run the dataset-to-plate script; make sure the names of the wells shown in the metadata panel (A-1, A-2, etc. ) are correct