### PR TITLE
Fix duplicate screen target

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -273,6 +273,8 @@ public class OMEROMetadataStoreClient
      */
     private Map<String, String[]> referenceStringCache;
 
+    private LSID screenKey;
+
     /** Our model processors. Will be called on saveToDB(). */
     private List<ModelProcessor> modelProcessors;
 
@@ -1374,6 +1376,10 @@ public class OMEROMetadataStoreClient
     @Override
     public void setUserSpecifiedTarget(IObject target)
     {
+        if (target instanceof Screen && null != screenKey) {
+          log.info("deleting screen ref in favor of user-specified one");
+          referenceCache.remove(screenKey);
+        }
         this.userSpecifiedTarget = target;
     }
 
@@ -6818,8 +6824,8 @@ public class OMEROMetadataStoreClient
     public void setScreenPlateRef(String plate, int screenIndex,
             int plateRefIndex)
     {
-        LSID key = new LSID(Screen.class, screenIndex);
-        addReference(key, new LSID(plate));
+        screenKey = new LSID(Screen.class, screenIndex);
+        addReference(screenKey, new LSID(plate));
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This PR addresses a problem encountered when importing `.screen` files.

 * *Without* this patch, if the user specifies a screen target, plates are linked to that screen *and* to the screen specified by Bio-Formats' `ScreenReader`
 * *With* this patch, the target specified by the user overrides the BF one

**NOTES**

 * It would be nice to simply skip `addReference` in `setScreenPlateRef`, but at that point in the import process `userSpecifiedTarget` has not been set yet (on the server's side)
 * `screenKey` should probably be changed to a list, or removed altogether if scanning the whole `referenceCache` for screen-plate refs is not too intensive
 * BF adds a screen -> plate ref, while `TargetProcessor` [adds a plate -> screen one](https://github.com/openmicroscopy/openmicroscopy/blob/983abca738b10367fe20ba2653ed99d3971e74ed/components/blitz/src/ome/formats/model/TargetProcessor.java#L86). Does this mean one of the two has to be fixed?