### PR TITLE
Rendering settings warning

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -90,7 +90,7 @@ class RendererComponent
     
     /** Warning message shown when the rendering settings are to be reset */
     public static final String RENDERINGSETTINGS_WARNING = "This will change the "
-            + "rendering settings of all images\nin the dataset/screen and cannot be undone.\n"
+            + "rendering settings of all images\nin the dataset/plate and cannot be undone.\n"
             + "Proceed?";
     
     /** The number of attempts to reload the rendering control. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -89,8 +89,9 @@ class RendererComponent
     		"the rendering settings.";
     
     /** Warning message shown when the rendering settings are to be reset */
-    private static final String RENDERINGSETTINGS_WARNING = "This will change the "
-            + " rendering settings of all images in the dataset. Proceed?";
+    public static final String RENDERINGSETTINGS_WARNING = "This will change the "
+            + "rendering settings of all images\nin the dataset/screen and cannot be undone.\n"
+            + "Proceed?";
     
     /** The number of attempts to reload the rendering control. */
     private static final int MAX_RETRY = 1;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import javax.swing.JComponent;
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 import omero.romio.PlaneDef;
 
@@ -86,6 +87,10 @@ class RendererComponent
     /** The default error message. */
     private static final String ERROR = " An error occurred while modifying " +
     		"the rendering settings.";
+    
+    /** Warning message shown when the rendering settings are to be reset */
+    private static final String RENDERINGSETTINGS_WARNING = "This will change the "
+            + " rendering settings of all images in the dataset. Proceed?";
     
     /** The number of attempts to reload the rendering control. */
     private static final int MAX_RETRY = 1;
@@ -663,7 +668,15 @@ class RendererComponent
      */
 	public void applyToAll()
 	{
-		if (!model.isGeneralIndex()) return;
+		if (!model.isGeneralIndex())
+		    return;
+		
+        MessageBox box = new MessageBox(
+                (JFrame) SwingUtilities.windowForComponent(view),
+                "Save rendering settings", RENDERINGSETTINGS_WARNING);
+        if (box.centerMsgBox() != MessageBox.YES_OPTION)
+            return;
+        
 		try {
 			saveCurrentSettings();
 			firePropertyChange(APPLY_TO_ALL_PROPERTY,  Boolean.valueOf(false), 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -169,10 +169,11 @@ class TreeViewerComponent
  	extends AbstractComponent
  	implements TreeViewer
 {
-  
-        /** Warning message shown when the rendering settings are to be reset */
-        private static final String RENDERINGSETTINGS_WARNING = "This will save new rendering settings and cannot be undone.";
     
+    /** Warning message shown when the rendering settings are to be reset */
+    public static final String RENDERINGSETTINGS_WARNING = "This will change the "
+            + " rendering settings of all images in the dataset. Proceed?";
+  
 	/** The Model sub-component. */
 	private TreeViewerModel     model;
 
@@ -2662,12 +2663,15 @@ class TreeViewerComponent
 			return;
 		}
 		
-        MessageBox box = new MessageBox(getUI(), "Save rendering settings",
-                RENDERINGSETTINGS_WARNING);
-        if (box.centerMsgBox() == MessageBox.YES_OPTION) {
-            model.firePasteRenderingSettings(ids, klass);
-            fireStateChange();
+		if (DatasetData.class.equals(klass)) {
+            MessageBox box = new MessageBox(getUI(),
+                    "Save rendering settings", RENDERINGSETTINGS_WARNING);
+            if (box.centerMsgBox() != MessageBox.YES_OPTION)
+                return;
         }
+		
+		model.firePasteRenderingSettings(ids, klass);
+        fireStateChange();
 	}
 
 	
@@ -2721,12 +2725,15 @@ class TreeViewerComponent
 			return;
 		}
 		
-		MessageBox box = new MessageBox(getUI(), "Reset rendering settings",
-	                RENDERINGSETTINGS_WARNING);
-	        if (box.centerMsgBox() == MessageBox.YES_OPTION) {
-	            model.fireResetRenderingSettings(ids, klass);
-	            fireStateChange();
-	        }
+		if (DatasetData.class.equals(klass)) {
+            MessageBox box = new MessageBox(getUI(),
+                    "Save rendering settings", RENDERINGSETTINGS_WARNING);
+            if (box.centerMsgBox() != MessageBox.YES_OPTION)
+                return;
+        }
+		
+		model.fireResetRenderingSettings(ids, klass);
+        fireStateChange();
 	}
 
 	/**
@@ -3051,12 +3058,15 @@ class TreeViewerComponent
 			return;
 		}
 		
-		MessageBox box = new MessageBox(getUI(), "Reset rendering settings",
-	                RENDERINGSETTINGS_WARNING);
-	        if (box.centerMsgBox() == MessageBox.YES_OPTION) {
-	            model.fireSetOwnerRenderingSettings(ids, klass);
-	            fireStateChange();
-	        }
+		if (DatasetData.class.equals(klass)) {
+            MessageBox box = new MessageBox(getUI(),
+                    "Save rendering settings", RENDERINGSETTINGS_WARNING);
+            if (box.centerMsgBox() != MessageBox.YES_OPTION)
+                return;
+        }
+		
+		model.fireSetOwnerRenderingSettings(ids, klass);
+        fireStateChange();
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -124,6 +124,7 @@ import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.ui.ActivityComponent;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.PojosUtil;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
@@ -172,7 +173,8 @@ class TreeViewerComponent
     
     /** Warning message shown when the rendering settings are to be reset */
     public static final String RENDERINGSETTINGS_WARNING = "This will change the "
-            + " rendering settings of all images in the dataset. Proceed?";
+            + "rendering settings of all images\nin the dataset/screen and cannot be undone.\n"
+            + "Proceed?";
   
 	/** The Model sub-component. */
 	private TreeViewerModel     model;
@@ -2663,7 +2665,7 @@ class TreeViewerComponent
 			return;
 		}
 		
