### PR TITLE
Webgateway api

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
@@ -22,11 +22,22 @@
 # import time
 import omero
 
-from omero.rtypes import unwrap   # wrap   # rlong
+from omero.rtypes import unwrap, rlong   # wrap   # rlong
 from django.conf import settings
 # from django.http import Http404
 # from datetime import datetime
 from copy import deepcopy
+
+
+def build_clause(components, name='', join=','):
+    ''' Build a string from a list of components.
+        This is to simplify building where clauses in particular that
+        may optionally have zero, one or more parts
+    '''
+    if not components:
+        return ''
+
+    return ' ' + name + ' ' + (' ' + join + ' ').join(components) + ' '
 
 
 def parse_permissions_css(permissions, ownerid, conn):
@@ -133,3 +144,117 @@ def marshal_projects(conn, group_id=-1, experimenter_id=-1,
              e[0]["project_details_permissions"], e[0]["childCount"]]
         projects.append(_marshal_project(conn, e[0:5]))
     return projects
+
+
+def _marshal_dataset(conn, row):
+    ''' Given a Dataset row (list) marshals it into a dictionary.  Order
+        and type of columns in row is:
+          * id (rlong)
+          * name (rstring)
+          * details.owner.id (rlong)
+          * details.permissions (dict)
+          * child_count (rlong)
+
+        @param conn OMERO gateway.
+        @type conn L{omero.gateway.BlitzGateway}
+        @param row The Dataset row to marshal
+        @type row L{list}
+    '''
+    dataset_id, name, owner_id, permissions, child_count = row
+    dataset = dict()
+    dataset['id'] = unwrap(dataset_id)
+    dataset['name'] = unwrap(name)
+    dataset['ownerId'] = unwrap(owner_id)
+    dataset['childCount'] = unwrap(child_count)
+    dataset['permsCss'] = \
+        parse_permissions_css(permissions, unwrap(owner_id), conn)
+    return dataset
+
+
+def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
+                     experimenter_id=-1, page=1, limit=settings.PAGE):
+    ''' Marshals datasets
+
+        @param conn OMERO gateway.
+        @type conn L{omero.gateway.BlitzGateway}
+        @param project_id The Project ID to filter by or `None` to
+        not filter by a specific project.
+        defaults to `None`
+        @type project_id L{long}
+        @param orphaned If this is to filter by orphaned data. Overridden
+        by project_id.
+        defaults to False
+        @type orphaned Boolean
+        @param group_id The Group ID to filter by or -1 for all groups,
+        defaults to -1
+        @type group_id L{long}
+        @param experimenter_id The Experimenter (user) ID to filter by
+        or -1 for all experimenters
+        @type experimenter_id L{long}
+        @param page Page number of results to get. `None` or 0 for no paging
+        defaults to 1
+        @type page L{long}
+        @param limit The limit of results per page to get
+        defaults to the value set in settings.PAGE
+        @type page L{long}
+    '''
+    datasets = []
+    params = omero.sys.ParametersI()
+    service_opts = deepcopy(conn.SERVICE_OPTS)
+
+    # Set the desired group context
+    if group_id is None:
+        group_id = -1
+    service_opts.setOmeroGroup(group_id)
+
+    # Paging
+    if page is not None and page > 0:
+        params.page((page-1) * limit, limit)
+
+    where_clause = []
+    if experimenter_id is not None and experimenter_id != -1:
+        params.addId(experimenter_id)
+        where_clause.append('dataset.details.owner.id = :id')
+
+    qs = conn.getQueryService()
+    q = """
+        select new map(dataset.id as id,
+               dataset.name as name,
+               dataset.details.owner.id as ownerId,
+               dataset as dataset_details_permissions,
+               (select count(id) from DatasetImageLink dil
+                 where dil.parent=dataset.id) as childCount)
+               from Dataset dataset
+        """
+
+    # If this is a query to get datasets from a parent project
+    if project_id:
+        params.add('pid', rlong(project_id))
+        q += 'join dataset.projectLinks plink'
+        where_clause.append('plink.parent.id = :pid')
+
+    # If this is a query to get datasets with no parent project
+    elif orphaned:
+        where_clause.append(
+            """
+            not exists (
+                select pdlink from ProjectDatasetLink as pdlink
+                where pdlink.child = dataset.id
+            )
+            """
+        )
+
+    q += """
+        %s
+        order by lower(dataset.name), dataset.id
+        """ % build_clause(where_clause, 'where', 'and')
+
+    for e in qs.projection(q, params, service_opts):
+        e = unwrap(e)
+        e = [e[0]["id"],
+             e[0]["name"],
+             e[0]["ownerId"],
+             e[0]["dataset_details_permissions"],
+             e[0]["childCount"]]
+        datasets.append(_marshal_dataset(conn, e[0:5]))
+    return datasets

