### PR TITLE
Handle display of pixel size units for each dimension

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -40,15 +40,27 @@
         <td id='pixels_type'>{{ image.getPixelsType }}</td>
     </tr>
     <tr>
-        <th>Pixels Size (XYZ) ({{ image.getPixelSizeUnits }}):</th>
+        {% with psX=image.getPixelSizeXMicrons psY=image.getPixelSizeYMicrons psZ=image.getPixelSizeZMicrons %}
+            {% with uX=psX|lengthunit uY=psY|lengthunit uZ=psZ|lengthunit %}
+        <th>Pixels Size (XYZ) ({{ uX }}):</th>
         <td id='pixels_size'>
-            <div class='tooltip'>{{ image.getPixelSizeXMicrons|lengthformat|floatformat:2 }} x {{ image.getPixelSizeYMicrons|lengthformat|floatformat:2 }} 
-                {% if image.getPixelSizeZMicrons %} x {{ image.getPixelSizeZMicrons|lengthformat|floatformat:2 }} {% endif %}
+            <div class='tooltip'>
+                {{ psX|lengthformat|floatformat:2 }} {% if uX != uY %}({{ uX }}){% endif %}
+                x {{ psY|lengthformat|floatformat:2 }} {% if uY != uX %}({{ uY }}){% endif %}
+                {% if psZ %}
+                    x {{ psZ|lengthformat|floatformat:2 }} {% if uZ != uX %}({{ uZ }}){% endif %}
+                {% endif %}
             </div>
