### PR TITLE
Api tagged perms

### DIFF
--- a/components/tools/OmeroPy/test/integration/helpers.py
+++ b/components/tools/OmeroPy/test/integration/helpers.py
@@ -35,3 +35,26 @@ def createTestImage(session):
                                       "description", dataset=None)
 
     return image.getId().getValue()
+
+
+def createImageWithPixels(client, name, sizes={}):
+        """
+        Create a new image with pixels
+        """
+        pixelsService = client.sf.getPixelsService()
+        queryService = client.sf.getQueryService()
+
+        pixelsType = queryService.findByQuery(
+            "from PixelsType as p where p.value='int8'", None)
+        assert pixelsType is not None
+
+        sizeX = "x" in sizes and sizes["x"] or 1
+        sizeY = "y" in sizes and sizes["y"] or 1
+        sizeZ = "z" in sizes and sizes["z"] or 1
+        sizeT = "t" in sizes and sizes["t"] or 1
+        sizeC = "c" in sizes and sizes["c"] or 1
+        channelList = range(1, sizeC+1)
+        id = pixelsService.createImage(
+            sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
+            name, description=None)
+        return id

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -135,7 +135,7 @@ class TestQuery(lib.ITest):
                 where alink.child.id=:tid and alink.parent.id=obj.id)"""
         query = q % uniqueClause
         result1 = queryService.projection(query, params,
-                                         {'omero.group': str(groupId)})
+                                          {'omero.group': str(groupId)})
         assert len(result1) == tagCount
 
         # Without the select statement, we get the same image returned
@@ -143,7 +143,7 @@ class TestQuery(lib.ITest):
         clause = "alink.parent.id=obj.id"
         query = q % clause
         result2 = queryService.projection(query, params,
-                                         {'omero.group': str(groupId)})
+                                          {'omero.group': str(groupId)})
         assert len(result2) == tagCount
         for idx in range(len(result1)-1):
             # Omit final since == isn't defined for Ice objects.

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -25,7 +25,12 @@
 """
 
 import library as lib
-from omero.rtypes import unwrap
+from omero.rtypes import unwrap, wrap
+from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
+from omero.model import PermissionsI
+from omero.sys import ParametersI
+from helpers import createImageWithPixels
+from time import time
 
 
 class TestQuery(lib.ITest):
@@ -51,3 +56,81 @@ class TestQuery(lib.ITest):
                 as_map[obj_array[0]] = obj_array[1]
             if len(as_map) > 0:
                 print "Group %s: %s" % (group.id.val, as_map)
+
+    def testQuerySpeedWithGroupContext(self):
+
+        # get group we're working on...
+        ctx = self.client.sf.getAdminService().getEventContext()
+        groupId = ctx.groupId
+        print 'groupId', groupId
+
+        # Admin sets permissions to read-ann
+        admin = self.root.sf.getAdminService()
+        gr = admin.getGroup(groupId)
+        p = PermissionsI()
+        p.setUserRead(True)
+        p.setUserWrite(True)
+        p.setGroupRead(True)
+        p.setGroupAnnotate(True)
+        p.setGroupWrite(False)
+        p.setWorldRead(False)
+        p.setWorldAnnotate(False)
+        p.setWorldWrite(False)
+        gr.details.permissions = p
+        admin.updateGroup(gr)
+
+        # Update context for user
+        ctx = self.client.sf.getAdminService().getEventContext()
+        update = self.client.sf.getUpdateService()
+        query = self.client.sf.getQueryService()
+        tagCount = 100
+        # create tag linked to many images
+        tag = TagAnnotationI()
+        tag.textValue = wrap("test_iQuerySpeed")
+        links = []
+
+        for i in range(tagCount):
+            iid = createImageWithPixels(self.client, self.uuid())
+            link = ImageAnnotationLinkI()
+            link.parent = ImageI(iid, False)
+            link.child = tag
+            links.append(link)
+        links = update.saveAndReturnArray(links)
+        tag = links[0].child
+        # check permissions
+        p = tag.getDetails().getPermissions()
+        assert p.isGroupRead()
+        assert p.isGroupAnnotate()
+
+        q = """select new map(obj.id as id,
+               obj.name as name,
+               obj.details.owner.id as ownerId,
+               obj as image_details_permissions,
+               obj.fileset.id as filesetId
+             ,
+             pix.sizeX as sizeX,
+             pix.sizeY as sizeY,
+             pix.sizeZ as sizeZ
+             )
+            from Image obj  left outer join obj.pixels pix
+            join obj.annotationLinks alink
+            where alink.id = (select max(alink.id)
+                from ImageAnnotationLink alink
+                where alink.child.id=:tid and alink.parent.id=obj.id)
+                    order by lower(obj.name), obj.id"""
+
+        params = ParametersI()
+        params.add('tid', tag.id)
+
+        startTime = time()
+        result = query.projection(q, params, {'omero.group': str(groupId)})
+        duration1 = time() - startTime
+        assert len(result) == tagCount
+
+        startTime = time()
+        result = query.projection(q, params, {'omero.group': '-1'})
+        duration2 = time() - startTime
+        assert len(result) == tagCount
+
+        # Should be faster when we specify groupId
+        assert duration1 < duration2

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -115,7 +115,8 @@ class TestQuery(lib.ITest):
                obj.name as name,
                obj.details.owner.id as ownerId,
                obj as image_details_permissions,
