### PR TITLE
Travis: use oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-jdk: oraclejdk7
+jdk: oraclejdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-jdk: oraclejdk8
+jdk: oraclejdk7
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
-jdk:
-  - openjdk7
+jdk: oraclejdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available


### PR DESCRIPTION
This JDK version seems to alleviate the memory issues our Travis build have been suffering from in the last few days. See https://travis-ci.org/sbesson/openmicroscopy/builds for the local tests, each build having built relaunched a few times.

/cc @aleksandra-tarkowska @joshmoore @jburel 