### PR TITLE
Incorrect redirect to http instead of https

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development-withoptions.conf
@@ -46,6 +46,7 @@ http {
         }
 
         location @proxy_to_app_test {
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-development.conf
@@ -46,6 +46,7 @@ http {
         }
 
         location @proxy_to_app {
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
@@ -21,6 +21,7 @@ server {
     }
 
     location @proxy_to_app_test {
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx.conf
@@ -21,6 +21,7 @@ server {
     }
 
     location @proxy_to_app {
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -433,7 +433,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
     "omero.web.secure_proxy_ssl_header":
-        ["SECURE_PROXY_SSL_HEADERO",
+        ["SECURE_PROXY_SSL_HEADER",
          '[]',
          json.loads,
          ("A tuple representing a HTTP header/value combination that "

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -437,10 +437,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
          '[]',
          json.loads,
          ("A tuple representing a HTTP header/value combination that "
-          "signifies a request is secure. Example ``SECURE_PROXY_SSL_HEADER"
-          " = ('HTTP_X_FORWARDED_PROTO', 'https')``. For more details see "
-          "https://docs.djangoproject.com/en/1.8/ref/settings/"
-          "#secure-proxy-ssl-header.")],
+          "signifies a request is secure. Example "
+          "``'[\"HTTP_X_FORWARDED_PROTO_OMERO_WEB\", \"https\"]'``. "
+          "For more details see :djangodoc:`secure proxy ssl header <ref/"
+          "settings/#secure-proxy-ssl-header>`.")],
 
     # Public user
     "omero.web.public.enabled":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -437,7 +437,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          '[]',
          json.loads,
          ("A tuple representing a HTTP header/value combination that "
-          "signifies a request is secure.Example ``SECURE_PROXY_SSL_HEADER"
+          "signifies a request is secure. Example ``SECURE_PROXY_SSL_HEADER"
           " = ('HTTP_X_FORWARDED_PROTO', 'https')``. For more details see "
           "https://docs.djangoproject.com/en/1.8/ref/settings/"
           "#secure-proxy-ssl-header.")],

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -432,6 +432,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "The name to use for session cookies"],
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
+    "omero.web.secure_proxy_ssl_header":
+        ["SECURE_PROXY_SSL_HEADERO",
+         '[]',
+         json.loads,
+         ("A tuple representing a HTTP header/value combination that "
+          "signifies a request is secure.Example ``SECURE_PROXY_SSL_HEADER"
+          " = ('HTTP_X_FORWARDED_PROTO'``, 'https')For more details see "
+          "https://docs.djangoproject.com/en/1.8/ref/settings/"
+          "#secure-proxy-ssl-header.")],
 
     # Public user
     "omero.web.public.enabled":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -438,7 +438,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          json.loads,
          ("A tuple representing a HTTP header/value combination that "
           "signifies a request is secure.Example ``SECURE_PROXY_SSL_HEADER"
-          " = ('HTTP_X_FORWARDED_PROTO'``, 'https')For more details see "
+          " = ('HTTP_X_FORWARDED_PROTO', 'https')``. For more details see "
           "https://docs.djangoproject.com/en/1.8/ref/settings/"
           "#secure-proxy-ssl-header.")],
 

--- a/etc/templates/web/nginx-development.conf.template
+++ b/etc/templates/web/nginx-development.conf.template
@@ -46,6 +46,7 @@ http {
         }
 
         location @proxy_to_app%(PREFIX_NAME)s {
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;

--- a/etc/templates/web/nginx.conf.template
+++ b/etc/templates/web/nginx.conf.template
@@ -21,6 +21,7 @@ server {
     }
 
     location @proxy_to_app%(PREFIX_NAME)s {
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;


### PR DESCRIPTION
This PR should fix incorrect redirection to ``​http://`` instead of ​``https://``

```
curl -i -s -c cookies.txt -b cookies.txt -e https://omero.local/omero/webclient/login/ -d 'csrfmiddlewaretoken=kyuLRduNLY3OQNUMUBiFjuQMDYrcEwt4&username=user-1&password=ome&server=2&url=url=%2Fmerge%2Fwebclient%2F' -X POST https://omero.local/omero/webclient/login/
HTTP/1.1 302 FOUND
Server: nginx/1.8.0
Date: Wed, 18 Nov 2015 13:00:58 GMT
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Cookie
Location: https://omero.local/omero/webclient/
Set-Cookie: sessionid=jix75augbw8i6xdwvydru249sq8vaj9n; httponly; Path=/
```

cc @manics see https://trello.com/c/7eFWt9Bj/8-django-secure-proxy-ssl-header