-               obj.fileset.id as filesetId
+               obj.fileset.id as filesetId,
+               lower(obj.name) as n
              ,
              pix.sizeX as sizeX,
              pix.sizeY as sizeY,
@@ -123,7 +124,8 @@ class TestQuery(lib.ITest):
              )
             from Image obj  left outer join obj.pixels pix
             join obj.annotationLinks alink
-            where %s"""
+            where %s
+            order by lower(obj.name), obj.id """
 
         params = ParametersI()
         params.add('tid', tag.id)
@@ -140,7 +142,7 @@ class TestQuery(lib.ITest):
 
         # Without the select statement, we get the same image returned
         # multiple times if there is no 'distinct'
-        clause = "alink.parent.id=obj.id"
+        clause = "alink.child.id=:tid"
         query = q % clause
         result2 = queryService.projection(query, params,
                                           {'omero.group': str(groupId)})

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -62,28 +62,10 @@ class TestQuery(lib.ITest):
         # get group we're working on...
         ctx = self.client.sf.getAdminService().getEventContext()
         groupId = ctx.groupId
-        print 'groupId', groupId
 
-        # Admin sets permissions to read-ann
-        admin = self.root.sf.getAdminService()
-        gr = admin.getGroup(groupId)
-        p = PermissionsI()
-        p.setUserRead(True)
-        p.setUserWrite(True)
-        p.setGroupRead(True)
-        p.setGroupAnnotate(True)
-        p.setGroupWrite(False)
-        p.setWorldRead(False)
-        p.setWorldAnnotate(False)
-        p.setWorldWrite(False)
-        gr.details.permissions = p
-        admin.updateGroup(gr)
-
-        # Update context for user
-        ctx = self.client.sf.getAdminService().getEventContext()
         update = self.client.sf.getUpdateService()
         query = self.client.sf.getQueryService()
-        tagCount = 100
+        tagCount = 10
         # create tag linked to many images
         tag = TagAnnotationI()
         tag.textValue = wrap("test_iQuerySpeed")
@@ -97,10 +79,6 @@ class TestQuery(lib.ITest):
             links.append(link)
         links = update.saveAndReturnArray(links)
         tag = links[0].child
-        # check permissions
-        p = tag.getDetails().getPermissions()
-        assert p.isGroupRead()
-        assert p.isGroupAnnotate()
 
         q = """select new map(obj.id as id,
                obj.name as name,

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -27,7 +27,6 @@
 import library as lib
 from omero.rtypes import unwrap, wrap
 from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
-from omero.model import PermissionsI
 from omero.sys import ParametersI
 from helpers import createImageWithPixels
 from time import time

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -25,7 +25,11 @@
 """
 
 import library as lib
-from omero.rtypes import unwrap
+from omero.rtypes import unwrap, wrap
+from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
+from omero.model import PermissionsI
+from omero.sys import ParametersI
+from helpers import createImageWithPixels
 
 
 class TestQuery(lib.ITest):
@@ -51,3 +55,91 @@ class TestQuery(lib.ITest):
                 as_map[obj_array[0]] = obj_array[1]
             if len(as_map) > 0:
                 print "Group %s: %s" % (group.id.val, as_map)
