### PR TITLE
Workaround for Gnome3 bug

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -41,6 +41,7 @@ import javax.swing.JFrame;
 
 
 
+
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -49,6 +50,7 @@ import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.login.LoginCredentials;
 import org.openmicroscopy.shoola.util.ui.login.ScreenLogin;
 import org.openmicroscopy.shoola.util.ui.login.ScreenLogo;
@@ -273,6 +275,7 @@ class SplashScreenManager
 		view.setVisible(true);
 		view.setStatusVisible(true, false);
 		isOpen = true;
+		UIUtilities.applyGnome3Workaround(view);
 		container.getRegistry().bind(LookupNames.LOGIN_SPLASHSCREEN, 
 				Boolean.valueOf(true));
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -575,7 +575,7 @@ public class UIUtilities
 	{
 		centerOnScreen(window);
 		window.setVisible(true);
-        applyGnome3Workaround((Frame) window);
+        applyGnome3Workaround(window);
 	}
     
 	/**
@@ -2952,22 +2952,22 @@ public class UIUtilities
      * (making it one pixel bigger); a simple call to repaint() is not
      * sufficient.
      * 
-     * @param w
-     *            The {@link Window}
+     * @param c
+     *            The {@link Component}
      */
-    public static void applyGnome3Workaround(Window w) {
+    public static void applyGnome3Workaround(Component c) {
         if (!GNOME)
             return;
 
         boolean undecorated = false;
-        if (w instanceof Frame)
-            undecorated = ((Frame) w).isUndecorated();
-        if (w instanceof Dialog)
-            undecorated = ((Dialog) w).isUndecorated();
+        if (c instanceof Dialog)
+            undecorated = ((Dialog) c).isUndecorated();
+        if (c instanceof Frame)
+            undecorated = ((Frame) c).isUndecorated();
 
         if (undecorated) {
-            Dimension size = w.getSize();
-            w.setSize(new Dimension(size.width + 1, size.height + 1));
+            Dimension size = c.getSize();
+            c.setSize(new Dimension(size.width + 1, size.height + 1));
         }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -503,6 +503,13 @@ public class UIUtilities
 		FONTS.put("Zapfino", "cursive");
 	}
 	
+    private static final boolean GNOME;
+
+    static {
+        String desktop = System.getenv("XDG_CURRENT_DESKTOP");
+        GNOME = desktop != null && desktop.toLowerCase().contains("gnome");
+    }
+	
 	/**
      * Returns <code>true</code> if the passed value is textual,
      * <code>false</code> otherwise.
@@ -2949,6 +2956,9 @@ public class UIUtilities
      *            The {@link Window}
      */
     public static void applyGnome3Workaround(Window w) {
+        if (!GNOME)
+            return;
+
         boolean undecorated = false;
         if (w instanceof Frame)
             undecorated = ((Frame) w).isUndecorated();
@@ -2956,11 +2966,8 @@ public class UIUtilities
             undecorated = ((Dialog) w).isUndecorated();
 
         if (undecorated) {
-            String desktop = System.getenv("XDG_CURRENT_DESKTOP");
-            if (desktop != null && desktop.toLowerCase().contains("gnome")) {
-                Dimension size = w.getSize();
-                w.setSize(new Dimension(size.width + 1, size.height + 1));
-            }
+            Dimension size = w.getSize();
+            w.setSize(new Dimension(size.width + 1, size.height + 1));
         }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.UIUtilities
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -2941,8 +2941,9 @@ public class UIUtilities
     /**
      * As workaround for https://bugzilla.gnome.org/show_bug.cgi?id=759492 an
      * internal repaint has to be triggered for undecorated frames in order to
-     * get displayed correctly. This is done by changing (and reverting) the
-     * size of the frame; a simple call to repaint() is not sufficient.
+     * get displayed correctly. This is done by changing the size of the frame
+     * (making it one pixel bigger); a simple call to repaint() is not
+     * sufficient.
      * 
      * @param w
      *            The {@link Window}
@@ -2958,10 +2959,7 @@ public class UIUtilities
             String desktop = System.getenv("XDG_CURRENT_DESKTOP");
             if (desktop != null && desktop.toLowerCase().contains("gnome")) {
                 Dimension size = w.getSize();
-                Dimension modSize = new Dimension(size.width + 1,
-                        size.height + 1);
-                w.setSize(modSize);
-                w.setSize(size);
+                w.setSize(new Dimension(size.width + 1, size.height + 1));
             }
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -38,6 +38,7 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.KeyEvent;
@@ -567,6 +568,7 @@ public class UIUtilities
 	{
 		centerOnScreen(window);
 		window.setVisible(true);
+        applyGnome3Workaround((Frame) window);
 	}
     
 	/**
@@ -2934,5 +2936,33 @@ public class UIUtilities
      */
     public static String replaceNonWordCharacters(String name) {
         return name.replaceAll("\\W", "_");
+    }
+    
+    /**
+     * As workaround for https://bugzilla.gnome.org/show_bug.cgi?id=759492 an
+     * internal repaint has to be triggered for undecorated frames in order to
+     * get displayed correctly. This is done by changing (and reverting) the
+     * size of the frame; a simple call to repaint() is not sufficient.
+     * 
+     * @param w
+     *            The {@link Window}
+     */
+    public static void applyGnome3Workaround(Window w) {
+        boolean undecorated = false;
+        if (w instanceof Frame)
+            undecorated = ((Frame) w).isUndecorated();
+        if (w instanceof Dialog)
+            undecorated = ((Dialog) w).isUndecorated();
+
+        if (undecorated) {
+            String desktop = System.getenv("XDG_CURRENT_DESKTOP");
+            if (desktop != null && desktop.toLowerCase().contains("gnome")) {
+                Dimension size = w.getSize();
+                Dimension modSize = new Dimension(size.width + 1,
+                        size.height + 1);
+                w.setSize(modSize);
+                w.setSize(size);
+            }
+        }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -503,6 +503,7 @@ public class UIUtilities
 		FONTS.put("Zapfino", "cursive");
 	}
 	
+    /** Flag indicating if desktop is GNOME **/
     private static final boolean GNOME;
 
     static {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tdialog/TinyDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/tdialog/TinyDialog.java
@@ -36,6 +36,8 @@ import java.util.List;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 //Third-party libraries
 
 //Application-internal dependencies
@@ -460,6 +462,13 @@ public class TinyDialog
     public void setUndecorated(boolean b)
     {
         super.setUndecorated(true);
+    }
+    
+    @Override
+    public void setVisible(boolean b) {
+        super.setVisible(b);
+        if (b)
+            UIUtilities.applyGnome3Workaround(this);
     }
 
 }


### PR DESCRIPTION
This is a workaround for https://bugzilla.gnome.org/show_bug.cgi?id=759492 , respectively  [OME forum post](http://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7966). I wrapped the workaround in a method in UIUtilities so it can be easily removed again when/if this gets fixed in Gnome3.

**Test**:
Start Insight on an OS with Gnome3 desktop (i. e. Debian (Jessie) default desktop). You should see the normal login screen (without the PR you'd just see a grey rectangle). Test the "Show parent project" and "Show location on server" pop up dialogs (buttons see toolbar in right hand side metadata panel). Select an image with a file attachment. Test the "Info..." dialog on the attachment. Again, without the PR these would just be grey rectangles. 