### PR TITLE
add OMERO graph policies for Folders

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -41,6 +41,7 @@
         <!-- containers -->
         <value>Dataset</value>
         <value>Project</value>
+        <value>Folder</value>
 
         <!-- core -->
         <value>Image</value>
@@ -308,15 +309,30 @@
                                        p:changes="D:{r}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}, D =/o I"
                                        p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}, F =/o I"
+                                       p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}, F =/o ROI"
+                                       p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{i}, P =/o C"
+                                       p:changes="C:{r}"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}/d"
                                        p:changes="D:{r}"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/d"
                                        p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}/d"
+                                       p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}/d"
+                                       p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, Folder[I].childFolders = C:[E]{i}/d"
+                                       p:changes="C:{r}"/>
 
         <!-- In considering moving a container's contents, do not move an object if it is in another container. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E]{ia}, L.child = D:[E]{r}" p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E]{ia}, L.child = ROI:[E]{r}" p:changes="ROI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="Folder[E]{ia}.childFolders = C:[E]{r}" p:changes="C:{a}"/>
 
         <!-- A private group cannot have container and contents differently owned. -->
 
@@ -324,37 +340,59 @@
                                        p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{r}, D =/!o I"
                                        p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{r}, F =/!o I"
+                                       p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{r}, F =/!o ROI"
+                                       p:changes="ROI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="$to_private, P:Folder[I].childFolders = C:[E]{r}, P =/!o C"
+                                       p:changes="C:{a}"/>
 
-        <!-- Move orphaned datasets. -->
+        <!-- Move orphaned datasets and folders. -->
 
         <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/o" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/o" p:changes="F:[I]"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, D:Dataset[E]{o}/d" p:changes="D:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, F:Folder[E]{o}/d" p:changes="F:[I]/n"/>
 
         <!--
-             If a project, dataset or image is moved for both sides of a link then, regardless of permissions, move the link if
-             same owners or not to private group.
+             If a project, dataset, folder, image or ROI is moved for both sides of a link then, regardless of permissions, move the
+             link if same owners or not to private group.
           -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent = P:[I], L.child = D:[I], P =/o D"
                                        p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent = D:[I], L.child = I:[I], D =/o I"
                                        p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = F:[I], L.child = I:[I], F =/o I"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = F:[I], L.child = ROI:[I], F =/o ROI"
+                                       p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]/n"/>
 
-        <!-- If a project, dataset or image is moved then delete their remaining links regardless of permissions. -->
+        <!-- If a project, dataset, folder, image or ROI is moved then delete their remaining links regardless of permissions. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I], L.child = [E]{ia}" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I], L.child = [E]{ia}" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I], L.child = [E]{ia}" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I], L.child = [E]{ia}" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
 
         <!-- CORE -->
 
@@ -566,11 +604,29 @@
 
         <!-- ROI -->
 
-        <!-- Regardless of permissions move ROIs, except to a private group delete them if another's. -->
+        <!-- Regardless of permissions consider moving deletable ROIs, except to a private group delete them if another's. -->
 
-        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]" p:changes="ROI:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, Image[I].rois = ROI:[E]" p:changes="ROI:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="$to_private, Image[I].rois = ROI:[E]" p:changes="ROI:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]{i}" p:changes="ROI:[E]{r}"/>
+
+        <!-- Do not move a ROI that is in a remaining image. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.rois = ROI:[E]{r}" p:changes="ROI:[E]{a}"/>
+
+        <!--  Move ROIs that are not used elsewhere if the have the same owner as their image or folder that is being moved. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E]{o}" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{o}, F =/o ROI"
+                                       p:changes="ROI:[I]"/>
+
+        <!-- If not to a private group or used elsewhere then move images' ROIs and folders' deletable ROIs. -->
+
+        <bean parent="graphPolicyRule" p:matches="!$to_private, Image[I].rois = ROI:[E]{o}" p:changes="ROI:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{o}"
+                                       p:changes="ROI:[I]/n"/>
+
+        <!-- If an image is moved to a private group then delete its differently owned ROIs that are not in remaining folders. -->
+
+        <bean parent="graphPolicyRule" p:matches="$to_private, Image[I].rois = ROI:[E]{o}" p:changes="ROI:[D]/n"/>
 
         <!-- Cannot move ROI out of image. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -118,6 +118,10 @@
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[E], L.child = D:[E], P =/!o D"
                                        p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[E], L.child = I:[E], D =/!o I"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[E], L.child = I:[E], F =/!o I"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[E], L.child = ROI:[E], F =/!o ROI"
                                        p:changes="L:[D]/n"/>
 
         <!-- CORE -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -44,6 +44,9 @@
         <value>DatasetImageLink</value>
         <value>Project</value>
         <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
 
         <!-- core -->
         <value>Image</value>
@@ -319,6 +322,12 @@
                                        p:changes="D:{r}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}, D =/o I"
                                        p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}, F =/o I"
+                                       p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}, F =/o ROI"
+                                       p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{i}, P =/o C"
+                                       p:changes="C:{r}"/>
 
         <!-- In considering giving a container's contents, do not give an object if it is in another container. -->
 
@@ -331,32 +340,53 @@
                                        p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=???-??, L.child = I:[E]{r}, D =/!o I"
                                        p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[I];perms=???-??, L.child = I:[E]{r}, F =/!o I"
