### PR TITLE
fix LSID creation for Shape to fit OME-XML schema

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
+++ b/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
@@ -197,6 +197,8 @@ public class OmeroMetadata extends DummyMetadata {
             Class<? extends IObject> k = obj.getClass();
             if (Annotation.class.isAssignableFrom(k)) {
                 k = Annotation.class;
+            } else if (Shape.class.isAssignableFrom(k)) {
+                k = Shape.class;
             }
             long id = obj.getId().getValue();
             Long v = (ue == null) ? null : ue.getId().getValue();
@@ -223,6 +225,8 @@ public class OmeroMetadata extends DummyMetadata {
         String prefix = obj.getClass().getSimpleName();
         if (Annotation.class.isAssignableFrom(obj.getClass())) {
             prefix = Annotation.class.getSimpleName();
+        } else if (Shape.class.isAssignableFrom(obj.getClass())) {
+            prefix = Shape.class.getSimpleName();
         }
         String lsid = prefix + ":" + uuid;
         ei.setLsid(rstring(lsid));


### PR DESCRIPTION
Fixes export of ROIs to write valid OME-XML. To test:

1. Draw ROIs on an image (no masks).
1. Export as OME-TIFF.
1. Import the exported file.
1. Ensure that the ROIs are preserved.
1. Check that the exported file's XML is valid.

For that last step https://www.openmicroscopy.org/site/support/bio-formats5/users/comlinetools/xml-validation.html may help.

--no-rebase