### PR TITLE
add initial version of deep copy to server

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -75,5 +75,6 @@
     <import resource="graph-rules/blitz-chmod-rules.xml"/>
     <import resource="graph-rules/blitz-chown-rules.xml"/>
     <import resource="graph-rules/blitz-delete-rules.xml"/>
+    <import resource="graph-rules/blitz-duplicate-rules.xml"/>
 
 </beans>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -367,6 +367,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodTargets"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownTargets"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteTargets"/>
+          <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateTargets"/>
         </map>
       </constructor-arg>
       <constructor-arg>
@@ -375,6 +376,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodRules"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownRules"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteRules"/>
+          <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateRules"/>
         </map>
       </constructor-arg>
       <constructor-arg>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -376,7 +376,7 @@
 
         <!-- EXPERIMENT -->
 
-        <!-- Delete an experiment if the last image or microbeam manipulation to use it is deleted. -->
+        <!-- Delete an experiment if the last image to use it is deleted. -->
 
         <bean parent="graphPolicyRule" p:matches="Image[D].experiment = E:[E]{i}/d" p:changes="E:{r}"/>
         <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.experiment = E:[E]{r}" p:changes="E:{a}"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+
+    <util:list id="duplicateTargets" value-type="java.lang.String">
+
+        <!-- acquisition -->
+        <value>Instrument</value>
+
+        <!-- annotations -->
+        <value>Annotation</value>
+        <value>IAnnotationLink</value>
+
+        <!-- containers -->
+        <value>Dataset</value>
+        <value>DatasetImageLink</value>
+        <value>Project</value>
+        <value>ProjectDatasetLink</value>
+
+        <!-- core -->
+        <value>Channel</value>
+        <value>Image</value>
+        <value>LogicalChannel</value>
+   <!-- <value>OriginalFile</value> -->
+        <value>Pixels</value>
+   <!-- <value>PixelsOriginalFileMap</value> -->
+        <value>PlaneInfo</value>
+
+        <!-- display -->
+        <value>ChannelBinding</value>
+        <value>CodomainMapContext</value>
+        <value>QuantumDef</value>
+        <value>RenderingDef</value>
+        <value>Thumbnail</value>
+
+        <!-- experiment -->
+        <value>Experiment</value>
+        <value>MicrobeamManipulation</value>
+
+        <!-- fs -->
+        <value>Fileset</value>
+   <!-- <value>FilesetEntry</value> -->
+        <value>FilesetJobLink</value>
+
+        <!-- internal -->
+        <value>Link</value>
+
+        <!-- jobs -->
+        <value>Job</value>
+   <!-- <value>JobOriginalFileLink</value> -->
+
+        <!-- meta -->
+        <value>ExternalInfo</value>
+
+        <!-- roi -->
+        <value>Roi</value>
+        <value>Shape</value>
+
+        <!-- screen -->
+        <value>Plate</value>
+        <value>PlateAcquisition</value>
+        <value>Reagent</value>
+        <value>Screen</value>
+        <value>ScreenPlateLink</value>
+        <value>Well</value>
+        <value>WellReagentLink</value>
+        <value>WellSample</value>
+
+        <!-- stats -->
+        <value>StatsInfo</value>
+
+    </util:list>
+
+    <util:list id="duplicateRules" value-type="ome.services.graphs.GraphPolicyRule">
+
+        <!-- see blitz-graph-rules.xml for rule syntax -->
+
+        <!-- ACQUISITION -->
+
+        <!-- If an instrument is duplicated then duplicate the subgraph below it. -->
+
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filter = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+
+        <!-- Continue instrument duplication deeper into subgraph. -->
+
+        <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <!-- An instrument may not be linked directly to the image, so note relevance via settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[EI], S.detector = D:[E]"
+                                       p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[EI], S.lightSource = LS:[E]"
+                                       p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[EI], S.objective = O:[E]"
+                                       p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].detector = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].lightSource = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].objective = [I]" p:changes="IN:[I]"/>
+
+        <!-- Duplicate emission and excitation filter links if both parent and child are duplicated. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[!O]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[!O]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[!O]" p:changes="S:[-]"/>
+
+        <!-- ANNOTATIONS -->
+
+        <!-- We can't yet duplicate file annotations. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = FA:FileAnnotation[E]" p:changes="L:[O], FA:[O]"/>
+
+        <!-- If an annotated object is duplicated then duplicate its annotations. -->
+        <!-- (n.b. child is included to ensure previous rule takes priority) -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I], L.child = [EI]" p:changes="L:[I]"/>
+
+        <!-- If a link to an annotation is duplicated then duplicate the annotation itself. -->
+
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].child = A:Annotation[E]" p:changes="A:[I]"/>
+
+        <!-- If an original file is duplicated then also duplicate the corresponding file annotation -->
+
+        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E].file = [I]" p:changes="A:[I]"/>
+
+        <!-- Ensure that rules with multiple matches may apply for links. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
+
+        <!-- Respect linking rules outside read-annotate groups. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} would cause annotation of another's data in a read-only group"/>
+
+        <!-- CONTAINERS -->
+
+        <!-- If a project or dataset is duplicated then duplicate their links -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I]" p:changes="L:[I]"/>
+
+        <!-- If a container's link is duplicated then duplicate the contents. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+
+        <!-- Respect linking rules outside read-write groups. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} creates a dataset in another's project in a read-only group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[I].parent = [E]/!o;perms=??ra??"
+                                       p:error="duplicating {L} creates a dataset in another's project in a read-annotate group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} creates an image in another's dataset in a read-only group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[I].parent = [E]/!o;perms=??ra??"
+                                       p:error="duplicating {L} creates an image in another's dataset in a read-annotate group"/>
+
+        <!-- CORE -->
+
+        <!-- We can't yet duplicate original files. -->
+
+        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap[E].parent = [I]" p:changes="POFM:[O]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]" p:changes="OF:[O]"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [I]" p:changes="L:[O]"/>
+
+        <!-- Duplicate an original file that is part of something duplicated. -->
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="JobOriginalFileLink[I].child = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PixelsOriginalFileMap[I].parent = OF:[E]" p:changes="OF:[I]"/>
+
+        <!-- If a logical channel is duplicated then duplicate the subgraph below it. -->
+
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E]" p:changes="DS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightPath = LP:[E]" p:changes="LP:[I]"/>
+
+        <!-- Duplicate a logical channel if its associated channel is duplicated. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <!--
+             If an image is duplicated then duplicate the subgraph below it.
+             Duplicate its rendering settings and thumbnails
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]" p:changes="IE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = OS:[E]" p:changes="OS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]" p:changes="SL:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].settings =/o RD:[E]" p:changes="RD:[I]"/>
+   <!-- <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails =/o T:[E]" p:changes="T:[I]"/> -->
+
+        <!-- We cannot yet duplicate original files. -->
+
+        <bean parent="graphPolicyRule" p:matches="OF:OriginalFile[I]"
+                                       p:error="cannot include {OF} as original files are not yet duplicable"/>
+
+        <!-- DISPLAY -->
+
+        <!-- If rendering settings are duplicated then duplicate the subgraph below. -->
+
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+
+        <!-- We cannot yet duplicate thumbnails. -->
+
+        <bean parent="graphPolicyRule" p:matches="T:Thumbnail[I]"
+                                       p:error="cannot include {T} as thumbnails are not yet duplicable"/>
+
+        <!-- EXPERIMENT -->
+
+        <!-- Duplicate an experiment if the last image to use it is duplicated. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment = E:[E]{i}" p:changes="E:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Image[E].experiment = E:[E]{r}" p:changes="E:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="E:Experiment[E]{o}" p:changes="E:[I]"/>
+
+        <!-- If an experiment is duplicated then duplicate associated microbeam manipulation. -->
+
+        <bean parent="graphPolicyRule" p:matches="Experiment[I].microbeamManipulation = M:[E]" p:changes="M:[I]"/>
+
+        <!-- FS -->
+
+        <!-- If a fileset is duplicated then duplicate the subgraph below, down to the linked jobs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].images = I:[E]" p:changes="I:[I]"/>
+   <!-- <bean parent="graphPolicyRule" p:matches="Fileset[I].usedFiles = FE:[E]" p:changes="FE:[I]"/> -->
+   <!-- <bean parent="graphPolicyRule" p:matches="Fileset[I].jobLinks = L:[E]" p:changes="L:[I]"/> -->
+        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].child = J:[E]" p:changes="J:[I]"/>
+
+        <!-- A fileset may be duplicated by means of its images only if all of its images are duplicated. -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{i}.images = [I]" p:changes="F:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{r}.images = [E]{ia}" p:changes="F:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{o}" p:changes="F:[I]"/>
+
+        <!-- Considering an image for duplication entails considering its fileset for duplication. -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E]{i}.images = [E]{r}" p:changes="F:[E]{r}"/>
+
+        <!-- If a fileset is not to be duplicated then nor are its images. -->
+
+        <bean parent="graphPolicyRule" p:matches="Fileset[E]{a}.images = I:[E]{r}" p:changes="I:{a}"/>
+
+        <!-- JOB -->
+
+        <!-- Can't yet duplicate original files. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [I]" p:changes="L:[O]"/>
+
+        <!-- If a job or original file is duplicated then duplicate their links -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <!-- META -->
+
+        <!-- If an object is duplicated then also duplicate its external info -->
+
+        <bean parent="graphPolicyRule" p:matches="[I].details.externalInfo = EI:[E]" p:changes="EI:[I]"/>
+
+        <!-- ROI -->
+
+        <!-- 
+             Duplicate contained objects: ROIs of duplicated images, shapes of duplicated ROIs,
+             pixels of duplicated masks if possible.
+          -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E], P.image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- SCREEN -->
+
+        <!-- If a field is duplicated then duplicate its image. -->
+
+        <bean parent="graphPolicyRule" p:matches="WellSample[I].image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- Duplicate a reagent and its link if it used by a duplicated screen or well. -->
+
+        <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]" p:changes="R:[I]"/>
+
+        <!-- If a screen is duplicated then also duplicate the plate and its link. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[I].child = P:[E]" p:changes="P:[I]"/>
+
+        <!-- Duplicate contained objects: wells and runs of plates, fields of wells and runs. -->
+
+        <bean parent="graphPolicyRule" p:matches="Plate[I].wells = W:[E]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:[E]" p:changes="WS:[I]"/>
+
+        <!-- Respect linking rules outside read-write groups. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} creates a plate in another's screen in a read-only group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[I].parent = [E]/!o;perms=??ra??"
+                                       p:error="duplicating {L} creates a plate in another's screen in a read-annotate group"/>
+
+        <!-- STATS -->
+
+        <!-- Duplicate the stats info for duplicated channels. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].statsInfo = SI:[E]" p:changes="SI:[I]"/>
+
+    </util:list>
+
+</beans>

