### PR TITLE
refactor the generation of the model object glossary

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -414,7 +414,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                         }
                     }
                     /* process property values that do not relate to edges in the model object graph */
-                    for (final String property : graphPathBean.getSimpleProperties(superclassName)) {
+                    for (final String property : graphPathBean.getSimpleProperties(superclassName, false)) {
                         /* ignore inaccessible properties */
                         if (!graphPathBean.isPropertyAccessible(superclassName, property)) {
                             continue;

--- a/components/server/src/ome/services/graphs/GraphPathBean.java
+++ b/components/server/src/ome/services/graphs/GraphPathBean.java
@@ -566,6 +566,17 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
     }
 
     /**
+     * Get the <q>simple</q> non-nested properties for the given class, not linking to other mapped classes.
+     * @param className the name of a class
+     * @return the <q>simple</q> properties of the given class; never {@code null}
+     * @deprecated instead use {@link #getSimpleProperties(String, boolean)} setting {@code isNested} to {@code false}
+     */
+    @Deprecated
+    public Set<String> getSimpleProperties(String className) {
+        return getSimpleProperties(className, false);
+    }
+
+    /**
      * Get the <q>simple</q> properties for the given class, not linking to other mapped classes.
      * @param className the name of a class
      * @param isNested if nested properties should have all components given separately with dot-notation


### PR DESCRIPTION
This PR refactors the graph path bean to offer the information required to construct the model object report. (The bean's API changes are fairly simple and minimal; it isn't worth putting much design work into it until the extended metadata functionality is understood then subsumed.) The model object report code is thus made far simpler without changing the output. Broadly, this PR should bring fewer code lines with no regressions. To generate the report used as the source for http://www.openmicroscopy.org/site/support/omero/developers/Model/EveryObject.html enter something like,
```
java -cp lib/server/\* `bin/omero config get | awk '{print"-D"$1}'` ome.services.graphs.GraphPathReport EveryObject.txt
```
which is how https://github.com/openmicroscopy/ome-documentation/pull/1408 was created.