### PR TITLE
Make lens tool work properly with units

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/DisplayAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/DisplayAction.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.DisplayAction 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -116,6 +116,13 @@ class DisplayAction
 		lens.setDisplayInPixels(index == PIXEL_OPTION);
     }
     
+	/**
+	 * Get the type of this action
+	 * @return See above
+	 */
+	int getIndex() {
+	    return index;
+	}
 }
 
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.lensComponent.java
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -41,6 +41,7 @@ import javax.swing.JFrame;
 import javax.swing.filechooser.FileFilter;
 
 import omero.model.Length;
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.util.filter.file.BMPFilter;
 import org.openmicroscopy.shoola.util.filter.file.CustomizedFileFilter;
 import org.openmicroscopy.shoola.util.filter.file.JPEGFilter;
@@ -324,6 +325,8 @@ public class LensComponent
 	public void setXYPixelMicron(Length  x, Length y)
 	{
 		zoomWindow.setXYPixelMicron(x, y);
+        menu.setMicronsMenuEnabled(!x.getUnit().equals(UnitsLength.PIXEL)
+                && !y.getUnit().equals(UnitsLength.PIXEL));
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensMenu.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensMenu.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.LensMenu 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -23,6 +23,8 @@
 package org.openmicroscopy.shoola.util.ui.lens;
 
 //Java imports
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Enumeration;
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBoxMenuItem;
@@ -98,6 +100,9 @@ class LensMenu
 	
 	/** Group hosting the zooming check box elements. */
 	private ButtonGroup			zoomGroup;
+	
+	/** The display actions to toggle between pixel and microns display */
+	private Collection<DisplayAction> displayActions = new ArrayList<DisplayAction>();
 	
 	/**
 	 * Creates the menu which will allow the user to adjust the size of the lens.
@@ -183,8 +188,10 @@ class LensMenu
 		int i;
 		for (i = 0 ; i < DisplayAction.MAX ; i++)
 		{
-			setDisplayScale = new JCheckBoxMenuItem(new DisplayAction
-													(lensComponent, i));
+		    DisplayAction action = new DisplayAction
+                    (lensComponent, i);
+		    displayActions.add(action);
+			setDisplayScale = new JCheckBoxMenuItem(action);
 			displayUnits.add(setDisplayScale);
 			displayOptions.add(setDisplayScale);
 			setDisplayScale.setSelected(i == 1);
@@ -298,6 +305,20 @@ class LensMenu
 		}
 	}
 	
+    /**
+     * Enables or disables the action, to set the display units to microns
+     * 
+     * @param b
+     *            Pass <code>true</code> to enable the action,
+     *            <code>false</code> to disable it
+     */
+    void setMicronsMenuEnabled(boolean b) {
+        for (DisplayAction action : displayActions) {
+            if (action.getIndex() == DisplayAction.MICRON_OPTION) {
+                action.setEnabled(b);
+            }
+        }
+    }
 }
 
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/StatusPanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/StatusPanel.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.StatusPanel 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -22,18 +22,14 @@
  */
 package org.openmicroscopy.shoola.util.ui.lens;
 
-//Java imports
 import java.awt.Dimension;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-
-
-
-//Third-party libraries
-
-//Application-internal dependencies
+import omero.model.Length;
+import omero.model.LengthI;
+import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /** 
@@ -78,11 +74,11 @@ class StatusPanel
 	/** Label showing zoomFactor of the lens. */
 	private JLabel			lensZoom;
 	
-	/** Number of pixels per micron in x axis. */
-	private double 	micronInXAxis = 1;
+	/** Length of a pixel in x axis. */
+	private Length 	pixelSizeX = new LengthI(1, UnitsLength.PIXEL);
 
-	/** Number of pixels per micron in y axis. */
-	private double 	micronInYAxis = 1;
+	/**  Length of a pixel in y axis. */
+	private Length 	pixelSizeY = new LengthI(1, UnitsLength.PIXEL);
 	
 	/** Display the units: width, height and x,y in pixels. */
 	private boolean displayInPixels = true;
@@ -117,7 +113,7 @@ class StatusPanel
 		displayInPixels = b;
 	}
 	
