### PR TITLE
Remove 'tilt' from stats pie chart

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.js
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.js
@@ -71,7 +71,6 @@
                             pie: {
                                 show: true,
                                 radius: 1,
-                                tilt: 0.7,
                                 label: {
                                     show: true,
                                     radius: 0.9,


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/13042

As suggested by @mtbc, just removed the 'tilt' attribute from the pie chart plugin.
To test, login as admin and look at Statistics tab for all users, and/or group owner and look at statistics for your owned groups.
In both cases, pie chart should be round, not an ellipse:

![screen shot 2015-12-01 at 14 01 00](https://cloud.githubusercontent.com/assets/900055/11502655/03f89740-9834-11e5-8ebd-6ceb3f87164b.png)


