### PR TITLE
Compression and thumbnail scaling

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
@@ -43,8 +43,7 @@ import omero.gateway.model.PixelsData;
 /** 
  * The class hosting the thumbnail corresponding to an {@link ImageData}.
  * We first retrieve a thumbnail of dimension {@link #THUMB_MAX_WIDTH}
- * and {@link #THUMB_MAX_HEIGHT} and scale it down i.e magnification factor
- * {@link #SCALING_FACTOR}.
+ * and {@link #THUMB_MAX_HEIGHT} and scale it down i.e magnification factor.
  *
  * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
@@ -43,7 +43,7 @@ import omero.gateway.model.PixelsData;
 /** 
  * The class hosting the thumbnail corresponding to an {@link ImageData}.
  * We first retrieve a thumbnail of dimension {@link #THUMB_MAX_WIDTH}
- * and {@link #THUMB_MAX_HEIGHT} and scale it down i.e magnification factor.
+ * and {@link #THUMB_MAX_HEIGHT} and scale it down i.e. magnification factor.
  *
  * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ThumbnailProvider.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -30,6 +30,7 @@ import javax.swing.ImageIcon;
 
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageNode;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.Thumbnail;
+import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowserFactory;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 
@@ -121,9 +122,10 @@ public class ThumbnailProvider
     //laid out.  Sort this out.
     private void computeDims()
     {
+        double scale = DataBrowserFactory.getThumbnailScaleFactor();
         PixelsData pxd = null;
-        width = (int) (THUMB_MAX_WIDTH*SCALING_FACTOR);
-        height = (int) (THUMB_MAX_HEIGHT*SCALING_FACTOR);
+        width = (int) (THUMB_MAX_WIDTH*scale);
+        height = (int) (THUMB_MAX_HEIGHT*scale);
         originalWidth = THUMB_MAX_WIDTH;
         originalHeight = THUMB_MAX_HEIGHT;
         try {
@@ -131,15 +133,15 @@ public class ThumbnailProvider
         		pxd = ((ImageData) imgInfo).getDefaultPixels();
         	else return;
 		} catch (Exception e) { //no pixels linked to it.
-			width = (int) (THUMB_MAX_WIDTH*SCALING_FACTOR);
-	        height = (int) (THUMB_MAX_HEIGHT*SCALING_FACTOR);
+			width = (int) (THUMB_MAX_WIDTH*scale);
+	        height = (int) (THUMB_MAX_HEIGHT*scale);
 	        originalWidth = THUMB_MAX_WIDTH;
 	        originalHeight = THUMB_MAX_HEIGHT;
 	        return;
 		}
 		if (pxd == null) {
-			width = (int) (THUMB_MAX_WIDTH*SCALING_FACTOR);
-	        height = (int) (THUMB_MAX_HEIGHT*SCALING_FACTOR);
+			width = (int) (THUMB_MAX_WIDTH*scale);
+	        height = (int) (THUMB_MAX_HEIGHT*scale);
 	        originalWidth = THUMB_MAX_WIDTH;
 	        originalHeight = THUMB_MAX_HEIGHT;
 	        return;
@@ -168,7 +170,7 @@ public class ThumbnailProvider
         	is instanceof FileData))
         	throw new IllegalArgumentException("Objet to supported.");
         imgInfo = is;
-        scalingFactor = SCALING_FACTOR;
+        scalingFactor = DataBrowserFactory.getThumbnailScaleFactor();
         computeDims();
         valid = true;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/Thumbnail.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/Thumbnail.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.browser.Thumbnail 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -58,9 +58,6 @@ public interface Thumbnail
     
     /** The maximum magnification factor. */
     public static final double  MAX_SCALING_FACTOR = 2.5;//1;
-    
-    /** The default magnification factor. */
-    public static final double  SCALING_FACTOR = 0.5;
     
     /** The minimum magnification factor. */
     public static final double  MIN_SCALING_FACTOR = 0.25;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
+import java.util.prefs.Preferences;
 
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageTimeSet;
@@ -75,6 +76,9 @@ public class DataBrowserFactory
 	private static final DataBrowserFactory  
 						singleton = new DataBrowserFactory();
 	
+    /** The name of the thumbnail scale factor property */
+    private static final String THUMBNAIL_SCALE_FACTOR = "thumbnailScaleFactor";
+    
 	/** Discards all the tracked {@link DataBrowser}s. */
 	public static final void discardAll()
 	{
@@ -389,6 +393,25 @@ public class DataBrowserFactory
 		onGroupSwitched(true);
 	}
 	