+                                       p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[I];perms=???-??, L.child = ROI:[E]{r}, F =/!o ROI"
+                                       p:changes="ROI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{r};perms=???-??, P =/!o C"
+                                       p:changes="C:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[I];perms=???a??, L.child = D:[E]{r}, P =/!o D"
                                        p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[I];perms=???a??, L.child = I:[E]{r}, D =/!o I"
                                        p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[I];perms=???a??, L.child = I:[E]{r}, F =/!o I"
+                                       p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[I];perms=???a??, L.child = ROI:[E]{r}, F =/!o ROI"
+                                       p:changes="ROI:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{r};perms=???a??, P =/!o C"
+                                       p:changes="C:{a}"/>
 
-        <!-- Give orphaned datasets. -->
+        <!-- Give orphaned datasets and folders. -->
 
         <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/o" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/o" p:changes="F:[I]"/>
 
         <!--
-             If a project, dataset or image is given for both sides of a link then, regardless of permissions, give the link if
-             same owners or not in private group.
+             If a project, dataset, folder, image or ROI is given for both sides of a link then, regardless of permissions, give the
+             link if same owners or not in private group.
           -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent = P:[I], L.child = D:[I], P =/o D"
                                        p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent = D:[I], L.child = I:[I], D =/o I"
                                        p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = F:[I], L.child = I:[I], F =/o I"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = F:[I], L.child = ROI:[I], F =/o ROI"
+                                       p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=??r???, L.child = [I]"
                                        p:changes="L:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=??r???, L.child = [I]"
                                        p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = [I];perms=??r???, L.child = [I]"
+                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = [I];perms=??r???, L.child = [I]"
+                                       p:changes="L:[I]/n"/>
 
         <!--
-             If a project, dataset or image is given then delete any remaining cross-owner links regardless of permissions
-             outside read-write groups.
+             If a project, dataset, folder, image or ROI is given then delete any remaining cross-owner links regardless of
+             permissions outside read-write groups.
           -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=???-??, L.child = [E]{ia}"
@@ -367,6 +397,14 @@
                                        p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=???-??, L.child = [I]"
                                        p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I];perms=???-??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [E];perms=???-??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I];perms=???-??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E];perms=???-??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=???a??, L.child = [E]{ia}"
                                        p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E];perms=???a??, L.child = [I]"
@@ -375,11 +413,21 @@
                                        p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E];perms=???a??, L.child = [I]"
                                        p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I];perms=???a??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [E];perms=???a??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I];perms=???a??, L.child = [E]{ia}"
+                                       p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E];perms=???a??, L.child = [I]"
+                                       p:changes="L:[D]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
 
         <!-- CORE -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -55,6 +55,9 @@
         <value>DatasetImageLink</value>
         <value>Project</value>
         <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
 
         <!-- core -->
         <value>Channel</value>
@@ -272,27 +275,39 @@
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = [D], L.child = D:[E]{i}/d" p:changes="D:{r}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = [D], L.child = I:[E]{i}/d" p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = [D], L.child = I:[E]{i}/d" p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = [D], L.child = ROI:[E]{i}/d" p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Folder[D].childFolders = C:[E]{i}/d" p:changes="C:{r}"/>
 
         <!-- In considering deleting a container's contents, do not delete an object if it is in another container. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [E]{ia}, L.child = D:[E]{r}" p:changes="D:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [E]{ia}, L.child = I:[E]{r}" p:changes="I:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E]{ia}, L.child = ROI:[E]{r}" p:changes="ROI:{a}"/>
 
-        <!-- Delete orphaned datasets. -->
+        <!-- Delete orphaned containers. -->
 
         <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/d" p:changes="D:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/d" p:changes="F:[D]"/>
 
-        <!-- If a project, dataset or image is deleted then delete their links regardless of permissions. -->
+        <!-- If a project, dataset, folder, image or ROI is deleted then delete their links regardless of permissions. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].child = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].child = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].child = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [D]" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].child = [D]" p:changes="L:[D]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
 
         <!-- CORE -->
 
@@ -430,9 +445,20 @@
 
         <!-- ROI -->
 
-        <!-- Delete contained objects: ROIs of deleted images, shapes of deleted ROIs, pixels of deleted masks if possible. -->
+        <!-- If an image is deleted then consider its ROIs for deletion. -->
 
-        <bean parent="graphPolicyRule" p:matches="Image[D].rois = ROI:[E]" p:changes="ROI:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[D].rois = ROI:[E]{i}/d" p:changes="ROI:[E]{r}"/>
+
+        <!-- Do not delete ROIs whose image is not to be deleted. -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[E]{ia}.rois = ROI:[E]{r}" p:changes="ROI:[E]{a}"/>
+
+        <!-- Delete orphaned ROIs. -->
+
+        <bean parent="graphPolicyRule" p:matches="ROI:[E]{o}/d" p:changes="ROI:[D]"/>
+
+        <!-- Delete contained objects: shapes of deleted ROIs, pixels of deleted masks if possible. -->
+
         <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E], P.image = I:[E]{i}/d" p:changes="I:{r}"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -44,6 +44,9 @@
         <value>DatasetImageLink</value>
         <value>Project</value>
         <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
 
         <!-- core -->
         <value>Channel</value>
@@ -190,15 +193,23 @@
 
         <!-- CONTAINERS -->
 
