### PR TITLE
Correct the stats_info_creation SQL action

### DIFF
--- a/components/model/resources/ome/util/actions/default.properties
+++ b/components/model/resources/ome/util/actions/default.properties
@@ -56,7 +56,7 @@ sql_action.roi_by_image_and_ns=select id from roi where image = ? and ? = any (n
 sql_action.set_file_repo=update originalfile set repo = :repo where id in (:ids)
 sql_action.shape_ids=select id from shape where roi = ?
 sql_action.share_data=select session_id, data from share where session_id in (:ids)
-sql_action.stats_info_creation=insert into statsinfo (id, permissions, globalmax, globalmin, creation_id, group_id, owner_id, update_id) select ?, ?, ?, ?, ?, ?, ?, ?
+sql_action.stats_info_creation=insert into statsinfo (id, permissions, globalmax, globalmin, creation_id, group_id, owner_id, update_id) values (?, ?, ?, ?, ?, ?, ?, ?)
 sql_action.stats_info_set_on_channel=update channel set statsinfo = ? where id = ?
 sql_action.update_config=update configuration set value = ? where name = ?
 sql_action.update_password=update password set hash = ?, changed = now() where experimenter_id = ?


### PR DESCRIPTION
This changes the `stats_info_creation` SQL action from using a `select`
subclause to the more appropriate `values (...)`.