### PR TITLE
for graph operations allow model subclasses to be named

### DIFF
--- a/components/server/src/ome/services/graphs/GraphPathBean.java
+++ b/components/server/src/ome/services/graphs/GraphPathBean.java
@@ -387,7 +387,22 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      * @return the class with that simple name, or {@code null} if one is not known
      */
     public Class<? extends IObject> getClassForSimpleName(String simpleName) {
-        return classesBySimpleName.get(simpleName);
+        Class<? extends IObject> namedClass = classesBySimpleName.get(simpleName);
+        if (namedClass != null) {
+            return namedClass;
+        }
+        /* may have named a subclass, try guessing */
+        Class<?> subclass;
+        try {
+            subclass = Class.forName("omero.model." + simpleName);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        while (namedClass == null && subclass != Object.class) {
+            subclass = subclass.getSuperclass();
+            namedClass = classesBySimpleName.get(subclass.getSimpleName());
+        }
+        return namedClass;
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -144,6 +144,20 @@ public class AdditionalDeleteTest extends AbstractServerTest {
     }
 
     /**
+     * Deletes the whole image using the subclass name {@link ImageI}.
+     */
+    public void testImageI() throws Exception {
+        final long imageId = iUpdate.saveAndReturnObject(mmFactory.createImage()).getId().getValue();
+        final Delete2 dc = Requests.delete("ImageI", imageId);
+        callback(true, client, dc);
+
+        // Check that data is gone
+        List<?> l = iQuery.projection("select i.id from Image i where i.id = "
+                + imageId, null);
+        Assert.assertTrue(l.isEmpty());
+    }
+
+    /**
      * Uses the /Image delete specification to remove an Image and its
      * annotations simply linked annotation. This is the most basic case.
      */

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -26,6 +26,7 @@ from test.integration.clitest.test_tag import AbstractTagTest
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
+model = ["", "I"]
 ordered = [True, False]
 
 
@@ -36,12 +37,13 @@ class TestDelete(CLITest):
         self.cli.register("delete", DeleteControl, "TEST")
         self.args += ["delete"]
 
+    @pytest.mark.parametrize("model", model)
     @pytest.mark.parametrize("object_type", object_types)
-    def testDeleteMyData(self, object_type):
+    def testDeleteMyData(self, object_type, model):
         oid = self.create_object(object_type)
 
         # Delete the object
-        self.args += ['/%s:%s' % (object_type, oid)]
+        self.args += ['/%s%s:%s' % (object_type, model, oid)]
         self.cli.invoke(self.args, strict=True)
 
         # Check the object has been deleted


### PR DESCRIPTION
Now for the CLI graph operations you should be able to name classes as `FooI` rather than just `Foo`. See https://trello.com/c/xdnCqVZy/609-omero-delete-doesn-t-handle-objecti.

--no-rebase