### PR TITLE
Jstree code cleanup

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -433,24 +433,6 @@ class BaseContainer(BaseController):
         self.c_size = (len(pr_list) + len(ds_list) + len(im_list) +
                        len(sc_list) + len(pl_list) + len(pa_list))
 
-    def listImagesInDataset(self, did, eid=None, page=None,
-                            load_pixels=False):
-        if eid is not None:
-            if eid == -1:       # Load data for all users
-                eid = None
-            # else:
-            #     self.experimenter = self.conn.getObject("Experimenter", eid)
-        im_list = list(self.conn.listImagesInDataset(
-            oid=did, eid=eid, page=page, load_pixels=load_pixels))
-        # List is already sorted by name, id in query
-        # im_list.sort(key=lambda x: (x.getName().lower(), x.getId()))
-        self.containers = {'images': im_list}
-        self.c_size = self.conn.getCollectionCount(
-            "Dataset", "imageLinks", [long(did)])[long(did)]
-
-        if page is not None:
-            self.paging = self.doPaging(page, len(im_list), self.c_size)
-
     def listContainerHierarchy(self, eid=None):
         if eid is not None:
             if eid == -1:

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -460,27 +460,6 @@ class BaseContainer(BaseController):
             'plates': pl_list}
         self.c_size = len(pr_list)+len(ds_list)+len(sc_list)+len(pl_list)
 
-    def listOrphanedImages(self, eid=None, page=None):
-        if eid is not None:
-            if eid == -1:
-                eid = None
-            else:
-                self.experimenter = self.conn.getObject("Experimenter", eid)
-        else:
-            eid = self.conn.getEventContext().userId
-
-        params = omero.sys.ParametersI()
-        if page is not None:
-            params.page((int(page)-1)*settings.PAGE, settings.PAGE)
-        im_list = list(self.conn.listOrphans(
-            "Image", eid=eid, params=params, loadPixels=True))
-        im_list.sort(key=lambda x: (x.getName().lower(), x.getId()))
-        self.containers = {'orphaned': True, 'images': im_list}
-        self.c_size = self.conn.countOrphans("Image", eid=eid)
-
-        if page is not None:
-            self.paging = self.doPaging(page, len(im_list), self.c_size)
-
     # Annotation list
     def annotationList(self):
         self.text_annotations = list()

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -68,13 +68,7 @@ urlpatterns = patterns(
         name="activities_update"),
 
     # loading data
