### PR TITLE
in graph traversal avoid awful removeAll performance

### DIFF
--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1490,7 +1490,7 @@ public class GraphTraversal {
         /* process the targets forward across links */
         while (!planning.blockedBy.isEmpty()) {
             /* determine which objects can be processed in this step */
-            final Collection<CI> nowUnblocked = new ArrayList<CI>();
+            final Collection<CI> nowUnblocked = new HashSet<CI>();
             final Iterator<Entry<CI, Set<CI>>> blocks = planning.blockedBy.entrySet().iterator();
             while (blocks.hasNext()) {
                 final Entry<CI, Set<CI>> block = blocks.next();


### PR DESCRIPTION
This is the same as gh-4359 but rebased onto metadata.

----

This PR should improve the performance of model graph traversal operations without any change in behavior. @joshmoore managed to run into a performance issue that this change should fix.

--no-rebase

                