-	/** set the XY values of the lens position text 
+	/** set the XY values of the lens position text (in pixels).
 	 * 
 	 * @param x See above.
 	 * @param y See above.
@@ -128,12 +124,12 @@ class StatusPanel
 			lensPosition.setText(LENS_X + x + " " + LENS_Y + y);
 		else
 			lensPosition.setText(LENS_X + 
-					UIUtilities.twoDecimalPlaces(x/micronInXAxis) + " " 
-					+ LENS_Y + UIUtilities.twoDecimalPlaces(y/micronInYAxis));
+					UIUtilities.twoDecimalPlaces(x*pixelSizeX.getValue()) + pixelSizeX.getSymbol()+ " " 
+					+ LENS_Y + UIUtilities.twoDecimalPlaces(y*pixelSizeY.getValue())+ pixelSizeY.getSymbol());
 			
 	}
 
-	/** set the W, H values of the lens Width, Height text. 
+	/** set the W, H values of the lens Width, Height text (in pixels). 
 	 * 
 	 * @param w See above.
 	 * @param h See above.
@@ -144,9 +140,9 @@ class StatusPanel
 			lensSize.setText(LENS_W + w + " " + LENS_H + h);
 		else
 			lensSize.setText(
-					LENS_W +UIUtilities.twoDecimalPlaces(w/micronInXAxis) 
-					+ " " + LENS_H + 
-					UIUtilities.twoDecimalPlaces(h/micronInYAxis));
+					LENS_W +UIUtilities.twoDecimalPlaces(w*pixelSizeX.getValue()) 
+					+ pixelSizeX.getSymbol()+" " + LENS_H + 
+					UIUtilities.twoDecimalPlaces(h*pixelSizeY.getValue())+pixelSizeY.getSymbol());
 	}
 	
 	/** Set the zoomFactor of the lens.
@@ -159,14 +155,14 @@ class StatusPanel
 	}
 	
 	/**
-	 * Set the mapping from pixel size to microns along the x and y axis. 
-	 * @param x mapping in x axis.
-	 * @param y mapping in y axis.
+	 * Set the mapping from pixel size to 'real' units along the x and y axis. 
+	 * @param x Length of a pixel in x axis.
+	 * @param y Length of a pixel in y axis.
 	 */
-	public void setXYPixelMicron(double x, double y)
+	public void setXYPixelSizes(Length x, Length y)
 	{
-		micronInXAxis = x;
-		micronInYAxis = y;
+		pixelSizeX = x;
+		pixelSizeY = y;
 	}
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.lens.ZoomWindow.java
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -148,22 +148,17 @@ class ZoomWindow
 	/**
 	 * Sets the mapping from pixel size to microns along the x and y axis. 
 	 * 
-	 * @param x mapping in x axis.
-	 * @param y mapping in y axis.
+	 * @param x Length of a pixel in x axis.
+	 * @param y Length of a pixel in y axis.
 	 */
 	void setXYPixelMicron(Length x, Length y) 
 	{
-	    try {
-            Length x1 = new LengthI(x, UnitsLength.MICROMETER);
-            Length y1 = new LengthI(y, UnitsLength.MICROMETER);
-            statusPanel.setXYPixelMicron(x1.getValue(), y1.getValue());
-        } catch (BigResult e) {
-        }
-		statusPanel.repaint();
+        statusPanel.setXYPixelSizes(x, y);
+        statusPanel.repaint();
 	}
 	
 	/**
-	 * Sets the X,Y coordinates of the lens on the ZoomWindowUI.
+	 * Sets the X,Y coordinates of the lens on the ZoomWindowUI (in pixels).
 	 * 
 	 * @param x See above.
 	 * @param y See above.
@@ -171,7 +166,7 @@ class ZoomWindow
 	void setLensXY(int x, int y) { statusPanel.setLensXY(x, y); }
 	
 	/**
-	 * Sets the w,h size of the lens on the ZoomWindowUI.
+	 * Sets the w,h size of the lens on the ZoomWindowUI (in pixels).
 	 * 
 	 * @param w See above.
 	 * @param h See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/ZoomWindow.java
@@ -36,9 +36,7 @@ import javax.swing.JFrame;
 import javax.swing.JLayeredPane;
 import javax.swing.JMenuBar;
 
-import ome.model.units.BigResult;
 import omero.model.Length;
-import omero.model.LengthI;
 import omero.model.enums.UnitsLength;
 
 //Third-party libraries
@@ -155,6 +153,8 @@ class ZoomWindow
 	{
         statusPanel.setXYPixelSizes(x, y);
         statusPanel.repaint();
+        lensMenu.setMicronsMenuEnabled(!x.getUnit().equals(UnitsLength.PIXEL)
+                && !y.getUnit().equals(UnitsLength.PIXEL));
 	}
 	
 	/**
@@ -237,17 +237,14 @@ class ZoomWindow
 
 	
 	public void componentHidden(ComponentEvent e) {
-		// TODO Auto-generated method stub
 		
 	}
 
 	public void componentMoved(ComponentEvent e) {
-		// TODO Auto-generated method stub
 		
 	}
 	
 	public void componentShown(ComponentEvent e) {
-		// TODO Auto-generated method stub
 		
 	}
 	


### PR DESCRIPTION
Fixes [QA 16995](https://www.openmicroscopy.org/qa2/qa/feedback/16995/)

Test:
- Use the lens tool with an image which has pixel size information. Toggle between pixels and microns. Make sure the values make sense.
- Use the lens tool with an image without pixel size information. Make sure lens tools also works and doesn't crash. The "Microns" option should be disabled.

![screen shot 2016-01-26 at 10 35 44](https://cloud.githubusercontent.com/assets/6575139/12578456/db066734-c418-11e5-9b8e-a2303b48f335.png)
