### PR TITLE
Blitz: docstring & indentation fixes

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -53,7 +53,7 @@ public class ImportCandidates extends DirectoryWalker
      * be raised for every file or directory, but the values will be valid for
      * each event.
      *
-     * If {@link #totalFiles} is less than 0, then the directory is currently be
+     * If {@link #totalFiles} is less than 0, then the directory is currently being
      * scanned and the count is unknown. Once {@link #totalFiles} is positive,
      * it will remain constant.
      *
@@ -122,7 +122,7 @@ public class ImportCandidates extends DirectoryWalker
     final private long start = System.currentTimeMillis();
 
     /**
-     * Time take for {@link IFormatReader#setId()}
+     * Time taken for {@link IFormatReader#setId()}
      */
     long readerTime = 0;
 
@@ -337,7 +337,7 @@ public class ImportCandidates extends DirectoryWalker
     }
 
     /**
-     * @return all containers as a array list
+     * @return all containers as an array list
      */
     public List<ImportContainer> getContainers()
     {
@@ -467,7 +467,7 @@ public class ImportCandidates extends DirectoryWalker
 
     /**
      * Retrieves Image names for each image that Bio-Formats has detected.
-     * @return See A list of Image names, in the order of <i>series</i>.
+     * @return a list of Image names, in the order of <i>series</i>.
      */
     private List<String> getImageNames() {
         List<String> toReturn = new ArrayList<String>();
@@ -581,7 +581,7 @@ public class ImportCandidates extends DirectoryWalker
     }
 
     /**
-     * The {@link Groups} class servers as an algorithm for sorting the usedBy
+     * The {@link Groups} class serves as an algorithm for sorting the usedBy
      * map from the {@link ImportCandidates#walk(File, Collection)} method.
      * These objects should never leave the outer class.
      *

--- a/components/blitz/src/ome/formats/model/BlitzInstanceProvider.java
+++ b/components/blitz/src/ome/formats/model/BlitzInstanceProvider.java
@@ -1,5 +1,5 @@
 /*
- * ome.formats.enums.IQueryEnumProvider
+ * ome.formats.model.BlitzInstanceProvider
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.

--- a/components/blitz/src/ome/formats/model/BlitzInstanceProvider.java
+++ b/components/blitz/src/ome/formats/model/BlitzInstanceProvider.java
@@ -40,71 +40,61 @@ import omero.model.IObject;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class BlitzInstanceProvider implements InstanceProvider
-{
-    /** Model object handler factory. */
-    private ModelObjectHandlerFactory modelObjectHandlerFactory;
+public class BlitzInstanceProvider implements InstanceProvider {
 
-    /** Constructor cache. */
-    private Map<Class<? extends IObject>, Constructor<? extends IObject>>
-	constructorCache = new HashMap<Class<? extends IObject>,
-	                               Constructor<? extends IObject>>();
+  /** Model object handler factory. */
+  private ModelObjectHandlerFactory modelObjectHandlerFactory;
 
-    /**
-     * Default constructor.
-     * @param enumProvider Enumeration provider we are to use.
-     */
-    public BlitzInstanceProvider(EnumerationProvider enumProvider)
-    {
-	modelObjectHandlerFactory = new ModelObjectHandlerFactory(enumProvider);
+  /** Constructor cache. */
+  private Map<Class<? extends IObject>,
+              Constructor<? extends IObject>> constructorCache =
+      new HashMap<Class<? extends IObject>, Constructor<? extends IObject>>();
+
+  /**
+   * Default constructor.
+   * @param enumProvider Enumeration provider we are to use.
+   */
+  public BlitzInstanceProvider(EnumerationProvider enumProvider) {
+    modelObjectHandlerFactory = new ModelObjectHandlerFactory(enumProvider);
+  }
+
+  /* (non-Javadoc)
+   * @see ome.formats.model.InstanceProvider#getInstance(java.lang.Class)
+   */
+  public <T extends IObject> T getInstance(Class<T> klass)
+      throws ModelException {
+    try {
+      Constructor<T> constructor = getConstructor(klass);
+      IObject o = constructor.newInstance();
+      return (T) modelObjectHandlerFactory.getHandler(klass).handle(o);
+    } catch (Exception e) {
+      String m = "Unable to instantiate object.";
+      throw new ModelException(m, klass, e);
     }
+  }
 
-	/* (non-Javadoc)
-	 * @see ome.formats.model.InstanceProvider#getInstance(java.lang.Class)
-	 */
-	public <T extends IObject> T getInstance(Class<T> klass)
-		throws ModelException
-	{
-		try
-		{
-            Constructor<T> constructor = getConstructor(klass);
-            IObject o = constructor.newInstance();
-            return (T) modelObjectHandlerFactory.getHandler(klass).handle(o);
-		}
-	    catch (Exception e)
-	    {
-	        String m = "Unable to instantiate object.";
-	        throw new ModelException(m, klass, e);
-	    }
-	}
+  /**
+   * Retrieves a constructor for a given class from the constructor cache if
+   * possible.
+   * @param klass Class to retrieve a constructor for.
+   * @return See above.
+   * @throws ModelException If there is an error retrieving the constructor.
+   */
+  private <T extends IObject> Constructor<T> getConstructor(Class<T> klass)
+      throws ModelException {
+    Constructor<? extends IObject> constructor = constructorCache.get(klass);
+    if (constructor == null) {
+      try {
+        Class<T> concreteClass =
+            (Class<T>) Class.forName(klass.getName() + "I");
+        constructor = concreteClass.getDeclaredConstructor();
+        constructorCache.put(klass, constructor);
+      } catch (Exception e) {
+        String m = "Unable to retrieve constructor.";
+        throw new ModelException(m, klass, e);
+      }
+    }
+    return (Constructor<T>) constructor;
+  }
 
-	/**
-	 * Retrieves a constructor for a given class from the constructor cache if
-	 * possible.
-	 * @param klass Class to retrieve a constructor for.
-	 * @return See above.
-	 * @throws ModelException If there is an error retrieving the constructor.
-	 */
-	private <T extends IObject> Constructor<T> getConstructor(Class<T> klass)
-		throws ModelException
-	{
-		Constructor<? extends IObject> constructor =
-			constructorCache.get(klass);
-		if (constructor == null)
-		{
-			try
-			{
-				Class<T> concreteClass =
-					(Class<T>) Class.forName(klass.getName() + "I");
-				constructor = concreteClass.getDeclaredConstructor();
-				constructorCache.put(klass, constructor);
-			}
-	        catch (Exception e)
-	        {
-	            String m = "Unable to retrieve constructor.";
-	            throw new ModelException(m, klass, e);
-	        }
-		}
-		return (Constructor<T>) constructor;
-	}
 }

--- a/components/blitz/src/ome/formats/model/ChannelData.java
+++ b/components/blitz/src/ome/formats/model/ChannelData.java
@@ -56,362 +56,329 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  * @author Jean-Marie <jburel at dundee dot ac dot uk>
  */
-public class ChannelData
-{
-	/** Logger for this class */
-	private static final Logger log = LoggerFactory.getLogger(ChannelProcessor.class);
+public class ChannelData {
 
-	/** Base channel data. */
-	private Channel channel;
+  /** Logger for this class */
+  private static final Logger log = LoggerFactory.getLogger(
+      ChannelProcessor.class);
 
-	/** Index of the channel for the image. */
-	private Integer channelIndex;
+  /** Base channel data. */
+  private Channel channel;
 
-	/** Channel --> LogicalChannel */
-	private LogicalChannel logicalChannel;
+  /** Index of the channel for the image. */
+  private Integer channelIndex;
 
-	/** ... LogicalChannel --> Filterset */
-	private FilterSet filterSet;
+  /** Channel --> LogicalChannel */
+  private LogicalChannel logicalChannel;
 
-	/** ... LogicalChannel --> FilterSet --> Filter (Em) */
-	private Filter filterSetEmFilter;
+  /** ... LogicalChannel --> Filterset */
+  private FilterSet filterSet;
 
-	/** ... LogicalChannel --> FilterSet --> Filter (Ex) */
-	private Filter filterSetExFilter;
+  /** ... LogicalChannel --> FilterSet --> Filter (Em) */
+  private Filter filterSetEmFilter;
 
-	/** ... LogicalChannel --> LightPath */
-	private LightPath lightPath;
+  /** ... LogicalChannel --> FilterSet --> Filter (Ex) */
+  private Filter filterSetExFilter;
 
-	/** ... LogicalChannel --> LightPath --> Filter (Em) */
-	private List<Filter> lightPathEmFilters;
+  /** ... LogicalChannel --> LightPath */
+  private LightPath lightPath;
 
-	/** ... LogicalChannel --> LightPath --> Filter (Ex) */
-	private  List<Filter> lightPathExFilters;
+  /** ... LogicalChannel --> LightPath --> Filter (Em) */
+  private List<Filter> lightPathEmFilters;
 
-	/** ... LogicalChannel --> LightSettings */
-	private LightSettings lightSourceSettings;
+  /** ... LogicalChannel --> LightPath --> Filter (Ex) */
+  private  List<Filter> lightPathExFilters;
 
-	/** ... LogicalChannel --> LightSettings --> LightSource */
-	private LightSource lightSource;
+  /** ... LogicalChannel --> LightSettings */
+  private LightSettings lightSourceSettings;
 
-    /** Exhaustive list of valid light source types from the model. */
-    private static final Class<?>[] LIGHT_SOURCE_TYPES = new Class<?>[]
-        { Arc.class, Filament.class, LightEmittingDiode.class, Laser.class };
+  /** ... LogicalChannel --> LightSettings --> LightSource */
+  private LightSource lightSource;
 
-	/**
-	 * Retrieves channel data from an object container store.
-	 * @param store Store to retrieve the channel data from.
-	 * @param imageIndex Index of the image to retrieve channel data for.
-	 * @param channelIndex Index of the channel to retrieve channel data for.
-	 * @return Populated channel data for the specified channel.
-	 */
-	public static ChannelData fromObjectContainerStore(
-			IObjectContainerStore store, int imageIndex, int channelIndex)
-	{
-		Map<LSID, List<LSID>> referenceCache = store.getReferenceCache();
-		Map<Class<? extends IObject>, Map<String, IObjectContainer>>
-			containerCache = store.getAuthoritativeContainerCache();
-		ChannelData data = new ChannelData();
-		String lsidString;
+  /** Exhaustive list of valid light source types from the model. */
+  private static final Class<?>[] LIGHT_SOURCE_TYPES = new Class<?>[]
+    { Arc.class, Filament.class, LightEmittingDiode.class, Laser.class };
 
-		// Channel
-		data.channel = (Channel) store.getSourceObject(
-				new LSID(Channel.class, imageIndex, channelIndex));
-		data.channelIndex = channelIndex;
+  /**
+   * Retrieves channel data from an object container store.
+   * @param store Store to retrieve the channel data from.
+   * @param imageIndex Index of the image to retrieve channel data for.
+   * @param channelIndex Index of the channel to retrieve channel data for.
+   * @return Populated channel data for the specified channel.
+   */
+  public static ChannelData fromObjectContainerStore(
+      IObjectContainerStore store, int imageIndex, int channelIndex) {
+    Map<LSID, List<LSID>> referenceCache = store.getReferenceCache();
+    Map<Class<? extends IObject>, Map<String, IObjectContainer>>
+      containerCache = store.getAuthoritativeContainerCache();
+    ChannelData data = new ChannelData();
+    String lsidString;
 
-		if (data.channel == null)
-		{
-			// Channel is missing, create it.
-			LinkedHashMap<Index, Integer> indexes =
-				new LinkedHashMap<Index, Integer>();
-			indexes.put(Index.IMAGE_INDEX, imageIndex);
-			indexes.put(Index.CHANNEL_INDEX, channelIndex);
-			IObjectContainer container =
-				store.getIObjectContainer(Channel.class, indexes);
-			data.channel = (Channel) container.sourceObject;
-		}
-		// Channel --> LogicalChannel
-		LSID logicalChannelLSID =
-			new LSID(LogicalChannel.class, imageIndex, channelIndex);
-		data.logicalChannel =
-			(LogicalChannel) store.getSourceObject(logicalChannelLSID);
-		if (data.logicalChannel == null)
-		{
-			// Channel is missing, create it.
-			LinkedHashMap<Index, Integer> indexes =
-				new LinkedHashMap<Index, Integer>();
-			indexes.put(Index.IMAGE_INDEX, imageIndex);
-			indexes.put(Index.CHANNEL_INDEX, channelIndex);
-			IObjectContainer container =
-				store.getIObjectContainer(LogicalChannel.class, indexes);
-			data.logicalChannel = (LogicalChannel) container.sourceObject;
-		}
-		List<Filter> lightPathEmFilters = new ArrayList<Filter>();
-		List<Filter> lightPathExFilters = new ArrayList<Filter>();
-		data.lightPathEmFilters = lightPathEmFilters;
-		data.lightPathExFilters = lightPathExFilters;
-		// ... LogicalChannel --> FilterSet
-		List<LSID> references = referenceCache.get(logicalChannelLSID);
+    // Channel
+    data.channel = (Channel) store.getSourceObject(
+        new LSID(Channel.class, imageIndex, channelIndex));
+    data.channelIndex = channelIndex;
 
-		Map<String, IObjectContainer> filterSetContainers =
-			containerCache.get(FilterSet.class);
-		Map<String, IObjectContainer> lightPathContainers =
-			containerCache.get(LightPath.class);
-		Map<String, IObjectContainer> filterContainers =
-			containerCache.get(Filter.class);
-		if (references != null)
-		{
-			for (LSID reference : references)
-			{
-				lsidString = reference.toString();
-				//filters set
-				if (filterSetContainers != null
-				    && filterSetContainers.containsKey(lsidString))
-				{
-					IObjectContainer filterSetContainer =
-						filterSetContainers.get(lsidString);
-					LSID filterSetLSID = new LSID(FilterSet.class,
-							filterSetContainer.indexes.get(
-									Index.INSTRUMENT_INDEX.getValue()),
-							filterSetContainer.indexes.get(
-									Index.FILTER_SET_INDEX.getValue()));
-					data.filterSet =
-						(FilterSet) filterSetContainer.sourceObject;
-					// ... LogicalChannel --> FilterSet --> Filter (Em) AND
-					// ... LogicalChannel --> FilterSet --> Filter (Ex)
-					List<LSID> filterSetReferences =
-						referenceCache.get(filterSetLSID);
-					if (filterSetReferences == null)
-					{
-						continue;
-					}
-					for (LSID filterSetReference : filterSetReferences)
-					{
-						lsidString = filterSetReference.toString();
-						String unsuffixed =
-							lsidString.substring(0, lsidString.lastIndexOf(':'));
-						if (lsidString.endsWith(
-								OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX))
-						{
-							data.filterSetEmFilter = (Filter)
-							filterContainers.get(unsuffixed).sourceObject;
-						}
-						if (lsidString.endsWith(
-								OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX))
-						{
-							data.filterSetExFilter = (Filter)
-							filterContainers.get(unsuffixed).sourceObject;
-						}
-					}
-				}
-				/*
-				if (lightPathContainers != null
-					    && lightPathContainers.containsKey(lsidString))
-					{
-						IObjectContainer lightPathContainer =
-							lightPathContainers.get(lsidString);
-						LSID lightPathLSID = new LSID(LightPath.class,
-								imageIndex, channelIndex);
-						data.lightPath =
-							(LightPath) lightPathContainer.sourceObject;
-						List<LSID> lightPathReferences =
-							referenceCache.get(lightPathLSID);
-						if (lightPathReferences == null)
-						{
-							continue;
-						}
-						for (LSID lightPathReference : lightPathReferences)
-						{
-							lsidString = lightPathReference.toString();
-							String unsuffixed =
-								lsidString.substring(0,
-										lsidString.lastIndexOf(':'));
-							if (lsidString.endsWith(
-									OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX))
-							{
-								lightPathEmFilters.add((Filter)
-								filterContainers.get(unsuffixed).sourceObject);
-							}
-							if (lsidString.endsWith(
-									OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX))
-							{
-								lightPathEmFilters.add((Filter)
-								filterContainers.get(unsuffixed).sourceObject);
-							}
-						}
-					}
-					*/
-			}
-		}
+    if (data.channel == null) {
+      // Channel is missing, create it.
+      LinkedHashMap<Index, Integer> indexes =
+        new LinkedHashMap<Index, Integer>();
+      indexes.put(Index.IMAGE_INDEX, imageIndex);
+      indexes.put(Index.CHANNEL_INDEX, channelIndex);
+      IObjectContainer container =
+        store.getIObjectContainer(Channel.class, indexes);
+      data.channel = (Channel) container.sourceObject;
+    }
+    // Channel --> LogicalChannel
+    LSID logicalChannelLSID =
+      new LSID(LogicalChannel.class, imageIndex, channelIndex);
+    data.logicalChannel =
+      (LogicalChannel) store.getSourceObject(logicalChannelLSID);
+    if (data.logicalChannel == null) {
+      // Channel is missing, create it.
+      LinkedHashMap<Index, Integer> indexes =
+        new LinkedHashMap<Index, Integer>();
+      indexes.put(Index.IMAGE_INDEX, imageIndex);
+      indexes.put(Index.CHANNEL_INDEX, channelIndex);
+      IObjectContainer container =
+        store.getIObjectContainer(LogicalChannel.class, indexes);
+      data.logicalChannel = (LogicalChannel) container.sourceObject;
+    }
+    List<Filter> lightPathEmFilters = new ArrayList<Filter>();
+    List<Filter> lightPathExFilters = new ArrayList<Filter>();
+    data.lightPathEmFilters = lightPathEmFilters;
+    data.lightPathExFilters = lightPathExFilters;
+    // ... LogicalChannel --> FilterSet
+    List<LSID> references = referenceCache.get(logicalChannelLSID);
 
-		//light path
-		LSID lightPathLSID = new LSID(LightPath.class, imageIndex,
-				channelIndex);
-		data.lightPath =
-			(LightPath) store.getSourceObject(lightPathLSID);
-		List<LSID> lightPathReferences =
-			referenceCache.get(lightPathLSID);
-		if (lightPathReferences != null) {
-			for (LSID lightPathReference : lightPathReferences)
-			{
-				lsidString = lightPathReference.toString();
-				String unsuffixed =
-					lsidString.substring(0,
-							lsidString.lastIndexOf(':'));
-				if (lsidString.endsWith(
-						OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX))
-				{
-					IObjectContainer c = filterContainers.get(unsuffixed);
-					if (c == null)
-					{
-						throw new ModelException("No filter with LSID: " + unsuffixed);
-					}
-					lightPathEmFilters.add((Filter) c.sourceObject);
-				}
-				if (lsidString.endsWith(
-						OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX))
-				{
-					IObjectContainer c = filterContainers.get(unsuffixed);
-					if (c == null)
-					{
-						throw new ModelException("No filter with LSID: " + unsuffixed);
-					}
-					lightPathExFilters.add((Filter) c.sourceObject);
-				}
-			}
-		}
-
-
-        // ... LogicalChannel --> LightSettings
-        LSID lightSettingsLSID = new LSID(LightSettings.class, imageIndex,
-                channelIndex);
-        data.lightSourceSettings = (LightSettings) store
-                .getSourceObject(lightSettingsLSID);
-        Map<String, IObjectContainer> lightSourceContainers =
-            new HashMap<String, IObjectContainer>();
-        if (data.lightSourceSettings != null)
-        {
-            // Pick up all potential light sources
-            for (Class<?> klass : LIGHT_SOURCE_TYPES)
-            {
-                Map<String, IObjectContainer> v = containerCache.get(klass);
-                if (v != null)
-                {
-                    lightSourceContainers.putAll(v);
-                }
+    Map<String, IObjectContainer> filterSetContainers =
+      containerCache.get(FilterSet.class);
+    Map<String, IObjectContainer> lightPathContainers =
+      containerCache.get(LightPath.class);
+    Map<String, IObjectContainer> filterContainers =
+      containerCache.get(Filter.class);
+    if (references != null) {
+      for (LSID reference : references) {
+        lsidString = reference.toString();
+        //filters set
+        if (filterSetContainers != null
+            && filterSetContainers.containsKey(lsidString)) {
+          IObjectContainer filterSetContainer =
+            filterSetContainers.get(lsidString);
+          LSID filterSetLSID = new LSID(
+              FilterSet.class,
+              filterSetContainer.indexes.get(
+                  Index.INSTRUMENT_INDEX.getValue()
+              ),
+              filterSetContainer.indexes.get(
+                  Index.FILTER_SET_INDEX.getValue()
+              )
+          );
+          data.filterSet = (FilterSet) filterSetContainer.sourceObject;
+          // ... LogicalChannel --> FilterSet --> Filter (Em) AND
+          // ... LogicalChannel --> FilterSet --> Filter (Ex)
+          List<LSID> filterSetReferences = referenceCache.get(filterSetLSID);
+          if (filterSetReferences == null) {
+            continue;
+          }
+          for (LSID filterSetReference : filterSetReferences) {
+            lsidString = filterSetReference.toString();
+            String unsuffixed =
+              lsidString.substring(0, lsidString.lastIndexOf(':'));
+            if (lsidString.endsWith(
+                    OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX)) {
+              data.filterSetEmFilter =
+                (Filter) filterContainers.get(unsuffixed).sourceObject;
             }
-            // ... LogicalChannel --> LightSettings --> LightSource
-            references = referenceCache.get(lightSettingsLSID);
-            if (references != null)
-            {
-                for (LSID reference : references)
-                {
-                    lsidString = reference.toString();
-                    if (lightSourceContainers.containsKey(lsidString))
-                    {
-                        data.lightSource = (LightSource) lightSourceContainers
-                                .get(lsidString).sourceObject;
-                    }
-                }
+            if (lsidString.endsWith(
+                    OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX)) {
+              data.filterSetExFilter =
+                (Filter) filterContainers.get(unsuffixed).sourceObject;
             }
+          }
         }
-        return data;
-	}
+        /*
+        if (lightPathContainers != null
+              && lightPathContainers.containsKey(lsidString))
+          {
+            IObjectContainer lightPathContainer =
+              lightPathContainers.get(lsidString);
+            LSID lightPathLSID = new LSID(LightPath.class,
+                imageIndex, channelIndex);
+            data.lightPath =
+              (LightPath) lightPathContainer.sourceObject;
+            List<LSID> lightPathReferences =
+              referenceCache.get(lightPathLSID);
+            if (lightPathReferences == null)
+            {
+              continue;
+            }
+            for (LSID lightPathReference : lightPathReferences)
+            {
+              lsidString = lightPathReference.toString();
+              String unsuffixed =
+                lsidString.substring(0,
+                    lsidString.lastIndexOf(':'));
+              if (lsidString.endsWith(
+                  OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX))
+              {
+                lightPathEmFilters.add((Filter)
+                filterContainers.get(unsuffixed).sourceObject);
+              }
+              if (lsidString.endsWith(
+                  OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX))
+              {
+                lightPathEmFilters.add((Filter)
+                filterContainers.get(unsuffixed).sourceObject);
+              }
+            }
+          }
+          */
+      }
+    }
 
-	/**
-	 * Returns the channel this channel data is for.
-	 * @return See above.
-	 */
-	public Channel getChannel()
-	{
-		return channel;
-	}
+    //light path
+    LSID lightPathLSID = new LSID(LightPath.class, imageIndex, channelIndex);
+    data.lightPath = (LightPath) store.getSourceObject(lightPathLSID);
+    List<LSID> lightPathReferences = referenceCache.get(lightPathLSID);
+    if (lightPathReferences != null) {
+      for (LSID lightPathReference : lightPathReferences) {
+        lsidString = lightPathReference.toString();
+        String unsuffixed = lsidString.substring(
+            0, lsidString.lastIndexOf(':'));
+        if (lsidString.endsWith(
+                OMEROMetadataStoreClient.OMERO_EMISSION_FILTER_SUFFIX)) {
+          IObjectContainer c = filterContainers.get(unsuffixed);
+          if (c == null) {
+            throw new ModelException("No filter with LSID: " + unsuffixed);
+          }
+          lightPathEmFilters.add((Filter) c.sourceObject);
+        }
+        if (lsidString.endsWith(
+                OMEROMetadataStoreClient.OMERO_EXCITATION_FILTER_SUFFIX)) {
+          IObjectContainer c = filterContainers.get(unsuffixed);
+          if (c == null) {
+            throw new ModelException("No filter with LSID: " + unsuffixed);
+          }
+          lightPathExFilters.add((Filter) c.sourceObject);
+        }
+      }
+    }
 
-	/**
-	 * Returns the index of the channel this channel data is for.
-	 * @return See above.
-	 */
-	public int getChannelIndex()
-	{
-		return channelIndex;
-	}
+    // ... LogicalChannel --> LightSettings
+    LSID lightSettingsLSID = new LSID(
+        LightSettings.class, imageIndex, channelIndex);
+    data.lightSourceSettings =
+      (LightSettings) store.getSourceObject(lightSettingsLSID);
+    Map<String, IObjectContainer> lightSourceContainers =
+      new HashMap<String, IObjectContainer>();
+    if (data.lightSourceSettings != null) {
+      // Pick up all potential light sources
+      for (Class<?> klass : LIGHT_SOURCE_TYPES) {
+        Map<String, IObjectContainer> v = containerCache.get(klass);
+        if (v != null) {
+          lightSourceContainers.putAll(v);
+        }
+      }
+      // ... LogicalChannel --> LightSettings --> LightSource
+      references = referenceCache.get(lightSettingsLSID);
+      if (references != null) {
+        for (LSID reference : references) {
+          lsidString = reference.toString();
+          if (lightSourceContainers.containsKey(lsidString)) {
+            data.lightSource =
+              (LightSource) lightSourceContainers .get(lsidString).sourceObject;
+          }
+        }
+      }
+    }
+    return data;
+  }
 
-	/**
-	 * Returns the logical channel for this channel data.
-	 * @return See above.
-	 */
-	public LogicalChannel getLogicalChannel()
-	{
-		return logicalChannel;
-	}
+  /**
+   * Returns the channel this channel data is for.
+   * @return See above.
+   */
+  public Channel getChannel() {
+    return channel;
+  }
 
-	/**
-	 * Returns the filter set for the logical channel of this channel data.
-	 * @return See above.
-	 */
-	public FilterSet getFilterSet()
-	{
-		return filterSet;
-	}
+  /**
+   * Returns the index of the channel this channel data is for.
+   * @return See above.
+   */
+  public int getChannelIndex() {
+    return channelIndex;
+  }
 
-	/**
-	 * Returns the filter set's emission filter for the logical channel of
-	 * this channel data.
-	 * @return See above.
-	 */
-	public Filter getFilterSetEmissionFilter()
-	{
-		return filterSetEmFilter;
-	}
+  /**
+   * Returns the logical channel for this channel data.
+   * @return See above.
+   */
+  public LogicalChannel getLogicalChannel() {
+    return logicalChannel;
+  }
 
-	/**
-	 * Returns the filter set's excitation filter for the logical channel of
-	 * this channel data.
-	 * @return See above.
-	 */
-	public Filter getFilterSetExcitationFilter()
-	{
-		return filterSetExFilter;
-	}
+  /**
+   * Returns the filter set for the logical channel of this channel data.
+   * @return See above.
+   */
+  public FilterSet getFilterSet() {
+    return filterSet;
+  }
 
-	/**
-	 * Returns the collection of emission filters in the light path.
-	 *
-	 * @return See above.
-	 */
-	public List<Filter> getLightPathEmissionFilters()
-	{
-		return lightPathEmFilters;
-	}
+  /**
+   * Returns the filter set's emission filter for the logical channel of
+   * this channel data.
+   * @return See above.
+   */
+  public Filter getFilterSetEmissionFilter() {
+    return filterSetEmFilter;
+  }
 
-	/**
-	 * Returns the collection of excitation filters in the light path.
-	 *
-	 * @return See above.
-	 */
-	public List<Filter> getLightPathExcitationFilters()
-	{
-		return  lightPathExFilters;
-	}
+  /**
+   * Returns the filter set's excitation filter for the logical channel of
+   * this channel data.
+   * @return See above.
+   */
+  public Filter getFilterSetExcitationFilter() {
+    return filterSetExFilter;
+  }
 
-	/**
-	 * Returns the light source settings for the logical channel of this
-	 * channel data.
-	 * @return See above.
-	 */
-	public LightSettings getLightSourceSettings()
-	{
-		return lightSourceSettings;
-	}
+  /**
+   * Returns the collection of emission filters in the light path.
+   *
+   * @return See above.
+   */
+  public List<Filter> getLightPathEmissionFilters() {
+    return lightPathEmFilters;
+  }
 
-	/**
-	 * Returns the light source for the light source settings of this channel
-	 * data.
-	 * @return See above.
-	 */
-	public LightSource getLightSource()
-	{
-		return lightSource;
-	}
+  /**
+   * Returns the collection of excitation filters in the light path.
+   *
+   * @return See above.
+   */
+  public List<Filter> getLightPathExcitationFilters() {
+    return  lightPathExFilters;
+  }
+
+  /**
+   * Returns the light source settings for the logical channel of this
+   * channel data.
+   * @return See above.
+   */
+  public LightSettings getLightSourceSettings() {
+    return lightSourceSettings;
+  }
+
+  /**
+   * Returns the light source for the light source settings of this channel
+   * data.
+   * @return See above.
+   */
+  public LightSource getLightSource() {
+    return lightSource;
+  }
 
 }

--- a/components/blitz/src/ome/formats/model/ChannelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ChannelProcessor.java
@@ -72,7 +72,7 @@ public class ChannelProcessor implements ModelProcessor
 	/** Name of the <code>blue</code> component when it is a graphics image. */
 	public static final String BLUE_TEXT = "Blue";
 
-	/** Name of the <code>blue</code> component when it is a graphics image. */
+	/** Name of the <code>alpha</code> component when it is a graphics image. */
 	public static final String ALPHA_TEXT = "Alpha";
 
 	/** Logger for this class */

--- a/components/blitz/src/ome/formats/model/ChannelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ChannelProcessor.java
@@ -60,492 +60,452 @@ import com.google.common.math.DoubleMath;
  * @author Jean-Marie <jburel at dundee dot ac dot uk>
  *
  */
-public class ChannelProcessor implements ModelProcessor
-{
+public class ChannelProcessor implements ModelProcessor {
 
-	/** Name of the <code>red</code> component when it is a graphics image. */
-	public static final String RED_TEXT = "Red";
+  /** Name of the <code>red</code> component when it is a graphics image. */
+  public static final String RED_TEXT = "Red";
 
-	/** Name of the <code>green</code> component when it is a graphics image. */
-	public static final String GREEN_TEXT = "Green";
+  /** Name of the <code>green</code> component when it is a graphics image. */
+  public static final String GREEN_TEXT = "Green";
 
-	/** Name of the <code>blue</code> component when it is a graphics image. */
-	public static final String BLUE_TEXT = "Blue";
+  /** Name of the <code>blue</code> component when it is a graphics image. */
+  public static final String BLUE_TEXT = "Blue";
 
-	/** Name of the <code>alpha</code> component when it is a graphics image. */
-	public static final String ALPHA_TEXT = "Alpha";
+  /** Name of the <code>alpha</code> component when it is a graphics image. */
+  public static final String ALPHA_TEXT = "Alpha";
 
-	/** Logger for this class */
-	private Logger log = LoggerFactory.getLogger(ChannelProcessor.class);
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(ChannelProcessor.class);
 
-	/** Container store we're currently working with. */
-	private IObjectContainerStore store;
+  /** Container store we're currently working with. */
+  private IObjectContainerStore store;
 
-	/** Bio-Formats reader implementation we're currently working with. */
-	private IFormatReader reader;
+  /** Bio-Formats reader implementation we're currently working with. */
+  private IFormatReader reader;
 
-	/**
-	 * Returns the name from the wavelength.
-	 *
-	 * @param value The value to handle.
-	 * @return See above.
-	 */
-	private String getNameFromWavelength(Length value)
-	{
-	    if (value == null) return null;
-	    //Check that the value is an int
-        if (DoubleMath.isMathematicalInteger(value.getValue())) {
-            return ""+value.getValue();
-        }
-        return value.toString();
-	}
+  /**
+   * Returns the name from the wavelength.
+   *
+   * @param value The value to handle.
+   * @return See above.
+   */
+  private String getNameFromWavelength(Length value) {
+    if (value == null) return null;
+    //Check that the value is an int
+    if (DoubleMath.isMathematicalInteger(value.getValue())) {
+      return ""+value.getValue();
+    }
+    return value.toString();
+  }
 
-	/**
-	 * Sets the default color if it is a single channel image.
-	 *
-	 * @param channelData Channel data to use to set the color.
-	 */
-	private void setSingleChannel(ChannelData channelData)
-	{
-	    int channelIndex = channelData.getChannelIndex();
-	    Channel channel = channelData.getChannel();
-	    Integer red = getValue(channel.getRed());
-        Integer green = getValue(channel.getGreen());
-        Integer blue = getValue(channel.getBlue());
-        Integer alpha = getValue(channel.getAlpha());
-        RString name;
-        //color already set by Bio-formats
-        if (red != null && green != null && blue != null && alpha != null) {
-            return;
-        }
-        int[] defaultColor = ColorsFactory.newGreyColor();
-        channel.setRed(
-                rint(defaultColor[ColorsFactory.RED_INDEX]));
-        channel.setGreen(
-                rint(defaultColor[ColorsFactory.GREEN_INDEX]));
-        channel.setBlue(
-                rint(defaultColor[ColorsFactory.BLUE_INDEX]));
-        channel.setAlpha(
-                rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
-	}
+  /**
+   * Sets the default color if it is a single channel image.
+   *
+   * @param channelData Channel data to use to set the color.
+   */
+  private void setSingleChannel(ChannelData channelData) {
+    int channelIndex = channelData.getChannelIndex();
+    Channel channel = channelData.getChannel();
+    Integer red = getValue(channel.getRed());
+    Integer green = getValue(channel.getGreen());
+    Integer blue = getValue(channel.getBlue());
+    Integer alpha = getValue(channel.getAlpha());
+    RString name;
+    //color already set by Bio-formats
+    if (red != null && green != null && blue != null && alpha != null) {
+      return;
+    }
+    int[] defaultColor = ColorsFactory.newGreyColor();
+    channel.setRed(rint(defaultColor[ColorsFactory.RED_INDEX]));
+    channel.setGreen(rint(defaultColor[ColorsFactory.GREEN_INDEX]));
+    channel.setBlue(rint(defaultColor[ColorsFactory.BLUE_INDEX]));
+    channel.setAlpha(rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
+  }
 
-	/**
-     * Populates the default color for the channel if one does not already
-     * exist.
-     *
-     * @param channelData Channel data to use to set the color.
-     * @param isGraphicsDomaind Whether or not the image is in the graphics
-	 * domain according to Bio-Formats.
-     */
-    private void populateDefault(ChannelData channelData,
-		                   boolean isGraphicsDomain)
-    {
-	int channelIndex = channelData.getChannelIndex();
-	Channel channel = channelData.getChannel();
-	LogicalChannel lc = channelData.getLogicalChannel();
-	int[] defaultColor;
-	if (isGraphicsDomain)
-		{
-	    log.debug("Setting color channel to RGB.");
-	    setDefaultChannelColor(channel, channelIndex);
-	    switch (channelIndex) {
-				case 0: //red
-		        if (lc.getName() == null)
-				lc.setName(rstring(RED_TEXT));
-		        break;
-				case 1: //green
-		        if (lc.getName() == null)
-				lc.setName(rstring(GREEN_TEXT));
-		        break;
-				case 2: //blue
-		        if (lc.getName() == null)
-				lc.setName(rstring(BLUE_TEXT));
-		        break;
-				case 3: //alpha, reset transparent
-					channel.setRed(rint(0));
-		        channel.setGreen(rint(0));
-		        channel.setBlue(rint(0));
-		        channel.setAlpha(rint(0)); //transparent
-		        if (lc.getName() == null)
-				lc.setName(rstring(ALPHA_TEXT));
-			}
-	    return;
-		}
+  /**
+   * Populates the default color for the channel if one does not already
+   * exist.
+   *
+   * @param channelData Channel data to use to set the color.
+   * @param isGraphicsDomaind Whether or not the image is in the graphics
+   * domain according to Bio-Formats.
+   */
+  private void populateDefault(
+      ChannelData channelData, boolean isGraphicsDomain) {
+    int channelIndex = channelData.getChannelIndex();
+    Channel channel = channelData.getChannel();
+    LogicalChannel lc = channelData.getLogicalChannel();
+    int[] defaultColor;
+    if (isGraphicsDomain) {
+      log.debug("Setting color channel to RGB.");
+      setDefaultChannelColor(channel, channelIndex);
+      switch (channelIndex) {
+      case 0: //red
+        if (lc.getName() == null)
+          lc.setName(rstring(RED_TEXT));
+        break;
+      case 1: //green
+        if (lc.getName() == null)
+          lc.setName(rstring(GREEN_TEXT));
+        break;
+      case 2: //blue
+        if (lc.getName() == null)
+          lc.setName(rstring(BLUE_TEXT));
+        break;
+      case 3: //alpha, reset transparent
+        channel.setRed(rint(0));
+        channel.setGreen(rint(0));
+        channel.setBlue(rint(0));
+        channel.setAlpha(rint(0)); //transparent
+        if (lc.getName() == null)
+          lc.setName(rstring(ALPHA_TEXT));
+      }
+      return;
+    }
 
-        Integer red = getValue(channel.getRed());
-        Integer green = getValue(channel.getGreen());
-        Integer blue = getValue(channel.getBlue());
-        Integer alpha = getValue(channel.getAlpha());
-        RString name;
-        //color already set by Bio-formats
-        if (red != null && green != null && blue != null && alpha != null) {
-            //Try to set the name.
-            log.debug("Already set in BF.");
-            if (lc.getName() == null) {
-                name = getChannelName(channelData);
-                if (name != null) lc.setName(name);
-            }
-            return;
-        }
+    Integer red = getValue(channel.getRed());
+    Integer green = getValue(channel.getGreen());
+    Integer blue = getValue(channel.getBlue());
+    Integer alpha = getValue(channel.getAlpha());
+    RString name;
+    //color already set by Bio-formats
+    if (red != null && green != null && blue != null && alpha != null) {
+      //Try to set the name.
+      log.debug("Already set in BF.");
+      if (lc.getName() == null) {
+        name = getChannelName(channelData);
+        if (name != null) lc.setName(name);
+      }
+      return;
+    }
 
-        //not set by
-        //First we check the emission wavelength.
+    //not set by
+    //First we check the emission wavelength.
 
-        Length valueWavelength = lc.getEmissionWave();
+    Length valueWavelength = lc.getEmissionWave();
+    if (valueWavelength != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueWavelength));
+      if (lc.getName() == null) {
+        lc.setName(rstring(getNameFromWavelength(valueWavelength)));
+      }
+      return;
+    }
+
+    Length valueFilter = null;
+
+    //First check the emission filter.
+    //First check if filter
+    Filter f = getValidFilter(channelData.getLightPathEmissionFilters(), true);
+    if (f != null)
+      valueFilter = ColorsFactory.getValueFromFilter(f, true);
+    if (valueFilter != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueFilter));
+      if (lc.getName() == null) {
+        name = getNameFromFilter(f);
+        if (name != null) lc.setName(name);
+      }
+      return;
+    }
+    f = channelData.getFilterSetEmissionFilter();
+    valueFilter = ColorsFactory.getValueFromFilter(f, true);
+
+    if (valueFilter != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueFilter));
+      if (lc.getName() == null) {
+        name = getNameFromFilter(f);
+        if (name != null) lc.setName(name);
+      }
+      return;
+    }
+    //Laser
+    if (channelData.getLightSource() != null) {
+      LightSource ls = channelData.getLightSource();
+      if (ls instanceof Laser) {
+        valueWavelength = ((Laser) ls).getWavelength();
         if (valueWavelength != null) {
-            setChannelColor(channel, channelIndex,
-                ColorsFactory.determineColor(valueWavelength));
-            if (lc.getName() == null) {
-                lc.setName(rstring(getNameFromWavelength(valueWavelength)));
+          setChannelColor(
+              channel, channelIndex,
+              ColorsFactory.determineColor(valueWavelength));
+          if (lc.getName() == null) {
+            lc.setName(rstring(getNameFromWavelength(valueWavelength)));
+          }
+          return;
+        }
+      }
+    }
+    //Excitation
+    valueWavelength = lc.getExcitationWave();
+    if (valueWavelength != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueWavelength));
+      if (lc.getName() == null) {
+        lc.setName(rstring(getNameFromWavelength(valueWavelength)));
+      }
+      return;
+    }
+    f = getValidFilter(channelData.getLightPathExcitationFilters(), false);
+    if (f != null)
+      valueFilter = ColorsFactory.getValueFromFilter(f, false);
+
+    if (valueFilter != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueFilter));
+      if (lc.getName() == null) {
+        name = getNameFromFilter(f);
+        if (name != null) lc.setName(name);
+      }
+      return;
+    }
+    f = channelData.getFilterSetExcitationFilter();
+    valueFilter = ColorsFactory.getValueFromFilter(f, false);
+
+    if (valueFilter != null) {
+      setChannelColor(
+          channel, channelIndex, ColorsFactory.determineColor(valueFilter));
+      if (lc.getName() == null) {
+        name = getNameFromFilter(f);
+        if (name != null) lc.setName(name);
+      }
+      return;
+    }
+
+    //not been able to set the color
+    setDefaultChannelColor(channel, channelIndex);
+  }
+
+  /**
+   * Returns the first filter from the list with a <code>not null</code>
+   * value.
+   *
+   * @param filters The collection to handle.
+   * @param emission Passed <code>true</code> to indicate that the filter
+   * is an emission filter, <code>false</code> otherwise.
+   * @return See above.
+   */
+  private Filter getValidFilter(List<Filter> filters, boolean emission) {
+    if (filters == null) return null;
+    Iterator<Filter> i = filters.iterator();
+    Length value = null;
+    Filter f;
+    while (i.hasNext()) {
+      f = i.next();
+      value = ColorsFactory.getValueFromFilter(f, emission);
+      if (value != null) return f;
+    }
+    return null;
+  }
+
+  /**
+   * Sets the default color of the channel.
+   *
+   * @param channel The channel to handle.
+   * @param index   The index of the channel.
+   */
+  private void setDefaultChannelColor(Channel channel, int index) {
+    //not been able to set the color
+    int[] defaultColor;
+    switch (index) {
+    case 0: //red
+      defaultColor = ColorsFactory.newRedColor();
+      break;
+    case 1: //green
+      defaultColor = ColorsFactory.newGreenColor();
+      break;
+    default: //blue
+      defaultColor = ColorsFactory.newBlueColor();
+    }
+    channel.setRed(rint(defaultColor[ColorsFactory.RED_INDEX]));
+    channel.setGreen(rint(defaultColor[ColorsFactory.GREEN_INDEX]));
+    channel.setBlue(rint(defaultColor[ColorsFactory.BLUE_INDEX]));
+    channel.setAlpha(rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
+  }
+
+  /**
+   * Sets the color of the channel.
+   *
+   * @param channel The channel to handle.
+   * @param index   The index of the channel.
+   * @param rgba    The color to set.
+   */
+  private void setChannelColor(Channel channel, int index, int[] rgba) {
+    if (rgba == null) {
+      setDefaultChannelColor(channel, index);
+      return;
+    }
+    channel.setRed(rint(rgba[0]));
+    channel.setGreen(rint(rgba[1]));
+    channel.setBlue(rint(rgba[2]));
+    channel.setAlpha(rint(rgba[3]));
+  }
+
+  /**
+   * Returns a channel name string from a given filter.
+   *
+   * @param filter Filter to retrieve a channel name from.
+   * @return See above.
+   */
+  private RString getNameFromFilter(Filter filter) {
+    if (filter == null) {
+      return null;
+    }
+    TransmittanceRange t = filter.getTransmittanceRange();
+    return t == null? null :
+      rstring(String.valueOf(t.getCutIn().getValue()));
+  }
+
+  /**
+   * Returns the concrete value of an OMERO rtype.
+   *
+   * @param value OMERO rtype to get the value of.
+   * @return Concrete value of <code>value</code> or <code>null</code> if
+   * <code>value == null</code>.
+   */
+  private Integer getValue(RInt value) {
+    return value == null? null : value.getValue();
+  }
+
+  /**
+   * Determines the name of the channel.
+   * This method should only be invoked when a color was assigned by
+   * Bio-formats.
+   *
+   * @param channelData The channel to handle.
+   * @return See above.
+   */
+  private RString getChannelName(ChannelData channelData) {
+    LogicalChannel lc = channelData.getLogicalChannel();
+    Length value = lc.getEmissionWave();
+    RString name;
+    if (value != null) {
+      return rstring(getNameFromWavelength(value));
+    }
+    Iterator<Filter> i;
+    List<Filter> filters = channelData.getLightPathEmissionFilters();
+    if (filters != null) {
+      i = filters.iterator();
+      while (i.hasNext()) {
+        name = getNameFromFilter(i.next());
+        if (name != null) return name;
+      }
+    }
+
+    name = getNameFromFilter(channelData.getFilterSetEmissionFilter());
+    if (name != null) {
+      return name;
+    }
+
+    //Laser
+    LightSource ls = channelData.getLightSource();
+    if (ls != null) {
+      if (ls instanceof Laser) {
+        Laser laser = (Laser) ls;
+        value = laser.getWavelength();
+        if (value != null) {
+          return rstring(getNameFromWavelength(value));
+        }
+      }
+    }
+    value = lc.getExcitationWave();
+    if (value != null) {
+      return rstring(getNameFromWavelength(value));
+    }
+    filters = channelData.getLightPathExcitationFilters();
+    if (filters != null) {
+      i = filters.iterator();
+      while (i.hasNext()) {
+        name = getNameFromFilter(i.next());
+        if (name != null) return name;
+      }
+    }
+    return getNameFromFilter(channelData.getFilterSetExcitationFilter());
+  }
+
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    this.store = store;
+    reader = this.store.getReader();
+    if (reader == null) {
+      log.warn("Unexpected null reader.");
+      return;
+    }
+
+    List<Image> images = store.getSourceObjects(Image.class);
+    String[] domains = reader.getDomains();
+    boolean isGraphicsDomain = false;
+    for (String domain : domains) {
+      if (FormatTools.GRAPHICS_DOMAIN.equals(domain)) {
+        log.debug("Images are of the graphics domain.");
+        isGraphicsDomain = true;
+        break;
+      }
+    }
+    log.debug("isGraphicsDomain: "+isGraphicsDomain);
+    int count;
+    boolean v;
+    Map<ChannelData, Boolean> m;
+    Pixels pixels;
+    int sizeC;
+    ChannelData channelData;
+    Iterator<ChannelData> k;
+    for (int i = 0; i < images.size(); i++) {
+      pixels = (Pixels) store.getSourceObject(new LSID(Pixels.class, i));
+      if (pixels == null) {
+        throw new ModelException("Unable to locate Pixels:" + i);
+      }
+      //Require to reset transmitted light
+      count = 0;
+      m = new HashMap<ChannelData, Boolean>();
+
+      //Think of strategy for images with high number of channels
+      //i.e. > 6
+      sizeC = pixels.getSizeC().getValue();
+      if (sizeC == 1) {
+        channelData = ChannelData.fromObjectContainerStore(store, i, 0);
+        setSingleChannel(channelData);
+      } else {
+        for (int c = 0; c < sizeC; c++) {
+          channelData = ChannelData.fromObjectContainerStore(store, i, c);
+          //Color section
+          populateDefault(channelData, isGraphicsDomain);
+
+          //only retrieve if not graphics
+          if (!isGraphicsDomain) {
+            //Determine if the channel same emission wavelength.
+            v = ColorsFactory.hasEmissionData(channelData);
+            if (!v) {
+              count++;
             }
-            return;
+            m.put(channelData, v);
+          }
         }
+      }
 
-        Length valueFilter = null;
+      //Need to reset the color of transmitted light
+      //i.e. images with several "emission channels"
+      //check if 0 size
 
-	//First check the emission filter.
-	//First check if filter
-	Filter f = getValidFilter(channelData.getLightPathEmissionFilters(),
-			true);
-	if (f != null)
-		valueFilter = ColorsFactory.getValueFromFilter(f, true);
-	if (valueFilter != null) {
-		setChannelColor(channel, channelIndex,
-				ColorsFactory.determineColor(valueFilter));
-		if (lc.getName() == null) {
-			name = getNameFromFilter(f);
-			if (name != null) lc.setName(name);
-		}
-		return;
-	}
-	f = channelData.getFilterSetEmissionFilter();
-	valueFilter = ColorsFactory.getValueFromFilter(f, true);
-
-	if (valueFilter != null) {
-		setChannelColor(channel, channelIndex,
-				ColorsFactory.determineColor(valueFilter));
-		if (lc.getName() == null) {
-			name = getNameFromFilter(f);
-			if (name != null) lc.setName(name);
-		}
-		return;
-	}
-	//Laser
-	if (channelData.getLightSource() != null) {
-		LightSource ls = channelData.getLightSource();
-		if (ls instanceof Laser) {
-			valueWavelength = ((Laser) ls).getWavelength();
-			if (valueWavelength != null) {
-			setChannelColor(channel, channelIndex,
-					ColorsFactory.determineColor(valueWavelength));
-			if (lc.getName() == null) {
-			    lc.setName(rstring(getNameFromWavelength(valueWavelength)));
-			}
-			return;
-		}
-		}
-	}
-	//Excitation
-	valueWavelength = lc.getExcitationWave();
-	if (valueWavelength != null) {
-		setChannelColor(channel, channelIndex,
-				ColorsFactory.determineColor(valueWavelength));
-		if (lc.getName() == null) {
-		    lc.setName(rstring(getNameFromWavelength(valueWavelength)));
-		}
-		return;
-	}
-	f = getValidFilter(channelData.getLightPathExcitationFilters(), false);
-	if (f != null)
-		valueFilter = ColorsFactory.getValueFromFilter(f, false);
-
-	if (valueFilter != null) {
-		setChannelColor(channel, channelIndex,
-				ColorsFactory.determineColor(valueFilter));
-		if (lc.getName() == null) {
-			name = getNameFromFilter(f);
-			if (name != null) lc.setName(name);
-		}
-		return;
-	}
-	f = channelData.getFilterSetExcitationFilter();
-	valueFilter = ColorsFactory.getValueFromFilter(f, false);
-
-	if (valueFilter != null) {
-		setChannelColor(channel, channelIndex,
-				ColorsFactory.determineColor(valueFilter));
-		if (lc.getName() == null) {
-			name = getNameFromFilter(f);
-			if (name != null) lc.setName(name);
-		}
-		return;
-	}
-
-	//not been able to set the color
-
-	setDefaultChannelColor(channel, channelIndex);
-    }
-
-    /**
-     * Returns the first filter from the list with a <code>not null</code>
-     * value.
-     *
-     * @param filters The collection to handle.
-     * @param emission Passed <code>true</code> to indicate that the filter
-     * is an emission filter, <code>false</code> otherwise.
-     * @return See above.
-     */
-    private Filter getValidFilter(List<Filter> filters, boolean emission)
-    {
-	if (filters == null) return null;
-	Iterator<Filter> i = filters.iterator();
-	Length value = null;
-	Filter f;
-	while (i.hasNext()) {
-		f = i.next();
-		value = ColorsFactory.getValueFromFilter(f, emission);
-			if (value != null) return f;
-		}
-	return null;
-    }
-
-    /**
-     * Sets the default color of the channel.
-     *
-     * @param channel The channel to handle.
-     * @param index   The index of the channel.
-     */
-    private void setDefaultChannelColor(Channel channel, int index)
-    {
-	//not been able to set the color
-	int[] defaultColor;
-	switch (index) {
-		case 0: //red
-			defaultColor = ColorsFactory.newRedColor();
-	        break;
-		case 1: //green
-			defaultColor = ColorsFactory.newGreenColor();
-	        break;
-		default: //blue
-			defaultColor = ColorsFactory.newBlueColor();
-	}
-	channel.setRed(
-				rint(defaultColor[ColorsFactory.RED_INDEX]));
-		channel.setGreen(
-				rint(defaultColor[ColorsFactory.GREEN_INDEX]));
-		channel.setBlue(
-				rint(defaultColor[ColorsFactory.BLUE_INDEX]));
-		channel.setAlpha(
-				rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
-    }
-
-    /**
-     * Sets the color of the channel.
-     *
-     * @param channel The channel to handle.
-     * @param index   The index of the channel.
-     * @param rgba    The color to set.
-     */
-    private void setChannelColor(Channel channel, int index, int[] rgba)
-    {
-	if (rgba == null) {
-		setDefaultChannelColor(channel, index);
-		return;
-	}
-	channel.setRed(rint(rgba[0]));
-	channel.setGreen(rint(rgba[1]));
-	channel.setBlue(rint(rgba[2]));
-	channel.setAlpha(rint(rgba[3]));
-    }
-
-    /**
-     * Returns a channel name string from a given filter.
-     *
-     * @param filter Filter to retrieve a channel name from.
-     * @return See above.
-     */
-    private RString getNameFromFilter(Filter filter)
-    {
-        if (filter == null)
-        {
-		return null;
+      if (count > 0 && count != m.size()) {
+        k = m.keySet().iterator();
+        while (k.hasNext()) {
+          channelData = k.next();
+          if (!m.get(channelData)) {
+            int[] defaultColor = ColorsFactory.newWhiteColor();
+            Channel channel = channelData.getChannel();
+            channel.setRed(rint(defaultColor[ColorsFactory.RED_INDEX]));
+            channel.setGreen(rint(defaultColor[ColorsFactory.GREEN_INDEX]));
+            channel.setBlue(rint(defaultColor[ColorsFactory.BLUE_INDEX]));
+            channel.setAlpha(rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
+          }
         }
-        TransmittanceRange t = filter.getTransmittanceRange();
-        return t == null? null :
-		rstring(String.valueOf(t.getCutIn().getValue()));
+      }
     }
-
-    /**
-     * Returns the concrete value of an OMERO rtype.
-     *
-     * @param value OMERO rtype to get the value of.
-     * @return Concrete value of <code>value</code> or <code>null</code> if
-     * <code>value == null</code>.
-     */
-    private Integer getValue(RInt value)
-    {
-	return value == null? null : value.getValue();
-    }
-
-    /**
-     * Determines the name of the channel.
-     * This method should only be invoked when a color was assigned by
-     * Bio-formats.
-     *
-     * @param channelData The channel to handle.
-     * @return See above.
-     */
-    private RString getChannelName(ChannelData channelData)
-    {
-	LogicalChannel lc = channelData.getLogicalChannel();
-	Length value = lc.getEmissionWave();
-	RString name;
-	if (value != null)
-	{
-		return rstring(getNameFromWavelength(value));
-	}
-	Iterator<Filter> i;
-	List<Filter> filters = channelData.getLightPathEmissionFilters();
-	if (filters != null) {
-		i = filters.iterator();
-		while (i.hasNext()) {
-			name = getNameFromFilter(i.next());
-			if (name != null) return name;
-		}
-	}
-
-	name = getNameFromFilter(channelData.getFilterSetEmissionFilter());
-	if (name != null)
-	{
-		return name;
-	}
-
-	//Laser
-	LightSource ls = channelData.getLightSource();
-	if (ls != null)
-	{
-		if (ls instanceof Laser)
-		{
-			Laser laser = (Laser) ls;
-			value = laser.getWavelength();
-			if (value != null)
-			{
-			    return rstring(getNameFromWavelength(value));
-			}
-		}
-	}
-	value = lc.getExcitationWave();
-	if (value != null)
-	{
-	    return rstring(getNameFromWavelength(value));
-	}
-	filters = channelData.getLightPathExcitationFilters();
-	if (filters != null) {
-		i = filters.iterator();
-		while (i.hasNext()) {
-			name = getNameFromFilter(i.next());
-			if (name != null) return name;
-			}
-	}
-	return getNameFromFilter(channelData.getFilterSetExcitationFilter());
-    }
-
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-	throws ModelException
-    {
-	this.store = store;
-	reader = this.store.getReader();
-	if (reader == null)
-	{
-		log.warn("Unexpected null reader.");
-		return;
-	}
-
-	List<Image> images = store.getSourceObjects(Image.class);
-	String[] domains = reader.getDomains();
-	boolean isGraphicsDomain = false;
-	for (String domain : domains)
-	{
-		if (FormatTools.GRAPHICS_DOMAIN.equals(domain))
-		{
-			log.debug("Images are of the graphics domain.");
-			isGraphicsDomain = true;
-			break;
-		}
-	}
-	log.debug("isGraphicsDomain: "+isGraphicsDomain);
-	int count;
-	boolean v;
-	Map<ChannelData, Boolean> m;
-	Pixels pixels;
-	int sizeC;
-	ChannelData channelData;
-	Iterator<ChannelData> k;
-	for (int i = 0; i < images.size(); i++)
-	{
-		pixels = (Pixels) store.getSourceObject(new LSID(Pixels.class, i));
-		if (pixels == null)
-		{
-			throw new ModelException("Unable to locate Pixels:" + i);
-		}
-		//Require to reset transmitted light
-		count = 0;
-		m = new HashMap<ChannelData, Boolean>();
-
-		//Think of strategy for images with high number of channels
-		//i.e. > 6
-		sizeC = pixels.getSizeC().getValue();
-		if (sizeC == 1) {
-		    channelData = ChannelData.fromObjectContainerStore(store, i, 0);
-		    setSingleChannel(channelData);
-		} else {
-		    for (int c = 0; c < sizeC; c++)
-	        {
-	            channelData = ChannelData.fromObjectContainerStore(store, i, c);
-	            //Color section
-	            populateDefault(channelData, isGraphicsDomain);
-
-	                //only retrieve if not graphics
-	                if (!isGraphicsDomain) {
-	            //Determine if the channel same emission wavelength.
-	            v = ColorsFactory.hasEmissionData(channelData);
-	            if (!v)
-	            {
-	                count++;
-	            }
-	                    m.put(channelData, v);
-	                }
-	        }
-		}
-
-		//Need to reset the color of transmitted light
-		//i.e. images with several "emission channels"
-		//check if 0 size
-
-		if (count > 0 && count != m.size()) {
-			k = m.keySet().iterator();
-			while (k.hasNext()) {
-				channelData = k.next();
-				if (!m.get(channelData)) {
-					int[] defaultColor = ColorsFactory.newWhiteColor();
-					Channel channel = channelData.getChannel();
-					channel.setRed(
-							rint(defaultColor[ColorsFactory.RED_INDEX]));
-					channel.setGreen(
-							rint(defaultColor[ColorsFactory.GREEN_INDEX]));
-					channel.setBlue(
-							rint(defaultColor[ColorsFactory.BLUE_INDEX]));
-					channel.setAlpha(
-							rint(defaultColor[ColorsFactory.ALPHA_INDEX]));
-				}
-			}
-		}
-	}
-    }
+  }
 
 }

--- a/components/blitz/src/ome/formats/model/ColorsFactory.java
+++ b/components/blitz/src/ome/formats/model/ColorsFactory.java
@@ -31,355 +31,356 @@ import omero.model.Length;
  */
 public class ColorsFactory {
 
-    /** Index of the red component of a color. */
-    public static final int RED_INDEX = 0;
+  /** Index of the red component of a color. */
+  public static final int RED_INDEX = 0;
 
-    /** Index of the red component of a color. */
-    public static final int GREEN_INDEX = 1;
+  /** Index of the red component of a color. */
+  public static final int GREEN_INDEX = 1;
 
-    /** Index of the red component of a color. */
-    public static final int BLUE_INDEX = 2;
+  /** Index of the red component of a color. */
+  public static final int BLUE_INDEX = 2;
 
-    /** Index of the red component of a color. */
-    public static final int ALPHA_INDEX = 3;
+  /** Index of the red component of a color. */
+  public static final int ALPHA_INDEX = 3;
 
-    /** The Default value for the alpha component. */
-    static final int DEFAULT_ALPHA = 255;
+  /** The Default value for the alpha component. */
+  static final int DEFAULT_ALPHA = 255;
 
-    /**
-     * Lower bound of the wavelength interval corresponding to a
-     * <code>BLUE</code> color.
-     */
-    private static final int BLUE_MIN = 400;
+  /**
+   * Lower bound of the wavelength interval corresponding to a
+   * <code>BLUE</code> color.
+   */
+  private static final int BLUE_MIN = 400;
 
-    /**
-     * Upper bound of the wavelength interval corresponding to a
-     * <code>BLUE</code> color and lower bound of the wavelength
-     * interval corresponding to a <code>GREEN</code> color.
-     */
-    private static final int BLUE_TO_GREEN_MIN = 500;
+  /**
+   * Upper bound of the wavelength interval corresponding to a
+   * <code>BLUE</code> color and lower bound of the wavelength
+   * interval corresponding to a <code>GREEN</code> color.
+   */
+  private static final int BLUE_TO_GREEN_MIN = 500;
 
-    /**
-     * Upper bound of the wavelength interval corresponding to a
-     * <code>GREEN</code> color and lower bound of the wavelength
-     * interval corresponding to a <code>RED</code> color.
-     */
-    private static final int GREEN_TO_RED_MIN = 560;
+  /**
+   * Upper bound of the wavelength interval corresponding to a
+   * <code>GREEN</code> color and lower bound of the wavelength
+   * interval corresponding to a <code>RED</code> color.
+   */
+  private static final int GREEN_TO_RED_MIN = 560;
 
-    /**
-     * Upper bound of the wavelength interval corresponding to a
-     * <code>RED</code> color.
-     */
-    private static final int RED_MAX = 700;
+  /**
+   * Upper bound of the wavelength interval corresponding to a
+   * <code>RED</code> color.
+   */
+  private static final int RED_MAX = 700;
 
-    /** The value to add to the cut-in to determine the color. */
-    private static final int RANGE = 15;
+  /** The value to add to the cut-in to determine the color. */
+  private static final int RANGE = 15;
 
-    /**
-     * Returns <code>true</code> if the wavelength is in the blue
-     * color band, <code>false</code> otherwise.
-     *
-     * @param wavelength The wavelength to handle.
-     * @return See above.
-     */
-    private static boolean rangeBlue(double wavelength) {
-        return wavelength < BLUE_TO_GREEN_MIN;
-    }
+  /**
+   * Returns <code>true</code> if the wavelength is in the blue
+   * color band, <code>false</code> otherwise.
+   *
+   * @param wavelength The wavelength to handle.
+   * @return See above.
+   */
+  private static boolean rangeBlue(double wavelength) {
+    return wavelength < BLUE_TO_GREEN_MIN;
+  }
 
-    /**
-     * Returns <code>true</code> if the wavelength is in the green
-     * color band, <code>false</code> otherwise.
-     *
-     * @param wavelength The wavelength to handle.
-     * @return See above.
-     */
-    private static boolean rangeGreen(double wavelength) {
-        return wavelength >= BLUE_TO_GREEN_MIN && wavelength < GREEN_TO_RED_MIN;
-    }
+  /**
+   * Returns <code>true</code> if the wavelength is in the green
+   * color band, <code>false</code> otherwise.
+   *
+   * @param wavelength The wavelength to handle.
+   * @return See above.
+   */
+  private static boolean rangeGreen(double wavelength) {
+    return wavelength >= BLUE_TO_GREEN_MIN && wavelength < GREEN_TO_RED_MIN;
+  }
 
-    /**
-     * Returns <code>true</code> if the wavelength is in the red
-     * color band, <code>false</code> otherwise.
-     *
-     * @param wavelength The wavelength to handle.
-     * @return See above.
-     */
-    private static boolean rangeRed(double wavelength) {
-        return wavelength >= GREEN_TO_RED_MIN;
-    }
+  /**
+   * Returns <code>true</code> if the wavelength is in the red
+   * color band, <code>false</code> otherwise.
+   *
+   * @param wavelength The wavelength to handle.
+   * @return See above.
+   */
+  private static boolean rangeRed(double wavelength) {
+    return wavelength >= GREEN_TO_RED_MIN;
+  }
 
-    /**
-     * Returns the concrete value of an OMERO rtype.
-     * @param value OMERO rtype to get the value of.
-     * @return Concrete value of <code>value</code> or <code>null</code> if
-     * <code>value == null</code>.
-     */
-    private static Integer getValue(RInt value)
-    {
-	return value == null? null : value.getValue();
-    }
+  /**
+   * Returns the concrete value of an OMERO rtype.
+   * @param value OMERO rtype to get the value of.
+   * @return Concrete value of <code>value</code> or <code>null</code> if
+   * <code>value == null</code>.
+   */
+  private static Integer getValue(RInt value) {
+    return value == null? null : value.getValue();
+  }
 
-    /**
-     * Returns <code>true</code> if the channel has emission metadata,
-     * <code>false</code> otherwise.
-     *
-     * @param f The filter to handle.
-     * @return See above.
-     */
-    private static boolean isFilterHasEmissionData(Filter f)
-    {
-	if (f == null) return false;
-	TransmittanceRange transmittance = f.getTransmittanceRange();
-	if (transmittance == null) return false;
-	return transmittance.getCutIn() != null;
-    }
+  /**
+   * Returns <code>true</code> if the channel has emission metadata,
+   * <code>false</code> otherwise.
+   *
+   * @param f The filter to handle.
+   * @return See above.
+   */
+  private static boolean isFilterHasEmissionData(Filter f) {
+    if (f == null) return false;
+    TransmittanceRange transmittance = f.getTransmittanceRange();
+    if (transmittance == null) return false;
+    return transmittance.getCutIn() != null;
+  }
 
-    /**
-     * Returns <code>true</code> if the channel has emission and/or excitation
-     * information, <code>false</code> otherwise.
-     *
-     * @param channelData Channel data to use to determine a color for.
-     * @param full Pass <code>true</code> to check emission and excitation,
-     * 			   <code>false</code> to only check emission.
-     * @return See above.
-     */
-    private static boolean hasEmissionExcitationData(ChannelData channelData,
-		boolean full)
-    {
-	LogicalChannel lc = channelData.getLogicalChannel();
-	if (lc == null) return false;
-	if (lc.getEmissionWave() != null) return true;
+  /**
+   * Returns <code>true</code> if the channel has emission and/or excitation
+   * information, <code>false</code> otherwise.
+   *
+   * @param channelData Channel data to use to determine a color for.
+   * @param full Pass <code>true</code> to check emission and excitation,
+   *          <code>false</code> to only check emission.
+   * @return See above.
+   */
+  private static boolean hasEmissionExcitationData(
+      ChannelData channelData, boolean full)
+  {
+    LogicalChannel lc = channelData.getLogicalChannel();
+    if (lc == null) return false;
+    if (lc.getEmissionWave() != null) return true;
 
-	List<Filter> filters = channelData.getLightPathEmissionFilters();
-	Iterator<Filter> i;
-	if (filters != null) {
-		i = filters.iterator();
-		while (i.hasNext()) {
-			if (isFilterHasEmissionData(i.next()))
-			return true;
-			}
-	}
-	if (channelData.getFilterSet() != null) {
-		Filter f = channelData.getFilterSetEmissionFilter();
-		if (isFilterHasEmissionData(f)) return true;
-	}
-
-	if (!full) return false;
-	//Excitation
-	//Laser
-	if (channelData.getLightSource() != null) {
-		LightSource src = channelData.getLightSource();
-		if (src instanceof Laser) {
-			Laser laser = (Laser) src;
-			if (laser.getWavelength() != null) return true;
-		}
-	}
-	if (lc.getExcitationWave() != null) return true;
-	filters = channelData.getLightPathExcitationFilters();
-	if (filters != null) {
-		i = filters.iterator();
-		while (i.hasNext()) {
-			if (isFilterHasEmissionData(i.next()))
-			return true;
-			}
-	}
-	if (channelData.getFilterSet() != null) {
-		Filter f = channelData.getFilterSetExcitationFilter();
-		if (isFilterHasEmissionData(f)) return true;
-	}
-
-	return false;
-    }
-
-    /**
-     * Returns the range of the wavelength or <code>null</code>.
-     *
-     * @param filter   The filter to handle.
-     * @param emission Passed <code>true</code> to indicate that the filter is
-     * 				   an emission filter, <code>false</code> otherwise.
-     * @return See above.
-     */
-    static Length getValueFromFilter(Filter filter, boolean emission)
-    {
-	if (filter == null) return null;
-	TransmittanceRange transmittance = filter.getTransmittanceRange();
-	if (transmittance == null) return null;
-	Length cutIn = transmittance.getCutIn();
-
-	if (emission) {
-		if (cutIn == null) return null;
-		return makeLength(cutIn.getValue()+RANGE, cutIn.getUnit());
-	}
-	Length cutOut = transmittance.getCutOut();
-	if (cutOut == null) return null;
-	if (cutIn == null || cutIn.getValue() == 0)
-	    cutIn = makeLength(cutOut.getValue()-2*RANGE, cutOut.getUnit());
-	// FIXME: are these in the same unit?
-	Length v = makeLength((cutIn.getValue()+cutOut.getValue())/2, cutIn.getUnit());
-	if (v.getValue() < 0) return makeLength(0.0, ome.formats.model.UnitsFactory.TransmittanceRange_CutIn);
-	return v;
-    }
-
-    /**
-     * Determines the color usually associated to the specified
-     * wavelength or explicitly defined for a particular channel.
-     *
-     * @param channelData Channel data to use to determine a color for.
-     */
-    public static int[] getColor(ChannelData channelData) {
-	LogicalChannel lc = channelData.getLogicalChannel();
-	Channel channel = channelData.getChannel();
-	if (lc == null) return null;
-	if (!hasEmissionExcitationData(channelData, true)) {
-		Integer red = getValue(channel.getRed());
-            Integer green = getValue(channel.getGreen());
-            Integer blue = getValue(channel.getBlue());
-            Integer alpha = getValue(channel.getAlpha());
-            if (red != null && green != null && blue != null && alpha != null) {
-		// We've got a color image of some type that has explicitly
-		// specified which channel is Red, Green, Blue or some other wacky
-		// color.
-		//if (red == 0 && green == 0 && blue == 0 && alpha == 0)
-		//	alpha = DEFAULT_ALPHA;
-                return new int[] { red, green, blue, alpha };
-            }
-            // XXX: Is commenting this out right?
-            //return null;
+    List<Filter> filters = channelData.getLightPathEmissionFilters();
+    Iterator<Filter> i;
+    if (filters != null) {
+      i = filters.iterator();
+      while (i.hasNext()) {
+        if (isFilterHasEmissionData(i.next()))
+          return true;
       }
+    }
+    if (channelData.getFilterSet() != null) {
+      Filter f = channelData.getFilterSetEmissionFilter();
+      if (isFilterHasEmissionData(f)) return true;
+    }
 
-      Length valueWavelength = lc.getEmissionWave();
-      //First we check the emission wavelength.
-        if (valueWavelength != null) return determineColor(valueWavelength);
+    if (!full) return false;
+    //Excitation
+    //Laser
+    if (channelData.getLightSource() != null) {
+      LightSource src = channelData.getLightSource();
+      if (src instanceof Laser) {
+        Laser laser = (Laser) src;
+        if (laser.getWavelength() != null) return true;
+      }
+    }
+    if (lc.getExcitationWave() != null) return true;
+    filters = channelData.getLightPathExcitationFilters();
+    if (filters != null) {
+      i = filters.iterator();
+      while (i.hasNext()) {
+        if (isFilterHasEmissionData(i.next()))
+          return true;
+      }
+    }
+    if (channelData.getFilterSet() != null) {
+      Filter f = channelData.getFilterSetExcitationFilter();
+      if (isFilterHasEmissionData(f)) return true;
+    }
 
-      Length valueFilter = null;
-      //First check the emission filter.
-      //First check if filter
-      //light path first
-      List<Filter> filters = channelData.getLightPathEmissionFilters();
-      Iterator<Filter> i;
+    return false;
+  }
+
+  /**
+   * Returns the range of the wavelength or <code>null</code>.
+   *
+   * @param filter   The filter to handle.
+   * @param emission Passed <code>true</code> to indicate that the filter is
+   *            an emission filter, <code>false</code> otherwise.
+   * @return See above.
+   */
+  static Length getValueFromFilter(Filter filter, boolean emission) {
+    if (filter == null) return null;
+    TransmittanceRange transmittance = filter.getTransmittanceRange();
+    if (transmittance == null) return null;
+    Length cutIn = transmittance.getCutIn();
+
+    if (emission) {
+      if (cutIn == null) return null;
+      return makeLength(cutIn.getValue()+RANGE, cutIn.getUnit());
+    }
+    Length cutOut = transmittance.getCutOut();
+    if (cutOut == null) return null;
+    if (cutIn == null || cutIn.getValue() == 0)
+      cutIn = makeLength(cutOut.getValue()-2*RANGE, cutOut.getUnit());
+    // FIXME: are these in the same unit?
+    Length v = makeLength(
+        (cutIn.getValue()+cutOut.getValue())/2, cutIn.getUnit());
+    if (v.getValue() < 0)
+      return makeLength(
+          0.0, ome.formats.model.UnitsFactory.TransmittanceRange_CutIn);
+    return v;
+  }
+
+  /**
+   * Determines the color usually associated to the specified
+   * wavelength or explicitly defined for a particular channel.
+   *
+   * @param channelData Channel data to use to determine a color for.
+   */
+  public static int[] getColor(ChannelData channelData) {
+    LogicalChannel lc = channelData.getLogicalChannel();
+    Channel channel = channelData.getChannel();
+    if (lc == null) return null;
+    if (!hasEmissionExcitationData(channelData, true)) {
+      Integer red = getValue(channel.getRed());
+      Integer green = getValue(channel.getGreen());
+      Integer blue = getValue(channel.getBlue());
+      Integer alpha = getValue(channel.getAlpha());
+      if (red != null && green != null && blue != null && alpha != null) {
+        // We've got a color image of some type that has explicitly
+        // specified which channel is Red, Green, Blue or some other wacky
+        // color.
+        //if (red == 0 && green == 0 && blue == 0 && alpha == 0)
+        //  alpha = DEFAULT_ALPHA;
+        return new int[] { red, green, blue, alpha };
+      }
+      // XXX: Is commenting this out right?
+      //return null;
+    }
+
+    Length valueWavelength = lc.getEmissionWave();
+    //First we check the emission wavelength.
+    if (valueWavelength != null) return determineColor(valueWavelength);
+
+    Length valueFilter = null;
+    //First check the emission filter.
+    //First check if filter
+    //light path first
+    List<Filter> filters = channelData.getLightPathEmissionFilters();
+    Iterator<Filter> i;
+    if (filters != null) {
+      i = filters.iterator();
+      while (valueFilter == null && i.hasNext()) {
+        valueFilter = getValueFromFilter(i.next(), true);
+      }
+    }
+
+    if (valueFilter == null)
+      valueFilter = getValueFromFilter(
+          channelData.getFilterSetEmissionFilter(), true);
+
+    //Laser
+    if (valueWavelength == null &&
+        valueFilter == null &&
+        channelData.getLightSource() != null) {
+      LightSource ls = channelData.getLightSource();
+      if (ls instanceof Laser) {
+        valueWavelength = ((Laser) ls).getWavelength();
+      }
+    }
+    if (valueWavelength != null) return determineColor(valueWavelength);
+
+    //Excitation
+    valueWavelength = lc.getExcitationWave();
+    if (valueWavelength != null) return determineColor(valueWavelength);
+
+    if (valueFilter == null) {
+      filters = channelData.getLightPathExcitationFilters();
       if (filters != null) {
-		i = filters.iterator();
-		while (valueFilter == null && i.hasNext()) {
-				valueFilter = getValueFromFilter(i.next(), true);
-			}
+        i = filters.iterator();
+        while (valueFilter == null && i.hasNext()) {
+          valueFilter = getValueFromFilter(i.next(), false);
+        }
       }
-
-	if (valueFilter == null)
-		valueFilter = getValueFromFilter(
-				channelData.getFilterSetEmissionFilter(), true);
-
-	//Laser
-	if (valueWavelength == null && valueFilter == null && channelData.getLightSource() != null) {
-		LightSource ls = channelData.getLightSource();
-		if (ls instanceof Laser) {
-			valueWavelength = ((Laser) ls).getWavelength();
-		}
-	}
-	if (valueWavelength != null) return determineColor(valueWavelength);
-
-	//Excitation
-	valueWavelength = lc.getExcitationWave();
-	if (valueWavelength != null) return determineColor(valueWavelength);
-
-	if (valueFilter == null) {
-		filters = channelData.getLightPathExcitationFilters();
-		if (filters != null) {
-		i = filters.iterator();
-		while (valueFilter == null && i.hasNext()) {
-				valueFilter = getValueFromFilter(i.next(), false);
-			}
-            }
-	}
-	if (valueFilter == null)
-		valueFilter = getValueFromFilter(
-				channelData.getFilterSetExcitationFilter(), false);
-
-	int[] toReturn = determineColor(valueFilter);
-	if (toReturn != null)
-	{
-		return toReturn;
-	}
-	switch (channelData.getChannelIndex()) {
-		case 0: return newRedColor();
-		case 1: return newGreenColor();
-		default: return newBlueColor();
-		/*
-		case 1: return newBlueColor();
-		default: return newGreenColor();
-		*/
-	}
-
     }
+    if (valueFilter == null)
+      valueFilter = getValueFromFilter(
+          channelData.getFilterSetExcitationFilter(), false);
 
-    /**
-     * Determines the color corresponding to the passed value.
-     *
-     * @param value The value to handle.
-     */
-    public static int[] determineColor(Length value)
-    {
-	if (value == null) return null;
-	if (rangeBlue(value.getValue())) return newBlueColor();
-	if (rangeGreen(value.getValue())) return newGreenColor();
-	if (rangeRed(value.getValue())) return newRedColor();
-	return null;
+    int[] toReturn = determineColor(valueFilter);
+    if (toReturn != null) {
+      return toReturn;
     }
+    switch (channelData.getChannelIndex()) {
+    case 0:
+      return newRedColor();
+    case 1:
+      return newGreenColor();
+    default:
+      return newBlueColor();
+    /*
+      case 1: return newBlueColor();
+      default: return newGreenColor();
+    */
+    }
+  }
 
-    /**
-     * Returns <code>true</code> if the channel has emission metadata,
-     * <code>false</code> otherwise.
-     *
-     * @param channelData Channel data to use to determine a color for.
-     * @return See above.
-     */
-    public static boolean hasEmissionData(ChannelData channelData)
-    {
-	return hasEmissionExcitationData(channelData, false);
-    }
+  /**
+   * Determines the color corresponding to the passed value.
+   *
+   * @param value The value to handle.
+   */
+  public static int[] determineColor(Length value) {
+    if (value == null) return null;
+    if (rangeBlue(value.getValue())) return newBlueColor();
+    if (rangeGreen(value.getValue())) return newGreenColor();
+    if (rangeRed(value.getValue())) return newRedColor();
+    return null;
+  }
 
-    /**
-     * Creates a new <i>Red</i> Color object.
-     *
-     * @return An RGBA array representation of the color Red.
-     */
-    public static int[] newRedColor() {
-        return new int[] { 255, 0, 0, DEFAULT_ALPHA };
-    }
+  /**
+   * Returns <code>true</code> if the channel has emission metadata,
+   * <code>false</code> otherwise.
+   *
+   * @param channelData Channel data to use to determine a color for.
+   * @return See above.
+   */
+  public static boolean hasEmissionData(ChannelData channelData) {
+    return hasEmissionExcitationData(channelData, false);
+  }
 
-    /**
-     * Creates a new <i>Green</i> Color object.
-     *
-     * @return An RGBA array representation of the color Green.
-     */
-    public static int[] newGreenColor() {
-        return new int[] { 0, 255, 0, DEFAULT_ALPHA };
-    }
+  /**
+   * Creates a new <i>Red</i> Color object.
+   *
+   * @return An RGBA array representation of the color Red.
+   */
+  public static int[] newRedColor() {
+    return new int[] { 255, 0, 0, DEFAULT_ALPHA };
+  }
 
-    /**
-     * Creates a new <i>Blue</i> Color object.
-     *
-     * @return An RGBA array representation of the color Blue.
-     */
-    public static int[] newBlueColor() {
-        return new int[] { 0, 0, 255, DEFAULT_ALPHA };
-    }
+  /**
+   * Creates a new <i>Green</i> Color object.
+   *
+   * @return An RGBA array representation of the color Green.
+   */
+  public static int[] newGreenColor() {
+    return new int[] { 0, 255, 0, DEFAULT_ALPHA };
+  }
 
-    /**
-     * Creates a new <i>Grey</i> Color object.
-     *
-     * @return An RGBA array representation of the color Blue.
-     */
-    public static int[] newGreyColor() {
-        return new int[] { 128, 128, 128, DEFAULT_ALPHA };
-    }
+  /**
+   * Creates a new <i>Blue</i> Color object.
+   *
+   * @return An RGBA array representation of the color Blue.
+   */
+  public static int[] newBlueColor() {
+    return new int[] { 0, 0, 255, DEFAULT_ALPHA };
+  }
 
-    /**
-     * Creates a new <i>White</i> Color object.
-     *
-     * @return An RGBA array representation of the color Blue.
-     */
-    public static int[] newWhiteColor() {
-        return new int[] { 255, 255, 255, DEFAULT_ALPHA };
-    }
+  /**
+   * Creates a new <i>Grey</i> Color object.
+   *
+   * @return An RGBA array representation of the color Blue.
+   */
+  public static int[] newGreyColor() {
+    return new int[] { 128, 128, 128, DEFAULT_ALPHA };
+  }
+
+  /**
+   * Creates a new <i>White</i> Color object.
+   *
+   * @return An RGBA array representation of the color Blue.
+   */
+  public static int[] newWhiteColor() {
+    return new int[] { 255, 255, 255, DEFAULT_ALPHA };
+  }
 
 }

--- a/components/blitz/src/ome/formats/model/IObjectContainerStore.java
+++ b/components/blitz/src/ome/formats/model/IObjectContainerStore.java
@@ -42,205 +42,203 @@ import omero.model.IObject;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public interface IObjectContainerStore
-{
-	/**
-	 * Returns the current Bio-Formats reader that has been used to populate
-	 * the container store.
-	 * @return See above.
-	 */
-	IFormatReader getReader();
+public interface IObjectContainerStore {
+  /**
+   * Returns the current Bio-Formats reader that has been used to populate
+   * the container store.
+   * @return See above.
+   */
+  IFormatReader getReader();
 
-	/**
-	 * Sets the Bio-Formats reader that will be used to populate the container
-	 * store.
-	 * @param reader Bio-Formats reader.
-	 */
-	void setReader(IFormatReader reader);
+  /**
+   * Sets the Bio-Formats reader that will be used to populate the container
+   * store.
+   * @param reader Bio-Formats reader.
+   */
+  void setReader(IFormatReader reader);
 
-	/**
-	 * Returns the user specified annotations.
-	 * @return See above.
-	 */
-	List<Annotation> getUserSpecifiedAnnotations();
+  /**
+   * Returns the user specified annotations.
+   * @return See above.
+   */
+  List<Annotation> getUserSpecifiedAnnotations();
 
-    /**
-     * Sets the user specified image annotations.
-     * @param annotations user specified annotations
-     */
-    void setUserSpecifiedAnnotations(List<Annotation> annotations);
+  /**
+   * Sets the user specified image annotations.
+   * @param annotations user specified annotations
+   */
+  void setUserSpecifiedAnnotations(List<Annotation> annotations);
 
-    /**
-     * Returns the user specified image/plate name.
-     * @return See above.
-     */
-    String getUserSpecifiedName();
+  /**
+   * Returns the user specified image/plate name.
+   * @return See above.
+   */
+  String getUserSpecifiedName();
 
-    /**
-     * Sets the user specified image/plate name.
-     * @param name user specified image/plate name
-     */
-    void setUserSpecifiedName(String name);
+  /**
+   * Sets the user specified image/plate name.
+   * @param name user specified image/plate name
+   */
+  void setUserSpecifiedName(String name);
 
-    /**
-     * Returns the user specified image/plate description.
-     * @return See above.
-     */
-    String getUserSpecifiedDescription();
+  /**
+   * Returns the user specified image/plate description.
+   * @return See above.
+   */
+  String getUserSpecifiedDescription();
 
-    /**
-     * Sets the user specified image/plate description.
-     * @param description user-specified image/plate description
-     */
-    void setUserSpecifiedDescription(String description);
+  /**
+   * Sets the user specified image/plate description.
+   * @param description user-specified image/plate description
+   */
+  void setUserSpecifiedDescription(String description);
 
-    /**
-     * Returns the user-specified linkage target (usually a Dataset for Images)
-     * and a Screen for Plates).
-     * @return See above.
-     */
-    IObject getUserSpecifiedTarget();
+  /**
+   * Returns the user-specified linkage target (usually a Dataset for Images)
+   * and a Screen for Plates).
+   * @return See above.
+   */
+  IObject getUserSpecifiedTarget();
 
-    /**
-     * Sets the user-specified linkage target (usually a Dataset for Images)
-     * and a Screen for Plates).
-     * @param target user-specified linkage target
-     */
-    void setUserSpecifiedTarget(IObject target);
+  /**
+   * Sets the user-specified linkage target (usually a Dataset for Images)
+   * and a Screen for Plates).
+   * @param target user-specified linkage target
+   */
+  void setUserSpecifiedTarget(IObject target);
 
-    /**
-     * Returns the user specified physical pixel sizes.
-     * @return An array of double[] { physicalSizeX, physicalSizeY,
-     * physicalSizeZ } as specified by the user. A value of <code>null</code>
-     * for any one index states the user has not made a choice for the size
-     * of that particular dimension.
-     */
-    Double[] getUserSpecifiedPhysicalPixelSizes();
+  /**
+   * Returns the user specified physical pixel sizes.
+   * @return An array of double[] { physicalSizeX, physicalSizeY,
+   * physicalSizeZ } as specified by the user. A value of <code>null</code>
+   * for any one index states the user has not made a choice for the size
+   * of that particular dimension.
+   */
+  Double[] getUserSpecifiedPhysicalPixelSizes();
 
-    /**
-     * Sets the user specified physical pixel sizes. A value of
-     * <code>null</code> states the original file physical size for that
-     * dimension should be used.
-     * @param physicalSizeX Physical pixel size width.
-     * @param physicalSizeY Physical pixel height.
-     * @param physicalSizeZ Physical pixel depth.
-     */
-    void setUserSpecifiedPhysicalPixelSizes(Double physicalSizeX,
-		                                Double physicalSizeY,
-		                                Double physicalSizeZ);
+  /**
+   * Sets the user specified physical pixel sizes. A value of
+   * <code>null</code> states the original file physical size for that
+   * dimension should be used.
+   * @param physicalSizeX Physical pixel size width.
+   * @param physicalSizeY Physical pixel height.
+   * @param physicalSizeZ Physical pixel depth.
+   */
+  void setUserSpecifiedPhysicalPixelSizes(
+      Double physicalSizeX, Double physicalSizeY, Double physicalSizeZ);
 
-    /**
-     * Returns the current authoritative LSID container cache. This container
-     * cache records the explicitly set LSID to container references.
-     * @return See above.
-     */
-    Map<Class<? extends IObject>, Map<String, IObjectContainer>>
-	getAuthoritativeContainerCache();
+  /**
+   * Returns the current authoritative LSID container cache. This container
+   * cache records the explicitly set LSID to container references.
+   * @return See above.
+   */
+  Map<Class<? extends IObject>, Map<String, IObjectContainer>>
+      getAuthoritativeContainerCache();
 
-    /**
-     * Returns the current container cache.
-     * @return See above.
-     */
-    Map<LSID, IObjectContainer> getContainerCache();
+  /**
+   * Returns the current container cache.
+   * @return See above.
+   */
+  Map<LSID, IObjectContainer> getContainerCache();
 
-    /**
-     * Returns the current reference cache.
-     * @return See above.
-     */
-    Map<LSID, List<LSID>> getReferenceCache();
+  /**
+   * Returns the current reference cache.
+   * @return See above.
+   */
+  Map<LSID, List<LSID>> getReferenceCache();
 
-    /**
-     * Adds a reference to the reference cache.
-     * @param source Source LSID to add.
-     * @param target Target LSID to add.
-     */
-    void addReference(LSID source, LSID target);
+  /**
+   * Adds a reference to the reference cache.
+   * @param source Source LSID to add.
+   * @param target Target LSID to add.
+   */
+  void addReference(LSID source, LSID target);
 
-    /**
-     * Returns the current string based reference cache. This is usually
-     * populated by a ReferenceProcessor instance.
-     * @return See above.
-     */
-    Map<String, String[]> getReferenceStringCache();
+  /**
+   * Returns the current string based reference cache. This is usually
+   * populated by a ReferenceProcessor instance.
+   * @return See above.
+   */
+  Map<String, String[]> getReferenceStringCache();
 
-    /**
-     * Sets the string based reference cache for this container store. This is
-     * usually called by a ReferenceProcessor instance.
-     * @param referenceStringCache String based reference cache to use.
-     */
-    void setReferenceStringCache(Map<String, String[]> referenceStringCache);
+  /**
+   * Sets the string based reference cache for this container store. This is
+   * usually called by a ReferenceProcessor instance.
+   * @param referenceStringCache String based reference cache to use.
+   */
+  void setReferenceStringCache(Map<String, String[]> referenceStringCache);
 
-    /**
-     * Retrieves an OMERO Blitz source object for a given LSID.
-     * @param LSID LSID to retrieve a source object for.
-     * @return See above.
-     */
-    IObject getSourceObject(LSID LSID);
+  /**
+   * Retrieves an OMERO Blitz source object for a given LSID.
+   * @param LSID LSID to retrieve a source object for.
+   * @return See above.
+   */
+  IObject getSourceObject(LSID LSID);
 
-    /**
-     * Retrieves all OMERO Blitz source objects of a given class.
-     * @param klass Class to retrieve source objects for.
-     * @return See above.
-     */
-    <T extends IObject> List<T> getSourceObjects(Class<T> klass);
+  /**
+   * Retrieves all OMERO Blitz source objects of a given class.
+   * @param klass Class to retrieve source objects for.
+   * @return See above.
+   */
+  <T extends IObject> List<T> getSourceObjects(Class<T> klass);
 
-    /**
-     * Retrieves an IObject container for a given class and location within the
-     * OME-XML data model. <b>NOTE:</b> The container will be created if it
-     * does not already exist.
-     * @param klass Class to retrieve a container for.
-     * @param indexes Indexes into the OME-XML data model.
-     * @return See above.
-     */
-    IObjectContainer getIObjectContainer(Class<? extends IObject> klass,
-		                             LinkedHashMap<Index, Integer> indexes);
+  /**
+   * Retrieves an IObject container for a given class and location within the
+   * OME-XML data model. <b>NOTE:</b> The container will be created if it
+   * does not already exist.
+   * @param klass Class to retrieve a container for.
+   * @param indexes Indexes into the OME-XML data model.
+   * @return See above.
+   */
+  IObjectContainer getIObjectContainer(
+      Class<? extends IObject> klass, LinkedHashMap<Index, Integer> indexes);
 
-    /**
-     * Removes an IObject container from within the OME-XML data model store.
-     * @param lsid LSID of the container to remove.
-     */
-    void removeIObjectContainer(LSID lsid);
+  /**
+   * Removes an IObject container from within the OME-XML data model store.
+   * @param lsid LSID of the container to remove.
+   */
+  void removeIObjectContainer(LSID lsid);
 
-    /**
-     * Retrieves all IObject containers of a given class. <b>NOTE:</b> this
-     * will only return <b>existing</b> containers.
-     * @param klass Class to retrieve containers for.
-     * @return See above.
-     */
-    List<IObjectContainer> getIObjectContainers(Class<? extends IObject> klass);
+  /**
+   * Retrieves all IObject containers of a given class. <b>NOTE:</b> this
+   * will only return <b>existing</b> containers.
+   * @param klass Class to retrieve containers for.
+   * @return See above.
+   */
+  List<IObjectContainer> getIObjectContainers(Class<? extends IObject> klass);
 
-    /**
-     * Counts the number of containers the MetadataStore has of a given class
-     * and at a given index of the hierarchy if specified.
-     * @param klass Class to count containers of.
-     * @param indexes Indexes to use in the container count. For example, if
-     * <code>klass</code> is <code>Image</code> and indexes is
-     * <code>int[] { 0 };</code> only containers that have an LSID of type
-     * <code>Image</code> and a first index of <code>0</code> will be counted.
-     * @return See above.
-     */
-    int countCachedContainers(Class<? extends IObject> klass, int... indexes);
+  /**
+   * Counts the number of containers the MetadataStore has of a given class
+   * and at a given index of the hierarchy if specified.
+   * @param klass Class to count containers of.
+   * @param indexes Indexes to use in the container count. For example, if
+   * <code>klass</code> is <code>Image</code> and indexes is
+   * <code>int[] { 0 };</code> only containers that have an LSID of type
+   * <code>Image</code> and a first index of <code>0</code> will be counted.
+   * @return See above.
+   */
+  int countCachedContainers(Class<? extends IObject> klass, int... indexes);
 
-    /**
-     * Counts the number of references the MetadataStore has between objects
-     * of two classes.
-     * @param source Class of the source object. If <code>null</code> it is
-     * treated as a wild card, all references whose target match
-     * <code>target</code> will be counted.
-     * @param target Class of the target object. If <code>null</code> it is
-     * treated as a wild card, all references whose source match
-     * <code>source</code> will be counted.
-     * @return See above.
-     */
-    int countCachedReferences(Class<? extends IObject> source,
-                              Class<? extends IObject> target);
+  /**
+   * Counts the number of references the MetadataStore has between objects
+   * of two classes.
+   * @param source Class of the source object. If <code>null</code> it is
+   * treated as a wild card, all references whose target match
+   * <code>target</code> will be counted.
+   * @param target Class of the target object. If <code>null</code> it is
+   * treated as a wild card, all references whose source match
+   * <code>source</code> will be counted.
+   * @return See above.
+   */
+  int countCachedReferences(
+      Class<? extends IObject> source, Class<? extends IObject> target);
 
-    /**
-     * Checks to see if there is currently an active reference for two LSIDs.
-     * @param source LSID of the source object.
-     * @param target LSID of the target object.
-     * @return <code>true</code> if a reference exists, <code>false</code>
-     * otherwise.
-     */
-    boolean hasReference(LSID source, LSID target);
+  /**
+   * Checks to see if there is currently an active reference for two LSIDs.
+   * @param source LSID of the source object.
+   * @param target LSID of the target object.
+   * @return <code>true</code> if a reference exists, <code>false</code>
+   * otherwise.
+   */
+  boolean hasReference(LSID source, LSID target);
 }

--- a/components/blitz/src/ome/formats/model/InstanceProvider.java
+++ b/components/blitz/src/ome/formats/model/InstanceProvider.java
@@ -34,13 +34,12 @@ import omero.model.IObject;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public interface InstanceProvider
-{
-    /**
-     * Retrieves an instance.
-     * @param klass Instance's base class from <code>omero.model</code>.
-     * @return Concrete instance of <code>klass</code>.
-     * @throws ModelException If there is an error retrieving the instance.
-     */
-	<T extends IObject> T getInstance(Class<T> klass) throws ModelException;
+public interface InstanceProvider {
+  /**
+   * Retrieves an instance.
+   * @param klass Instance's base class from <code>omero.model</code>.
+   * @return Concrete instance of <code>klass</code>.
+   * @throws ModelException If there is an error retrieving the instance.
+   */
+  <T extends IObject> T getInstance(Class<T> klass) throws ModelException;
 }

--- a/components/blitz/src/ome/formats/model/InstanceProvider.java
+++ b/components/blitz/src/ome/formats/model/InstanceProvider.java
@@ -1,5 +1,5 @@
 /*
- * ome.formats.enums.EnumerationProvider
+ * ome.formats.enums.InstanceProvider
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.

--- a/components/blitz/src/ome/formats/model/InstrumentProcessor.java
+++ b/components/blitz/src/ome/formats/model/InstrumentProcessor.java
@@ -48,43 +48,39 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class InstrumentProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(InstrumentProcessor.class);
+public class InstrumentProcessor implements ModelProcessor {
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(InstrumentProcessor.class);
 
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-    throws ModelException
-    {
-        List<IObjectContainer> containers =
-            store.getIObjectContainers(Detector.class);
-        containers.addAll(store.getIObjectContainers(Objective.class));
-        containers.addAll(store.getIObjectContainers(OTF.class));
-        containers.addAll(store.getIObjectContainers(Arc.class));
-        containers.addAll(store.getIObjectContainers(Laser.class));
-        containers.addAll(store.getIObjectContainers(Filament.class));
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    List<IObjectContainer> containers =
+      store.getIObjectContainers(Detector.class);
+    containers.addAll(store.getIObjectContainers(Objective.class));
+    containers.addAll(store.getIObjectContainers(OTF.class));
+    containers.addAll(store.getIObjectContainers(Arc.class));
+    containers.addAll(store.getIObjectContainers(Laser.class));
+    containers.addAll(store.getIObjectContainers(Filament.class));
 
-        for (IObjectContainer container : containers)
-        {
-            Integer instrumentIndex = container.indexes.get(Index.INSTRUMENT_INDEX.getValue());
-            Instrument instrument =
-		(Instrument) store.getSourceObject(new LSID(Instrument.class,
-				                           instrumentIndex));
+    for (IObjectContainer container : containers) {
+      Integer instrumentIndex = container.indexes.get(
+          Index.INSTRUMENT_INDEX.getValue());
+      Instrument instrument = (Instrument) store.getSourceObject(
+          new LSID(Instrument.class, instrumentIndex));
 
-            // If instrument is missing
-            if (instrument == null)
-            {
-                LinkedHashMap<Index, Integer> indexes =
-                    new LinkedHashMap<Index, Integer>();
-                indexes.put(Index.INSTRUMENT_INDEX, instrumentIndex);
-                container = store.getIObjectContainer(Instrument.class, indexes);
-                instrument = (Instrument) container.sourceObject;
-            }
-        }
-     }
+      // If instrument is missing
+      if (instrument == null) {
+        LinkedHashMap<Index, Integer> indexes =
+          new LinkedHashMap<Index, Integer>();
+        indexes.put(Index.INSTRUMENT_INDEX, instrumentIndex);
+        container = store.getIObjectContainer(Instrument.class, indexes);
+        instrument = (Instrument) container.sourceObject;
+      }
+    }
+  }
+
 }

--- a/components/blitz/src/ome/formats/model/ModelException.java
+++ b/components/blitz/src/ome/formats/model/ModelException.java
@@ -31,51 +31,46 @@ import omero.model.IObject;
  *
  * @author Chris Allan <callan at blackcat dot ca>
  */
-public class ModelException extends RuntimeException
-{
-	private static final long serialVersionUID = 4158130517527782400L;
+public class ModelException extends RuntimeException {
 
-	/** The class that was used in a failed instantiation. */
-    private Class<? extends IObject> failureClass;
+  private static final long serialVersionUID = 4158130517527782400L;
 
-    /**
-     * Default constructor.
-     * @param message Error message.
-     */
-    public ModelException(String message)
-    {
-	super(message);
+  /** The class that was used in a failed instantiation. */
+  private Class<? extends IObject> failureClass;
+
+  /**
+   * Default constructor.
+   * @param message Error message.
+   */
+  public ModelException(String message) {
+    super(message);
+  }
+
+  /**
+   * Default constructor.
+   * @param message Error message.
+   * @param klass Failed instantiation class.
+   * @param exception Upstream exception.
+   */
+  public ModelException(
+      String message, Class<? extends IObject> klass, Exception exception) {
+    super(message, exception);
+    this.failureClass = klass;
+  }
+
+  /**
+   * Returns the class that was used during a failed instantiation.
+   * @return See above.
+   */
+  public Class<? extends IObject> getFailureClass() {
+    return failureClass;
+  }
+
+  @Override
+  public String toString() {
+    if (failureClass == null) {
+      return getMessage();
     }
-
-    /**
-     * Default constructor.
-     * @param message Error message.
-     * @param klass Failed instantiation class.
-     * @param exception Upstream exception.
-     */
-    public ModelException(String message, Class<? extends IObject> klass,
-		              Exception exception)
-    {
-        super(message, exception);
-        this.failureClass = klass;
-    }
-
-    /**
-     * Returns the class that was used during a failed instantiation.
-     * @return See above.
-     */
-    public Class<? extends IObject> getFailureClass()
-    {
-        return failureClass;
-    }
-
-    @Override
-    public String toString()
-    {
-	if (failureClass == null)
-	{
-		return getMessage();
-	}
-        return getMessage() + " for " + failureClass;
-    }
+    return getMessage() + " for " + failureClass;
+  }
 }

--- a/components/blitz/src/ome/formats/model/ModelException.java
+++ b/components/blitz/src/ome/formats/model/ModelException.java
@@ -1,5 +1,5 @@
 /*
- * ome.formats.EnumerationException
+ * ome.formats.ModelException
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.

--- a/components/blitz/src/ome/formats/model/ModelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ModelProcessor.java
@@ -29,12 +29,11 @@ package ome.formats.model;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public interface ModelProcessor
-{
-    /**
-     * Processes an IObjectContainerStore.
-     * @param store IObjectContainer store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    void process(IObjectContainerStore store) throws ModelException;
+public interface ModelProcessor {
+  /**
+   * Processes an IObjectContainerStore.
+   * @param store IObjectContainer store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  void process(IObjectContainerStore store) throws ModelException;
 }

--- a/components/blitz/src/ome/formats/model/ModelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ModelProcessor.java
@@ -32,8 +32,8 @@ package ome.formats.model;
 public interface ModelProcessor
 {
     /**
-     * Processes the an IObjectContainerStore.
-     * @param store IObjectContainer store store to process.
+     * Processes an IObjectContainerStore.
+     * @param store IObjectContainer store to process.
      * @throws ModelException If there is an error during processing.
      */
     void process(IObjectContainerStore store) throws ModelException;

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -44,10 +44,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Processes the pixels sets of an IObjectContainerStore and ensures
- * that the physical pixel dimensions are updated if they were specified by
- * the user. If Image containers are present, Image.acquisitionDate is filled
- * out and that the Image name and description match that which was specified
- * by the user if the if provided either.
+ * that the physical pixel dimensions, Image name and description are
+ * updated to the corresponding user-provided values, if present.
  *
  * @author Chris Allan <callan at blackcat dot ca>
  *

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -132,32 +132,6 @@ public class PixelsProcessor implements ModelProcessor
                 image = (Image) container.sourceObject;
             }
 
-            /*
-             * Acquisition dates returned to being nullable, but this code may have value following
-             * TODO deeper review of why it was added in the first place.
-
-            // If acquistionDate is missing
-            if (image.getAcquisitionDate() == null)
-            {
-                if (earliestMTime == null)
-                {
-                    String[] fileNameList = store.getReader().getUsedFiles();
-
-                    long mtime = Long.MAX_VALUE;
-
-                    for (int j = 0; j < fileNameList.length; j++)
-                    {
-                        File f = new File(fileNameList[j]);
-
-                        if (f.lastModified() < mtime)
-                            mtime = f.lastModified();
-                    }
-                    earliestMTime = new Timestamp(mtime);
-                }
-                image.setAcquisitionDate(rtime(earliestMTime));
-            }
-            */
-
             // Ensure that the Image name is set
             String userSpecifiedName = store.getUserSpecifiedName();
             if (userSpecifiedName != null) {

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -1,4 +1,6 @@
 /*
+ * ome.formats.model.PixelsProcessor
+ *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
  *

--- a/components/blitz/src/ome/formats/model/PlaneInfoProcessor.java
+++ b/components/blitz/src/ome/formats/model/PlaneInfoProcessor.java
@@ -40,37 +40,33 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class PlaneInfoProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(PlaneInfoProcessor.class);
+public class PlaneInfoProcessor implements ModelProcessor {
 
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-    throws ModelException
-    {
-        List<IObjectContainer> containers =
-            store.getIObjectContainers(PlaneInfo.class);
-        for (IObjectContainer container : containers)
-        {
-		PlaneInfo pi = (PlaneInfo) container.sourceObject;
-		if (pi.getDeltaT() == null
-			&& pi.getExposureTime() == null
-			&& pi.getPositionX() == null
-			&& pi.getPositionY() == null
-			&& pi.getPositionZ() == null)
-		{
-			LSID lsid = new LSID(
-			        PlaneInfo.class,
-			        container.indexes.get(Index.IMAGE_INDEX.getValue()),
-			        container.indexes.get(Index.PLANE_INDEX.getValue()));
-			log.debug("Removing empty PlaneInfo: " + lsid);
-			store.removeIObjectContainer(lsid);
-		}
-        }
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(PlaneInfoProcessor.class);
+
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    List<IObjectContainer> containers =
+        store.getIObjectContainers(PlaneInfo.class);
+    for (IObjectContainer container : containers) {
+      PlaneInfo pi = (PlaneInfo) container.sourceObject;
+      if (pi.getDeltaT() == null &&
+          pi.getExposureTime() == null &&
+          pi.getPositionX() == null &&
+          pi.getPositionY() == null &&
+          pi.getPositionZ() == null) {
+        LSID lsid = new LSID(
+            PlaneInfo.class,
+            container.indexes.get(Index.IMAGE_INDEX.getValue()),
+            container.indexes.get(Index.PLANE_INDEX.getValue()));
+        log.debug("Removing empty PlaneInfo: " + lsid);
+        store.removeIObjectContainer(lsid);
+      }
     }
+  }
 }

--- a/components/blitz/src/ome/formats/model/ReferenceProcessor.java
+++ b/components/blitz/src/ome/formats/model/ReferenceProcessor.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * Processes the references of an IObjectContainerStore and ensures
  * that container references are consistent with the LSID stored in the
  * IObjectContainer itself. It also keeps track of all LSID references
- * in their string form so that the may be given to the IObjectContainerStore.
+ * in their string form so that they may be given to the IObjectContainerStore.
  *
  * @author Chris Allan <callan at blackcat dot ca>
  *

--- a/components/blitz/src/ome/formats/model/ReferenceProcessor.java
+++ b/components/blitz/src/ome/formats/model/ReferenceProcessor.java
@@ -51,119 +51,94 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class ReferenceProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(ReferenceProcessor.class);
+public class ReferenceProcessor implements ModelProcessor {
 
-    /* (non-Javadoc)
-     * @see ome.formats.model.ModelProcessor#process(ome.formats.model.IObjectContainerStore)
-     */
-    public void process(IObjectContainerStore store)
-	throws ModelException
-    {
-        Map<String, String[]> referenceStringCache =
-		new HashMap<String, String[]>();
-	Map<LSID, List<LSID>> referenceCache = store.getReferenceCache();
-	Map<LSID, IObjectContainer> containerCache = store.getContainerCache();
-	try
-        {
-            for (LSID target : referenceCache.keySet())
-            {
-		IObjectContainer container = containerCache.get(target);
-		Class targetClass = target.getJavaClass();
-		List<String> references = new ArrayList<String>();
-		for (LSID reference : referenceCache.get(target))
-		{
-			if (container == null)
-			{
-				// Handle the cases where a "Settings" object has been
-				// used to link an element of the Instrument to the
-				// Image but there were no acquisition specific
-				// settings to record. Hence, the "Settings" object
-				// needs to be created as no MetadataStore methods
-				// pertaining to the "Settings" object have been
-				// entered.
-				LinkedHashMap<Index, Integer> indexes =
-					new LinkedHashMap<Index, Integer>();
-				int[] indexArray = target.getIndexes();
-				if (targetClass == null)
-				{
-					log.warn("Unknown target class for LSID: " + target);
-					references.add(reference.toString());
-					continue;
-				}
-				else if (targetClass.equals(DetectorSettings.class))
-				{
-					indexes.put(Index.IMAGE_INDEX, indexArray[0]);
-					indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
-				}
-				else if (targetClass.equals(LightSettings.class))
-				{
-					if (indexArray.length == 2) {
-						indexes.put(Index.IMAGE_INDEX, indexArray[0]);
-						indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
-					}
-					else if (indexArray.length == 3) {
-						indexes.put(Index.EXPERIMENT_INDEX, indexArray[0]);
-						indexes.put(Index.MICROBEAM_MANIPULATION_INDEX, indexArray[1]);
-						indexes.put(Index.LIGHT_SOURCE_SETTINGS_INDEX, indexArray[2]);
-					}
-				}
-				else if (targetClass.equals(ObjectiveSettings.class))
-				{
-					indexes.put(Index.IMAGE_INDEX, indexArray[0]);
-				}
-				else if (targetClass.equals(WellSample.class))
-				{
-					// A WellSample has been used to link an Image to
-					// a Well and there was no acquisition specific
-					// metadata to record about the WellSample. We now
-					// need to create it.
-					indexes.put(Index.PLATE_INDEX, indexArray[0]);
-					indexes.put(Index.WELL_INDEX, indexArray[1]);
-					indexes.put(Index.WELL_SAMPLE_INDEX, indexArray[2]);
-				}
-				else if (targetClass.equals(LightPath.class))
-				{
-				    // A LightPath has been used to link emission or
-				    // excition filters and / or a dichroic to an
-				    // image. We now need to create it.
-				    indexes.put(Index.IMAGE_INDEX, indexArray[0]);
-				    indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
-				}
-				else
-				{
-					throw new RuntimeException(String.format(
-							"Unable to synchronize reference %s --> %s",
-							reference, target));
-				}
-				container =
-					store.getIObjectContainer(targetClass, indexes);
-			}
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(ReferenceProcessor.class);
 
-			// Add our LSIDs to the string based reference cache.
-			references.add(reference.toString());
-		}
-		String lsid = targetClass == null? target.toString()
-						: container.LSID;
-		// We don't want to overwrite any existing references that may
-		// have come from other LSID mappings (such as a generated
-		// LSID) so add any existing LSIDs to the list of references.
-		if (referenceStringCache.containsKey(lsid))
-		{
-			String[] existing = referenceStringCache.get(lsid);
-			references.addAll(Arrays.asList(existing));
-		}
-			String[] referencesAsString =
-				references.toArray(new String[references.size()]);
-			referenceStringCache.put(lsid, referencesAsString);
+  /* (non-Javadoc)
+   * @see ome.formats.model.ModelProcessor#process(ome.formats.model.IObjectContainerStore)
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    Map<String, String[]> referenceStringCache =
+      new HashMap<String, String[]>();
+    Map<LSID, List<LSID>> referenceCache = store.getReferenceCache();
+    Map<LSID, IObjectContainer> containerCache = store.getContainerCache();
+    try {
+      for (LSID target : referenceCache.keySet()) {
+        IObjectContainer container = containerCache.get(target);
+        Class targetClass = target.getJavaClass();
+        List<String> references = new ArrayList<String>();
+        for (LSID reference : referenceCache.get(target)) {
+          if (container == null) {
+            // Handle the cases where a "Settings" object has been
+            // used to link an element of the Instrument to the
+            // Image but there were no acquisition specific
+            // settings to record. Hence, the "Settings" object
+            // needs to be created as no MetadataStore methods
+            // pertaining to the "Settings" object have been entered.
+            LinkedHashMap<Index, Integer> indexes =
+                new LinkedHashMap<Index, Integer>();
+            int[] indexArray = target.getIndexes();
+            if (targetClass == null) {
+              log.warn("Unknown target class for LSID: " + target);
+              references.add(reference.toString());
+              continue;
+            } else if (targetClass.equals(DetectorSettings.class)) {
+              indexes.put(Index.IMAGE_INDEX, indexArray[0]);
+              indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
+            } else if (targetClass.equals(LightSettings.class)) {
+              if (indexArray.length == 2) {
+                indexes.put(Index.IMAGE_INDEX, indexArray[0]);
+                indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
+              } else if (indexArray.length == 3) {
+                indexes.put(Index.EXPERIMENT_INDEX, indexArray[0]);
+                indexes.put(
+                    Index.MICROBEAM_MANIPULATION_INDEX, indexArray[1]);
+                indexes.put(Index.LIGHT_SOURCE_SETTINGS_INDEX, indexArray[2]);
+              }
+            } else if (targetClass.equals(ObjectiveSettings.class)) {
+              indexes.put(Index.IMAGE_INDEX, indexArray[0]);
+            } else if (targetClass.equals(WellSample.class)) {
+              // A WellSample has been used to link an Image to
+              // a Well and there was no acquisition specific
+              // metadata to record about the WellSample. We now
+              // need to create it.
+              indexes.put(Index.PLATE_INDEX, indexArray[0]);
+              indexes.put(Index.WELL_INDEX, indexArray[1]);
+              indexes.put(Index.WELL_SAMPLE_INDEX, indexArray[2]);
+            } else if (targetClass.equals(LightPath.class)) {
+              // A LightPath has been used to link emission or
+              // excition filters and / or a dichroic to an
+              // image. We now need to create it.
+              indexes.put(Index.IMAGE_INDEX, indexArray[0]);
+              indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
+            } else {
+              throw new RuntimeException(
+                  String.format("Unable to synchronize reference %s --> %s",
+                                reference, target));
             }
-            store.setReferenceStringCache(referenceStringCache);
+            container = store.getIObjectContainer(targetClass, indexes);
+          }
+          // Add our LSIDs to the string based reference cache.
+          references.add(reference.toString());
         }
-	catch (Exception e)
-	{
-		throw new ModelException("Error processing references.", null, e);
-	}
+        String lsid = targetClass == null? target.toString() : container.LSID;
+        // We don't want to overwrite any existing references that may
+        // have come from other LSID mappings (such as a generated
+        // LSID) so add any existing LSIDs to the list of references.
+        if (referenceStringCache.containsKey(lsid)) {
+          String[] existing = referenceStringCache.get(lsid);
+          references.addAll(Arrays.asList(existing));
+        }
+        String[] referencesAsString =
+            references.toArray(new String[references.size()]);
+        referenceStringCache.put(lsid, referencesAsString);
+      }
+      store.setReferenceStringCache(referenceStringCache);
     }
+    catch (Exception e) {
+      throw new ModelException("Error processing references.", null, e);
+    }
+  }
 }

--- a/components/blitz/src/ome/formats/model/ShapeProcessor.java
+++ b/components/blitz/src/ome/formats/model/ShapeProcessor.java
@@ -51,50 +51,45 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class ShapeProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(ShapeProcessor.class);
+public class ShapeProcessor implements ModelProcessor {
 
-    /** Exhaustive list of ROI types. */
-    private static final List<Class<? extends IObject>> SHAPE_TYPES =
-	new ArrayList<Class<? extends IObject>>();
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(ShapeProcessor.class);
 
-    static
-    {
-        SHAPE_TYPES.add(Line.class);
-        SHAPE_TYPES.add(Rectangle.class);
-        SHAPE_TYPES.add(Mask.class);
-        SHAPE_TYPES.add(Ellipse.class);
-        SHAPE_TYPES.add(Point.class);
-        SHAPE_TYPES.add(Polyline.class);
-        SHAPE_TYPES.add(Path.class);
-        SHAPE_TYPES.add(Label.class);
-        // XXX: Unused OME-XML type
-        SHAPE_TYPES.add(Polygon.class);
+  /** Exhaustive list of ROI types. */
+  private static final List<Class<? extends IObject>> SHAPE_TYPES =
+      new ArrayList<Class<? extends IObject>>();
+
+  static {
+    SHAPE_TYPES.add(Line.class);
+    SHAPE_TYPES.add(Rectangle.class);
+    SHAPE_TYPES.add(Mask.class);
+    SHAPE_TYPES.add(Ellipse.class);
+    SHAPE_TYPES.add(Point.class);
+    SHAPE_TYPES.add(Polyline.class);
+    SHAPE_TYPES.add(Path.class);
+    SHAPE_TYPES.add(Label.class);
+    // XXX: Unused OME-XML type
+    SHAPE_TYPES.add(Polygon.class);
+  }
+
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    for (Class<? extends IObject> klass : SHAPE_TYPES) {
+      List<IObjectContainer> containers =
+        store.getIObjectContainers(klass);
+      for (IObjectContainer container : containers) {
+        Integer roiIndex = container.indexes.get(Index.ROI_INDEX.getValue());
+        LinkedHashMap<Index, Integer> indexes =
+            new LinkedHashMap<Index, Integer>();
+        indexes.put(Index.ROI_INDEX, roiIndex);
+        // Creates an ROI if one doesn't exist
+        store.getIObjectContainer(Roi.class, indexes);
+      }
     }
-
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-    throws ModelException
-    {
-	for (Class<? extends IObject> klass : SHAPE_TYPES)
-	{
-	        List<IObjectContainer> containers =
-			store.getIObjectContainers(klass);
-	        for (IObjectContainer container : containers)
-	        {
-	            Integer roiIndex = container.indexes.get(Index.ROI_INDEX.getValue());
-				LinkedHashMap<Index, Integer> indexes =
-					new LinkedHashMap<Index, Integer>();
-				indexes.put(Index.ROI_INDEX, roiIndex);
-				// Creates an ROI if one doesn't exist
-				store.getIObjectContainer(Roi.class, indexes);
-	        }
-	}
-    }
+  }
 }

--- a/components/blitz/src/ome/formats/model/TargetProcessor.java
+++ b/components/blitz/src/ome/formats/model/TargetProcessor.java
@@ -43,47 +43,38 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class TargetProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(TargetProcessor.class);
+public class TargetProcessor implements ModelProcessor {
 
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-    throws ModelException
-    {
-        IObject target = store.getUserSpecifiedTarget();
-        if (target == null)
-        {
-            return;
-        }
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(TargetProcessor.class);
 
-        List<IObjectContainer> containers = null;
-
-        if (target instanceof Dataset)
-        {
-            containers = store.getIObjectContainers(Image.class);
-        }
-        else if (target instanceof Screen)
-        {
-            containers = store.getIObjectContainers(Plate.class);
-        }
-        else
-        {
-            throw new ModelException("Unable to handle target: " + target);
-        }
-
-        for (IObjectContainer container : containers)
-        {
-            LSID targetLSID = new LSID(container.LSID);
-            LSID referenceLSID =
-                new LSID(String.format("%s:%d", target.getClass().getName(),
-                        target.getId().getValue()));
-            store.addReference(targetLSID, referenceLSID);
-        }
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    IObject target = store.getUserSpecifiedTarget();
+    if (target == null) {
+      return;
     }
+
+    List<IObjectContainer> containers = null;
+
+    if (target instanceof Dataset) {
+      containers = store.getIObjectContainers(Image.class);
+    } else if (target instanceof Screen) {
+      containers = store.getIObjectContainers(Plate.class);
+    } else {
+      throw new ModelException("Unable to handle target: " + target);
+    }
+
+    for (IObjectContainer container : containers) {
+      LSID targetLSID = new LSID(container.LSID);
+      LSID referenceLSID =
+          new LSID(String.format("%s:%d", target.getClass().getName(),
+                                 target.getId().getValue()));
+      store.addReference(targetLSID, referenceLSID);
+    }
+  }
 }

--- a/components/blitz/src/ome/formats/model/UnitsFactory.java
+++ b/components/blitz/src/ome/formats/model/UnitsFactory.java
@@ -56,428 +56,524 @@ import omero.model.enums.UnitsTime;
  */
 public class UnitsFactory {
 
-
     //
     // ElectricPotential
     //
 
-    public static ome.xml.model.enums.UnitsElectricPotential makeElectricPotentialUnitXML(String unit) {
-        return ElectricPotentialI.makeXMLUnit(unit);
-    }
+  public static ome.xml.model.enums.UnitsElectricPotential
+      makeElectricPotentialUnitXML(String unit) {
+    return ElectricPotentialI.makeXMLUnit(unit);
+  }
 
-    public static ome.units.quantity.ElectricPotential makeElectricPotentialXML(double d, String unit) {
-        return ElectricPotentialI.makeXMLQuantity(d, unit);
-    }
+  public static ome.units.quantity.ElectricPotential
+      makeElectricPotentialXML(double d, String unit) {
+    return ElectricPotentialI.makeXMLQuantity(d, unit);
+  }
 
-    public static ElectricPotential makeElectricPotential(double d,
-            Unit<ome.units.quantity.ElectricPotential> unit) {
-        return new ElectricPotentialI(d, unit);
-    }
+  public static ElectricPotential makeElectricPotential(
+      double d, Unit<ome.units.quantity.ElectricPotential> unit) {
+    return new ElectricPotentialI(d, unit);
+  }
 
-    public static ElectricPotential makeElectricPotential(double d, UnitsElectricPotential unit) {
-        return new ElectricPotentialI(d, unit);
-    }
+  public static ElectricPotential makeElectricPotential(
+      double d, UnitsElectricPotential unit) {
+    return new ElectricPotentialI(d, unit);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link ElectricPotential} to an OMERO ElectricPotential. A null will be
-     * returned if the input is null.
-     */
-    public static ElectricPotential convertElectricPotential(ome.units.quantity.ElectricPotential value) {
-        if (value == null)
-            return null;
-        String internal = xmlElectricPotentialEnumToOMERO(value.unit().getSymbol());
-        UnitsElectricPotential ul = UnitsElectricPotential.valueOf(internal);
-        return new omero.model.ElectricPotentialI(value.value().doubleValue(), ul);
-    }
+  /**
+   * Convert a Bio-Formats {@link ElectricPotential} to an OMERO
+   * ElectricPotential. A null will be returned if the input is null.
+   */
+  public static ElectricPotential convertElectricPotential(
+      ome.units.quantity.ElectricPotential value) {
+    if (value == null)
+      return null;
+    String internal = xmlElectricPotentialEnumToOMERO(value.unit().getSymbol());
+    UnitsElectricPotential ul = UnitsElectricPotential.valueOf(internal);
+    return new omero.model.ElectricPotentialI(value.value().doubleValue(), ul);
+  }
 
-    public static ome.units.quantity.ElectricPotential convertElectricPotential(ElectricPotential t) {
-        return ElectricPotentialI.convert(t);
-    }
+  public static ome.units.quantity.ElectricPotential convertElectricPotential(
+      ElectricPotential t) {
+    return ElectricPotentialI.convert(t);
+  }
 
-    public static ElectricPotential convertElectricPotential(ElectricPotential value, Unit<ome.units.quantity.ElectricPotential> ul) throws BigResult {
-        return convertElectricPotentialXML(value, ul.getSymbol());
-    }
+  public static ElectricPotential convertElectricPotential(
+      ElectricPotential value, Unit<ome.units.quantity.ElectricPotential> ul
+  ) throws BigResult {
+    return convertElectricPotentialXML(value, ul.getSymbol());
+  }
 
-    public static ElectricPotential convertElectricPotentialXML(ElectricPotential value, String xml) throws BigResult {
-        String omero = xmlElectricPotentialEnumToOMERO(xml);
-        return new ElectricPotentialI(value, omero);
-    }
+  public static ElectricPotential convertElectricPotentialXML(
+      ElectricPotential value, String xml) throws BigResult {
+    String omero = xmlElectricPotentialEnumToOMERO(xml);
+    return new ElectricPotentialI(value, omero);
+  }
 
-    public static String xmlElectricPotentialEnumToOMERO(Unit<ome.units.quantity.ElectricPotential> xml) {
-        return ome.model.enums.UnitsElectricPotential.bySymbol(xml.getSymbol()).toString();
-    }
+  public static String xmlElectricPotentialEnumToOMERO(
+      Unit<ome.units.quantity.ElectricPotential> xml) {
+    return ome.model.enums.UnitsElectricPotential.bySymbol(
+        xml.getSymbol()).toString();
+  }
 
-    public static String xmlElectricPotentialEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsElectricPotential.bySymbol(xml).toString();
-    }
+  public static String xmlElectricPotentialEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsElectricPotential.bySymbol(xml).toString();
+  }
 
+  //
+  // Frequency
+  //
 
-    //
-    // Frequency
-    //
+  public static ome.xml.model.enums.UnitsFrequency makeFrequencyUnitXML(
+      String unit) {
+    return FrequencyI.makeXMLUnit(unit);
+  }
 
-    public static ome.xml.model.enums.UnitsFrequency makeFrequencyUnitXML(String unit) {
-        return FrequencyI.makeXMLUnit(unit);
-    }
+  public static ome.units.quantity.Frequency makeFrequencyXML(
+      double d, String unit) {
+    return FrequencyI.makeXMLQuantity(d, unit);
+  }
 
-    public static ome.units.quantity.Frequency makeFrequencyXML(double d, String unit) {
-        return FrequencyI.makeXMLQuantity(d, unit);
-    }
+  public static Frequency makeFrequency(
+      double d, Unit<ome.units.quantity.Frequency> unit) {
+    return new FrequencyI(d, unit);
+  }
 
-    public static Frequency makeFrequency(double d,
-            Unit<ome.units.quantity.Frequency> unit) {
-        return new FrequencyI(d, unit);
-    }
+  public static Frequency makeFrequency(double d, UnitsFrequency unit) {
+    return new FrequencyI(d, unit);
+  }
 
-    public static Frequency makeFrequency(double d, UnitsFrequency unit) {
-        return new FrequencyI(d, unit);
-    }
+  /**
+   * Convert a Bio-Formats {@link Frequency} to an OMERO Frequency. A
+   * null will be returned if the input is null.
+   */
+  public static Frequency convertFrequency(ome.units.quantity.Frequency value) {
+    if (value == null)
+      return null;
+    String internal = xmlFrequencyEnumToOMERO(value.unit().getSymbol());
+    UnitsFrequency ul = UnitsFrequency.valueOf(internal);
+    return new omero.model.FrequencyI(value.value().doubleValue(), ul);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Frequency} to an OMERO Frequency. A null will be
-     * returned if the input is null.
-     */
-    public static Frequency convertFrequency(ome.units.quantity.Frequency value) {
-        if (value == null)
-            return null;
-        String internal = xmlFrequencyEnumToOMERO(value.unit().getSymbol());
-        UnitsFrequency ul = UnitsFrequency.valueOf(internal);
-        return new omero.model.FrequencyI(value.value().doubleValue(), ul);
-    }
+  public static ome.units.quantity.Frequency convertFrequency(Frequency t) {
+    return FrequencyI.convert(t);
+  }
 
-    public static ome.units.quantity.Frequency convertFrequency(Frequency t) {
-        return FrequencyI.convert(t);
-    }
+  public static Frequency convertFrequency(
+      Frequency value, Unit<ome.units.quantity.Frequency> ul) throws BigResult {
+    return convertFrequencyXML(value, ul.getSymbol());
+  }
 
-    public static Frequency convertFrequency(Frequency value, Unit<ome.units.quantity.Frequency> ul) throws BigResult {
-        return convertFrequencyXML(value, ul.getSymbol());
-    }
+  public static Frequency convertFrequencyXML(Frequency value, String xml)
+      throws BigResult {
+    String omero = xmlFrequencyEnumToOMERO(xml);
+    return new FrequencyI(value, omero);
+  }
 
-    public static Frequency convertFrequencyXML(Frequency value, String xml) throws BigResult {
-        String omero = xmlFrequencyEnumToOMERO(xml);
-        return new FrequencyI(value, omero);
-    }
+  public static String xmlFrequencyEnumToOMERO(
+      Unit<ome.units.quantity.Frequency> xml) {
+    return ome.model.enums.UnitsFrequency.bySymbol(xml.getSymbol()).toString();
+  }
 
-    public static String xmlFrequencyEnumToOMERO(Unit<ome.units.quantity.Frequency> xml) {
-        return ome.model.enums.UnitsFrequency.bySymbol(xml.getSymbol()).toString();
-    }
+  public static String xmlFrequencyEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsFrequency.bySymbol(xml).toString();
+  }
 
-    public static String xmlFrequencyEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsFrequency.bySymbol(xml).toString();
-    }
+  //
+  // Length
+  //
 
+  public static ome.xml.model.enums.UnitsLength makeLengthUnitXML(String unit) {
+    return LengthI.makeXMLUnit(unit);
+  }
 
-    //
-    // Length
-    //
+  public static ome.units.quantity.Length makeLengthXML(double d, String unit) {
+    return LengthI.makeXMLQuantity(d, unit);
+  }
 
-    public static ome.xml.model.enums.UnitsLength makeLengthUnitXML(String unit) {
-        return LengthI.makeXMLUnit(unit);
-    }
+  public static Length makeLength(
+      double d, Unit<ome.units.quantity.Length> unit) {
+    return new LengthI(d, unit);
+  }
 
-    public static ome.units.quantity.Length makeLengthXML(double d, String unit) {
-        return LengthI.makeXMLQuantity(d, unit);
-    }
+  public static Length makeLength(double d, UnitsLength unit) {
+    return new LengthI(d, unit);
+  }
 
-    public static Length makeLength(double d,
-            Unit<ome.units.quantity.Length> unit) {
-        return new LengthI(d, unit);
-    }
+  /**
+   * Convert a Bio-Formats {@link Length} to an OMERO Length. A null will be
+   * returned if the input is null.
+   */
+  public static Length convertLength(ome.units.quantity.Length value) {
+    if (value == null)
+      return null;
+    String internal = xmlLengthEnumToOMERO(value.unit().getSymbol());
+    UnitsLength ul = UnitsLength.valueOf(internal);
+    return new omero.model.LengthI(value.value().doubleValue(), ul);
+  }
 
-    public static Length makeLength(double d, UnitsLength unit) {
-        return new LengthI(d, unit);
-    }
+  public static ome.units.quantity.Length convertLength(Length t) {
+    return LengthI.convert(t);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Length} to an OMERO Length. A null will be
-     * returned if the input is null.
-     */
-    public static Length convertLength(ome.units.quantity.Length value) {
-        if (value == null)
-            return null;
-        String internal = xmlLengthEnumToOMERO(value.unit().getSymbol());
-        UnitsLength ul = UnitsLength.valueOf(internal);
-        return new omero.model.LengthI(value.value().doubleValue(), ul);
-    }
+  public static Length convertLength(
+      Length value, Unit<ome.units.quantity.Length> ul) throws BigResult {
+    return convertLengthXML(value, ul.getSymbol());
+  }
 
-    public static ome.units.quantity.Length convertLength(Length t) {
-        return LengthI.convert(t);
-    }
+  public static Length convertLengthXML(Length value, String xml)
+      throws BigResult {
+    String omero = xmlLengthEnumToOMERO(xml);
+    return new LengthI(value, omero);
+  }
 
-    public static Length convertLength(Length value, Unit<ome.units.quantity.Length> ul) throws BigResult {
-        return convertLengthXML(value, ul.getSymbol());
-    }
+  public static String xmlLengthEnumToOMERO(
+      Unit<ome.units.quantity.Length> xml) {
+    return ome.model.enums.UnitsLength.bySymbol(xml.getSymbol()).toString();
+  }
 
-    public static Length convertLengthXML(Length value, String xml) throws BigResult {
-        String omero = xmlLengthEnumToOMERO(xml);
-        return new LengthI(value, omero);
-    }
+  public static String xmlLengthEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsLength.bySymbol(xml).toString();
+  }
 
-    public static String xmlLengthEnumToOMERO(Unit<ome.units.quantity.Length> xml) {
-        return ome.model.enums.UnitsLength.bySymbol(xml.getSymbol()).toString();
-    }
+  //
+  // Power
+  //
 
-    public static String xmlLengthEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsLength.bySymbol(xml).toString();
-    }
+  public static ome.xml.model.enums.UnitsPower makePowerUnitXML(String unit) {
+    return PowerI.makeXMLUnit(unit);
+  }
 
+  public static ome.units.quantity.Power makePowerXML(double d, String unit) {
+    return PowerI.makeXMLQuantity(d, unit);
+  }
 
-    //
-    // Power
-    //
+  public static Power makePower(
+      double d, Unit<ome.units.quantity.Power> unit) {
+    return new PowerI(d, unit);
+  }
 
-    public static ome.xml.model.enums.UnitsPower makePowerUnitXML(String unit) {
-        return PowerI.makeXMLUnit(unit);
-    }
+  public static Power makePower(double d, UnitsPower unit) {
+    return new PowerI(d, unit);
+  }
 
-    public static ome.units.quantity.Power makePowerXML(double d, String unit) {
-        return PowerI.makeXMLQuantity(d, unit);
-    }
+  /**
+   * Convert a Bio-Formats {@link Power} to an OMERO Power. A null
+   * will be returned if the input is null.
+   */
+  public static Power convertPower(ome.units.quantity.Power value) {
+    if (value == null)
+      return null;
+    String internal = xmlPowerEnumToOMERO(value.unit().getSymbol());
+    UnitsPower ul = UnitsPower.valueOf(internal);
+    return new omero.model.PowerI(value.value().doubleValue(), ul);
+  }
 
-    public static Power makePower(double d,
-            Unit<ome.units.quantity.Power> unit) {
-        return new PowerI(d, unit);
-    }
+  public static ome.units.quantity.Power convertPower(Power t) {
+    return PowerI.convert(t);
+  }
 
-    public static Power makePower(double d, UnitsPower unit) {
-        return new PowerI(d, unit);
-    }
+  public static Power convertPower(
+      Power value, Unit<ome.units.quantity.Power> ul) throws BigResult {
+    return convertPowerXML(value, ul.getSymbol());
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Power} to an OMERO Power. A null will be
-     * returned if the input is null.
-     */
-    public static Power convertPower(ome.units.quantity.Power value) {
-        if (value == null)
-            return null;
-        String internal = xmlPowerEnumToOMERO(value.unit().getSymbol());
-        UnitsPower ul = UnitsPower.valueOf(internal);
-        return new omero.model.PowerI(value.value().doubleValue(), ul);
-    }
+  public static Power convertPowerXML(Power value, String xml)
+    throws BigResult {
+    String omero = xmlPowerEnumToOMERO(xml);
+    return new PowerI(value, omero);
+  }
 
-    public static ome.units.quantity.Power convertPower(Power t) {
-        return PowerI.convert(t);
-    }
+  public static String xmlPowerEnumToOMERO(Unit<ome.units.quantity.Power> xml) {
+    return ome.model.enums.UnitsPower.bySymbol(xml.getSymbol()).toString();
+  }
 
-    public static Power convertPower(Power value, Unit<ome.units.quantity.Power> ul) throws BigResult {
-        return convertPowerXML(value, ul.getSymbol());
-    }
-
-    public static Power convertPowerXML(Power value, String xml) throws BigResult {
-        String omero = xmlPowerEnumToOMERO(xml);
-        return new PowerI(value, omero);
-    }
-
-    public static String xmlPowerEnumToOMERO(Unit<ome.units.quantity.Power> xml) {
-        return ome.model.enums.UnitsPower.bySymbol(xml.getSymbol()).toString();
-    }
-
-    public static String xmlPowerEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsPower.bySymbol(xml).toString();
-    }
-
+  public static String xmlPowerEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsPower.bySymbol(xml).toString();
+  }
 
     //
     // Pressure
     //
 
-    public static ome.xml.model.enums.UnitsPressure makePressureUnitXML(String unit) {
-        return PressureI.makeXMLUnit(unit);
-    }
+  public static ome.xml.model.enums.UnitsPressure makePressureUnitXML(
+      String unit) {
+    return PressureI.makeXMLUnit(unit);
+  }
 
-    public static ome.units.quantity.Pressure makePressureXML(double d, String unit) {
-        return PressureI.makeXMLQuantity(d, unit);
-    }
+  public static ome.units.quantity.Pressure makePressureXML(
+      double d, String unit) {
+    return PressureI.makeXMLQuantity(d, unit);
+  }
 
-    public static Pressure makePressure(double d,
-            Unit<ome.units.quantity.Pressure> unit) {
-        return new PressureI(d, unit);
-    }
+  public static Pressure makePressure(
+      double d, Unit<ome.units.quantity.Pressure> unit) {
+    return new PressureI(d, unit);
+  }
 
-    public static Pressure makePressure(double d, UnitsPressure unit) {
-        return new PressureI(d, unit);
-    }
+  public static Pressure makePressure(double d, UnitsPressure unit) {
+    return new PressureI(d, unit);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Pressure} to an OMERO Pressure. A null will be
-     * returned if the input is null.
-     */
-    public static Pressure convertPressure(ome.units.quantity.Pressure value) {
-        if (value == null)
-            return null;
-        String internal = xmlPressureEnumToOMERO(value.unit().getSymbol());
-        UnitsPressure ul = UnitsPressure.valueOf(internal);
-        return new omero.model.PressureI(value.value().doubleValue(), ul);
-    }
+  /**
+   * Convert a Bio-Formats {@link Pressure} to an OMERO Pressure. A null will be
+   * returned if the input is null.
+   */
+  public static Pressure convertPressure(ome.units.quantity.Pressure value) {
+    if (value == null)
+      return null;
+    String internal = xmlPressureEnumToOMERO(value.unit().getSymbol());
+    UnitsPressure ul = UnitsPressure.valueOf(internal);
+    return new omero.model.PressureI(value.value().doubleValue(), ul);
+  }
 
-    public static ome.units.quantity.Pressure convertPressure(Pressure t) {
-        return PressureI.convert(t);
-    }
+  public static ome.units.quantity.Pressure convertPressure(Pressure t) {
+    return PressureI.convert(t);
+  }
 
-    public static Pressure convertPressure(Pressure value, Unit<ome.units.quantity.Pressure> ul) throws BigResult {
-        return convertPressureXML(value, ul.getSymbol());
-    }
+  public static Pressure convertPressure(
+      Pressure value, Unit<ome.units.quantity.Pressure> ul) throws BigResult {
+    return convertPressureXML(value, ul.getSymbol());
+  }
 
-    public static Pressure convertPressureXML(Pressure value, String xml) throws BigResult {
-        String omero = xmlPressureEnumToOMERO(xml);
-        return new PressureI(value, omero);
-    }
+  public static Pressure convertPressureXML(Pressure value, String xml)
+      throws BigResult {
+    String omero = xmlPressureEnumToOMERO(xml);
+    return new PressureI(value, omero);
+  }
 
-    public static String xmlPressureEnumToOMERO(Unit<ome.units.quantity.Pressure> xml) {
-        return ome.model.enums.UnitsPressure.bySymbol(xml.getSymbol()).toString();
-    }
+  public static String xmlPressureEnumToOMERO(
+      Unit<ome.units.quantity.Pressure> xml) {
+    return ome.model.enums.UnitsPressure.bySymbol(xml.getSymbol()).toString();
+  }
 
-    public static String xmlPressureEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsPressure.bySymbol(xml).toString();
-    }
+  public static String xmlPressureEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsPressure.bySymbol(xml).toString();
+  }
 
+  //
+  // Temperature
+  //
 
-    //
-    // Temperature
-    //
+  public static ome.xml.model.enums.UnitsTemperature makeTemperatureUnitXML(
+      String unit) {
+    return TemperatureI.makeXMLUnit(unit);
+  }
 
-    public static ome.xml.model.enums.UnitsTemperature makeTemperatureUnitXML(String unit) {
-        return TemperatureI.makeXMLUnit(unit);
-    }
+  public static ome.units.quantity.Temperature makeTemperatureXML(
+      double d, String unit) {
+    return TemperatureI.makeXMLQuantity(d, unit);
+  }
 
-    public static ome.units.quantity.Temperature makeTemperatureXML(double d, String unit) {
-        return TemperatureI.makeXMLQuantity(d, unit);
-    }
+  public static Temperature makeTemperature(
+      double d, Unit<ome.units.quantity.Temperature> unit) {
+    return new TemperatureI(d, unit);
+  }
 
-    public static Temperature makeTemperature(double d,
-            Unit<ome.units.quantity.Temperature> unit) {
-        return new TemperatureI(d, unit);
-    }
+  public static Temperature makeTemperature(double d, UnitsTemperature unit) {
+    return new TemperatureI(d, unit);
+  }
 
-    public static Temperature makeTemperature(double d, UnitsTemperature unit) {
-        return new TemperatureI(d, unit);
-    }
+  /**
+   * Convert a Bio-Formats {@link Temperature} to an OMERO
+   * Temperature. A null will be returned if the input is null.
+   */
+  public static Temperature convertTemperature(
+      ome.units.quantity.Temperature value) {
+    if (value == null)
+      return null;
+    String internal = xmlTemperatureEnumToOMERO(value.unit().getSymbol());
+    UnitsTemperature ul = UnitsTemperature.valueOf(internal);
+    return new omero.model.TemperatureI(value.value().doubleValue(), ul);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Temperature} to an OMERO Temperature. A null will be
-     * returned if the input is null.
-     */
-    public static Temperature convertTemperature(ome.units.quantity.Temperature value) {
-        if (value == null)
-            return null;
-        String internal = xmlTemperatureEnumToOMERO(value.unit().getSymbol());
-        UnitsTemperature ul = UnitsTemperature.valueOf(internal);
-        return new omero.model.TemperatureI(value.value().doubleValue(), ul);
-    }
+  public static ome.units.quantity.Temperature convertTemperature(
+      Temperature t) {
+    return TemperatureI.convert(t);
+  }
 
-    public static ome.units.quantity.Temperature convertTemperature(Temperature t) {
-        return TemperatureI.convert(t);
-    }
+  public static Temperature convertTemperature(
+      Temperature value, Unit<ome.units.quantity.Temperature> ul)
+      throws BigResult {
+    return convertTemperatureXML(value, ul.getSymbol());
+  }
 
-    public static Temperature convertTemperature(Temperature value, Unit<ome.units.quantity.Temperature> ul) throws BigResult {
-        return convertTemperatureXML(value, ul.getSymbol());
-    }
+  public static Temperature convertTemperatureXML(
+      Temperature value, String xml) throws BigResult {
+    String omero = xmlTemperatureEnumToOMERO(xml);
+    return new TemperatureI(value, omero);
+  }
 
-    public static Temperature convertTemperatureXML(Temperature value, String xml) throws BigResult {
-        String omero = xmlTemperatureEnumToOMERO(xml);
-        return new TemperatureI(value, omero);
-    }
+  public static String xmlTemperatureEnumToOMERO(
+      Unit<ome.units.quantity.Temperature> xml) {
+    return ome.model.enums.UnitsTemperature.bySymbol(
+        xml.getSymbol()).toString();
+  }
 
-    public static String xmlTemperatureEnumToOMERO(Unit<ome.units.quantity.Temperature> xml) {
-        return ome.model.enums.UnitsTemperature.bySymbol(xml.getSymbol()).toString();
-    }
+  public static String xmlTemperatureEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsTemperature.bySymbol(xml).toString();
+  }
 
-    public static String xmlTemperatureEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsTemperature.bySymbol(xml).toString();
-    }
+  //
+  // Time
+  //
 
+  public static ome.xml.model.enums.UnitsTime makeTimeUnitXML(String unit) {
+    return TimeI.makeXMLUnit(unit);
+  }
 
-    //
-    // Time
-    //
+  public static ome.units.quantity.Time makeTimeXML(double d, String unit) {
+    return TimeI.makeXMLQuantity(d, unit);
+  }
 
-    public static ome.xml.model.enums.UnitsTime makeTimeUnitXML(String unit) {
-        return TimeI.makeXMLUnit(unit);
-    }
+  public static Time makeTime(
+      double d, Unit<ome.units.quantity.Time> unit) {
+    return new TimeI(d, unit);
+  }
 
-    public static ome.units.quantity.Time makeTimeXML(double d, String unit) {
-        return TimeI.makeXMLQuantity(d, unit);
-    }
+  public static Time makeTime(double d, UnitsTime unit) {
+    return new TimeI(d, unit);
+  }
 
-    public static Time makeTime(double d,
-            Unit<ome.units.quantity.Time> unit) {
-        return new TimeI(d, unit);
-    }
+  /**
+   * Convert a Bio-Formats {@link Time} to an OMERO Time. A null will be
+   * returned if the input is null.
+   */
+  public static Time convertTime(ome.units.quantity.Time value) {
+    if (value == null)
+      return null;
+    String internal = xmlTimeEnumToOMERO(value.unit().getSymbol());
+    UnitsTime ul = UnitsTime.valueOf(internal);
+    return new omero.model.TimeI(value.value().doubleValue(), ul);
+  }
 
-    public static Time makeTime(double d, UnitsTime unit) {
-        return new TimeI(d, unit);
-    }
+  public static ome.units.quantity.Time convertTime(Time t) {
+    return TimeI.convert(t);
+  }
 
-    /**
-     * Convert a Bio-Formats {@link Time} to an OMERO Time. A null will be
-     * returned if the input is null.
-     */
-    public static Time convertTime(ome.units.quantity.Time value) {
-        if (value == null)
-            return null;
-        String internal = xmlTimeEnumToOMERO(value.unit().getSymbol());
-        UnitsTime ul = UnitsTime.valueOf(internal);
-        return new omero.model.TimeI(value.value().doubleValue(), ul);
-    }
+  public static Time convertTime(Time value, Unit<ome.units.quantity.Time> ul)
+      throws BigResult {
+    return convertTimeXML(value, ul.getSymbol());
+  }
 
-    public static ome.units.quantity.Time convertTime(Time t) {
-        return TimeI.convert(t);
-    }
+  public static Time convertTimeXML(Time value, String xml) throws BigResult {
+    String omero = xmlTimeEnumToOMERO(xml);
+    return new TimeI(value, omero);
+  }
 
-    public static Time convertTime(Time value, Unit<ome.units.quantity.Time> ul) throws BigResult {
-        return convertTimeXML(value, ul.getSymbol());
-    }
+  public static String xmlTimeEnumToOMERO(Unit<ome.units.quantity.Time> xml) {
+    return ome.model.enums.UnitsTime.bySymbol(xml.getSymbol()).toString();
+  }
 
-    public static Time convertTimeXML(Time value, String xml) throws BigResult {
-        String omero = xmlTimeEnumToOMERO(xml);
-        return new TimeI(value, omero);
-    }
+  public static String xmlTimeEnumToOMERO(String xml) {
+    return ome.model.enums.UnitsTime.bySymbol(xml).toString();
+  }
 
-    public static String xmlTimeEnumToOMERO(Unit<ome.units.quantity.Time> xml) {
-        return ome.model.enums.UnitsTime.bySymbol(xml.getSymbol()).toString();
-    }
-
-    public static String xmlTimeEnumToOMERO(String xml) {
-        return ome.model.enums.UnitsTime.bySymbol(xml).toString();
-    }
-
-
-
-    public static UnitsLength Plane_PositionX = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionXUnitXsdDefault()));
-    public static UnitsLength Plane_PositionZ = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionZUnitXsdDefault()));
-    public static UnitsLength Plane_PositionY = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionYUnitXsdDefault()));
-    public static UnitsTime Plane_DeltaT = UnitsTime.valueOf(xmlTimeEnumToOMERO(ome.xml.model.Plane.getDeltaTUnitXsdDefault()));
-    public static UnitsTime Plane_ExposureTime = UnitsTime.valueOf(xmlTimeEnumToOMERO(ome.xml.model.Plane.getExposureTimeUnitXsdDefault()));
-    public static UnitsLength Shape_StrokeWidth = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Shape.getStrokeWidthUnitXsdDefault()));
-    public static UnitsLength Shape_FontSize = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Shape.getFontSizeUnitXsdDefault()));
-    public static UnitsElectricPotential DetectorSettings_Voltage = UnitsElectricPotential.valueOf(xmlElectricPotentialEnumToOMERO(ome.xml.model.DetectorSettings.getVoltageUnitXsdDefault()));
-    public static UnitsFrequency DetectorSettings_ReadOutRate = UnitsFrequency.valueOf(xmlFrequencyEnumToOMERO(ome.xml.model.DetectorSettings.getReadOutRateUnitXsdDefault()));
-    public static UnitsTemperature ImagingEnvironment_Temperature = UnitsTemperature.valueOf(xmlTemperatureEnumToOMERO(ome.xml.model.ImagingEnvironment.getTemperatureUnitXsdDefault()));
-    public static UnitsPressure ImagingEnvironment_AirPressure = UnitsPressure.valueOf(xmlPressureEnumToOMERO(ome.xml.model.ImagingEnvironment.getAirPressureUnitXsdDefault()));
-    public static UnitsLength LightSourceSettings_Wavelength = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.LightSourceSettings.getWavelengthUnitXsdDefault()));
-    public static UnitsLength Plate_WellOriginX = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Plate.getWellOriginXUnitXsdDefault()));
-    public static UnitsLength Plate_WellOriginY = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Plate.getWellOriginYUnitXsdDefault()));
-    public static UnitsLength Objective_WorkingDistance = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Objective.getWorkingDistanceUnitXsdDefault()));
-    public static UnitsLength Pixels_PhysicalSizeX = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Pixels.getPhysicalSizeXUnitXsdDefault()));
-    public static UnitsLength Pixels_PhysicalSizeZ = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Pixels.getPhysicalSizeZUnitXsdDefault()));
-    public static UnitsLength Pixels_PhysicalSizeY = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Pixels.getPhysicalSizeYUnitXsdDefault()));
-    public static UnitsTime Pixels_TimeIncrement = UnitsTime.valueOf(xmlTimeEnumToOMERO(ome.xml.model.Pixels.getTimeIncrementUnitXsdDefault()));
-    public static UnitsLength StageLabel_Z = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.StageLabel.getZUnitXsdDefault()));
-    public static UnitsLength StageLabel_Y = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.StageLabel.getYUnitXsdDefault()));
-    public static UnitsLength StageLabel_X = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.StageLabel.getXUnitXsdDefault()));
-    public static UnitsPower LightSource_Power = UnitsPower.valueOf(xmlPowerEnumToOMERO(ome.xml.model.LightSource.getPowerUnitXsdDefault()));
-    public static UnitsElectricPotential Detector_Voltage = UnitsElectricPotential.valueOf(xmlElectricPotentialEnumToOMERO(ome.xml.model.Detector.getVoltageUnitXsdDefault()));
-    public static UnitsLength WellSample_PositionX = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.WellSample.getPositionXUnitXsdDefault()));
-    public static UnitsLength WellSample_PositionY = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.WellSample.getPositionYUnitXsdDefault()));
-    public static UnitsLength Channel_EmissionWavelength = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Channel.getEmissionWavelengthUnitXsdDefault()));
-    public static UnitsLength Channel_PinholeSize = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Channel.getPinholeSizeUnitXsdDefault()));
-    public static UnitsLength Channel_ExcitationWavelength = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Channel.getExcitationWavelengthUnitXsdDefault()));
-    public static UnitsLength TransmittanceRange_CutOutTolerance = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.TransmittanceRange.getCutOutToleranceUnitXsdDefault()));
-    public static UnitsLength TransmittanceRange_CutInTolerance = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.TransmittanceRange.getCutInToleranceUnitXsdDefault()));
-    public static UnitsLength TransmittanceRange_CutOut = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.TransmittanceRange.getCutOutUnitXsdDefault()));
-    public static UnitsLength TransmittanceRange_CutIn = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.TransmittanceRange.getCutInUnitXsdDefault()));
-    public static UnitsFrequency Laser_RepetitionRate = UnitsFrequency.valueOf(xmlFrequencyEnumToOMERO(ome.xml.model.Laser.getRepetitionRateUnitXsdDefault()));
-    public static UnitsLength Laser_Wavelength = UnitsLength.valueOf(xmlLengthEnumToOMERO(ome.xml.model.Laser.getWavelengthUnitXsdDefault()));
+  public static UnitsLength Plane_PositionX = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionXUnitXsdDefault()));
+  public static UnitsLength Plane_PositionZ = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionZUnitXsdDefault()));
+  public static UnitsLength Plane_PositionY = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Plane.getPositionYUnitXsdDefault()));
+  public static UnitsTime Plane_DeltaT = UnitsTime.valueOf(
+      xmlTimeEnumToOMERO(ome.xml.model.Plane.getDeltaTUnitXsdDefault()));
+  public static UnitsTime Plane_ExposureTime = UnitsTime.valueOf(
+      xmlTimeEnumToOMERO(ome.xml.model.Plane.getExposureTimeUnitXsdDefault()));
+  public static UnitsLength Shape_StrokeWidth = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Shape.getStrokeWidthUnitXsdDefault()));
+  public static UnitsLength Shape_FontSize = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Shape.getFontSizeUnitXsdDefault()));
+  public static UnitsElectricPotential DetectorSettings_Voltage =
+      UnitsElectricPotential.valueOf(
+          xmlElectricPotentialEnumToOMERO(
+              ome.xml.model.DetectorSettings.getVoltageUnitXsdDefault()));
+  public static UnitsFrequency DetectorSettings_ReadOutRate =
+      UnitsFrequency.valueOf(
+          xmlFrequencyEnumToOMERO(
+              ome.xml.model.DetectorSettings.getReadOutRateUnitXsdDefault()));
+  public static UnitsTemperature ImagingEnvironment_Temperature =
+      UnitsTemperature.valueOf(
+          xmlTemperatureEnumToOMERO(
+              ome.xml.model.ImagingEnvironment.getTemperatureUnitXsdDefault()));
+  public static UnitsPressure ImagingEnvironment_AirPressure =
+      UnitsPressure.valueOf(
+          xmlPressureEnumToOMERO(
+              ome.xml.model.ImagingEnvironment.getAirPressureUnitXsdDefault()));
+  public static UnitsLength LightSourceSettings_Wavelength =
+      UnitsLength.valueOf(
+          xmlLengthEnumToOMERO(
+              ome.xml.model.LightSourceSettings.getWavelengthUnitXsdDefault()));
+  public static UnitsLength Plate_WellOriginX = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Plate.getWellOriginXUnitXsdDefault()));
+  public static UnitsLength Plate_WellOriginY =
+      UnitsLength.valueOf(
+          xmlLengthEnumToOMERO(
+              ome.xml.model.Plate.getWellOriginYUnitXsdDefault()));
+  public static UnitsLength Objective_WorkingDistance =
+      UnitsLength.valueOf(
+          xmlLengthEnumToOMERO(
+              ome.xml.model.Objective.getWorkingDistanceUnitXsdDefault()));
+  public static UnitsLength Pixels_PhysicalSizeX = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Pixels.getPhysicalSizeXUnitXsdDefault()));
+  public static UnitsLength Pixels_PhysicalSizeZ = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Pixels.getPhysicalSizeZUnitXsdDefault()));
+  public static UnitsLength Pixels_PhysicalSizeY = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Pixels.getPhysicalSizeYUnitXsdDefault()));
+  public static UnitsTime Pixels_TimeIncrement = UnitsTime.valueOf(
+      xmlTimeEnumToOMERO(
+          ome.xml.model.Pixels.getTimeIncrementUnitXsdDefault()));
+  public static UnitsLength StageLabel_Z = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.StageLabel.getZUnitXsdDefault()));
+  public static UnitsLength StageLabel_Y = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.StageLabel.getYUnitXsdDefault()));
+  public static UnitsLength StageLabel_X = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.StageLabel.getXUnitXsdDefault()));
+  public static UnitsPower LightSource_Power = UnitsPower.valueOf(
+      xmlPowerEnumToOMERO(ome.xml.model.LightSource.getPowerUnitXsdDefault()));
+  public static UnitsElectricPotential Detector_Voltage =
+      UnitsElectricPotential.valueOf(
+          xmlElectricPotentialEnumToOMERO(
+              ome.xml.model.Detector.getVoltageUnitXsdDefault()));
+  public static UnitsLength WellSample_PositionX = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.WellSample.getPositionXUnitXsdDefault()));
+  public static UnitsLength WellSample_PositionY = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.WellSample.getPositionYUnitXsdDefault()));
+  public static UnitsLength Channel_EmissionWavelength = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Channel.getEmissionWavelengthUnitXsdDefault()));
+  public static UnitsLength Channel_PinholeSize = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Channel.getPinholeSizeUnitXsdDefault()));
+  public static UnitsLength Channel_ExcitationWavelength = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.Channel.getExcitationWavelengthUnitXsdDefault()));
+  public static UnitsLength TransmittanceRange_CutOutTolerance =
+      UnitsLength.valueOf(
+          xmlLengthEnumToOMERO(
+              ome.xml.model.TransmittanceRange.
+                  getCutOutToleranceUnitXsdDefault()));
+  public static UnitsLength TransmittanceRange_CutInTolerance =
+      UnitsLength.valueOf(
+          xmlLengthEnumToOMERO(
+              ome.xml.model.TransmittanceRange.
+                  getCutInToleranceUnitXsdDefault()));
+  public static UnitsLength TransmittanceRange_CutOut = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.TransmittanceRange.getCutOutUnitXsdDefault()));
+  public static UnitsLength TransmittanceRange_CutIn = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(
+          ome.xml.model.TransmittanceRange.getCutInUnitXsdDefault()));
+  public static UnitsFrequency Laser_RepetitionRate = UnitsFrequency.valueOf(
+      xmlFrequencyEnumToOMERO(
+          ome.xml.model.Laser.getRepetitionRateUnitXsdDefault()));
+  public static UnitsLength Laser_Wavelength = UnitsLength.valueOf(
+      xmlLengthEnumToOMERO(ome.xml.model.Laser.getWavelengthUnitXsdDefault()));
 
 }
