### PR TITLE
Fix conn.getInterpolateSetting() always return True

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1559,7 +1559,7 @@ class _BlitzGateway (object):
         try:
             interpolate = (
                 toBoolean(self.getConfigService().getConfigValue(
-                    "omero.client.viewer.interpolate_pixels")) or True
+                    "omero.client.viewer.interpolate_pixels"))
             )
         except:
             interpolate = True

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -20,14 +20,16 @@ def testInterpolateSetting(gatewaywrapper):
     """
     gatewaywrapper.loginAsAdmin()
     configService = gatewaywrapper.gateway.getConfigService()
-    configService.setConfigValue("omero.client.viewer.interpolate_pixels", "true")
+    configService.setConfigValue(
+        "omero.client.viewer.interpolate_pixels", "true")
 
     gatewaywrapper.loginAsAuthor()
     assert gatewaywrapper.gateway.getInterpolateSetting()
 
     gatewaywrapper.loginAsAdmin()
     configService = gatewaywrapper.gateway.getConfigService()
-    configService.setConfigValue("omero.client.viewer.interpolate_pixels", "false")
+    configService.setConfigValue(
+        "omero.client.viewer.interpolate_pixels", "false")
 
     gatewaywrapper.loginAsAuthor()
     assert not gatewaywrapper.gateway.getInterpolateSetting()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -20,17 +20,21 @@ def testInterpolateSetting(gatewaywrapper):
     """
     gatewaywrapper.loginAsAdmin()
     configService = gatewaywrapper.gateway.getConfigService()
-    configService.setConfigValue(
-        "omero.client.viewer.interpolate_pixels", "false")
 
-    gatewaywrapper.loginAsAuthor()
-    assert gatewaywrapper.gateway.getInterpolateSetting()
+    try:
+        configService.setConfigValue(
+            "omero.client.viewer.interpolate_pixels", "false")
 
-    # Set back to 'true' (default value) to clean up
-    gatewaywrapper.loginAsAdmin()
-    configService = gatewaywrapper.gateway.getConfigService()
-    configService.setConfigValue(
-        "omero.client.viewer.interpolate_pixels", "true")
+        gatewaywrapper.loginAsAuthor()
+        assert gatewaywrapper.gateway.getInterpolateSetting()
+
+    finally:
+        # try/finally to make sure that we
+        # set back to 'true' (default value) to clean up
+        gatewaywrapper.loginAsAdmin()
+        configService = gatewaywrapper.gateway.getConfigService()
+        configService.setConfigValue(
+            "omero.client.viewer.interpolate_pixels", "true")
 
     gatewaywrapper.loginAsAuthor()
     assert gatewaywrapper.gateway.getInterpolateSetting()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -26,7 +26,7 @@ def testInterpolateSetting(gatewaywrapper):
             "omero.client.viewer.interpolate_pixels", "false")
 
         gatewaywrapper.loginAsAuthor()
-        assert gatewaywrapper.gateway.getInterpolateSetting()
+        assert not gatewaywrapper.gateway.getInterpolateSetting()
 
     finally:
         # try/finally to make sure that we

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -21,15 +21,16 @@ def testInterpolateSetting(gatewaywrapper):
     gatewaywrapper.loginAsAdmin()
     configService = gatewaywrapper.gateway.getConfigService()
     configService.setConfigValue(
-        "omero.client.viewer.interpolate_pixels", "true")
+        "omero.client.viewer.interpolate_pixels", "false")
 
     gatewaywrapper.loginAsAuthor()
     assert gatewaywrapper.gateway.getInterpolateSetting()
 
+    # Set back to 'true' (default value) to clean up
     gatewaywrapper.loginAsAdmin()
     configService = gatewaywrapper.gateway.getConfigService()
     configService.setConfigValue(
-        "omero.client.viewer.interpolate_pixels", "false")
+        "omero.client.viewer.interpolate_pixels", "true")
 
     gatewaywrapper.loginAsAuthor()
-    assert not gatewaywrapper.gateway.getInterpolateSetting()
+    assert gatewaywrapper.gateway.getInterpolateSetting()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+   Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+                      All Rights Reserved.
+   Copyright 2013 Glencoe Software, Inc. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+
+   pytest fixtures used as defined in conftest.py:
+   - gatewaywrapper
+
+"""
+
+
+def testInterpolateSetting(gatewaywrapper):
+    """
+    Tests conn.getInterpolateSetting(), setting the value as Admin and
+    testing the output as a regular user.
+    """
+    gatewaywrapper.loginAsAdmin()
+    configService = gatewaywrapper.gateway.getConfigService()
+    configService.setConfigValue("omero.client.viewer.interpolate_pixels", "true")
+
+    gatewaywrapper.loginAsAuthor()
+    assert gatewaywrapper.gateway.getInterpolateSetting()
+
+    gatewaywrapper.loginAsAdmin()
+    configService = gatewaywrapper.gateway.getConfigService()
+    configService.setConfigValue("omero.client.viewer.interpolate_pixels", "false")
+
+    gatewaywrapper.loginAsAuthor()
+    assert not gatewaywrapper.gateway.getInterpolateSetting()


### PR DESCRIPTION
This fixes a bug in Blitz Gateway (#4191) where conn.getInterpolateSetting() always returns True.
See https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7991&p=16657

To test
```
$ bin/omero config set omero.client.viewer.interpolate_pixels false
```
Restart omero server and log out of web client.
Then log in and check that viewer has interpolation off by default.

Question: is there any way we could have tests for config service methods within Blitz Gateway? Seems tricky if they require a server restart?