-        <!-- If a project or dataset is duplicated then duplicate their links -->
+        <!-- If a project, dataset or folder is duplicated then duplicate their links -->
 
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I]" p:changes="L:[I]"/>
+
+        <!-- If a folder is duplicated then duplicate its child folders. -->
+
+        <bean parent="graphPolicyRule" p:matches="Folder[I].childFolders = C:[E]" p:changes="C:[I]"/>
 
         <!-- If a container's link is duplicated then duplicate the contents. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderRoiLink[I].child = ROI:[E]" p:changes="ROI:[I]"/>
 
         <!-- Respect linking rules outside read-write groups. -->
 
@@ -213,6 +224,18 @@
 
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[I].parent = [E]/!o;perms=??ra??"
                                        p:error="duplicating {L} creates an image in another's dataset in a read-annotate group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} creates an image in another's folder in a read-only group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[I].parent = [E]/!o;perms=??ra??"
+                                       p:error="duplicating {L} creates an image in another's folder in a read-annotate group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[I].parent = [E]/!o;perms=??r-??"
+                                       p:error="duplicating {L} creates a ROI in another's folder in a read-only group"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[I].parent = [E]/!o;perms=??ra??"
+                                       p:error="duplicating {L} creates a ROI in another's folder in a read-annotate group"/>
 
         <!-- CORE -->
 

--- a/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
+++ b/components/blitz/src/omero/cmd/graphs/BaseGraphPolicyAdjuster.java
@@ -45,7 +45,7 @@ public abstract class BaseGraphPolicyAdjuster extends GraphPolicy {
      * @param graphPolicy the graph policy that is to be adjusted
      */
     public BaseGraphPolicyAdjuster(GraphPolicy graphPolicy) {
-        this.graphPolicy = graphPolicy.getCleanInstance();
+        this.graphPolicy = graphPolicy;
     }
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -59,6 +59,7 @@ import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
+import ome.services.graphs.PermissionsPredicate;
 import ome.system.EventContext;
 import ome.system.Roles;
 import omero.cmd.Duplicate;
@@ -222,6 +223,8 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
             graphPolicyWithOptions = adjuster.apply(graphPolicyWithOptions);
         }
         graphPolicyAdjusters = null;
+
+        graphPolicyWithOptions.registerPredicate(new PermissionsPredicate());
 
         GraphTraversal.Processor processor = new InternalProcessor();
         if (dryRun) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -654,6 +654,24 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Logs in the user.