+
+    def testQueryTaggedUnique(self):
+
+        # get group we're working on...
+        ctx = self.client.sf.getAdminService().getEventContext()
+        groupId = ctx.groupId
+        print 'groupId', groupId
+
+        # Admin sets permissions to read-ann
+        admin = self.root.sf.getAdminService()
+        rootUpdate = self.root.sf.getUpdateService()
+        gr = admin.getGroup(groupId)
+        p = PermissionsI()
+        p.setUserRead(True)
+        p.setUserWrite(True)
+        p.setGroupRead(True)
+        p.setGroupAnnotate(True)
+        p.setGroupWrite(False)
+        p.setWorldRead(False)
+        p.setWorldAnnotate(False)
+        p.setWorldWrite(False)
+        gr.details.permissions = p
+        admin.updateGroup(gr)
+
+        # Update context for user
+        ctx = self.client.sf.getAdminService().getEventContext()
+        update = self.client.sf.getUpdateService()
+        queryService = self.client.sf.getQueryService()
+        tagCount = 5
+        # User creates tag linked to images
+        tag = TagAnnotationI()
+        tag.textValue = wrap("test_iQuerySpeed")
+        links = []
+
+        for i in range(tagCount):
+            iid = createImageWithPixels(self.client, self.uuid())
+            link = ImageAnnotationLinkI()
+            link.parent = ImageI(iid, False)
+            link.child = tag
+            links.append(link)
+        links = update.saveAndReturnArray(links)
+        tag = links[0].child
+        # check permissions
+        p = tag.getDetails().getPermissions()
+        assert p.isGroupRead()
+        assert p.isGroupAnnotate()
+
+        # Root also links user's tag to images
+        rootLinks = []
+        for l in links:
+            link = ImageAnnotationLinkI()
+            link.parent = ImageI(l.parent.id, False)
+            link.child = TagAnnotationI(l.child.id, False)
+            rootLinks.append(link)
+        rootUpdate.saveAndReturnArray(rootLinks, {'omero.group': str(groupId)})
+
+        q = """select new map(obj.id as id,
+               obj.name as name,
+               obj.details.owner.id as ownerId,
+               obj as image_details_permissions,
+               obj.fileset.id as filesetId
+             ,
+             pix.sizeX as sizeX,
+             pix.sizeY as sizeY,
+             pix.sizeZ as sizeZ
+             )
+            from Image obj  left outer join obj.pixels pix
+            join obj.annotationLinks alink
+            where %s"""
+
+        params = ParametersI()
+        params.add('tid', tag.id)
+
+        # We can get all the tagged images like this.
+        # We use an additional select statement to give 'unique' results
+        uniqueClause = """alink.id = (select max(alink.id)
+                from ImageAnnotationLink alink
+                where alink.child.id=:tid and alink.parent.id=obj.id)"""
+        query = q % uniqueClause
+        result = queryService.projection(query, params, {'omero.group': str(groupId)})
+        assert len(result) == tagCount
+
+        # Without the select statement, we get the same image returned multiple times
+        # TODO: is there a 'nicer' way to ensure unique results without a second select statement?
+        clause = "alink.parent.id=obj.id"
+        query = q % clause
+        result = queryService.projection(query, params, {'omero.group': str(groupId)})
+        assert len(result) == tagCount

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -134,12 +134,16 @@ class TestQuery(lib.ITest):
                 from ImageAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)"""
         query = q % uniqueClause
-        result = queryService.projection(query, params, {'omero.group': str(groupId)})
+        result = queryService.projection(query, params,
+                                         {'omero.group': str(groupId)})
         assert len(result) == tagCount
 
-        # Without the select statement, we get the same image returned multiple times
-        # TODO: is there a 'nicer' way to ensure unique results without a second select statement?
+        # Without the select statement, we get the same image returned
+        # multiple times
+        # TODO: is there a 'nicer' way to ensure unique results without
+        # a second select statement?
         clause = "alink.parent.id=obj.id"
         query = q % clause
-        result = queryService.projection(query, params, {'omero.group': str(groupId)})
+        result = queryService.projection(query, params,
+                                         {'omero.group': str(groupId)})
         assert len(result) == tagCount

--- a/components/tools/OmeroPy/test/integration/test_pixelsService.py
+++ b/components/tools/OmeroPy/test/integration/test_pixelsService.py
@@ -27,37 +27,17 @@
 import omero
 import omero.gateway
 import library as lib
+from helpers import createImageWithPixels
 
 
 class TestPixelsService(lib.ITest):
-
-    def createImage(self):
-        """
-        Create a new image
-        """
-        pixelsService = self.client.sf.getPixelsService()
-        queryService = self.client.sf.getQueryService()
-
-        pixelsType = queryService.findByQuery(
-            "from PixelsType as p where p.value='int8'", None)
-        assert pixelsType is not None
-
-        sizeX = 1
-        sizeY = 1
-        sizeZ = 1
-        sizeT = 1
-        channelList = range(1, 4)
-        id = pixelsService.createImage(
-            sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
-            self.uuid(), description=None)
-        return id
 
     def test9655(self):
         # Create an image without statsinfo objects and attempt
         # to retrieve it from the Rendering service.
 
         # Get the pixels
-        image_id = self.createImage()
+        image_id = createImageWithPixels(self.client, self.uuid())
         gateway = omero.gateway.BlitzGateway(client_obj=self.client)
         image = gateway.getObject("Image", image_id)
         pixels_id = image.getPrimaryPixels().id

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -1323,7 +1323,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
                 where dil.parent=obj.id) as childCount)
             from Project obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from ProjectAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from ProjectAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         ''' % common_clause
@@ -1349,7 +1350,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
                 where dil.parent=obj.id) as childCount)
             from Dataset obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from DatasetAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from DatasetAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         ''' % common_clause
@@ -1390,7 +1392,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
                obj.fileset.id as filesetId %s)
             from Image obj %s
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from ImageAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from ImageAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         """ % (extraValues, extraObjs, common_clause)
@@ -1423,7 +1426,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
                 where spl.parent=obj.id) as childCount)
             from Screen obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from ScreenAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from ScreenAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         ''' % common_clause
@@ -1449,7 +1453,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
                 where pa.plate.id=obj.id) as childCount)
             from Plate obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from PlateAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from PlateAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         ''' % common_clause
