### PR TITLE
Use omero.util.Resources to keep imports alive

### DIFF
--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -405,6 +405,7 @@
      <constructor-arg ref="ring"/>
      <constructor-arg ref="/OMERO/Pixels"/>
      <property name="iceCommunicator" ref="Ice.Communicator"/>
+     <constructor-arg ref="resources"/>
   </bean>
 
   <!-- "Self"-factories -->
@@ -437,6 +438,15 @@
     <constructor-arg index="1" ref="roles"/>
     <constructor-arg index="2" ref="executor"/>
     <constructor-arg index="3" ref="statefulExecutor"/>
+  </bean>
+
+  <bean id="scheduledExecutorService" class="java.util.concurrent.ScheduledThreadPoolExecutor">
+      <constructor-arg value="16"/><!-- at most 16 pings at once -->
+  </bean>
+
+  <bean id="resources" class="omero.util.Resources">
+      <constructor-arg value="60"/><!-- ping every 60 seconds -->
+      <constructor-arg ref="scheduledExecutorService"/>
   </bean>
 
 </beans>

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -276,8 +276,8 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
     }
 
     /**
-     * If the {@link #setResources()} has been called with a non-null
-     * value, then create an {@link Entry} which will ping the
+     * If the {@link #setResources(Resources)} has been called with a
+     * non-null value, then create an {@link Entry} which will ping the
      * {@link ServiceFactoryPrx} instance periodically to keep the import
      * from timing out. This is especially important for autoClose imports
      * since no other client is likely to keep them alive.

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -68,6 +68,8 @@ import omero.model.Plate;
 import omero.model.ScriptJob;
 import omero.model.ThumbnailGenerationJob;
 import omero.util.IceMapper;
+import omero.util.Resources;
+import omero.util.Resources.Entry;
 
 import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
@@ -116,6 +118,10 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
     private ServiceFactoryPrx sf = null;
 
     private OMEROMetadataStoreClient store = null;
+
+    private Resources resources = null;
+
+    private Resources.Entry resourcesEntry = null;
 
     private OMEROWrapper reader = null;
 
@@ -173,6 +179,13 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         this.token = token;
     }
 
+    /**
+     * Late injection to not break the constructor
+     */
+    public void setResources(Resources resources) {
+        this.resources = resources;
+    }
+
     //
     // IRequest methods
     //
@@ -206,6 +219,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             store = new OMEROMetadataStoreClient();
             store.setCurrentLogFile(logFilename, token);
             store.initialize(sf);
+            registerKeepAlive();
 
             fileName = file.getFullFsPath();
             shortName = file.getName();
@@ -258,6 +272,41 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             throw helper.cancel(new ERR(), t, "error-on-init");
         } finally {
             MDC.clear();
+        }
+    }
+
+    /**
+     * If the {@link #setResources()} has been called with a non-null
+     * value, then create an {@link Entry} which will ping the
+     * {@link ServiceFactoryPrx} instance periodically to keep the import
+     * from timing out. This is especially important for autoClose imports
+     * since no other client is likely to keep them alive.
+     *
+     * If the ping fails, then the {@link Entry} returns null which will
+     * remove the instance for the {@link Resources} object. Otherwise,
+     * during {@link #cleanup()} remove will be called explicitly.
+     */
+    protected void registerKeepAlive() {
+        if (resources != null) {
+            resourcesEntry = new Entry() {
+                public boolean check() {
+                    try {
+                        if (sf != null) {
+                            log.info("-------------->keepalive");
+                            sf.keepAlive(null);
+                            return true;
+                        }
+                    } catch (Exception e) {
+                        log.warn("Proxy keep alive failed.", e);
+                    }
+                    return false;
+                }
+
+                public void cleanup() {
+                    // Nothing to do.
+                }
+            };
+            resources.add(resourcesEntry);
         }
     }
 
