### PR TITLE
Adding discontinued note to VM readme

### DIFF
--- a/docs/install/VM/README.md
+++ b/docs/install/VM/README.md
@@ -2,3 +2,6 @@ Building an OMERO Virtual Appliance
 ===================================
 
 The scripts have been migrated to https://github.com/ome/omero-virtual-appliance.
+
+**The Virtual Appliance has been discontinued, OMERO 5.2.1 is the last version
+available.**


### PR DESCRIPTION
See https://trello.com/c/gKMVgoQ8/3-consider-replacing-virtual-applicance-with-docker

Marking VM as discontinued. Don't know if there is another readme somewhere I've missed?