### PR TITLE
5.2 DB: fix script generation (rebased onto regions)

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -355,7 +355,7 @@ CREATE OR REPLACE FUNCTION annotation_updates_note_reindex() RETURNS void AS $$
 
     DECLARE
         curs CURSOR FOR SELECT * FROM _updated_annotations ORDER BY event_id LIMIT 100000 FOR UPDATE;
-        row _updated_annotations%rowtype;
+        row _updated_annotations%%rowtype;
 
     BEGIN
         FOR row IN curs

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -40,6 +40,10 @@ java_test()
         fold end $dir
     done
 
+    # Check for the use of '%' in the SQL templates. Since they are later passed through a python
+    # format statement, any use must be escaped as '%%'.
+    if [[ "2" -ne $(git grep -E '[^%]%[^%]' components/dsl/resources/ome/dsl/  | wc -l) ]]; then exit 2; fi
+
     # make sure that the current db script has no code-generated
     # foreign key names in it
     dist/bin/omero db script "" "" ome -f- | grep -LiE "fk[a-z]*[0-9]+[a-z0-9]{5}" && {


### PR DESCRIPTION

This is the same as gh-4334 but rebased onto regions.

----

see: https://trello.com/c/ztZtO5t6/75-5-2-schema-generation-is-busted

To test:

 * `ant build-schema`
 * `ant build-default`
 * `dist/bin/omero db script --password ome -f- | psql $YOURDB` should no longer fail.

Note: https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration has been updated to perform the same test.

                