### PR TITLE
fix equivalence typos

### DIFF
--- a/components/blitz/test/ome/formats/utests/ContainerCacheOrderTest.java
+++ b/components/blitz/test/ome/formats/utests/ContainerCacheOrderTest.java
@@ -142,7 +142,7 @@ public class ContainerCacheOrderTest extends TestCase
 	}
 
 	@Test
-	public void testPlateLSIDEquivilence()
+	public void testPlateLSIDEquivalence()
 	{
 		LSID a = new LSID(Plate.class, 0);
 		LSID b = new LSID("omero.model.Plate:0");

--- a/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
+++ b/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
@@ -196,7 +196,7 @@ public class MetadataValidatorTest
     }
 
     @Test(dependsOnMethods={"testMetadataLevel"})
-    public void testMetadataLevelEquivilentDimensions()
+    public void testMetadataLevelEquivalentDimensions()
     {
         assertEquals(wrapper.getSeriesCount(), minimalWrapper.getSeriesCount());
         for (int i = 0; i < minimalWrapper.getSeriesCount(); i++)
@@ -216,7 +216,7 @@ public class MetadataValidatorTest
     }
 
     @Test(dependsOnMethods={"testMetadataLevel"})
-    public void testMetadataLevelEquivilentUsedFiles()
+    public void testMetadataLevelEquivalentUsedFiles()
         throws FormatException, IOException
     {
         for (int i = 0; i < minimalWrapper.getSeriesCount(); i++)
@@ -240,7 +240,7 @@ public class MetadataValidatorTest
     }
 
     @Test(dependsOnMethods={"testMetadataLevel"})
-    public void testMetadataLevelEquivilentPlaneData()
+    public void testMetadataLevelEquivalentPlaneData()
         throws FormatException, IOException
     {
         for (int i = 0; i < minimalWrapper.getSeriesCount(); i++)
@@ -267,7 +267,7 @@ public class MetadataValidatorTest
     }
 
     @Test(dependsOnMethods={"testMetadataLevel"})
-    public void testEquivilentBlockRetrievalPlaneData()
+    public void testEquivalentBlockRetrievalPlaneData()
         throws FormatException, IOException
     {
         String fileName = wrapper.getCurrentFile();

--- a/components/model/test/ome/util/utests/LSIDEquivalenceTest.java
+++ b/components/model/test/ome/util/utests/LSIDEquivalenceTest.java
@@ -26,7 +26,7 @@ import ome.util.LSID;
 import org.testng.annotations.Test;
 
 @Test
-public class LSIDEquivilenceTest extends TestCase
+public class LSIDEquivalenceTest extends TestCase
 {
 	public void testStringHashMapContainsKey()
 	{


### PR DESCRIPTION
A trivial PR that fixes the spelling of "equivalence". All should remain green.

--no-rebase