### PR TITLE
adjust log level for probing nested simple properties

### DIFF
--- a/components/server/src/ome/services/graphs/GraphPathBean.java
+++ b/components/server/src/ome/services/graphs/GraphPathBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -288,7 +288,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
                         } catch (NoSuchMethodException e) {
                             /* expected for collection properties */
                         } catch (NestedNullException e) {
-                            log.warn("guessing " + propertyPath + " of " + property.holder + " to be accessible");
+                            log.debug("guessing " + propertyPath + " of " + property.holder + " to be accessible");
                             propertyIsAccessible = true;
                         }
                     } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
RFE documented at https://trello.com/c/XyOslw9x/24-reduce-warn-in-graphpathbean. Check the `Blitz-0.log` after the server starts up for a lack of the mentioned warnings. One needn't do anything with a client.

--no-rebase