### PR TITLE
LocationDialog loading

### DIFF
--- a/components/blitz/src/omero/gateway/SecurityContext.java
+++ b/components/blitz/src/omero/gateway/SecurityContext.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -183,4 +183,13 @@ public class SecurityContext {
                 && Objects.equal(((SecurityContext) obj).getExperimenter(),
                         this.getExperimenter());
     }
+
+    @Override
+    public String toString() {
+        return "SecurityContext [groupID=" + groupID + ", experimenter="
+                + experimenter + ", sudo=" + sudo + ", serverInformation="
+                + serverInformation + ", compression=" + compression + "]";
+    }
+    
+    
 }

--- a/components/blitz/src/omero/gateway/ServerInformation.java
+++ b/components/blitz/src/omero/gateway/ServerInformation.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -122,4 +122,11 @@ public class ServerInformation {
         return true;
     }
 
+    @Override
+    public String toString() {
+        return "ServerInformation [hostname=" + hostname + ", port=" + port
+                + "]";
+    }
+
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/DataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/DataLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -55,7 +55,10 @@ public class DataLoader
 
     /** Flag indicating that the group has been modified.*/
     private boolean changeGroup;
-
+    
+    /** Flag indicating if the loader has been cancelled */
+    private boolean cancelled = false;
+    
     /**
      * Creates a new instance.
      * 
@@ -93,11 +96,15 @@ public class DataLoader
                 -1, this);
     }
 
-    /** 
+    /**
      * Cancels the data loading.
+     * 
      * @see DataImporterLoader#load()
      */
-    public void cancel() { handle.cancel(); }
+    public void cancel() {
+        cancelled = true;
+        handle.cancel();
+    }
 
     /**
      * Feeds the result back to the viewer.
@@ -105,7 +112,7 @@ public class DataLoader
      */
     public void handleResult(Object result)
     {
-        if (viewer.getState() == Importer.DISCARDED)
+        if (viewer.getState() == Importer.DISCARDED || cancelled)
             return;
         int type = Importer.PROJECT_TYPE;
         if (ScreenData.class.equals(rootType))

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -624,6 +624,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		locationDialog = new LocationDialog(owner, selectedContainer, type,
 				objects, model, groupId, true);
 		locationDialog.addPropertyChangeListener(this);
+		addPropertyChangeListener(locationDialog);
 		
 		int plugin = ImporterAgent.runAsPlugin();
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -27,6 +27,7 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -56,7 +57,6 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTabbedPane;
-import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -549,10 +549,12 @@ class LocationDialog extends JDialog implements ActionListener,
 		buttonPanel.add(Box.createHorizontalGlue());
 		buttonPanel.add(addButton);
 		
-		JPanel buttonWrapper = wrapInPaddedPanel(buttonPanel, UI_GAP, 0, 0, 0);
-		Border border =
-				BorderFactory.createMatteBorder(1, 0, 0, 0, Color.BLACK); 
-		buttonWrapper.setBorder(border);
+		buttonPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, 0, UI_GAP));
+		
+		JPanel buttonWrapper = new JPanel(new BorderLayout());
+		buttonWrapper.add(buttonPanel, BorderLayout.CENTER);
+		buttonWrapper.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.BLACK));
+		
 		return buttonWrapper;
 	}
 
@@ -579,6 +581,8 @@ class LocationDialog extends JDialog implements ActionListener,
 		
 		tabbedPane.addChangeListener(this);
 		
+		tabbedPane.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, UI_GAP, UI_GAP));
+		
 		return tabbedPane;
 	}
 	
@@ -590,6 +594,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		final JPanel groupPanel = new JPanel(new GridBagLayout());
 		GridBagConstraints c = new GridBagConstraints();
+		c.insets = new Insets(1, 1, 1, 1);
 		c.gridx = 0;
 		c.gridy = 0;
 		c.fill = GridBagConstraints.HORIZONTAL;
@@ -634,6 +639,7 @@ class LocationDialog extends JDialog implements ActionListener,
         JPanel projectPanel = new JPanel(new GridBagLayout());
 
         GridBagConstraints c = new GridBagConstraints();
+        c.insets = new Insets(1, 1, 1, 1);
         c.gridx = 0;
         c.gridy = 0;
         c.fill = GridBagConstraints.NONE;
