### PR TITLE
Elide object ids in standard CLI output

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1844,11 +1844,11 @@ class GraphControl(CmdControl):
         objects = []
         for req in doall.requests:
             for type in req.targetObjects.keys():
-                ids = ",".join(map(str, req.targetObjects[type]))
+                ids = self._order_and_range_ids(req.targetObjects[type])
                 if isinstance(req, omero.cmd.SkipHead):
                     type += ("/" + req.startFrom[0])
-                objects.append('%s %s' % (type, ids))
-        return "%s %s... " % (cmd_type, ', '.join(objects))
+                objects.append('%s:%s' % (type, ids))
+        return "%s %s " % (cmd_type, ' '.join(objects))
 
     def _get_object_ids(self, objDict):
         import collections

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -457,6 +457,38 @@ class TestDelete(CLITest):
         assert not self.query.find('FileAnnotation', fa.id.val)
         assert not self.query.find('FileAnnotation', fa2.id.val)
 
+    def testOutputWithElision(self, capfd):
+        IMAGES = 8
+        # Import several images
+        ids = []
+        for i in range(IMAGES):
+            ids.append(self.importSingleImage().id.val)
+        ids = sorted(ids)
+        assert len(ids) == IMAGES
+        assert ids[-1] - ids[0] + 1 == IMAGES
+        ids = [str(id) for id in ids]
+        # Now delete some of those images, mix up the order
+        iids = [ids[5], ids[4], ids[0], ids[7], ids[2], ids[1]]
+        self.args += ['Image:%s' % ",".join(iids)]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capfd.readouterr()
+        o = o.strip().split(" ")
+        # The output should contain:...
+        # ... the command and an ok at either end,...
+        assert o[0] == "omero.cmd.Delete2"
+        assert o[2] == "ok"
+        type, oids = o[1].split(":")
+        # ... the object type,...
+        assert type == "Image"
+        oids = oids.split(",")
+        # ... the first three sequential ids elided,...
+        assert oids[0] == ids[0]+"-"+ids[2]
+        # ... the next two sequential ids, not elided,...
+        assert oids[1] == ids[4]
+        assert oids[2] == ids[5]
+        # ... and the final separate single id.
+        assert oids[3] == ids[7]
+
 
 class TestTagDelete(AbstractTagTest):
 


### PR DESCRIPTION
This PR adds object id elision to the basic output from CLI delete, chgrp, etc. This has been in the detailed report for some time but had been omitted from the default response. See https://trello.com/c/Y37tzyrK/25-missing-range-collapsing-on-delete

To test import and then move or delete a number of objects and check the response. 
```
$ omero delete Image:1,2,3
...
omero.cmd.Delete2 Image:1-3 ok
```
Try with broken sequences of ids too, the results should not be surprising!

The added test should pass.