### PR TITLE
Add OMERO.web viewer view configurability

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -494,6 +494,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.webgateway_cache":
         ["WEBGATEWAY_CACHE", None, leave_none_unset, None],
 
+    # VIEWER
+    "omero.web.viewer.view":
+        ["VIEWER_VIEW",
+         'omeroweb.webclient.views.image_viewer',
+         str,
+         ("Django view which handles display of, or redirection to, the "
+          "desired full image viewer.")],
+
     # PIPELINE 1.3.20
 
     # Pipeline is an asset packaging library for Django, providing both CSS

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -23,6 +23,7 @@
 # Version: 1.0
 #
 
+from django.conf import settings
 from django.conf.urls import url, patterns
 
 from omeroweb.webclient import views
@@ -153,7 +154,7 @@ urlpatterns = patterns(
         {'download': True},
         name="web_render_image_download"),
     url(r'^(?:(?P<share_id>[0-9]+)/)?img_detail/(?P<iid>[0-9]+)/$',
-        views.image_viewer,
+        settings.VIEWER_VIEW,
         name="web_image_viewer"),
     url(r'^(?:(?P<share_id>[0-9]+)/)?imgData/(?P<iid>[0-9]+)/$',
         webgateway.imageData_json,

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -30,7 +30,7 @@ from omeroweb.webgateway import views as webgateway
 from omeroweb.webclient.webclient_gateway import defaultThumbnail
 
 urlpatterns = patterns(
-    'django.views.generic.simple',
+    '',
 
     # Home page is the main 'Data' page
     url(r'^$', views.load_template, {'menu': 'userdata'}, name="webindex"),


### PR DESCRIPTION
Add OMERO.web viewer view configurability which allows for the complete override or installation of a redirect view for the existing full viewer. This is particularly useful where an OMERO.web plugin is being used in production that replaces or extends the current full viewer, during development or during proof of concept work on new full viewer technology.

Out of the box there should be no affect on existing functionality. The additional configuration option is `omeroweb.web.viewer.view` and this accepts a fully qualified view function name which defaults to `omeroweb.webclient.views.image_viewer`. It can be tested at a very basic level by running the following:

```
    bin/omero config set omero.web.viewer.view 'omeroweb.webclient.views.list_scripts'
```

This will display the current list of scripts in the full viewer window, as JSON, when an image thumbnail is doubled clicked on or the "Full Viewer" button in the right hand panel is clicked.

If a plugin wants to perform a conditional redirect, maintaining existing full viewer functionality for the majority of images, adding the following to its `urls.py` is likely desired:

```
...
    url(
        r'^vanilla-viewer/(?P<iid>\d+)/$', webclient_views.image_viewer,
        name='myviewer-vanilla-viewer'
    ),
...
```

A view similar to the following, which would be the target of `omero.web.viewer.view`, is then possible:

```
...
@login_required()
def viewer_redirect(request, iid, conn=None, **kwargs):
    """
    Use regular viewer, except when image name contains 'test'
    """
    image = conn.getObject('Image', iid)
    if image is not None:
        try:
            if 'test' in image.name:
                return HttpResponseRedirect(reverse('myviewer-viewer', args=(iid,)))
        except:
            pass
    return HttpResponseRedirect(reverse('myviewer-vanilla-viewer', args=(iid,)))
...
```
/cc @jburel, @joshmoore 