### PR TITLE
Don't set Ice.Default.Host by default

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1022,7 +1022,8 @@ present, the user will enter a console""")
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
-            '@Ice.Default.Host@': config.get('Ice.Default.Host', '127.0.0.1')
+            '@omero.master.host@': config.get('omero.master.host', config.get(
+                'Ice.Default.Host', '127.0.0.1'))
             }
 
         def copy_template(input_file, output_dir):
@@ -1045,8 +1046,8 @@ present, the user will enter a console""")
                 self._get_templates_dir() / "grid" / "*default.xml"):
             copy_template(xml_file, self._get_etc_dir() / "grid")
         ice_config = self._get_templates_dir() / "ice.config"
-        substitutions['@Ice.Default.Host@'] = config.get(
-            'Ice.Default.Host', 'localhost')
+        substitutions['@omero.master.host@'] = config.get(
+            'omero.master.host', config.get('Ice.Default.Host', 'localhost'))
         copy_template(ice_config, self._get_etc_dir())
 
         return rv

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -263,6 +263,7 @@ def leave_none_unset_int(s):
         return int(s)
 
 CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
+CUSTOM_HOST = CUSTOM_SETTINGS.get("omero.master.host", CUSTOM_HOST)
 # DO NOT EDIT!
 INTERNAL_SETTINGS_MAPPING = {
     "omero.qa.feedback":

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -49,7 +49,7 @@
     <node name="master">
       <server-instance template="Glacier2Template"
         client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
-        server-endpoints="tcp -h @Ice.Default.Host@"/>
+        server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>
       <server-instance template="DropBoxTemplate"/>

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -455,7 +455,7 @@
          </adapter>
          <properties>
             <properties refid="Profile"/>
-            <property name="IcePatch2.Admin.Endpoints" value="tcp -h @Ice.Default.Host@"/>
+            <property name="IcePatch2.Admin.Endpoints" value="tcp -h @omero.master.host@"/>
             <property name="IcePatch2.Admin.RegisterProcess" value="1"/>
             <property name="IcePatch2.InstanceName" value="${instance-name}"/>
             <property name="IcePatch2.Directory" value="${directory}"/>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -58,7 +58,7 @@
     <node name="master">
       <server-instance template="Glacier2Template"
         client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
-        server-endpoints="tcp -h @Ice.Default.Host@"/>
+        server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>
       <server-instance template="DropBoxTemplate"/>

--- a/etc/templates/ice.config
+++ b/etc/templates/ice.config
@@ -47,7 +47,7 @@
 # it is also an option to specify just omero.host which will
 # be inserted into a template Ice.Default.Router
 
-omero.host=@Ice.Default.Host@
+omero.host=@omero.master.host@
 
 
 # If your blitz server runs on a non-standard port (not 4064)

--- a/etc/templates/internal.cfg
+++ b/etc/templates/internal.cfg
@@ -2,7 +2,7 @@
 # OMERO Internal Lookup Configuration
 # Copyright 2007 Glencoe Software, Inc.  All Rights Reserved.
 #
-Ice.Default.Locator=IceGrid/Locator:tcp -h @Ice.Default.Host@ -p @omero.ports.prefix@@omero.ports.registry@
+Ice.Default.Locator=IceGrid/Locator:tcp -h @omero.master.host@ -p @omero.ports.prefix@@omero.ports.registry@
 IceGridAdmin.Username=root
 IceGridAdmin.Password=ome
 

--- a/etc/templates/master.cfg
+++ b/etc/templates/master.cfg
@@ -7,21 +7,21 @@
 ########################################################
 # Registry properties
 ########################################################
-IceGrid.Registry.Client.Endpoints=tcp -h @Ice.Default.Host@ -p @omero.ports.prefix@@omero.ports.registry@
-IceGrid.Registry.Server.Endpoints=tcp -h @Ice.Default.Host@
-IceGrid.Registry.Internal.Endpoints=tcp -h @Ice.Default.Host@
+IceGrid.Registry.Client.Endpoints=tcp -h @omero.master.host@ -p @omero.ports.prefix@@omero.ports.registry@
+IceGrid.Registry.Server.Endpoints=tcp -h @omero.master.host@
+IceGrid.Registry.Internal.Endpoints=tcp -h @omero.master.host@
 IceGrid.Registry.Data=var/registry
 IceGrid.Registry.DynamicRegistration=0
 IceGrid.Registry.AdminPermissionsVerifier=IceGrid/NullPermissionsVerifier
 #IceGrid.Registry.DefaultTemplates=etc/grid/templates.xml
-#IceGrid.Registry.SessionManager.Endpoints=tcp -h @Ice.Default.Host@
+#IceGrid.Registry.SessionManager.Endpoints=tcp -h @omero.master.host@
 #IceGrid.Registry.AdminCryptPasswords=etc/passwd
 
 ########################################################
 # Node properties
 ########################################################
 IceGrid.Node.CollocateRegistry=1
-IceGrid.Node.Endpoints=tcp -h @Ice.Default.Host@
+IceGrid.Node.Endpoints=tcp -h @omero.master.host@
 IceGrid.Node.Name=master
 IceGrid.Node.Data=var/master
 #IceGrid.Node.Output=var/log


### PR DESCRIPTION
`Ice.Default.Host` is useful when running multiple servers on the same host, but appears to break a multi-host OMERO.grid setup. My guess is that `Ice.Default.Host` is propagated to the slave nodes which then attempt to listen on that invalid IP (feature? bug? your guess).

This replaces `Ice.Default.Host` with a new property `omero.master.host` that allows the master's IP to be set in all templates as described in https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/grid.html#nodes-on-multiple-hosts without actually setting `Ice.Default.Host`.

The single host behaviour should be identical to before, `Ice.Default.Host` is used in all templates and the server should only listen on `Ice.Default.Host`.

See
- https://trello.com/c/3fY2taKP/37-omero-grid-omero-node-bugs-issues
- https://github.com/openmicroscopy/openmicroscopy/pull/4245
- https://github.com/openmicroscopy/openmicroscopy/pull/2705