### PR TITLE
Metadata panel bugfixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -68,6 +68,12 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
     
     /** The collection of annotations to replace. */
     private List<FileAnnotationData>        toReplace;
+    
+    /** Remove attachments button */
+    private JButton removeDocsButton;
+    
+    /** Add attachments button */
+    private JButton addDocsButton;
     
     /**
      * Creates a new instance
@@ -279,6 +285,9 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
             list = model.getAttachments();
         
         layoutAttachments(list);
+        
+        addDocsButton.setEnabled(model.canAddAnnotationLink());
+        removeDocsButton.setEnabled(model.canAddAnnotationLink());
     }
     
     void layoutAttachments(Collection list) {
@@ -362,7 +371,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
 
         IconManager icons = IconManager.getInstance();
 
-        final JButton addDocsButton = new JButton(
+        addDocsButton = new JButton(
                 icons.getIcon(IconManager.PLUS_12));
         addDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
         addDocsButton.setToolTipText("Attach a document.");
@@ -379,7 +388,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         UIUtilities.unifiedButtonLookAndFeel(addDocsButton);
         buttons.add(addDocsButton);
 
-        final JButton removeDocsButton = new JButton(
+        removeDocsButton = new JButton(
                 icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeDocsButton);
         removeDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -229,24 +229,6 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
     void handleObjectsSelection(Class<?> type, Collection objects, boolean fire)
     {
         layoutAttachments(objects);
-        List<Long> ids = new ArrayList<Long>();
-        Iterator i = objects.iterator();
-        FileAnnotationData data;
-        Collection attachments = model.getAllAttachments();
-        if (attachments == null || attachments.size() != objects.size()) {
-        } else {
-            while (i.hasNext()) {
-                data = (FileAnnotationData) i.next();
-                if  (data != null) ids.add(data.getId());
-            }
-            i = attachments.iterator();
-            while (i.hasNext()) {
-                data = (FileAnnotationData) i.next();
-                if (data != null && !ids.contains(data.getId())) {
-                    break;
-                }
-            }
-        }
     }
     /**
      * Returns the list of attachments currently selected by the user.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -367,24 +367,7 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
         List<AnnotationData> comments = getAnnotationToSave();
 
         if (!comments.isEmpty()) {
-            model.fireAnnotationSaving(
-                    new DataToSave(comments, Collections.emptyList()), null,
-                    true);
-
-            TextualAnnotationData data = (TextualAnnotationData) comments
-                    .get(0);
-            TextualAnnotationComponent comp = new TextualAnnotationComponent(
-                    model, data);
-            comp.addPropertyChangeListener(controller);
-            comp.setAreaColor(bgColor);
-            add(comp, constraints);
-            constraints.gridy++;
-
-            if (bgColor == UIUtilities.BACKGROUND_COLOUR_ODD)
-                bgColor = UIUtilities.BACKGROUND_COLOUR_EVEN;
-            else
-                bgColor = UIUtilities.BACKGROUND_COLOUR_ODD;
-
+            view.saveData(true);
             commentArea.setText("");
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -890,7 +890,7 @@ class EditorModel
 				return false;
 			case LookupNames.EXPERIMENTER_DISPLAY:
 			default:
-				return EditorUtil.isUserOwner(data, getUserID());
+				return EditorUtil.isUserOwner(data, getLoggedInUserID());
 		}
 	}
 
@@ -1075,14 +1075,14 @@ class EditorModel
 	 */
 	boolean isUserOwner(Object object)
 	{
-		long id = getUserID();
+		long id = getLoggedInUserID();
 		if (object == null) return false;
 		if (object instanceof ExperimenterData) 
 			return (((ExperimenterData) object).getId() == id);
 		if (!(object instanceof DataObject)) return false;
 		if (object instanceof FileData || object instanceof ImageData) {
 			DataObject f = (DataObject) object;
-			if (f.getId() < 0) return id == getUserID();
+			if (f.getId() < 0) return id == getLoggedInUserID();
 		} 
 		return EditorUtil.isUserOwner(object, id);
 	}
@@ -1108,7 +1108,7 @@ class EditorModel
 		AnnotationLinkData link;
 		DataObject ann = (DataObject) annotation;
 		
