### PR TITLE
Fix python Training ROIs

### DIFF
--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -82,11 +82,12 @@ roi.addShape(line)
 
 # create a point shape and add to ROI
 point = omero.model.PointI()
-point.x = rdouble(x)
-point.y = rdouble(y)
+point.cx = rdouble(x)
+point.cy = rdouble(y)
 point.theZ = rint(theZ)
 point.theT = rint(theT)
 point.textValue = rstring("test-Point")
+roi.addShape(point)
 
 
 # Save the ROI (saves any linked shapes too)

--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -16,6 +16,7 @@ from omero.rtypes import rdouble, rint, rstring
 from omero.gateway import BlitzGateway
 from Parse_OMERO_Properties import USERNAME, PASSWORD, HOST, PORT
 from Parse_OMERO_Properties import imageId
+imageId = int(imageId)
 
 
 # Create a connection

--- a/examples/Training/python/__main__.py
+++ b/examples/Training/python/__main__.py
@@ -21,6 +21,6 @@ if __name__ == "__main__":
         execfile(os.path.join(training_dir, 'Raw_Data_Access.py'))
         execfile(os.path.join(training_dir, 'Read_Data.py'))
         execfile(os.path.join(training_dir, 'Render_Images.py'))
-        # execfile(os.path.join(training_dir, 'ROIs.py'))  # broken
+        execfile(os.path.join(training_dir, 'ROIs.py'))
         execfile(os.path.join(training_dir, 'Tables.py'))
         execfile(os.path.join(training_dir, 'Write_Data.py'))


### PR DESCRIPTION
Update ROIs.py example in python training docs.
Also turns on the ROIs.py examples in the training job - check status at https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-training/