### PR TITLE
Apache cleanup

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
@@ -54,8 +54,6 @@
 
 <VirtualHost _default_:1234>
 
-  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
-
   WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
@@ -62,7 +62,7 @@
 
   WSGIApplicationGroup %{GLOBAL}
 
-  WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+  WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Order allow,deny

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22-withoptions.conf
@@ -57,14 +57,12 @@
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
-  
-  WSGIProcessGroup omeroweb_test
-
-  WSGIApplicationGroup %{GLOBAL}
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
+    WSGIProcessGroup omeroweb_test
+    WSGIApplicationGroup %{GLOBAL}
     Order allow,deny
     Allow from all
   </Directory>

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
@@ -57,14 +57,12 @@
   DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
-  
-  WSGIProcessGroup omeroweb
-
-  WSGIApplicationGroup %{GLOBAL}
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
+    WSGIProcessGroup omeroweb
+    WSGIApplicationGroup %{GLOBAL}
     Order allow,deny
     Allow from all
   </Directory>

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
@@ -54,8 +54,6 @@
 
 <VirtualHost _default_:80>
 
-  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
-
   WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache22.conf
@@ -62,7 +62,7 @@
 
   WSGIApplicationGroup %{GLOBAL}
 
-  WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+  WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Order allow,deny

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
@@ -8,13 +8,11 @@
 
   WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIProcessGroup omeroweb_test
-
-  WSGIApplicationGroup %{GLOBAL}
-
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
+    WSGIProcessGroup omeroweb_test
+    WSGIApplicationGroup %{GLOBAL}
     Require all granted
   </Directory>
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
@@ -12,7 +12,7 @@
 
   WSGIApplicationGroup %{GLOBAL}
 
-  WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+  WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Require all granted

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24-withoptions.conf
@@ -4,8 +4,6 @@
 
 <VirtualHost _default_:1234>
 
-  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
-
   WSGIDaemonProcess omeroweb_test processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIScriptAlias /test /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb_test

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
@@ -8,13 +8,11 @@
 
   WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
-  WSGIProcessGroup omeroweb
-
-  WSGIApplicationGroup %{GLOBAL}
-
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
+    WSGIProcessGroup omeroweb
+    WSGIApplicationGroup %{GLOBAL}
     Require all granted
   </Directory>
 

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
@@ -12,7 +12,7 @@
 
   WSGIApplicationGroup %{GLOBAL}
 
-  WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py
+  WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb
 
   <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
     Require all granted

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/apache24.conf
@@ -4,8 +4,6 @@
 
 <VirtualHost _default_:80>
 
-  DocumentRoot /home/omero/OMERO.server/lib/python/omeroweb
-
   WSGIDaemonProcess omeroweb processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/home/omero/ice/python:/home/omero/OMERO.server/lib/python:/home/omero/OMERO.server/lib/fallback:/home/omero/OMERO.server/lib/python/omeroweb
 
   WSGIScriptAlias / /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py process-group=omeroweb

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -378,7 +378,6 @@ class TestWeb(object):
         if prefix:
             missing = self.required_lines_in([
                 ("<VirtualHost _default_:%s>" % (http or 80)),
-                ('DocumentRoot ', 'lib/python/omeroweb'),
                 ('WSGIDaemonProcess %s ' % upstream_name +
                  'processes=5 threads=1 '
                  'display-name=%%{GROUP} user=%s ' % username +
@@ -393,7 +392,6 @@ class TestWeb(object):
         else:
             missing = self.required_lines_in([
                 ("<VirtualHost _default_:%s>" % (http or 80)),
-                ('DocumentRoot ', 'lib/python/omeroweb'),
                 ('WSGIDaemonProcess %s ' % upstream_name +
                  'processes=5 threads=1 '
                  'display-name=%%{GROUP} user=%s ' % username +

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -386,6 +386,7 @@ class TestWeb(object):
                 ('WSGIScriptAlias %s ' % prefix,
                  'lib/python/omeroweb/wsgi.py ' +
                  'process-group=omeroweb_%s' % prefix.strip("/")),
+                ('WSGIProcessGroup omeroweb_%s' % prefix.strip("/")),
                 ('Alias %s ' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
                 ], lines)
@@ -399,6 +400,7 @@ class TestWeb(object):
                  'python-path=%s' % icepath, 'lib/python/omeroweb'),
                 ('WSGIScriptAlias / ', 'lib/python/omeroweb/wsgi.py ' +
                  'process-group=omeroweb'),
+                ('WSGIProcessGroup omeroweb'),
                 ('Alias /static ', 'lib/python/omeroweb/static'),
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -384,7 +384,8 @@ class TestWeb(object):
                  'display-name=%%{GROUP} user=%s ' % username +
                  'python-path=%s' % icepath, 'lib/python/omeroweb'),
                 ('WSGIScriptAlias %s ' % prefix,
-                 'lib/python/omeroweb/wsgi.py'),
+                 'lib/python/omeroweb/wsgi.py ' +
+                 'process-group=omeroweb_%s' % prefix.strip("/")),
                 ('Alias %s ' % static_prefix[:-1],
                  'lib/python/omeroweb/static'),
                 ], lines)
