### PR TITLE
Fix centre panel refresh on paste

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -690,7 +690,7 @@
                 })
                 .on('copy_node.jstree', function(e, data) {
                     /**
-                    * Fired when a node is copied and paste_rdef
+                    * Fired when a node is pasted
                     * Updates the server, adding the new link
                     */
                     var inst = data.instance;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -179,6 +179,7 @@ $(document).ready(function() {
 
         var newParentId = parentNode.type + "-" + parentNode.data.obj.id;
         if (parentId === newParentId
+                && event.type !== "copy_node"
                 && event.type !== "create_node"
                 && event.type !== "load_node"
                 && event.type !== "delete_node"

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -179,6 +179,7 @@ $(document).ready(function() {
 
         var newParentId = parentNode.type + "-" + parentNode.data.obj.id;
         if (parentId === newParentId
+                && event.type !== "create_node"
                 && event.type !== "load_node"
                 && event.type !== "delete_node"
                 && event.type !== "refreshThumb"


### PR DESCRIPTION
Fixes a failure of the centre panel to update when you paste an image into selected Dataset.

To test:
 - Copy an image from a Dataset
 - Select another Dataset
 - Paste the image and check that centre panel updates to show it