### PR TITLE
log parameters and results of graph requests

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -66,6 +66,8 @@ import omero.cmd.Response;
  */
 public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Chgrp2I.class);
+
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.OWN);
@@ -119,6 +121,15 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("groupId", groupId);
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
 
@@ -262,6 +273,13 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
             helper.setResponseIfNull(response);
             helper.info("in " + (dryRun ? "mock " : "") + "chgrp to " + groupId + " of " + targetObjectCount +
                     ", moved " + movedObjectCount + " and deleted " + deletedObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("includedObjects", response.includedObjects);
+                arguments.addParameter("deletedObjects", response.deletedObjects);
+                LOGGER.debug("response: " + arguments);
+            }
         }
     }
 

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -72,6 +72,8 @@ import omero.cmd.Response;
  */
 public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Chmod2I.class);
+
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.CHMOD);
@@ -129,6 +131,15 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("permissions", permissions);
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
 
@@ -306,6 +317,13 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
             helper.setResponseIfNull(response);
             helper.info("in " + (dryRun ? "mock " : "") + "chmod to " + permissions + " of " + targetObjectCount +
                     ", changed " + changedObjectCount + " and deleted " + deletedObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("includedObjects", response.includedObjects);
+                arguments.addParameter("deletedObjects", response.deletedObjects);
+                LOGGER.debug("response: " + arguments);
+            }
         }
     }
 

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -68,6 +68,8 @@ import omero.cmd.Response;
  */
 public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Chown2I.class);
+
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.DELETE);
@@ -123,6 +125,15 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("userId", userId);
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
 
@@ -265,6 +276,13 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             helper.setResponseIfNull(response);
             helper.info("in " + (dryRun ? "mock " : "") + "chown to " + userId + " of " + targetObjectCount +
                     ", gave " + givenObjectCount + " and deleted " + deletedObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("includedObjects", response.includedObjects);
+                arguments.addParameter("deletedObjects", response.deletedObjects);
+                LOGGER.debug("response: " + arguments);
+            }
         }
     }
 

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -61,6 +64,8 @@ import omero.cmd.Response;
  * @since 5.1.0
  */
 public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Delete2> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Delete2I.class);
 
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
@@ -114,6 +119,14 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
 
@@ -238,6 +251,12 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
             helper.setResponseIfNull(response);
             helper.info("in " + (dryRun ? "mock " : "") + "delete of " + targetObjectCount +
                     ", deleted " + deletedObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("deletedObjects", response.deletedObjects);
+                LOGGER.debug("response: " + arguments);
+            }
         }
     }
 

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -162,6 +162,17 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("typesToDuplicate", typesToDuplicate);
+            arguments.addParameter("typesToReference", typesToReference);
+            arguments.addParameter("typesToIgnore", typesToIgnore);
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
         helper.setSteps(dryRun ? 3 : 6);
 
@@ -522,6 +533,12 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
             final DuplicateResponse response = new DuplicateResponse(duplicatedObjects);
             helper.setResponseIfNull(response);
             helper.info("in duplication of " + targetObjectCount + ", duplicated " + duplicatedObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("duplicates", response.duplicates);
+                LOGGER.debug("response: " + arguments);
+            }
         }
     }
 

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -24,6 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -52,6 +55,8 @@ import omero.cmd.Status;
  * @since 5.1.0
  */
 public class SkipHeadI extends SkipHead implements IRequest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipHeadI.class);
 
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
@@ -87,6 +92,18 @@ public class SkipHeadI extends SkipHead implements IRequest {
 
     @Override
     public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("startFrom", startFrom);
+            if (request != null) {
+                arguments.addParameter("request", request.getClass().getName());
+            }
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("dryRun", dryRun);
+            LOGGER.debug("request: " + arguments);
+        }
+
         this.helper = helper;
 
         final GraphPolicy.Action startAction;


### PR DESCRIPTION
Adjust ` etc/logback.xml` such that `omero.cmd.graphs` is logged at `DEBUG`, then try some graph requests (delete, move, whatever you like) and see that the request parameters and the response values are logged in `Blitz-0.log`.

--no-rebase