-		long id = getUserID();
+		long id = getLoggedInUserID();
 		
 		while (j.hasNext()) {
 			e = j.next();
@@ -1142,7 +1142,7 @@ class EditorModel
 		if (annotators == null || annotators.size() == 0) return false;
 		if (annotators.size() == 1) {
 			ExperimenterData exp = annotators.get(0);
-			long id = getUserID();
+			long id = getLoggedInUserID();
 			return exp.getId() != id;
 		}
 		return true;
@@ -2329,7 +2329,7 @@ class EditorModel
 		StructuredDataResults results;
 		Iterator<RatingAnnotationData> j;
 		int n = 0;
-		long userID = getUserID();
+		long userID = getLoggedInUserID();
 		while (i.hasNext()) {
 			e = i.next();
 			results = e.getValue();
@@ -2402,7 +2402,7 @@ class EditorModel
 		RatingAnnotationData rating;
 		Map<DataObject, RatingAnnotationData> 
 		map = new HashMap<DataObject, RatingAnnotationData>();
-		long id = getUserID();
+		long id = getLoggedInUserID();
 		while (i.hasNext()) {
 			e = i.next();
 			results = e.getValue();
@@ -2486,7 +2486,7 @@ class EditorModel
 		RatingAnnotationData rating;
 		int n = 0;
 		int value = 0;
-		long userID = getUserID();
+		long userID = getLoggedInUserID();
 		while (i.hasNext()) {
 			e = i.next();
 			results = e.getValue();
@@ -3988,6 +3988,14 @@ class EditorModel
 	 */
 	long getUserID() { return parent.getUserID(); }
 
+	/**
+	 * Returns the id of the currently logged in user.
+	 * @return See above.
+	 */
+	long getLoggedInUserID() {
+	    return MetadataViewerAgent.getUserDetails().getId();
+	}
+	
 	/**
 	 * Returns the user currently logged in.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -492,7 +492,7 @@ class GeneralPaneUI extends JPanel
             namePane.setVisible(!multi);
             idLabel.setVisible(!multi);
             propertiesTaskPane.setVisible(!multi);
-      
+            mapTaskPane.setVisible(!multi);
    
             revalidate();
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -140,6 +140,7 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         rating.removePropertyChangeListener(this);
         rating.setValue(originalValue);
         rating.addPropertyChangeListener(this);
+        rating.setEnabled(model.canAnnotate());
     }
 
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -144,6 +144,9 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
             l = model.getAllTags();
         
         layoutTags(l);
+        
+        addTagsButton.setEnabled(model.canAddAnnotationLink());
+        removeTagsButton.setEnabled(model.canAddAnnotationLink());
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -96,6 +96,9 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         removeAll();
         tagsDocList.clear();
         DocComponent doc;
+        
+        filter(list);
+        
         if (list != null && list.size() > 0) {
             Iterator i = list.iterator();
             DataObject data;
@@ -136,6 +139,24 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
             doc = new DocComponent(null, model);
             tagsDocList.add(doc);
             add(doc);
+        }
+    }
+    
+    /**
+     * Removes duplicate entries from the collection
+     * 
+     * @param collection
+     */
+    void filter(Collection collection) {
+        Set<Long> ids = new HashSet<Long>();
+        Iterator it = collection.iterator();
+        while (it.hasNext()) {
+            long id = ((DataObject) it.next()).getId();
+            if (ids.contains(id)) {
+                it.remove();
+                continue;
+            }
+            ids.add(id);
         }
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -280,18 +280,12 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
 
     @Override
     List<AnnotationData> getAnnotationsToSave() {
-        List<AnnotationData> result = new ArrayList<AnnotationData>();
-        for(TagAnnotationData tag : toAdd)
-            result.add(tag);
-        return result;
+        return new ArrayList<AnnotationData>(toAdd);
     }
 
     @Override
     List<Object> getAnnotationsToRemove() {
-        List<Object> result = new ArrayList<Object>();
-        for(TagAnnotationData tag : toRemove)
-            result.add(tag);
-        return result;
+        return new ArrayList<Object>(toRemove);
     }
 
     List<TagAnnotationData> getCurrentSelection() {


### PR DESCRIPTION
The permissions weren't checked properly on the right hand side metadata panel (for Tags, Attachments and Rating), which leads to actions being enabled although the user is not allowed to perform the action (which throws an exception on attempt to execute the action), see [Ticket 13130](http://trac.openmicroscopy.org/ome/ticket/13130).

**Test**: 
- Perform a couple of metadata actions (adding/removing tags, attachments and ratings) within a read-only group on your own data. Make sure you can't perform these actions (add/remove button, rating panel should be disabled) for other users' data in the read-only group.
- Make sure filtering by "added by me", "added by others" works
- Test adding and removing tags with multiselection, while also making sure, same tags aren't shown multiple times.
- Add a key-value pair and directly add a comment as well. Make sure both modifications are stored.
- Make sure Key-Value pairs metadata is not shown for multiselection.