@@ -410,7 +459,10 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
 
             cleanupSession();
         } finally {
-            autoClose();
+            autoClose(); // Doesn't throw
+            if (resources != null) {
+                resources.remove(resourcesEntry);
+            }
         }
     }
 

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -292,7 +292,6 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
                 public boolean check() {
                     try {
                         if (sf != null) {
-                            log.info("-------------->keepalive");
                             sf.keepAlive(null);
                             return true;
                         }

--- a/components/blitz/src/ome/services/blitz/repo/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/ome/services/blitz/repo/RequestObjectFactoryRegistry.java
@@ -33,6 +33,8 @@ import ome.system.OmeroContext;
 import ome.formats.importer.ImportConfig;
 import ome.formats.importer.OMEROWrapper;
 
+import omero.util.Resources;
+
 
 /**
  * Requests which are handled by the repository servants.
@@ -50,16 +52,24 @@ public class RequestObjectFactoryRegistry extends
 
     private final PixelsService pixels;
 
+    private final Resources resources;
+
     private/* final */OmeroContext ctx;
 
     public RequestObjectFactoryRegistry(Registry reg, TileSizes sizes,
             RepositoryDao repositoryDao, Ring ring,
             PixelsService pixels) {
+        this(reg, sizes, repositoryDao, ring, pixels, null);
+    }
+    public RequestObjectFactoryRegistry(Registry reg, TileSizes sizes,
+            RepositoryDao repositoryDao, Ring ring,
+            PixelsService pixels, Resources resources) {
         this.reg = reg;
         this.sizes = sizes;
         this.dao = repositoryDao;
         this.ring = ring;
         this.pixels = pixels;
+        this.resources = resources;
     }
 
     public void setApplicationContext(ApplicationContext ctx)
@@ -73,12 +83,14 @@ public class RequestObjectFactoryRegistry extends
                 ManagedImportRequestI.ice_staticId()) {
             @Override
             public Ice.Object create(String name) {
-                return new ManagedImportRequestI(reg, sizes, dao,
+                ManagedImportRequestI mir = new ManagedImportRequestI(reg, sizes, dao,
                         new OMEROWrapper(
                                 new ImportConfig(),
                                 pixels.getMemoizerWait(),
                                 pixels.getMemoizerDirectory()),
                         ring.uuid);
+                mir.setResources(resources);
+                return mir;
             }
 
         });

--- a/components/blitz/src/omero/util/Resources.java
+++ b/components/blitz/src/omero/util/Resources.java
@@ -126,7 +126,7 @@ public class Resources {
         log.finest("Stopped");
     }
 
-    protected void remove(Entry entry) {
+    public void remove(Entry entry) {
         log.finest("Cleaning " + entry);
         try {
             entry.cleanup();

--- a/components/blitz/src/omero/util/Resources.java
+++ b/components/blitz/src/omero/util/Resources.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 /**
  * Container class for storing resources which should be cleaned up on close and
  * periodically checked.
- * 
+ *
  * Note: this class uses java.util.logging (JUL) rather than commons-logging
  * since it may be used on the client-side. Any use server-side will have logs
  * forwarded to log4j via slf4j.
@@ -104,6 +104,10 @@ public class Resources {
     }
 
     public void add(Entry entry) {
+        if (entry == null) {
+            log.warning("Entry null");
+            return;
+        }
         log.finest("Adding object " + entry);
         stuff.add(entry);
     }
@@ -111,9 +115,9 @@ public class Resources {
     public int size() {
         return stuff.size();
     }
-    
+
     public void cleanup() {
-        
+
         log.finest("Cleaning called");
 
         for (Entry entry : stuff) {
@@ -127,6 +131,10 @@ public class Resources {
     }
 
     public void remove(Entry entry) {
+        if (entry == null) {
+            log.warning("Entry null");
+            return;
+        }
         log.finest("Cleaning " + entry);
         try {
             entry.cleanup();

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -241,11 +241,11 @@ class TestImport(CLITest):
 
         # Check that there are no servants leftover
         stateful = []
-        for x in range(10):
+        for x in range(1000):
             stateful = self.client.getStatefulServices()
             if stateful:
                 import time
-                time.sleep(0.5)  # Give the backend some time to close
+                time.sleep(0.1)  # Give the backend some time to close
             else:
                 break
 


### PR DESCRIPTION
Recently reported by Christian Sachs, when `--auto_close` is
used, long-running imports may die in unusual ways. This maintains
a keep-alive as long as the `ManagedImportRequestI` servant is
open.

Testing this was facilitated by placing an artificial sleep in

```
@@ -1593,6 +1593,12 @@ public class OMEROMetadataStoreClient
     public void setPixelsFile(long pixelsId, String file, String repo) throws ServerError {
```

and setting the default session timeout to 10 seconds.

See:
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-January/005791.html