@@ -396,7 +397,8 @@ class TestWeb(object):
                  'processes=5 threads=1 '
                  'display-name=%%{GROUP} user=%s ' % username +
                  'python-path=%s' % icepath, 'lib/python/omeroweb'),
-                ('WSGIScriptAlias / ', 'lib/python/omeroweb/wsgi.py'),
+                ('WSGIScriptAlias / ', 'lib/python/omeroweb/wsgi.py ' +
+                 'process-group=omeroweb'),
                 ('Alias /static ', 'lib/python/omeroweb/static'),
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)

--- a/components/tools/OmeroWeb/omeroweb/wsgi.py
+++ b/components/tools/OmeroWeb/omeroweb/wsgi.py
@@ -28,7 +28,12 @@ import sys
 # OMERO.web is set up with the "omeroweb" package also on the PYTHONPATH
 sys.path.append(os.path.dirname(__file__))
 
+# We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
+# if running multiple sites in the same mod_wsgi process. To fix this, use
+# mod_wsgi daemon mode with each site in its own daemon process, or use
+# os.environ["DJANGO_SETTINGS_MODULE"] = "omeroweb.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
+
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION

--- a/components/tools/OmeroWeb/omeroweb/wsgi.py
+++ b/components/tools/OmeroWeb/omeroweb/wsgi.py
@@ -34,7 +34,6 @@ sys.path.append(os.path.dirname(__file__))
 # os.environ["DJANGO_SETTINGS_MODULE"] = "omeroweb.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
 
-
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.

--- a/etc/templates/web/apache22.conf.template
+++ b/etc/templates/web/apache22.conf.template
@@ -62,7 +62,7 @@
 
   WSGIApplicationGroup %%{GLOBAL}
 
-  WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
+  WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s
 
   <Directory "%(OMEROWEBROOT)s">
     Order allow,deny

--- a/etc/templates/web/apache22.conf.template
+++ b/etc/templates/web/apache22.conf.template
@@ -54,8 +54,6 @@
 
 <VirtualHost _default_:%(HTTPPORT)d>
 
