### PR TITLE
update Insight's reference to JAX-RPC artifact

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -48,7 +48,7 @@
     <dependency org="com.google.guava" name="guava" rev="${versions.guava}"/>
     <dependency org="org.apache.httpcomponents" name="httpmime" rev="${versions.httpmime}"/>
     <dependency org="net.imagej" name="ij" rev="${versions.ij}"/>
-    <dependency org="javax.xml" name="jaxrpc" rev="${versions.jaxrpc}"/>
+    <dependency org="javax.xml" name="jaxrpc-api" rev="${versions.jaxrpc}"/>
     <dependency org="org.jfree" name="jfreechart" rev="${versions.jfreechart}"/>
     <dependency org="insight" name="JHotDraw" rev="${versions.JHotDraw}"/>
     <dependency org="org.apache.poi" name="poi" rev="${versions.poi}"/>


### PR DESCRIPTION
Build logs contain,
```
javax.xml#jaxrpc;1.1 is relocated to javax.xml#jaxrpc-api;1.1. Please update your dependencies.
```
See http://mvnrepository.com/artifact/javax.xml/jaxrpc/1.1: "This artifact was moved..."

--no-rebase