@@ -678,6 +684,7 @@ class LocationDialog extends JDialog implements ActionListener,
         JPanel screenPanel = new JPanel(new GridBagLayout());
 
         GridBagConstraints c = new GridBagConstraints();
+        c.insets = new Insets(1, 1, 1, 1);
         c.gridx = 0;
         c.gridy = 0;
         c.fill = GridBagConstraints.NONE;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -514,9 +514,9 @@ class LocationDialog extends JDialog implements ActionListener,
 		closeButton.addActionListener(this);
 		closeButton.setActionCommand("" + CMD_CLOSE);
 		
-		Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH, 
+        Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH,
                 UIUtilities.DEFAULT_ICON_HEIGHT);
-		busyLabel = new JXBusyLabel(d);
+        busyLabel = new JXBusyLabel(d);
         busyLabel.setVisible(true);
         busyLabel.setBusy(true);
         
@@ -593,8 +593,8 @@ class LocationDialog extends JDialog implements ActionListener,
 		c.gridx = 0;
 		c.gridy = 0;
 		c.fill = GridBagConstraints.HORIZONTAL;
-        c.weightx = 0;
-        c.weighty = 0;
+		c.weightx = 0;
+		c.weighty = 0;
 		c.anchor = GridBagConstraints.WEST;
 		
 		if (groups.size() > 1) {
@@ -625,81 +625,81 @@ class LocationDialog extends JDialog implements ActionListener,
 		return groupPanel;
 	}
 	
-	/**
-	 * Builds a JPanel holding the project selection section.
-	 * 
-	 * @return JPanel holding the project selection UI elements
-	 */
-	private JPanel buildProjectSelectionPanel()
-	{
-		JPanel projectPanel = new JPanel(new GridBagLayout());
-		
-		GridBagConstraints c = new GridBagConstraints();
-		c.gridx = 0;
-		c.gridy = 0;
-		c.fill = GridBagConstraints.NONE;
-		c.anchor = GridBagConstraints.WEST;
-		c.weightx = 0;
-		c.weighty = 0;
-		
-		projectPanel.add(UIUtilities.setTextFont(TEXT_PROJECT), c);
-		c.gridx++;
-		c.fill = GridBagConstraints.HORIZONTAL;
-		c.weightx = 1;
-		projectPanel.add(projectsBox, c);
-		c.gridx++;
-		c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-		projectPanel.add(newProjectButton, c);
-		c.gridy++;
-		
-		c.gridx = 0;
-		projectPanel.add(UIUtilities.setTextFont(TEXT_DATASET), c);
-		c.gridx++;
-		c.fill = GridBagConstraints.HORIZONTAL;
-        c.weightx = 1;
-		projectPanel.add(datasetsBox, c);
-		c.gridx++;
-		c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-		projectPanel.add(newDatasetButton, c);
-		
-		projectPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, UI_GAP, UI_GAP));
-		
-		return projectPanel;
-	}
+    /**
+     * Builds a JPanel holding the project selection section.
+     * 
+     * @return JPanel holding the project selection UI elements
+     */
+    private JPanel buildProjectSelectionPanel() {
+        JPanel projectPanel = new JPanel(new GridBagLayout());
 
-	/**
-	 * Builds a JPanel holding the screen selection section.
-	 * 
-	 * @return JPanel holding the screen selection UI elements
-	 */
-	private JPanel buildScreenSelectionPanel()
-	{
-		JPanel screenPanel = new JPanel(new GridBagLayout());
-
-		GridBagConstraints c = new GridBagConstraints();
+        GridBagConstraints c = new GridBagConstraints();
         c.gridx = 0;
         c.gridy = 0;
         c.fill = GridBagConstraints.NONE;
         c.anchor = GridBagConstraints.WEST;
         c.weightx = 0;
         c.weighty = 0;
-        
-		screenPanel.add(UIUtilities.setTextFont(TEXT_SCREEN), c);
-		c.gridx++;
+
+        projectPanel.add(UIUtilities.setTextFont(TEXT_PROJECT), c);
+        c.gridx++;
         c.fill = GridBagConstraints.HORIZONTAL;
         c.weightx = 1;
-		screenPanel.add(screensBox,c);
-		c.gridx++;
+        projectPanel.add(projectsBox, c);
+        c.gridx++;
         c.fill = GridBagConstraints.NONE;
         c.weightx = 0;
-		screenPanel.add(newScreenButton,c);
+        projectPanel.add(newProjectButton, c);
+        c.gridy++;
 
-		screenPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, UI_GAP, UI_GAP));
-		
-		return screenPanel;
-	}
+        c.gridx = 0;
+        projectPanel.add(UIUtilities.setTextFont(TEXT_DATASET), c);
+        c.gridx++;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.weightx = 1;
+        projectPanel.add(datasetsBox, c);
+        c.gridx++;
+        c.fill = GridBagConstraints.NONE;
+        c.weightx = 0;
+        projectPanel.add(newDatasetButton, c);
+
+        projectPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
+                UI_GAP, UI_GAP));
+
+        return projectPanel;
+    }
+
+    /**
+     * Builds a JPanel holding the screen selection section.
+     * 
+     * @return JPanel holding the screen selection UI elements
+     */
+    private JPanel buildScreenSelectionPanel() {
+        JPanel screenPanel = new JPanel(new GridBagLayout());
+
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridx = 0;
+        c.gridy = 0;
+        c.fill = GridBagConstraints.NONE;
+        c.anchor = GridBagConstraints.WEST;
+        c.weightx = 0;
+        c.weighty = 0;
+
+        screenPanel.add(UIUtilities.setTextFont(TEXT_SCREEN), c);
+        c.gridx++;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.weightx = 1;
+        screenPanel.add(screensBox, c);
+        c.gridx++;
+        c.fill = GridBagConstraints.NONE;
+        c.weightx = 0;
+        screenPanel.add(newScreenButton, c);
+
+        screenPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
+                UI_GAP, UI_GAP));
+
+        return screenPanel;
+    }
 
 	/**
 	 * Builds the toolbar when the importer is the entry point.
@@ -859,7 +859,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	}
 	
 	/**
-	 * Wraps the container in a JPanel with a bordered TableLayout
+	 * Wraps the container in a JPanel with an empty border
 	 * with the border width specified
 	 * @param container
 	 * @param top The amount of padding on the top of the container

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -352,6 +352,8 @@ class LocationDialog extends JDialog implements ActionListener,
      */
     private boolean activeWindow;
 
