### PR TITLE
Fix Robot failure when long usernames truncated in jstree

### DIFF
--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -10,6 +10,7 @@ ${ROOT FULL NAME}		root root
 
 ${USERNAME}             %(USER)s
 ${PASSWORD}             %(PASS)s
+${LAST NAME}            %(USER)s
 ${FULL NAME}            %(USER)s %(USER)s
 
 # Web config

--- a/components/tests/ui/testcases/web/create_scenario.txt
+++ b/components/tests/ui/testcases/web/create_scenario.txt
@@ -118,15 +118,17 @@ Test Container Creation Enabled
     ...                 creating various containers are enabled.
 
     Tree Should Be Visible
-    Wait For Node To Be Visible                 ${FULL NAME}
+    # Full name may be truncated at start (right panel not wide enough)
+    # just check last name
+    Wait For Node To Be Visible                 ${LAST NAME}
     Wait For Node To Be Visible                 Orphaned Images
     Create Button Should Be Enabled             project
     Create Button Should Be Enabled             dataset
     Create Button Should Be Enabled             screen
-    Node Popup Menu Item Should Be Enabled      Project    ${FULL NAME}
-    Node Popup Menu Item Should Be Enabled      Dataset    ${FULL NAME}
-    Node Popup Menu Item Should Be Enabled      Screen     ${FULL NAME}
-    Node Popup Menu Item Should Be Disabled     Delete     ${FULL NAME}
+    Node Popup Menu Item Should Be Enabled      Project    ${LAST NAME}
+    Node Popup Menu Item Should Be Enabled      Dataset    ${LAST NAME}
+    Node Popup Menu Item Should Be Enabled      Screen     ${LAST NAME}
+    Node Popup Menu Item Should Be Disabled     Delete     ${LAST NAME}
     Select First Project With Children
     Create Button Should Be Enabled             project
     Create Button Should Be Enabled             dataset

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -143,7 +143,7 @@ Test Rdef Copy Paste Save
     Click Element                           id=rdef-save-all
 
     # Return to Previous Image (now Blue)
-    Click Element                           id=image_icon-${imageId}
+    Select Image By Id                      ${imageId}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  rgb(0, 0, 255)
 
@@ -227,7 +227,7 @@ Test Owners Rdef
     Right Click Image Rendering Settings    ${imageId_2}            Paste and Save
     Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
-    Click Element                           id=image_icon-${imageId_2}
+    Select Image By Id                      ${imageId_2}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
     Wait For Channel Color                  rgb(255, 255, 255)
     Textfield Value Should Be               wblitz-ch0-cw-end           200

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -78,7 +78,14 @@ Test Rdef Copy Paste Save
     [Documentation]     Tests Copy and Paste rdef, then Save and 'Save All'
 
     Select Experimenter
-    Select And Expand Image
+
+    Select First Project With Children
+    # Start by resetting rdefs to imported settings within Dataset
+    # In case previous failed tests left unexpected rdefs
+    ${datasetId}=                           Select First Dataset With Children
+    Right Click Dataset Rendering Settings  ${datasetId}            Set Imported and Save
+    Select First Image
+
     ${imageId}=                             Wait For General Panel And Return Id    Image
     Click Link                              Preview
     ${status}    ${oldId}                   Wait For Preview Load       FAIL      '1'

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -58,6 +58,15 @@ Wait For Toolbar Button Disabled
 Right Click Image Rendering Settings
     [Arguments]            ${imageId}       ${optionText}
     ${treeId}=                              Wait For Image Node           ${imageId}
+    Right Click Rendering Settings          ${treeId}       ${optionText}
+
+Right Click Dataset Rendering Settings
+    [Arguments]            ${datasetId}       ${optionText}
+    ${treeId}=                              Wait For Dataset Node           ${datasetId}
+    Right Click Rendering Settings          ${treeId}       ${optionText}
+
+Right Click Rendering Settings
+    [Arguments]            ${treeId}       ${optionText}
     Open Context Menu                       xpath=//li[@id='${treeId}']/a
     Mouse Over                              xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), 'Rendering Settings...')]
     Click Element                           xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), "${optionText}")]


### PR DESCRIPTION
Fixes various failing robot tests:

 - In Create Scenario, https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/157/robot/Web%20&%20Web/Web/Create%20Scenario/Test%20Container%20Creation%20Enabled/ instead of checking that the full Firstname and Lastname is in jsTree, we just check for Lastname, so that ```...irstname Lastname``` is matched, since it contains Lastname.

 - For rdef tests, we now click on the jsTree to select images following a "Save All" or other actions that refreshThumbnails(), since the clicking thumbnails gives us "Element not in DOM". Fixes E.g. https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/157/robot/Web%20&%20Web/Web/Rdef%20Test/Test%20Owners%20Rdef/

 - We now reset rdefs to "imported" on the Dataset at the start of the first test, in case settings were left in an unexpected state by a previous failing test.