### PR TITLE
Error report via feedback

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -42,6 +42,9 @@ from django.template import RequestContext
 from django.views.defaults import page_not_found
 from django.core.urlresolvers import reverse
 
+from django.views.debug import get_exception_reporter_filter
+from django.utils.encoding import force_text
+
 from omeroweb.feedback.sendfeedback import SendFeedback
 from omeroweb.feedback.forms import ErrorForm, CommentForm
 
@@ -144,15 +147,15 @@ def handler500(request):
     If debug is True, Django returns it's own debug error page
     """
     logger.error('handler500: Server error')
+
     as_string = '\n'.join(traceback.format_exception(*sys.exc_info()))
     logger.error(as_string)
 
-    try:
-        request_repr = repr(request)
-    except:
-        request_repr = "Request repr() unavailable"
+    error_filter = get_exception_reporter_filter(request)
+    request_repr = '\n{}'.format(
+        force_text(error_filter.get_request_repr(request)))
 
-    error500 = "%s\n\n%s" % (as_string, request_repr)
+    error500 = "%s\n%s" % (as_string, request_repr)
 
     # If AJAX, return JUST the error message (not within html page)
     if request.is_ajax():

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -151,9 +151,18 @@ def handler500(request):
     as_string = '\n'.join(traceback.format_exception(*sys.exc_info()))
     logger.error(as_string)
 
-    error_filter = get_exception_reporter_filter(request)
-    request_repr = '\n{}'.format(
-        force_text(error_filter.get_request_repr(request)))
+    try:
+        error_filter = get_exception_reporter_filter(request)
+        try:
+            request_repr = '\n{}'.format(
+                force_text(error_filter.get_request_repr(request)))
+        except:
+            request_repr = error_filter.get_request_repr(request)
+    except:
+        try:
+            request_repr = repr(request)
+        except:
+            request_repr = "Request unavailable"
 
     error500 = "%s\n%s" % (as_string, request_repr)
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -73,11 +73,11 @@ if not os.path.isdir(LOGDIR):
 
 STANDARD_LOGFORMAT = (
     '%(asctime)s %(levelname)5.5s [%(name)40.40s]'
-    ' (proc.%(process)5.5d) %(funcName)s:%(lineno)d %(message)s')
+    ' (proc.%(process)5.5d) %(funcName)s():%(lineno)d %(message)s')
 
 FULL_REQUEST_LOGFORMAT = (
     '%(asctime)s %(levelname)5.5s [%(name)40.40s]'
-    ' (proc.%(process)5.5d) %(funcName)s:%(lineno)d'
+    ' (proc.%(process)5.5d) %(funcName)s():%(lineno)d'
     ' HTTP %(status_code)d %(request)s')
 
 if platform.system() in ("Windows",):


### PR DESCRIPTION
This PR fixes https://trac.openmicroscopy.org/ome/ticket/13091

With Django 1.8 ``repr(request)`` is no longer friendly that means we were missing WSGIRequest details in feedback form.

To test on eel (Django 1.6) and cowfish (Django 1.8):
 - go to ``weberror/error_500`` and check if you get WSGIRequest GET, POST, COOKIE and META information along side stacktrace

 ```
Traceback (most recent call last):
...
NameError: global name 'view_raise_500' is not defined

<WSGIRequest
path:/weberror/error_500/,
GET:...
POST:...
COOKIES:...
META:...
```
 - check if admin notification sent exactly the same data (notofication goes to: ci-web-errors).
 - check if log on eel shows WSGIRequest details (this is still broken on cowfish, see https://trac.openmicroscopy.org/ome/ticket/13090)