+    /** Flag indicating if projects/datasets have been loaded */
+    private boolean loaded = false;
     
 	/**
 	 * Creates a new instance.
@@ -1101,12 +1103,22 @@ class LocationDialog extends JDialog implements ActionListener,
 			List<DataNode> listItems, DataNode select,
 			ItemListener itemListener)
 	{
-		if (comboBox == null || listItems == null) return;
+		if (comboBox == null || listItems == null)
+		    return;
 		//Only add the item the user can actually select
 		if (itemListener != null)
 			comboBox.removeItemListener(itemListener);
 		comboBox.removeAllItems();
 
+        if (!loaded) {
+            SelectableComboBoxModel model = new SelectableComboBoxModel();
+            model.addElement("Loading...");
+            comboBox.setModel(model);
+            if (itemListener != null)
+                comboBox.addItemListener(itemListener);
+            return;
+        }
+		
 		List<String> tooltips = new ArrayList<String>(listItems.size());
 		List<String> lines;
 		ExperimenterData exp;
@@ -1683,6 +1695,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	    this.dataType = type;
 	    this.objects = objects;
 	    this.container = container;
+	    this.loaded = true;
 	    populateUIWithDisplayData(findWithId(groups, currentGroupId), userID);
 	    setInputsEnabled(true);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1004,11 +1004,21 @@ class LocationDialog extends JDialog implements ActionListener,
 		{
 			case Importer.PROJECT_TYPE:
 				DataNode project = getSelectedItem(projectsBox);
+				if (project == null)
+				    project = new DataNode(DataNode.createDefaultProject(), null);
+				
 				DataNode dataset = getSelectedItem(datasetsBox);
+				if (dataset == null)
+				    dataset = new DataNode(DataNode.createDefaultDataset(), null);
+				
 				return new ProjectImportLocationSettings(group, user,
 						project, dataset);
 			case Importer.SCREEN_TYPE:
 				DataNode screen = getSelectedItem(screensBox);
+				
+				if (screen == null) 
+				    screen = new DataNode(DataNode.createDefaultScreen(), null);
+				
 				return new ScreenImportLocationSettings(group, user, screen);
 		}
 		

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1401,10 +1401,13 @@ class LocationDialog extends JDialog implements ActionListener,
                 || ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
             busyLabel.setBusy(true);
             busyLabel.setVisible(true);
-            ImportLocationDetails details = (ImportLocationDetails) evt
-                    .getNewValue();
-            if (details != null)
-                dataType = (int) details.getDataType();
+            Object value = evt.getNewValue();
+            if(value != null && value instanceof ImportLocationDetails) {
+                ImportLocationDetails details = (ImportLocationDetails) evt
+                        .getNewValue();
+                if (details != null)
+                    dataType = (int) details.getDataType();
+            }
         }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1364,7 +1364,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		DataNode project = getSelectedItem(projectsBox);
 
-		displayItemsWithTooltips(datasetsBox, datasets.get(project));
+		displayItemsWithTooltips(datasetsBox, sortByUser(datasets.get(project)));
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1289,7 +1289,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		newDatasets.add(newDefaultDatasetNode);
 		
 		projects.add(newProjectNode);
-		projects = sort(projects); 
+		projects = sortByUser(projects); 
 		datasets.put(newProjectNode, newDatasets);
 		
 		currentProject = newProjectNode;
@@ -1325,7 +1325,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		}
 		
 		projectDatasets.add(newDatasetNode);
-		projectDatasets = sort(projectDatasets);
+		projectDatasets = sortByUser(projectDatasets);
 		
 		datasets.put(selectedProject, projectDatasets);
 
@@ -1348,7 +1348,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		DataNode newScreenNode = new DataNode(newScreenObject);
 		
 		screens.add(newScreenNode);
-		screens = sort(screens);
+		screens = sortByUser(screens);
 		
 		currentScreen = newScreenNode;
 		

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -84,6 +84,9 @@ public interface Importer
 
     /** Flag to denote the <i>Importing</i> state. */
     public static final int IMPORTING = 4;
