### PR TITLE
Fixing hanging Ice callback

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -254,7 +254,13 @@ class WebControl(BaseControl):
             print traceback.print_exc()
             self.ctx.err(
                 "Cannot import Ice.")
-        d["OMEROPYTHONROOT"] = self._get_python_dir()
+        try:
+            pythopath = ":".join([
+                self._get_python_dir(),
+                os.environ.get("PYTHONPATH", None)])
+        except:
+            pythopath = self._get_python_dir()
+        d["OMEROPYTHONROOT"] = pythopath
         d["OMEROFALLBACKROOT"] = self._get_fallback_dir()
 
     @config_required

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -255,12 +255,12 @@ class WebControl(BaseControl):
             self.ctx.err(
                 "Cannot import Ice.")
         try:
-            pythopath = ":".join([
+            pythonpath = os.pathsep.join([
                 self._get_python_dir(),
                 os.environ.get("PYTHONPATH", None)])
         except:
-            pythopath = self._get_python_dir()
-        d["OMEROPYTHONROOT"] = pythopath
+            pythonpath = self._get_python_dir()
+        d["OMEROPYTHONROOT"] = pythonpath
         d["OMEROFALLBACKROOT"] = self._get_fallback_dir()
 
     @config_required

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
@@ -80,8 +80,7 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi
-
-
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
@@ -60,6 +60,8 @@
   
   WSGIProcessGroup omeroweb_test
 
+  WSGIApplicationGroup %{GLOBAL}
+
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
@@ -80,8 +80,7 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi
-
-
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
@@ -60,6 +60,8 @@
   
   WSGIProcessGroup omeroweb
 
+  WSGIApplicationGroup %{GLOBAL}
+
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
@@ -10,6 +10,8 @@
 
   WSGIProcessGroup omeroweb_test
 
+  WSGIApplicationGroup %{GLOBAL}
+
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
@@ -28,7 +28,7 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
-# Use this on Ubuntu/Debian systems:
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
@@ -10,6 +10,8 @@
 
   WSGIProcessGroup omeroweb
 
+  WSGIApplicationGroup %{GLOBAL}
+
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
@@ -28,7 +28,7 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
-# Use this on Ubuntu/Debian systems:
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi
 
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -430,22 +430,24 @@ class TestWeb(object):
         # Note: the differences between the generated apache22 and apache24
         # configurations are in unchanged parts of the template
         if python_path:
+            pp = os.pathsep.join([icepath, pythondir,
+                                  python_path, fallbackdir])
             missing = self.required_lines_in([
                 ("<VirtualHost _default_:%s>" % (80)),
                 ('WSGIDaemonProcess omeroweb ' +
                  'processes=5 threads=1 '
                  'display-name=%%{GROUP} user=%s ' % username +
-                 'python-path=%s:%s:%s:%s' % (icepath, pythondir,
-                                              python_path, fallbackdir),
+                 'python-path=%s' % pp,
                  'lib/python/omeroweb'),
                 ], lines)
         else:
+            pp = os.pathsep.join([icepath, pythondir, fallbackdir])
             missing = self.required_lines_in([
                 ("<VirtualHost _default_:%s>" % (80)),
                 ('WSGIDaemonProcess omeroweb ' +
                  'processes=5 threads=1 '
                  'display-name=%%{GROUP} user=%s ' % username +
-                 'python-path=%s:%s:%s:' % (icepath, pythondir, fallbackdir),
+                 'python-path=%s' % pp,
                  'lib/python/omeroweb'),
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -46,6 +46,12 @@ class TestWeb(object):
         monkeypatch.setattr(WebControl, '_get_web_templates_dir',
                             lambda x: dist_dir / "etc" / "templates" / "web")
 
+    def set_python_path(self, monkeypatch, python_path=None):
+        if python_path:
+            monkeypatch.setenv('PYTHONPATH', python_path)
+        else:
+            monkeypatch.delenv('PYTHONPATH')
+
     def set_python_dir(self, monkeypatch):
 
         dist_dir = path(__file__) / ".." / ".." / ".." / ".." / ".." /\
@@ -344,7 +350,7 @@ class TestWeb(object):
     @pytest.mark.parametrize('http', [False, 8081])
     def testApacheWSGIConfig(self, server_type, prefix, app_server, http,
                              capsys, monkeypatch):
-
+        self.set_python_path(monkeypatch)
         self.add_application_server(app_server, monkeypatch)
         static_prefix = self.add_prefix(prefix, monkeypatch)
         upstream_name = self.add_upstream_name(prefix, monkeypatch)
@@ -395,6 +401,55 @@ class TestWeb(object):
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)
 
+    @pytest.mark.parametrize('server_type', ["apache", "apache22", "apache24"])
+    @pytest.mark.parametrize('app_server', ['wsgi'])
+    @pytest.mark.parametrize('python_path', [None, '/python/path/location'])
+    def testApacheWSGIConfigPythonPath(self, server_type, app_server,
+                                       python_path, capsys, monkeypatch):
+        self.set_python_path(monkeypatch, python_path)
+        self.add_application_server(app_server, monkeypatch)
+
+        try:
+            import pwd
+            username = pwd.getpwuid(os.getuid()).pw_name
+        except ImportError:
+            import getpass
+            username = getpass.getuser()
+        icepath = os.path.dirname(Ice.__file__)
+        ctx = self.cli.controls["web"]
+        pythondir = ctx.dir / "lib" / "python"
+        fallbackdir = ctx.dir / "lib" / "fallback"
+
+        self.args += ["config", server_type]
+
+        self.set_templates_dir(monkeypatch)
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+
+        lines = self.clean_generated_file(o)
+        # Note: the differences between the generated apache22 and apache24
+        # configurations are in unchanged parts of the template
+        if python_path:
+            missing = self.required_lines_in([
+                ("<VirtualHost _default_:%s>" % (80)),
+                ('WSGIDaemonProcess omeroweb ' +
+                 'processes=5 threads=1 '
+                 'display-name=%%{GROUP} user=%s ' % username +
+                 'python-path=%s:%s:%s:%s' % (icepath, pythondir,
+                                              python_path, fallbackdir),
+                 'lib/python/omeroweb'),
+                ], lines)
+        else:
+            missing = self.required_lines_in([
+                ("<VirtualHost _default_:%s>" % (80)),
+                ('WSGIDaemonProcess omeroweb ' +
+                 'processes=5 threads=1 '
+                 'display-name=%%{GROUP} user=%s ' % username +
+                 'python-path=%s:%s:%s:' % (icepath, pythondir, fallbackdir),
+                 'lib/python/omeroweb'),
+                ], lines)
+        assert not missing, 'Line not found: ' + str(missing)
+
     @pytest.mark.parametrize('server_type', [
         ["nginx", 'wsgi-tcp'],
         ["nginx-development", 'wsgi-tcp'],
@@ -410,6 +465,7 @@ class TestWeb(object):
         self.add_application_server(app_server, monkeypatch)
         self.args += ["config"] + server_type
         self.set_templates_dir(monkeypatch)
+        self.set_python_path(monkeypatch)
         self.cli.invoke(self.args, strict=True)
 
         o, e = capsys.readouterr()
@@ -443,6 +499,7 @@ class TestWeb(object):
 
         self.args += ["config"] + server_type
         self.set_templates_dir(monkeypatch)
+        self.set_python_path(monkeypatch)
         self.cli.invoke(self.args, strict=True)
 
         o, e = capsys.readouterr()

--- a/etc/templates/web/apache22.conf.template
+++ b/etc/templates/web/apache22.conf.template
@@ -60,6 +60,8 @@
   
   WSGIProcessGroup omeroweb%(PREFIX_NAME)s
 
+  WSGIApplicationGroup %%{GLOBAL}
+
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 
   <Directory "%(OMEROWEBROOT)s">

--- a/etc/templates/web/apache22.conf.template
+++ b/etc/templates/web/apache22.conf.template
@@ -80,6 +80,5 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi
-
-

--- a/etc/templates/web/apache24.conf.template
+++ b/etc/templates/web/apache24.conf.template
@@ -10,6 +10,8 @@
 
   WSGIProcessGroup omeroweb%(PREFIX_NAME)s
 
+  WSGIApplicationGroup %%{GLOBAL}
+
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
 
   <Directory "%(OMEROWEBROOT)s">

--- a/etc/templates/web/apache24.conf.template
+++ b/etc/templates/web/apache24.conf.template
@@ -28,5 +28,5 @@
 
 # see https://code.google.com/p/modwsgi/wiki/ConfigurationIssues
 WSGISocketPrefix run/wsgi
-# Use this on Ubuntu/Debian systems:
+# Use this on Ubuntu/Debian/MacOSX systems:
 # WSGISocketPrefix /var/run/wsgi


### PR DESCRIPTION
1. hanging web

 > For each vhost Django site should use a separate daemon process group. WSGIApplicationGroup %{GLOBAL} https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIApplicationGroup is forcing the use of the main interpreter context within the respective process groups. It is not shared across process groups.

 Looks like we are using Python modules (IcePy?) that are not loaded correctly in Python sub interpreters, see https://code.google.com/p/modwsgi/wiki/ApplicationIssues#Python_Simplified_GIL_State_API

 To test:
 - delete image and check activities, it shouldn't hang anymore.

1. I also updated python-path as it was missing env, cc @kennethgillen 
 To test:
 -  default ``PYTHONPATH``
    - set ``bin/omero config set omero.web.application_server 'wsgi'``
    - make sure there is nothing in your pythonpath ``$echo $PYTHONAPTH``
    - generate config ``bin/omero web config {apache22|apache24}``
    - ``WSGIDaemonProcess`` should contain only  defaults in ``python-path=..python2.7/site-packages:..dist/lib/python:...``
  - custom PYTHONPATH:
    - set ``bin/omero config set omero.web.application_server 'wsgi'``
    - export ``$PYTHONPATH=/some/location:$PYTHONPATH``
    - generate config ``bin/omero web config {apache22|apache24}``
    - check if ``WSGIDaemonProcess`` contains ``/some/location`` in ``python-path=..python2.7/site-packages:..dist/lib/python:/some/location``

**Note: for multiple WSGI applications, config delegate each WSGI application to run in its own daemon process group.** See https://groups.google.com/forum/m/#!topic/modwsgi/7NRGTm4VUp4