-		if (DatasetData.class.equals(klass)) {
+		if (PojosUtil.isContainerClass(klass)) {
             MessageBox box = new MessageBox(getUI(),
                     "Save rendering settings", RENDERINGSETTINGS_WARNING);
             if (box.centerMsgBox() != MessageBox.YES_OPTION)
@@ -2673,7 +2675,6 @@ class TreeViewerComponent
 		model.firePasteRenderingSettings(ids, klass);
         fireStateChange();
 	}
-
 	
 	/**
 	 * Implemented as specified by the {@link TreeViewer} interface.
@@ -2725,7 +2726,7 @@ class TreeViewerComponent
 			return;
 		}
 		
-		if (DatasetData.class.equals(klass)) {
+		if (PojosUtil.isContainerClass(klass)) {
             MessageBox box = new MessageBox(getUI(),
                     "Save rendering settings", RENDERINGSETTINGS_WARNING);
             if (box.centerMsgBox() != MessageBox.YES_OPTION)
@@ -3058,7 +3059,7 @@ class TreeViewerComponent
 			return;
 		}
 		
-		if (DatasetData.class.equals(klass)) {
+		if (PojosUtil.isContainerClass(klass)) {
             MessageBox box = new MessageBox(getUI(),
                     "Save rendering settings", RENDERINGSETTINGS_WARNING);
             if (box.centerMsgBox() != MessageBox.YES_OPTION)
@@ -4984,4 +4985,5 @@ class TreeViewerComponent
        if (rnd == null) return null;
        return rnd.getSelectedDef();
    }
+   
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -173,7 +173,7 @@ class TreeViewerComponent
     
     /** Warning message shown when the rendering settings are to be reset */
     public static final String RENDERINGSETTINGS_WARNING = "This will change the "
-            + "rendering settings of all images\nin the dataset/screen and cannot be undone.\n"
+            + "rendering settings of all images\nin the dataset/plate and cannot be undone.\n"
             + "Proceed?";
   
 	/** The Model sub-component. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
@@ -1,0 +1,55 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
+package org.openmicroscopy.shoola.util;
+
+import omero.gateway.model.DataObject;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.PlateAcquisitionData;
+import omero.gateway.model.PlateData;
+import omero.gateway.model.ProjectData;
+import omero.gateway.model.ScreenData;
+
+/**
+ * Provides some static utility methods for dealing the with Gateway
+ * {@link DataObject}s
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ */
+public class PojosUtil {
+
+    /**
+     * Checks if a given class is a container class, i. e. can contain multiple
+     * images
+     * 
+     * @param type
+     *            The class to check
+     * @return See above.
+     */
+    public static boolean isContainerClass(Class<?> type) {
+        return DatasetData.class.equals(type) || ProjectData.class.equals(type)
+                || ScreenData.class.equals(type)
+                || PlateData.class.equals(type)
+                || PlateAcquisitionData.class.equals(type);
+    }
+
+}


### PR DESCRIPTION
Proposal for fixing [Ticket 13104](http://trac.openmicroscopy.org/ome/ticket/13104)

With this PR a warning dialog is only shown when all images of a dataset are affected by a rendering settings change action:
- Save to All
- Paste rendering settings on a dataset
- Reset to owner on dataset level
- Reset to imported on dataset level

But *not* if only one or a selection of images is affected, i. e. deliberately pasting a rendering setting on a selected image (in that case the user is well aware what he's doing - in my opinion). 

This is not in sync with OMERO.web yet. But as I just noticed, the current state is also not in sync with OMERO.web anyway (e. g. web doesn't show a warning on "save to all").

/cc @gusferguson @pwalczysko 