### PR TITLE
Eschew edu.emory.mathcs.backport imports

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.Box;
@@ -38,9 +39,6 @@ import omero.gateway.model.RatingAnnotationData;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.util.ui.RatingComponent;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
-
-import edu.emory.mathcs.backport.java.util.Collections;
-
 
 /**
  * A {@link AnnotationTaskPaneUI} for displaying the user rating
@@ -185,7 +183,7 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
     @Override
     List<AnnotationData> getAnnotationsToSave() {
         if (selectedValue != originalValue)
-            return Collections.singletonList(new RatingAnnotationData(selectedValue));
+            return Collections.<AnnotationData>singletonList(new RatingAnnotationData(selectedValue));
         else
             return Collections.emptyList();
     }
@@ -195,7 +193,7 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         if (selectedValue != originalValue && selectedValue == 0) {
             RatingAnnotationData rating = model.getUserRatingAnnotation();
             if (rating != null) 
-                return Collections.singletonList(rating);
+                return Collections.<Object>singletonList(rating);
         }
         return Collections.emptyList();
     }

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -65,6 +65,9 @@ java_test()
     # format statement, any use must be escaped as '%%'.
     if [[ "2" -ne $(git grep -E '[^%]%[^%]' components/dsl/resources/ome/dsl/  | wc -l) ]]; then exit 2; fi
 
+    # Check for IDE auto-import of certainly unintended Java package.
+    git grep -q '^import edu\.emory\.mathcs\.backport\.' && exit 2
+
     # make sure that the current db script has no code-generated
     # foreign key names in it
     dist/bin/omero db script "" "" ome -f- | grep -LiE "fk[a-z]*[0-9]+[a-z0-9]{5}" && {


### PR DESCRIPTION
Travis should be red until https://github.com/openmicroscopy/openmicroscopy/pull/4347#discussion_r52726799 is fixed to remove,
```java
import edu.emory.mathcs.backport.java.util.Arrays;
```
Then, restarting travis for *this* PR should turn it green.

--no-rebase
--depends-on #4347