### PR TITLE
Make linkAnnotation synchronized

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -594,7 +594,7 @@ class OmeroMetadataServiceImpl
 	 * @throws DSAccessException If an error occurred while trying to 
 	 * retrieve data from OMEDS service.
 	 */
-	private void linkAnnotation(SecurityContext ctx, DataObject data,
+	private synchronized void linkAnnotation(SecurityContext ctx, DataObject data,
 			AnnotationData annotation)
 		throws DSOutOfServiceException, DSAccessException
 	{			


### PR DESCRIPTION
Tiny bug fix for [Ticket 13129](http://trac.openmicroscopy.org/ome/ticket/13129)

**Test**: Select lots of images on a remote server (local just works too fast), add a tag to them. Now quickly - while the previous action is still running - do the same again (select the images again, add **the same** tag again). Maybe repeat this a few times, to be sure.
