### PR TITLE
Remove HDF5_DIR overriding in python_deps.sh

### DIFF
--- a/docs/install/python_deps.sh
+++ b/docs/install/python_deps.sh
@@ -56,7 +56,6 @@ export CFLAGS="-I/usr/X11/include -I/usr/X11/include/freetype2 -I/usr/X11/includ
 install matplotlib
 
 # PyTables requirements ===========================================
-export HDF5_DIR=`pwd`
 install Cython
 install numexpr
 install tables

--- a/docs/install/python_deps.sh
+++ b/docs/install/python_deps.sh
@@ -58,7 +58,7 @@ install matplotlib
 # PyTables requirements ===========================================
 install Cython
 install numexpr
-install tables
+install tables==2.4
 
 echo "Done."
 


### PR DESCRIPTION
This export command currently makes the dependency installation script unusable for PyTables in any other location than the ones under which the HDF libraries are accessible (e.g. /usr/local for Homebrew). Reported by @pwalczysko during testing. 

Without this change, on OSX with Homebrew installed packages, running the following command

```
virtualenv /tmp/venv
source /tmp/ven/bin/activate
bash path/to/python_deps.sh
```

from any other location than `/usr/local` should fail. With this change, the Python packages installation should complete and find the HDF libraries under `/usr/local`.