### PR TITLE
Disable orphaned container

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -169,6 +169,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.name">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -174,6 +174,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.name">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -169,7 +169,7 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans.enabled">
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.orphans">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -249,11 +249,8 @@ class login_required(object):
 
         if request.session.get('server_settings') is None:
             request.session['server_settings'] = {'ui': {}}
-            orphans_name, orphans_desc = conn.getOrphanedContainerSettings()
-            request.session['server_settings']['ui'] = {
-                'orphans_name': orphans_name,
-                'orphans_desc': orphans_desc
-            }
+            request.session['server_settings']['ui']['orphans'] = \
+                conn.getOrphanedContainerSettings()
             request.session['server_settings']['ui']['dropdown_menu'] = \
                 conn.getDropdownMenuSettings()
             request.session['server_settings']['email'] = \

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -129,10 +129,8 @@ class render_response(omeroweb.decorators.render_response):
                 'server_settings').get('email', False)
             if request.session.get('server_settings').get('ui'):
                 context.setdefault('ui', {})  # don't overwrite existing ui
-                context['ui']['orphans_name'] = request.session.get(
-                    'server_settings').get('ui').get('orphans_name')
-                context['ui']['orphans_desc'] = request.session.get(
-                    'server_settings').get('ui').get('orphans_desc')
+                context['ui']['orphans'] = request.session.get(
+                    'server_settings').get('ui').get('orphans')
                 context['ui']['dropdown_menu'] = request.session.get(
                     'server_settings').get('ui').get('dropdown_menu')
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -645,7 +645,7 @@ $(function() {
                             if (data.hasOwnProperty('orphaned')) {
                                 node = {
                                     'data': {'obj': data.orphaned},
-                                    'text': 'Orphaned Images',
+                                    'text': data.orphaned.name,
                                     'children': data.orphaned.childCount > 0 ? true : false,
                                     'type': 'orphaned'
                                 };

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -92,7 +92,7 @@ $(function () {
             if ($metadata_general.is(":visible") && $metadata_general.is(":empty")) {
                 // orphaned
                 if (oid.indexOf("orphaned")>=0) {
-                    $metadata_general.html('<div class="right_tab_inner"><p class="description">{{ ui.orphans_desc }}</p></div>');
+                    $metadata_general.html('<div class="right_tab_inner"><p class="description">{{ ui.orphans.description }}</p></div>');
                     //return;
                 // experimenter
                 } else if (oid.indexOf("experimenter")>=0) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -641,7 +641,8 @@ def api_container_list(request, conn=None, **kwargs):
             page=page,
             limit=limit)
         # Get the orphaned images container
-        if (conn.isAdmin() or conn.isLeader() or
+        if (conn.isAdmin() or
+            conn.isLeader(gid=request.session.get('active_group')) or
             experimenter_id == conn.getUserId() or
             request.session['server_settings']
                            ['ui']['orphans']['enabled']):

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -641,7 +641,10 @@ def api_container_list(request, conn=None, **kwargs):
             page=page,
             limit=limit)
         # Get the orphaned images container
-        if request.session['server_settings']['ui']['orphans']['enabled']:
+        if (conn.isAdmin() or conn.isLeader() or
+            experimenter_id == conn.getUserId() or
+            request.session['server_settings']
+                           ['ui']['orphans']['enabled']):
             orphaned = tree.marshal_orphaned(
                 conn=conn,
                 group_id=group_id,

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -641,7 +641,7 @@ def api_container_list(request, conn=None, **kwargs):
             page=page,
             limit=limit)
         # Get the orphaned images container
-        if request.session['server_settings']['ui']['orphans']:
+        if request.session['server_settings']['ui']['orphans']['enabled']:
             orphaned = tree.marshal_orphaned(
                 conn=conn,
                 group_id=group_id,

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -179,12 +179,17 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             return False
 
     def getOrphanedContainerSettings(self):
-        name = (self.getConfigService().getConfigValue(
-                "omero.client.ui.tree.orphans.name") or "Orphaned image")
-        description = (self.getConfigService().getConfigValue(
-                       "omero.client.ui.tree.orphans.description") or
-                       "This is a virtual container with orphaned images.")
-        return name, description
+        orphans = dict()
+        if toBoolean(self.getConfigService().getConfigValue(
+                "omero.client.ui.tree.orphans.enabled")):
+            orphans['name'] = \
+                self.getConfigService().getConfigValue(
+                    "omero.client.ui.tree.orphans.name") or "Orphaned image"
+            orphans['description'] = \
+                (self.getConfigService().getConfigValue(
+                 "omero.client.ui.tree.orphans.description") or
+                 "This is a virtual container with orphaned images.")
+        return orphans
 
     def getDropdownMenuSettings(self):
         dropdown_menu = dict()

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -185,7 +185,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 self.getConfigService()
                 .getConfigValue("omero.client.ui.tree.orphans.enabled"))
         except:
-            orphans['enabled'] = False
+            orphans['enabled'] = True
         if orphans['enabled']:
             try:
                 orphans['name'] = \

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -191,7 +191,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 orphans['name'] = \
                     (self.getConfigService().getConfigValue(
                      "omero.client.ui.tree.orphans.name") or
-                     "Orphaned Image")
+                     "Orphaned Images")
             except:
                 orphans['name'] = "Orphaned image"
             try:

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -181,11 +181,12 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
     def getOrphanedContainerSettings(self):
         orphans = dict()
         try:
-            enabled = toBoolean(self.getConfigService().getConfigValue(
-                                "omero.client.ui.tree.orphans.enabled"))
+            orphans['enabled'] = toBoolean(
+                self.getConfigService()
+                .getConfigValue("omero.client.ui.tree.orphans.enabled"))
         except:
-            enabled = False
-        if enabled:
+            orphans['enabled'] = False
+        if orphans['enabled']:
             try:
                 orphans['name'] = \
                     (self.getConfigService().getConfigValue(

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -193,7 +193,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                      "omero.client.ui.tree.orphans.name") or
                      "Orphaned Images")
             except:
-                orphans['name'] = "Orphaned image"
+                orphans['name'] = "Orphaned Images"
             try:
                 orphans['description'] = \
                     (self.getConfigService().getConfigValue(

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -184,7 +184,6 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             orphans = json.loads(
                 self.getConfigService()
                 .getConfigValue("omero.client.ui.tree.orphans"))
-            orphans["enabled"] = toBoolean(orphans["enabled"])
         except:
             orphans = {
                 "enabled": True,

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -180,17 +180,23 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             return False
 
     def getOrphanedContainerSettings(self):
+        default = {
+            "enabled": True,
+            "name": "Orphaned Images",
+            "description": ("This is a virtual container with "
+                            "orphaned images.")
+        }
         try:
             orphans = json.loads(
                 self.getConfigService()
                 .getConfigValue("omero.client.ui.tree.orphans"))
+            for k in default.iterkeys():
+                try:
+                    orphans[k]
+                except KeyError:
+                    orphans[k] = default[k]
         except:
-            orphans = {
-                "enabled": True,
-                "name": "Orphaned Images",
-                "description": ("This is a virtual container with "
-                                "orphaned images.")
-            }
+            orphans = default
         return orphans
 
     def getDropdownMenuSettings(self):

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -27,6 +27,7 @@
 import cStringIO
 import traceback
 import logging
+import json
 
 from StringIO import StringIO
 
@@ -179,32 +180,18 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             return False
 
     def getOrphanedContainerSettings(self):
-        orphans = dict()
-        if self.isAdmin():
-            orphans['enabled'] = True
-        else:
-            try:
-                orphans['enabled'] = toBoolean(
-                    self.getConfigService()
-                    .getConfigValue("omero.client.ui.tree.orphans.enabled"))
-            except:
-                orphans['enabled'] = True
-        if orphans['enabled']:
-            try:
-                orphans['name'] = \
-                    (self.getConfigService().getConfigValue(
-                     "omero.client.ui.tree.orphans.name") or
-                     "Orphaned Images")
-            except:
-                orphans['name'] = "Orphaned Images"
-            try:
-                orphans['description'] = \
-                    (self.getConfigService().getConfigValue(
-                     "omero.client.ui.tree.orphans.description") or
-                     "This is a virtual container with orphaned images.")
-            except:
-                orphans['description'] = \
-                    "This is a virtual container with orphaned images."
+        try:
+            orphans = json.loads(
+                self.getConfigService()
+                .getConfigValue("omero.client.ui.tree.orphans"))
+            orphans["enabled"] = toBoolean(orphans["enabled"])
+        except:
+            orphans = {
+                "enabled": True,
+                "name": "Orphaned Images",
+                "description": ("This is a virtual container with "
+                                "orphaned images.")
+            }
         return orphans
 
     def getDropdownMenuSettings(self):

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -191,7 +191,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 orphans['name'] = \
                     (self.getConfigService().getConfigValue(
                      "omero.client.ui.tree.orphans.name") or
-                     "Orphaned image")
+                     "Orphaned Image")
             except:
                 orphans['name'] = "Orphaned image"
             try:

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -192,7 +192,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 .getConfigValue("omero.client.ui.tree.orphans"))
             for k in default.iterkeys():
                 try:
-                    orphans[k]
+                    if k == "enabled":
+                        orphans[k] = toBoolean(orphans[k])
+                    else:
+                        orphans[k]
                 except KeyError:
                     orphans[k] = default[k]
         except:

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -180,12 +180,15 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
     def getOrphanedContainerSettings(self):
         orphans = dict()
-        try:
-            orphans['enabled'] = toBoolean(
-                self.getConfigService()
-                .getConfigValue("omero.client.ui.tree.orphans.enabled"))
-        except:
+        if self.isAdmin():
             orphans['enabled'] = True
+        else:
+            try:
+                orphans['enabled'] = toBoolean(
+                    self.getConfigService()
+                    .getConfigValue("omero.client.ui.tree.orphans.enabled"))
+            except:
+                orphans['enabled'] = True
         if orphans['enabled']:
             try:
                 orphans['name'] = \

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -180,15 +180,27 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
     def getOrphanedContainerSettings(self):
         orphans = dict()
-        if toBoolean(self.getConfigService().getConfigValue(
-                "omero.client.ui.tree.orphans.enabled")):
-            orphans['name'] = \
-                self.getConfigService().getConfigValue(
-                    "omero.client.ui.tree.orphans.name") or "Orphaned image"
-            orphans['description'] = \
-                (self.getConfigService().getConfigValue(
-                 "omero.client.ui.tree.orphans.description") or
-                 "This is a virtual container with orphaned images.")
+        try:
+            enabled = toBoolean(self.getConfigService().getConfigValue(
+                                "omero.client.ui.tree.orphans.enabled"))
+        except:
+            enabled = False
+        if enabled:
+            try:
+                orphans['name'] = \
+                    (self.getConfigService().getConfigValue(
+                     "omero.client.ui.tree.orphans.name") or
+                     "Orphaned image")
+            except:
+                orphans['name'] = "Orphaned image"
+            try:
+                orphans['description'] = \
+                    (self.getConfigService().getConfigValue(
+                     "omero.client.ui.tree.orphans.description") or
+                     "This is a virtual container with orphaned images.")
+            except:
+                orphans['description'] = \
+                    "This is a virtual container with orphaned images."
         return orphans
 
     def getDropdownMenuSettings(self):

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -35,8 +35,7 @@ class TestClientConfig(lib.ITest):
             "omero.client.ui.tree.orphans.enabled", enabled)
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
         orphans = conn.getOrphanedContainerSettings()
-        if enabled is None:
-            assert orphans['enabled'] == toBoolean(enabled)
+        assert orphans['enabled'] == toBoolean(enabled)
 
     @pytest.mark.parametrize("name",
                              ["Trash", "", None])

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+   Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+                      All Rights Reserved.
+   Copyright 2013 Glencoe Software, Inc. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+
+   pytest fixtures used as defined in conftest.py:
+   - gatewaywrapper
+
+"""
+
+import pytest
+import omero
+from omeroweb.webclient import webclient_gateway  # NOQA
+from omero.gateway.utils import toBoolean
+import library as lib
+
+
+class TestClientConfig(lib.ITest):
+
+    @pytest.mark.parametrize("enabled",
+                             ["foo", "", "False", "false",
+                              "True", "true", "", None])
+    def testOrphansEnabledSetting(self, enabled):
+        """
+        Tests conn.getOrphanedContainerSettings()
+        """
+        if enabled is None:
+            enabled = self.root.sf.getConfigService() \
+                .getConfigDefaults()['omero.client.ui.tree.orphans.enabled']
+        self.root.sf.getConfigService().setConfigValue(
+            "omero.client.ui.tree.orphans.enabled", enabled)
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        orphans = conn.getOrphanedContainerSettings()
+        if enabled is None:
+            assert orphans['enabled'] == toBoolean(enabled)
+
+    @pytest.mark.parametrize("name",
+                             ["Trash", "", None])
+    def testOrphansNameSetting(self, name):
+        """
+        Tests conn.getOrphanedContainerSettings()
+        """
+        if name is None:
+            name = self.root.sf.getConfigService() \
+                .getConfigDefaults()['omero.client.ui.tree.orphans.name']
+        self.root.sf.getConfigService().setConfigValue(
+            "omero.client.ui.tree.orphans.name", name)
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        orphans = conn.getOrphanedContainerSettings()
+        assert orphans['name'] == name
+
+    @pytest.mark.parametrize("description",
+                             ["Description", "", None])
+    def testOrphansDescriptionSetting(self, description):
+        """
+        Tests conn.getOrphanedContainerSettings()
+        """
+        if description is None:
+            description = self.root.sf.getConfigService() \
+                .getConfigDefaults()[
+                    'omero.client.ui.tree.orphans.description']
+        self.root.sf.getConfigService().setConfigValue(
+            "omero.client.ui.tree.orphans.description", description)
+
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        orphans = conn.getOrphanedContainerSettings()
+        assert orphans['description'] == description

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -826,7 +826,7 @@ omero.client.ui.tree.orphans.name=Orphaned Images
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
 # Flag to show/hide "Orphaned images" container
-omero.client.ui.tree.orphans={"enabled": "True", "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
+omero.client.ui.tree.orphans={"enabled": true, "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -819,14 +819,14 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
-# Flag to show/hide "Orphaned images" container
-omero.client.ui.tree.orphans.enabled=true
-
 # Name of the "Orphaned images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned Images
 
 # Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
+
+# Flag to show/hide "Orphaned images" container
+omero.client.ui.tree.orphans={"enabled": "True", "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -819,6 +819,9 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
+# Flag to show/hide "Orphaned images" container
+omero.client.ui.tree.orphans.enabled=true
+
 # Name of the "Orphaned images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned images
 
@@ -827,7 +830,7 @@ omero.client.ui.tree.orphans.description=This is a virtual container with orphan
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners
-## Flag to show/hide leader.
+# Flag to show/hide leader.
 omero.client.ui.menu.dropdown.leaders.enabled=true
 
 # Client dropdown menu colleagues label.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -827,7 +827,7 @@ omero.client.ui.tree.orphans.name=Orphaned Images
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
 # helper combining all orphans properties. Do not set manually that property.
-omero.client.ui.tree.orphans={"enabled": ${omero.client.ui.tree.orphans.enabled}, "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
+omero.client.ui.tree.orphans={"enabled": "${omero.client.ui.tree.orphans.enabled}", "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -823,7 +823,7 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 omero.client.ui.tree.orphans.enabled=true
 
 # Name of the "Orphaned images" container located in client tree data manager.
-omero.client.ui.tree.orphans.name=Orphaned images
+omero.client.ui.tree.orphans.name=Orphaned Images
 
 # Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -819,14 +819,15 @@ omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
 /omero/setup_scripts/FLIM_initialise.py,/omero/import_scripts/Populate_ROI.py
 
+# Flag to show/hide "Orphaned images" container. Only accept "true" or "false"
+omero.client.ui.tree.orphans.enabled=true
 # Name of the "Orphaned images" container located in client tree data manager.
 omero.client.ui.tree.orphans.name=Orphaned Images
-
 # Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
-# Flag to show/hide "Orphaned images" container
-omero.client.ui.tree.orphans={"enabled": true, "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
+# helper combining all orphans properties. Do not set manually that property.
+omero.client.ui.tree.orphans={"enabled": ${omero.client.ui.tree.orphans.enabled}, "name": "${omero.client.ui.tree.orphans.name}", "description": "${omero.client.ui.tree.orphans.description}"}
 
 # Client dropdown menu leader label.
 omero.client.ui.menu.dropdown.leaders=Owners


### PR DESCRIPTION
Allowing to disable orphaned container as tweaked in https://github.com/openmicroscopy/openmicroscopy/pull/4246/

Test defaults:
 - if you tested that PR before unset ``bin/omero config set omero.client.ui.tree.orphans ``otherwise you shouldn't touch it.
 - test own and someone else data as user, group owner and admin. you should see "Orphaned container" everytime 

Test custom name via old properties:
 - set ``bin/omero config set omero.client.ui.tree.orphans.name 'Trash'`` and ``bin/omero config set omero.client.ui.tree.orphans.description "This is trash."'``
 - test if custom name works

Test disabled:
**you can only disable while viewing other users data as regular user. For admin and group owners container will be present**
 - set ``bin/omero config set omero.client.ui.tree.orphans.enabled False``
 - load your own tree, default "Orphaned Images" should be present,
 - chose someone else data, tree should not load orphaned container
 - cut image if you have permissions

**Scenario updated as functionality has changed since https://github.com/openmicroscopy/openmicroscopy/pull/4431#issuecomment-177925015 and https://github.com/openmicroscopy/openmicroscopy/pull/4431#issuecomment-178493209** 