### PR TITLE
Raise exception on setPixelsFile failure

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -1592,7 +1592,8 @@ public class OMEROMetadataStoreClient
         catch (Exception e)
         {
             log.error("Server error setting extended properties for Pixels:" +
-                      pixelsId + " Target file:" + file);
+                      pixelsId + " Target file:" + file, e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -1593,7 +1593,8 @@ public class OMEROMetadataStoreClient
         {
             log.error("Server error setting extended properties for Pixels:" +
                       pixelsId + " Target file:" + file, e);
-            throw new RuntimeException(e);
+            throw e instanceof RuntimeException ?
+                (RuntimeException) e : new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
setPixelsFile in OMEROMetadataStoreClient is the only method
which silently catches ServerError. Most methods wrap the SE
in a runtime exception. This avoids silently having
corrupted images.

See:
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-December/005770.html

**Testing:** Unclear how to reproduce from the email thread. Likely a low-memory issue. Primarily a code-review is necessary.

cc: @chris-allan 