-

--- a/components/blitz/src/ome/formats/model/UnitsFactory.java
+++ b/components/blitz/src/ome/formats/model/UnitsFactory.java
@@ -1,4 +1,7 @@
 /*
+ * ome.formats.model.UnitsFactory
+ *
+ *------------------------------------------------------------------------------
  * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment
  * All rights reserved.
  *

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -47,83 +47,70 @@ import org.slf4j.LoggerFactory;
  * @author Chris Allan <callan at blackcat dot ca>
  *
  */
-public class WellProcessor implements ModelProcessor
-{
-    /** Logger for this class */
-    private Logger log = LoggerFactory.getLogger(WellProcessor.class);
+public class WellProcessor implements ModelProcessor {
 
-    /** Object container store to process. */
-    private IObjectContainerStore store;
+  /** Logger for this class */
+  private Logger log = LoggerFactory.getLogger(WellProcessor.class);
 
-    /**
-     * Processes the OMERO client side metadata store.
-     * @param store OMERO metadata store to process.
-     * @throws ModelException If there is an error during processing.
-     */
-    public void process(IObjectContainerStore store)
-    throws ModelException
-    {
-        this.store = store;
-        List<IObjectContainer> containers =
-            store.getIObjectContainers(Well.class);
-        for (IObjectContainer container : containers)
-        {
-            Integer plateIndex =
-                container.indexes.get(Index.PLATE_INDEX.getValue());
-            // Validate Plate
-            Plate plate = validatePlate(plateIndex);
-            Well well = (Well) container.sourceObject;
-            if (well.getColumn() != null
-                && well.getColumn().getValue() >= plate.getColumns().getValue())
-            {
-                plate.setColumns(rint(well.getColumn().getValue() + 1));
-            }
-            if (well.getRow() != null
-                && well.getRow().getValue() >= plate.getRows().getValue())
-            {
-                plate.setRows(rint(well.getRow().getValue() + 1));
-            }
-        }
+  /** Object container store to process. */
+  private IObjectContainerStore store;
+
+  /**
+   * Processes the OMERO client side metadata store.
+   * @param store OMERO metadata store to process.
+   * @throws ModelException If there is an error during processing.
+   */
+  public void process(IObjectContainerStore store) throws ModelException {
+    this.store = store;
+    List<IObjectContainer> containers =
+        store.getIObjectContainers(Well.class);
+    for (IObjectContainer container : containers) {
+      Integer plateIndex = container.indexes.get(Index.PLATE_INDEX.getValue());
+      // Validate Plate
+      Plate plate = validatePlate(plateIndex);
+      Well well = (Well) container.sourceObject;
+      if (well.getColumn() != null &&
+          well.getColumn().getValue() >= plate.getColumns().getValue()) {
+        plate.setColumns(rint(well.getColumn().getValue() + 1));
+      }
+      if (well.getRow() != null &&
+          well.getRow().getValue() >= plate.getRows().getValue()) {
+        plate.setRows(rint(well.getRow().getValue() + 1));
+      }
     }
+  }
 
-    /**
-     * Validates that a Plate object container exists and that the Plate source
-     * object has a name and that its row and column count are initialized.
-     * @param plateIndex Index of the plate within the data model.
-     * @return The existing or created plate.
-     */
-    private Plate validatePlate(int plateIndex)
-    {
-        LinkedHashMap<Index, Integer> indexes =
-            new LinkedHashMap<Index, Integer>();
-        indexes.put(Index.PLATE_INDEX, plateIndex);
-        IObjectContainer container =
-            store.getIObjectContainer(Plate.class, indexes);
-        Plate plate = (Plate) container.sourceObject;
-        String userSpecifiedPlateName = store.getUserSpecifiedName();
-        String userSpecifiedPlateDescription =
-            store.getUserSpecifiedDescription();
-        if (userSpecifiedPlateName != null)
-        {
-            plate.setName(rstring(userSpecifiedPlateName));
-        }
-        if (userSpecifiedPlateDescription != null)
-        {
-            plate.setDescription(rstring(userSpecifiedPlateDescription));
-        }
-        if (plate.getName() == null)
-        {
-            log.warn("Missing plate name for: " + container.LSID);
-            plate.setName(rstring("Plate"));
-        }
-        if (plate.getRows() == null)
-        {
-            plate.setRows(rint(1));
-        }
-        if (plate.getColumns() == null)
-        {
-            plate.setColumns(rint(1));
-        }
-        return plate;
+  /**
+   * Validates that a Plate object container exists and that the Plate source
+   * object has a name and that its row and column count are initialized.
+   * @param plateIndex Index of the plate within the data model.
+   * @return The existing or created plate.
+   */
+  private Plate validatePlate(int plateIndex) {
+    LinkedHashMap<Index, Integer> indexes =
+        new LinkedHashMap<Index, Integer>();
+    indexes.put(Index.PLATE_INDEX, plateIndex);
+    IObjectContainer container =
+        store.getIObjectContainer(Plate.class, indexes);
+    Plate plate = (Plate) container.sourceObject;
+    String userSpecifiedPlateName = store.getUserSpecifiedName();
+    String userSpecifiedPlateDescription = store.getUserSpecifiedDescription();
+    if (userSpecifiedPlateName != null) {
+      plate.setName(rstring(userSpecifiedPlateName));
     }
+    if (userSpecifiedPlateDescription != null) {
+      plate.setDescription(rstring(userSpecifiedPlateDescription));
+    }
+    if (plate.getName() == null) {
+      log.warn("Missing plate name for: " + container.LSID);
+      plate.setName(rstring("Plate"));
+    }
+    if (plate.getRows() == null) {
+      plate.setRows(rint(1));
+    }
+    if (plate.getColumns() == null) {
+      plate.setColumns(rint(1));
+    }
+    return plate;
+  }
 }


### PR DESCRIPTION
This PR fixes a few docstrings in the blitz code. It also reindents `blitz/src/ome/formats/model/*.java`, where a mix of different conventions (most notably tabs and spaces) makes the code hard to read.

**TEST:** check that it does not break anything