+	/**
+     * Returns the thumbnail scale factor
+     * @return See above.
+     */
+    public static double getThumbnailScaleFactor() {
+        Preferences p = Preferences.userNodeForPackage(DataBrowserFactory.class);
+        String value = p.get(THUMBNAIL_SCALE_FACTOR, "0.5");
+        return Double.parseDouble(value);
+    }
+    
+    /**
+     * Sets the thumbnail scale factor
+     * @param d The factor
+     */
+    public static void setThumbnailScaleFactor(double d) {
+        Preferences p = Preferences.userNodeForPackage(DataBrowserFactory.class);
+        p.put(THUMBNAIL_SCALE_FACTOR, ""+d);
+    }
+    
 	/**
 	 * Returns <code>true</code> if there are rendering settings to copy,
 	 * <code>false</code> otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserStatusBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserStatusBar.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowserStatusBar 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -85,8 +85,10 @@ class DataBrowserStatusBar
 	/** Initializes the components. */
 	private void initComponents()
 	{
+	    double scale = DataBrowserFactory.getThumbnailScaleFactor();
+	    
 		mag = new MagnificationComponent(Thumbnail.MIN_SCALING_FACTOR,
-				Thumbnail.MAX_SCALING_FACTOR, Thumbnail.SCALING_FACTOR);
+				Thumbnail.MAX_SCALING_FACTOR, scale);
 		mag.addPropertyChangeListener(
 				MagnificationComponent.MAGNIFICATION_PROPERTY, this);
 		fieldsZoomSlider = new OneKnobSlider(OneKnobSlider.HORIZONTAL,
@@ -99,7 +101,7 @@ class DataBrowserStatusBar
 		zoomSlider = new OneKnobSlider(OneKnobSlider.HORIZONTAL,
 				(int) (Thumbnail.MIN_SCALING_FACTOR*FACTOR),
 				(int) (Thumbnail.MAX_SCALING_FACTOR*FACTOR),
-				(int) (Thumbnail.SCALING_FACTOR*FACTOR));
+				(int) (scale*FACTOR));
 		//zoomSlider.setEnabled(false);
 		zoomSlider.addChangeListener(this);
 		zoomSlider.setToolTipText("Magnifies the thumbnails.");
@@ -202,6 +204,7 @@ class DataBrowserStatusBar
 			int v = fieldsZoomSlider.getValue();
 	    	double f = (double) v/FACTOR;
 			view.setMagnificationUnscaled(f);
