### PR TITLE
Show image in well develop

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -350,6 +350,9 @@ class Show(object):
             # Need to see if first item has parents
             if first_selected is not None:
                 for p in first_selected.getAncestry():
+                    if p.OMERO_CLASS == "Well":
+                        self._initially_select = ['well.id-%s' % p.getId()]
+                        return self._find_first_selected()
                     if first_obj == "tag":
                         # Parents of tags must be tags (no OMERO_CLASS)
                         self._initially_open.insert(0, "tag-%s" % p.getId())

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -351,8 +351,8 @@ class Show(object):
             if first_selected is not None:
                 for p in first_selected.getAncestry():
                     # If 'Well' is a parent, we have stared with Image.
-                    # We want to start again at 'Well' to _load_first_selected with
-                    # well, so we get 'acquisition' in ancestors.
+                    # We want to start again at 'Well' to _load_first_selected
+                    # with well, so we get 'acquisition' in ancestors.
                     if p.OMERO_CLASS == "Well":
                         self._initially_select = ['well.id-%s' % p.getId()]
                         return self._find_first_selected()

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -350,6 +350,9 @@ class Show(object):
             # Need to see if first item has parents
             if first_selected is not None:
                 for p in first_selected.getAncestry():
+                    # If 'Well' is a parent, we have stared with Image.
+                    # We want to start again at 'Well' to _load_first_selected with
+                    # well, so we get 'acquisition' in ancestors.
                     if p.OMERO_CLASS == "Well":
                         self._initially_select = ['well.id-%s' % p.getId()]
                         return self._find_first_selected()

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1566,8 +1566,8 @@ class TestShow(IWebTest):
         assert len(paths) == 0, 'More results than expected found\n %s' % paths
 
         # Path to image in well...
-        paths = paths_to_object(self.conn, None, None, None, ws_a1.image.id.val,
-                                None, None, None, None)
+        paths = paths_to_object(self.conn, None, None, None,
+                                ws_a1.image.id.val, None, None, None, None)
         # Image is only in ONE acquisition
         assert len(paths) == 1
         assert paths[0] == expected[0]

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1533,7 +1533,6 @@ class TestShow(IWebTest):
 
         ws_a1, ws_b1, ws_a2, ws_b2 = well_a.copyWellSamples()
 
-        ws_c1, = well_c.copyWellSamples()
         plate_acquisition1 = ws_a1.plateAcquisition
         plate_acquisition2 = ws_a2.plateAcquisition
 
@@ -1565,6 +1564,13 @@ class TestShow(IWebTest):
                 assert False, 'Did not find in results: %s' % str(e)
 
         assert len(paths) == 0, 'More results than expected found\n %s' % paths
+
+        # Path to image in well...
+        paths = paths_to_object(self.conn, None, None, None, ws_a1.image.id.val,
+                                None, None, None, None)
+        # Image is only in ONE acquisition
+        assert len(paths) == 1
+        assert paths[0] == expected[0]
 
     def test_well_restrict_acquisition_multi(self,
                                              screen_plate_run_well_multi):


### PR DESCRIPTION
This is https://github.com/openmicroscopy/openmicroscopy/pull/4241/ rebased onto develop (with extra changes to work with new jsTree).

Fixes ```webclient/?show=image-123``` when the image is in a well.

 - To test, pick ID of an image in a Well and use it in the link above.
 - This will browse to the well containing the image - Not necessarily the correct well-index (just first index).