### PR TITLE
Viewer prev next btns

### DIFF
--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -10,24 +10,6 @@ Library           Collections
 Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
 Suite Teardown      Close all browsers
 
-*** Test Cases ***
-
-Test Open Viewer
-    [Documentation]     Tests double-click to open image viewer
-
-    Tree Should Be Visible
-    ${imageId}=                         Select And Expand Image
-    ${nodeId}=                          Wait For Image Node         ${imageId}
-    ${imageName}=                       Wait For General Panel And Return Name      Image
-    # Open Image Viewer 3 different ways and check
-    Click Element                       xpath=//button[@title='Open full image viewer in new window']
-    Check Image Viewer                  ${imageName}
-    Double Click Element                xpath=//li[@id='image_icon-${imageId}']//img
-    Check Image Viewer                  ${imageName}
-    Double Click Element                css=#${nodeId}>a
-    Check Image Viewer                  ${imageName}
-
-
 *** Keywords ***
 
 Check Image Viewer
@@ -46,3 +28,42 @@ Check Image Viewer
     Close Window
     # Select parent window
     Select Window
+
+*** Test Cases ***
+
+Test Open Viewer
+    [Documentation]     Tests double-click to open image viewer
+
+    Tree Should Be Visible
+    ${imageId}=                         Select And Expand Image
+    ${nodeId}=                          Wait For Image Node         ${imageId}
+    ${imageName}=                       Wait For General Panel And Return Name      Image
+    # Open Image Viewer 3 different ways and check
+    Click Element                       xpath=//button[@title='Open full image viewer in new window']
+    Check Image Viewer                  ${imageName}
+    Double Click Element                xpath=//li[@id='image_icon-${imageId}']//img
+    Check Image Viewer                  ${imageName}
+    Double Click Element                css=#${nodeId}>a
+    Check Image Viewer                  ${imageName}
+
+
+Test Prev Next Buttons
+
+    ${imageId}=                         Select And Expand Image
+    ${nodeId}=                          Wait For Image Node         ${imageId}
+    ${imageName}=                       Wait For General Panel And Return Name      Image
+    # Check we have a 'Next' image, but no 'Previous' image
+    Page Should Contain Element         xpath=//ul[@id='dataIcons']/li[contains(@class, 'ui-selected')]/following-sibling::li[contains(@class, 'row')]
+    Page Should Not Contain Element     xpath=//ul[@id='dataIcons']/li[contains(@class, 'ui-selected')]/preceding-sibling::li[contains(@class, 'row')]
+
+    # Open image viewer
+    Double Click Element                css=#${nodeId}>a
+    Wait Until Keyword Succeeds  ${TIMEOUT}     ${INTERVAL}     Select Window   title=${imageName}
+
+    # Prev button should be disabled, Next button enabled
+    Element Should Be Disabled          id=prevImage
+    Element Should Be Enabled           id=nextImage
+
+    # Clicking Next button will enable Prev button
+    Click Element                       id=nextImage
+    Wait Until Page Contains Element    xpath=//button[@id='prevImage' and not (@disabled='disabled')]

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -974,10 +974,10 @@
           </div>
 {% endblock roi_buttons %}
           <div class="odd row">
-             <button class="btn prev_next_image prev" title="Previous Image" disabled="disabled">
+             <button id="prevImage" class="btn prev_next_image" title="Previous Image" disabled="disabled">
                 <span>< Prev</span>
             </button>
-            <button class="btn prev_next_image next" title="Next Image" disabled="disabled">
+            <button id="nextImage" class="btn prev_next_image" title="Next Image" disabled="disabled">
                 <span>Next ></span>
             </button>
           </div>
@@ -1396,12 +1396,10 @@
       }
       // Enable Prev / Next buttons if available (disabled by default)
       if (prevImgId) {
-        $(".btn.prev_next_image.prev").removeAttr('disabled')
-                                      .prop('disabled', false);
+        $("#prevImage").removeAttr('disabled').prop('disabled', false);
       }
       if (nextImgId) {
-        $(".btn.prev_next_image.next").removeAttr('disabled')
-                                      .prop('disabled', false);
+        $("#nextImage").removeAttr('disabled').prop('disabled', false);
       }
 
       // Handle Prev / Next button clicks or keys
@@ -1437,12 +1435,11 @@
           e.preventDefault();
       });
 
-      $(".btn.prev_next_image").click(function(){
-          if ( $(this).hasClass('prev') ){
-              nextPrevImage(-1);
-          } else {
-              nextPrevImage(1);
-          }
+      $("#prevImage").click(function(){
+        nextPrevImage(-1);
+      });
+      $("#nextImage").click(function(){
+        nextPrevImage(1);
       });
     }
     

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1378,8 +1378,10 @@
           prevImgId, nextImgId;
       if ($currentImg.length === 1) {
         // Main thumbnails window
-        var prevImgId = $currentImg.prevAll(":visible").first().find("img").attr('id');
-        var nextImgId = $currentImg.nextAll(":visible").first().find("img").attr('id');
+        prevImgId = $currentImg.prevAll(":visible").first().attr('id');
+        if (prevImgId) {prevImgId = prevImgId.split('image_icon-')[1]}
+        nextImgId = $currentImg.nextAll(":visible").first().attr('id');
+        if (nextImgId) {nextImgId = nextImgId.split('image_icon-')[1]}
       } else if ($currentImg.length === 0) {
         // if not found, try "Search" results page layout
         $currentImg = window.opener.$("#image-{{ image.id }}");

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1394,35 +1394,28 @@
           nextImgId = nextImgId.split('image-')[1];
         }
       }
-
       // Enable Prev / Next buttons if available (disabled by default)
       if (prevImgId) {
-        $(".btn.prev_next_image.prev").removeAttr('disabled');
+        $(".btn.prev_next_image.prev").removeAttr('disabled')
+                                      .prop('disabled', false);
       }
       if (nextImgId) {
-        $(".btn.prev_next_image.next").removeAttr('disabled');
+        $(".btn.prev_next_image.next").removeAttr('disabled')
+                                      .prop('disabled', false);
       }
 
-    // Enable Prev / Next buttons if available (disabled by default)
-    if (prevImgId) {
-      $(".btn.prev_next_image.prev").prop('disabled', false);
-    }
-    if (nextImgId) {
-      $(".btn.prev_next_image.next").prop('disabled', false);
-    }
-
-    // Handle Prev / Next button clicks or keys
-    function nextPrevImage(direction) {
-      var id;
-      if( direction == -1 ) {
-        id = prevImgId;
-      } else {
-        id = nextImgId
+      // Handle Prev / Next button clicks or keys
+      function nextPrevImage(direction) {
+        var id;
+        if( direction == -1 ) {
+          id = prevImgId;
+        } else {
+          id = nextImgId
+        }
+        if( id ) {
+          window.location.href = "{{ viewport_server }}/img_detail/" + id
+        }
       }
-      if( id ) {
-        window.location.href = "{{ viewport_server }}/img_detail/" + id
-      }
-    }
 
       // Prev / Next keys
       $(document).keydown(function(e) {


### PR DESCRIPTION
This fixes the broken "Prev" and "Next" buttons in the image viewer (were always disabled).
Bug is in 5.2.1, probably as a result of https://github.com/openmicroscopy/openmicroscopy/pull/4242

To test:
 - Open a Dataset with multiple images, double click first image to open viewer.
 - "Next" button should be enabled, allowing you to move to next image
 - "Prev" button should be disabled when viewing first image, but become enabled for other images.
 - Check that new Robot test is passing.