### PR TITLE
Prevent NPE in IntensityResultsView

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityResultsView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityResultsView.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -408,6 +408,10 @@ class IntensityResultsView
 		
 		final ShapeAsID shapeID = new ShapeAsID(shape);
 		Iterator<String> channelIterator = channelName.values().iterator();
+
+        if (minStats.get(coord) == null)
+            return;
+		
 		channelMin = minStats.get(coord);
 		channelMax = maxStats.get(coord);
 		channelMean = meanStats.get(coord);


### PR DESCRIPTION
Just fixes a NPE in the measurement tool, see [Trello - Measurement Tool](https://trello.com/c/HbaU4XcU/17-measurement-tool).

**Test**: Open a multi-z (and/or -t) image. Create an ROI. Propagate the ROI through some z (and/or t) planes. Select the ROI. Go to intensity results view. Click on "Add selected". The ROI of the current plane should be added to the results table (without the PR: Crash due to NPE).
