### PR TITLE
short url

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webredirect/baseconv.py
+++ b/components/tools/OmeroWeb/omeroweb/webredirect/baseconv.py
@@ -1,0 +1,59 @@
+"""
+Original: http://www.djangosnippets.org/snippets/1431/
+
+Convert numbers from base 10 integers to base X strings and back again.
+
+Sample usage:
+
+>>> base20 = BaseConverter('0123456789abcdefghij')
+>>> base20.from_decimal(1234)
+'31e'
+>>> base20.to_decimal('31e')
+1234
+"""
+
+
+class BaseConverter(object):
+    decimal_digits = "0123456789"
+
+    def __init__(self, digits):
+        self.digits = digits
+
+    def from_decimal(self, i):
+        return self.convert(i, self.decimal_digits, self.digits)
+
+    def to_decimal(self, s):
+        return int(self.convert(s, self.digits, self.decimal_digits))
+
+    def convert(number, fromdigits, todigits):
+        # Based on http://code.activestate.com/recipes/111286/
+        if str(number)[0] == '-':
+            number = str(number)[1:]
+            neg = 1
+        else:
+            neg = 0
+
+        # make an integer out of the number
+        x = 0
+        for digit in str(number):
+            x = x * len(fromdigits) + fromdigits.index(digit)
+
+        # create the result in base 'len(todigits)'
+        if x == 0:
+            res = todigits[0]
+        else:
+            res = ""
+            while x > 0:
+                digit = x % len(todigits)
+                res = todigits[digit] + res
+                x = int(x / len(todigits))
+            if neg:
+                res = '-' + res
+        return res
+    convert = staticmethod(convert)
+
+base62 = BaseConverter(
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz'
+)
+binconv = BaseConverter('01')
+hexconv = BaseConverter('0123456789ABCDEF')

--- a/components/tools/OmeroWeb/omeroweb/webredirect/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webredirect/urls.py
@@ -29,4 +29,5 @@ from omeroweb.webredirect import views
 urlpatterns = patterns(
     'django.views.generic.simple',
     url(r'^$', views.index, name='webredirect'),
+    url(r'(?P<short>\w+)$', views.shorturl, name='webshorturl'),
 )

--- a/components/tools/OmeroWeb/test/integration/test_redirect.py
+++ b/components/tools/OmeroWeb/test/integration/test_redirect.py
@@ -1,0 +1,27 @@
+import omero
+from weblibrary import IWebTest
+from weblibrary import _response
+
+from django.core.urlresolvers import reverse
+from omeroweb.webredirect.baseconv import base62
+
+
+class TestShortUrl(IWebTest):
+    """
+    Tests short url.
+    """
+
+    def test_short_url(self):
+        origin = "/webclient/?show=image-1"
+        alias = omero.model.CommentAnnotationI()
+        alias.setNs(omero.rtypes.rstring("host/port"))
+        alias.description = omero.rtypes.rstring(origin)
+        alias.details.permissions = omero.model.PermissionsI("rwr-r-")
+        alias = self.root.sf.getUpdateService().saveAndReturnObject(alias)
+        short = base62.from_decimal(alias.id.val)
+        request_url = reverse('webshorturl', args=[short])
+        rsp = _response(self.django_root_client, request_url, 'get', {}, 200,
+                        follow=True)
+        location = "%s?%s" % (rsp.wsgi_request.META['PATH_INFO'],
+                              rsp.wsgi_request.META['QUERY_STRING'])
+        assert origin == location

--- a/components/tools/OmeroWeb/test/integration/test_redirect.py
+++ b/components/tools/OmeroWeb/test/integration/test_redirect.py
@@ -22,6 +22,13 @@ class TestShortUrl(IWebTest):
         request_url = reverse('webshorturl', args=[short])
         rsp = _response(self.django_root_client, request_url, 'get', {}, 200,
                         follow=True)
-        location = "%s?%s" % (rsp.wsgi_request.META['PATH_INFO'],
-                              rsp.wsgi_request.META['QUERY_STRING'])
+
+        # Work arround for Django 1.6
+        try:
+            location = "%s?%s" % (rsp.wsgi_request.META['PATH_INFO'],
+                                  rsp.wsgi_request.META['QUERY_STRING'])
+        except:
+            # TODO: remove when 1.6 is dropped
+            location = "%s?%s" % (rsp.request['PATH_INFO'],
+                                  rsp.request['QUERY_STRING'])
         assert origin == location


### PR DESCRIPTION
This PR is a proposal for https://trello.com/c/sJCSdD7P/174-redirect-service

To test:

- create short url for ``/webclient/?show=image-1`` (currently stored as CommentAnnotation)

 ```
c=omero.client('localhost', 4064)
sess=c.createSession('root', 'secret')
conn=omero.gateway.BlitzGateway(client_obj=c)
update = conn.getUpdateService()
ns = "host/port/prefix" #or referrer
short = omero.model.CommentAnnotationI()
short.setNs(omero.rtypes.rstring(ns))
short.description = omero.rtypes.rstring("/webclient/?show=image-1")
short.details.permissions = omero.model.PermissionsI("rwr-r-")
short = update.saveAndReturnObject(short)
print short.id.val, short.description.val
print 'short', base62.from_decimal(short.id.val)
 ```

- go to https://host:port/prefix/url/_SHORT_
- check if you were redirected to the expected location

cc: @joshmoore 

--excluded