### PR TITLE
Ticket 12546

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -1600,6 +1600,9 @@ class DataBrowserComponent
 		//depends on the view.
 		WellsModel wm = (WellsModel) model;
 		
+        if (wm.getSelectedWell() == null)
+            return;
+		
 		int index = view.getSelectedView();
 		
 		if (index == DataBrowserUI.FIELDS_VIEW) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserComponent.java
@@ -1633,6 +1633,8 @@ class DataBrowserComponent
 		WellsModel wm = (WellsModel) model;
 		if (!wm.isSameWell(row, column)) return;
 		WellImageSet well = wm.getSelectedWell();
+		if (well == null)
+		    return;
 		List<WellSampleNode> nodes = well.getWellSamples();
 		Iterator<WellSampleNode> j = nodes.iterator();
 		WellSampleNode n; 


### PR DESCRIPTION
This would fix the NPE of ticket 12546, although I don't know the real cause for this (and therefore can't say how to test it). ```wm.getSelectedWell()``` is the only object which theoretically could be ```null``` in the line of code which triggered the NPE, so this PR at least provides a workaround for the issue (i. e. prevents Insight from crashing).

Test: Code review only (as I've not been able to reproduce the NPE)
