### PR TITLE
Activities fixes

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -32,7 +32,7 @@
     }
 
     // this is called by the setInterval loop below
-    OME.activitiesUpdate = function(i) {
+    OME.activitiesUpdate = function(recursive) {
         $.get("{% url 'activities' %}", function(data) {
             $('#activities_spinner').hide();
             var inprogress = $("#inprogress", data).text();
@@ -41,13 +41,13 @@
             
             // if we've got no jobs still running, stop checking
             if ((typeof inprogress == 'undefined') || (inprogress.length == 0)) {
-                if (i) clearInterval(i);
+                recursive = false;
                 showJobCount(0);
                 //return;
             }
             inprogress = parseInt( inprogress );
-            if (inprogress==0) {
-                if (i != undefined) clearInterval(i);
+            if (inprogress === 0) {
+                recursive = false;
             }
             
             // display what we recieved, bind events etc
@@ -77,10 +77,14 @@
                 new_results = -1;   // hide notification number
             }
             OME.displayStatus(new_results, inprogress);
+            if (recursive) {
+                setTimeout(function(){
+                    OME.activitiesUpdate(true);
+                }, 5000);
+            }
 
         }).error(function() {
             // this requires jQuery 1.5 or later
-            clearInterval(i);
         });
     }
 
@@ -120,10 +124,7 @@
     }
 
     OME.refreshActivities = function() {
-        var i = setInterval(function (){
-                OME.activitiesUpdate(i);
-        }, 5000);
-        OME.activitiesUpdate(i);
+        OME.activitiesUpdate(true);
     }
     $(document).ready(function() {
         OME.displayStatus(-1);  // reset new_results

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -85,6 +85,8 @@
 
         }).error(function() {
             // this requires jQuery 1.5 or later
+            $('#activities_spinner').hide();
+            $("#activities_content").html("<table><tbody><tr><td><span>Activity unavailable - timeout</span></td></tr></tbody></table>");
         });
     }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -86,7 +86,7 @@
         }).error(function() {
             // this requires jQuery 1.5 or later
             $('#activities_spinner').hide();
-            $("#activities_content").html("<table><tbody><tr><td><span>Activity unavailable - timeout</span></td></tr></tbody></table>");
+            $("#activities_content").html("<table id='activitiesTimeoutMsg'><tbody><tr><td><span>Activity unavailable - timeout</span></td></tr></tbody></table>");
         });
     }
 