-    url(r'^load_data/(?:(?P<o1_type>'
-        r'((?i)project|dataset|image|screen|plate|well|orphaned))/)'
-        r'?(?:(?P<o1_id>[0-9]+)/)'
-        r'?(?:(?P<o2_type>((?i)dataset|image|plate|acquisition|well))/)'
-        r'?(?:(?P<o2_id>[0-9]+)/)'
-        r'?(?:(?P<o3_type>((?i)image|well))/)'
-        r'?(?:(?P<o3_id>[0-9]+)/)?$',
+    url(r'^load_data/(?P<o1_type>((?i)plate|acquisition))/(?:(?P<o1_id>[0-9]+)/)?$',
         views.load_data,
         name="load_data"),
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -68,7 +68,8 @@ urlpatterns = patterns(
         name="activities_update"),
 
     # loading data
-    url(r'^load_data/(?P<o1_type>((?i)plate|acquisition))/(?:(?P<o1_id>[0-9]+)/)?$',
+    url(r'^load_data/(?P<o1_type>((?i)plate|acquisition))/'
+        r'(?:(?P<o1_id>[0-9]+)/)?$',
         views.load_data,
         name="load_data"),
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1137,8 +1137,7 @@ def api_share_list(request, conn=None, **kwargs):
 
 @login_required()
 @render_response()
-def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
-              o3_type=None, o3_id=None, conn=None, **kwargs):
+def load_data(request, o1_type=None, o1_id=None, conn=None, **kwargs):
     """
     This loads data for the center panel, via AJAX calls.
     Used for Plates & Runs.
@@ -1147,18 +1146,11 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
     # get index of the plate
     index = getIntOrDefault(request, 'index', 0)
 
-    # prepare data. E.g. kw = {}  or  {'dataset': 301L}  or  {'project': 151L,
-    # 'dataset': 301L}
+    # prepare data. E.g. {'plate': 301L}  or  {'acquisition': 151L}
     kw = dict()
     if o1_type is not None:
         if o1_id is not None and o1_id > 0:
             kw[str(o1_type)] = long(o1_id)
-        else:
-            kw[str(o1_type)] = bool(o1_id)
-    if o2_type is not None and o2_id > 0:
-        kw[str(o2_type)] = long(o2_id)
-    if o3_type is not None and o3_id > 0:
-        kw[str(o3_type)] = long(o3_id)
 
     try:
         manager = BaseContainer(conn, **kw)
@@ -1207,7 +1199,6 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
         context['form_well_index'] = form_well_index
         context['index'] = index
 
-    context['isLeader'] = conn.isLeader()
     context['template'] = "webclient/data/plate.html"
     return context
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1141,12 +1141,8 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
               o3_type=None, o3_id=None, conn=None, **kwargs):
     """
     This loads data for the center panel, via AJAX calls.
-    Used for Datasets, Plates & Orphaned Images.
+    Used for Plates & Runs.
     """
-
-    # get page
-    page = getIntOrDefault(request, 'page', 1)
-    # limit = get_long_or_default(request, 'limit', settings.PAGE)
 
     # get index of the plate
     index = getIntOrDefault(request, 'index', 0)
@@ -1170,31 +1166,14 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
         return handlerInternalError(request, x)
 
     # prepare forms
-    filter_user_id = request.session.get('user_id')
     form_well_index = None
 
     context = {
         'manager': manager,
-        'form_well_index': form_well_index,
         'index': index}
 
     # load data & template
-    template = None
-    template = "webclient/data/containers_icon.html"
-    if 'orphaned' in kw:
-        # We need to set group context since we don't have a container Id
-        groupId = request.session.get('active_group')
-        if groupId is None:
-            groupId = conn.getEventContext().groupId
-        conn.SERVICE_OPTS.setOmeroGroup(groupId)
-        manager.listOrphanedImages(filter_user_id, page)
-    elif 'dataset' in kw:
-        # we need the sizeX and sizeY for these
-        load_pixels = True
-        filter_user_id = None   # Show images belonging to all users
-        manager.listImagesInDataset(kw.get('dataset'), filter_user_id,
-                                    page, load_pixels=load_pixels)
-    elif 'plate' in kw or 'acquisition' in kw:
+    if 'plate' in kw or 'acquisition' in kw:
         fields = manager.getNumberOfFields()
         if fields is not None:
             form_well_index = WellIndexForm(
@@ -1227,10 +1206,9 @@ def load_data(request, o1_type=None, o1_id=None, o2_type=None, o2_id=None,
         context['baseurl'] = reverse('webgateway').rstrip('/')
         context['form_well_index'] = form_well_index
         context['index'] = index
-        template = "webclient/data/plate.html"
 
     context['isLeader'] = conn.isLeader()
-    context['template'] = template
+    context['template'] = "webclient/data/plate.html"
     return context
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -545,46 +545,6 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 return rslt[0][0].val
         return 0
 
-    def listImagesInDataset(self, oid, eid=None, page=None,
-                            load_pixels=False):
-        """
-        List Images in the given Dataset.
-        Optinally filter by experimenter 'eid'
-
-        @param eid:         experimenter id
-        @type eid:          Long
-        @param page:        page number
-        @type page:         Long
-        @return:            Generator yielding Images
-        @rtype:             L{ImageWrapper} generator
-        """
-
-        q = self.getQueryService()
-        p = omero.sys.ParametersI()
-        p.map["oid"] = rlong(long(oid))
-        if page is not None:
-            p.page(((int(page)-1)*settings.PAGE), settings.PAGE)
-        if load_pixels:
-            pixels = ("join fetch im.pixels as pix"
-                      " left outer join fetch pix.thumbnails ")
-        else:
-            pixels = ""
-        sql = ("select im from Image im "
-               "join fetch im.details.creationEvent "
-               "join fetch im.details.owner join fetch im.details.group "
-               "left outer join fetch im.datasetLinks dil "
-               "left outer join fetch dil.parent d %s"
-               "where d.id = :oid" % pixels)
-        if eid is not None:
-            p.map["eid"] = rlong(long(eid))
-            sql += " and im.details.owner.id=:eid"
-        sql += " order by lower(im.name), im.id"
-
-        for e in q.findAllByQuery(sql, p, self.SERVICE_OPTS):
-            kwargs = {'link': omero.gateway.BlitzObjectWrapper(
-                self, e.copyDatasetLinks()[0])}
-            yield ImageWrapper(self, e, None, **kwargs)
-
     def createDataset(self, name, description=None, img_ids=None):
         """
         Creates a Dataset and adds images if img_ids is specified.


### PR DESCRIPTION
This removes and cleans up code no-longer used since the loading of Projects, Datasets, Screens & Orphaned images for jsTree and centre panel are handled by /api/ methods.

To test:
 - Browse tree, load Dataset & Plate data into centre panel.
 - Brief code review could be useful

cc @aleksandra-tarkowska 