### PR TITLE
Delete rois docs

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3882,6 +3882,7 @@ class _BlitzGateway (object):
                                 * 'Well'
                                 * 'Annotation'
                                 * 'OriginalFile'
+                                * 'Roi'
                                 * 'Image/Pixels/Channel'
 
                                 As of OMERO 4.4.0 the correct case is now

--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -51,7 +51,7 @@ def createROI(img, shapes):
     for shape in shapes:
         roi.addShape(shape)
     # Save the ROI (saves any linked shapes too)
-    updateService.saveObject(roi)
+    return updateService.saveAndReturnObject(roi)
 
 
 # Another helper for generating the color integers for shapes
@@ -182,6 +182,13 @@ for roi in result.rois:
             print "Removing Shape from ROI..."
             roi.removeShape(s)
             roi = updateService.saveAndReturnObject(roi)
+
+
+# Delete ROIs and all the Shapes they contain
+# =================================================================
+roiToDelete = createROI(image, [rect])
+print "Deleting ROI:", roi.id.val
+conn.deleteObjects("Roi", [roi.id.val], wait=True)
 
 
 # Close connection:


### PR DESCRIPTION
This improves our documentation & examples of deleting ROIs with conn.deleteObjects() and gives an example of using the ```wait=True``` parameter.

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-January/005822.html

Check that tests are passing for these examples and the code changes & comments make sense.