### PR TITLE
5.2.2 version history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,34 @@
 OMERO version history
 =====================
 
+5.2.2 (February 2016)
+---------------------
+
+A bug-fix release covering all components. Improvements include:
+
+-  measurement tool fixes
+-  support for units in the OMERO.web image viewer scalebar
+-  OMERO.web fixes to improve synchronicity when deleting many images
+-  better handling of dates in search
+-  client support for map annotations in OME.tiff
+-  fixes for displaying bulk annotations script in OMERO.insight
+-  OMERO.web clean-up to remove defunct volume viewer
+
+Developer updates include:
+
+-  OMERO.tables documentation extended
+-  updating 'What's New for developers' to clarify that ``pogos`` has been
+   renamed as ``omero.gateway.model``
+-  dynamic scripts functionality documented
+
+System administrator updates include:
+
+-  new configurations for fixing OMERO.web download issues
+-  documentation of hard-linking issues for in-place import on linux systems
+
+Note that the OMERO Virtual Appliance has been discontinued and will not be
+updated for version 5.2.2 or any later releases.
+
 5.2.1 (December 2015)
 ---------------------
 

--- a/history.txt
+++ b/history.txt
@@ -4,26 +4,37 @@ OMERO version history
 5.2.2 (February 2016)
 ---------------------
 
-A bug-fix release covering all components. Improvements include:
+A bug-fix release which also introduces some new client features. Improvements
+include:
 
+-  display of ROI masks in OMERO.web image viewer
+-  display of OMERO.tables data for Wells in the OMERO.web right hand panel
+-  'Populate Metadata' script to enable generation of OMERO.tables for
+   Wells is now usable from both OMERO.web and OMERO.insight (note this is
+   still in development and has some limitations)
 -  measurement tool fixes
--  support for units in the OMERO.web image viewer scalebar
--  OMERO.web fixes to improve synchronicity when deleting many images
+-  fixed pixel size metadata and scalebar in OMERO.web image viewer for images
+   with pixel size units other than micrometer
+-  fixed OMERO.web handling of turning off interpolation of pixels
+-  previous and next buttons fixed in OMERO.web image viewer
+-  delete and change group performance improvements
 -  better handling of dates in search
 -  client support for map annotations in OME.tiff
--  fixes for displaying bulk annotations script in OMERO.insight
--  OMERO.web clean-up to remove defunct volume viewer
+-  disabled orphaned container feature
+-  OMERO.web clean-up to remove obsolete volume viewer
 
 Developer updates include:
 
+-  Python API examples for creating Polygon and Mask shapes
 -  OMERO.tables documentation extended
--  updating 'What's New for developers' to clarify that ``pojos`` has been
+-  updated 'What's New for developers' to clarify that ``pojos`` has been
    renamed as ``omero.gateway.model``
 -  dynamic scripts functionality documented
 
 System administrator updates include:
 
--  new configurations for fixing OMERO.web download issues
+-  clarification of OMERO.web documentation, including an experimental
+   solution to resolve download issues
 -  documentation of hard-linking issues for in-place import on linux systems
 
 Note that the OMERO Virtual Appliance has been discontinued and will not be

--- a/history.txt
+++ b/history.txt
@@ -19,7 +19,7 @@ include:
 -  previous and next buttons fixed in OMERO.web image viewer
 -  delete and change group performance improvements
 -  better handling of dates in search
--  client support for map annotations in OME.tiff
+-  client support for map annotations in OME-TIFF
 -  disabled orphaned container feature
 -  OMERO.web clean-up to remove obsolete volume viewer
 

--- a/history.txt
+++ b/history.txt
@@ -36,8 +36,8 @@ Developer updates include:
 
 System administrator updates include:
 
--  clarification of OMERO.web documentation, including an experimental
-   solution to resolve download issues
+-  clarification of OMERO.web documentation for nginx deployment, including an
+   experimental solution to resolve download issues
 -  documentation of hard-linking issues for in-place import on linux systems
 
 Note that the OMERO Virtual Appliance has been discontinued and will not be

--- a/history.txt
+++ b/history.txt
@@ -26,10 +26,13 @@ include:
 Developer updates include:
 
 -  Python API examples for creating Polygon and Mask shapes
+-  Python API example for "Populate Metadata" to create OMERO.tables for
+   Wells
 -  OMERO.tables documentation extended
 -  updated 'What's New for developers' to clarify that ``pojos`` has been
    renamed as ``omero.gateway.model``
 -  dynamic scripts functionality documented
+-  dynamic loading of omero.client server settings into HTTP sessions
 
 System administrator updates include:
 

--- a/history.txt
+++ b/history.txt
@@ -17,7 +17,7 @@ A bug-fix release covering all components. Improvements include:
 Developer updates include:
 
 -  OMERO.tables documentation extended
--  updating 'What's New for developers' to clarify that ``pogos`` has been
+-  updating 'What's New for developers' to clarify that ``pojos`` has been
    renamed as ``omero.gateway.model``
 -  dynamic scripts functionality documented
 


### PR DESCRIPTION
Will be staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/users/history.html but not until the autogen branches have been updated so initial review should be of the text and I'll check the formatting later (although it should be fine).