+			
 		} else if (src == zoomSlider) {
 			int v = zoomSlider.getValue();
 	    	double f = (double) v/FACTOR;
@@ -209,6 +212,7 @@ class DataBrowserStatusBar
 			firePropertyChange(
 			        MagnificationComponent.MAGNIFICATION_UPDATE_PROPERTY,
 			        null, f);
+			DataBrowserFactory.setThumbnailScaleFactor(f);
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -152,7 +152,7 @@ class DataBrowserUI
 		else {
 		    selectedView = THUMB_VIEW;
 		}
-		factor = Thumbnail.SCALING_FACTOR;
+		factor = DataBrowserFactory.getThumbnailScaleFactor();
 		setNumberOfImages(-1);
 		setLayout(new BorderLayout(0, 0));
 		buildGUI(true);
@@ -318,7 +318,7 @@ class DataBrowserUI
     void setSelectedView(int index) 
     {
     	removeAll();
-    	double f = Thumbnail.SCALING_FACTOR;
+    	double f = DataBrowserFactory.getThumbnailScaleFactor();
     	switch (index) {
 			case THUMB_VIEW:
 				selectedView = index;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1079,7 +1079,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	 */
 	private boolean isFastConnection() {
 		int value = (Integer) ImporterAgent.getRegistry().lookup(
-				LookupNames.CONNECTION_SPEED);
+				LookupNames.IMAGE_QUALITY_LEVEL);
 		return value == RenderingControl.UNCOMPRESSED;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -130,7 +130,7 @@ public class ImViewerAgent
      */
     public static boolean isFastConnection()
     {
-        int value = (Integer) registry.lookup(LookupNames.CONNECTION_SPEED);
+        int value = (Integer) registry.lookup(LookupNames.IMAGE_QUALITY_LEVEL);
         return value == ImViewer.UNCOMPRESSED;
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
@@ -42,13 +42,13 @@ import javax.swing.JToolBar;
 
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.events.iviewer.ScriptDisplay;
-
 import org.openmicroscopy.shoola.agents.imviewer.IconManager;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ActivityImageAction;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ROIToolAction;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.LookupNames;
+import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 import omero.gateway.model.GroupData;
@@ -377,10 +377,10 @@ class ToolBar
 		int compression = ImViewerFactory.getCompressionLevel();
 		
 		int value = (Integer) 
-			ImViewerAgent.getRegistry().lookup(LookupNames.CONNECTION_SPEED);
+			ImViewerAgent.getRegistry().lookup(LookupNames.IMAGE_QUALITY_LEVEL);
 		int setUp = view.convertCompressionLevel(value);
 		if (compression != setUp) compression = setUp;
-		if (view.isLargePlane()) {
+		if (view.isLargePlane() && value > RenderingControl.UNCOMPRESSED) {
 			compression = ImViewer.LOW;
 		}
 		int index = view.convertCompressionLevel();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -157,7 +157,7 @@ public class MetadataViewerAgent
 	 */
 	public static boolean isFastConnection()
 	{
-		int value = (Integer) registry.lookup(LookupNames.CONNECTION_SPEED);
+		int value = (Integer) registry.lookup(LookupNames.IMAGE_QUALITY_LEVEL);
 		return value == RenderingControl.UNCOMPRESSED;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -171,7 +171,7 @@ public class LookupNames
     public static final String USER_ADMINISTRATOR = "/users/administrator";
 
     /** Field to indicate if the connection is fast or not. */
-    public static final String CONNECTION_SPEED = "/connection/speed";
+    public static final String IMAGE_QUALITY_LEVEL = "/connection/speed";
 
     /** Field to indicate the default size of a plane. */
     public static final String PLANE_SIZE = "/services/RE/planeSize";

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -205,13 +205,13 @@ public class DataServicesFactory
     }
     
     /**
-     * Returns <code>true</code> if the connection is fast,
-     * <code>false</code> otherwise.
+     * Returns the image quality with respect to the
+     * connection speed
      * 
      * @param connectionSpeed The connection speed.
      * @return See above.
      */
-    private int isFastConnection(int connectionSpeed)
+    private int determineImageQuality(int connectionSpeed)
     {
         switch (connectionSpeed) {
             case UserCredentials.HIGH:
@@ -606,8 +606,8 @@ public class DataServicesFactory
         registry.getLogger().info(this, msg);
 
         registry.bind(LookupNames.CURRENT_USER_DETAILS, exp);
-        registry.bind(LookupNames.CONNECTION_SPEED, 
-        		isFastConnection(uc.getSpeedLevel()));
+        registry.bind(LookupNames.IMAGE_QUALITY_LEVEL, 
+        		determineImageQuality(uc.getSpeedLevel()));
         
         try {
             // Load the omero client properties from the server
@@ -700,8 +700,8 @@ public class DataServicesFactory
 				reg.bind(LookupNames.USER_GROUP_DETAILS, available);
 				reg.bind(LookupNames.USERS_DETAILS, exps);
 				reg.bind(LookupNames.USER_ADMINISTRATOR, uc.isAdministrator());
-				reg.bind(LookupNames.CONNECTION_SPEED, 
-						isFastConnection(uc.getSpeedLevel()));
+				reg.bind(LookupNames.IMAGE_QUALITY_LEVEL, 
+				        determineImageQuality(uc.getSpeedLevel()));
 				reg.bind(LookupNames.BINARY_AVAILABLE, b);
 				reg.bind(LookupNames.HELP_ON_LINE_SEARCH, url);
 			}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -70,13 +70,13 @@ public interface RenderingControl
 	public static final int		UNCOMPRESSED = 0;
 	
 	/** 
-	 * Flag to indicate that the image is not compressed using a
+	 * Flag to indicate that the image is compressed using a
 	 * medium Level of compression. 
 	 */
 	public static final int		MEDIUM = 1;
 	
 	/** 
-	 * Flag to indicate that the image is not compressed using a
+	 * Flag to indicate that the image is compressed using a
 	 * low Level of compression. 
 	 */
 	public static final int		LOW = 2;


### PR DESCRIPTION
This PR addresses two issues which came up on the [Forum](https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7991).

- Only switch the default to high compression for non-LAN connections (previously the compression for large images ( between 512x512px and 2000x2000px) was automatically set to "high" which led to visible JPEG artifacts). **Test**: Open a large image in full viewer, make sure compression is set to "none" (when your connection is set to be a LAN connection) Note: On this occasion I changed the Insight property "CONNECTION_SPEED" to "IMAGE_QUALITY_LEVEL" because that's what the property is actually about. [Ticket 13148](http://trac.openmicroscopy.org/ome/ticket/13148)

- Preserve the chosen thumbnail size. **Test**: Change the thumbnail size (slider at the bottom left of the central panel). Make sure this setting is preserved, also after a restart of Insight. [Ticket 13149](http://trac.openmicroscopy.org/ome/ticket/13149)
