### PR TITLE
removing OMERO_HOME from settings

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -21,7 +21,8 @@ if not omero.gateway.BlitzGateway.ICE_CONFIG:
         import settings
         iceconfig = os.environ.get('ICE_CONFIG', None)
         if iceconfig is None:
-            iceconfig = os.path.join(settings.OMERO_HOME, 'etc', 'ice.config')
+            iceconfig = os.path.join(
+                settings.OMERO_BASE_DIR, 'etc', 'ice.config')
         omero.gateway.BlitzGateway.ICE_CONFIG = iceconfig
     except ImportError:
         pass

--- a/components/tools/OmeroPy/src/omero_web_iis.py
+++ b/components/tools/OmeroPy/src/omero_web_iis.py
@@ -23,10 +23,10 @@
 import os
 import sys
 CWD = os.path.dirname(__file__)
-OMERO_HOME = os.path.join(CWD, os.path.pardir, os.path.pardir)
-CONFIG = os.path.join(OMERO_HOME, "etc", "grid", "config.xml")
-LOGS = os.path.join(OMERO_HOME, "var", "log")
-STATICS = os.path.join(OMERO_HOME, "lib", "python", "omeroweb", "static")
+OMERO_BASE_DIR = os.path.join(CWD, os.path.pardir, os.path.pardir)
+CONFIG = os.path.join(OMERO_BASE_DIR, "etc", "grid", "config.xml")
+LOGS = os.path.join(OMERO_BASE_DIR, "var", "log")
+STATICS = os.path.join(OMERO_BASE_DIR, "lib", "python", "omeroweb", "static")
 STATICS = os.path.realpath(STATICS)
 
 sys.path.append(str(CWD))

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -44,19 +44,15 @@ from omero_ext import portalocker
 
 logger = logging.getLogger(__name__)
 
+OMERO_BASE_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+OMERO_BASE_DIR = os.path.normpath(OMERO_BASE_DIR)
+
 # LOGS
 # NEVER DEPLOY a site into production with DEBUG turned on.
 # Debuging mode.
 # A boolean that turns on/off debug mode.
 # handler404 and handler500 works only when False
-if 'OMERO_HOME' in os.environ:
-    OMERO_HOME = os.environ.get('OMERO_HOME')
-else:
-    OMERO_HOME = os.path.join(os.path.dirname(__file__), '..', '..', '..')
-    OMERO_HOME = os.path.normpath(OMERO_HOME)
-
-# Logging
-LOGDIR = os.path.join(OMERO_HOME, 'var', 'log').replace('\\', '/')
+LOGDIR = os.path.join(OMERO_BASE_DIR, 'var', 'log').replace('\\', '/')
 
 if not os.path.isdir(LOGDIR):
     try:
@@ -162,7 +158,7 @@ LOGGING = {
 # Load custom settings from etc/grid/config.xml
 # Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
 from omero.util.concurrency import get_event
-CONFIG_XML = os.path.join(OMERO_HOME, 'etc', 'grid', 'config.xml')
+CONFIG_XML = os.path.join(OMERO_BASE_DIR, 'etc', 'grid', 'config.xml')
 count = 10
 event = get_event("websettings")
 
@@ -814,7 +810,7 @@ LANGUAGE_CODE = 'en-gb'
 try:
     SECRET_KEY
 except NameError:
-    secret_path = os.path.join(OMERO_HOME, 'var',
+    secret_path = os.path.join(OMERO_BASE_DIR, 'var',
                                'django_secret_key').replace('\\', '/')
     if not os.path.isfile(secret_path):
         try:

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -18,9 +18,6 @@ for tools in glob.glob("../../../lib/repository/setuptools*.egg"):
         sys.path.insert(0, os.path.abspath(tools))
 
 if "test" in sys.argv:
-    os.environ.setdefault('OMERO_HOME', os.path.abspath(
-        os.path.join("..", "..", "..", "dist")))
-
     sys.path.insert(0, os.path.join("..", "target", "lib", "fallback"))
     LIB = os.path.join("..", "target", "lib", "python")
     sys.path.insert(0, LIB)


### PR DESCRIPTION
Removing OMERO_HOME form web as is not needed. See https://trello.com/c/KRlpnQnW/11-remove-uses-of-omero-home

Questions:
 - is https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py#L437 still valid?

--breaking
--exclude