--- a/components/blitz/resources/omero/RTypes.ice
+++ b/components/blitz/resources/omero/RTypes.ice
@@ -29,7 +29,7 @@ module omero {
      *   rbool(true).compare(rbool(true)) == 0
      * </pre>
      *
-     * This method was originally addd (Oct 2008) to force the
+     * This method was originally added (Oct 2008) to force the
      * base RType class to be abstract in all languages.
      **/
     int compare(RType rhs);

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -362,6 +362,47 @@ module omero {
         };
 
         /**
+         * Duplicate model objects with some selection of their subgraph.
+         * All target model objects must be in the current group context.
+         * The extra three data members allow adjustment of the related
+         * subgraph. The same type must not be listed in more than one of
+         * those data members. Use of a more specific sub-type in a data
+         * member always overrides the more general type in another.
+         **/
+        class Duplicate extends GraphModify2 {
+
+            /**
+             * The types of the model objects to actually duplicate.
+             **/
+            omero::api::StringSet typesToDuplicate;
+
+            /**
+             * The types of the model objects that should not be duplicated
+             * but that may participate in references involving duplicates.
+             **/
+            omero::api::StringSet typesToReference;
+
+            /**
+             * The types of the model objects that should not be duplicated
+             * and that may not participate in references involving duplicates.
+             **/
+            omero::api::StringSet typesToIgnore;
+        };
+
+        /**
+         * Result of duplicating model objects.
+         **/
+        class DuplicateResponse extends OK {
+
+            /**
+             * The duplicate model objects created by the request.
+             * Note: If dryRun is set to true then this instead lists the model
+             * objects that would have been duplicated.
+             **/
+            omero::api::StringLongListMap duplicates;
+        };
+
+        /**
          * Graph requests typically allow only specific model object classes
          * to be targeted. This request lists the legal targets for a given
          * request. The request's fields are ignored, only its class matters.

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -40,6 +40,7 @@ import omero.cmd.graphs.ChownFacadeI;
 import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
 import omero.cmd.graphs.DiskUsageI;
+import omero.cmd.graphs.DuplicateI;
 import omero.cmd.graphs.GraphRequestFactory;
 import omero.cmd.graphs.LegalGraphTargetsI;
 import omero.cmd.graphs.SkipHeadI;
@@ -236,6 +237,13 @@ public class RequestObjectFactoryRegistry extends
                     @Override
                     public Ice.Object create(String name) {
                         return new DiskUsageI(pixelsService, thumbnailService, graphRequestFactory.getGraphPathBean());
+                    }
+                });
+        factories.put(DuplicateI.ice_staticId(),
+                new ObjectFactory(DuplicateI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return graphRequestFactory.getRequest(DuplicateI.class);
                     }
                 });
         factories.put(SendEmailRequestI.ice_staticId(),

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -96,7 +96,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
-     * @param targetClasses legal target object classes for chown
+     * @param targetClasses legal target object classes for chgrp
      * @param graphPolicy the graph policy to apply for chgrp
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -105,7 +105,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
-     * @param targetClasses legal target object classes for chown
+     * @param targetClasses legal target object classes for chmod
      * @param graphPolicy the graph policy to apply for chmod
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -91,7 +91,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
      * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param deletionInstance a deletion instance for deleting files
-     * @param targetClasses legal target object classes for chown
+     * @param targetClasses legal target object classes for delete
      * @param graphPolicy the graph policy to apply for delete
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      */

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -1,0 +1,600 @@
+/*
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.beanutils.NestedNullException;
+import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang.StringUtils;
+import org.hibernate.FlushMode;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.proxy.HibernateProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+
+import ome.model.IObject;
+import ome.security.ACLVoter;
+import ome.security.SystemTypes;
+import ome.services.delete.Deletion;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPathBean;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphTraversal;
+import ome.system.EventContext;
+import ome.system.Roles;
+import omero.cmd.Duplicate;
+import omero.cmd.DuplicateResponse;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+
+/**
+ * Request to duplicate model objects.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.1
+ */
+public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<Duplicate> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DuplicateI.class);
+
+    private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
+
+    /* all bulk operations are batched; this size should be suitable for IN (:ids) for HQL */
+    private static final int BATCH_SIZE = 256;
+
+    private static enum Inclusion {
+        /* the object is to be duplicated */
+        DUPLICATE,
+        /* the object is not to be duplicated, but it may be referenced from duplicates */
+        REFERENCE,
+        /* the object is not to be duplicated, nor is it to be referenced from duplicates */
+        IGNORE
+    };
+
+    private final ACLVoter aclVoter;
+    private final SystemTypes systemTypes;
+    private final GraphPathBean graphPathBean;
+    private final Set<Class<? extends IObject>> targetClasses;
+    private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
+    private final SetMultimap<String, String> unnullable;
+
+    /* a taxonomy based on the class hierarchy of model objects in Java */
+    private SpecificityClassifier<Class<? extends IObject>, Inclusion> classifier;
+
+    private List<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters = new ArrayList<Function<GraphPolicy, GraphPolicy>>();
+    private Helper helper;
+    private GraphTraversal graphTraversal;
+
+    private FlushMode flushMode;
+    private GraphTraversal.PlanExecutor processor;
+
+    private int targetObjectCount = 0;
+    private int duplicatedObjectCount = 0;
+
+    private final Map<IObject, IObject> originalsToDuplicates = new HashMap<IObject, IObject>();
+
+    /**
+     * Given class names provided by the user, find the corresponding set of actual classes.
+     * @param classNames names of model object classes
+     * @return the named classes
+     */
+    private Set<Class<? extends IObject>> getClassesFromNames(Collection<String> classNames) {
+        final Set<Class<? extends IObject>> classes = new HashSet<Class<? extends IObject>>();
+        for (String className : classNames) {
+            final int lastDot = className.lastIndexOf('.');
+            if (lastDot > 0) {
+                className = className.substring(lastDot + 1);
+            }
+            final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
+            if (actualClass == null) {
+                throw new IllegalArgumentException("unknown model object class named: " + className);
+            }
+            classes.add(actualClass);
+        }
+        return classes;
+    }
+
+    /**
+     * Construct a new <q>duplicate</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
+     * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
+     * @param systemTypes for identifying the system types
+     * @param graphPathBean the graph path bean to use
+     * @param deletionInstance a deletion instance for deleting files
+     * @param targetClasses legal target object classes for duplicate
+     * @param graphPolicy the graph policy to apply for duplicate
+     * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
+     */
+    public DuplicateI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable) {
+        this.aclVoter = aclVoter;
+        this.systemTypes = systemTypes;
+        this.graphPathBean = graphPathBean;
+        this.targetClasses = targetClasses;
+        this.graphPolicy = graphPolicy;
+        this.unnullable = unnullable;
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+        return null;
+    }
+
+    @Override
+    public void init(Helper helper) {
+        this.helper = helper;
+        helper.setSteps(dryRun ? 3 : 6);
+
+        final EventContext eventContext = helper.getEventContext();
+
+        final List<ChildOptionI> childOptions = ChildOptionI.castChildOptions(this.childOptions);
+
+        if (childOptions != null) {
+            for (final ChildOptionI childOption : childOptions) {
+                childOption.init();
+            }
+        }
+
+        classifier = new SpecificityClassifier<Class<? extends IObject>, Inclusion>(
+                new SpecificityClassifier.ContainmentTester<Class<? extends IObject>>() {
+                    @Override
+                    public boolean isProperSupersetOf(Class<? extends IObject> parent, Class<? extends IObject> child) {
+                        return parent != child && parent.isAssignableFrom(child);
+                    }});
+
+        try {
+            classifier.addClass(Inclusion.DUPLICATE, getClassesFromNames(typesToDuplicate));
+            classifier.addClass(Inclusion.REFERENCE, getClassesFromNames(typesToReference));
+            classifier.addClass(Inclusion.IGNORE,    getClassesFromNames(typesToIgnore));
+        } catch (IllegalArgumentException e) {
+            throw helper.cancel(new ERR(), e, "bad-class");
+        }
+
+        GraphPolicy graphPolicyWithOptions = graphPolicy;
+
+        graphPolicyWithOptions = ChildOptionsPolicy.getChildOptionsPolicy(graphPolicyWithOptions, childOptions, REQUIRED_ABILITIES);
+
+        graphPolicyWithOptions = SkipTailPolicy.getSkipTailPolicy(graphPolicyWithOptions,
+                new Predicate<Class<? extends IObject>>() {
+            @Override
+            public boolean apply(Class<? extends IObject> modelObject) {
+                final Inclusion classification = classifier.getClass(modelObject);
+                return classification == Inclusion.REFERENCE || classification == Inclusion.IGNORE;
+            }});
+
+        for (final Function<GraphPolicy, GraphPolicy> adjuster : graphPolicyAdjusters) {
+            graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);
+        }
+        graphPolicyAdjusters = null;
+
+        GraphTraversal.Processor processor = new InternalProcessor();
+        if (dryRun) {
+            processor = GraphUtil.disableProcessor(processor);
+        }
+
+        graphTraversal = new GraphTraversal(helper.getSession(), eventContext, aclVoter, systemTypes, graphPathBean, unnullable,
+                graphPolicyWithOptions, processor);
+    }
+
+    /**
+     * Duplicate model object properties, linking them as appropriate with each other and with other model objects.
+     * @throws GraphException if duplication failed
+     */
+    private void setDuplicatePropertyValues() throws GraphException {
+        /* organize duplicate index by class name and ID */
+        final Map<Entry<String, Long>, IObject> duplicatesByOriginalClassAndId = new HashMap<Entry<String, Long>, IObject>();
+        for (final Entry<IObject, IObject> originalAndDuplicate : originalsToDuplicates.entrySet()) {
+            final IObject original = originalAndDuplicate.getKey();
+            final String originalClass = Hibernate.getClass(original).getName();
+            final Long originalId = original.getId();
+            final IObject duplicate = originalAndDuplicate.getValue();
+            duplicatesByOriginalClassAndId.put(Maps.immutableEntry(originalClass, originalId), duplicate);
+        }
+        /* allow lookup regardless of if original is actually a Hibernate proxy object */
+        final Function<Object, Object> duplicateLookup = new Function<Object, Object>() {
+            @Override
+            public Object apply(Object original) {
+                if (original instanceof IObject) {
+                    final String originalClass;
+                    if (original instanceof HibernateProxy) {
+                        originalClass = Hibernate.getClass(original).getName();
+                    } else {
+                        originalClass = original.getClass().getName();
+                    }
+                    final Long originalId = ((IObject) original).getId();
+                    return duplicatesByOriginalClassAndId.get(Maps.immutableEntry(originalClass, originalId));
+                } else {
+                    return null;
+                }
+            }
+        };
+        /* copy property values into duplicates and link with other model objects */
+        final Session session = helper.getSession();
+        for (final Entry<IObject, IObject> originalAndDuplicate : originalsToDuplicates.entrySet()) {
+            final IObject original = originalAndDuplicate.getKey();
+            final IObject duplicate = originalAndDuplicate.getValue();
+            final String originalClass = Hibernate.getClass(original).getName();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("copying properties from " + originalClass + ":" + original.getId());
+            }
+            try {
+                /* process property values for a given object that is duplicated */
+                for (final String superclassName : graphPathBean.getSuperclassesOfReflexive(originalClass)) {
+                    /* process property values that link from the duplicate to other model objects */
+                    for (final Entry<String, String> forwardLink : graphPathBean.getLinkedTo(superclassName)) {
+                        /* next forward link */
+                        final String linkedClassName = forwardLink.getKey();
+                        final String property = forwardLink.getValue();
+                        /* ignore details for now, duplicates never preserve original ownership */
+                        if (property.startsWith("details.")) {
+                            continue;
+                        }
+                        /* note which of the objects to which the original links should be ignored */
+                        final Set<Long> linkedToIdsToIgnore = new HashSet<Long>();
+                        for (final Entry<String, Collection<Long>> linkedToClassIds :
+                            graphTraversal.getLinkeds(linkedClassName, property, original.getId()).asMap().entrySet()) {
+                            final String linkedToClass = linkedToClassIds.getKey();
+                            final Collection<Long> linkedToIds = linkedToClassIds.getValue();
+                            if (classifier.getClass(Class.forName(linkedToClass).asSubclass(IObject.class)) == Inclusion.IGNORE) {
+                                linkedToIdsToIgnore.addAll(linkedToIds);
+                            }
+                        }
+                        /* check for another accessor for inaccessible properties */
+                        if (graphPathBean.isPropertyAccessible(superclassName, property)) {
+                            /* copy the linking from the original's property over to the duplicate's */
+                            Object value;
+                            try {
+                                value = PropertyUtils.getNestedProperty(original, property);
+                            } catch (NestedNullException e) {
+                                continue;
+                            }
+                            if (value instanceof Collection) {
+                                /* if a collection property, include only the objects that aren't to be ignored */
+                                final Collection<IObject> valueCollection = (Collection<IObject>) value;
+                                final Collection<IObject> valueToCopy;
+                                if (value instanceof List) {
+                                    valueToCopy = new ArrayList<IObject>();
+                                } else if (value instanceof Set) {
+                                    valueToCopy = new HashSet<IObject>();
+                                } else {
+                                    throw new GraphException("unexpected collection type: " + value.getClass());
+                                }
+                                for (final IObject linkedTo : valueCollection) {
+                                    if (!linkedToIdsToIgnore.contains(linkedTo.getId())) {
+                                        valueToCopy.add(linkedTo);
+                                    }
+                                }
+                                value = valueToCopy;
+                            } else if (value instanceof IObject) {
+                                /* if the property value is to be ignored then null it */
+                                if (linkedToIdsToIgnore.contains(((IObject) value).getId())) {
+                                    value = null;
+                                }
+                            }
+                            /* copy the property value, replacing originals with corresponding duplicates */
+                            final Object duplicateValue = GraphUtil.copyComplexValue(duplicateLookup, value);
+                            try {
+                                PropertyUtils.setNestedProperty(duplicate, property, duplicateValue);
+                            } catch (NestedNullException e) {
+                                throw new GraphException(
+                                        "cannot set property " + superclassName + '.' + property + " on duplicate");
+                            }
+                        } else {
+                            /* this could be a one-to-many property with direct accessors protected */
+                            final Class<? extends IObject> linkerClass = Class.forName(superclassName).asSubclass(IObject.class);
+                            final Class<? extends IObject> linkedClass = Class.forName(linkedClassName).asSubclass(IObject.class);
+                            final Method reader, writer;
+                            try {
+                                reader = linkerClass.getMethod("iterate" + StringUtils.capitalize(property));
+                                writer = linkerClass.getMethod("add" + linkedClass.getSimpleName(), linkedClass);
+                            } catch (NoSuchMethodException | SecurityException e) {
+                                /* no luck, so ignore this property */
+                                continue;
+                            }
+                            /* copy the linking from the original's property over to the duplicate's */
+                            final Iterator<IObject> linkedTos = (Iterator<IObject>) reader.invoke(original);
+                            while (linkedTos.hasNext()) {
+                                final IObject linkedTo = linkedTos.next();
+                                /* copy only links to other duplicates, as otherwise we may steal objects from the original */
+                                final IObject duplicateOfLinkedTo = (IObject) duplicateLookup.apply(linkedTo);
+                                if (duplicateOfLinkedTo != null) {
+                                    writer.invoke(duplicate, duplicateOfLinkedTo);
+                                }
+                            }
+                        }
+                    }
+                    /* process property values that link to the duplicate from other model objects */
+                    for (final Entry<String, String> backwardLink : graphPathBean.getLinkedBy(superclassName)) {
+                        /* next backward link */
+                        final String linkingClass = backwardLink.getKey();
+                        final String property = backwardLink.getValue();
+                        /* ignore inaccessible properties */
+                        if (!graphPathBean.isPropertyAccessible(linkingClass, property)) {
+                            continue;
+                        }
+                        for (final Entry<String, Collection<Long>> linkedFromClassIds :
+                            graphTraversal.getLinkers(linkingClass, property, original.getId()).asMap().entrySet()) {
+                            final String linkedFromClass = linkedFromClassIds.getKey();
+                            final Collection<Long> linkedFromIds = linkedFromClassIds.getValue();
+                            if (classifier.getClass(Class.forName(linkedFromClass).asSubclass(IObject.class)) == Inclusion.IGNORE) {
+                                /* these linkers are to be ignored */
+                                continue;
+                            }
+                            /* load the instances that link to the original */
+                            final String rootQuery = "FROM " + linkedFromClass + " WHERE id IN (:ids)";
+                            for (final List<Long> idsBatch : Iterables.partition(linkedFromIds, BATCH_SIZE)) {
+                                final List<IObject> linkers =
+                                        session.createQuery(rootQuery).setParameterList("ids", idsBatch).list();
+                                for (final IObject linker : linkers) {
+                                    if (originalsToDuplicates.containsKey(linker)) {
+                                        /* ignore linkers that are to be duplicated, those are handled as forward links */
+                                        continue;
+                                    }
+                                    /* copy the linking from the original's property over to the duplicate's */
+                                    Object value;
+                                    try {
+                                        value = PropertyUtils.getNestedProperty(linker, property);
+                                    } catch (NestedNullException e) {
+                                        continue;
+                                    }
+                                    /* for linkers only adjust collection properties */
+                                    if (value instanceof Collection) {
+                                        final Collection<IObject> valueCollection = (Collection<IObject>) value;
+                                        final Collection<IObject> newDuplicates = new ArrayList<IObject>();
+                                        for (final IObject originalLinker : valueCollection) {
+                                            final IObject duplicateOfValue = originalsToDuplicates.get(originalLinker);
+                                            if (duplicateOfValue != null) {
+                                                /* previous had just original, now include duplicate too */
+                                                newDuplicates.add(duplicateOfValue);
+                                            }
+                                        }
+                                        valueCollection.addAll(newDuplicates);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    /* process property values that do not relate to edges in the model object graph */
+                    for (final String property : graphPathBean.getSimpleProperties(superclassName)) {
+                        /* ignore inaccessible properties */
+                        if (!graphPathBean.isPropertyAccessible(superclassName, property)) {
+                            continue;
+                        }
+                        /* copy original property value to duplicate */
+                        final Object value = PropertyUtils.getProperty(original, property);
+                        PropertyUtils.setProperty(duplicate, property, GraphUtil.copyComplexValue(duplicateLookup, value));
+                    }
+                }
+            } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new GraphException("failed to duplicate " + originalClass + ':' + original.getId());
+            }
+        }
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+        final Session session = helper.getSession();
+        try {
+            switch (step) {
+            case 0:
+                /* if targetObjects were an IObjectList then this would need IceMapper.reverse */
+                final SetMultimap<String, Long> targetMultimap = HashMultimap.create();
+                for (final Entry<String, List<Long>> oneClassToTarget : targetObjects.entrySet()) {
+                    /* determine actual class from given target object class name */
+                    String targetObjectClassName = oneClassToTarget.getKey();
+                    final int lastDot = targetObjectClassName.lastIndexOf('.');
+                    if (lastDot > 0) {
+                        targetObjectClassName = targetObjectClassName.substring(lastDot + 1);
+                    }
+                    final Class<? extends IObject> targetObjectClass = graphPathBean.getClassForSimpleName(targetObjectClassName);
+                    /* check that it is legal to target the given class */
+                    final Iterator<Class<? extends IObject>> legalTargetsIterator = targetClasses.iterator();
+                    do {
+                        if (!legalTargetsIterator.hasNext()) {
+                            final Exception e = new IllegalArgumentException("cannot target " + targetObjectClassName);
+                            throw helper.cancel(new ERR(), e, "bad-target");
+                        }
+                    } while (!legalTargetsIterator.next().isAssignableFrom(targetObjectClass));
+                    /* note IDs to target for the class */
+                    final Collection<Long> ids = oneClassToTarget.getValue();
+                    targetMultimap.putAll(targetObjectClass.getName(), ids);
+                    targetObjectCount += ids.size();
+                }
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(session, targetMultimap, true, true);
+                if (plan.getValue().isEmpty()) {
+                    graphTraversal.assertNoUnlinking();
+                } else {
+                    final Exception e = new IllegalArgumentException("duplication plan unexpectedly includes deletion");
+                    throw helper.cancel(new ERR(), e, "bad-plan");
+                }
+                return plan.getKey();
+            case 1:
+                graphTraversal.assertNoPolicyViolations();
+                return null;
+            case 2:
+                processor = graphTraversal.processTargets();
+                return null;
+            case 3:
+                processor.execute();
+                return null;
+            case 4:
+                /* prevent premature flush triggered by duplication queries */
+                flushMode = session.getFlushMode();
+                session.setFlushMode(FlushMode.COMMIT);
+                setDuplicatePropertyValues();
+                return null;
+            case 5:
+                for (final IObject duplicate : originalsToDuplicates.values()) {
+                    session.persist(duplicate);
+                }
+                session.flush();
+                session.setFlushMode(flushMode);
+                return null;
+            default:
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
+            }
+        } catch (Cancel c) {
+            throw c;
+        } catch (GraphException ge) {
+            final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
+            graphERR.message = ge.message;
+            throw helper.cancel(graphERR, ge, "graph-fail");
+        } catch (Throwable t) {
+            throw helper.cancel(new ERR(), t, "graph-fail");
+        }
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        /* if the results object were in terms of IObjectList then this would need IceMapper.map */
+        if (dryRun && step == 0) {
+            final SetMultimap<String, Long> result = (SetMultimap<String, Long>) object;
+            final Map<String, List<Long>> duplicatedObjects = new HashMap<String, List<Long>>();
+            for (final Entry<String, Collection<Long>> oneDuplicatedClass : result.asMap().entrySet()) {
+                final String className = oneDuplicatedClass.getKey();
+                final Collection<Long> ids = oneDuplicatedClass.getValue();
+                duplicatedObjects.put(className, new ArrayList<Long>(ids));
+                duplicatedObjectCount += ids.size();
+            }
+            final DuplicateResponse response = new DuplicateResponse(duplicatedObjects);
+            helper.setResponseIfNull(response);
+            helper.info("in mock duplication of " + targetObjectCount + ", duplicated " + duplicatedObjectCount + " in total");
+        } else if (!dryRun && step == 5) {
+            final Map<String, List<Long>> duplicatedObjects = new HashMap<String, List<Long>>();
+            for (final IObject duplicate : originalsToDuplicates.values()) {
+                final String className = duplicate.getClass().getName();
+                List<Long> ids = duplicatedObjects.get(className);
+                if (ids == null) {
+                    ids = new ArrayList<Long>();
+                    duplicatedObjects.put(className, ids);
+                }
+                ids.add(duplicate.getId());
+                duplicatedObjectCount++;
+            }
+            final DuplicateResponse response = new DuplicateResponse(duplicatedObjects);
+            helper.setResponseIfNull(response);
+            helper.info("in duplication of " + targetObjectCount + ", duplicated " + duplicatedObjectCount + " in total");
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+
+    @Override
+    public void copyFieldsTo(Duplicate request) {
+        GraphUtil.copyFields(this, request);
+        request.typesToDuplicate = new ArrayList<String>(typesToDuplicate);
+        request.typesToReference = new ArrayList<String>(typesToReference);
+        request.typesToIgnore = new ArrayList<String>(typesToIgnore);
+    }
+
+    @Override
+    public void adjustGraphPolicy(Function<GraphPolicy, GraphPolicy> adjuster) {
+        if (graphPolicyAdjusters == null) {
+            throw new IllegalStateException("request is already initialized");
+        } else {
+            graphPolicyAdjusters.add(adjuster);
+        }
+    }
+
+    @Override
+    public int getStepProvidingCompleteResponse() {
+        return dryRun ? 0 : 5;
+    }
+
+    @Override
+    public GraphPolicy.Action getActionForStarting() {
+        return GraphPolicy.Action.INCLUDE;
+    }
+
+    @Override
+    public Map<String, List<Long>> getStartFrom(Response response) {
+        return ((DuplicateResponse) response).duplicates;
+    }
+
+    /**
+     * A <q>duplicate</q> processor that assists with duplicating model objects.
+     * This processor merely reads from the database and initializes the duplicate objects.
+     * The updates to the objects' property values occur in a later step.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.1
+     */
+    private final class InternalProcessor extends BaseGraphTraversalProcessor {
+
+        public InternalProcessor() {
+            super(helper.getSession());
+        }
+
+        @Override
+        public void processInstances(String className, Collection<Long> ids) throws GraphException {
+            final String rootQuery = "FROM " + className + " WHERE id IN (:ids)";
+            for (final List<Long> idsBatch : Iterables.partition(ids, BATCH_SIZE)) {
+                final List<IObject> originals = session.createQuery(rootQuery).setParameterList("ids", idsBatch).list();
+                for (final IObject original : originals) {
+                    final IObject duplicate;
+                    try {
+                        duplicate = (IObject) Hibernate.getClass(original).newInstance();
+                    } catch (InstantiationException | IllegalAccessException e) {
+                        throw new GraphException("cannot create a duplicate of " + original);
+                    }
+                    originalsToDuplicates.put(original, duplicate);
+                }
+            }
+        }
+
+        @Override
+        public Set<GraphPolicy.Ability> getRequiredPermissions() {
+            return REQUIRED_ABILITIES;
+        }
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -156,7 +156,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
         }
 
         /* set step count */
-        graphRequestSkipStatus.steps = 1 + wrappedRequest.getStepProvidingCompleteResponse();
+        graphRequestSkipStatus.steps = 1 + ((WrappableRequest<?>) graphRequestSkip).getStepProvidingCompleteResponse();
         helper.setSteps(graphRequestSkipStatus.steps + graphRequestPerformStatus.steps);
     }
 

--- a/components/blitz/src/omero/cmd/graphs/SkipTailPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipTailPolicy.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+import ome.model.IObject;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphPolicyRulePredicate;
+
+/**
+ * Adjust graph traversal policy to avoid processing or acting on certain model object classes.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.1
+ */
+public class SkipTailPolicy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipTailPolicy.class);
+
+    /**
+     * Adjust an existing graph traversal policy so that processing stops at certain model object classes.
+     * @param graphPolicy the graph policy to adjust
+     * @param isSkipClass if a given class should be not be reviewed or acted on
+     * @return the adjusted graph policy
+     */
+    public static GraphPolicy getSkipTailPolicy(final GraphPolicy graphPolicy,
+            final Predicate<Class<? extends IObject>> isSkipClass) {
+
+        /* construct the function corresponding to the model graph descent truncation */
+
+        return new GraphPolicy() {
+            @Override
+            public void registerPredicate(GraphPolicyRulePredicate predicate) {
+                graphPolicy.registerPredicate(predicate);
+            }
+
+            @Override
+            public GraphPolicy getCleanInstance() {
+                throw new IllegalStateException("not expecting to provide a clean instance");
+            }
+
+            @Override
+            public void setCondition(String name) {
+                graphPolicy.setCondition(name);
+            }
+
+            @Override
+            public boolean isCondition(String name) {
+                return graphPolicy.isCondition(name);
+            }
+
+            @Override
+            public void noteDetails(Session session, IObject object, String realClass, long id) {
+                graphPolicy.noteDetails(session, object, realClass, id);
+            }
+
+            @Override
+            public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject,
+                    Map<String, Set<Details>> linkedTo, Set<String> notNullable, boolean isErrorRules) throws GraphException {
+                if (isSkipClass.apply(rootObject.subject.getClass())) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("halting review at " + rootObject);
+                    }
+                    /* request parameters specify to review no further */
+                    return Collections.emptySet();
+                } else {
+                    /* do the review */
+                    final Set<Details> changes = graphPolicy.review(linkedFrom, rootObject, linkedTo, notNullable, isErrorRules);
+                    final Iterator<Details> changesIterator = changes.iterator();
+                    while (changesIterator.hasNext()) {
+                        final Details change = changesIterator.next();
+                        if (change.action == Action.INCLUDE && isSkipClass.apply(change.subject.getClass())) {
+                            if (LOGGER.isDebugEnabled()) {
+                                LOGGER.debug("forestalling policy-based change " + change);
+                            }
+                            /* do not act on skipped classes */
+                            changesIterator.remove();
+                        }
+                    }
+                    return changes;
+                }
+            }
+        };
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/SpecificityClassifier.java
+++ b/components/blitz/src/omero/cmd/graphs/SpecificityClassifier.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A classifier that assigns an entity to the classification listed for the most specific group of which the entity is a member.
+ * Consider entities themselves to be singleton groups.
+ * Implemented more for obvious correctness than for performance on large data.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.1
+ * @param <G> the type of the groups of which entities may be members, and also of the entities themselves
+ * @param <C> the classes to which entities may be assigned
+ */
+class SpecificityClassifier<G, C> {
+
+    /**
+     * Tests group membership. The membership relation must be irreflexive, asymmetric, and transitive.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.1
+     * @param <G> the type of the groups of which entities may be members, and also of the entities themselves
+     */
+    interface ContainmentTester<G> {
+
+        /**
+         * Report if one group is a proper superset of the other.
+         * @param parent a group that may contain another
+         * @param child the other group
+         * @return if the first group contains the other without being the same as it
+         */
+        boolean isProperSupersetOf(G parent, G child);
+    }
+
+    private final ContainmentTester<G> tester;
+    private final Map<G, C> classOfGroup = new HashMap<G, C>();
+
+    /**
+     * Create a classifier that uses the given definition of group membership.
+     * @param tester the group membership tester
+     */
+    SpecificityClassifier(ContainmentTester<G> tester) {
+        this.tester = tester;
+    }
+
+    /**
+     * Assert that specific groups are of the given classification.
+     * @param classification a classification
+     * @param groupsInClass the groups that are of this classification
+     * @throws IllegalArgumentException if any of the groups are already of a different classification
+     */
+    void addClass(C classification, Iterable<G> groupsInClass) throws IllegalArgumentException {
+        for (final G group : groupsInClass) {
+            final C previousClass = classOfGroup.put(group, classification);
+            if (!(previousClass == null || previousClass.equals(classification))) {
+                throw new IllegalArgumentException("cannot classify " + group + " as " + classification +
+                        " because it is also " + previousClass);
+            }
+        }
+    }
+
+    /**
+     * Classify the given group.
+     * @param group a group
+     * @return its classification, or {@code null} if it could not be classified
+     */
+    C getClass(G group) {
+        final C directLookup = classOfGroup.get(group);
+        if (directLookup != null) {
+            return directLookup;
+        }
+        Map.Entry<G, C> bestGroupClassification = null;
+        for (final Map.Entry<G, C> currentGroupClassification : classOfGroup.entrySet()) {
+            if (tester.isProperSupersetOf(currentGroupClassification.getKey(), group) &&
+                    (bestGroupClassification == null ||
+                    tester.isProperSupersetOf(bestGroupClassification.getKey(), currentGroupClassification.getKey()))) {
+                bestGroupClassification = currentGroupClassification;
+            }
+        }
+        return bestGroupClassification == null ? null : bestGroupClassification.getValue();
+    }
+}

--- a/components/blitz/test/omero/cmd/graphs/SpecificityClassifierTest.java
+++ b/components/blitz/test/omero/cmd/graphs/SpecificityClassifierTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Arrays;
+
+import omero.cmd.graphs.SpecificityClassifier;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+/**
+ * Test the specificity classifier by classifying creatures by their favorite room.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.1
+ */
+@Test
+public class SpecificityClassifierTest {
+
+    private enum Creature { MAMMAL, CAT, DOG, DACHSHUND, FISH, COD, HAKE, BIRD, FINCH, GREENFINCH, MAGPIE, LEVIATHAN };
+    private enum Room { KITCHEN, BEDROOM, DRAWING_ROOM, BATHROOM };
+
+    private SpecificityClassifier<Creature, Room> classifier;
+
+    private final SetMultimap<Creature, Creature> subclasses = HashMultimap.create();
+
+    /**
+     * Populate the taxonomy, providing the transitive closure manually.
+     */
+    @BeforeClass
+    public void populateSubclasses() {
+        subclasses.putAll(Creature.MAMMAL, Arrays.asList(Creature.CAT, Creature.DOG, Creature.DACHSHUND));
+        subclasses.putAll(Creature.DOG, Arrays.asList(Creature.DACHSHUND));
+        subclasses.putAll(Creature.FISH, Arrays.asList(Creature.COD, Creature.HAKE));
+        subclasses.putAll(Creature.BIRD, Arrays.asList(Creature.FINCH, Creature.GREENFINCH, Creature.MAGPIE));
+        subclasses.putAll(Creature.FINCH, Arrays.asList(Creature.GREENFINCH));
+    }
+
+    /**
+     * Create an empty classifier for each new test.
+     */
+    @BeforeMethod
+    public void refreshClassifier() {
+        classifier = new SpecificityClassifier<Creature, Room>(new SpecificityClassifier.ContainmentTester<Creature>() {
+            @Override
+            public boolean isProperSupersetOf(Creature parent, Creature child) {
+                return subclasses.containsEntry(parent, child);
+            }});
+    }
+
+    /**
+     * Test that an unknown group is not classified.
+     */
+    @Test
+    public void testUnknown() {
+        Assert.assertNull(classifier.getClass(Creature.LEVIATHAN));
+    }
+
+    /**
+     * Test that classification succeeds when exactly the known group is queried.
+     */
+    @Test
+    public void testExactClass() {
+        classifier.addClass(Room.DRAWING_ROOM, Arrays.asList(Creature.FINCH));
+        Assert.assertEquals(classifier.getClass(Creature.FINCH), Room.DRAWING_ROOM);
+    }
+
+    /**
+     * Test that classification succeeds when a subclass of the known group is queried.
+     */
+    @Test
+    public void testSuperclass() {
+        classifier.addClass(Room.DRAWING_ROOM, Arrays.asList(Creature.BIRD));
+        Assert.assertEquals(classifier.getClass(Creature.FINCH), Room.DRAWING_ROOM);
+    }
+
+    /**
+     * Test that the most specific classification is used when exactly the more specific group is queried.
+     */
+    @Test
+    public void testOverriddenDirectSuperclass() {
+        classifier.addClass(Room.BATHROOM, Arrays.asList(Creature.BIRD));
+        classifier.addClass(Room.BEDROOM, Arrays.asList(Creature.FINCH));
+        Assert.assertEquals(classifier.getClass(Creature.BIRD), Room.BATHROOM);
+        Assert.assertEquals(classifier.getClass(Creature.FINCH), Room.BEDROOM);
+        Assert.assertEquals(classifier.getClass(Creature.GREENFINCH), Room.BEDROOM);
+    }
+
+    /**
+     * Test that the most specific classification is used when a group of intermediate specificity is queried.
+     */
+    @Test
+    public void testOverriddenIndirectSuperclass() {
+        classifier.addClass(Room.BATHROOM, Arrays.asList(Creature.BIRD));
+        classifier.addClass(Room.BEDROOM, Arrays.asList(Creature.GREENFINCH));
+        Assert.assertEquals(classifier.getClass(Creature.BIRD), Room.BATHROOM);
+        Assert.assertEquals(classifier.getClass(Creature.FINCH), Room.BATHROOM);
+        Assert.assertEquals(classifier.getClass(Creature.GREENFINCH), Room.BEDROOM);
+    }
+
+    /**
+     * Test that the same classification may be asserted repeatedly for a group.
+     */
+    @Test
+    public void testSameConsistent() {
+        classifier.addClass(Room.KITCHEN, Arrays.asList(Creature.COD));
+        classifier.addClass(Room.KITCHEN, Arrays.asList(Creature.COD));
+        Assert.assertEquals(classifier.getClass(Creature.COD), Room.KITCHEN);
+    }
+
+    /**
+     * Test that different classifications may not be asserted for a group.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSameInconsistent() {
+        classifier.addClass(Room.KITCHEN, Arrays.asList(Creature.COD));
+        classifier.addClass(Room.BATHROOM, Arrays.asList(Creature.COD));
+    }
+
+    /**
+     * Test a more complex classification scenario.
+     */
+    @Test
+    public void testComplex() {
+        classifier.addClass(Room.KITCHEN, Arrays.asList(Creature.MAMMAL, Creature.DACHSHUND, Creature.HAKE));
+        classifier.addClass(Room.BEDROOM, Arrays.asList(Creature.FISH, Creature.DOG));
+        classifier.addClass(Room.DRAWING_ROOM, Arrays.asList(Creature.FINCH, Creature.LEVIATHAN));
+        classifier.addClass(Room.BATHROOM, Arrays.asList(Creature.BIRD));
+        Assert.assertEquals(classifier.getClass(Creature.MAMMAL), Room.KITCHEN);
+        Assert.assertEquals(classifier.getClass(Creature.CAT), Room.KITCHEN);
+        Assert.assertEquals(classifier.getClass(Creature.DOG), Room.BEDROOM);
+        Assert.assertEquals(classifier.getClass(Creature.DACHSHUND), Room.KITCHEN);
+        Assert.assertEquals(classifier.getClass(Creature.FISH), Room.BEDROOM);
+        Assert.assertEquals(classifier.getClass(Creature.COD), Room.BEDROOM);
+        Assert.assertEquals(classifier.getClass(Creature.HAKE), Room.KITCHEN);
+        Assert.assertEquals(classifier.getClass(Creature.BIRD), Room.BATHROOM);
+        Assert.assertEquals(classifier.getClass(Creature.FINCH), Room.DRAWING_ROOM);
+        Assert.assertEquals(classifier.getClass(Creature.GREENFINCH), Room.DRAWING_ROOM);
+        Assert.assertEquals(classifier.getClass(Creature.MAGPIE), Room.BATHROOM);
+        Assert.assertEquals(classifier.getClass(Creature.LEVIATHAN), Room.DRAWING_ROOM);
+    }
+}

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -1,7 +1,5 @@
 /*
- *   $Id$
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -166,7 +164,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
                                     String
                                             .format(
                                                     "The requested object (%s,%s) is not available.\n"
-                                                            + "Please use IQuery.find to deteremine existance.\n",
+                                                            + "Please use IQuery.find to determine existence.\n",
                                                     klass.getName(), id));
                         }
 

--- a/components/server/src/ome/services/fulltext/FullTextThread.java
+++ b/components/server/src/ome/services/fulltext/FullTextThread.java
@@ -190,7 +190,7 @@ public class FullTextThread extends ExecutionThread {
 
         acquiredLock = DetailsFieldBridge.tryLock();
         if (!acquiredLock) {
-            log.error("Cound not acquire bridge lock. "
+            log.error("Could not acquire bridge lock. "
                     + "Waiting 60 seconds and aborting.");
             try {
                 Thread.sleep(60 * 1000L);

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1363,6 +1363,20 @@ public class GraphTraversal {
     }
 
     /**
+     * Assert that {@link #unlinkTargets(boolean)} need not be called.
+     * @throws GraphException if any model objects are to be {@link Action#DELETE}d
+     */
+    public void assertNoUnlinking() throws GraphException {
+        if (!progress.contains(Milestone.PLANNED)) {
+            throw new IllegalStateException("operation not yet planned");
+        }
+        if (!planning.deleted.isEmpty()) {
+            throw new GraphException("cannot bypass unlinking step if any model objects are to be deleted");
+        }
+        progress.add(Milestone.UNLINKED);
+    }
+
+    /**
      * Prepare to remove links between the targeted model objects and the remainder of the model object graph.
      * @param isUnlinkIncludeFromExclude if {@link Action#EXCLUDE} objects must be unlinked from {@link Action#INCLUDE} objects
      * and vice versa
@@ -1575,5 +1589,43 @@ public class GraphTraversal {
                 progress.add(Milestone.PROCESSED);
             }
         };
+    }
+
+    /**
+     * Get the model objects that are linked to by the given object via the given property.
+     * Provides a window into the model object cache accumulated in planning a graph operation.
+     * @param propertyValueClass the full name of the model class that declares the given property
+     * @param propertyName a property name, may be nested
+     * @param id the ID of the model object doing the linking
+     * @return the class and ID of the model objects that are linked to by the given object, never {@code null}
+     */
+    public SetMultimap<String, Long> getLinkeds(String propertyValueClass, String propertyName, Long id) {
+        if (!progress.contains(Milestone.PLANNED)) {
+            throw new IllegalStateException("operation not yet planned");
+        }
+        final SetMultimap<String, Long> linkeds = HashMultimap.create();
+        for (final CI linked : planning.forwardLinksCached.get(new CPI(propertyValueClass, propertyName, id))) {
+            linkeds.put(linked.className, linked.id);
+        }
+        return linkeds;
+    }
+
+    /**
+     * Get the model objects that link to the given object via the given property.
+     * Provides a window into the model object cache accumulated in planning a graph operation.
+     * @param propertyValueClass the full name of the model class that declares the given property
+     * @param propertyName a property name, may be nested
+     * @param id the ID of the model object being linked to
+     * @return the class and ID of the model objects that link to the given object, never {@code null}
+     */
+    public SetMultimap<String, Long> getLinkers(String propertyValueClass, String propertyName, Long id) {
+        if (!progress.contains(Milestone.PLANNED)) {
+            throw new IllegalStateException("operation not yet planned");
+        }
+        final SetMultimap<String, Long> linkers = HashMultimap.create();
+        for (final CI linker : planning.backwardLinksCached.get(new CPI(propertyValueClass, propertyName, id))) {
+            linkers.put(linker.className, linker.id);
+        }
+        return linkers;
     }
 }

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1,0 +1,1116 @@
+/*
+ * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import omero.RLong;
+import omero.RType;
+import omero.ServerError;
+import omero.cmd.Delete2;
+import omero.cmd.Duplicate;
+import omero.cmd.DuplicateResponse;
+import omero.cmd.ERR;
+import omero.gateway.util.Requests;
+import omero.model.Annotation;
+import omero.model.AnnotationAnnotationLink;
+import omero.model.AnnotationAnnotationLinkI;
+import omero.model.Channel;
+import omero.model.DoubleAnnotationI;
+import omero.model.Ellipse;
+import omero.model.EllipseI;
+import omero.model.FileAnnotation;
+import omero.model.FileAnnotationI;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.ImageAnnotationLink;
+import omero.model.ImageAnnotationLinkI;
+import omero.model.Line;
+import omero.model.LineI;
+import omero.model.LogicalChannel;
+import omero.model.LongAnnotation;
+import omero.model.LongAnnotationI;
+import omero.model.MapAnnotationI;
+import omero.model.Pixels;
+import omero.model.PlaneInfo;
+import omero.model.Point;
+import omero.model.PointI;
+import omero.model.Rectangle;
+import omero.model.RectangleI;
+import omero.model.Roi;
+import omero.model.RoiI;
+import omero.model.Shape;
+import omero.model.StatsInfo;
+import omero.model.TagAnnotationI;
+import omero.model.TextAnnotation;
+import omero.model.XmlAnnotationI;
+import omero.sys.Parameters;
+import omero.sys.ParametersI;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+/**
+ * Tests that {@link Duplicate} behaves as expected.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.1
+ */
+public class DuplicationTest extends AbstractServerTest {
+
+    /**
+     * A <em>Z</em>, <em>T</em>, <em>C</em> key for indexing {@link PlaneInfo} instances in hash tables.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.1
+     */
+    private static class PlaneInfoKey {
+
+        private final int z, t, c;
+
+        /**
+         * Construct a new key.
+         * @param planeInfo the {@link PlaneInfo} to which this key is to correspond
+         */
+        PlaneInfoKey(PlaneInfo planeInfo) {
+            this.z = planeInfo.getTheZ().getValue();
+            this.t = planeInfo.getTheT().getValue();
+            this.c = planeInfo.getTheC().getValue();
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            } else if (object instanceof PlaneInfoKey) {
+                final PlaneInfoKey other = (PlaneInfoKey) object;
+                return this.z == other.z && this.t == other.t && this.c == other.c;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getClass(), z, t, c);
+        }
+    }
+
+    private final List<Long> testImages = Collections.synchronizedList(new ArrayList<Long>());
+
+    /**
+     * Clear the list of test images.
+     */
+    @BeforeClass
+    public void clearTestImages() {
+        testImages.clear();
+    }
+
+    /**
+     * Delete the test images then clear the list.
+     * @throws Exception unexpected
+     */
+    @AfterClass
+    public void deleteTestImages() throws Exception {
+        final Delete2 delete = Requests.delete("Image", testImages);
+        doChange(root, root.getSession(), delete, true);
+        clearTestImages();
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Image original, Image duplicate) {
+        Assert.assertEquals(duplicate.getDescription().getValue(), original.getDescription().getValue());
+        Assert.assertEquals(duplicate.getFormat().getValue(), original.getFormat().getValue());
+        Assert.assertEquals(duplicate.getName().getValue(), original.getName().getValue());
+        Assert.assertEquals(duplicate.getSeries().getValue(), original.getSeries().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Pixels original, Pixels duplicate) {
+        Assert.assertEquals(duplicate.getPhysicalSizeX().getUnit(), original.getPhysicalSizeX().getUnit());
+        Assert.assertEquals(duplicate.getPhysicalSizeX().getValue(), original.getPhysicalSizeX().getValue());
+        Assert.assertEquals(duplicate.getPhysicalSizeY().getUnit(), original.getPhysicalSizeY().getUnit());
+        Assert.assertEquals(duplicate.getPhysicalSizeY().getValue(), original.getPhysicalSizeY().getValue());
+        Assert.assertEquals(duplicate.getPhysicalSizeZ().getUnit(), original.getPhysicalSizeZ().getUnit());
+        Assert.assertEquals(duplicate.getPhysicalSizeZ().getValue(), original.getPhysicalSizeZ().getValue());
+        Assert.assertEquals(duplicate.getSizeX().getValue(), original.getSizeX().getValue());
+        Assert.assertEquals(duplicate.getSizeY().getValue(), original.getSizeY().getValue());
+        Assert.assertEquals(duplicate.getSizeZ().getValue(), original.getSizeZ().getValue());
+        Assert.assertEquals(duplicate.getSizeT().getValue(), original.getSizeT().getValue());
+        Assert.assertEquals(duplicate.getSizeC().getValue(), original.getSizeC().getValue());
+        Assert.assertEquals(duplicate.getSha1().getValue(), original.getSha1().getValue());
+        Assert.assertEquals(duplicate.getDimensionOrder().getValue().getValue(),
+                original.getDimensionOrder().getValue().getValue());
+        Assert.assertEquals(duplicate.getPixelsType().getBitSize().getValue(), original.getPixelsType().getBitSize().getValue());
+        Assert.assertEquals(duplicate.getPixelsType().getValue().getValue(), original.getPixelsType().getValue().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Channel original, Channel duplicate) {
+        // nothing
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(LogicalChannel original, LogicalChannel duplicate) {
+        Assert.assertEquals(duplicate.getContrastMethod().getValue().getValue(),
+                original.getContrastMethod().getValue().getValue());
+        Assert.assertEquals(duplicate.getEmissionWave().getUnit(), original.getEmissionWave().getUnit());
+        Assert.assertEquals(duplicate.getEmissionWave().getValue(), original.getEmissionWave().getValue());
+        Assert.assertEquals(duplicate.getIllumination().getValue(), original.getIllumination().getValue());
+        Assert.assertEquals(duplicate.getMode().getValue().getValue(), original.getMode().getValue().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(PlaneInfo original, PlaneInfo duplicate) {
+        Assert.assertEquals(duplicate.getTheZ().getValue(), original.getTheZ().getValue());
+        Assert.assertEquals(duplicate.getTheT().getValue(), original.getTheT().getValue());
+        Assert.assertEquals(duplicate.getTheC().getValue(), original.getTheC().getValue());
+        Assert.assertEquals(duplicate.getDeltaT().getUnit(), original.getDeltaT().getUnit());
+        Assert.assertEquals(duplicate.getDeltaT().getValue(), original.getDeltaT().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(StatsInfo original, StatsInfo duplicate) {
+        Assert.assertEquals(duplicate.getGlobalMin().getValue(), original.getGlobalMin().getValue());
+        Assert.assertEquals(duplicate.getGlobalMax().getValue(), original.getGlobalMax().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Rectangle original, Rectangle duplicate) {
+        Assert.assertEquals(duplicate.getTheZ().getValue(), original.getTheZ().getValue());
+        Assert.assertEquals(duplicate.getTheT().getValue(), original.getTheT().getValue());
+        Assert.assertEquals(duplicate.getTheC().getValue(), original.getTheC().getValue());
+        Assert.assertEquals(duplicate.getX().getValue(), original.getX().getValue());
+        Assert.assertEquals(duplicate.getY().getValue(), original.getY().getValue());
+        Assert.assertEquals(duplicate.getWidth().getValue(), original.getWidth().getValue());
+        Assert.assertEquals(duplicate.getHeight().getValue(), original.getHeight().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Ellipse original, Ellipse duplicate) {
+        Assert.assertEquals(duplicate.getTheZ().getValue(), original.getTheZ().getValue());
+        Assert.assertEquals(duplicate.getTheT().getValue(), original.getTheT().getValue());
+        Assert.assertEquals(duplicate.getTheC().getValue(), original.getTheC().getValue());
+        Assert.assertEquals(duplicate.getCx().getValue(), original.getCx().getValue());
+        Assert.assertEquals(duplicate.getCy().getValue(), original.getCy().getValue());
+        Assert.assertEquals(duplicate.getRx().getValue(), original.getRx().getValue());
+        Assert.assertEquals(duplicate.getRy().getValue(), original.getRy().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Line original, Line duplicate) {
+        Assert.assertEquals(duplicate.getTheZ().getValue(), original.getTheZ().getValue());
+        Assert.assertEquals(duplicate.getTheT().getValue(), original.getTheT().getValue());
+        Assert.assertEquals(duplicate.getTheC().getValue(), original.getTheC().getValue());
+        Assert.assertEquals(duplicate.getX1().getValue(), original.getX1().getValue());
+        Assert.assertEquals(duplicate.getY1().getValue(), original.getY1().getValue());
+        Assert.assertEquals(duplicate.getX2().getValue(), original.getX2().getValue());
+        Assert.assertEquals(duplicate.getY2().getValue(), original.getY2().getValue());
+    }
+
+    /**
+     * Assert that the given instances have the same property values.
+     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
+     * @param original the original instance
+     * @param duplicate the duplicate instance that is expected to correspond to the original
+     */
+    private static void assertSameProperties(Point original, Point duplicate) {
+        Assert.assertEquals(duplicate.getTheZ().getValue(), original.getTheZ().getValue());
+        Assert.assertEquals(duplicate.getTheT().getValue(), original.getTheT().getValue());
+        Assert.assertEquals(duplicate.getTheC().getValue(), original.getTheC().getValue());
+        Assert.assertEquals(duplicate.getCx().getValue(), original.getCx().getValue());
+        Assert.assertEquals(duplicate.getCy().getValue(), original.getCy().getValue());
+    }
+
+    /**
+     * Get the IDs of an image's annotations.
+     * @param imageId the ID of an image
+     * @return the IDs of the annotations on the image
+     * @throws ServerError unexpected
+     */
+    private Set<Long> getImageAnnotations(long imageId) throws ServerError {
+        final Set<Long> annotationIds = new HashSet<Long>();
+        for (final List<RType> result : iQuery.projection(
+                "SELECT child.id FROM ImageAnnotationLink WHERE parent.id = :id",
+                new ParametersI().addId(imageId))) {
+            annotationIds.add(((RLong) result.get(0)).getValue());
+        }
+        return annotationIds;
+    }
+
+    private String followLongAnnotations(LongAnnotation start, int depth) throws ServerError {
+        if (depth < 1) {
+            return "";
+        }
+        final StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        sb.append(start.getLongValue().getValue());
+        for (final IObject result : iQuery.findAllByQuery(
+                "SELECT l.child FROM AnnotationAnnotationLink AS l WHERE l.parent.id = :id ORDER BY l.child.longValue",
+                new ParametersI().addId(start.getId().getValue()))) {
+            if (result instanceof LongAnnotation) {
+                sb.append(followLongAnnotations((LongAnnotation) result, depth - 1));
+            }
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    /**
+     * Create then duplicate an image and test that the properties of the instances in it and its subgraph are correctly duplicated.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageProperties() throws Exception {
+        newUserAndGroup("rwr---");
+
+        /* create and save an image */
+
+        final Image originalImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage(1,2,3,4,5));
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImage.getId().getValue();
+        testImages.add(originalImageId);
+        final Pixels originalPixels = originalImage.getPrimaryPixels();
+        final long originalPixelsId = originalPixels.getId().getValue();
+        final List<Channel> originalChannels = new ArrayList<Channel>(originalPixels.sizeOfChannels());
+        final Set<Long> originalChannelIds = new HashSet<Long>();
+        final List<LogicalChannel> originalLogicalChannels = new ArrayList<LogicalChannel>(originalChannels.size());
+        final Set<Long> originalLogicalChannelIds = new HashSet<Long>();
+        final List<StatsInfo> originalStatsInfos = new ArrayList<StatsInfo>(originalChannels.size());
+        final Set<Long> originalStatsInfoIds = new HashSet<Long>();
+        for (int channelIndex = 0; channelIndex < originalPixels.sizeOfChannels(); channelIndex++) {
+            final Channel originalChannel = originalPixels.getChannel(channelIndex);
+            originalChannels.add(originalChannel);
+            originalChannelIds.add(originalChannel.getId().getValue());
+            final LogicalChannel originalLogicalChannel = originalChannel.getLogicalChannel();
+            originalLogicalChannels.add(originalLogicalChannel);
+            originalLogicalChannelIds.add(originalLogicalChannel.getId().getValue());
+            final StatsInfo originalStatsInfo = originalChannel.getStatsInfo();
+            originalStatsInfos.add(originalStatsInfo);
+            originalStatsInfoIds.add(originalStatsInfo.getId().getValue());
+        }
+        final Map<PlaneInfoKey, PlaneInfo> originalPlaneInfos = new HashMap<PlaneInfoKey, PlaneInfo>();
+        final Set<Long> originalPlaneInfoIds = new HashSet<Long>();
+        for (final PlaneInfo originalPlaneInfo : originalPixels.copyPlaneInfo()) {
+            originalPlaneInfos.put(new PlaneInfoKey(originalPlaneInfo), originalPlaneInfo);
+            originalPlaneInfoIds.add(originalPlaneInfo.getId().getValue());
+        }
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* find out which objects the duplication claims to have created */
+
+        Assert.assertEquals(response.duplicates.size(), 6);
+        final Set<Long> remainingImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        final Set<Long> remainingPixelsIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Pixels"));
+        final Set<Long> remainingChannelIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Channel"));
+        final Set<Long> remainingLogicalChannelIds = new HashSet<Long>(response.duplicates.get("ome.model.core.LogicalChannel"));
+        final Set<Long> remainingStatsInfoIds = new HashSet<Long>(response.duplicates.get("ome.model.stats.StatsInfo"));
+        final Set<Long> remainingPlaneInfoIds = new HashSet<Long>(response.duplicates.get("ome.model.core.PlaneInfo"));
+
+        /* check that the new image's subgraph is a set of new IDs that match the response and whose properties are as expected */
+
+        final Long duplicateImageId = remainingImageIds.iterator().next();
+        testImages.add(duplicateImageId);
+        final Parameters parameters = new ParametersI().addId(duplicateImageId);
+        final Image duplicateImage = (Image) iQuery.findByQuery(
+                "SELECT i FROM Image i " +
+                "JOIN FETCH i.pixels AS p " +
+                "JOIN FETCH i.format " +
+                "JOIN FETCH p.dimensionOrder " +
+                "JOIN FETCH p.pixelsType " +
+                "JOIN FETCH p.channels AS c " +
+                "JOIN FETCH p.planeInfo AS pi " +
+                "JOIN FETCH c.logicalChannel AS lc " +
+                "JOIN FETCH lc.contrastMethod " +
+                "JOIN FETCH lc.illumination " +
+                "JOIN FETCH lc.mode " +
+                "JOIN FETCH c.statsInfo " +
+                "WHERE i.id = :id", parameters);
+        Assert.assertNotEquals(originalImageId, duplicateImageId);
+        Assert.assertTrue(remainingImageIds.remove(duplicateImageId));
+        assertSameProperties(originalImage, duplicateImage);
+
+        final Pixels duplicatePixels = duplicateImage.getPrimaryPixels();
+        final long duplicatePixelsId = duplicatePixels.getId().getValue();
+        Assert.assertNotEquals(originalPixelsId, duplicatePixelsId);
+        Assert.assertTrue(remainingPixelsIds.remove(duplicatePixelsId));
+        assertSameProperties(originalPixels, duplicatePixels);
+
+        for (int channelIndex = 0; channelIndex < duplicatePixels.sizeOfChannels(); channelIndex++) {
+            final Channel duplicateChannel = duplicatePixels.getChannel(channelIndex);
+            final long duplicateChannelId = duplicateChannel.getId().getValue();
+            Assert.assertFalse(originalChannelIds.contains(duplicateChannelId));
+            Assert.assertTrue(remainingChannelIds.remove(duplicateChannelId));
+            assertSameProperties(originalChannels.get(channelIndex), duplicateChannel);
+
+            final LogicalChannel duplicateLogicalChannel = duplicateChannel.getLogicalChannel();
+            final long duplicateLogicalChannelId = duplicateLogicalChannel.getId().getValue();
+            Assert.assertFalse(originalLogicalChannelIds.contains(duplicateLogicalChannelId));
+            Assert.assertTrue(remainingLogicalChannelIds.remove(duplicateLogicalChannelId));
+            assertSameProperties(originalLogicalChannels.get(channelIndex), duplicateLogicalChannel);
+
+            final StatsInfo duplicateStatsInfo = duplicateChannel.getStatsInfo();
+            final long duplicateStatsInfoId = duplicateStatsInfo.getId().getValue();
+            Assert.assertFalse(originalStatsInfoIds.contains(duplicateStatsInfoId));
+            Assert.assertTrue(remainingStatsInfoIds.remove(duplicateStatsInfoId));
+            assertSameProperties(originalStatsInfos.get(channelIndex), duplicateStatsInfo);
+        }
+        for (final PlaneInfo duplicatePlaneInfo : duplicatePixels.copyPlaneInfo()) {
+            final long duplicatePlaneInfoId = duplicatePlaneInfo.getId().getValue();
+            Assert.assertFalse(originalPlaneInfoIds.contains(duplicatePlaneInfoId));
+            Assert.assertTrue(remainingPlaneInfoIds.remove(duplicatePlaneInfoId));
+            assertSameProperties(originalPlaneInfos.get(new PlaneInfoKey(duplicatePlaneInfo)), duplicatePlaneInfo);
+        }
+
+        /* check that the response reported no IDs for instances whose properties we did not check */
+
+        Assert.assertTrue(remainingImageIds.isEmpty());
+        Assert.assertTrue(remainingPixelsIds.isEmpty());
+        Assert.assertTrue(remainingChannelIds.isEmpty());
+        Assert.assertTrue(remainingLogicalChannelIds.isEmpty());
+        Assert.assertTrue(remainingStatsInfoIds.isEmpty());
+        Assert.assertTrue(remainingPlaneInfoIds.isEmpty());
+    }
+
+    /**
+     * Create then duplicate an image in dry-run mode and test that the image's subgraph is returned in the response.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageDryRun() throws Exception {
+        newUserAndGroup("rwr---");
+
+        /* create and save an image */
+
+        final Image originalImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage(1,2,3,4,5));
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImage.getId().getValue();
+        testImages.add(originalImageId);
+        final Pixels originalPixels = originalImage.getPrimaryPixels();
+        final long originalPixelsId = originalPixels.getId().getValue();
+        final Set<Long> originalChannelIds = new HashSet<Long>();
+        final Set<Long> originalLogicalChannelIds = new HashSet<Long>();
+        final Set<Long> originalStatsInfoIds = new HashSet<Long>();
+        for (int channelIndex = 0; channelIndex < originalPixels.sizeOfChannels(); channelIndex++) {
+            final Channel originalChannel = originalPixels.getChannel(channelIndex);
+            originalChannelIds.add(originalChannel.getId().getValue());
+            final LogicalChannel originalLogicalChannel = originalChannel.getLogicalChannel();
+            originalLogicalChannelIds.add(originalLogicalChannel.getId().getValue());
+            final StatsInfo originalStatsInfo = originalChannel.getStatsInfo();
+            originalStatsInfoIds.add(originalStatsInfo.getId().getValue());
+        }
+        final Set<Long> originalPlaneInfoIds = new HashSet<Long>();
+        for (final PlaneInfo originalPlaneInfo : originalPixels.copyPlaneInfo()) {
+            originalPlaneInfoIds.add(originalPlaneInfo.getId().getValue());
+        }
+
+        /* duplicate the image in dry-run mode */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        dup.dryRun = true;
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* find out which objects the duplication reports as being targets for processing */
+
+        Assert.assertEquals(response.duplicates.size(), 6);
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        final Set<Long> reportedPixelsIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Pixels"));
+        final Set<Long> reportedChannelIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Channel"));
+        final Set<Long> reportedLogicalChannelIds = new HashSet<Long>(response.duplicates.get("ome.model.core.LogicalChannel"));
+        final Set<Long> reportedStatsInfoIds = new HashSet<Long>(response.duplicates.get("ome.model.stats.StatsInfo"));
+        final Set<Long> reportedPlaneInfoIds = new HashSet<Long>(response.duplicates.get("ome.model.core.PlaneInfo"));
+
+        /* check that the duplication reported exactly the expected targets */
+
+        Assert.assertEquals(reportedImageIds, Collections.singleton(originalImageId));
+        Assert.assertEquals(reportedPixelsIds, Collections.singleton(originalPixelsId));
+        Assert.assertEquals(reportedChannelIds, originalChannelIds);
+        Assert.assertEquals(reportedLogicalChannelIds, originalLogicalChannelIds);
+        Assert.assertEquals(reportedStatsInfoIds, originalStatsInfoIds);
+        Assert.assertEquals(reportedPlaneInfoIds, originalPlaneInfoIds);
+    }
+
+    /**
+     * Test duplication of an annotated image with duplication of its annotation.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithAnnotation() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an annotated image */
+
+        final String annotationText = getClass().getSimpleName() + ':' + System.nanoTime();
+
+        final Image originalImage = mmFactory.simpleImage();
+        final TextAnnotation originalAnnotation = new XmlAnnotationI();
+        originalAnnotation.setTextValue(omero.rtypes.rstring(annotationText));
+        ImageAnnotationLink originalLink = new ImageAnnotationLinkI();
+        originalLink.setParent(originalImage);
+        originalLink.setChild(originalAnnotation);
+        originalLink = (ImageAnnotationLink) iUpdate.saveAndReturnObject(originalLink);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalLink.getParent().getId().getValue();
+        final long originalAnnotationId = originalLink.getChild().getId().getValue();
+        final long originalLinkId = originalLink.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image, link, and annotation */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        final Set<Long> reportedAnnotationIds = new HashSet<Long>(response.duplicates.get("ome.model.annotations.XmlAnnotation"));
+        final Set<Long> reportedLinkIds = new HashSet<Long>(response.duplicates.get("ome.model.annotations.ImageAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+        Assert.assertEquals(reportedAnnotationIds.size(), 1);
+        Assert.assertEquals(reportedLinkIds.size(), 1);
+
+        /* check that the reported image, link, and annotation each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        final long reportedAnnotationId = reportedAnnotationIds.iterator().next();
+        final long reportedLinkId = reportedLinkIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+        Assert.assertNotEquals(originalAnnotationId, reportedAnnotationId);
+        Assert.assertNotEquals(originalLinkId, reportedLinkId);
+
+        /* check that the annotations on the images are exactly as expected */
+
+        Assert.assertEquals(getImageAnnotations(originalImageId), Collections.singleton(originalAnnotationId));
+        Assert.assertEquals(getImageAnnotations(reportedImageId), Collections.singleton(reportedAnnotationId));
+
+        /* check that the annotation is indeed a duplicate of the original */
+
+        final TextAnnotation duplicatedAnnotation = (TextAnnotation) iQuery.findByQuery(
+                "FROM Annotation WHERE id = :id",
+                new ParametersI().addId(reportedAnnotationId));
+
+        Assert.assertEquals(duplicatedAnnotation.getTextValue().getValue(), annotationText);
+    }
+
+    /**
+     * Test duplication of an annotated image such that it links to the original's annotation.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithPreviousAnnotation() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an annotated image */
+
+        final String annotationText = getClass().getSimpleName() + ':' + System.nanoTime();
+
+        final Image originalImage = mmFactory.simpleImage();
+        final TextAnnotation originalAnnotation = new XmlAnnotationI();
+        originalAnnotation.setTextValue(omero.rtypes.rstring(annotationText));
+        ImageAnnotationLink originalLink = new ImageAnnotationLinkI();
+        originalLink.setParent(originalImage);
+        originalLink.setChild(originalAnnotation);
+        originalLink = (ImageAnnotationLink) iUpdate.saveAndReturnObject(originalLink);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalLink.getParent().getId().getValue();
+        final long originalAnnotationId = originalLink.getChild().getId().getValue();
+        final long originalLinkId = originalLink.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        dup.typesToReference = ImmutableList.of("TextAnnotation");
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image and link, but not an annotation */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.XmlAnnotation"));
+        final Set<Long> reportedLinkIds = new HashSet<Long>(response.duplicates.get("ome.model.annotations.ImageAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+        Assert.assertEquals(reportedLinkIds.size(), 1);
+
+        /* check that the reported image and annotation each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        final long reportedLinkId = reportedLinkIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+        Assert.assertNotEquals(originalLinkId, reportedLinkId);
+
+        /* check that the annotations on the images are exactly as expected */
+
+        Assert.assertEquals(getImageAnnotations(originalImageId), Collections.singleton(originalAnnotationId));
+        Assert.assertEquals(getImageAnnotations(reportedImageId), Collections.singleton(originalAnnotationId));
+    }
+
+    /**
+     * Test duplication of an annotated image such that it does not link to an annotation.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithNoAnnotation() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an annotated image */
+
+        final String annotationText = getClass().getSimpleName() + ':' + System.nanoTime();
+
+        final Image originalImage = mmFactory.simpleImage();
+        final TextAnnotation originalAnnotation = new XmlAnnotationI();
+        originalAnnotation.setTextValue(omero.rtypes.rstring(annotationText));
+        ImageAnnotationLink originalLink = new ImageAnnotationLinkI();
+        originalLink.setParent(originalImage);
+        originalLink.setChild(originalAnnotation);
+        originalLink = (ImageAnnotationLink) iUpdate.saveAndReturnObject(originalLink);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalLink.getParent().getId().getValue();
+        final long originalAnnotationId = originalLink.getChild().getId().getValue();
+        final long originalLinkId = originalLink.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        dup.typesToIgnore = ImmutableList.of("IAnnotationLink");
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image and link, but not an annotation */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.XmlAnnotation"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.ImageAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+
+        /* check that the reported image and annotation each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+
+        /* check that the annotations on the images are exactly as expected */
+
+        Assert.assertEquals(getImageAnnotations(originalImageId), Collections.singleton(originalAnnotationId));
+        Assert.assertEquals(getImageAnnotations(reportedImageId), Collections.emptySet());
+    }
+
+
+    /**
+     * Test duplication of an annotated image such that it does not duplicate an attachment.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithFileAnnotation() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an image with an attachment */
+
+        final Image originalImage = mmFactory.simpleImage();
+        final FileAnnotation originalAttachment = new FileAnnotationI();
+        ImageAnnotationLink originalLink = new ImageAnnotationLinkI();
+        originalLink.setParent(originalImage);
+        originalLink.setChild(originalAttachment);
+        originalLink = (ImageAnnotationLink) iUpdate.saveAndReturnObject(originalLink);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalLink.getParent().getId().getValue();
+        final long originalAttachmentId = originalLink.getChild().getId().getValue();
+        final long originalLinkId = originalLink.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image and link, but not the attachment */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.FileAnnotation"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.ImageAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+
+        /* check that the reported image and annotation each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+
+        /* check that the annotations on the images are exactly as expected */
+
+        Assert.assertEquals(getImageAnnotations(originalImageId), Collections.singleton(originalAttachmentId));
+        Assert.assertEquals(getImageAnnotations(reportedImageId), Collections.emptySet());
+    }
+
+    /**
+     * Tests duplication of a cyclic subgraph.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithCyclicAnnotation() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create a graph of annotations */
+
+        final Image originalImage = mmFactory.simpleImage();
+        final List<LongAnnotation> originalAnnotations = new ArrayList<LongAnnotation>();
+        List<IObject> originalLinks = new ArrayList<IObject>();
+        /* create a string of annotations */
+        for (int index = 0; index < 5; index++) {
+            originalAnnotations.add(new LongAnnotationI());
+            originalAnnotations.get(index).setLongValue(omero.rtypes.rlong(index));
+            if (index > 0) {
+                final AnnotationAnnotationLink annotationLink = new AnnotationAnnotationLinkI();
+                annotationLink.setParent((Annotation) originalAnnotations.get(index - 1));
+                annotationLink.setChild(originalAnnotations.get(index));
+                originalLinks.add(annotationLink);
+            }
+        }
+        /* add a back-link within the string of annotations */
+        final AnnotationAnnotationLink annotationLink = new AnnotationAnnotationLinkI();
+        annotationLink.setParent((Annotation) originalAnnotations.get(3));
+        annotationLink.setChild(originalAnnotations.get(1));
+        originalLinks.add(annotationLink);
+
+        /* annotate an image with the graph */
+
+        ImageAnnotationLink originalImageLink = new ImageAnnotationLinkI();
+        originalImageLink.setParent(originalImage);
+        originalImageLink.setChild(originalAnnotations.get(0));
+        originalLinks.add(0, originalImageLink);
+        originalLinks = iUpdate.saveAndReturnArray(originalLinks);
+        originalImageLink = (ImageAnnotationLink) originalLinks.get(0);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImageLink.getParent().getId().getValue();
+        final long originalImageLinkId = ((ImageAnnotationLink) originalLinks.get(0)).getId().getValue();
+        final Set<Long> originalAnnotationIds = new HashSet<Long>();
+        final Set<Long> originalAnnotationLinkIds = new HashSet<Long>();
+        for (final IObject object : originalLinks.subList(1, originalLinks.size())) {
+            final AnnotationAnnotationLink link = (AnnotationAnnotationLink) object;
+            originalAnnotationIds.add(link.getParent().getId().getValue());
+            originalAnnotationIds.add(link.getChild().getId().getValue());
+            originalAnnotationLinkIds.add(link.getId().getValue());
+        }
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image and annotations and the links among them */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.core.Image"));
+        final Set<Long> reportedAnnotationIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.LongAnnotation"));
+        final Set<Long> reportedImageLinkIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.ImageAnnotationLink"));
+        final Set<Long> reportedAnnotationLinkIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.AnnotationAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+        Assert.assertEquals(reportedAnnotationIds.size(), originalAnnotations.size());
+        Assert.assertEquals(reportedImageLinkIds.size() + reportedAnnotationLinkIds.size(), originalLinks.size());
+
+        /* check that the reported image and annotation each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        final long reportedImageLinkId = reportedImageLinkIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+        Assert.assertNotEquals(originalImageLinkId, reportedImageLinkId);
+        Assert.assertTrue(Sets.intersection(originalAnnotationIds, reportedAnnotationIds).isEmpty());
+        Assert.assertTrue(Sets.intersection(originalAnnotationLinkIds, reportedAnnotationLinkIds).isEmpty());
+
+        /* check that the duplicate image has a different annotation from the original image */
+
+        final Set<Long> originalImageAnnotationIds = getImageAnnotations(originalImageId);
+        final Set<Long> duplicateImageAnnotationIds = getImageAnnotations(reportedImageId);
+        Assert.assertEquals(originalImageAnnotationIds.size(), 1);
+        Assert.assertEquals(duplicateImageAnnotationIds.size(), 1);
+        final long originalImageAnnotationId = originalImageAnnotationIds.iterator().next();
+        final long duplicateImageAnnotationId = duplicateImageAnnotationIds.iterator().next();
+        Assert.assertNotEquals(originalImageAnnotationId, duplicateImageAnnotationId);
+
+        /* check that the structure of the cyclic graph of annotations has been correctly duplicated */
+
+        final LongAnnotation originalImageAnnotation  = (LongAnnotation) iQuery.get("LongAnnotation", originalImageAnnotationId);
+        final LongAnnotation duplicateImageAnnotation = (LongAnnotation) iQuery.get("LongAnnotation", duplicateImageAnnotationId);
+
+        Assert.assertEquals(followLongAnnotations(originalImageAnnotation,  6), "[0[1[2[3[1[2]][4]]]]]");
+        Assert.assertEquals(followLongAnnotations(duplicateImageAnnotation, 6), "[0[1[2[3[1[2]][4]]]]]");
+    }
+
+    /**
+     * Test preservation of shapes and their properties when duplicating an image with an ROI.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateShapeProperties() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an image with ROIs */
+
+        Image originalImage = mmFactory.simpleImage();
+        Roi originalRoi = new RoiI();
+        Rectangle originalRectangle = new RectangleI();
+        originalRoi.addShape(originalRectangle);
+        Ellipse originalEllipse = new EllipseI();
+        originalRoi.addShape(originalEllipse);
+        Line originalLine = new LineI();
+        originalRoi.addShape(originalLine);
+        Point originalPoint = new PointI();
+        originalRoi.addShape(originalPoint);
+
+        int propertyValue = 1;
+        originalRectangle.setTheZ(omero.rtypes.rint(propertyValue++));
+        originalRectangle.setTheT(omero.rtypes.rint(propertyValue++));
+        originalRectangle.setTheC(omero.rtypes.rint(propertyValue++));
+        originalRectangle.setX(omero.rtypes.rdouble(propertyValue++));
+        originalRectangle.setY(omero.rtypes.rdouble(propertyValue++));
+        originalRectangle.setWidth(omero.rtypes.rdouble(propertyValue++));
+        originalRectangle.setHeight(omero.rtypes.rdouble(propertyValue++));
+        originalEllipse.setTheZ(omero.rtypes.rint(propertyValue++));
+        originalEllipse.setTheT(omero.rtypes.rint(propertyValue++));
+        originalEllipse.setTheC(omero.rtypes.rint(propertyValue++));
+        originalEllipse.setCx(omero.rtypes.rdouble(propertyValue++));
+        originalEllipse.setCy(omero.rtypes.rdouble(propertyValue++));
+        originalEllipse.setRx(omero.rtypes.rdouble(propertyValue++));
+        originalEllipse.setRy(omero.rtypes.rdouble(propertyValue++));
+        originalLine.setTheZ(omero.rtypes.rint(propertyValue++));
+        originalLine.setTheT(omero.rtypes.rint(propertyValue++));
+        originalLine.setTheC(omero.rtypes.rint(propertyValue++));
+        originalLine.setX1(omero.rtypes.rdouble(propertyValue++));
+        originalLine.setY1(omero.rtypes.rdouble(propertyValue++));
+        originalLine.setX2(omero.rtypes.rdouble(propertyValue++));
+        originalLine.setY2(omero.rtypes.rdouble(propertyValue++));
+        originalPoint.setTheZ(omero.rtypes.rint(propertyValue++));
+        originalPoint.setTheT(omero.rtypes.rint(propertyValue++));
+        originalPoint.setTheC(omero.rtypes.rint(propertyValue++));
+        originalPoint.setCx(omero.rtypes.rdouble(propertyValue++));
+        originalPoint.setCy(omero.rtypes.rdouble(propertyValue++));
+
+        originalRoi = (Roi) iUpdate.saveAndReturnObject(originalRoi);
+        final Iterator<Shape> originalShapes = originalRoi.copyShapes().iterator();
+        originalRectangle = (Rectangle) originalShapes.next();
+        originalEllipse = (Ellipse) originalShapes.next();
+        originalLine = (Line) originalShapes.next();
+        originalPoint = (Point) originalShapes.next();
+        Assert.assertFalse(originalShapes.hasNext());
+        originalImage.addRoi(originalRoi);
+        originalImage = (Image) iUpdate.saveAndReturnObject(originalImage);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImage.getId().getValue();
+        final long originalRoiId = originalRoi.getId().getValue();
+        final long originalRectangleId = originalRectangle.getId().getValue();
+        final long originalEllipseId = originalEllipse.getId().getValue();
+        final long originalLineId = originalLine.getId().getValue();
+        final long originalPointId = originalPoint.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image, link, and annotation */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(response.duplicates.get("ome.model.core.Image"));
+        final Set<Long> reportedRoiIds = new HashSet<Long>(response.duplicates.get("ome.model.roi.Roi"));
+        final Set<Long> reportedRectangleIds = new HashSet<Long>(response.duplicates.get("ome.model.roi.Rectangle"));
+        final Set<Long> reportedEllipseIds = new HashSet<Long>(response.duplicates.get("ome.model.roi.Ellipse"));
+        final Set<Long> reportedLineIds = new HashSet<Long>(response.duplicates.get("ome.model.roi.Line"));
+        final Set<Long> reportedPointIds = new HashSet<Long>(response.duplicates.get("ome.model.roi.Point"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+        Assert.assertEquals(reportedRoiIds.size(), 1);
+        Assert.assertEquals(reportedRectangleIds.size(), 1);
+        Assert.assertEquals(reportedEllipseIds.size(), 1);
+        Assert.assertEquals(reportedLineIds.size(), 1);
+        Assert.assertEquals(reportedPointIds.size(), 1);
+
+        /* check that the reported image, ROI and shapes each have a new ID */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        final long reportedRoiId = reportedRoiIds.iterator().next();
+        final long reportedRectangleId = reportedRectangleIds.iterator().next();
+        final long reportedEllipseId = reportedEllipseIds.iterator().next();
+        final long reportedLineId = reportedLineIds.iterator().next();
+        final long reportedPointId = reportedPointIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+        Assert.assertNotEquals(originalRoiId, reportedRoiId);
+        Assert.assertNotEquals(originalRectangleId, reportedRectangleId);
+        Assert.assertNotEquals(originalEllipseId, reportedEllipseId);
+        Assert.assertNotEquals(originalLineId, reportedLineId);
+        Assert.assertNotEquals(originalPointId, reportedPointId);
+
+        /* check that the ROI on the images is exactly as expected */
+
+        final Parameters parameters = new ParametersI().addId(reportedImageId);
+        final Image duplicateImage = (Image) iQuery.findByQuery(
+                "SELECT i FROM Image i " +
+                "JOIN FETCH i.rois AS r " +
+                "JOIN FETCH r.shapes " +
+                "WHERE i.id = :id", parameters);
+        final Iterator<Shape> duplicateShapes = duplicateImage.copyRois().get(0).copyShapes().iterator();
+        final Rectangle duplicateRectangle = (Rectangle) duplicateShapes.next();
+        final Ellipse duplicateEllipse = (Ellipse) duplicateShapes.next();
+        final Line duplicateLine = (Line) duplicateShapes.next();
+        final Point duplicatePoint = (Point) duplicateShapes.next();
+        Assert.assertFalse(duplicateShapes.hasNext());
+
+        Assert.assertEquals(duplicateRectangle.getId().getValue(), reportedRectangleId);
+        Assert.assertEquals(duplicateEllipse.getId().getValue(), reportedEllipseId);
+        Assert.assertEquals(duplicateLine.getId().getValue(), reportedLineId);
+        Assert.assertEquals(duplicatePoint.getId().getValue(), reportedPointId);
+
+        assertSameProperties(originalRectangle, duplicateRectangle);
+        assertSameProperties(originalEllipse, duplicateEllipse);
+        assertSameProperties(originalLine, duplicateLine);
+        assertSameProperties(originalPoint, duplicatePoint);
+}
+    /**
+     * Test duplication of an annotated image with various annotation types treated differently.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithTypeOptions() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an annotated image */
+
+        Image originalImage = mmFactory.simpleImage();
+        originalImage = (Image) iUpdate.saveAndReturnObject(originalImage).proxy();
+
+        List<IObject> originalLinks = new ArrayList<IObject>();
+        for (final Class<? extends Annotation> annotationClass : new Class[]{
+                DoubleAnnotationI.class, LongAnnotationI.class, MapAnnotationI.class, TagAnnotationI.class, XmlAnnotationI.class}) {
+            final ImageAnnotationLink originalLink = new ImageAnnotationLinkI();
+            originalLink.setParent(originalImage);
+            originalLink.setChild(annotationClass.newInstance());
+            originalLinks.add(originalLink);
+        }
+        originalLinks = iUpdate.saveAndReturnArray(originalLinks);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImage.getId().getValue();
+        final Map<String, Long> originalAnnotationIds = new HashMap<String, Long>();
+        final Set<Long> originalLinkIds = new HashSet<Long>();
+        for (final IObject originalLink : originalLinks) {
+            final Annotation annotation = ((ImageAnnotationLink) originalLink).getChild();
+            originalAnnotationIds.put(annotation.getClass().getSimpleName(), annotation.getId().getValue());
+            originalLinkIds.add(originalLink.getId().getValue());
+        }
+        testImages.add(originalImageId);
+
+        /* duplicate the image */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        dup.typesToDuplicate = ImmutableList.of("BasicAnnotation", "XmlAnnotation");
+        dup.typesToReference = ImmutableList.of("DoubleAnnotation", "TextAnnotation");
+        final DuplicateResponse response = (DuplicateResponse) doChange(dup);
+
+        /* check that the response includes duplication of an image, annotations and their links */
+
+        final Set<Long> reportedImageIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.core.Image"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.DoubleAnnotation"));
+        final Set<Long> reportedLongAnnotationIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.LongAnnotation"));
+        final Set<Long> reportedMapAnnotationIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.MapAnnotation"));
+        Assert.assertFalse(response.duplicates.containsKey("ome.model.annotations.TagAnnotation"));
+        final Set<Long> reportedXmlAnnotationIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.XmlAnnotation"));
+        final Set<Long> reportedLinkIds = new HashSet<Long>(
+                response.duplicates.get("ome.model.annotations.ImageAnnotationLink"));
+
+        Assert.assertEquals(reportedImageIds.size(), 1);
+        Assert.assertEquals(reportedLongAnnotationIds.size(), 1);
+        Assert.assertEquals(reportedMapAnnotationIds.size(), 1);
+        Assert.assertEquals(reportedXmlAnnotationIds.size(), 1);
+        Assert.assertEquals(reportedLinkIds.size(), originalLinkIds.size());
+
+        /* check that the reported image, links, and annotations each have a new ID where expected */
+
+        final long reportedImageId = reportedImageIds.iterator().next();
+        final long reportedLongAnnotationId = reportedLongAnnotationIds.iterator().next();
+        final long reportedMapAnnotationId = reportedMapAnnotationIds.iterator().next();
+        final long reportedXmlAnnotationId = reportedXmlAnnotationIds.iterator().next();
+        testImages.add(reportedImageId);
+
+        Assert.assertNotEquals(originalImageId, reportedImageId);
+        Assert.assertNotEquals(originalAnnotationIds.get("LongAnnotationI"), reportedLongAnnotationId);
+        Assert.assertNotEquals(originalAnnotationIds.get("MapAnnotationI"), reportedMapAnnotationId);
+        Assert.assertNotEquals(originalAnnotationIds.get("XmlAnnotationI"), reportedXmlAnnotationId);
+        Assert.assertTrue(Sets.intersection(originalLinkIds, reportedLinkIds).isEmpty());
+
+        /* check that the annotations on the images are exactly as expected */
+
+        final Set<Long> expectedAnnotationIds = ImmutableSet.of(
+                /* reference includes DoubleAnnotation */
+                originalAnnotationIds.get("DoubleAnnotationI"),
+                /* duplicate includes BasicAnnotation */
+                reportedLongAnnotationId,
+                /* default behavior */
+                reportedMapAnnotationId,
+                /* reference includes TextAnnotation */
+                originalAnnotationIds.get("TagAnnotationI"),
+                /* duplicate includes XmlAnnotation */
+                reportedXmlAnnotationId);
+
+        Assert.assertEquals(getImageAnnotations(originalImageId), new HashSet<Long>(originalAnnotationIds.values()));
+        Assert.assertEquals(getImageAnnotations(reportedImageId), expectedAnnotationIds);
+    }
+
+    /**
+     * Test duplication of an annotated image with contradictory treatments for the same annotation typs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testDuplicateImageWithOpposingTypeOptions() throws Exception {
+        newUserAndGroup("rwra--");
+
+        /* create an image */
+
+        Image originalImage = mmFactory.simpleImage();
+        originalImage = (Image) iUpdate.saveAndReturnObject(originalImage);
+
+        /* note the objects (and their IDs) that were thus created and saved */
+
+        final long originalImageId = originalImage.getId().getValue();
+        testImages.add(originalImageId);
+
+        /* duplicate the image with contradictory instructions */
+
+        final Duplicate dup = new Duplicate();
+        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+
+        for (int i = 0; i < 4; i++) {
+            dup.typesToDuplicate = i == 0 ? null : ImmutableList.of("IAnnotationLink");
+            dup.typesToReference = i == 1 ? null : ImmutableList.of("IAnnotationLink");
+            dup.typesToIgnore    = i == 2 ? null : ImmutableList.of("IAnnotationLink");
+            final ERR response = (ERR) doChange(client, factory, dup, false);
+            Assert.assertEquals(response.name, "bad-class");
+        }
+    }
+}

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -238,7 +238,6 @@ public class DuplicationTest extends AbstractServerTest {
 
     /**
      * Assert that the given instances have the same property values.
-     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
      * @param original the original instance
      * @param duplicate the duplicate instance that is expected to correspond to the original
      */
@@ -254,7 +253,6 @@ public class DuplicationTest extends AbstractServerTest {
 
     /**
      * Assert that the given instances have the same property values.
-     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
      * @param original the original instance
      * @param duplicate the duplicate instance that is expected to correspond to the original
      */
@@ -270,7 +268,6 @@ public class DuplicationTest extends AbstractServerTest {
 
     /**
      * Assert that the given instances have the same property values.
-     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
      * @param original the original instance
      * @param duplicate the duplicate instance that is expected to correspond to the original
      */
@@ -286,7 +283,6 @@ public class DuplicationTest extends AbstractServerTest {
 
     /**
      * Assert that the given instances have the same property values.
-     * (The properties to compare are based on the behavior of {@link ModelMockFactory#createImage(int, int, int, int, int)}.)
      * @param original the original instance
      * @param duplicate the duplicate instance that is expected to correspond to the original
      */


### PR DESCRIPTION
To copy instruments for http://trac.openmicroscopy.org/ome/ticket/11532 and ROIs for the folder/template work, some ability for deep copy would be useful. This is the initial version sufficient to serve those two needs. It does not yet offer everything: for instance, original files cannot be copied without a breaking database schema change, so if one tries to copy an image, one will still find acquisition data, etc., but no actual pixels. Check that https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/DuplicationTest/ passes and that `./build.py -f components/blitz/build.xml test -DTEST=omero/cmd/graphs/SpecificityClassifierTest` passes.

To test further, you would have to try creating `DuplicateI` requests from a client. If @ximenesuk decides to provide a CLI interface, I'd recommend it be hidden among the advanced options for now, lest users are too optimistic about what this feature can yet do before we can afford more time for it, not least for adding more integration tests.

--no-rebase as this is a new feature