-  DocumentRoot %(OMEROWEBROOT)s
-
   WSGIDaemonProcess omeroweb%(PREFIX_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s

--- a/etc/templates/web/apache22.conf.template
+++ b/etc/templates/web/apache22.conf.template
@@ -57,14 +57,12 @@
   DocumentRoot %(OMEROWEBROOT)s
 
   WSGIDaemonProcess omeroweb%(PREFIX_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
-  
-  WSGIProcessGroup omeroweb%(PREFIX_NAME)s
-
-  WSGIApplicationGroup %%{GLOBAL}
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s
 
   <Directory "%(OMEROWEBROOT)s">
+    WSGIProcessGroup omeroweb%(PREFIX_NAME)s
+    WSGIApplicationGroup %%{GLOBAL}
     Order allow,deny
     Allow from all
   </Directory>

--- a/etc/templates/web/apache24.conf.template
+++ b/etc/templates/web/apache24.conf.template
@@ -12,7 +12,7 @@
 
   WSGIApplicationGroup %%{GLOBAL}
 
-  WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py
+  WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s
 
   <Directory "%(OMEROWEBROOT)s">
     Require all granted

--- a/etc/templates/web/apache24.conf.template
+++ b/etc/templates/web/apache24.conf.template
@@ -8,13 +8,11 @@
 
   WSGIDaemonProcess omeroweb%(PREFIX_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
 
-  WSGIProcessGroup omeroweb%(PREFIX_NAME)s
-
-  WSGIApplicationGroup %%{GLOBAL}
-
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s
 
   <Directory "%(OMEROWEBROOT)s">
+    WSGIProcessGroup omeroweb%(PREFIX_NAME)s
+    WSGIApplicationGroup %%{GLOBAL}
     Require all granted
   </Directory>
 

--- a/etc/templates/web/apache24.conf.template
+++ b/etc/templates/web/apache24.conf.template
@@ -4,8 +4,6 @@
 
 <VirtualHost _default_:%(HTTPPORT)d>
 
-  DocumentRoot %(OMEROWEBROOT)s
-
   WSGIDaemonProcess omeroweb%(PREFIX_NAME)s processes=5 threads=1 display-name=%%{GROUP} user=%(OMEROUSER)s python-path=%(ICEPYTHONROOT)s:%(OMEROPYTHONROOT)s:%(OMEROFALLBACKROOT)s:%(OMEROWEBROOT)s
 
   WSGIScriptAlias %(WEB_PREFIX)s %(OMEROWEBROOT)s/wsgi.py process-group=omeroweb%(PREFIX_NAME)s


### PR DESCRIPTION
This PR improve Apache templates to allow multiple wsgi apps deployment under the same VirtualHost

----------

As we do not have any apache testing environment, this is deployed on 2.2

- http://ola-test-1.docker.openmicroscopy.org/omero/
- http://ola-test-1.docker.openmicroscopy.org/omero2/

-----------

**Follow the https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/unix/install-web/install-apache.html with new output of the apache config this PR changed. Then merge 2 configs within one VirtualHost as show below**

```
<VirtualHost _default_:80>
  # /omero
  WSGIDaemonProcess omeroweb_omero processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/opt/Ice-3.5.1/python:/home/omero/OMERO.server...

  WSGIScriptAlias /omero /home/omero/OMERO.server/lib/python/omeroweb/wsgi.py

  <Directory "/home/omero/OMERO.server/lib/python/omeroweb">
    WSGIProcessGroup omeroweb_omero
    WSGIApplicationGroup %{GLOBAL}
    Order allow,deny
    Allow from all
  </Directory>

  Alias /omero/static /home/omero/OMERO.server/lib/python/omeroweb/static
  <Directory "/home/omero/OMERO.server/lib/python/omeroweb/static">
      Options -Indexes FollowSymLinks
      Order allow,deny
      Allow from all
  </Directory>

  # /omero2
  WSGIDaemonProcess omeroweb_omero2 processes=5 threads=1 display-name=%{GROUP} user=omero python-path=/opt/Ice-3.5.1/python:/home/omero/OMERO.server2...
  
  WSGIScriptAlias /omero2 /home/omero/OMERO.server2/lib/python/omeroweb/wsgi.py

  <Directory "/home/omero/OMERO.server2/lib/python/omeroweb">
    WSGIProcessGroup omeroweb_omero2
    WSGIApplicationGroup %{GLOBAL}
    Order allow,deny
    Allow from all
  </Directory>

  Alias /omero2/static /home/omero/OMERO.server2/lib/python/omeroweb/static
  <Directory "/home/omero/OMERO.server2/lib/python/omeroweb/static">
      Options -Indexes FollowSymLinks
      Order allow,deny
      Allow from all
  </Directory>

</VirtualHost>
```

**Note: if you deploy multiple web please make sure you set different list of servers and cookie name in each.**

```
# first
omero/bin/omero config set omero.web.server_list '[["localhost", 4064, "localhost"], ["eel.openmicroscopy.org", 4064, "eel-merge"]]'
omero/bin/omero config set omero.web.session_cookie_name 'sessionid_omero'

# second
omero2/bin/omero config set omero.web.server_list '[["localhost", 14064, "localhost"], ["eel.openmicroscopy.org", 14064, "eel-latest"]]'
omero/bin/omero config set omero.web.session_cookie_name 'sessionid_omero2'
```