-            <span class="tooltip_html" style='display:none'>{{ image.getPixelSizeXMicrons }} x {{ image.getPixelSizeYMicrons }}
-                {% if image.getPixelSizeZMicrons %} x {{ image.getPixelSizeZMicrons }} {% endif %} (&#181m)
+            <span class="tooltip_html" style='display:none'>
+                {{ psX }} ({{ uX }})
+                x {{ psY }} ({{ uY }})
+                {% if psZ %}
+                    x {{ psZ }} ({{ uZ }})
+                {% endif %}
             </span>
         </td>
+            {% endwith %}
+        {% endwith %}
     </tr>
     <tr>
         <th>Z-sections/Timepoints:</th>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -55,7 +55,7 @@
                 {{ psX.0 }} ({{ uX }})
                 x {{ psY.0 }} ({{ uY }})
                 {% if psZ.0 %}
-                    x {{ psZ }} ({{ uZ }})
+                    x {{ psZ.0 }} ({{ uZ }})
                 {% endif %}
             </span>
         </td>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -40,21 +40,21 @@
         <td id='pixels_type'>{{ image.getPixelsType }}</td>
     </tr>
     <tr>
-        {% with psX=image.getPixelSizeXMicrons psY=image.getPixelSizeYMicrons psZ=image.getPixelSizeZMicrons %}
-            {% with uX=psX|lengthunit uY=psY|lengthunit uZ=psZ|lengthunit %}
-        <th>Pixels Size (XYZ) ({{ uX }}):</th>
+        {% with psX=image.getPixelSizeXWithUnits psY=image.getPixelSizeYWithUnits psZ=image.getPixelSizeZWithUnits %}
+            {% with uX=psX.1 uY=psY.1 uZ=psZ.1 %}
+        <th>Pixels Size (XYZ){% if uX == uY and uX == uZ %} ({{ uX }}){% endif %}:</th>
         <td id='pixels_size'>
             <div class='tooltip'>
-                {{ psX|lengthformat|floatformat:2 }} {% if uX != uY %}({{ uX }}){% endif %}
-                x {{ psY|lengthformat|floatformat:2 }} {% if uY != uX %}({{ uY }}){% endif %}
-                {% if psZ %}
-                    x {{ psZ|lengthformat|floatformat:2 }} {% if uZ != uX %}({{ uZ }}){% endif %}
+                {{ psX.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
+                x {{ psY.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
+                {% if psZ.0 %}
+                    x {{ psZ.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
                 {% endif %}
             </div>
             <span class="tooltip_html" style='display:none'>
-                {{ psX }} ({{ uX }})
-                x {{ psY }} ({{ uY }})
-                {% if psZ %}
+                {{ psX.0 }} ({{ uX }})
+                x {{ psY.0 }} ({{ uY }})
+                {% if psZ.0 %}
                     x {{ psZ }} ({{ uZ }})
                 {% endif %}
             </span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2380,16 +2380,7 @@ class ImageWrapper (OmeroWebObjectWrapper,
         convert to more appropriate units & value
         """
         size = self.getPixelSizeX(True)
-        if size is None:
-            return (0, "µm")
-        length = size.getValue()
-        unit = size.getUnit()
-        if unit == "MICROMETER":
-            unit = lengthunit(length)
-            length = lengthformat(length)
-        else:
-            unit = size.getSymbol()
-        return (length, unit)
+        return self.formatPixelSizeWithUnits(size)
 
     def getPixelSizeYWithUnits(self):
         """
@@ -2398,16 +2389,7 @@ class ImageWrapper (OmeroWebObjectWrapper,
         convert to more appropriate units & value
         """
         size = self.getPixelSizeY(True)
-        if size is None:
-            return (0, "µm")
-        length = size.getValue()
-        unit = size.getUnit()
-        if unit == "MICROMETER":
-            unit = lengthunit(length)
-            length = lengthformat(length)
-        else:
-            unit = size.getSymbol()
-        return (length, unit)
+        return self.formatPixelSizeWithUnits(size)
 
     def getPixelSizeZWithUnits(self):
         """
@@ -2416,6 +2398,15 @@ class ImageWrapper (OmeroWebObjectWrapper,
         convert to more appropriate units & value
         """
         size = self.getPixelSizeZ(True)
+        return self.formatPixelSizeWithUnits(size)
+
+    def formatPixelSizeWithUnits(self, size):
+        """
+        Formats the response for methods above.
+        Returns [value, unitSymbol]
+        If the unit is MICROMETER in database (default), we
+        convert to more appropriate units & value
+        """
         if size is None:
             return (0, "µm")
         length = size.getValue()

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -53,6 +53,7 @@ from django.utils.encoding import smart_str
 from django.conf import settings
 
 from omero.gateway.utils import toBoolean
+from webgateway.templatetags.common_filters import lengthunit, lengthformat
 
 try:
     import hashlib
@@ -2324,7 +2325,6 @@ class ImageWrapper (OmeroWebObjectWrapper,
         However, if unit can't be converted, then we just return the
         current unit's symbol.
         """
-        from webgateway.templatetags.common_filters import lengthunit
         try:
             size = self.getPixelSizeX(units="MICROMETER")
         except:
@@ -2372,6 +2372,60 @@ class ImageWrapper (OmeroWebObjectWrapper,
         if size is None:
             return 0
         return size.getValue()
+
+    def getPixelSizeXWithUnits(self):
+        """
+        Returns [value, unitSymbol]
+        If the unit is MICROMETER in database (default), we
+        convert to more appropriate units & value
+        """
+        size = self.getPixelSizeX(True)
+        if size is None:
+            return (0, "µm")
+        length = size.getValue()
+        unit = size.getUnit()
+        if unit == "MICROMETER":
+            unit = lengthunit(length)
+            length = lengthformat(length)
+        else:
+            unit = size.getSymbol()
+        return (length, unit)
+
+    def getPixelSizeYWithUnits(self):
+        """
+        Returns [value, unitSymbol]
+        If the unit is MICROMETER in database (default), we
+        convert to more appropriate units & value
+        """
+        size = self.getPixelSizeY(True)
+        if size is None:
+            return (0, "µm")
+        length = size.getValue()
+        unit = size.getUnit()
+        if unit == "MICROMETER":
+            unit = lengthunit(length)
+            length = lengthformat(length)
+        else:
+            unit = size.getSymbol()
+        return (length, unit)
+
+    def getPixelSizeZWithUnits(self):
+        """
+        Returns [value, unitSymbol]
+        If the unit is MICROMETER in database (default), we
+        convert to more appropriate units & value
+        """
+        size = self.getPixelSizeZ(True)
+        if size is None:
+            return (0, "µm")
+        length = size.getValue()
+        unit = size.getUnit()
+        if unit == "MICROMETER":
+            unit = lengthunit(length)
+            length = lengthformat(length)
+        else:
+            unit = size.getSymbol()
+        return (length, unit)
 
     def getChannels(self, *args, **kwargs):
         """

--- a/components/tools/OmeroWeb/test/integration/test_metadata.py
+++ b/components/tools/OmeroWeb/test/integration/test_metadata.py
@@ -60,4 +60,5 @@ class TestCoreMetadata(IWebTest):
         rsp = _get_response(self.django_client,
                             request_url, data, status_code=200)
         html = rsp.content
-        assert "Pixels Size (XYZ) (pixel):" in html
+        assert "Pixels Size (XYZ):" in html
+        assert "1.20 (pixel)" in html


### PR DESCRIPTION
See https://trello.com/c/7IzMpre0/15-unit-display-in-web

Previously we got the suitable units for sizeX and only displayed these, alongside the most suitable value for sizeX, sizeY and sizeZ. So, if the sizeZ for example was using different units this would appear incorrect:

![screen shot 2015-11-19 at 10 12 06](https://cloud.githubusercontent.com/assets/900055/11267985/6eead744-8ea6-11e5-93b2-680609ec1952.png)

Now, if units are different for any dimension, we show them:

![screen shot 2015-11-19 at 10 16 26](https://cloud.githubusercontent.com/assets/900055/11268030/a988f3c2-8ea6-11e5-95d1-2e305e964320.png)

This is slightly different from Insight's strategy, but to get it exactly the same will require a bigger re-working of the code here (worth it)?

![screen shot 2015-11-19 at 10 23 41](https://cloud.githubusercontent.com/assets/900055/11268255/d62772f4-8ea7-11e5-93e4-3030d2d36af5.png)