@@ -152,6 +152,8 @@
         $("#clear_activities").click(function() {
             $.post("{% url 'activities_update' action='clean' %}");
             $("#jobsTable>tbody>tr").filter(":not(.in_progress)").remove();
+            // In case we have shown timeout message...
+            $("#activitiesTimeoutMsg").remove();
         });
 
         // close panels on 'ESCAPE'

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -33,60 +33,65 @@
 
     // this is called by the setInterval loop below
     OME.activitiesUpdate = function(recursive) {
-        $.get("{% url 'activities' %}", function(data) {
-            $('#activities_spinner').hide();
-            var inprogress = $("#inprogress", data).text();
-            var new_results = $("#new_results", data).text();
-            var failure = $("#failure", data).text();
-            
-            // if we've got no jobs still running, stop checking
-            if ((typeof inprogress == 'undefined') || (inprogress.length == 0)) {
-                recursive = false;
-                showJobCount(0);
-                //return;
-            }
-            inprogress = parseInt( inprogress );
-            if (inprogress === 0) {
-                recursive = false;
-            }
-            
-            // display what we recieved, bind events etc
-            $("#activities_content").empty();
-            $("#activities_content").append( $("#jobsTable", $(data)) );
-            $("#jobsTable").alternateRowColors();
-            
-            // bind events
-            $("#activities_content a").click(function() {
-                var href = $(this).attr('href');
-                if (href) {
-                    window.location.href = href;
+
+        $.ajax({
+            url: "{% url 'activities' %}",
+            dataType: 'html',
+            success: function(data) {
+                $('#activities_spinner').hide();
+                var inprogress = $("#inprogress", data).text();
+                var new_results = $("#new_results", data).text();
+                var failure = $("#failure", data).text();
+
+                // if we've got no jobs still running, stop checking
+                if ((typeof inprogress == 'undefined') || (inprogress.length == 0)) {
+                    recursive = false;
+                    showJobCount(0);
+                    //return;
                 }
-            });
-            // show chgrp errors in new window
-            $(".chgrp_error a").click(function(event) {
-                var error_msg = $(this).next().html();
-                var newWindow=window.open('','','height=500,width=500,scrollbars=yes, top=50, left=100');
-                newWindow.document.write(error_msg);
-                newWindow.document.close();
-                return false;
-            });
+                inprogress = parseInt( inprogress );
+                if (inprogress === 0) {
+                    recursive = false;
+                }
 
-            // If we've got new errors - show Activities
-            if ($("#new_errors", data).length > 0) {
-                $("#activities_panel").show();
-                new_results = -1;   // hide notification number
-            }
-            OME.displayStatus(new_results, inprogress);
-            if (recursive) {
-                setTimeout(function(){
-                    OME.activitiesUpdate(true);
-                }, 5000);
-            }
+                // display what we recieved, bind events etc
+                $("#activities_content").empty();
+                $("#activities_content").append( $("#jobsTable", $(data)) );
+                $("#jobsTable").alternateRowColors();
 
-        }).error(function() {
-            // this requires jQuery 1.5 or later
-            $('#activities_spinner').hide();
-            $("#activities_content").html("<table id='activitiesTimeoutMsg'><tbody><tr><td><span>Activity unavailable - timeout</span></td></tr></tbody></table>");
+                // bind events
+                $("#activities_content a").click(function() {
+                    var href = $(this).attr('href');
+                    if (href) {
+                        window.location.href = href;
+                    }
+                });
+                // show chgrp errors in new window
+                $(".chgrp_error a").click(function(event) {
+                    var error_msg = $(this).next().html();
+                    var newWindow=window.open('','','height=500,width=500,scrollbars=yes, top=50, left=100');
+                    newWindow.document.write(error_msg);
+                    newWindow.document.close();
+                    return false;
+                });
+
+                // If we've got new errors - show Activities
+                if ($("#new_errors", data).length > 0) {
+                    $("#activities_panel").show();
+                    new_results = -1;   // hide notification number
+                }
+                OME.displayStatus(new_results, inprogress);
+                if (recursive) {
+                    setTimeout(function(){
+                        OME.activitiesUpdate(true);
+                    }, 5000);
+                }
+            },
+            error: function() {
+                // this requires jQuery 1.5 or later
+                $('#activities_spinner').hide();
+                $("#activities_content").html("<table id='activitiesTimeoutMsg'><tbody><tr><td><span>Activity unavailable - timeout</span></td></tr></tbody></table>");
+            }
         });
     }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3610,9 +3610,19 @@ def activities(request, conn=None, **kwargs):
                 continue  # ignore
             if status not in ("failed", "finished"):
                 logger.info("Check callback on script: %s" % cbString)
-                proc = omero.grid.ScriptProcessPrx.checkedCast(
-                    conn.c.ic.stringToProxy(cbString))
-                cb = omero.scripts.ProcessCallbackI(conn.c, proc)
+                try:
+                    proc = omero.grid.ScriptProcessPrx.checkedCast(
+                        conn.c.ic.stringToProxy(cbString))
+                    cb = omero.scripts.ProcessCallbackI(conn.c, proc)
+                except Exception, x:
+                    logger.error(traceback.format_exc())
+                    logger.error("Status job '%s'error:" % cbString)
+                    update_callback(
+                        request, cbString,
+                        error=1,
+                        status="failed",
+                        dreport=str(x))
+                    failure += 1
                 # check if we get something back from the handle...
                 if cb.block(0):  # ms.
                     cb.close()


### PR DESCRIPTION
This fixes a couple of issues noticed as part of 5.2.0 update on nightshade, where ping of 'activities' in web was hanging, but the webclient continued to ping every 5 seconds.
Now, we only re-try to get activities 5 seconds AFTER the previous call returns successfully.
Also add a try/except around the cast of string to proxy object where it was missing for scripts.

To test, check that scripts run OK and results are returned in the activities panel.
Also try an OMERO.figure export.