### PR TITLE
Fix editing of map annotation values containing single quote

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -144,7 +144,7 @@
                     $td.prev().text("");
                 }
             }
-            $input = $("<input value='" + value + "' />");
+            $input = $("<input />").attr('value', value);
             $td.empty().append($input);
             $input.focus();
             $input.get(0).select();


### PR DESCRIPTION
Just found this bug (hence the last minute PR).
Fixes editng keys or values in map annotations with single quotes in them.

To test:
 - Edit keys and values in a Map Annotation, including a single quote in the text.
 - When you re-edit the text, the text field should be correctly with the text, without truncating at the quote mark.