### PR TITLE
Gateway followup critical

### DIFF
--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -71,9 +71,8 @@ public class AdminFacility extends Facility {
      * @param owner The owner of the group.
      * @param permissions The group's permissions.
      * @return See above.
-     * @throws DSOutOfServiceException If the connection is broken, or logged in.
-     * @throws DSAccessException If an error occurred while trying to
-     * retrieve data from OMERO service.
+     * @throws DSOutOfServiceException 
+     * @throws DSAccessException 
      */
     public GroupData createGroup(SecurityContext ctx, GroupData groupData,
             ExperimenterData owner, int permissions)
@@ -118,9 +117,8 @@ public class AdminFacility extends Facility {
      * @param isGroupOwner Pass <code>true</code> if the user is a group owner,
      *                <code>false</code> otherwise.
      * @return See above.
-     * @throws DSOutOfServiceException If the connection is broken, or logged in.
-     * @throws DSAccessException If an error occurred while trying to
-     * retrieve data from OMERO service.
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException 
      */
     public ExperimenterData createExperimenter(SecurityContext ctx,
             ExperimenterData exp, String username, String password,
@@ -186,10 +184,7 @@ public class AdminFacility extends Facility {
      *            The name of the group.
      * @return See above
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public GroupData lookupGroup(SecurityContext ctx, String name)
             throws DSOutOfServiceException, DSAccessException {
@@ -216,10 +211,7 @@ public class AdminFacility extends Facility {
      *            The name of the experimenter.
      * @return See above
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public ExperimenterData lookupExperimenter(SecurityContext ctx, String name)
             throws DSOutOfServiceException, DSAccessException {

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -454,12 +454,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx) {
         try {
-            ParametersI param = new ParametersI();
-            param.leaves();
-
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> datasets = service.loadContainerHierarchy(PojoMapper
-                    .getModelType(DatasetData.class).getName(), null, param);
+                    .getModelType(DatasetData.class).getName(), null, null);
 
             Collection<DatasetData> result = new ArrayList<DatasetData>(
                     datasets.size());
@@ -527,8 +524,7 @@ public class BrowseFacility extends Facility {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
-            param.leaves();
-
+            
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> datasets = service.loadContainerHierarchy(PojoMapper
                     .getModelType(DatasetData.class).getName(), null, param);

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -84,7 +84,7 @@ public class BrowseFacility extends Facility {
      * @return See above.
      * @throws DSOutOfServiceException  If the connection is broken, or logged in.
      */
-    public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
+    public Collection<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             long userId) throws DSOutOfServiceException {
         ParametersI param = new ParametersI();
         if (userId >= 0) {
@@ -105,7 +105,7 @@ public class BrowseFacility extends Facility {
      * @return See above.
      * @throws DSOutOfServiceException If the connection is broken, or logged in.
      */
-    public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
+    public Collection<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
             throws DSOutOfServiceException {
         try {

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -83,9 +83,10 @@ public class BrowseFacility extends Facility {
      * @param userId The user's to retrieve the data to handle.
      * @return See above.
      * @throws DSOutOfServiceException
+     * @throws DSAccessException 
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
-            long userId) throws DSOutOfServiceException {
+            long userId) throws DSOutOfServiceException, DSAccessException {
         ParametersI param = new ParametersI();
         if (userId >= 0) {
             param.exp(omero.rtypes.rlong(userId));
@@ -104,17 +105,18 @@ public class BrowseFacility extends Facility {
      * @param options The retrieval options.
      * @return See above.
      * @throws DSOutOfServiceException
+     * @throws DSAccessException 
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
-            throws DSOutOfServiceException {
+            throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             return PojoMapper.asDataObjects(service.loadContainerHierarchy(
                     PojoMapper.getModelType(rootType).getName(), rootIDs,
                     options));
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load hierarchy");
         }
 
         return Collections.emptySet();
@@ -347,8 +349,10 @@ public class BrowseFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @return A collection of {@link ProjectData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<ProjectData> getProjects(SecurityContext ctx) {
+    public Collection<ProjectData> getProjects(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> projects = service.loadContainerHierarchy(PojoMapper
@@ -361,7 +365,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load projects");
         }
 
         return Collections.emptyList();
@@ -375,9 +379,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the projects to fetch
      * @return A collection of {@link ProjectData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -398,7 +404,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load projects");
         }
 
         return Collections.emptyList();
@@ -412,8 +418,10 @@ public class BrowseFacility extends Facility {
      * @param ownerId
      *            The id of the owner
      * @return A collection of {@link ProjectData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<ProjectData> getProjects(SecurityContext ctx, long ownerId) {
+    public Collection<ProjectData> getProjects(SecurityContext ctx, long ownerId) throws DSOutOfServiceException, DSAccessException {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
@@ -429,7 +437,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load projects");
         }
 
         return Collections.emptyList();
@@ -445,9 +453,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the projects to fetch
      * @return A collection of {@link ProjectData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx,
-            long ownerId, Collection<Long> ids) {
+            long ownerId, Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -471,7 +481,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load projects");
         }
 
         return Collections.emptyList();
@@ -485,8 +495,10 @@ public class BrowseFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @return A collection of {@link DatasetData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<DatasetData> getDatasets(SecurityContext ctx) {
+    public Collection<DatasetData> getDatasets(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> datasets = service.loadContainerHierarchy(PojoMapper
@@ -499,7 +511,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load datasets");
         }
 
         return Collections.emptyList();
@@ -513,9 +525,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the datasets to load
      * @return A collection of {@link DatasetData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -539,7 +553,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load datasets");
         }
 
         return Collections.emptyList();
@@ -553,8 +567,10 @@ public class BrowseFacility extends Facility {
      * @param ownerId
      *            The id of the user
      * @return A collection of {@link DatasetData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<DatasetData> getDatasets(SecurityContext ctx, long ownerId) {
+    public Collection<DatasetData> getDatasets(SecurityContext ctx, long ownerId) throws DSOutOfServiceException, DSAccessException {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
@@ -570,7 +586,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load datasets");
         }
 
         return Collections.emptyList();
@@ -586,9 +602,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the datasets to load
      * @return A collection of {@link DatasetData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx,
-            long ownerId, Collection<Long> ids) {
+            long ownerId, Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -613,7 +631,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load datasets");
         }
 
         return Collections.emptyList();
@@ -627,8 +645,10 @@ public class BrowseFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @return A collection of {@link ScreenData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<ScreenData> getScreens(SecurityContext ctx) {
+    public Collection<ScreenData> getScreens(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> screens = service.loadContainerHierarchy(PojoMapper
@@ -641,7 +661,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load screens");
         }
 
         return Collections.emptyList();
@@ -655,9 +675,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the screens to load
      * @return A collection of {@link ScreenData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -678,7 +700,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load screens");
         }
 
         return Collections.emptyList();
@@ -692,8 +714,10 @@ public class BrowseFacility extends Facility {
      * @param ownerId
      *            The id of the user
      * @return A collection of {@link ScreenData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<ScreenData> getScreens(SecurityContext ctx, long ownerId) {
+    public Collection<ScreenData> getScreens(SecurityContext ctx, long ownerId) throws DSOutOfServiceException, DSAccessException {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
@@ -709,7 +733,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load screens");
         }
 
         return Collections.emptyList();
@@ -725,9 +749,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the screens to load
      * @return A collection of {@link ScreenData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx, long ownerId,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -751,7 +777,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load screens");
         }
 
         return Collections.emptyList();
@@ -765,8 +791,10 @@ public class BrowseFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @return A collection of {@link PlateData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<PlateData> getPlates(SecurityContext ctx) {
+    public Collection<PlateData> getPlates(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> plates = service.loadContainerHierarchy(PojoMapper
@@ -779,7 +807,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load plates");
         }
 
         return Collections.emptyList();
@@ -793,9 +821,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the screens to load
      * @return A collection of {@link PlateData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<PlateData> getPlates(SecurityContext ctx,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -816,7 +846,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load plates");
         }
 
         return Collections.emptyList();
@@ -830,8 +860,10 @@ public class BrowseFacility extends Facility {
      * @param ownerId
      *            The id of the user
      * @return A collection of {@link PlateData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<PlateData> getPlates(SecurityContext ctx, long ownerId) {
+    public Collection<PlateData> getPlates(SecurityContext ctx, long ownerId) throws DSOutOfServiceException, DSAccessException {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
@@ -847,7 +879,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load plates");
         }
 
         return Collections.emptyList();
@@ -863,9 +895,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the plates to load
      * @return A collection of {@link PlateData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<PlateData> getPlates(SecurityContext ctx, long ownerId,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -889,7 +923,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load plates");
         }
 
         return Collections.emptyList();
@@ -900,8 +934,10 @@ public class BrowseFacility extends Facility {
      * @param ctx The {@link SecurityContext}
      * @param plateId The ID of the plate
      * @return A collection of {@link WellData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<WellData> getWells(SecurityContext ctx, long plateId) {
+    public Collection<WellData> getWells(SecurityContext ctx, long plateId) throws DSOutOfServiceException, DSAccessException {
         Collection<WellData> result = new ArrayList<WellData>();
         try {
             IQueryPrx proxy = gateway.getQueryService(ctx);
@@ -925,7 +961,7 @@ public class BrowseFacility extends Facility {
                 result.add(well);
             }
         } catch (Throwable t) {
-            logError(this, "Could not load wells", t);
+            handleException(this, t, "Could not load wells");
         }
         return result;
     }
@@ -938,8 +974,10 @@ public class BrowseFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public Collection<ImageData> getUserImages(SecurityContext ctx) {
+    public Collection<ImageData> getUserImages(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
         try {
             ParametersI param = new ParametersI();
             param.grp(omero.rtypes.rlong(ctx.getGroupID()));
@@ -956,7 +994,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not images");
         }
 
         return Collections.emptyList();
@@ -970,8 +1008,10 @@ public class BrowseFacility extends Facility {
      * @param id
      *            The ids of the image to load
      * @return The {@link ImageData}
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public ImageData getImage(SecurityContext ctx, long id) {
+    public ImageData getImage(SecurityContext ctx, long id) throws DSOutOfServiceException, DSAccessException {
         return getImages(ctx, Collections.singleton(id)).iterator().next();
     }
     
@@ -985,8 +1025,10 @@ public class BrowseFacility extends Facility {
      * @param params
      *            Custom parameters, can be <code>null</code>
      * @return The {@link ImageData}
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
-    public ImageData getImage(SecurityContext ctx, long id, ParametersI params) {
+    public ImageData getImage(SecurityContext ctx, long id, ParametersI params) throws DSOutOfServiceException, DSAccessException {
         return getImages(ctx, Collections.singleton(id), params).iterator()
                 .next();
     }
@@ -999,9 +1041,11 @@ public class BrowseFacility extends Facility {
      * @param ids
      *            The ids of the images to load
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ImageData> getImages(SecurityContext ctx,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         return getImages(ctx, ids, null);
     }
     
@@ -1015,9 +1059,11 @@ public class BrowseFacility extends Facility {
      * @param params
      *            Custom parameters, can be <code>null</code>
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ImageData> getImages(SecurityContext ctx,
-            Collection<Long> ids, ParametersI params) {
+            Collection<Long> ids, ParametersI params) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -1038,7 +1084,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load images");
         }
 
         return Collections.emptyList();
@@ -1053,9 +1099,11 @@ public class BrowseFacility extends Facility {
      *            The id of the user
      * @param ids The image ids
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ImageData> getImages(SecurityContext ctx, long ownerId,
-            Collection<Long> ids) {
+            Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
         if (ids == null)
             return Collections.emptyList();
         
@@ -1079,7 +1127,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load images");
         }
 
         return Collections.emptyList();
@@ -1093,9 +1141,11 @@ public class BrowseFacility extends Facility {
      * @param datasetIds
      *            The ids of the datasets
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ImageData> getImagesForDatasets(SecurityContext ctx,
-            Collection<Long> datasetIds) {
+            Collection<Long> datasetIds) throws DSOutOfServiceException, DSAccessException {
         if (datasetIds == null)
             return Collections.emptyList();
         
@@ -1112,7 +1162,7 @@ public class BrowseFacility extends Facility {
 
             return result;
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load images");
         }
 
         return Collections.emptyList();
@@ -1126,9 +1176,11 @@ public class BrowseFacility extends Facility {
      * @param projectIds
      *            The ids of the projects
      * @return A collection of {@link ImageData}s
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public Collection<ImageData> getImagesForProjects(SecurityContext ctx,
-            Collection<Long> projectIds) {
+            Collection<Long> projectIds) throws DSOutOfServiceException, DSAccessException {
         if (projectIds == null)
             return Collections.emptyList();
         
@@ -1141,7 +1193,7 @@ public class BrowseFacility extends Facility {
             }
             return getImagesForDatasets(ctx, dsIds);
         } catch (Throwable t) {
-            logError(this, "Could not load hierarchy", t);
+            handleException(this, t, "Could not load images");
         }
 
         return Collections.emptyList();

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -108,7 +108,6 @@ public class BrowseFacility extends Facility {
     public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
             throws DSOutOfServiceException {
-
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             return PojoMapper.asDataObjects(service.loadContainerHierarchy(
@@ -345,6 +344,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -412,6 +414,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx,
             long ownerId, Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -480,6 +485,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             ParametersI param = new ParametersI();
             param.leaves();
@@ -551,6 +559,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx,
             long ownerId, Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -617,6 +628,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -684,6 +698,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx, long ownerId,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -749,6 +766,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<PlateData> getPlates(SecurityContext ctx,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -816,6 +836,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<PlateData> getPlates(SecurityContext ctx, long ownerId,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
@@ -965,6 +988,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImages(SecurityContext ctx,
             Collection<Long> ids, ParametersI params) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             List<Long> idsList = new ArrayList<Long>(ids.size());
             for (long id : ids)
@@ -1000,6 +1026,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImages(SecurityContext ctx, long ownerId,
             Collection<Long> ids) {
+        if (ids == null)
+            return Collections.emptyList();
+        
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
@@ -1037,6 +1066,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImagesForDatasets(SecurityContext ctx,
             Collection<Long> datasetIds) {
+        if (datasetIds == null)
+            return Collections.emptyList();
+        
         try {
             Collection<ImageData> result = new ArrayList<ImageData>();
 
@@ -1067,6 +1099,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImagesForProjects(SecurityContext ctx,
             Collection<Long> projectIds) {
+        if (projectIds == null)
+            return Collections.emptyList();
+        
         try {
             Collection<ProjectData> projects = getProjects(ctx, projectIds);
             Collection<Long> dsIds = new ArrayList<Long>();

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -84,14 +84,14 @@ public class BrowseFacility extends Facility {
      * @return See above.
      * @throws DSOutOfServiceException  If the connection is broken, or logged in.
      */
-    public Collection<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
+    public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             long userId) throws DSOutOfServiceException {
         ParametersI param = new ParametersI();
         if (userId >= 0) {
             param.exp(omero.rtypes.rlong(userId));
         }
         param.orphan();
-        return loadHierarchy(ctx, rootType, null, param);
+        return getHierarchy(ctx, rootType, null, param);
     }
 
     /**
@@ -105,7 +105,59 @@ public class BrowseFacility extends Facility {
      * @return See above.
      * @throws DSOutOfServiceException If the connection is broken, or logged in.
      */
-    public Collection<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
+    public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
+            List<Long> rootIDs, Parameters options)
+            throws DSOutOfServiceException {
+        try {
+            IContainerPrx service = gateway.getPojosService(ctx);
+            return PojoMapper.asDataObjects(service.loadContainerHierarchy(
+                    PojoMapper.getModelType(rootType).getName(), rootIDs,
+                    options));
+        } catch (Throwable t) {
+            logError(this, "Could not load hierarchy", t);
+        }
+
+        return Collections.emptySet();
+    }
+    
+    /**
+     * Retrieves hierarchy trees rooted by a given node.
+     * i.e. the requested node as root and all of its descendants.
+     *
+     * @deprecated Please use the more generic method 
+     *          {@link #getHierarchy(SecurityContext, Class, List, Parameters)}
+     *          
+     * @param ctx The security context.
+     * @param rootType The type of node to handle.
+     * @param userId The user's to retrieve the data to handle.
+     * @return See above.
+     * @throws DSOutOfServiceException  If the connection is broken, or logged in.
+     */
+    public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
+            long userId) throws DSOutOfServiceException {
+        ParametersI param = new ParametersI();
+        if (userId >= 0) {
+            param.exp(omero.rtypes.rlong(userId));
+        }
+        param.orphan();
+        return loadHierarchy(ctx, rootType, null, param);
+    }
+
+    /**
+     * Retrieves hierarchy trees rooted by a given node.
+     * i.e. the requested node as root and all of its descendants.
+     *
+     * @deprecated Please use the more generic method 
+     *          {@link #getHierarchy(SecurityContext, Class, long)}
+     *          
+     * @param ctx The security context.
+     * @param rootType The type of node to handle.
+     * @param rootIDs The node's id.
+     * @param options The retrieval options.
+     * @return See above.
+     * @throws DSOutOfServiceException If the connection is broken, or logged in.
+     */
+    public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
             throws DSOutOfServiceException {
         try {

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -91,7 +91,6 @@ public class BrowseFacility extends Facility {
             param.exp(omero.rtypes.rlong(userId));
         }
         param.orphan();
-        param.leaves();
         return loadHierarchy(ctx, rootType, null, param);
     }
 
@@ -318,11 +317,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx) {
         try {
-            ParametersI param = new ParametersI();
-
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> projects = service.loadContainerHierarchy(PojoMapper
-                    .getModelType(ProjectData.class).getName(), null, param);
+                    .getModelType(ProjectData.class).getName(), null, null);
 
             Collection<ProjectData> result = new ArrayList<ProjectData>(
                     projects.size());
@@ -592,11 +589,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx) {
         try {
-            ParametersI param = new ParametersI();
-
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> screens = service.loadContainerHierarchy(PojoMapper
-                    .getModelType(ScreenData.class).getName(), null, param);
+                    .getModelType(ScreenData.class).getName(), null, null);
 
             Collection<ScreenData> result = new ArrayList<ScreenData>(
                     screens.size());
@@ -726,12 +721,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<PlateData> getPlates(SecurityContext ctx) {
         try {
-            ParametersI param = new ParametersI();
-            param.leaves();
-
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> plates = service.loadContainerHierarchy(PojoMapper
-                    .getModelType(PlateData.class).getName(), null, param);
+                    .getModelType(PlateData.class).getName(), null, null);
 
             Collection<PlateData> result = new ArrayList<PlateData>(
                     plates.size());
@@ -760,15 +752,12 @@ public class BrowseFacility extends Facility {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
 
-            ParametersI param = new ParametersI();
-            param.leaves();
-
             List<Long> idsList = new ArrayList<Long>(ids.size());
             for (long id : ids)
                 idsList.add(id);
 
             List<IObject> plates = service.loadContainerHierarchy(PojoMapper
-                    .getModelType(PlateData.class).getName(), idsList, param);
+                    .getModelType(PlateData.class).getName(), idsList, null);
 
             Collection<PlateData> result = new ArrayList<PlateData>(
                     plates.size());
@@ -796,7 +785,6 @@ public class BrowseFacility extends Facility {
         try {
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
-            param.leaves();
 
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> plates = service.loadContainerHierarchy(PojoMapper
@@ -837,8 +825,7 @@ public class BrowseFacility extends Facility {
 
             ParametersI param = new ParametersI();
             param.exp(omero.rtypes.rlong(ownerId));
-            param.leaves();
-
+            
             List<IObject> plates = service.loadContainerHierarchy(PojoMapper
                     .getModelType(PlateData.class).getName(), idsList, param);
 

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -82,7 +82,7 @@ public class BrowseFacility extends Facility {
      * @param rootType The type of node to handle.
      * @param userId The user's to retrieve the data to handle.
      * @return See above.
-     * @throws DSOutOfServiceException  If the connection is broken, or logged in.
+     * @throws DSOutOfServiceException
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             long userId) throws DSOutOfServiceException {
@@ -103,7 +103,7 @@ public class BrowseFacility extends Facility {
      * @param rootIDs The node's id.
      * @param options The retrieval options.
      * @return See above.
-     * @throws DSOutOfServiceException If the connection is broken, or logged in.
+     * @throws DSOutOfServiceException
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
@@ -131,7 +131,7 @@ public class BrowseFacility extends Facility {
      * @param rootType The type of node to handle.
      * @param userId The user's to retrieve the data to handle.
      * @return See above.
-     * @throws DSOutOfServiceException  If the connection is broken, or logged in.
+     * @throws DSOutOfServiceException
      */
     public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             long userId) throws DSOutOfServiceException {
@@ -155,7 +155,7 @@ public class BrowseFacility extends Facility {
      * @param rootIDs The node's id.
      * @param options The retrieval options.
      * @return See above.
-     * @throws DSOutOfServiceException If the connection is broken, or logged in.
+     * @throws DSOutOfServiceException
      */
     public Set<DataObject> loadHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
@@ -183,10 +183,7 @@ public class BrowseFacility extends Facility {
      *            The object's id.
      * @return The last version of the object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public <T extends DataObject> T findObject(SecurityContext ctx,
             Class<T> klass, long id) throws DSOutOfServiceException,
@@ -208,10 +205,7 @@ public class BrowseFacility extends Facility {
      *            <code>false</code> to only use ctx's group
      * @return The last version of the object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public <T extends DataObject> T findObject(SecurityContext ctx,
             Class<T> klass, long id, boolean allGroups)
@@ -232,10 +226,7 @@ public class BrowseFacility extends Facility {
      *            The object's id.
      * @return The last version of the object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public IObject findIObject(SecurityContext ctx, String klassName, long id)
             throws DSOutOfServiceException, DSAccessException {
@@ -254,10 +245,7 @@ public class BrowseFacility extends Facility {
      * @param allGroups Pass <code>true</code> to look for all groups
      * @return The last version of the object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public IObject findIObject(SecurityContext ctx, String klassName, long id,
             boolean allGroups) throws DSOutOfServiceException,
@@ -289,10 +277,7 @@ public class BrowseFacility extends Facility {
      *            The object to retrieve.
      * @return The last version of the object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public IObject findIObject(SecurityContext ctx, IObject o)
             throws DSOutOfServiceException, DSAccessException {
@@ -318,10 +303,7 @@ public class BrowseFacility extends Facility {
      *            The user currently logged in.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public Set<GroupData> getAvailableGroups(SecurityContext ctx,
             ExperimenterData user) throws DSOutOfServiceException,

--- a/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
+++ b/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
@@ -80,10 +80,7 @@ public class DataManagerFacility extends Facility {
      *            The object to delete.
      * @return The {@link Response} handle
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public Response deleteObject(SecurityContext ctx, IObject object)
             throws DSOutOfServiceException, DSAccessException {
@@ -99,10 +96,7 @@ public class DataManagerFacility extends Facility {
      *            The objects to delete.
      * @return The {@link Response} handle
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     public Response deleteObjects(SecurityContext ctx, List<IObject> objects)
             throws DSOutOfServiceException, DSAccessException {
@@ -153,10 +147,7 @@ public class DataManagerFacility extends Facility {
      *            Options to update the data.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object,
@@ -181,10 +172,7 @@ public class DataManagerFacility extends Facility {
      *            The object to update.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public DataObject saveAndReturnObject(SecurityContext ctx, DataObject object)
@@ -201,10 +189,7 @@ public class DataManagerFacility extends Facility {
      *            The object to update.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object)
@@ -232,10 +217,7 @@ public class DataManagerFacility extends Facility {
      *            The name of the user to create the data for.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object,
@@ -264,10 +246,7 @@ public class DataManagerFacility extends Facility {
      *            The name of the user to create the data for.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public DataObject saveAndReturnObject(SecurityContext ctx,
@@ -287,10 +266,7 @@ public class DataManagerFacility extends Facility {
      *            The name of the user to create the data for.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public IObject saveAndReturnObject(SecurityContext ctx,
@@ -318,10 +294,7 @@ public class DataManagerFacility extends Facility {
      * @param userName The username
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public List<IObject> saveAndReturnObject(SecurityContext ctx,
@@ -347,10 +320,7 @@ public class DataManagerFacility extends Facility {
      *            Options to update the data.
      * @return The updated object.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObject(IObject, Parameters)
      */
     public IObject updateObject(SecurityContext ctx, IObject object,
@@ -378,10 +348,7 @@ public class DataManagerFacility extends Facility {
      *            Options to update the data.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      * @see IContainerPrx#updateDataObjects(List, Parameters)
      */
     public List<IObject> updateObjects(SecurityContext ctx,

--- a/components/blitz/src/omero/gateway/facility/MetadataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/MetadataFacility.java
@@ -66,9 +66,11 @@ public class MetadataFacility extends Facility {
      * @param imageId
      *            The imageId
      * @return See above
+     * @throws DSAccessException 
+     * @throws DSOutOfServiceException 
      */
     public ImageAcquisitionData getImageAcquisitionData(SecurityContext ctx,
-            long imageId) {
+            long imageId) throws DSOutOfServiceException, DSAccessException {
         ParametersI params = new ParametersI();
         params.acquisitionData();
         ImageData img = browse.getImage(ctx, imageId, params);

--- a/components/blitz/src/omero/gateway/facility/MetadataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/MetadataFacility.java
@@ -83,9 +83,8 @@ public class MetadataFacility extends Facility {
      * @param imageId
      *            The imageId to get the ChannelData for
      * @return List of ChannelData
-     * @throws DSOutOfServiceException If the connection is broken, or logged in.
-     * @throws DSAccessException If an error occurred while trying to
-     * retrieve data from OMERO service.
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException 
      */
     public List<ChannelData> getChannelData(SecurityContext ctx, long imageId)
             throws DSOutOfServiceException, DSAccessException {

--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -87,10 +87,7 @@ public class ROIFacility extends Facility {
      *            The ROI's id.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public ROIResult loadROI(SecurityContext ctx, long roiId)
             throws DSOutOfServiceException, DSAccessException {
@@ -120,10 +117,7 @@ public class ROIFacility extends Facility {
      *          The selection timepoint.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public List<ROIResult> loadROIsByPlane(SecurityContext ctx, long imageID, int z, int t)
             throws DSOutOfServiceException, DSAccessException {
@@ -150,10 +144,7 @@ public class ROIFacility extends Facility {
      *            The image's ID.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public List<ROIResult> loadROIs(SecurityContext ctx, long imageID)
             throws DSOutOfServiceException, DSAccessException {
@@ -193,10 +184,7 @@ public class ROIFacility extends Facility {
      *            The user's ID.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public List<ROIResult> loadROIs(SecurityContext ctx, long imageID,
             List<Long> measurements, long userID)
@@ -253,10 +241,7 @@ public class ROIFacility extends Facility {
      *            The list of ROI to save.
      * @return updated list of ROIData objects.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public Collection<ROIData> saveROIs(SecurityContext ctx, long imageID,
             Collection<ROIData> roiList) throws DSOutOfServiceException,
@@ -278,10 +263,7 @@ public class ROIFacility extends Facility {
      *            The list of ROI to save.
      * @return updated list of ROIData objects.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public Collection<ROIData> saveROIs(SecurityContext ctx, long imageID,
             long userID, Collection<ROIData> roiList) throws DSOutOfServiceException,

--- a/components/blitz/src/omero/gateway/facility/SearchFacility.java
+++ b/components/blitz/src/omero/gateway/facility/SearchFacility.java
@@ -83,10 +83,7 @@ public class SearchFacility extends Facility {
      *            search will be the group set in the security context)
      * @return The found objects.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public SearchResultCollection search(SecurityContext ctx, SearchParameters context)
             throws DSOutOfServiceException, DSAccessException {

--- a/components/blitz/src/omero/gateway/facility/TransferFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TransferFacility.java
@@ -67,10 +67,7 @@ public class TransferFacility extends Facility {
      * @param image The image to upload.
      * @param observer The observer to notify components of upload status.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      * @throws ImportException If an error occurred while importing data.
      */
     public void uploadImage(SecurityContext context, File image,
@@ -91,10 +88,7 @@ public class TransferFacility extends Facility {
      * @param user The owner of the image.
      * @param observer The observer to notify components of upload status.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      * @throws ImportException If an error occurred while importing data.
      */
     public void uploadImage(SecurityContext context, File image,
@@ -120,10 +114,7 @@ public class TransferFacility extends Facility {
      * @param username The OMERO user name.
      * @param groupname The group to import the data to.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public void uploadImage(SecurityContext context, File image,
             IObserver observer, String username, String groupname)
@@ -138,10 +129,7 @@ public class TransferFacility extends Facility {
      * @param imageId The identifier of the image.
      * @return See above
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     public List<File> downloadImage(SecurityContext context, String targetPath,
             long imageId) throws DSAccessException, DSOutOfServiceException {

--- a/components/blitz/src/omero/gateway/facility/TransferFacilityHelper.java
+++ b/components/blitz/src/omero/gateway/facility/TransferFacilityHelper.java
@@ -806,10 +806,7 @@ public class TransferFacilityHelper {
      *            The name of the user to create the data for.
      * @return See above.
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMERO
-     *             service.
      */
     private IObject determineContainer(SecurityContext ctx,
             DatasetData dataset, DataObject container, ImportableObject object,
@@ -941,10 +938,7 @@ public class TransferFacilityHelper {
      * @param imageId The identifier of the image.
      * @return See above
      * @throws DSOutOfServiceException
-     *             If the connection is broken, or logged in.
      * @throws DSAccessException
-     *             If an error occurred while trying to retrieve data from OMEDS
-     *             service.
      */
     List<File> downloadImage(SecurityContext context, String targetPath,
             long imageId) throws DSAccessException, DSOutOfServiceException {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1632,13 +1632,9 @@ class OMEROGateway
 	{
 	    try {
             BrowseFacility f = gw.getFacility(BrowseFacility.class);
-            // tmp solution, should be changed to Collection<DataObject> throughout
-            Set result = new HashSet();
-            Collection<DataObject> col = f.loadHierarchy(ctx, rootType,
-                    rootIDs, options);
-            for (DataObject obj : col)
-                result.add(obj);
-            return result;
+            // TODO: tmp solution, should be changed to Collection<DataObject> throughout
+           return new HashSet(f.loadHierarchy(ctx, rootType,
+                    rootIDs, options));
         } catch (Throwable e) {
             handleException(e, "Cannot load hierarchy for "+rootType+".");
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1632,7 +1632,13 @@ class OMEROGateway
 	{
 	    try {
             BrowseFacility f = gw.getFacility(BrowseFacility.class);
-            return f.loadHierarchy(ctx, rootType, rootIDs, options);
+            // tmp solution, should be changed to Collection<DataObject> throughout
+            Set result = new HashSet();
+            Collection<DataObject> col = f.loadHierarchy(ctx, rootType,
+                    rootIDs, options);
+            for (DataObject obj : col)
+                result.add(obj);
+            return result;
         } catch (Throwable e) {
             handleException(e, "Cannot load hierarchy for "+rootType+".");
         }

--- a/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
@@ -22,6 +22,7 @@ package integration.gateway;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
@@ -112,6 +113,14 @@ public class BrowseFacilityTest extends GatewayTest {
         Collection<ProjectData> result = browseFacility.getProjects(ctx);
         Assert.assertEquals(result.size(), 2);
 
+        // check that we do *not* load the whole tree by default
+        for(ProjectData p : result) {
+            Set<DatasetData> datasets = p.getDatasets();
+            for(DatasetData ds : datasets) {
+                Assert.assertNull(ds.getImages(), "Images should not have been loaded at this point!");
+            }
+        }
+        
         // get specific project
         Collection<Long> ids = new ArrayList<Long>(1);
         ids.add(proj.getId());

--- a/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
@@ -76,7 +76,7 @@ public class BrowseFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetDatasets() {
+    public void testGetDatasets() throws DSOutOfServiceException, DSAccessException {
         SecurityContext ctx = new SecurityContext(group.getId());
 
         // get datasets of the group
@@ -106,7 +106,7 @@ public class BrowseFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetProjects() {
+    public void testGetProjects() throws DSOutOfServiceException, DSAccessException {
         SecurityContext ctx = new SecurityContext(group.getId());
 
         // get projects of the group
@@ -144,7 +144,7 @@ public class BrowseFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetScreens() {
+    public void testGetScreens() throws DSOutOfServiceException, DSAccessException {
         SecurityContext ctx = new SecurityContext(group.getId());
 
         // get screens of the group
@@ -174,7 +174,7 @@ public class BrowseFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetPlates() {
+    public void testGetPlates() throws DSOutOfServiceException, DSAccessException {
         SecurityContext ctx = new SecurityContext(group.getId());
 
         // get plates of the group
@@ -204,7 +204,7 @@ public class BrowseFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetImages() {
+    public void testGetImages() throws DSOutOfServiceException, DSAccessException {
         SecurityContext ctx = new SecurityContext(group.getId());
 
         // get images of the root user

--- a/components/tools/OmeroJava/test/integration/gateway/MetadataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/MetadataFacilityTest.java
@@ -69,7 +69,7 @@ public class MetadataFacilityTest extends GatewayTest {
 
     @Test
     public void testGetImageAcquisitionData() throws ExecutionException,
-            BigResult {
+            BigResult, DSOutOfServiceException, DSAccessException {
         MetadataFacility mdf = gw.getFacility(MetadataFacility.class);
         ImageAcquisitionData d = mdf.getImageAcquisitionData(rootCtx,
                 img.getId());

--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 
 import omero.api.IPixelsPrx;
 import omero.api.RawPixelsStorePrx;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.DataSourceException;
 import omero.gateway.rnd.Plane2D;
 import omero.model.IObject;
@@ -61,7 +63,7 @@ public class RawDataFacilityTest extends GatewayTest {
     }
 
     @Test
-    public void testGetPlane() throws DataSourceException {
+    public void testGetPlane() throws DataSourceException, DSOutOfServiceException, DSAccessException {
         ImageData img = browseFacility.getImage(rootCtx, imgId);
         Plane2D plane = rawdataFacility.getPlane(rootCtx, img.getDefaultPixels(), 0, 0, 0);
         byte[] planeData = new byte[100*100];
@@ -72,7 +74,7 @@ public class RawDataFacilityTest extends GatewayTest {
     }
     
     @Test
-    public void testGetTile() throws DataSourceException {
+    public void testGetTile() throws DataSourceException, DSOutOfServiceException, DSAccessException {
         ImageData img = browseFacility.getImage(rootCtx, imgId);
         int x = 0, y=0, w=img.getDefaultPixels().getSizeX(), h=1;
         


### PR DESCRIPTION
Contains critical bugfixes which have to go into 5.2.1

- Removes the leaves() parameter where it can be dangerous (accidentally pull *everything* from the server)
