### PR TITLE
Use bash in travis-build

### DIFF
--- a/components/blitz/src/omero/gateway/facility/TransferFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TransferFacility.java
@@ -22,8 +22,8 @@ package omero.gateway.facility;
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.Arrays;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
 import ome.formats.importer.IObserver;
 import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script is used for testing the build, primarily for use
 # with travis, but may be used by hand as well.
 


### PR DESCRIPTION
The use of `sh` led to failures of the form:

```
./components/tools/travis-build: 66: ./components/tools/travis-build: [[: not found]]
```

See:
https://trello.com/c/Bh0YqjQU/631-fix-bashism-in-travis-shell-script

cc: @sbesson 