### PR TITLE
Scroll to selected thumbnail

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -19,6 +19,7 @@
             data-type="image"
             data-id="<%= img.id %>"
             data-perms="<%= img.data.obj.permsCss %>"
+            tabindex="0"
             <% if(img.shareId) { %> data-share="<%= img.shareId %>" <% }%>
             data-owned="">
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -597,6 +597,8 @@ $(document).ready(function() {
             $("#dataIcons").removeClass("iconLayout");
             $("#dataIcons").addClass("tableLayout");
         }
+        // on larger pages, may need to scroll to show selected thumbnail again
+        focusThumbnail();
     }
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -289,6 +289,9 @@ $(document).ready(function() {
             setupSelectable();
         }
 
+        // scroll to selected thumbnail (if any)
+        focusThumbnail();
+
         return;
     }
 
@@ -311,6 +314,15 @@ $(document).ready(function() {
         selFileSets.forEach(function(fsId){
             $("#dataIcons li[data-fileset='" + fsId + "']").addClass("fs-selected");
         });
+        focusThumbnail();
+    }
+
+    var focusThumbnail = function() {
+        // We focus the thumbnail to make sure it's scrolled into view
+        var $focused = $(':focus');
+        $("#dataIcons li.ui-selected").first().focus();
+        // Then re-focus the jstree node, so that hot-keys work etc
+        $focused.focus();
     }
 
     var getRandom = function() {


### PR DESCRIPTION
This addresses comment at https://github.com/openmicroscopy/openmicroscopy/pull/4242#issuecomment-150147878 which is listed on https://trello.com/c/6ugBp0HG/5-web-center-panel-follow-up.

To test, find a dataset with a large number of images (so that the centre panel needs scrolling).
 - In the tree, select the dataset, then select an image near the bottom. Centre panel should scroll to that thumbnail.
 - Hotkeys should continue to work in jsTree as usual, with centre panel scrolling as needed to show selected thumbnail.
 - This should also work when in "table" view in centre panel
 - Switching between table and icon views should maintain the selected thumbnail in view (scroll to show it if needed)