### PR TITLE
Populate metadata example

### DIFF
--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -91,8 +91,9 @@ ellipse.theT = rint(theT)
 ellipse.textValue = rstring("test-Ellipse")
 
 # Create an ROI containing 2 shapes on same plane
-# NB: OMERO.insight client doesn't support this
-# The ellipse is removed later (see below)
+# NB: OMERO.insight client doesn't support display
+# of multiple shapes on a single plane.
+# Therefore the ellipse is removed later (see below)
 createROI(image, [rect, ellipse])
 
 # create an ROI with single line shape
@@ -178,7 +179,7 @@ createROI(image, [point])
 
 
 def pointsToString(points):
-    """ Returns strange format supported by Insight """
+    """ Returns legacy format supported by Insight """
     points = ["%s,%s" % (p[0], p[1]) for p in points]
     csv = ", ".join(points)
     return "points[%s] points1[%s] points2[%s]" % (csv, csv, csv)

--- a/examples/Training/python/Tables.py
+++ b/examples/Training/python/Tables.py
@@ -12,10 +12,12 @@ FOR TRAINING PURPOSES ONLY!
 """
 
 import omero
+import os
 import omero.grid
 from omero.gateway import BlitzGateway
+from omero.util.populate_metadata import ParsingContext
 from Parse_OMERO_Properties import USERNAME, PASSWORD, HOST, PORT
-from Parse_OMERO_Properties import datasetId
+from Parse_OMERO_Properties import datasetId, plateId
 
 #
 # .. _python_omero_tables_code_samples:
@@ -127,6 +129,25 @@ orig_table_file = conn.getObject(
     "OriginalFile", attributes={'name': tablename})    # if name is unique
 savedTable = conn.c.sf.sharedResources().openTable(orig_table_file._obj)
 print "Opened table with row-count:", savedTable.getNumberOfRows()
+
+
+# Populate a table on a Plate from a csv file.
+# =================================================================
+colNames = "Well, Well Type, Concentration\n"
+csvLines = [
+    colNames,
+    "A1, Control, 0\n",
+    "A2, Treatment, 5\n",
+    "A3, Treatment, 10\n"]
+with open('data.csv', 'w') as csvData:
+    csvData.writelines(csvLines)
+plate = conn.getObject("Plate", plateId)
+target_object = plate._obj
+client = conn.c
+ctx = ParsingContext(client, target_object, 'data.csv')
+ctx.parse()
+ctx.write_to_omero()
+os.remove('data.csv')
 
 
 # Close connection:

--- a/examples/Training/training_setup.sh
+++ b/examples/Training/training_setup.sh
@@ -62,8 +62,8 @@ bin/omero obj new ScreenPlateLink parent=$screen child=$plate
 
 # Import orphaned plate
 echo "Importing SPW file"
-touch "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake"
-bin/omero import -r $screen "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake" > plate_import.log 2>&1
+touch "SPW&plates=1&plateRows=1&plateCols=3&fields=1&plateAcqs=1.fake"
+bin/omero import -r $screen "SPW&plates=1&plateRows=1&plateCols=3&fields=1&plateAcqs=1.fake" > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 
 # Logout


### PR DESCRIPTION
Now that the webclient will display bulk metadata for Plates #4446 (and Insight has done for some time), this gives users an example of how to use populate_metadata from within a python script to upload Table data to a plate from a csv.

To test:
 - try running the code sample, then check result in webclient (using PR https://github.com/openmicroscopy/openmicroscopy/pull/4446)