--- a/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
@@ -118,7 +118,7 @@ def marshal_projects(conn, group_id=-1, experimenter_id=-1,
     service_opts.setOmeroGroup(group_id)
 
     # Paging
-    if page is not None and page > 0:
+    if page:
         params.page((page-1) * limit, limit)
 
     where_clause = ''
@@ -209,7 +209,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
     service_opts.setOmeroGroup(group_id)
 
     # Paging
-    if page is not None and page > 0:
+    if page:
         params.page((page-1) * limit, limit)
 
     where_clause = []
@@ -375,7 +375,7 @@ def marshal_images(conn, dataset_id=None, orphaned=False, share_id=None,
     service_opts.setOmeroGroup(group_id)
 
     # Paging
-    if page is not None and page > 0:
+    if page:
         params.page((page-1) * limit, limit)
 
     from_join_clauses = []

--- a/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/api_marshal.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2008-2015 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+''' Helper functions for views that handle object trees '''
+
+# import time
+import omero
+
+from omero.rtypes import unwrap   # wrap   # rlong
+from django.conf import settings
+# from django.http import Http404
+# from datetime import datetime
+from copy import deepcopy
+
+
+def parse_permissions_css(permissions, ownerid, conn):
+    ''' Parse numeric permissions into a string of space separated
+        CSS classes.
+
+        @param permissions Permissions to parse
+        @type permissions L{omero.rtypes.rmap}
+        @param ownerid Owner Id for the object having Permissions
+        @type ownerId Integer
+        @param conn OMERO gateway.
+        @type conn L{omero.gateway.BlitzGateway}
+    '''
+    restrictions = ('canEdit',
+                    'canAnnotate',
+                    'canLink',
+                    'canDelete')
+    permissionsCss = [r for r in restrictions if permissions.get(r)]
+    if ownerid == conn.getUserId():
+        permissionsCss.append("isOwned")
+    if ownerid == conn.getUserId() or conn.isAdmin():
+        permissionsCss.append("canChgrp")
+    return ' '.join(permissionsCss)
+
+
+def _marshal_project(conn, row):
+    ''' Given a Project row (list) marshals it into a dictionary.  Order
+        and type of columns in row is:
+          * id (rlong)
+          * name (rstring)
+          * details.owner.id (rlong)
+          * details.permissions (dict)
+          * child_count (rlong)
+
+        @param conn OMERO gateway.
+        @type conn L{omero.gateway.BlitzGateway}
+        @param row The Project row to marshal
+        @type row L{list}
+    '''
+    project_id, name, owner_id, permissions, child_count = row
+    project = dict()
+    project['id'] = unwrap(project_id)
+    project['name'] = unwrap(name)
+    project['ownerId'] = unwrap(owner_id)
+    project['childCount'] = unwrap(child_count)
+    project['permsCss'] = \
+        parse_permissions_css(permissions, unwrap(owner_id), conn)
+    return project
+
+
+def marshal_projects(conn, group_id=-1, experimenter_id=-1,
+                     page=1, limit=settings.PAGE):
+    ''' Marshals projects
+
+        @param conn OMERO gateway.
+        @type conn L{omero.gateway.BlitzGateway}
+        @param group_id The Group ID to filter by or -1 for all groups,
+        defaults to -1
+        @type group_id L{long}
+        @param experimenter_id The Experimenter (user) ID to filter by
+        or -1 for all experimenters
+        @type experimenter_id L{long}
+        @param page Page number of results to get. `None` or 0 for no paging
+        defaults to 1
+        @type page L{long}
+        @param limit The limit of results per page to get
+        defaults to the value set in settings.PAGE
+        @type page L{long}
+    '''
+    projects = []
+    params = omero.sys.ParametersI()
+    service_opts = deepcopy(conn.SERVICE_OPTS)
+
+    # Set the desired group context
+    if group_id is None:
+        group_id = -1
+    service_opts.setOmeroGroup(group_id)
+
+    # Paging
+    if page is not None and page > 0:
+        params.page((page-1) * limit, limit)
+
+    where_clause = ''
+    if experimenter_id is not None and experimenter_id != -1:
+        params.addId(experimenter_id)
+        where_clause = 'where project.details.owner.id = :id'
+    qs = conn.getQueryService()
+
+    q = """
+        select new map(project.id as id,
+               project.name as name,
+               project.details.owner.id as ownerId,
+               project as project_details_permissions,
+               (select count(id) from ProjectDatasetLink pdl
+                where pdl.parent = project.id) as childCount)
+        from Project project
+        %s
+        order by lower(project.name), project.id
+        """ % (where_clause)
+
+    for e in qs.projection(q, params, service_opts):
+        e = unwrap(e)
+        e = [e[0]["id"], e[0]["name"], e[0]["ownerId"],
+             e[0]["project_details_permissions"], e[0]["childCount"]]
+        projects.append(_marshal_project(conn, e[0:5]))
+    return projects

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -411,6 +411,12 @@ List all datasets.  To list datasets within a Project, use ?id=projectId
 api_dataset_list = url(r'^api/datasets/$', views.api_dataset_list,
                        name='api_datasets')
 
+"""
+List all images.  To list images within a Dataset, use ?id=datasetId
+"""
+api_image_list = url(r'^api/images/$', views.api_image_list,
+                     name='api_images')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -462,6 +468,7 @@ urlpatterns = patterns(
     # api
     api_container_list,
     api_dataset_list,
+    api_image_list,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -411,7 +411,8 @@ api_experimenter_list = url(r'^api/experimenters/$',
                             views.api_experimenter_list,
                             name='api_experimenters')
 """
-List all experimenters
+List all experimenters.
+To show experimenters in a single group, use 'group' query parameter.
 """
 
 api_experimenter_detail = url(
@@ -426,45 +427,54 @@ Get detail for an experimenter
 # datasets/etc which do not belong to any project
 api_container_list = url(r'^api/containers/$', views.api_container_list,
                          name='api_containers')
+"""
+List all 'top level' containers: Projects, orphaned Datasets, Screens,
+orphaned Plates and an 'Orphaned' images container with image count.
+Filter by 'group' or 'user' ids in query.
+Also supports 'page' and 'limit' parameters for pagination.
+"""
 
+api_project_list = url(r'^api/projects/$', views.api_project_list,
+                       name='api_projects')
 """
 List all projects.
 """
-api_project_list = url(r'^api/projects/$', views.api_project_list,
-                       name='api_projects')
 
+api_dataset_list = url(r'^api/datasets/$', views.api_dataset_list,
+                       name='api_datasets')
 """
 List all datasets.  To list datasets within a Project, use ?id=projectId
 """
-api_dataset_list = url(r'^api/datasets/$', views.api_dataset_list,
-                       name='api_datasets')
 
+api_image_list = url(r'^api/images/$', views.api_image_list,
+                     name='api_images')
 """
 List all images.  To list images within a Dataset, use ?id=datasetId
 """
-api_image_list = url(r'^api/images/$', views.api_image_list,
-                     name='api_images')
 
+api_screen_list = url(r'^api/screens/$', views.api_screen_list,
+                      name='api_screens')
 """
 List all screens.
 """
-api_screen_list = url(r'^api/screens/$', views.api_screen_list,
-                      name='api_screens')
 
+api_plate_list = url(r'^api/plates/$', views.api_plate_list,
+                     name='api_plates')
 """
 List all plates.  To list plates within a Screen, use ?id=screenId
 """
-api_plate_list = url(r'^api/plates/$', views.api_plate_list,
-                     name='api_plates')
 
+api_plate_acquisition_list = url(r'^api/plate_acquisitions/$',
+                                 views.api_plate_acquisition_list,
+                                 name='api_plate_acquisitions')
 """
 List Plate Aquisitions (Runs) under a plate.
 Specify Plate in query with ?id=plateId
 """
-api_plate_acquisition_list = url(r'^api/plate_acquisitions/$',
-                                 views.api_plate_acquisition_list,
-                                 name='api_plate_acquisitions')
 
+api_tags_and_tagged = url(r'^api/tags/$',
+                          views.api_tags_and_tagged_list,
+                          name='api_tags_and_tagged')
 """
 List tags with a GET request or delete specified tags with DELETE.
 For listing tagged data, use 'id' to specify tag. This returns all
@@ -472,19 +482,16 @@ the 'projects', 'datasets' etc as well as any 'tags' (e.g. if the
 tag is a TagSet).
 Or with no id, this will list all tags.
 """
-api_tags_and_tagged = url(r'^api/tags/$',
-                          views.api_tags_and_tagged_list,
-                          name='api_tags_and_tagged')
 
+api_shares = url(r'^api/shares/$',
+                 views.api_share_list,
+                 name='api_shares')
 """
 List all shares and discussions.
 To filter by those that you are a member of (including owner)
 use 'member_id'. To list those that you own, use the
 'user' parameter as for other urls. TODO: change this to 'owner'?
 """
-api_shares = url(r'^api/shares/$',
-                 views.api_share_list,
-                 name='api_shares')
 
 urlpatterns = patterns(
     '',

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -443,6 +443,17 @@ api_plate_acquisition_list = url(r'^api/plate_acquisitions/$',
                                  views.api_plate_acquisition_list,
                                  name='api_plate_acquisitions')
 
+"""
+List tags with a GET request or delete specified tags with DELETE.
+For listing tagged data, use 'id' to specify tag. This returns all
+the 'projects', 'datasets' etc as well as any 'tags' (e.g. if the
+tag is a TagSet).
+Or with no id, this will list all tags.
+"""
+api_tags_and_tagged = url(r'^api/tags/$',
+                          views.api_tags_and_tagged_list,
+                          name='api_tags_and_tagged')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -499,6 +510,7 @@ urlpatterns = patterns(
     api_screen_list,
     api_plate_list,
     api_plate_acquisition_list,
+    api_tags_and_tagged,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -430,7 +430,7 @@ api_container_list = url(r'^api/containers/$', views.api_container_list,
 """
 List all 'top level' containers: Projects, orphaned Datasets, Screens,
 orphaned Plates and an 'Orphaned' images container with image count.
-Filter by 'group' or 'user' ids in query.
+Filter by 'group' or 'owner' ids in query.
 Also supports 'page' and 'limit' parameters for pagination.
 """
 
@@ -490,7 +490,7 @@ api_shares = url(r'^api/shares/$',
 List all shares and discussions.
 To filter by those that you are a member of (including owner)
 use 'member_id'. To list those that you own, use the
-'user' parameter as for other urls. TODO: change this to 'owner'?
+'owner' parameter as for other urls.
 """
 
 urlpatterns = patterns(

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -14,6 +14,7 @@
 # Author: Carlos Neves <carlos(at)glencoesoftware.com>
 
 from django.conf.urls import url, patterns
+from omeroweb.webgateway import views
 
 webgateway = url(r'^$', 'webgateway.views.index', name="webgateway")
 """
@@ -399,6 +400,11 @@ Get a json dict of original file paths.
 'client' is a list of paths for original files on the client when imported
 """
 
+# Generic container list. This is necessary as an experimenter may have
+# datasets/etc which do not belong to any project
+api_container_list = url(r'^api/containers/$', views.api_container_list,
+                         name='api_containers')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -446,6 +452,9 @@ urlpatterns = patterns(
     annotations,
     table_query,
     object_table_query,
+
+    # api
+    api_container_list,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -406,6 +406,12 @@ api_container_list = url(r'^api/containers/$', views.api_container_list,
                          name='api_containers')
 
 """
+List all projects.
+"""
+api_project_list = url(r'^api/projects/$', views.api_project_list,
+                       name='api_projects')
+
+"""
 List all datasets.  To list datasets within a Project, use ?id=projectId
 """
 api_dataset_list = url(r'^api/datasets/$', views.api_dataset_list,
@@ -467,6 +473,7 @@ urlpatterns = patterns(
 
     # api
     api_container_list,
+    api_project_list,
     api_dataset_list,
     api_image_list,
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -405,6 +405,12 @@ Get a json dict of original file paths.
 api_container_list = url(r'^api/containers/$', views.api_container_list,
                          name='api_containers')
 
+"""
+List all datasets.  To list datasets within a Project, use ?id=projectId
+"""
+api_dataset_list = url(r'^api/datasets/$', views.api_dataset_list,
+                       name='api_datasets')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -455,6 +461,7 @@ urlpatterns = patterns(
 
     # api
     api_container_list,
+    api_dataset_list,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -400,6 +400,28 @@ Get a json dict of original file paths.
 'client' is a list of paths for original files on the client when imported
 """
 
+api_group_list = url(r'^api/groups/$', views.api_group_list,
+                     name='api_groups')
+"""
+List all groups.
+To filter groups that a user is member of, use 'member' query parameter.
+"""
+
+api_experimenter_list = url(r'^api/experimenters/$',
+                            views.api_experimenter_list,
+                            name='api_experimenters')
+"""
+List all experimenters
+"""
+
+api_experimenter_detail = url(
+    r'^api/experimenters/(?P<experimenter_id>[0-9]+)/$',
+    views.api_experimenter_detail,
+    name='api_experimenter')
+"""
+Get detail for an experimenter
+"""
+
 # Generic container list. This is necessary as an experimenter may have
 # datasets/etc which do not belong to any project
 api_container_list = url(r'^api/containers/$', views.api_container_list,
@@ -513,6 +535,9 @@ urlpatterns = patterns(
     object_table_query,
 
     # api
+    api_group_list,
+    api_experimenter_list,
+    api_experimenter_detail,
     api_container_list,
     api_project_list,
     api_dataset_list,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -454,6 +454,16 @@ api_tags_and_tagged = url(r'^api/tags/$',
                           views.api_tags_and_tagged_list,
                           name='api_tags_and_tagged')
 
+"""
+List all shares and discussions.
+To filter by those that you are a member of (including owner)
+use 'member_id'. To list those that you own, use the
+'user' parameter as for other urls. TODO: change this to 'owner'?
+"""
+api_shares = url(r'^api/shares/$',
+                 views.api_share_list,
+                 name='api_shares')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -511,6 +521,7 @@ urlpatterns = patterns(
     api_plate_list,
     api_plate_acquisition_list,
     api_tags_and_tagged,
+    api_shares,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -423,6 +423,18 @@ List all images.  To list images within a Dataset, use ?id=datasetId
 api_image_list = url(r'^api/images/$', views.api_image_list,
                      name='api_images')
 
+"""
+List all screens.
+"""
+api_screen_list = url(r'^api/screens/$', views.api_screen_list,
+                      name='api_screens')
+
+"""
+List all plates.  To list plates within a Screen, use ?id=screenId
+"""
+api_plate_list = url(r'^api/plates/$', views.api_plate_list,
+                     name='api_plates')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -476,6 +488,8 @@ urlpatterns = patterns(
     api_project_list,
     api_dataset_list,
     api_image_list,
+    api_screen_list,
+    api_plate_list,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -435,6 +435,14 @@ List all plates.  To list plates within a Screen, use ?id=screenId
 api_plate_list = url(r'^api/plates/$', views.api_plate_list,
                      name='api_plates')
 
+"""
+List Plate Aquisitions (Runs) under a plate.
+Specify Plate in query with ?id=plateId
+"""
+api_plate_acquisition_list = url(r'^api/plate_acquisitions/$',
+                                 views.api_plate_acquisition_list,
+                                 name='api_plate_acquisitions')
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -490,6 +498,7 @@ urlpatterns = patterns(
     api_image_list,
     api_screen_list,
     api_plate_list,
+    api_plate_acquisition_list,
 
     # Debug stuff
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -72,6 +72,25 @@ def getBoolOrDefault(request, name, default):
     return rv
 
 
+def getLongs(request, name):
+    """
+    Retrieves parameters from the request. If the parameters are not present
+    an empty list is returned
+
+    This does not catch exceptions as it makes sense to throw exceptions if
+    the arguments provided do not pass basic type validation
+
+    @param request:     http request
+    @param name:        name of parameter
+    @return:            List of Longs
+    """
+    vals = []
+    vals_raw = request.GET.getlist(name)
+    for val_raw in vals_raw:
+        vals.append(long(val_raw))
+    return vals
+
+
 def zip_archived_files(images, temp, zipName):
     """
     Util function to download original files from a list of images

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -47,6 +47,31 @@ def getIntOrDefault(request, name, default):
     return index
 
 
+def getBoolOrDefault(request, name, default):
+    """
+    Helper method for parsing query string parameters from http request.
+    Returns the named value as a boolean.
+
+    @param request:     http request
+    @param name:        name of parameter
+    @param default:     value to return if not found in request
+    @return:            Boolean
+    """
+
+    rv = default
+    try:
+        value = request.GET.get(name, request.POST.get(name, None))
+        if value is not None:
+            if value.lower() == 'true':
+                rv = True
+            elif value.lower() != 'false' and int(value) == 1:
+                rv = True
+    except ValueError:
+        msg = "Invalid value '%s' for parameter '%s'" % (value, name)
+        raise ValueError(msg)
+    return rv
+
+
 def zip_archived_files(images, temp, zipName):
     """
     Util function to download original files from a list of images

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -37,9 +37,12 @@ def getIntOrDefault(request, name, default):
     @return:            Integer or None
     """
 
-    index = request.GET.get(name, request.POST.get(name, default))
-    if index is not None:
-        index = int(index)
+    try:
+        index = request.GET.get(name, request.POST.get(name, default))
+        if index is not None:
+            index = int(index)
+    except ValueError:
+        raise ValueError("Invalid value '%s' for parameter '%s'" % (index, name))
     return index
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -26,14 +26,20 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-# helper method
 def getIntOrDefault(request, name, default):
-    try:
-        index = request.GET.get(name, request.POST.get(name, default))
-        if index is not None:
-            index = int(index)
-    except ValueError:
-        index = 0
+    """
+    Helper method for parsing query string parameters from http request.
+    Returns the named value or a default value or None.
+
+    @param request:     http request
+    @param name:        name of parameter
+    @param default:     value to return if not found in request
+    @return:            Integer or None
+    """
+
+    index = request.GET.get(name, request.POST.get(name, default))
+    if index is not None:
+        index = int(index)
     return index
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -42,7 +42,8 @@ def getIntOrDefault(request, name, default):
         if index is not None:
             index = int(index)
     except ValueError:
-        raise ValueError("Invalid value '%s' for parameter '%s'" % (index, name))
+        msg = "Invalid value '%s' for parameter '%s'" % (index, name)
+        raise ValueError(msg)
     return index
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1341,7 +1341,7 @@ def api_container_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1411,7 +1411,7 @@ def api_project_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1439,7 +1439,7 @@ def api_dataset_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
         project_id = getIntOrDefault(request, 'id', None)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
@@ -1484,7 +1484,7 @@ def api_image_list(request, conn=None, **kwargs):
         thumb_version = getBoolOrDefault(request, 'thumbVersion', False)
         date = getBoolOrDefault(request, 'date', False)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1525,7 +1525,7 @@ def api_screen_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1555,7 +1555,7 @@ def api_plate_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1631,7 +1631,7 @@ def api_tags_and_tagged_list_GET(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'user', -1)
+        experimenter_id = getIntOrDefault(request, 'owner', -1)
         tag_id = getIntOrDefault(request, 'id', None)
         orphaned = getBoolOrDefault(request, 'orphaned', False)
         load_pixels = getBoolOrDefault(request, 'sizeXYZ', False)
@@ -1718,7 +1718,7 @@ def api_share_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         member_id = getIntOrDefault(request, 'member_id', -1)
-        owner_id = getIntOrDefault(request, 'user', -1)
+        owner_id = getIntOrDefault(request, 'owner', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1258,7 +1258,7 @@ def api_container_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
-        experimenter_id = getIntOrDefault(request, 'id', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
@@ -1328,12 +1328,14 @@ def api_project_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 
     try:
         projects = marshal_projects(conn=conn,
                                     group_id=group_id,
+                                    experimenter_id=experimenter_id,
                                     page=page,
                                     limit=limit)
     except ApiUsageException as e:
@@ -1354,6 +1356,7 @@ def api_dataset_list(request, conn=None, **kwargs):
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
         project_id = getIntOrDefault(request, 'id', None)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
@@ -1363,6 +1366,7 @@ def api_dataset_list(request, conn=None, **kwargs):
         datasets = marshal_datasets(conn=conn,
                                     project_id=project_id,
                                     group_id=group_id,
+                                    experimenter_id=experimenter_id,
                                     page=page,
                                     limit=limit)
     except ApiUsageException as e:
@@ -1391,13 +1395,13 @@ def api_image_list(request, conn=None, **kwargs):
     try:
         page = getIntOrDefault(request, 'page', 1)
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
-        group_id = getIntOrDefault(request, 'group', -1)
         dataset_id = getIntOrDefault(request, 'id', None)
         orphaned = getBoolOrDefault(request, 'orphaned', False)
         load_pixels = getBoolOrDefault(request, 'sizeXYZ', False)
         thumb_version = getBoolOrDefault(request, 'thumbVersion', False)
         date = getBoolOrDefault(request, 'date', False)
-        experimenter_id = getIntOrDefault(request, 'experimenter_id', -1)
+        group_id = getIntOrDefault(request, 'group', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
     except ValueError as ex:
         return HttpResponseBadRequest(str(ex))
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1257,8 +1257,8 @@ def api_container_list(request, conn=None, **kwargs):
         limit = getIntOrDefault(request, 'limit', settings.PAGE)
         group_id = getIntOrDefault(request, 'group', -1)
         experimenter_id = getIntOrDefault(request, 'id', -1)
-    except ValueError:
-        return HttpResponseBadRequest('Invalid parameter value')
+    except ValueError as ex:
+        return HttpResponseBadRequest(str(ex))
 
     # While this interface does support paging, it does so in a
     # very odd way. The results per page is enforced per query so this

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1322,6 +1322,32 @@ def api_container_list(request, conn=None, **kwargs):
 
 @login_required()
 @jsonp
+def api_project_list(request, conn=None, **kwargs):
+    # Get parameters
+    try:
+        page = getIntOrDefault(request, 'page', 1)
+        limit = getIntOrDefault(request, 'limit', settings.PAGE)
+        group_id = getIntOrDefault(request, 'group', -1)
+    except ValueError as ex:
+        return HttpResponseBadRequest(str(ex))
+
+    try:
+        projects = marshal_projects(conn=conn,
+                                    group_id=group_id,
+                                    page=page,
+                                    limit=limit)
+    except ApiUsageException as e:
+        return HttpResponseBadRequest(e.serverStackTrace)
+    except ServerError as e:
+        return HttpResponseServerError(e.serverStackTrace)
+    except IceException as e:
+        return HttpResponseServerError(e.message)
+
+    return {'projects': projects}
+
+
+@login_required()
+@jsonp
 def api_dataset_list(request, conn=None, **kwargs):
     # Get parameters
     try:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -34,7 +34,7 @@ from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox
 from plategrid import PlateGrid
 from omero_version import build_year
 from marshal import imageMarshal, shapeMarshal
-from api_marshal import marshal_projects
+from api_marshal import marshal_projects, marshal_datasets
 
 try:
     from hashlib import md5
@@ -1275,12 +1275,12 @@ def api_container_list(request, conn=None, **kwargs):
                                     limit=limit)
 
         # Get the orphaned datasets (without project parents)
-        # datasets = tree.marshal_datasets(conn=conn,
-        #                                  orphaned=True,
-        #                                  group_id=group_id,
-        #                                  experimenter_id=experimenter_id,
-        #                                  page=page,
-        #                                  limit=limit)
+        datasets = marshal_datasets(conn=conn,
+                                    orphaned=True,
+                                    group_id=group_id,
+                                    experimenter_id=experimenter_id,
+                                    page=page,
+                                    limit=limit)
 
         # # Get the screens for the current user
         # screens = tree.marshal_screens(conn=conn,
@@ -1311,7 +1311,7 @@ def api_container_list(request, conn=None, **kwargs):
         return HttpResponseServerError(e.message)
 
     return HttpJsonResponse({'projects': projects,
-                             # 'datasets': datasets,
+                             'datasets': datasets,
                              # 'screens': screens,
                              # 'plates': plates,
                              # 'orphaned': orphaned

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -35,7 +35,7 @@ from plategrid import PlateGrid
 from omero_version import build_year
 from marshal import imageMarshal, shapeMarshal
 from api_marshal import marshal_projects, marshal_datasets, \
-    marshal_images
+    marshal_images, marshal_screens, marshal_plates
 
 try:
     from hashlib import md5
@@ -1285,19 +1285,19 @@ def api_container_list(request, conn=None, **kwargs):
                                     limit=limit)
 
         # # Get the screens for the current user
-        # screens = tree.marshal_screens(conn=conn,
-        #                                group_id=group_id,
-        #                                experimenter_id=experimenter_id,
-        #                                page=page,
-        #                                limit=limit)
+        screens = marshal_screens(conn=conn,
+                                  group_id=group_id,
+                                  experimenter_id=experimenter_id,
+                                  page=page,
+                                  limit=limit)
 
         # # Get the orphaned plates (without project parents)
-        # plates = tree.marshal_plates(conn=conn,
-        #                              orphaned=True,
-        #                              group_id=group_id,
-        #                              experimenter_id=experimenter_id,
-        #                              page=page,
-        #                              limit=limit)
+        plates = marshal_plates(conn=conn,
+                                orphaned=True,
+                                group_id=group_id,
+                                experimenter_id=experimenter_id,
+                                page=page,
+                                limit=limit)
 
         # # Get the orphaned images container
         # orphaned = tree.marshal_orphaned(conn=conn,
@@ -1314,8 +1314,8 @@ def api_container_list(request, conn=None, **kwargs):
 
     return {'projects': projects,
             'datasets': datasets,
-            # 'screens': screens,
-            # 'plates': plates,
+            'screens': screens,
+            'plates': plates,
             # 'orphaned': orphaned
             }
 
@@ -1432,6 +1432,66 @@ def api_image_list(request, conn=None, **kwargs):
         return HttpResponseServerError(e.message)
 
     return {'images': images}
+
+
+@login_required()
+@jsonp
+def api_screen_list(request, conn=None, **kwargs):
+    # Get parameters
+    try:
+        page = getIntOrDefault(request, 'page', 1)
+        limit = getIntOrDefault(request, 'limit', settings.PAGE)
+        group_id = getIntOrDefault(request, 'group', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
+    except ValueError as ex:
+        return HttpResponseBadRequest(str(ex))
+
+    try:
+        # Get the screens
+        screens = marshal_screens(conn=conn,
+                                  group_id=group_id,
+                                  experimenter_id=experimenter_id,
+                                  page=page,
+                                  limit=limit)
+    except ApiUsageException as e:
+        return HttpResponseBadRequest(e.serverStackTrace)
+    except ServerError as e:
+        return HttpResponseServerError(e.serverStackTrace)
+    except IceException as e:
+        return HttpResponseServerError(e.message)
+
+    return {'screens': screens}
+
+
+@login_required()
+@jsonp
+def api_plate_list(request, conn=None, **kwargs):
+    # Get parameters
+    try:
+        screen_id = getIntOrDefault(request, 'id', None)
+        page = getIntOrDefault(request, 'page', 1)
+        limit = getIntOrDefault(request, 'limit', settings.PAGE)
+        group_id = getIntOrDefault(request, 'group', -1)
+        experimenter_id = getIntOrDefault(request, 'user', -1)
+    except ValueError as ex:
+        return HttpResponseBadRequest(str(ex))
+
+    try:
+        # Get the plates
+        plates = marshal_plates(conn=conn,
+                                screen_id=screen_id,
+                                group_id=group_id,
+                                experimenter_id=experimenter_id,
+                                page=page,
+                                limit=limit)
+    except ApiUsageException as e:
+        return HttpResponseBadRequest(e.serverStackTrace)
+    except ServerError as e:
+        return HttpResponseServerError(e.serverStackTrace)
+    except IceException as e:
+        return HttpResponseServerError(e.message)
+
+    return {'plates': plates}
 
 
 @login_required()

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1310,15 +1310,16 @@ def api_container_list(request, conn=None, **kwargs):
     except IceException as e:
         return HttpResponseServerError(e.message)
 
-    return HttpJsonResponse({'projects': projects,
-                             'datasets': datasets,
-                             # 'screens': screens,
-                             # 'plates': plates,
-                             # 'orphaned': orphaned
-                             })
+    return {'projects': projects,
+            'datasets': datasets,
+            # 'screens': screens,
+            # 'plates': plates,
+            # 'orphaned': orphaned
+            }
 
 
 @login_required()
+@jsonp
 def api_dataset_list(request, conn=None, **kwargs):
     # Get parameters
     try:
@@ -1343,7 +1344,7 @@ def api_dataset_list(request, conn=None, **kwargs):
     except IceException as e:
         return HttpResponseServerError(e.message)
 
-    return HttpJsonResponse({'datasets': datasets})
+    return {'datasets': datasets}
 
 
 @login_required()

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1319,6 +1319,34 @@ def api_container_list(request, conn=None, **kwargs):
 
 
 @login_required()
+def api_dataset_list(request, conn=None, **kwargs):
+    # Get parameters
+    try:
+        page = getIntOrDefault(request, 'page', 1)
+        limit = getIntOrDefault(request, 'limit', settings.PAGE)
+        group_id = getIntOrDefault(request, 'group', -1)
+        project_id = getIntOrDefault(request, 'id', None)
+    except ValueError as ex:
+        return HttpResponseBadRequest(str(ex))
+
+    try:
+        # Get the datasets
+        datasets = marshal_datasets(conn=conn,
+                                    project_id=project_id,
+                                    group_id=group_id,
+                                    page=page,
+                                    limit=limit)
+    except ApiUsageException as e:
+        return HttpResponseBadRequest(e.serverStackTrace)
+    except ServerError as e:
+        return HttpResponseServerError(e.serverStackTrace)
+    except IceException as e:
+        return HttpResponseServerError(e.message)
+
+    return HttpJsonResponse({'datasets': datasets})
+
+
+@login_required()
 @jsonp
 def imageData_json(request, conn=None, _internal=False, **kwargs):
     """

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,11 +32,12 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_images, marshal_plates, \
+    marshal_plates, \
     marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
-from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets
+from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
+    marshal_images
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,11 +32,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
 from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
-    marshal_images, marshal_screens, marshal_plates
+    marshal_images, marshal_screens, marshal_plates, marshal_plate_acquisitions, \
+    marshal_orphaned
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,11 +32,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_datasets, marshal_images, marshal_plates, \
+    marshal_images, marshal_plates, \
     marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
-from omeroweb.webgateway.api_marshal import marshal_projects
+from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -31,12 +31,12 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     DatasetAnnotationLinkI, ImageAnnotationLinkI, ScreenAnnotationLinkI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
-from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_shares, marshal_discussions
+from omeroweb.webclient.tree import marshal_experimenter
 
 from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
     marshal_images, marshal_screens, marshal_plates, marshal_plate_acquisitions, \
-    marshal_orphaned, marshal_tags, marshal_tagged
+    marshal_orphaned, marshal_tags, marshal_tagged, \
+    marshal_shares, marshal_discussions
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,9 +32,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_projects, marshal_datasets, marshal_images, marshal_plates, \
+    marshal_datasets, marshal_images, marshal_plates, \
     marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
+
+from omeroweb.webgateway.api_marshal import marshal_projects
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -31,12 +31,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     DatasetAnnotationLinkI, ImageAnnotationLinkI, ScreenAnnotationLinkI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
-from omeroweb.webclient.tree import marshal_experimenter
 
 from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
     marshal_images, marshal_screens, marshal_plates, marshal_plate_acquisitions, \
     marshal_orphaned, marshal_tags, marshal_tagged, \
-    marshal_shares, marshal_discussions
+    marshal_shares, marshal_discussions, marshal_experimenter
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,12 +32,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_plates, \
-    marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
+    marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
 from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
-    marshal_images
+    marshal_images, marshal_screens, marshal_plates
 
 from datetime import datetime
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -32,11 +32,11 @@ from omero.model import ProjectI, DatasetI, ImageI, ScreenI, PlateI, \
     PlateAnnotationLinkI, PlateAcquisitionAnnotationLinkI
 from omero.rtypes import rstring, rtime
 from omeroweb.webclient.tree import marshal_experimenter, \
-    marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
+    marshal_shares, marshal_discussions
 
 from omeroweb.webgateway.api_marshal import marshal_projects, marshal_datasets, \
     marshal_images, marshal_screens, marshal_plates, marshal_plate_acquisitions, \
-    marshal_orphaned
+    marshal_orphaned, marshal_tags, marshal_tagged
 
 from datetime import datetime
 


### PR DESCRIPTION
I have started to port the webclient /api/ methods over to webgateway so we can discuss various location / naming / api / error handling issues.

There is already a ```webgateway/marshal.py``` module. For now, I've created a new ```webgateway/api_marshal.py``` file to keep the ported code separate from existing marshalling code, but this could just as well go all together in ```marshal.py```

We handle errors in parsing query parameters such that ```webclient/api/containers/?page=one``` returns ```HttpResponseBadRequest("Invalid value 'ome' for parameter 'page'")```

I've preserved the naming of the views methods, e.g. ```api_container_list``` and url ```api/containers/``` both with the api prefix. Maybe we don't need the extra ```api``` prefix, since everything in webgateway should be an api?

In the webclient, ```api_container_list``` takes an "id" query parameter to filter by experimenter. All the other urls use ```id``` to filter by the parent container. E.g. For ```api_images``` id is for dataset ID.
Now I have used ```user``` to filter by experimenter ID for ALL urls.

I notice that there's a lot of stuff in ```webgateway/views.py``` that could be moved out.
This should really just contain the request handling methods, with other helper methods elsewhere.
Also there's stuff here that is required by the webgateway viewer but is maybe not useful as part of the api, such as ROI/Shape thumbnails? This could all be moved to a new app just for the viewer?

It would be good to discuss these issues and develop a consensus, since we want this to be a very stable API. Meanwhile I can continue porting more code using the same pattern as above.
