### PR TITLE
Node not valid exception

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1111,7 +1111,7 @@ class BrowserComponent
 	public void loadExperimenterData(TreeImageDisplay exp, TreeImageDisplay n)
 	{
 		if (exp == null)
-			throw new IllegalArgumentException("Node not valid.");
+			return;
 		Object uo = exp.getUserObject();
 		if (!(uo instanceof ExperimenterData || uo instanceof GroupData))
 			throw new IllegalArgumentException("Node not valid.");


### PR DESCRIPTION
This would "fix" [Ticket 9490](https://trac.openmicroscopy.org/ome/ticket/9490) by simply just not throwing the exception. I couldn't replicate the issue by any of the actions reported in the QAs, but I found a different way which also throws the exception: In the Projects/Datasets tree switch to Group Display (i. e. disable "Display Users"). Expand the groups. Go to search tab. Search for any image. Select an image in the search results view. Open the "Located in" tab on the right hand side metadata panel. Double click on the dataset. This will trigger the exception. With the PR the Project/Datasets tab will be active again, with the dataset selected.
/cc @jburel 