+     *
+     * @param ownerEc
+     *            The context of the user.
+     * @param g
+     *            The group to log into.
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    protected void loginUser(EventContext ownerEc, ExperimenterGroup g) throws Exception {
+        final omero.client client = newOmeroClient();
+        client.createSession(ownerEc.userName, ownerEc.userName);
+        client.getSession().setSecurityContext(
+                new ExperimenterGroupI(g.getId(), false));
+        init(client);
+    }
+
+    /**
      * Creates a new {@link omero.client} for root based on the current group.
      */
     protected void logRootIntoGroup() throws Exception {

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -250,6 +250,38 @@ public class ModelMockFactory {
     }
 
     /**
+     * Creates a default project and returns it.
+     *
+     * @return See above.
+     */
+    public Project simpleProject() {
+        // prepare data
+        final Project project = new ProjectI();
+        String uuidAsString = UUID.randomUUID().toString();
+        String uniqueName = String.format("test-project:%s", uuidAsString);
+        String uniqueDesc = String.format("test-desc:%s", uuidAsString);
+        project.setName(rstring(uniqueName));
+        project.setDescription(rstring(uniqueDesc));
+        return project;
+    }
+
+    /**
+     * Creates a default screen and returns it.
+     *
+     * @return See above.
+     */
+    public Screen simpleScreen() {
+        // prepare data
+        final Screen screen = new ScreenI();
+        String uuidAsString = UUID.randomUUID().toString();
+        String uniqueName = String.format("test-screen:%s", uuidAsString);
+        String uniqueDesc = String.format("test-desc:%s", uuidAsString);
+        screen.setName(rstring(uniqueName));
+        screen.setDescription(rstring(uniqueDesc));
+        return screen;
+    }
+
+    /**
      * Creates a default dataset and returns it.
      *
      * @return See above.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 University of Dundee. All rights reserved.
+ * Copyright 2006-2016 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -8,19 +8,34 @@ package integration.chgrp;
 import integration.AbstractServerTest;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
+import omero.RLong;
+import omero.ServerError;
 import omero.cmd.Chgrp2;
+import omero.cmd.graphs.ChildOption;
 import omero.gateway.util.Requests;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
 import omero.model.ExperimenterGroup;
+import omero.model.ExperimenterGroupI;
+import omero.model.Folder;
+import omero.model.IObject;
 import omero.model.Image;
+import omero.model.Roi;
+import omero.model.RoiI;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -776,4 +791,423 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         assertNull(iQuery.findByQuery(sb.toString(), param));
     }
 
+    /**
+     * Test that moving a child folder out of a folder hierarchy moves its own child but leaves its parent behind.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testMoveChildFolder() throws Exception {
+
+        /* set up user and groups */
+
+        final EventContext user = newUserAndGroup("rw----");
+        final ExperimenterGroup fromGroup = new ExperimenterGroupI(user.groupId, false);
+        final ExperimenterGroup toGroup = newGroupAddUser("rw----", user.userId);
+
+        /* work in first group */
+
+        loginUser(fromGroup);
+
+        /* create three levels of folder */
+
+        Folder topFolder = saveAndReturnFolder(mmFactory.simpleFolder());
+        Folder middleFolder = saveAndReturnFolder(mmFactory.simpleFolder());
+        Folder bottomFolder = saveAndReturnFolder(mmFactory.simpleFolder());
+
+        topFolder.addChildFolders(middleFolder);
+        topFolder = saveAndReturnFolder(topFolder);
+        middleFolder = returnFolder(middleFolder);
+
+        middleFolder.addChildFolders(bottomFolder);
+        middleFolder = saveAndReturnFolder(middleFolder);
+        bottomFolder = returnFolder(bottomFolder);
+
+        /* check that the three levels are connected as expected */
+
+        topFolder = returnFolder(topFolder);
+        Assert.assertNull(topFolder.getParentFolder());
+        Assert.assertEquals(topFolder.copyChildFolders().size(), 1);
+        Assert.assertEquals(topFolder.copyChildFolders().get(0).getId().getValue(), middleFolder.getId().getValue());
+
+        middleFolder = returnFolder(middleFolder);
+        Assert.assertEquals(middleFolder.getParentFolder().getId().getValue(), topFolder.getId().getValue());
+        Assert.assertEquals(middleFolder.copyChildFolders().size(), 1);
+        Assert.assertEquals(middleFolder.copyChildFolders().get(0).getId().getValue(), bottomFolder.getId().getValue());
+
+        bottomFolder = returnFolder(bottomFolder);
+        Assert.assertEquals(bottomFolder.getParentFolder().getId().getValue(), middleFolder.getId().getValue());
+        Assert.assertTrue(bottomFolder.copyChildFolders().isEmpty());
+
+        /* move the middle folder from the first group to the second */
+
+        doChange(Requests.chgrp("Folder", middleFolder.getId().getValue(), toGroup.getId().getValue()));
+
+        /* check that only the top folder remains */
+
+        topFolder = returnFolder(topFolder);
+        Assert.assertNull(topFolder.getParentFolder());
+        Assert.assertTrue(topFolder.copyChildFolders().isEmpty());
+
+        Assert.assertNull(returnFolder(middleFolder));
+
+        Assert.assertNull(returnFolder(bottomFolder));
+
+        disconnect();
+
+        /* work in second group */
+
+        loginUser(toGroup);
+
+        /* check that only the middle and bottom folders have moved */
+
+        Assert.assertNull(returnFolder(topFolder));
+
+        middleFolder = returnFolder(middleFolder);
+        Assert.assertNull(middleFolder.getParentFolder());
+        Assert.assertEquals(middleFolder.copyChildFolders().size(), 1);
+        Assert.assertEquals(middleFolder.copyChildFolders().get(0).getId().getValue(), bottomFolder.getId().getValue());
+
+        bottomFolder = returnFolder(bottomFolder);
+        Assert.assertEquals(bottomFolder.getParentFolder().getId().getValue(), middleFolder.getId().getValue());
+        Assert.assertTrue(bottomFolder.copyChildFolders().isEmpty());
+
+        disconnect();
+    }
+
+    /**
+     * Assert that the given object is in the given group.
+     * @param object a model object
+     * @param group an experimenter group
+     * @throws Exception unexpected
+     */
+    private void assertObjectInGroup(IObject object, ExperimenterGroup group) throws Exception {
+        if (iAdmin.getEventContext().groupId != group.getId().getValue()) {
+            disconnect();
+            loginUser(group);
+        }
+        Class <? extends IObject> objectClass = object.getClass();
+        while (objectClass.getSuperclass() != IObject.class) {
+            objectClass = objectClass.getSuperclass().asSubclass(IObject.class);
+        }
+        object = iQuery.get(objectClass.getSimpleName(), object.getId().getValue());
+        Assert.assertEquals(object.getDetails().getGroup().getId().getValue(), group.getId().getValue());
+    }
+
+    /**
+     * Test moving folder hierarchies.
+     * @param folderOption if the child option should target folders
+     * @param includeOrphans how to set child options
+     * @param fromReadWrite if the target folder starts in a read-write group, otherwise read-annotate
+     * @param toPrivate if the target folder moves to a private group, otherwise the move is between groups of the same kind
+     * @param myChildFolder if the child folder should share ownership with the top-level folder owned by the mover
+     * @param myRoi if the ROI in the child folder should share ownership with the top-level folder owned by the mover
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "hierarchical folder test cases")
+    public void testMoveTopLevelFolder(boolean folderOption, Boolean includeOrphans, boolean fromReadWrite, boolean toPrivate,
+            boolean myChildFolder, boolean myRoi)
+            throws Exception {
+
+        /* set up user and groups */
+
+        final EventContext mover = newUserAndGroup(fromReadWrite ? "rwrw--" : "rwra--");
+        final EventContext other = newUserAndGroup(toPrivate ? "rw----" : fromReadWrite ? "rwrw--" : "rwra--");
+        final ExperimenterGroup fromGroup = new ExperimenterGroupI(mover.groupId, false);
+        final ExperimenterGroup toGroup = new ExperimenterGroupI(other.groupId, false);
+        addUsers(fromGroup, Collections.singletonList(other.userId), false);
+        addUsers(toGroup, Collections.singletonList(mover.userId), false);
+
+        /* set up the data */
+
+        loginUser(mover, fromGroup);
+        Folder parentFolder = (Folder) saveAndReturnFolder(mmFactory.simpleFolder()).proxy();
+
+        if (!myChildFolder) {
+            disconnect();
+            loginUser(myChildFolder ? mover : other, fromGroup);
+        }
+
+        Folder childFolder = mmFactory.simpleFolder();
+        childFolder.setParentFolder(parentFolder);
+        childFolder = (Folder) saveAndReturnFolder(childFolder).proxy();
+
+        if (myChildFolder != myRoi) {
+            disconnect();
+            loginUser(myRoi ? mover : other, fromGroup);
+        }
+
+        Roi roi = new RoiI();
+        roi.linkFolder(childFolder);
+        roi = (Roi) iUpdate.saveAndReturnObject(roi).proxy();
+
+        /* check that the three objects exist */
+
+        assertExists(parentFolder);
+        assertExists(childFolder);
+        assertExists(roi);
+
+        /* determine expectations for move */
+
+        boolean childFolderMoves = (myChildFolder || fromReadWrite && !toPrivate) &&
+                !(folderOption && Boolean.FALSE.equals(includeOrphans));
+        boolean roiMoves = (myChildFolder && myRoi || fromReadWrite && !toPrivate) &&
+                !Boolean.FALSE.equals(includeOrphans);
+
+        /* perform the specified move */
+
+        if (!myRoi) {
+            disconnect();
+            loginUser(mover, fromGroup);
+        }
+
+        final ChildOption option;
+        if (Boolean.TRUE.equals(includeOrphans)) {
+            option = Requests.option(folderOption ? "Folder" : "Roi", null);
+        } else if (Boolean.FALSE.equals(includeOrphans)) {
+            option = Requests.option(null, folderOption ? "Folder" : "Roi");
+        } else {
+            option = null;
+        }
+        final Chgrp2 move = new Chgrp2();
+        move.groupId = toGroup.getId().getValue();
+        move.targetObjects = ImmutableMap.of("Folder", Collections.singletonList(parentFolder.getId().getValue()));
+        if (option != null) {
+            move.childOptions = Collections.singletonList(option);
+        }
+        doChange(move);
+
+        /* check which objects are now in which groups */
+
+        assertObjectInGroup(parentFolder, toGroup);
+        assertObjectInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);
+        assertObjectInGroup(roi, roiMoves ? toGroup : fromGroup);
+    }
+
+    /**
+     * @return a variety of test cases for moving folder hierarchies
+     */
+    @DataProvider(name = "hierarchical folder test cases")
+    public Object[][] provideFolderMoveCases() {
+        int index = 0;
+        final int ORPHAN_FOLDER = index++;
+        final int INCLUDE_ORPHANS = index++;
+        final int FROM_READ_WRITE = index++;
+        final int TO_PRIVATE = index++;
+        final int MY_CHILD_FOLDER = index++;
+        final int MY_ROI = index++;
+
+        final Boolean[] booleanCases = new Boolean[]{false, true};
+        final Boolean[] booleanCasesWithNull = new Boolean[]{null, false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Boolean folderOption : booleanCases) {
+            for (final Boolean includeOption : booleanCasesWithNull) {
+                for (final Boolean fromReadWrite : booleanCases) {
+                    for (final Boolean toPrivate : booleanCases) {
+                        for (final Boolean myChildFolder : booleanCases) {
+                            for (final Boolean myRoi : booleanCases) {
+                                if (folderOption == true && includeOption == null ||
+                                        fromReadWrite == false && (myChildFolder == false || myRoi == false)) {
+                                    continue;
+                                }
+                                final Object[] testCase = new Object[index];
+                                testCase[ORPHAN_FOLDER] = folderOption;
+                                testCase[INCLUDE_ORPHANS] = includeOption;
+                                testCase[FROM_READ_WRITE] = fromReadWrite;
+                                testCase[TO_PRIVATE] = toPrivate;
+                                testCase[MY_CHILD_FOLDER] = myChildFolder;
+                                testCase[MY_ROI] = myRoi;
+                                // DEBUG: if (folderOption == true && Boolean.TRUE.equals(includeOption) &&
+                                //       fromReadWrite == true && toPrivate == true && myChildFolder == false && myRoi == false)
+                                testCases.add(testCase);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+
+    /**
+     * Count how many specific instances of a class remain.
+     * @param type the type of the instances
+     * @param ids the IDs of the instances of interest
+     * @return how many of the instances remain
+     * @throws ServerError unexpected
+     */
+    private long countInstances(Class<? extends IObject> type, Collection<Long> ids) throws ServerError {
+        if (ids.isEmpty()) {
+            return 0;
+        }
+        final String query = "SELECT COUNT(*) FROM " + type.getSimpleName() + " WHERE id IN (:ids)";
+        final omero.sys.Parameters params = new ParametersI().addIds(ids);
+        return ((RLong) iQuery.projection(query, params).get(0).get(0)).getValue();
+    }
+
+    /**
+     * Test moving ROIs that are on images and in folders.
+     * @param folderCount how many folders the ROI should be in
+     * @param imageCount how many images the ROI should be on (0 or 1)
+     * @param targetFolder if the move should target a folder
+     * @param targetImage if the move should target an image
+     * @param includeOrphans how to set child options for moving ROIs
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "contained ROI test cases")
+    public void testMoveRois(int folderCount, int imageCount, boolean targetFolder, boolean targetImage, Boolean includeOrphans)
+            throws Exception {
+
+        /* set up user and groups */
+
+        final EventContext user = newUserAndGroup("rw----");
+        final ExperimenterGroup fromGroup = new ExperimenterGroupI(user.groupId, false);
+        final ExperimenterGroup toGroup = newGroupAddUser("rw----", user.userId);
+
+        /* work in first group */
+
+        loginUser(fromGroup);
+
+        /* set up the data and note the IDs */
+
+        final Roi roi = new RoiI();
+        final List<Long> roiIds = new ArrayList<Long>();
+        final List<Long> folderIds = new ArrayList<Long>();
+        final List<Long> imageIds = new ArrayList<Long>();
+
+        for (int f = 0; f < folderCount; f++) {
+            final Folder folder = (Folder) iUpdate.saveAndReturnObject(mmFactory.simpleFolder());
+            folderIds.add(folder.getId().getValue());
+            roi.linkFolder((Folder) folder.proxy());
+        }
+
+        for (int i = 0; i < imageCount; i++) {
+            final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.simpleImage());
+            imageIds.add(image.getId().getValue());
+            roi.setImage((Image) image.proxy());
+        }
+
+        roiIds.add(iUpdate.saveAndReturnObject(roi).proxy().getId().getValue());
+
+        /* cannot move an ROI without its image */
+
+        final boolean isLegalMove = targetImage || imageCount == 0 || !Boolean.TRUE.equals(includeOrphans);
+
+        /* check that the object counts are as expected */
+
+        int expectedRemainingRoiCount = 1;
+        int expectedRemainingFolderCount = folderCount;
+        int expectedRemainingImageCount = imageCount;
+
+        int expectedMovedRoiCount = 0;
+        int expectedMovedFolderCount = 0;
+        int expectedMovedImageCount = 0;
+
+        Assert.assertEquals(countInstances(Roi.class, roiIds), expectedRemainingRoiCount);
+        Assert.assertEquals(countInstances(Folder.class, folderIds), expectedRemainingFolderCount);
+        Assert.assertEquals(countInstances(Image.class, imageIds), expectedRemainingImageCount);
+
+        /* perform the specified move and update the expected object counts */
+
+        final Chgrp2 move = new Chgrp2();
+        move.groupId = toGroup.getId().getValue();
+        move.targetObjects = new HashMap<String, List<Long>>();
+        if (targetFolder) {
+            move.targetObjects.put("Folder", Collections.singletonList(folderIds.get(0)));
+            expectedRemainingFolderCount--;
+            expectedMovedFolderCount++;
+        }
+        if (targetImage) {
+            move.targetObjects.put("Image", Collections.singletonList(imageIds.get(0)));
+            expectedRemainingImageCount--;
+            expectedMovedImageCount++;
+        }
+        if (Boolean.TRUE.equals(includeOrphans)) {
+            final ChildOption option = new ChildOption();
+            option.includeType = Collections.singletonList("Roi");
+            move.childOptions = Collections.singletonList(option);
+            expectedRemainingRoiCount--;
+            expectedMovedRoiCount++;
+        } else if (Boolean.FALSE.equals(includeOrphans)) {
+            final ChildOption option = new ChildOption();
+            option.excludeType = Collections.singletonList("Roi");
+            move.childOptions = Collections.singletonList(option);
+        } else if (expectedRemainingFolderCount + expectedRemainingImageCount == 0) {
+            expectedRemainingRoiCount--;
+            expectedMovedRoiCount++;
+        }
+        doChange(client, factory, move, isLegalMove);
+
+        if (isLegalMove) {
+
+            /* check that the counts of remaining objects are as expected */
+
+            Assert.assertEquals(countInstances(Roi.class, roiIds), expectedRemainingRoiCount);
+            Assert.assertEquals(countInstances(Folder.class, folderIds), expectedRemainingFolderCount);
+            Assert.assertEquals(countInstances(Image.class, imageIds), expectedRemainingImageCount);
+
+            disconnect();
+
+            /* work in second group */
+
+            loginUser(toGroup);
+
+            /* check that the counts of moved objects are as expected */
+
+            Assert.assertEquals(countInstances(Roi.class, roiIds), expectedMovedRoiCount);
+            Assert.assertEquals(countInstances(Folder.class, folderIds), expectedMovedFolderCount);
+            Assert.assertEquals(countInstances(Image.class, imageIds), expectedMovedImageCount);
+        }
+
+        disconnect();
+    }
+
+    /**
+     * @return a variety of test cases for moving ROIs
+     */
+    @DataProvider(name = "contained ROI test cases")
+    public Object[][] provideMoveRoiCases() {
+        int index = 0;
+        final int FOLDER_COUNT = index++;
+        final int IMAGE_COUNT = index++;
+        final int TARGET_FOLDER = index++;
+        final int TARGET_IMAGE = index++;
+        final int INCLUDE_ORPHANS = index++;
+
+        final Integer[] folderCountCases = new Integer[]{0, 1, 2};
+        final Integer[] imageCountCases = new Integer[]{0, 1};
+        final Boolean[] targetCases = new Boolean[]{false, true};
+        final Boolean[] includeCases = new Boolean[]{null, false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Integer folderCount : folderCountCases) {
+            for (final Integer imageCount : imageCountCases) {
+                for (final Boolean targetFolder : targetCases) {
+                    for (final Boolean targetImage : targetCases) {
+                        for (final Boolean includeOrphans : includeCases) {
+                            if (targetFolder && folderCount == 0 || targetImage && imageCount == 0 ||
+                                    !(targetFolder || targetImage)) {
+                                continue;
+                            }
+                            final Object[] testCase = new Object[index];
+                            testCase[FOLDER_COUNT] = folderCount;
+                            testCase[IMAGE_COUNT] = imageCount;
+                            testCase[TARGET_FOLDER] = targetFolder;
+                            testCase[TARGET_IMAGE] = targetImage;
+                            testCase[INCLUDE_ORPHANS] = includeOrphans;
+                            // DEBUG: if (folderCount == 1 && imageCount == 1 && targetFolder == true && targetImage == false
+                            //        && Boolean.TRUE.equals(includeOrphans))
+                            testCases.add(testCase);
+                        }
+                    }
+                }
+            }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -30,6 +30,7 @@ import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
 import omero.cmd.Delete2;
+import omero.cmd.graphs.ChildOption;
 import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
@@ -40,6 +41,8 @@ import omero.model.DatasetImageLinkI;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
+import omero.model.Folder;
+import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
@@ -53,6 +56,7 @@ import omero.model.PlateI;
 import omero.model.Project;
 import omero.model.ProjectI;
 import omero.model.Roi;
+import omero.model.RoiI;
 import omero.model.Screen;
 import omero.model.ScreenI;
 import omero.model.Well;
@@ -678,6 +682,238 @@ public class HierarchyDeleteTest extends AbstractServerTest {
             testCase[TARGET] = target;
             // DEBUG: if (target == Target.DATASET)
             testCases.add(testCase);
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * Test the deletion of folder hierarchies.
+     * @param folderOption if the child option should target folders
+     * @param includeOrphans how to set child options
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "hierarchical folder test cases")
+    public void testDeletingTopLevelFolder(boolean folderOption, Boolean includeOrphans) throws Exception {
+
+        /* set up the data */
+
+        Folder parentFolder = (Folder) saveAndReturnFolder(mmFactory.simpleFolder()).proxy();
+        Folder childFolder = mmFactory.simpleFolder();
+        childFolder.setParentFolder(parentFolder);
+        childFolder = (Folder) saveAndReturnFolder(childFolder).proxy();
+        Roi roi = new RoiI();
+        roi.linkFolder(childFolder);
+        roi = (Roi) iUpdate.saveAndReturnObject(roi).proxy();
+
+        /* check that the three objects exist */
+
+        assertExists(parentFolder);
+        assertExists(childFolder);
+        assertExists(roi);
+
+        /* determine expectations for after deletion */
+
+        boolean childExpected = folderOption && Boolean.FALSE.equals(includeOrphans);
+        boolean roiExpected = Boolean.FALSE.equals(includeOrphans);
+
+        /* perform the specified deletion */
+
+        final ChildOption option;
+        if (Boolean.TRUE.equals(includeOrphans)) {
+            option = Requests.option(folderOption ? "Folder" : "Roi", null);
+        } else if (Boolean.FALSE.equals(includeOrphans)) {
+            option = Requests.option(null, folderOption ? "Folder" : "Roi");
+        } else {
+            option = null;
+        }
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = ImmutableMap.of("Folder", Collections.singletonList(parentFolder.getId().getValue()));
+        if (option != null) {
+            delete.childOptions = Collections.singletonList(option);
+        }
+        doChange(delete);
+
+        /* check which objects now exist */
+
+        assertDoesNotExist(parentFolder);
+        if (childExpected) {
+            assertExists(childFolder);
+        } else {
+            assertDoesNotExist(childFolder);
+        }
+        if (roiExpected) {
+            assertExists(roi);
+        } else {
+            assertDoesNotExist(roi);
+        }
+    }
+
+    /**
+     * @return a variety of test cases for deletion of folder hierarchies
+     */
+    @DataProvider(name = "hierarchical folder test cases")
+    public Object[][] provideFolderDeletionCases() {
+        int index = 0;
+        final int ORPHAN_FOLDER = index++;
+        final int INCLUDE_ORPHANS = index++;
+
+        final Boolean[] classCases = new Boolean[]{false, true};
+        final Boolean[] includeCases = new Boolean[]{null, false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Boolean folderOption : classCases) {
+            for (final Boolean includeOption : includeCases) {
+                    if (folderOption == true && includeOption == null) {
+                        continue;
+                    }
+                    final Object[] testCase = new Object[index];
+                    testCase[ORPHAN_FOLDER] = folderOption;
+                    testCase[INCLUDE_ORPHANS] = includeOption;
+                    // DEBUG: if (folderOption == true && Boolean.TRUE.equals(includeOption))
+                    testCases.add(testCase);
+                }
+        }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+
+    /**
+     * Count how many specific instances of a class remain.
+     * @param type the type of the instances
+     * @param ids the IDs of the instances of interest
+     * @return how many of the instances remain
+     * @throws ServerError unexpected
+     */
+    private long countInstances(Class<? extends IObject> type, Collection<Long> ids) throws ServerError {
+        if (ids.isEmpty()) {
+            return 0;
+        }
+        final String query = "SELECT COUNT(*) FROM " + type.getSimpleName() + " WHERE id IN (:ids)";
+        final omero.sys.Parameters params = new ParametersI().addIds(ids);
+        return ((RLong) iQuery.projection(query, params).get(0).get(0)).getValue();
+    }
+
+    /**
+     * Test the deletion of ROIs that are on images and in folders.
+     * @param folderCount how many folders the ROI should be in
+     * @param imageCount how many images the ROI should be on (0 or 1)
+     * @param targetFolder if the deletion should target a folder
+     * @param targetImage if the deletion should target an image
+     * @param includeOrphans how to set child options for deleting ROIs
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "contained ROI test cases")
+    public void testRoiDeletion(int folderCount, int imageCount, boolean targetFolder, boolean targetImage, Boolean includeOrphans)
+            throws Exception {
+
+        /* set up the data and note the IDs */
+
+        final Roi roi = new RoiI();
+        final List<Long> roiIds = new ArrayList<Long>();
+        final List<Long> folderIds = new ArrayList<Long>();
+        final List<Long> imageIds = new ArrayList<Long>();
+
+        for (int f = 0; f < folderCount; f++) {
+            final Folder folder = (Folder) iUpdate.saveAndReturnObject(mmFactory.simpleFolder());
+            folderIds.add(folder.getId().getValue());
+            roi.linkFolder((Folder) folder.proxy());
+        }
+
+        for (int i = 0; i < imageCount; i++) {
+            final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.simpleImage());
+            imageIds.add(image.getId().getValue());
+            roi.setImage((Image) image.proxy());
+        }
+
+        roiIds.add(iUpdate.saveAndReturnObject(roi).proxy().getId().getValue());
+
+        /* check that the object counts are as expected */
+
+        int expectedRoiCount = 1;
+        int expectedFolderCount = folderCount;
+        int expectedImageCount = imageCount;
+
+        Assert.assertEquals(countInstances(Roi.class, roiIds), expectedRoiCount);
+        Assert.assertEquals(countInstances(Folder.class, folderIds), expectedFolderCount);
+        Assert.assertEquals(countInstances(Image.class, imageIds), expectedImageCount);
+
+        /* perform the specified deletion and update the expected object counts */
+
+        final Delete2 delete = new Delete2();
+        delete.targetObjects = new HashMap<String, List<Long>>();
+        if (targetFolder) {
+            delete.targetObjects.put("Folder", Collections.singletonList(folderIds.get(0)));
+            expectedFolderCount--;
+        }
+        if (targetImage) {
+            delete.targetObjects.put("Image", Collections.singletonList(imageIds.get(0)));
+            expectedImageCount--;
+        }
+        if (Boolean.TRUE.equals(includeOrphans)) {
+            final ChildOption option = new ChildOption();
+            option.includeType = Collections.singletonList("Roi");
+            delete.childOptions = Collections.singletonList(option);
+            expectedRoiCount--;
+        } else if (Boolean.FALSE.equals(includeOrphans)) {
+            final ChildOption option = new ChildOption();
+            option.excludeType = Collections.singletonList("Roi");
+            delete.childOptions = Collections.singletonList(option);
+        } else if (expectedFolderCount + expectedImageCount == 0) {
+            expectedRoiCount--;
+        }
+        doChange(delete);
+
+        /* check that the object counts are as expected */
+
+        Assert.assertEquals(countInstances(Roi.class, roiIds), expectedRoiCount);
+        Assert.assertEquals(countInstances(Folder.class, folderIds), expectedFolderCount);
+        Assert.assertEquals(countInstances(Image.class, imageIds), expectedImageCount);
+    }
+
+    /**
+     * @return a variety of test cases for ROI deletion
+     */
+    @DataProvider(name = "contained ROI test cases")
+    public Object[][] provideRoiDeletionCases() {
+        int index = 0;
+        final int FOLDER_COUNT = index++;
+        final int IMAGE_COUNT = index++;
+        final int TARGET_FOLDER = index++;
+        final int TARGET_IMAGE = index++;
+        final int INCLUDE_ORPHANS = index++;
+
+        final Integer[] folderCountCases = new Integer[]{0, 1, 2};
+        final Integer[] imageCountCases = new Integer[]{0, 1};
+        final Boolean[] targetCases = new Boolean[]{false, true};
+        final Boolean[] includeCases = new Boolean[]{null, false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final Integer folderCount : folderCountCases) {
+            for (final Integer imageCount : imageCountCases) {
+                for (final Boolean targetFolder : targetCases) {
+                    for (final Boolean targetImage : targetCases) {
+                        for (final Boolean includeOrphans : includeCases) {
+                            if (targetFolder && folderCount == 0 || targetImage && imageCount == 0 ||
+                                    !(targetFolder || targetImage)) {
+                                continue;
+                            }
+                            final Object[] testCase = new Object[index];
+                            testCase[FOLDER_COUNT] = folderCount;
+                            testCase[IMAGE_COUNT] = imageCount;
+                            testCase[TARGET_FOLDER] = targetFolder;
+                            testCase[TARGET_IMAGE] = targetImage;
+                            testCase[INCLUDE_ORPHANS] = includeOrphans;
+                            // DEBUG: if (folderCount == 1 && imageCount == 1 && targetFolder == true && targetImage == true
+                            //        && includeOrphans == null)
+                            testCases.add(testCase);
+                        }
+                    }
+                }
+            }
         }
 
         return testCases.toArray(new Object[testCases.size()][]);


### PR DESCRIPTION
Adjusts graph policies to incorporate Folders and adds corresponding integration tests:

* Delete2: http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.delete/HierarchyDeleteTest/
* Chgrp2: http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.chgrp/HierarchyMoveAndPermissionsTest/
* Chown2: http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.chown/PermissionsTest/
* Chmod2: http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.chmod/PermissionsTest/
* Duplicate: http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration/DuplicationTest/