### PR TITLE
Slice documentation: hyperlinks cleanup

### DIFF
--- a/components/blitz/resources/omero/API.ice
+++ b/components/blitz/resources/omero/API.ice
@@ -89,8 +89,9 @@ module omero {
          * Starting point for all OMERO.blitz interaction.
          *
          * <p> A ServiceFactory once acquired can be used to create any number
-         * of service proxies to the server. Most services implement [ServiceInterface]
-         * or its subinterface [StatefulServiceInterface]. </p>
+         * of service proxies to the server. Most services implement
+         * {@link ServiceInterface} or its subinterface
+         * {@link StatefulServiceInterface}. </p>
          **/
         interface ServiceFactory extends omero::cmd::Session
         {
@@ -99,8 +100,8 @@ module omero {
 
             /**
              * Provides a list of all valid security contexts for this session.
-             * Each of the returned [omero::model::IObject] instances can be
-             * passed to setSecurityContext.
+             * Each of the returned {@link omero.model.IObject} instances can
+             * be passed to {@link #setSecurityContext}.
              **/
             IObjectList getSecurityContexts() throws ServerError;
 
@@ -113,20 +114,23 @@ module omero {
              *
              * <p> Current valid values for security context:
              * <ul>
-             *  <li>[omero::model::ExperimenterGroup] - logs into a specific group</li>
-             *  <li>[omero::model::Share] - uses IShare to activate a share</li>
+             *  <li>{@link omero.model.ExperimenterGroup} - logs into a
+             * specific group</li>
+             *  <li>{@link omero.model.Share} - uses IShare to activate a
+             * share</li>
              * </ul> </p>
              *
              * <p> Passing an unloaded version of either object type will change
              * the way the current session operates. Note: only objects which
-             * are returned by the [getSecurityContexts] method are considered
-             * valid. Any other instance will cause an exception to be thrown. </p>
+             * are returned by the {@link #getSecurityContexts} method are
+             * considered valid. Any other instance will cause an exception to
+             * be thrown. </p>
              *
              * <h4>Example usage in Python:<h4>
              * <pre>
              * sf = client.createSession()
              * objs = sf.getSecurityContexts()
-             * old = sf.setSecurityContext(objs[-1])
+             * old = sf.setSecurityContext(objs\[-1])
              * </pre>
              *
              **/
@@ -172,15 +176,16 @@ module omero {
             // Shared resources -----------------------------------------------
 
             /**
-             * Returns a reference to a back-end manager. The [omero::grid::SharedResources]
-             * service provides look ups for various facilities offered by OMERO:
+             * Returns a reference to a back-end manager. The
+             * {@link omero.grid.SharedResources} service provides look ups
+             * for various facilities offered by OMERO:
              * <ul>
              *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/scripts/">OMERO.scripts</a>
              *   <li><a href="http://www.openmicroscopy.org/site/support/omero5.2/developers/Tables.html">OMERO.tables</a>
              * </ul>
              * These facilities may or may not be available on first request.
              *
-             * @see omero::grid::SharedResources
+             * @see omero.grid.SharedResources
              **/
             omero::grid::SharedResources* sharedResources() throws ServerError;
 

--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -140,7 +140,7 @@ module omero {
 
     /**
      * Constants used for field defaults and similar
-     * in the [omero::model::] classes.
+     * in the {@link omero.model} classes.
      **/
     module data {
 
@@ -152,7 +152,7 @@ module omero {
     };
 
     /**
-     * Namespaces for the [omero::api::IMetadata] interface.
+     * Namespaces for the {@link omero.api.IMetadata} interface.
      **/
     module metadata {
         const string NSINSIGHTTAGSET = "openmicroscopy.org/omero/insight/tagset";
@@ -228,29 +228,29 @@ module omero {
     module permissions {
 
       /**
-       * Index into the [omero::model::Permissions::restrictions]
-       * [omero::api::BoolArray] field to test whether or not
+       * Index into the {@link omero.model.Permissions#restrictions}
+       * {@link omero.api.BoolArray} field to test whether or not
        * the link restriction has been applied to the current object.
        **/
       const int LINKRESTRICTION = 0;
 
       /**
-       * Index into the [omero::model::Permissions::restrictions]
-       * [omero::api::BoolArray] field to test whether or not
+       * Index into the {@link omero.model.Permissions#restrictions}
+       * {@link omero.api.BoolArray} field to test whether or not
        * the edit restriction has been applied to the current object.
        **/
       const int EDITRESTRICTION = 1;
 
       /**
-       * Index into the [omero::model::Permissions::restrictions]
-       * [omero::api::BoolArray] field to test whether or not
+       * Index into the {@link omero.model.Permissions#restrictions}
+       * {@link omero.api.BoolArray} field to test whether or not
        * the delete restriction has been applied to the current object.
        **/
       const int DELETERESTRICTION = 2;
 
       /**
-       * Index into the [omero::model::Permissions::restrictions]
-       * [omero::api::BoolArray] field to test whether or not
+       * Index into the {@link omero.model.Permissions#restrictions}
+       * {@link omero.api.BoolArray} field to test whether or not
        * the annotate restriction has been applied to the current object.
        **/
       const int ANNOTATERESTRICTION = 3;

--- a/components/blitz/resources/omero/ROMIO.ice
+++ b/components/blitz/resources/omero/ROMIO.ice
@@ -20,8 +20,8 @@ module omero
 
 Primitives for working with binary data.
 
-@see omero::api::RenderingEngine
-@see omero::api::RawPixelsStore
+@see omero.api.RenderingEngine
+@see omero.api.RawPixelsStore
 
  **/
 module romio

--- a/components/blitz/resources/omero/RTypes.ice
+++ b/components/blitz/resources/omero/RTypes.ice
@@ -97,8 +97,8 @@ module omero {
   /**
    * Extends RString and simply provides runtime
    * information to the server that this string
-   * is intended as a ["protected"] class parameter. Used especially
-   * by omero::system::ParamMap (omero/System.ice)
+   * is intended as a "protected" class parameter. Used especially
+   * by {@link omero.system.ParamMap} (omero/System.ice)
    * 
    * Usage:
    * <pre>
@@ -123,10 +123,10 @@ module omero {
   // Collections
 
   /**
-   * Simple sequence of [RType] instances. Note: when passing
-   * an RTypeSeq over the wire, null sequence is maintained and
+   * Simple sequence of {@link RType} instances. Note: when passing
+   * an {@link RTypeSeq} over the wire, null sequence is maintained and
    * will be turned into an empty sequence. If nullability is
-   * required, see the [RCollection] types.
+   * required, see the {@link RCollection} types.
    *
    * @see RCollection
    * @see RTypeDict
@@ -141,14 +141,14 @@ module omero {
   sequence<RTypeSeq> RTypeSeqSeq;
 
   /**
-   * The collection ["protected"] classes permit the passing of sequences of all
-   * other RTypes (including other collections) and it is itself
-   * nullable. The allows for similar arguments to collections in
-   * languages with a unified inheritance hierarchy (e.g., Java in
-   * which all ["protected"] classes extend from java.lang.Object).
+   * The collection "protected" classes permit the passing of sequences of all
+   * other RTypes (including other collections) and it is itself nullable. The
+   * allows for similar arguments to collections in languages with a unified
+   * inheritance hierarchy (e.g., Java in which all "protected" classes extend
+   * from java.lang.Object).
    *
    * Unlike the other rtypes which are used internally within the
-   * omero.model classes, these types are mutable since they solely
+   * {@link omero.model} classes, these types are mutable since they solely
    * pass through the
    *
    * This flexible mechanism is not used in all API calls because
@@ -165,7 +165,7 @@ module omero {
   };
 
   /**
-   * [RCollection] mapped to an array on the server of a type given
+   * {@link RCollection} mapped to an array on the server of a type given
    * by a random member of the RTypeSeq. Only pass consistent arrays!
    * homogenous lists.
    **/
@@ -174,31 +174,31 @@ module omero {
   };
 
   /**
-   * [RCollection] mapped to a java.util.List on the server
+   * {@link RCollection} mapped to a java.util.List on the server
    **/
   ["protected"] class RList extends RCollection
   {
   };
 
   /**
-   * [RCollection] mapped to a java.util.HashSet on the server
+   * {@link RCollection} mapped to a java.util.HashSet on the server
    **/
   ["protected"] class RSet extends RCollection
   {
   };
 
   /**
-   * Simple dictionary of [RType] instances. Note: when passing
+   * Simple dictionary of {@link RType} instances. Note: when passing
    * an RTypeDict over the wire, a null map will not be maintained and
    * will be turned into an empty map. If nullability is
-   * required, see the [RMap] type.
+   * required, see the {@link RMap} type.
    **/
   ["java:type:java.util.HashMap<String,omero.RType>"]
   dictionary<string,omero::RType> RTypeDict;
 
   /**
-   * Similar to [RCollection], the [RMap] class permits the passing
-   * of a possible null [RTypeDict] where any other [RType] is
+   * Similar to {@link RCollection}, the {@link RMap} class permits the passing
+   * of a possible null {@link RTypeDict} where any other {@link RType} is
    * expected.
    *
    * @see RTypeDict

--- a/components/blitz/resources/omero/RTypes.ice
+++ b/components/blitz/resources/omero/RTypes.ice
@@ -16,7 +16,7 @@
 module omero {
 
   /**
-   * Simple base ["protected"] class. Essentially abstract.
+   * Simple base "protected" class. Essentially abstract.
    **/
   ["protected"] class RType
   {

--- a/components/blitz/resources/omero/Repositories.ice
+++ b/components/blitz/resources/omero/Repositories.ice
@@ -41,7 +41,7 @@ module omero {
         /**
          * Specifies that a file is located at the given location
          * that is not otherwise known by the repository. A
-         * subsequent call to [Repository::register] will create
+         * subsequent call to {@link Repository.register} will create
          * the given file. The mimetype field of the file may or
          * may not be set. If it is set, clients are suggested to
          * either omit the mimetype argument to the register method
@@ -89,7 +89,7 @@ module omero {
              * files in the directory denoted by an abstract pathname.  It
              * is expected that at a minimum the "name", "path", "size" and
              * "mtime" attributes will be present for each
-             * [omero::model::OriginalFile] instance.
+             * {@link omero.model.OriginalFile} instance.
              **/
             omero::api::OriginalFileList listFiles(string path)
                     throws ServerError;
@@ -119,8 +119,8 @@ module omero {
 
             /**
              * Returns true if the file or path exists within the repository.
-             * In other words, if a call on `dirname path` to [listFiles] would
-             * return an object for this path.
+             * In other words, if a call on `dirname path` to
+             * {@link #listFiles} would return an object for this path.
              **/
             bool fileExists(string path) throws ServerError;
 
@@ -134,12 +134,12 @@ module omero {
             void makeDir(string path, bool parents) throws ServerError;
 
             /**
-             * Similar to [list] but recursive and returns only primitive
-             * values for the file at each location. Guaranteed for each
-             * path is only the values id and mimetype.
+             * Similar to {@link #list} but recursive and returns only
+             * primitive values for the file at each location. Guaranteed for
+             * each path is only the values id and mimetype.
              *
-             * After a call to unwrap, the returned [omero::RMap] for a call
-             * to treeList("/user_1/dir0") might look something like:
+             * After a call to unwrap, the returned {@link omero.RMap} for a
+             * call to treeList("/user_1/dir0") might look something like:
              *
              * <pre>
              *  {
@@ -173,7 +173,7 @@ module omero {
 
             /**
              * Delete several individual paths. Internally, this converts
-             * all of the paths into a single [omero::cmd::Delete2] command
+             * all of the paths into a single {@link omero.cmd.Delete2} command
              * and submits it.
              *
              * If a "recursively" is true, then directories will be searched
@@ -200,7 +200,7 @@ module omero {
         };
 
         /**
-         * Returned by [ManagedRepository::importFileset] with
+         * Returned by {@link ManagedRepository#importFileset} with
          * the information needed to proceed with an FS import.
          * For the examples that follow, assume that the used
          * files passed to importFileset were:
@@ -231,7 +231,7 @@ module omero {
              * Parsed string names which should be used by the
              * clients during upload. This array will be of the
              * same length as the argument passed to
-             * [ManagedRepository::importFileset] but will have
+             * {@link ManagedRepository#importFileset} but will have
              * shortened paths.
              *
              * <pre>
@@ -296,9 +296,10 @@ module omero {
              omero::model::ChecksumAlgorithm checksumAlgorithm;
 
              /**
-              * If set, the [ImportProcess*] and the [Handle*] associated with
-              * the import will be closed as soon as complete. This will prevent
-              * clients from finding out the status of the import itself.
+              * If set, the {@link ImportProcess*} and the {@link Handle*}
+              * associated with the import will be closed as soon as complete.
+              * This will prevent clients from finding out the status of the
+              * import itself.
               **/
 
              /*
@@ -321,20 +322,23 @@ module omero {
             /**
              * Step 1: Returns a RawFileStore that can be used to upload one of
              * the used files. The index is the same as the used file listed in
-             * [ImportLocation]. [omero::api::RawFileStore::close] should be
-             * called once all data has been transferred. If the file must be
-             * re-written, call [getUploader] with the same index again. Once
-             * all uploads have been completed, [verifyUpload] should be called
-             * to initiate background processing
+             * {@link ImportLocation}. {@link omero.api.RawFileStore#close}
+             * should be called once all data has been transferred. If the
+             * file must be re-written, call {@link #getUploader} with the
+             * same index again. Once all uploads have been completed,
+             * {@link verifyUpload} should be called to initiate background
+             * processing
              **/
              omero::api::RawFileStore* getUploader(int i) throws ServerError;
 
             /**
-             * Step 2: Passes a set of client-side calculated hashes to the server
-             * for verifying that all of the files were correctly uploaded. If this
-             * passes then a [omero::cmd::Handle] proxy is returned, which completes
-             * all the necessary import steps. A successful import will return an
-             * [ImportResponse]. Otherwise, some [omero::cmd::ERR] will be returned.
+             * Step 2: Passes a set of client-side calculated hashes to the
+             * server for verifying that all of the files were correctly
+             * uploaded. If this passes then a {@link omero.cmd.Handle}
+             * proxy is returned, which completes all the necessary import
+             * steps. A successful import will return an
+             * {@link ImportResponse}. Otherwise, some {@link omero.cmd.ERR}
+             * will be returned.
              **/
              omero::cmd::Handle* verifyUpload(omero::api::StringSet hash) throws ServerError;
 
@@ -350,10 +354,10 @@ module omero {
 
             /**
              * Reacquire the handle which was returned by
-             * [verifyUpload]. This is useful in case a new
+             * {@link #verifyUpload}. This is useful in case a new
              * client is re-attaching to a running import.
-             * From the [omero::cmd::Handle] instance, the
-             * original [ImportRequest] can also be found.
+             * From the {@link omero.cmd.Handle} instance, the
+             * original {@link ImportRequest} can also be found.
              **/
              omero::cmd::Handle* getHandle() throws ServerError;
 
@@ -366,8 +370,8 @@ module omero {
 
         /**
          * Command object which will be used to create
-         * the [omero::cmd::Handle] instances passed
-         * back by the [ImportProcess].
+         * the {@link omero.cmd.Handle} instances passed
+         * back by the {@link ImportProcess}.
          **/
         class ImportRequest extends omero::cmd::Request {
 
@@ -395,25 +399,26 @@ module omero {
             /**
              * Activity that this will be filling
              * out in the database. This always points to a
-             * [omero::model::MetadataImportJob] which is the
-             * first server-side phase after the [omero::model::UploadJob].
+             * {@link omero.model.MetadataImportJob} which is the
+             * first server-side phase after the
+             * {@link omero.model.UploadJob}.
              **/
             omero::model::FilesetJobLink activity;
 
             /**
-             * [ImportSettings] which are provided by the
-             * client on the call to [ManagedRepository::importFileset].
+             * {@link ImportSettings} which are provided by the
+             * client on the call to {@link ManagedRepository#importFileset}.
              **/
              ImportSettings settings;
 
             /**
-             * [ImportLocation] which is calculated during
-             * the call to [ManagedRepository::importFileset].
+             * {@link ImportLocation} which is calculated during
+             * the call to {@link ManagedRepository#importFileset}.
              **/
              ImportLocation location;
 
             /**
-             * [OriginalFile] object representing the import log file.
+             * {@link OriginalFile} object representing the import log file.
              **/
              omero::model::OriginalFile logFile;
 
@@ -422,7 +427,7 @@ module omero {
 
         /**
          * Successful response returned from execution
-         * of [ImportRequest]. This is the simplest way
+         * of {@link ImportRequest}. This is the simplest way
          * to return the results, but is likely not the
          * overall best strategy.
          **/
@@ -447,33 +452,33 @@ module omero {
         ["ami"] interface ManagedRepository extends Repository {
 
             /**
-             * Returns an [ImportProcess] which can be used to upload files.
-             * On [ImportProcess::verifyUpload], an [omero::cmd::Handle] will be
+             * Returns an {@link ImportProcess} which can be used to upload files.
+             * On {@link ImportProcess#verifyUpload}, an {@link omero.cmd.Handle} will be
              * returned which can be watched for knowing when the server-side import
              * is complete.
              *
              * Client paths set in the fileset entries must /-separate their components.
              *
-             * Once the upload is complete, the [ImportProcess] must be closed.
-             * Once [omero::cmd::Handle::getResponse] returns a non-null value, the
+             * Once the upload is complete, the {@link ImportProcess} must be closed.
+             * Once {@link omero.cmd.Handle#getResponse} returns a non-null value, the
              * handle instance can and must be closed.
              **/
             ImportProcess* importFileset(omero::model::Fileset fs, ImportSettings settings) throws ServerError;
 
             /**
              * For clients without access to Bio-Formats, the simplified
-             * [importPaths] method allows passing solely the absolute
+             * {@link #importPaths} method allows passing solely the absolute
              * path of the files to be uploaded (no directories) and all
              * configuration happens server-side. Much of the functionality
-             * provided via [omero::model::Fileset] and [omero::grid::ImportSettings]
-             * is of course lost.
+             * provided via {@link omero.model.Fileset} and
+             * {@link omero.grid.ImportSettings} is of course lost.
              **/
             ImportProcess* importPaths(omero::api::StringSet filePaths) throws ServerError;
 
             /**
              * List imports that are currently running in this importer.
              * These will be limited based on user/group membership for
-             * the [omero::model::Fileset] object which is being created
+             * the {@link omero.model.Fileset} object which is being created
              * by the import. If the user has write permissions for the
              * fileset, then the import will be included.
              **/
@@ -488,13 +493,13 @@ module omero {
              * different bit widths.
              * They are listed in descending order of preference,
              * as set by the server administrator, and any of them may
-             * be specified for [ImportSettings::checksumAlgorithm].
+             * be specified for {@link ImportSettings#checksumAlgorithm}.
              */
             omero::api::ChecksumAlgorithmList listChecksumAlgorithms();
 
             /**
              * Suggest a checksum algorithm to use for
-             * [ImportSettings::checksumAlgorithm] according to the
+             * {@link ImportSettings#checksumAlgorithm} according to the
              * preferences set by the server administrator. Provide a
              * list of the algorithms supported by the client, and the
              * server will report which of them is most preferred by
@@ -575,7 +580,7 @@ module omero {
             sequence<Repository*> RepositoryProxyList;
 
         /**
-         * Return value for [omero::grid::SharedResources].acquireRepositories()
+         * Return value for {@link omero.grid.SharedResources#repositories}
          * The descriptions and proxies arrays will have the same size and each
          * index in descriptions (non-null) will match a possibly null proxy, if
          * the given repository is not currently accessible.

--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -25,12 +25,12 @@
 module omero {
 
     /**
-     * Base class similar to [omero::model::IObject] but for non-model-objects.
+     * Base class similar to {@link omero.model.IObject} but for non-model-objects.
      **/
     class Internal{};
 
     /**
-     * Base type for [RType]s whose contents will not be parsed by
+     * Base type for {@link RType}s whose contents will not be parsed by
      * the server. This allows Blitz-specific types to be safely
      * passed in as the inputs/outputs of scripts.
      **/
@@ -46,7 +46,7 @@ module omero {
 
     /**
      * Sequences cannot subclass other types, so the Plane
-     * class extends [Internal] and wraps a [Bytes2D] instance.
+     * class extends {@link Internal} and wraps a {@link Bytes2D} instance.
      **/
     class Plane extends Internal {
         Bytes2D data;
@@ -115,9 +115,9 @@ module omero {
             /**
              * Whether or not a script will require this value to be present
              * in the input or output. If an input is missing or None when
-             * non-optional, then a [omero::ValidationException] will be thrown
-             * on [processJob]. A missing output param will be marked after
-             * execution.
+             * non-optional, then a {@link omero.ValidationException} will be
+             * thrown on {@link #processJob}. A missing output param will be
+             * marked after execution.
              **/
             bool \optional;
 
@@ -130,18 +130,19 @@ module omero {
              * param = ...;
              * inputs = ...;
              * if name in inputs:
-             *     value = inputs[name]
-             * elif param.inputs[name].useDefault:
-             *     value = param.inputs[name].prototype
+             *     value = inputs\[name]
+             * elif param.inputs\[name].useDefault:
+             *     value = param.inputs\[name].prototype
              * </pre>
              **/
             bool useDefault;
 
             /**
-             * [omero::RType] which represents what the input or output value
-             * should look like. If this is a collection type (i.e. [omero::RCollection]
-             * or [omero::RMap] or their subclasses), then the first contents of
-             * the collection will be used (recursively).
+             * {@link omero.RType} which represents what the input or output
+             * value should look like. If this is a collection type (i.e.
+             * {@link omero.RCollection} or {@link omero.RMap} or their
+             * subclasses), then the first contents of the collection will be
+             * used (recursively).
              *
              * <pre>
              * param.prototype = rlist(rlist(rstring)))
@@ -188,19 +189,20 @@ module omero {
 
             /**
              * An enumeration of acceptable values which can be used
-             * for this parameter. If [min] and [max] are set, this value
-             * will be ignored. If [prototype] is an [omero::RCollection]
-             * or [omero::RMap] instance, then the values in this [omero::RList]
-             * will be of the member types of the collection or map, and not
-             * a collection or map instance.
+             * for this parameter. If {@link #min} and {@link #max} are set,
+             * this value will be ignored. If {@link prototype} is an
+             * {@link omero.RCollection} or {@link omero.RMap} instance, then
+             * the values in this {@link omero.RList} will be of the member
+             * types of the collection or map, and not a collection or map
+             * instance.
              **/
             omero::RList values;
 
             /**
-             * Defines the grouping strategy for this [Param].
+             * Defines the grouping strategy for this {@link Param}.
              *
              * <p>
-             * A set of [Param] objects in a single [JobParams] can
+             * A set of {@link Param} objects in a single {@link JobParams} can
              * use dot notation to specify that they belong together,
              * and in which order they should be presented to the user.
              * </p>
@@ -272,11 +274,13 @@ module omero {
              * </p>
              *
              * <p>
-             * [omero::constants::namespaces::NSDOWNLOAD], for example,
+             * {@link omero.constants.namespaces.NSDOWNLOAD}, for example,
              * indicates that users may want to download the resulting
-             * file. The [prototype] of the [Param] should be one of:
-             * [omero::model::OriginalFile], [omero::model::FileAnnotation],
-             * or an annotation link (like [omero::model::ImageAnnotationLink])
+             * file. The {@link #prototype} of the {@link Param} should be one
+             * of: {@link omero.model.OriginalFile},
+             * {@link omero.model.FileAnnotation},
+             * or an annotation link (like
+             * {@link omero.model.ImageAnnotationLink})
              * which points to a file annotation.
              * </p>
              **/
@@ -382,10 +386,11 @@ module omero {
             ParamMap outputs;
 
             /**
-             * [omero::model::Format].value of the stdout stream produced by
-             * the script. If this value is not otherwise set (i.e. is None),
-             * the default of "text/plain" will be set. This is typically a
-             * good idea if the script uses "print" or the logging module.
+             * {@link omero.model.Format#value} of the stdout stream produced
+             * by the script. If this value is not otherwise set (i.e. is
+             * None), the default of "text/plain" will be set. This is
+             * typically a good idea if the script uses "print" or the logging
+             * module.
              *
              * If you would like to disable stdout upload, set the value to ""
              * (the empty string).
@@ -395,7 +400,7 @@ module omero {
             string stdoutFormat;
 
             /**
-             * [omero::model::Format].value of the stderr stream produced by
+             * {@link omero.model.Format#value} of the stderr stream produced by
              * the script. If this value is not otherwise set (i.e. is None),
              * the default of "text/plain" will be set. This is typically a
              * good idea if the script uses "print" or the logging module.
@@ -408,7 +413,8 @@ module omero {
             string stderrFormat;
 
             /**
-             * Defines machine readable interpretations for this [JobParams].
+             * Defines machine readable interpretations for this
+             * {@link JobParams}.
              *
              * <p>
              * Where the description field should provide information for
@@ -502,10 +508,10 @@ module omero {
         };
 
         /**
-         * Extension of the [Process] interface which is returned by [IScript]
-         * when an [omero::model::ScriptJob] is launched. It is critical that
-         * instances of [ScriptProcess] are closed on completetion. See the close
-         * method for more information.
+         * Extension of the {@link Process} interface which is returned by
+         * {@link IScript} when an {@link omero.model.ScriptJob} is launched.
+         * It is critical that instances of (@link ScriptProcess} are closed
+         * on completetion. See the {@link #close} method for more information.
          **/
         interface ScriptProcess extends Process {
 
@@ -520,14 +526,14 @@ module omero {
             /**
              * Returns the results immediately if present. If the process
              * is not yet finished, waits "waitSecs" before throwing an
-             * [omero.ApiUsageException]. If poll has returned a non-null
+             * {@link omero.ApiUsageException}. If poll has returned a non-null
              * value, then this method will always return a non-null value.
              **/
             idempotent
             omero::RTypeDict getResults(int waitSecs) throws ServerError;
 
             /**
-             * Sets the message on the [omero::model::ScriptJob] object.
+             * Sets the message on the {@link omero.model.ScriptJob} object.
              * This value MAY be overwritten by the server if the script
              * fails.
              **/
@@ -538,7 +544,7 @@ module omero {
              * Closes this process and frees server resources attached to it.
              * If the detach argument is True, then the background process
              * will continue executing. The user can reconnect to the process
-             * via the [IScript] service.
+             * via the {@link IScript} service.
              *
              * If the detach argument is False, then the background process
              * will be shutdown immediately, and all intermediate results
@@ -559,7 +565,8 @@ module omero {
         interface Processor;
 
         /**
-         * Internal callback interface which is passed to the [Processor::accepts] method
+         * Internal callback interface which is passed to the
+         * {@link Processor#accepts} method
          * to query whether or not a processor will accept a certain operation.
          **/
         interface ProcessorCallback {
@@ -580,10 +587,10 @@ module omero {
         ["ami"] interface Processor {
 
             /**
-             * Called by [omero::grid::SharedResources] to find a suitable
-             * target for [omero::grid::SharedResources::acquireProcessor].
+             * Called by {@link omero.grid.SharedResources} to find a suitable
+             * target for {@link omero.grid.SharedResources#acquireProcessor}.
              * New processor instances are added to the checklist by using
-             * [omero::grid::SharedResources::addProcessor]. All processors
+             * {@link omero.grid.SharedResources#addProcessor}. All processors
              * must respond with their session uuid in order to authorize
              * the action.
              **/
@@ -595,7 +602,8 @@ module omero {
 
             /**
              * Used by servers to find out what jobs are still active.
-             * Response will be sent to [ProcessorCallback::responseRunning]
+             * Response will be sent to
+             * {@link ProcessorCallback#responseRunning}
              **/
             idempotent
             void requestRunning(ProcessorCallback* cb);
@@ -603,7 +611,7 @@ module omero {
             /**
              * Parses a job and returns metadata definition required
              * for properly submitting the job. This object will be
-             * cached by the server, and passed back into [processJob]
+             * cached by the server, and passed back into {@link #processJob}
              **/
             idempotent
             JobParams parseJob(string session, omero::model::Job jobObject) throws ServerError;
@@ -611,8 +619,8 @@ module omero {
             /**
              * Starts a process based on the given job
              * If this processor cannot handle the given job, a
-             * null process will be returned. The [params] argument
-             * was created by a previously call to [parseJob].
+             * null process will be returned. The {@param params} argument
+             * was created by a previously call to {@link #parseJob}.
              **/
             Process* processJob(string session, JobParams params, omero::model::Job jobObject) throws ServerError;
 
@@ -673,9 +681,10 @@ module omero {
 
             /**
              * Sets whether or not cancel will be called on the current
-             * [Process] on stop. If detach is true, then the [Process]
-             * will continue running. Otherwise, Process.cancel() willl
-             * be called, before prepairing for another run.
+             * {@link Process} on stop. If detach is true, then the
+             * {@link Process} will continue running. Otherwise,
+             * {@link Process#cancel} will be called, before preparing for
+             * another run.
              *
              * false by default
              *
@@ -684,10 +693,10 @@ module omero {
             bool setDetach(bool detach) throws ServerError;
 
             /**
-             * Clears the current execution of [omero::model::Job] from
+             * Clears the current execution of {@link omero.model.Job} from
              * the processor to prepare for another execution.
              *
-             * cancel() will be called on the current [Process]
+             * cancel() will be called on the current {@link Process}
              * if detach is set to false.
              **/
             idempotent

--- a/components/blitz/resources/omero/Scripts.ice
+++ b/components/blitz/resources/omero/Scripts.ice
@@ -95,7 +95,7 @@ module omero {
          *
          * <pre>
          * a = omero.scripts.String("a")
-         * a.param().values = ["hi", "bye"]
+         * a.param().values = \["hi", "bye"]
          * </pre>
          **/
         class Param {
@@ -254,10 +254,10 @@ module omero {
              *
              * <pre>
              *
-             *  Scale Bar: [ on/off ]
+             *  Scale Bar: \[ on/off ]
              *  ======================
-             *    Color:  [rgb]
-             *    Size:   [ 10]
+             *    Color:  \[rgb]
+             *    Size:   \[ 10]
              *
              * </pre>
              *
@@ -304,7 +304,7 @@ module omero {
          *
          * <pre>
          * params = omero.grid.JobParams()
-         * params.authors = ["Andy", "Kathy"]
+         * params.authors = \["Andy", "Kathy"]
          * params.version = "0.0.1"
          * params.description = """
          *     Clever way to count to 5
@@ -355,20 +355,20 @@ module omero {
             omero::api::StringArray institutions;
 
             /**
-             * For authors[i], authorInstitutions[i] should be
+             * For authors\[i], authorInstitutions\[i] should be
              * and array of indexes j such that author i is a member
-             * of authorsInstitutions[i][j].
+             * of authorsInstitutions\[i]\[j].
              *
              * Example:
-             *   authors = ["Jane", "Mike"]
-             *   institutions = ["Acme U.", "Private Corp."]
-             *   authorsInstitutions = [[1, 2], [1]]
+             *   authors = \["Jane", "Mike"]
+             *   institutions = \["Acme U.", "Private Corp."]
+             *   authorsInstitutions = \[\[1, 2], \[1]]
              *
              * which means that Jane is a member of both "Acme U."
              * and "Private Corp." while Mike is only a member of
              * "Acme U."
              *
-             * An empty authorsInsitutations array implies that all
+             * An empty authorsInstitutions array implies that all
              * authors are from all institutions.
              **/
             omero::api::IntegerArrayArray authorsInstitutions;

--- a/components/blitz/resources/omero/ServerErrors.ice
+++ b/components/blitz/resources/omero/ServerErrors.ice
@@ -25,11 +25,11 @@
  *
  * <p>
  * All exceptions that are thrown by a remote call (any call on a *Prx instance)
- * will be either a subclass of [Ice::UserException] or [Ice::LocalException].
+ * will be either a subclass of {@link Ice.UserException} or {@link Ice.LocalException}.
  * <a href="http://doc.zeroc.com/display/Ice/Run-Time+Exceptions#Run-TimeExceptions-InheritanceHierarchyforExceptions">Inheritance Hierarchy for Exceptions</a>
  * from the Ice manual shows the entire exception hierarchy. The exceptions described in
- * this file will subclass from [Ice::UserException]. Other Ice-runtime exceptions subclass
- * from [Ice::LocalException].
+ * this file will subclass from {@link Ice.UserException}. Other Ice-runtime exceptions subclass
+ * from {@link Ice.LocalException}.
  * </p>
  *
  * <pre>
@@ -71,8 +71,8 @@
  *
  *
  * <p>
- * However, in addition to [Ice::LocalException] subclasses, the Ice runtime also
- * defines subclasses of [Ice::UserException]. In some cases, OMERO subclasses
+ * However, in addition to {@link Ice.LocalException} subclasses, the Ice runtime also
+ * defines subclasses of {@link Ice.UserException}. In some cases, OMERO subclasses
  * from these exceptions. The subclasses shown below are not exhaustive, but show those
  * which an application's exception handler may want to deal with.
  * </p>

--- a/components/blitz/resources/omero/SharedResources.ice
+++ b/components/blitz/resources/omero/SharedResources.ice
@@ -36,7 +36,7 @@ module omero {
                 throws ServerError;
 
             /**
-             * Registers a [omero::grid::Processor] for Storm notifications
+             * Registers a {@link omero.grid.Processor} for Storm notifications
              * so that other sessions can query whether or not a given
              * processor would accept a given task.
              **/
@@ -45,9 +45,9 @@ module omero {
                 throws ServerError;
 
             /**
-             * Unregisters a [omero::grid::Processor] from Storm notifications.
-             * If the processor was not already registered via [addProcessor]
-             * this is a no-op.
+             * Unregisters a {@link omero.grid.Processor} from Storm
+             * notifications. If the processor was not already registered via
+             * {@link #addProcessor} this is a no-op.
              **/
             void
                 removeProcessor(omero::grid::Processor* proc)
@@ -72,9 +72,9 @@ module omero {
                 throws ServerError;
 
             /**
-             * Returns true if a [Tables] service is active in the grid.
-             * If this value is false, then all calls to [newTable]
-             * or [openTable] will either fail or return null (possibly
+             * Returns true if a {@link Tables} service is active in the grid.
+             * If this value is false, then all calls to {@link #newTable}
+             * or {@link #openTable} will either fail or return null (possibly
              * blocking while waiting for a service to startup)
              **/
             idempotent

--- a/components/blitz/resources/omero/Tables.ice
+++ b/components/blitz/resources/omero/Tables.ice
@@ -44,7 +44,7 @@ module omero {
         /**
          * Base type for dealing working with tabular data. For efficiency,
          * data is grouped by type, i.e. column. These value objects are passed
-         * through the [Table] interface.
+         * through the {@link Table} interface.
          **/
         class Column {
 
@@ -174,8 +174,8 @@ module omero {
             /**
              * Read the given rows of data.
              *
-             * [rowNumbers] must contain at least one element or an
-             * [omero::ApiUsageException] will be thrown.
+             * {@param rowNumbers} must contain at least one element or an
+             * {@link omero.ApiUsageException} will be thrown.
              **/
             idempotent
             Data
@@ -222,8 +222,8 @@ module omero {
             /**
              * Allows the user to modify a Data instance passed back
              * from a query method and have the values modified. It
-             * is critical that the [Data::lastModification] and the
-             * [Data::rowNumbers] fields are properly set. An exception
+             * is critical that the {@link Data#lastModification} and the
+             * {@link Data#rowNumbers} fields are properly set. An exception
              * will be thrown if the data has since been modified.
              **/
             void update(Data modifiedData)
@@ -308,7 +308,7 @@ module omero {
              * This service will open the file locally to access the data.
              * After any modification, the file will be saved locally and
              * the server asked to update the database record. This is done
-             * via services in the [omero::api::ServiceFactory].
+             * via services in the {@link omero.api.ServiceFactory}.
              */
             idempotent
             Table*

--- a/components/blitz/resources/omero/Tables.ice
+++ b/components/blitz/resources/omero/Tables.ice
@@ -202,8 +202,8 @@ module omero {
              * data = table.slice(None, None)
              * assert len(data.rowNumbers) == table.getNumberOfRows()
              *
-             * data = table.slice(None, [3,2,1])
-             * assert data.rowNumbers == [3,2,1]
+             * data = table.slice(None, \[3,2,1])
+             * assert data.rowNumbers == \[3,2,1]
              * </pre>
              **/
             idempotent

--- a/components/blitz/resources/omero/api/Exporter.ice
+++ b/components/blitz/resources/omero/api/Exporter.ice
@@ -44,7 +44,7 @@ module omero {
          *   // Exporter instances.
          *
          *   long read = 0
-         *   byte[] buf;
+         *   byte\[] buf;
          *   while (true) {
          *      buf = e.read(read, 1000000);
          *      // Store to file locally here

--- a/components/blitz/resources/omero/api/IQuery.ice
+++ b/components/blitz/resources/omero/api/IQuery.ice
@@ -36,7 +36,7 @@ module omero {
                 idempotent IObjectList           findAllByFullText(string klass, string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
-                 * Return a sequence of [omero::RType] sequences.
+                 * Return a sequence of {@link omero.RType} sequences.
                  *
                  * <p>
                  * Each element of the outer sequence is one row in the return value.
@@ -44,20 +44,22 @@ module omero {
                  * </p>
                  *
                  * <p>
-                 * [omero::model::IObject] instances are returned wrapped in an [omero::rtype::RObject]
-                 * instance. Primitives are mapped to the expected [omero::RType] subclass. Types without
-                 * an [omero::RType] mapper if returned will throw an exception if present in the select
-                 * except where a manual conversion is present on the server. This includes:
+                 * {@link omero.model.IObject} instances are returned wrapped
+                 * in an {@link omero.rtype.RObject} instance. Primitives are
+                 * mapped to the expected {@link omero.RType} subclass. Types
+                 * without an {@link omero.RType} mapper if returned will
+                 * throw an exception if present in the select except where a
+                 * manual conversion is present on the server. This includes:
                  * </p>
                  *
                  * <ul>
                  * <li>
-                 *     [omero::model::Permissions] instances are serialized to an [omero::RMap]
+                 *     {@link omero.model.Permissions} instances are serialized to an {@link omero.RMap}
                  *     containing the keys: perms, canAnnotate, canEdit, canLink, canDelete
                  * </li>
                  * <li>
-                 *     The quantity types like [omero::model::Length] are serialized
-                 *     to an [omero::RMap] containing the keys: value, unit, symbol
+                 *     The quantity types like {@link omero.model.Length} are serialized
+                 *     to an {@link omero.RMap} containing the keys: value, unit, symbol
                  * </li>
                  * </ul>
                  *

--- a/components/blitz/resources/omero/api/IRoi.ice
+++ b/components/blitz/resources/omero/api/IRoi.ice
@@ -189,19 +189,23 @@ module omero {
                 //
 
                 /**
-                 * Returns a list of [omero::model::FileAnnotation] instances with the namespace
-                 * "openmicroscopy.org/measurements" which are attached to the [omero::model::Plate]
-                 * containing the given image AND which are attached to at least one [omero::model::Roi]
+                 * Returns a list of {@link omero.model.FileAnnotation}
+                 * instances with the namespace
+                 * "openmicroscopy.org/measurements" which are attached to the
+                 * {@link omero.model.Plate} containing the given image AND
+                 * which are attached to at least one
+                 * {@link omero.model.Roi}
                  *
-                 * @param opts, userId and groupId are respected based on the ownership of the annotation.
+                 * @param opts, userId and groupId are respected based on the
+                 *        ownership of the annotation.
                  **/
                 ["deprecated:IROI is deprecated."]
                 idempotent
                 AnnotationList getRoiMeasurements(long imageId, RoiOptions opts) throws omero::ServerError;
 
                 /**
-                 * Loads the ROIs which are linked to by the given [omero::model::FileAnnotation] id for
-                 * the given image.
+                 * Loads the ROIs which are linked to by the given
+                 * {@link omero.model.FileAnnotation} id for the given image.
                  *
                  * @param annotationId if -1, logic is identical to findByImage(imageId, opts)
                  **/
@@ -210,7 +214,8 @@ module omero {
                 RoiResult getMeasuredRois(long imageId, long annotationId, RoiOptions opts) throws omero::ServerError;
 
                 /**
-                 * Returns a map from [omero::model::FileAnnotation] ids to [RoiResult] instances.
+                 * Returns a map from {@link omero.model.FileAnnotation} ids
+                 * to {@link RoiResult} instances.
                  * Logic is identical to getMeasuredRois, but Roi data will not be duplicated. (i.e.
                  * the objects are referentially identical)
                  **/
@@ -219,8 +224,9 @@ module omero {
                 LongRoiResultMap getMeasuredRoisMap(long imageId, LongList annotationIds, RoiOptions opts) throws omero::ServerError;
 
                 /**
-                 * Returns the OMERO.tables service via the [omero::model::FileAnnotation] id returned
-                 * by getImageMeasurements.
+                 * Returns the OMERO.tables service via the
+                 * {@link omero.model.FileAnnotation} id returned
+                 * by {@link #getImageMeasurements}.
                  **/
                 ["deprecated:IROI is deprecated."]
                 idempotent

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -65,7 +65,7 @@ module omero {
                  * necessary for proper functioning can be retrieved via
                  * {@link #getParams}.
                  *
-                 * The {@link omero.model.OriginalFil#path} value can be used
+                 * The {@link omero.model.OriginalFile#path} value can be used
                  * in other official scripts via the
                  * language specific import command, since the script
                  * directory will be placed on the appropriate

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -58,18 +58,23 @@ module omero {
                 //
 
                 /**
-                 * This method returns official server scripts as a list of [omero::model::OriginalFile] objects.
-                 * These scripts will be executed by the server if submitted via [runScript]. The input parameters
-                 * necessary for proper functioning can be retrieved via [getParams].
+                 * This method returns official server scripts as a list of
+                 * {@link omero.model.OriginalFile} objects.
+                 * These scripts will be executed by the server if submitted
+                 * via {@link #runScript}. The input parameters
+                 * necessary for proper functioning can be retrieved via
+                 * {@link #getParams}.
                  *
-                 * The [omero::model::OriginalFil::path] value can be used in other official scripts via the
-                 * language specific import command, since the script directory will be placed on the appropriate
+                 * The {@link omero.model.OriginalFil#path} value can be used
+                 * in other official scripts via the
+                 * language specific import command, since the script
+                 * directory will be placed on the appropriate
                  * environment path variable.
                  * <pre>
                  * scripts = scriptService.getScripts()
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
-                 *     path = script.path.val[1:] # First symbol is a "/"
+                 *     path = script.path.val\[1:\] # First symbol is a "/"
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
                  * </pre>
@@ -125,8 +130,9 @@ module omero {
                 long uploadScript(string path, string scriptText) throws ServerError;
 
                 /**
-                 * Like [uploadScript] but is only callable by administrators. The parameters
-                 * for the script are also checked.
+                 * Like {@link #uploadScript} but is only callable by
+                 * administrators. The parameters for the script are also
+                 * checked.
                  **/
                 long uploadOfficialScript(string path, string scriptText) throws ServerError;
 
@@ -177,9 +183,10 @@ module omero {
                 //
 
                 /**
-                 * If [ResourceError] is thrown, then no [Processor] is available. Use [scheduleJob]
-                 * to create a [omero::model::ScriptJob] in the "Waiting" state. A [Processor] may
-                 * become available.
+                 * If {@link ResourceError} is thrown, then no
+                 * {@link Processor} is available. Use {@link #scheduleJob}
+                 * to create a {@link omero.model.ScriptJob} in the "Waiting"
+                 * state. A {@link Processor} may become available.
                  *
                  * <pre>
                  * try:
@@ -188,9 +195,9 @@ module omero {
                  *     job = scriptService.scheduleScript(1, {}, None)
                  * </pre>
                  *
-                 * The [ScriptProcess] proxy MUST be closed before exiting.
-                 * If you would like the script execution to continue in the
-                 * background, pass "True" as the argument.
+                 * The {@link ScriptProcess} proxy MUST be closed before
+                 * exiting. If you would like the script execution to continue
+                 * in the background, pass "True" as the argument.
                  *
                  * <pre>
                  * try:
@@ -203,12 +210,14 @@ module omero {
                 omero::grid::ScriptProcess* runScript(long scriptID, omero::RTypeDict inputs, omero::RInt waitSecs) throws ServerError;
 
                 /**
-                 * Returns true if there is a processor which will run the given script.
+                 * Returns true if there is a processor which will run the
+                 * given script.
                  *
                  * <p>
-                 * Either the script is an official script and this method will return true
-                 * (though an individual invocation may fail with an [omero::ResourceError]
-                 * for some reason) <em>or</em> this is a user script, and a usermode processor
+                 * Either the script is an official script and this method
+                 * will return true (though an individual invocation may fail
+                 * with an {@link omero.ResourceError} for some reason)
+                 * <em>or</em> this is a user script, and a usermode processor
                  * must be active which takes the scripts user or group.
                  * </p>
                  *
@@ -217,8 +226,10 @@ module omero {
                 bool canRunScript(long scriptID) throws ServerError;
 
                 /**
-                 * Used internally by processor.py to check if the script attached to the [omero::model::Job]
-                 * has a valid script attached, based on the [acceptsList] and the current security context.
+                 * Used internally by processor.py to check if the script
+                 * attached to the {@link omero.model.Job} has a valid script
+                 * attached, based on the {@link #acceptsList} and the current
+                 * security context.
                  *
                  * An example of an acceptsList might be <pre>Experimenter(myUserId, False)</pre>, meaning that
                  * only scripts belonging to me should be trusted. An empty list implies that the server should

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -27,7 +27,7 @@ module omero {
          * scripts = svc.getScripts()
          *
          * if len(scripts) >= 1:
-         *   script_id = svc.keys()[0]
+         *   script_id = svc.keys()\[-1]
          * else:
          *   script_id = svc.uploadScript('/test/my_script.py', SCRIPT_TEXT)
          *

--- a/components/blitz/resources/omero/api/ITimeline.ice
+++ b/components/blitz/resources/omero/api/ITimeline.ice
@@ -34,7 +34,7 @@ module omero {
          * The map return values will be indexed by the short type name above:
          * "Project", "Image", ... All keys which are passed in the StringSet
          * argument will be included in the returned map, even if they have no
-         * values. A default value of 0 or the empty list [] will be used.
+         * values. A default value of 0 or the empty list \[] will be used.
          * The only exception to this rule is that the null or empty StringSet
          * implies all valid keys.
          *
@@ -52,8 +52,8 @@ module omero {
          * -------
          * The methods which take a StringSet and a Parameters object, also have
          * a "bool merge" argument. This argument defines whether or not the LIMIT
-         * applies to each object independently (["a","b"] @ 100 == 200) or merges
-         * the lists together chronologically (["a","b"] @ 100 merged == 100).
+         * applies to each object independently (\["a","b"] @ 100 == 200) or merges
+         * the lists together chronologically (\["a","b"] @ 100 merged == 100).
          *
          * Time used:
          * =========
@@ -68,7 +68,7 @@ module omero {
          *
          *     timeline = sf.getTimelineService()
          *     params = ParametersI().page(0,100)
-         *     types = ["Project","Dataset"])
+         *     types = \["Project","Dataset"])
          *     map = timeline.getByPeriod(types, params, False)
          *
          * At this point, map will not contain more than 200 objects.

--- a/components/blitz/resources/omero/api/MetadataStore.ice
+++ b/components/blitz/resources/omero/api/MetadataStore.ice
@@ -29,7 +29,8 @@ module omero {
     module metadatastore {
 
         /**
-         * Container-class used by the import mechanism. Passed to [omero::api::MetadataStore]
+         * Container-class used by the import mechanism. Passed to
+         * {@link omero.api.MetadataStore}
          **/
         class IObjectContainer {
             string LSID;

--- a/components/blitz/resources/omero/api/PyramidService.ice
+++ b/components/blitz/resources/omero/api/PyramidService.ice
@@ -49,9 +49,9 @@ module omero {
                 idempotent int getResolutionLevels() throws ServerError;
 
                 /**
-                 * Retrives a more complete definition of the resolution
+                 * Retrieves a more complete definition of the resolution
                  * level in question. The size of this array will be of
-                 * length [getResolutionLevels].
+                 * length {@link #getResolutionLevels}.
                  **/
                 idempotent ResolutionDescriptions getResolutionDescriptions() throws ServerError;
 

--- a/components/blitz/resources/omero/api/RawFileStore.ice
+++ b/components/blitz/resources/omero/api/RawFileStore.ice
@@ -29,9 +29,9 @@ module omero {
 
                 /**
                  * This method manages the state of the service. This method
-                 * will throw a [omero::SecurityViolation] if for the current user
-                 * context either the file is not readable or a
-                 * [omero::constants::permissions:DOWNLOAD] restriction is in
+                 * will throw a {@link omero.SecurityViolation} if for the
+                 * current user context either the file is not readable or a
+                 * {@link omero.constants.permissions#DOWNLOAD} restriction is in
                  * place.
                  */
                 void setFileId(long fileId) throws ServerError;

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -48,7 +48,7 @@ module omero {
                  * a brand new pixel buffer using <code>true</code> here is a safe
                  * optimization otherwise <code>false</code> is expected.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 void setPixelsId(long pixelsId, bool bypassOriginalFile) throws ServerError;
 
@@ -252,7 +252,7 @@ module omero {
                  * @throws BufferOverflowException if an attempt is made to write off the
                  * end of the file.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  */
                 idempotent void setTile(Ice::ByteSeq buf, int z, int c, int t, int x, int y, int w, int h) throws ServerError;
 
@@ -262,7 +262,7 @@ module omero {
                  * @param offset offset within the pixel buffer.
                  * @param buf a byte array of the data.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 idempotent void setRegion(int size, long offset, Ice::ByteSeq buf) throws ServerError;
 
@@ -274,7 +274,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 idempotent void setRow(Ice::ByteSeq buf, int y, int z, int c, int t) throws ServerError;
 
@@ -285,7 +285,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 idempotent void setPlane(Ice::ByteSeq buf, int z, int c, int t) throws ServerError;
 
@@ -296,7 +296,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 idempotent void setStack(Ice::ByteSeq buf, int z, int c, int t) throws ServerError;
 
@@ -306,7 +306,7 @@ module omero {
                  * @param buf a byte array of the data comprising this timepoint.
                  * @param t offset across the T-axis of the pixel buffer.
                  *
-                 * See "read-only caveat" under [RawPixelsStore]
+                 * See "read-only caveat" under {@link RawPixelsStore}
                  **/
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
@@ -339,7 +339,7 @@ module omero {
                  * only be called AFTER all data is successfully set. Future invocations
                  * of set methods may be disallowed. This read-only status will allow
                  * background processing (generation of thumbnails, compression, etc)
-                 * to begin. More information under [RawPixelsStore].
+                 * to begin. More information under {@link RawPixelsStore}.
                  *
                  * A null instance will be returned if no save was performed.
                  *

--- a/components/blitz/resources/omero/cmd/API.ice
+++ b/components/blitz/resources/omero/cmd/API.ice
@@ -93,7 +93,7 @@ module omero {
 
             /**
              * Called when the command has completed in any fashion
-             * including cancellation. The [Status::flags] list will
+             * including cancellation. The {@link Status#flags} list will
              * contain information about whether or not the process
              * was cancelled.
              */
@@ -129,14 +129,14 @@ module omero {
              * Returns a status object for the current execution.
              *
              * This will likely be the same object that would be
-             * returned as a component of the [Response] value.
+             * returned as a component of the {@link Response} value.
              *
              * Never null.
              **/
             Status getStatus();
 
             /**
-             * Attempts to cancel execution of this [Request]. Returns
+             * Attempts to cancel execution of this {@link Request}. Returns
              * true if cancellation was successful. Returns false if not,
              * in which case likely this request will run to completion.
              **/

--- a/components/blitz/resources/omero/cmd/Admin.ice
+++ b/components/blitz/resources/omero/cmd/Admin.ice
@@ -34,9 +34,9 @@ module omero {
          };
 
          /**
-          * Successful response for [ResetPasswordRequest].
+          * Successful response for {@link ResetPasswordRequest}.
           * If no valid user with matching email is found,
-          * an [ERR] will be returned.
+          * an {@link ERR} will be returned.
           **/
          class ResetPasswordResponse extends Response {
          };
@@ -49,7 +49,7 @@ module omero {
          * interpreted as the the millisecond value which should
          * be set. Non-administrators will not be able to reduce
          * current values. No special response is returned, but
-         * an [omero::cmd::OK] counts as success.
+         * an {@link omero.cmd.OK} counts as success.
          **/
         class UpdateSessionTimeoutRequest extends Request {
             string session;
@@ -59,33 +59,34 @@ module omero {
 
         /**
          * Argument-less request that will produce a
-         * [CurrentSessionsResponse] if no [omero::cmd::ERR] occurs.
+         * {@link CurrentSessionsResponse} if no {@link omero.cmd.ERR} occurs.
          **/
         class CurrentSessionsRequest extends Request {
         };
 
         /**
-         * Return value from [omero::cmd::CurrentSessionsRequest] consisting of
-         * two ordered lists of matching length. The sessions field
-         * contains a list of the OMERO [omero::model::Session] objects
-         * that are currently active *after* all timeouts have been applied.
+         * Return value from {@link omero.cmd.CurrentSessionsRequest}
+         * consisting of two ordered lists of matching length. The sessions
+         * field contains a list of the OMERO {@link omero.model.Session}
+         * objects that are currently active *after* all timeouts have been
+         * applied.
          * This is the value that would be returned by
-         * [omero::api::ISession::getSession] when joined to that session.
+         * {@link omero.api.ISession#getSession} when joined to that session.
          * Similarly, the contexts field contains the value that would be
-         * returned by a call to [omero::api::IAdmin::getEventContext].
+         * returned by a call to {@link omero.api.IAdmin#getEventContext}.
          * For non-administrators, most values for all sessions other than
          * those belonging to that user will be nulled.
          **/
         class CurrentSessionsResponse extends Response {
 
             /**
-             * [omero::model::Session] objects loaded from
+             * {@link omero.model.Session} objects loaded from
              * the database.
              **/
             omero::api::SessionList sessions;
 
             /**
-             * [omero::sys::EventContext] objects stored in
+             * {@link omero.sys.EventContext} objects stored in
              * memory by the server.
              **/
             omero::api::EventContextList contexts;

--- a/components/blitz/resources/omero/cmd/Basic.ice
+++ b/components/blitz/resources/omero/cmd/Basic.ice
@@ -22,7 +22,7 @@ module omero {
             /**
              * List of call context objects which should get applied to each Request.
              * The list need only be as large as necessary to apply to a given request.
-             * Null and empty [StringMap] instances will be ignored.
+             * Null and empty {@link StringMap} instances will be ignored.
              **/
             StringMapList contexts;
         };

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -30,8 +30,8 @@ module omero {
          * Requests the file metadata to be loaded for a given
          * image. This should handle both the pre-FS metadata
          * in file annotations as well as loading the metadata
-         * directly from the FS files. A [OriginalMetadataResponse]
-         * will be returned under normal conditions, otherwise a [ERR]
+         * directly from the FS files. A {@link OriginalMetadataResponse}
+         * will be returned under normal conditions, otherwise a {@link ERR}
          * will be returned.
          **/
         class OriginalMetadataRequest extends Request {
@@ -39,36 +39,39 @@ module omero {
         };
 
         /**
-         * Successful response for [OriginalMetadataRequest]. Contains
+         * Successful response for {@link OriginalMetadataRequest}. Contains
          * both the global and the series metadata as maps. Only one
-         * of [filesetId] or [filesetAnnotationId] will be set. Pre-FS
-         * images will have [filesetAnnotationId] set; otherwise
-         * [filesetId] will be set.
+         * of {@link #filesetId} or {@link #filesetAnnotationId} will be set.
+         * Pre-FS images will have {@link #filesetAnnotationId} set; otherwise
+         * {@link #filesetId} will be set.
          **/
         class OriginalMetadataResponse extends Response {
 
             /**
-             * Set to the id of the [omero::model::Fileset] that this
-             * [omero::model::Image] contained in if one exists.
+             * Set to the id of the {@link omero.model.Fileset} that this
+             * {@link omero.model.Image} contained in if one exists.
              **/
             omero::RLong filesetId;
 
             /**
-             * Set to the id of the [omero::model::FilesetAnnotation] linked to
-             * this [omero::model::Image] if one exists.
+             * Set to the id of the {@link omero.model.FilesetAnnotation}
+             * linked to this {@link omero.model.Image} if one exists.
              **/
             omero::RLong fileAnnotationId;
 
             /**
-             * Metadata which applies to the entire [omero::model::Fileset]
+             * Metadata which applies to the entire
+             * {@link omero.model.Fileset}
              **/
             omero::RTypeDict globalMetadata;
 
             /**
-             * Metadata specific to the series id of this [omero::model::Image].
-             * In the [omero::model::Fileset] that this [omero::model::Image] is
-             * contained in, there may be a large number of other images, but the
-             * series metadata applies only to this specific one.
+             * Metadata specific to the series id of this
+             * {@link omero.model.Image}.
+             * In the {@link omero.model.Fileset} that this
+             * {@link omero.model.Image] is contained in, there may be a large
+             * number of other images, but the series metadata applies only to
+             * this specific one.
              **/
             omero::RTypeDict seriesMetadata;
         };
@@ -140,14 +143,15 @@ module omero {
 
         /**
          * Queries and modifies the various binary artifacts
-         * which may be linked to an [omero::model::Image].
+         * which may be linked to an {@link omero.model.Image}.
          *
          * This can be useful, e.g., after converting pre-OMERO-5
-         * archived original files into [omero::model::Fileset].
+         * archived original files into {@link omero.model.Fileset}.
          *
          * The command works in several stages:
          *
-         *   1. loads an [omero::model::Image] by id, failing if none present.
+         *   1. loads an {@link omero.model.Image} by id, failing if none
+         *      present.
          *   2. renames Pixels file to '*_bak'
          *   3. deletes existing Pyramidfiles if present;
          *
@@ -163,7 +167,7 @@ module omero {
         };
 
         /**
-         * [Response] from a [ManageImageBinaries] [Request].
+         * {@link Response} from a {@link ManageImageBinaries} {@link Request}.
          * If no action is requested, then the fields of this
          * instance can be examined to see what would be done
          * if requested.

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -88,9 +88,9 @@ module omero {
         };
 
         /**
-         * Delete requests will return a [omero::cmd::DeleteRsp]
+         * Delete requests will return a {@link omero.cmd.DeleteRsp}
          * unless an error has occurred in which case a standard
-         * [omero::cmd::ERR] may be returned.
+         * {@link omero.cmd.ERR} may be returned.
          **/
         ["deprecated:use omero::cmd::Delete2 instead"]
         class Delete extends GraphModify {
@@ -122,12 +122,12 @@ module omero {
             omero::api::IdListMap undeletedFiles;
 
             /**
-             * Number of steps that this [DeleteCommand] requires.
+             * Number of steps that this {@link DeleteCommand} requires.
              **/
             int steps;
 
             /**
-             * Number of objects that this [DeleteCommand] will attempt
+             * Number of objects that this {@link DeleteCommand} will attempt
              * to delete.
              **/
             long scheduledDeletes;

--- a/components/blitz/resources/omero/cmd/Mail.ice
+++ b/components/blitz/resources/omero/cmd/Mail.ice
@@ -34,10 +34,10 @@ module omero {
          *  - omero.cmd.SendEmailRequest(subject, body, everyone=True, inactive=True)
          *      sends message to everyone who has email set,
          *      even inactive users
-         *  - omero.cmd.SendEmailRequest(subject, body, groupIds=[...],
-         *      userIds=[...] )
+         *  - omero.cmd.SendEmailRequest(subject, body, groupIds=\[...],
+         *      userIds=\[...] )
          *      sends email to active members of given groups and selected users
-         *  - extra=[...] allows to set extra email address if not in DB
+         *  - extra=\[...] allows to set extra email address if not in DB
          **/
          class SendEmailRequest extends Request {
              string subject;

--- a/components/blitz/resources/omero/cmd/Mail.ice
+++ b/components/blitz/resources/omero/cmd/Mail.ice
@@ -51,9 +51,10 @@ module omero {
          };
 
          /**
-         * Successful response for [SendEmailRequest]. Contains
+         * Successful response for {@link SendEmailRequest}. Contains
          * a list of invalid users that has no email address set.
-         * If no recipients or invalid users found, an [ERR] will be returned.
+         * If no recipients or invalid users found, an {@link ERR} will be
+         * returned.
          *
          * - invalidusers is a list of userIds that email didn't pass criteria
          *                  such as was empty or less then 5 characters

--- a/components/blitz/resources/omero/model/Details.ice
+++ b/components/blitz/resources/omero/model/Details.ice
@@ -70,7 +70,7 @@ module omero {
 
       /**
        * Context which would have been returned by a
-       * simultaneous call to [omero::api::IAdmin::getEventContext]
+       * simultaneous call to {@link omero.api.IAdmin#getEventContext}
        * while this object was being loaded.
        **/
       omero::sys::EventContext event;

--- a/components/blitz/resources/omero/model/ElectricPotential.ice
+++ b/components/blitz/resources/omero/model/ElectricPotential.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of ElectricPotential which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. detectorSettings.volatage
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsElectricPotential]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsElectricPotential} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsElectricPotential] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsElectricPotential} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsElectricPotential getUnit();

--- a/components/blitz/resources/omero/model/Frequency.ice
+++ b/components/blitz/resources/omero/model/Frequency.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Frequency which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. detectorSettings.readOutRate
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsFrequency]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsFrequency} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsFrequency] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsFrequency} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsFrequency getUnit();

--- a/components/blitz/resources/omero/model/Length.ice
+++ b/components/blitz/resources/omero/model/Length.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Length which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. pixels.physicalSizeX
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsLength]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsLength} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsLength] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsLength} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsLength getUnit();

--- a/components/blitz/resources/omero/model/Permissions.ice
+++ b/components/blitz/resources/omero/model/Permissions.ice
@@ -28,7 +28,7 @@ module omero {
       /**
        * Restrictions placed on the current object for the current
        * user. Indexes into this array are based on constants
-       * in the [omero::constants::permissions] module. If a
+       * in the {@link omero.constants.permissions} module. If a
        * restriction index is not present, then it is safe to
        * assume that there is no such restriction.
        *
@@ -41,9 +41,9 @@ module omero {
        * at runtime. Individual service methods will specify
        * which strings MAY NOT be present in this field for
        * execution to be successful. For example, if an
-       * [omero::model::Image] contains a "DOWNLOAD" restriction,
-       * then an attempt to call [omero::api::RawFileStore::read]
-       * will fail with an [omero::SecurityViolation].
+       * {@link omero.model.Image} contains a "DOWNLOAD" restriction,
+       * then an attempt to call {@link omero.api.RawFileStore#read}
+       * will fail with an {@link omero.SecurityViolation}.
        **/
       omero::api::StringSet extendedRestrictions;
 
@@ -63,7 +63,7 @@ module omero {
 
       /**
        * Do not use!
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setPerm1(long value);
 
@@ -145,47 +145,47 @@ module omero {
       // throw a ClientError
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setUserRead(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setUserAnnotate(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setUserWrite(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setGroupRead(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setGroupAnnotate(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setGroupWrite(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setWorldRead(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setWorldAnnotate(bool value);
 
       /**
-       * Throws [omero::ClientError] if mutation not allowed.
+       * Throws {@link omero.ClientError} if mutation not allowed.
        **/
       void setWorldWrite(bool value);
 

--- a/components/blitz/resources/omero/model/Power.ice
+++ b/components/blitz/resources/omero/model/Power.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Power which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. lightSource.power
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsPower]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsPower} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsPower] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsPower} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsPower getUnit();

--- a/components/blitz/resources/omero/model/Pressure.ice
+++ b/components/blitz/resources/omero/model/Pressure.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Pressure which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. imagingEnvironment.pressure
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsPressure]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsPressure} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsPressure] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsPressure} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsPressure getUnit();

--- a/components/blitz/resources/omero/model/RTypes.ice
+++ b/components/blitz/resources/omero/model/RTypes.ice
@@ -18,7 +18,7 @@
 module omero {
 
   /**
-   * Wrapper for an [omero::model::IObject] instance.
+   * Wrapper for an {@link omero.model.IObject} instance.
    **/
   ["protected"] class RObject extends RType
   {

--- a/components/blitz/resources/omero/model/Temperature.ice
+++ b/components/blitz/resources/omero/model/Temperature.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Temperature which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. imagingEnvironment.temperature
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsTemperature]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsTemperature} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsTemperature] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsTemperature} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsTemperature getUnit();

--- a/components/blitz/resources/omero/model/Time.ice
+++ b/components/blitz/resources/omero/model/Time.ice
@@ -29,7 +29,7 @@ module omero {
 
       /**
        * Unit of Time which is used through the model. This is not
-       * an [omero::model::IObject] implementation and as such does
+       * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. planeInfo.exposureTime
@@ -47,15 +47,16 @@ module omero {
 
       /**
        * Actual value for this unit-based field. The interpretation of
-       * the value is only possible along with the [omero::model::enums::UnitsTime]
-       * enum.
+       * the value is only possible along with the
+       * {@link omero.model.enums.UnitsTime} enum.
        **/
       double getValue();
 
       void setValue(double value);
 
       /**
-       * [omero::model::enums::UnitsTime] instance which is an [omero::model::IObject]
+       * {@link omero.model.enums.UnitsTime} instance which is an
+       * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
        **/
       omero::model::enums::UnitsTime getUnit();


### PR DESCRIPTION
As of Ice 3.5 and above, the usage of [square brackets](https://doc.zeroc.com/display/Ice34/Generating+Slice+Documentation#GeneratingSliceDocumentation-Hyperlinks) to create hyperlinks in the generated slice documentation is deprecated and replaced by [@link](https://doc.zeroc.com/display/Ice35/Generating+Slice+Documentation#GeneratingSliceDocumentation-Hyperlinks) markers.

This PR reviews all usages of square brackets in the Slice documentation and:
- changes them to `@link` markers when meant to be linking to the generated slice documentation
- escapes them with `\[` when used to give Python/Java array examples

With these changes the output of `./build.py release-slice2html` should produce no warnings and the generated documentation should be unchanged with both internal hyperlinks and squire brackets correctly rendered.