### PR TITLE
Rewrite templates in `omero node start`, add --foreground

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/node.py
+++ b/components/tools/OmeroPy/src/omero/plugins/node.py
@@ -73,8 +73,8 @@ class NodeControl(BaseControl):
 
     def start(self, args):
 
-        self._initDir()
         self.ctx.invoke(["admin", "rewrite"])
+        self._initDir()
 
         try:
             command = ["icegridnode", self._icecfg()]


### PR DESCRIPTION
- Adds a `--foreground` flag to `omero node`
- Forces a call to `admin rewrite` before `node start`, otherwise you may get a warning about a missing `/etc/internal.cfg` file
- I've added `die` to `node start` on windows because the code doesn't appear to have been tested for a while- `args.node` isn't an argument AFAICT.

See also
- https://trello.com/c/3fY2taKP/37-omero-grid-omero-node-bugs-issues
- https://github.com/openmicroscopy/openmicroscopy/pull/4414

In conjunction with #4414 it should be possible to remove the workarounds in https://github.com/ome/ome-docker/pull/24 ... I'll test assuming this ends up in the next merge build.