### PR TITLE
13074 autoclose anotations

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -327,7 +327,10 @@ public class ImportContainer
                 : rstring(getUserSpecifiedName());
         settings.userSpecifiedDescription = getUserSpecifiedDescription() == null ? null
                 : rstring(getUserSpecifiedDescription());
-        settings.userSpecifiedAnnotationList = getCustomAnnotationList();
+        // Creating a new list so that later additions aren't propagated
+        // to further images. trac:13074
+        settings.userSpecifiedAnnotationList = new ArrayList<Annotation>(
+                getCustomAnnotationList());
 
         // 5.0.x: pass an annotation
         if (config.autoClose.get()) {

--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -329,8 +329,8 @@ public class ImportContainer
                 : rstring(getUserSpecifiedDescription());
         // Creating a new list so that later additions aren't propagated
         // to further images. trac:13074
-        settings.userSpecifiedAnnotationList = new ArrayList<Annotation>(
-                getCustomAnnotationList());
+        settings.userSpecifiedAnnotationList = getCustomAnnotationList() == null ? null :
+            new ArrayList<Annotation>(getCustomAnnotationList());
 
         // 5.0.x: pass an annotation
         if (config.autoClose.get()) {

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -251,7 +251,7 @@ class TestImport(CLITest):
 
         assert len(stateful) == 0
 
-    @pytest.mark.parametrize("args", [
+    CA_TESTS = [
         (False, 'Adler-32'),  # one underscore only
         (True, 'Adler-32'),
         (True, 'CRC-32'),
@@ -259,7 +259,11 @@ class TestImport(CLITest):
         (True, 'MD5-128'),
         (True, 'Murmur3-32'),
         (True, 'Murmur3-128'),
-        (True, 'SHA1-160')])
+        (True, 'SHA1-160')]
+    CA_NAMES = ["%s-%s" % (x[1], x[0] and "underscore" or "legacy")
+                for x in CA_TESTS]
+
+    @pytest.mark.parametrize("args", CA_TESTS, ids=CA_NAMES)
     def testChecksumAlgorithm(self, tmpdir, capfd, args):
         """Test checksum algorithm argument"""
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -251,13 +251,20 @@ class TestImport(CLITest):
 
         assert len(stateful) == 0
 
-    @pytest.mark.parametrize("arg", [
-        '--checksum-algorithm', '--checksum_algorithm'])
-    @pytest.mark.parametrize("algorithm", [
-        'Adler-32', 'CRC-32', 'File-Size-64', 'MD5-128', 'Murmur3-32',
-        'Murmur3-128', 'SHA1-160'])
-    def testChecksumAlgorithm(self, tmpdir, capfd, arg, algorithm):
+    @pytest.mark.parametrize("args", [
+        (False, 'Adler-32'),  # one underscore only
+        (True, 'Adler-32'),
+        (True, 'CRC-32'),
+        (True, 'File-Size-64'),
+        (True, 'MD5-128'),
+        (True, 'Murmur3-32'),
+        (True, 'Murmur3-128'),
+        (True, 'SHA1-160')])
+    def testChecksumAlgorithm(self, tmpdir, capfd, args):
         """Test checksum algorithm argument"""
+
+        dash, algorithm = args
+        arg = dash and '--checksum-algorithm' or '--checksum_algorithm'
 
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')


### PR DESCRIPTION
Fixes the error reported by @mtbc in https://trac.openmicroscopy.org/ome/ticket/13074

To test:

```
mkdir fakes
for x in $(seq 10 20); do touch $x.fake; done
bin/omero import -- --auto_close --annotation-text foo --annotation-ns foo fakes/
bin/omero -q hql "select i.id, a.ns, count(a.id) from Image i join i.annotationLinks l join l.child a group by i.id, a.ns order by i.id desc"
```

**Without this PR** one sees:

```
 #  | Col1 | Col2                                      | Col3
----+------+-------------------------------------------+------
 0  | 144  | foo                                       | 1
 1  | 144  | openmicroscopy.org/omero/import/autoClose | 11
 2  | 143  | foo                                       | 1
 3  | 143  | openmicroscopy.org/omero/import/autoClose | 10
 4  | 142  | foo                                       | 1
 5  | 142  | openmicroscopy.org/omero/import/autoClose | 9
 6  | 141  | foo                                       | 1
 7  | 141  | openmicroscopy.org/omero/import/autoClose | 8
 8  | 140  | foo                                       | 1
 9  | 140  | openmicroscopy.org/omero/import/autoClose | 7
 10 | 139  | foo                                       | 1
 11 | 139  | openmicroscopy.org/omero/import/autoClose | 6
 12 | 138  | foo                                       | 1
 13 | 138  | openmicroscopy.org/omero/import/autoClose | 5
 14 | 137  | foo                                       | 1
 15 | 137  | openmicroscopy.org/omero/import/autoClose | 4
 16 | 136  | foo                                       | 1
 17 | 136  | openmicroscopy.org/omero/import/autoClose | 3
 18 | 135  | foo                                       | 1
 19 | 135  | openmicroscopy.org/omero/import/autoClose | 2

```

**With** this PR:
```
 #  | Col1 | Col2                                      | Col3
----+------+-------------------------------------------+------
 0  | 159  | foo                                       | 1
 1  | 159  | openmicroscopy.org/omero/import/autoClose | 1
 2  | 158  | foo                                       | 1
 3  | 158  | openmicroscopy.org/omero/import/autoClose | 1
 4  | 157  | foo                                       | 1
 5  | 157  | openmicroscopy.org/omero/import/autoClose | 1
 6  | 156  | foo                                       | 1
 7  | 156  | openmicroscopy.org/omero/import/autoClose | 1
 8  | 155  | foo                                       | 1
 9  | 155  | openmicroscopy.org/omero/import/autoClose | 1
 10 | 154  | foo                                       | 1
 11 | 154  | openmicroscopy.org/omero/import/autoClose | 1
 12 | 153  | foo                                       | 1
 13 | 153  | openmicroscopy.org/omero/import/autoClose | 1
 14 | 152  | foo                                       | 1
 15 | 152  | openmicroscopy.org/omero/import/autoClose | 1
 16 | 151  | foo                                       | 1
 17 | 151  | openmicroscopy.org/omero/import/autoClose | 1
(18 rows)
```

Note: the test_import.py test is not directly related to this change, but does speed up the time taken to run `test_import.py`