### PR TITLE
Bio-Formats Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -658,6 +658,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 <link href="http://docs.oracle.com/javase/8/docs/api/"/>
                 <link href="http://docs.spring.io/spring/docs/${versions.spring}/api/"/>
                 <link href="http://aopalliance.sourceforge.net/doc/"/>
+                <link href="http://downloads.openmicroscopy.org/bio-formats/5.1.6/api/"/>
 
             </javadoc>
         </presetdef>

--- a/components/tools/bump_bf_version.py
+++ b/components/tools/bump_bf_version.py
@@ -5,11 +5,18 @@ import os
 import re
 import argparse
 
-etc_dir = os.path.join(os.path.dirname(__file__), "..", "..", "etc")
+toplevel_dir = os.path.join(os.path.dirname(__file__), "..", "..")
+etc_dir = os.path.join(toplevel_dir, "etc")
+build_file = os.path.join(toplevel_dir, "build.xml")
 properties_file = os.path.join(etc_dir, "omero.properties")
+localproperties_file = os.path.join(etc_dir, "build.properties")
+
+
+javadoc_pattern = re.compile(
+    r"(?P<base>http://downloads\.openmicroscopy\.org/"
+    "bio-formats/)(\d+.\d+.\d+)")
 properties_pattern = re.compile(
     r"(?P<base>versions.bioformats=)(\d+.\d+.\d+.*)")
-localproperties_file = os.path.join(etc_dir, "build.properties")
 resolver_pattern = re.compile(r"(?P<base>ome\.resolver=)([a-z\-]+)")
 
 
@@ -39,7 +46,8 @@ def bump_bf_version(version):
     else:
         resolver = 'ome-resolver'
     replace_file(localproperties_file, resolver_pattern, resolver)
-
+    if not version.endswith('SNAPSHOT'):
+        replace_file(build_file, javadoc_pattern, version)
 
 if __name__ == "__main__":
     # Input check


### PR DESCRIPTION
See https://trello.com/c/jyrfor6w/99-cross-reference-javadocs. This Request:
- modifies the `release-javadocs` build target to allow the OMERO API to create hyperlink to the Bio-Formats API documentation
- modifies the `bump_bf_version.py` script to bump this Javadoc link for release version numbers

To test it:
- check the [OMERO Javadoc](https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-build/ICE=3.5,jdk=8_LATEST,label=octopus/javadoc/) links to the [Bio-Formats Javadoc](http://downloads.openmicroscopy.org/bio-formats/5.1.6/api/) - see the Trello card for an example of page with cross-references
- check that the bump script also bumps the Bio-Formats API URL when a non-SNAPSHOT version number is passed i.e. 

  ```
# Should not bump the Bio-Formats Javadoc link
./components/tools/bump_bf_version.py 5.1.7-SNAPSHOT
# Should bump the Bio-Formats Javadoc link to 5.1.8
./components/tools/bump_bf_version.py 5.1.8
# Should bump the Bio-Formats Javadoc link to 5.2.0
./components/tools/bump_bf_version.py 5.2.0
```

/cc @mtbc 