@@ -1475,7 +1480,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
             obj.endTime as endTime)
         from PlateAcquisition obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id) from PlateAcquisitionAnnotationLink alink
+            where alink.id = (select max(alink.id)
+                from PlateAcquisitionAnnotationLink alink
                 where alink.child.id=:tid and alink.parent.id=obj.id)
         %s
         ''' % common_clause

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -1315,17 +1315,16 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
 
     # Projects
     q = '''
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
             obj.name as name,
+            lower(obj.name) as lowername,
             obj.details.owner.id as ownerId,
             obj as project_details_permissions,
             (select count(id) from ProjectDatasetLink dil
                 where dil.parent=obj.id) as childCount)
             from Project obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from ProjectAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         ''' % common_clause
 
@@ -1342,17 +1341,16 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
 
     # Datasets
     q = '''
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
             obj.name as name,
+            lower(obj.name) as lowername,
             obj.details.owner.id as ownerId,
             obj as dataset_details_permissions,
             (select count(id) from DatasetImageLink dil
                 where dil.parent=obj.id) as childCount)
             from Dataset obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from DatasetAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         ''' % common_clause
 
@@ -1385,16 +1383,15 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
             """
 
     q = """
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
                obj.name as name,
+               lower(obj.name) as lowername,
                obj.details.owner.id as ownerId,
                obj as image_details_permissions,
                obj.fileset.id as filesetId %s)
             from Image obj %s
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from ImageAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         """ % (extraValues, extraObjs, common_clause)
 
@@ -1418,17 +1415,16 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
 
     # Screens
     q = '''
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
             obj.name as name,
+            lower(obj.name) as lowername,
             obj.details.owner.id as ownerId,
             obj as screen_details_permissions,
             (select count(id) from ScreenPlateLink spl
                 where spl.parent=obj.id) as childCount)
             from Screen obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from ScreenAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         ''' % common_clause
 
@@ -1445,17 +1441,16 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
 
     # Plate
     q = '''
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
             obj.name as name,
+            lower(obj.name) as lowername,
             obj.details.owner.id as ownerId,
             obj as plate_details_permissions,
             (select count(id) from PlateAcquisition pa
                 where pa.plate.id=obj.id) as childCount)
             from Plate obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from PlateAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         ''' % common_clause
 
@@ -1472,17 +1467,16 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
 
     # Plate Acquisitions
     q = '''
-        select new map(obj.id as id,
+        select distinct new map(obj.id as id,
             obj.name as name,
+            lower(obj.name) as lowername,
             obj.details.owner.id as ownerId,
             obj as plateacquisition_details_permissions,
             obj.startTime as startTime,
             obj.endTime as endTime)
         from PlateAcquisition obj
             join obj.annotationLinks alink
-            where alink.id = (select max(alink.id)
-                from PlateAcquisitionAnnotationLink alink
-                where alink.child.id=:tid and alink.parent.id=obj.id)
+            where alink.child.id=:tid
         %s
         ''' % common_clause
 


### PR DESCRIPTION
This uses the ```select map( )``` format of iQuery when loading tagged data, as we already do with other jsTree data, in order to work-around the hibernate projection permissions issues.

This fixes permissions on tagged objects belonging to other users.
Also adds tests to check this.

To review:
 - Check that all tests are passing
 - Look at the queries to check they make sense (that there isn't an obviously better way than the inner ```select``` to ensure that results are distinct)?