+    
+    /** Flag to denote the <i>Loading</i> state. */
+    public static final int LOADING = 5;
 
     /**
      * Starts the data loading process when the current state is {@link #NEW}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -627,6 +627,7 @@ class ImporterComponent
 			case DISCARDED:
 				return;
 		}
+		model.setState(Importer.READY);
 		if (chooser == null) return;
 		Set nodes = TreeViewerTranslator.transformHierarchy(result);
 		chooser.reset(nodes, type, model.getGroupId(), userID);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -413,11 +413,8 @@ class ImporterModel
 			changeGroup, ExperimenterData user)
 	{
 		if (!(ProjectData.class.equals(rootType) ||
-			ScreenData.class.equals(rootType))) return;
-		if (user != null) {
-		    ctx.setExperimenter(user);
-		    ctx.sudo();
-		}
+			ScreenData.class.equals(rootType))) 
+		    return;
 		
 		// cancel the previous loader
 		if(containerLoader != null && state == Importer.LOADING)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -57,7 +57,6 @@ import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.model.ResultsObject;
 
 import omero.gateway.SecurityContext;
-import omero.gateway.ServerInformation;
 
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.roi.io.ROIReader;
@@ -122,6 +121,9 @@ class ImporterModel
     /** The id of the user to import for.*/
     private long userId;
 
+    /** Loader for screen/plates, projects/datasets */
+    private DataLoader containerLoader;
+    
     /**
      * The result object used to determine setting when saving rois/measurement
      * post import.
@@ -416,9 +418,15 @@ class ImporterModel
 		    ctx.setExperimenter(user);
 		    ctx.sudo();
 		}
-		DataLoader loader = new DataLoader(component, ctx, rootType,
+		
+		// cancel the previous loader
+		if(containerLoader != null && state == Importer.LOADING)
+		    containerLoader.cancel();
+		
+		state = Importer.LOADING;
+		containerLoader = new DataLoader(component, ctx, rootType,
 				refreshImport, changeGroup);
-		loader.load();
+		containerLoader.load();
 	}
 
 	/**


### PR DESCRIPTION
Fixes [Ticket 13113](https://trac.openmicroscopy.org/ome/ticket/13113)

**Test:** Log in as user who has many projects/datasets. Open the import dialog, select a file to import, which brings up the LocationDialog. The Project and Dataset selection boxes should only show one item "Loading..." while the projects and datasets are loading. When the projects/datasets are loaded, the selection boxes should be populated. 

*This is not easy to test, I had to artifically delay the loading by adding a Thread.sleep() to the DMLoader. Created a 1000 datasets and projects for user-3/read-only, but still the loading is so fast, that you can't see the bug.* 
