### PR TITLE
Get thumb version no images

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -694,7 +694,7 @@ def marshal_images(conn, dataset_id=None, orphaned=False, share_id=None,
 
     # Load thumbnails separately
     # We want version of most recent thumbnail (max thumbId) owned by user
-    if thumb_version:
+    if thumb_version and len(images) > 0:
         userId = conn.getUserId()
         iids = [i['id'] for i in images]
         params = omero.sys.ParametersI()

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2005,6 +2005,8 @@ def batch_annotate(request, conn=None, **kwargs):
                 'type': key.title(), 'id': o.id, 'name': o.getName()})
     obj_string = "&".join(obj_ids)
     link_string = "|".join(obj_ids).replace("=", "-")
+    if len(groupIds) == 0:
+        raise Http404("No objects found")
     groupId = list(groupIds)[0]
     conn.SERVICE_OPTS.setOmeroGroup(groupId)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2006,7 +2006,7 @@ def batch_annotate(request, conn=None, **kwargs):
     obj_string = "&".join(obj_ids)
     link_string = "|".join(obj_ids).replace("=", "-")
     if len(groupIds) == 0:
-        raise Http404("No objects found")
+        return handlerInternalError(request, "No objects found")
     groupId = list(groupIds)[0]
     conn.SERVICE_OPTS.setOmeroGroup(groupId)
 


### PR DESCRIPTION
This fixes/handles a couple of QA bugs which are due to async when deleting lots of images (webclient showing images that have been deleted): See https://www.openmicroscopy.org/qa2/qa/feedback/16974/

https://trello.com/c/EaUFEq8m/74-batch-annotate-no-groupids
https://trello.com/c/W1AFZ231/75-getthumbversion-no-images

To test these it is easiest if you load the tree and images in one browser, then delete the images in another client (Insight or web with a different browser).

 - Expand a dataset of thumbnails in web, then delete these images in another browser/Insight.
 - Now select several thumbnails in web - should see a suitable message (same as for single image)

![screen shot 2016-02-04 at 13 22 06](https://cloud.githubusercontent.com/assets/900055/12816157/ad56d4a0-cb42-11e5-892e-f6550c946270.png)

 - Load the tree in web, pick a Dataset that has images but don't expand Dataset.
 - Then empty this Dataset in another browser/Insight (E.g. by deleting all the images or moving them to a different Dataset
 - Now expand the Dataset in web. This will fail silently (no errors).