### PR TITLE
Make sure pixel dimensions are in microns

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -163,7 +163,7 @@ def imageMarshal(image, key=None, request=None):
                 size = method('MICROMETER')
                 return size.getValue() if size else None
             except:
-                logger.warn(
+                logger.debug(
                     'Unable to convert physical pixel size to microns',
                     exc_info=True
                 )

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -159,8 +159,15 @@ def imageMarshal(image, key=None, request=None):
 
     try:
         def pixel_size_in_microns(method):
-            size = method('MICROMETER')
-            return size.getValue() if size else None
+            try:
+                size = method('MICROMETER')
+                return size.getValue() if size else None
+            except:
+                logger.warn(
+                    'Unable to convert physical pixel size to microns',
+                    exc_info=True
+                )
+                return None
 
         rv.update({
             'interpolate': interpolate,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -158,6 +158,10 @@ def imageMarshal(image, key=None, request=None):
     interpolate = server_settings.get('interpolate_pixels', True)
 
     try:
+        def pixel_size_in_microns(method):
+            size = method('MICROMETER')
+            return size.getValue() if size else None
+
         rv.update({
             'interpolate': interpolate,
             'size': {'width': image.getSizeX(),
@@ -165,9 +169,9 @@ def imageMarshal(image, key=None, request=None):
                      'z': image.getSizeZ(),
                      't': image.getSizeT(),
                      'c': image.getSizeC()},
-            'pixel_size': {'x': image.getPixelSizeX(),
-                           'y': image.getPixelSizeY(),
-                           'z': image.getPixelSizeZ()},
+            'pixel_size': {'x': pixel_size_in_microns(image.getPixelSizeX),
+                           'y': pixel_size_in_microns(image.getPixelSizeY),
+                           'z': pixel_size_in_microns(image.getPixelSizeZ)},
             })
         if init_zoom is not None:
             rv['init_zoom'] = init_zoom


### PR DESCRIPTION
The expectation of all downstream code is that the physical pixel
dimensions are in microns.  This commit restores the behaviour to that
expected prior to the introduction of units to OMERO and the
introduction of blind `getValue()` retrieval.

The downstream code in the OMERO.web that relies on physical dimensions being in microns:

 * https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js#L346
 * https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js#L131

The underlying gateway code in action as an illustration:

```
$ dist/bin/omero shell
Python 2.7.9 (default, Apr  2 2015, 15:33:21) 
Type "copyright", "credits" or "license" for more information.

IPython 2.3.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import omero

In [2]: import omero.clients

In [3]: import omero.gateway

In [4]: pixels = omero.model.PixelsI()

In [5]: pixels.physicalSizeX = omero.model.LengthI(100, omero.model.enums.UnitsLength.MICROMETER)

In [6]: image = omero.model.ImageI()

In [7]: image.addPixels(pixels)

In [8]: wrapper = omero.gateway.ImageWrapper(obj=image)

In [9]: wrapper.getPixelSizeX()
Out[9]: 100

In [10]: pixels.physicalSizeX
Out[10]: 
object #0 (::omero::model::Length)
{
    _value = 100
    _unit = MICROMETER
}

In [13]: wrapper.getPixelSizeX('MICROMETER')
Out[13]: 
object #0 (::omero::model::Length)
{
    _value = 100
    _unit = MICROMETER
}

In [14]: pixels.physicalSizeX = omero.model.LengthI(100, omero.model.enums.UnitsLength.NANOMETER)

In [15]: pixels.physicalSizeX
Out[15]: 
object #0 (::omero::model::Length)
{
    _value = 100
    _unit = NANOMETER
}

In [16]: wrapper.getPixelSizeX()
Out[16]: 100

In [17]: wrapper.getPixelSizeX('MICROMETER')
Out[17]: 
object #0 (::omero::model::Length)
{
    _value = 0.1
    _unit = MICROMETER
}
```

I would extend the marshaling test cases to cover all possible unit types for physical pixel dimensions but this will be incredibly laborious relative to the changes included here. The number of elements to mock up due to interactions with the rendering engine, etc. unfortunately creates a great deal of complexity for potential unit testing of the code in question. Happy to discuss otherwise.

There are no doubt images in our repository that have physical pixel sizes specified in a unit other than microns. These can be used to both examine the bug and this fix.

At a minimum we should assure that images with physical pixel values using the following units work, have no JavaScript errors in the console, that values displayed in the OMERO.web right hand panel correspond (even if the units are not the same) with those in the "Image Information" dialog of the full image viewer and finally that the scale bar is both displaying under the correct conditions and with the correct value:

 * millimeters
 * micrometers
 * nanometers
 * pixels

**Edit:** Added scope for testing from the comments below.

/cc @will-moore, @aleksandra-tarkowska, @knabar, @emilroz