### PR TITLE
Improve OMERO build system integration with local Maven build

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -16,6 +16,7 @@
   <properties file="${ivy.settings.dir}/build.properties"/>
   <properties file="${ivy.settings.dir}/local.properties"/>
   <properties file="${ivy.settings.dir}/../target/omero.version"/>
+  <property name="local-maven2-dir" value="${user.home}/.m2/repository/"/>
 
   <settings defaultResolver="${omero.resolver}"/>
 
@@ -27,7 +28,7 @@
            while maven is for any stable, unchanging jar that is being
            downloaded -->
       <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
-      <cache name="maven" basedir="${user.home}/.m2/repository/"
+      <cache name="maven" basedir="${local-maven2-dir}"
         artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
         lockStrategy="artifact-lock"
@@ -54,8 +55,8 @@
           checkmodified="true" changingMatcher="regexp"
           changingPattern=".*SNAPSHOT.*"
           cache="local" descriptor="required">
-        <artifact pattern="${user.home}/.m2/repository/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
-        <ivy pattern="${user.home}/.m2/repository/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
+        <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
+        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
       </filesystem>
 
       <!-- Remote downloads; cached to '~/.m2/repository' -->


### PR DESCRIPTION
Previously the local Maven resolver was using the default Ivy pattern (ending with `.xml`) which was making the build incompatible with local artifacts build by Maven i.e. when working on coupled branches. This PR attempts to improve the developer workflow by taking advantage of the resolution of `.pom` files by Ivy.

To test this PR:

1. clean `~/.m2/repository/ome` (or alternatively clean the entire local Maven repository), re-run `./build.py build-dev` and check the build completes and the `~/.m2/repository/ome` is regenerated with the release version of Bio-Formats
2. re-run `./build.py build-dev` and check the build completes without waiting on artifacts retrieval
3. test a local coupled Bio-Formats/OMERO development workflow
  1. from a local Bio-Formats repository, checkout `origin/dev_5_1`, bump the version number to a non-existing published snapshot, e.g. `./tools/bump_maven_version.py 5.9.0-SNAPSHOT` then build the Bio-Formats artifacts using `mvn clean install`
  2.  check the Bio-Formats artifacts have been generated for this version under `~/.m2/repository/ome/` including both the `.jar` and the `.pom` files
  3. from the OMERO repository, modify `versions.bioformats` in `etc/omero.properties` to point at the chosen Bio-Formats version, e.g. 5.9.0-SNAPSHOT
  4. run `./build.py build-dev` and check the OMERO build completes
  5. run `dist/bin/omero import -f test.fake` and check the reported Bio-Formats version

Once signed off, a corresponding documentation PR will be opened to document this workflow.

/cc @mtbc @ximenesuk 