### PR TITLE
Separate pom and xml filesystem resolvers

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -57,8 +57,8 @@
           cache="local" descriptor="required">
         <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
         <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
-       <!-- Ivy pattern for artifacts installed locally via Maven -->
-       <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
+        <!-- Ivy pattern for artifacts installed locally via Maven -->
+        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
       </filesystem>
 
       <!-- Remote downloads; cached to '~/.m2/repository' -->

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -56,6 +56,14 @@
           changingPattern=".*SNAPSHOT.*"
           cache="local" descriptor="required">
         <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
+        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
+      </filesystem>
+
+      <filesystem name="user-maven2" m2compatible="true" force="false"
+          checkmodified="true" changingMatcher="regexp"
+          changingPattern=".*SNAPSHOT.*"
+          cache="local" descriptor="required">
+        <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
         <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
       </filesystem>
 
@@ -94,6 +102,7 @@
 
     <!-- Resolver for OME dependencies-->
     <chain name="ome-resolver" returnFirst="true">
+        <resolver ref="user-maven2"/>
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
     </chain>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -57,14 +57,8 @@
           cache="local" descriptor="required">
         <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
         <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
-      </filesystem>
-
-      <filesystem name="user-maven2" m2compatible="true" force="false"
-          checkmodified="true" changingMatcher="regexp"
-          changingPattern=".*SNAPSHOT.*"
-          cache="local" descriptor="required">
-        <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
-        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
+       <!-- Ivy pattern for artifacts installed locally via Maven -->
+       <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
       </filesystem>
 
       <!-- Remote downloads; cached to '~/.m2/repository' -->
@@ -102,7 +96,6 @@
 
     <!-- Resolver for OME dependencies-->
     <chain name="ome-resolver" returnFirst="true">
-        <resolver ref="user-maven2"/>
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
     </chain>


### PR DESCRIPTION
This commit follows-up 8aedc97834af6edea75de58747f5c760bce24ac3 and defines two Ivy patterns in the `user-maven` file system resolver:
- the first pattern ending in `.xml` will be used for artifacts downloaded by Ivy from a remote repository (e.g. Maven Central)
- the second pattern ending with `.pom` will be used for components built locally by Maven

Apart from checking the CI builds are green, the same testing procedure as in https://github.com/openmicroscopy/openmicroscopy/pull/4411 could be reapplied here. In a nutshell, clean the Maven repository under `~/.m2`, install the Bio-Formats artifacts locally using `mvn clean install` and then build the server using `./build.py build-dev`. In addition to `build-dev`, one should check the `release-javadoc` target also completes without failure (while it should fail without this PR). This PR will be  tested independently on the `develop` CI devspace where the OMERO build is currently failing.