### PR TITLE
Insight folders Step 3.0 - Bugfixes - 2

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -558,6 +558,8 @@ public class ROINode
                 // therefore take a step of length 2 to get the folder node
                 ROINode folder = (ROINode) path.getPathComponent(path
                         .getPathCount() - 3);
+                if (folder.isRoot())
+                    return shape.isVisible();
                 if (b == null)
                     b = folder.isVisible();
                 else

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -97,6 +97,7 @@ import omero.gateway.model.GroupData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.model.ROIData;
+import omero.gateway.util.Pojos;
 import ome.model.units.BigResult;
 import omero.model.Length;
 import omero.model.LengthI;
@@ -1228,6 +1229,16 @@ class MeasurementViewerModel
      *            The Folders
      */
     void deleteFolders(Collection<FolderData> folders) {
+        // remove from the local data model
+        Collection<Long> ids = Pojos.extractIds(folders);
+        Iterator<FolderData> it = this.folders.iterator();
+        while(it.hasNext()) {
+            FolderData f = it.next();
+            if(ids.contains(f.getId()))
+                it.remove();
+        }
+        
+        // delete on the server
         ExperimenterData exp = (ExperimenterData) MeasurementAgent
                 .getUserDetails();
         currentSaver = new ROIFolderSaver(component, getSecurityContext(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -1229,16 +1229,6 @@ class MeasurementViewerModel
      *            The Folders
      */
     void deleteFolders(Collection<FolderData> folders) {
-        // remove from the local data model
-        Collection<Long> ids = Pojos.extractIds(folders);
-        Iterator<FolderData> it = this.folders.iterator();
-        while(it.hasNext()) {
-            FolderData f = it.next();
-            if(ids.contains(f.getId()))
-                it.remove();
-        }
-        
-        // delete on the server
         ExperimenterData exp = (ExperimenterData) MeasurementAgent
                 .getUserDetails();
         currentSaver = new ROIFolderSaver(component, getSecurityContext(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -97,7 +97,6 @@ import omero.gateway.model.GroupData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.model.ROIData;
-import omero.gateway.util.Pojos;
 import ome.model.units.BigResult;
 import omero.model.Length;
 import omero.model.LengthI;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -123,7 +123,7 @@ class MeasurementViewerUI
 	static final String DEFAULT_MSG = "";
 	
 	/** The default size of the window. */
-	private static final Dimension DEFAULT_SIZE = new Dimension(400, 300);
+	private static final Dimension DEFAULT_SIZE = new Dimension(500, 300);
 
 	/** The title for the measurement tool main window. */
 	private static final String WINDOW_TITLE = "";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -114,7 +114,7 @@ class ObjectManager
 	
 	static{
 		COLUMN_WIDTHS = new HashMap<String, Integer>();
-        COLUMN_WIDTHS.put(COLUMN_NAMES.get(0), 80);
+        COLUMN_WIDTHS.put(COLUMN_NAMES.get(0), 180);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(1), 36);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(2), 36);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(3), 36);
@@ -284,6 +284,7 @@ class ObjectManager
         }
         objectsTable.collapseAll();
         objectsTable.expandFolders(expandedFolderIds);
+        objectsTable.setAutoCreateColumnsFromModel( false );
     }
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
 
@@ -41,10 +42,6 @@ import javax.swing.JScrollPane;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.TreeSelectionModel;
-
-
-
-
 
 
 //Third-party libraries
@@ -72,6 +69,7 @@ import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FolderData;
 import omero.gateway.model.ROIData;
+import omero.gateway.util.Pojos;
 import omero.log.LogMessage;
 
 /** 
@@ -265,26 +263,28 @@ class ObjectManager
     	objectsTable.showROIManagementMenu(view.getDrawingView(), x, y);
     }
     
-	/** Rebuilds Tree */
-	void rebuildTable()
-	{
-		TreeMap<Long, ROI> roiList = model.getROI();
-		Iterator<ROI> iterator = roiList.values().iterator();
-		ROI roi;
-		TreeMap<Coord3D, ROIShape> shapeList;
-		Iterator<ROIShape> shapeIterator;
-		objectsTable.clear();
-		objectsTable.initFolders(getFolders());
-		while(iterator.hasNext())
-		{
-			roi = iterator.next();
-			shapeList = roi.getShapes();
-			shapeIterator = shapeList.values().iterator();
-			while (shapeIterator.hasNext())
-				objectsTable.addROIShape(shapeIterator.next());
-		}
-		objectsTable.collapseAll();
-	}
+    /** Rebuilds Tree */
+    void rebuildTable() {
+        TreeMap<Long, ROI> roiList = model.getROI();
+        Iterator<ROI> iterator = roiList.values().iterator();
+        ROI roi;
+        TreeMap<Coord3D, ROIShape> shapeList;
+        Iterator<ROIShape> shapeIterator;
+        Set<Long> expandedFolderIds = objectsTable.getExpandedFolders();
+        expandedFolderIds.addAll(Pojos.extractIds(objectsTable
+                .getRecentlyModifiedFolders()));
+        objectsTable.clear();
+        objectsTable.initFolders(getFolders());
+        while (iterator.hasNext()) {
+            roi = iterator.next();
+            shapeList = roi.getShapes();
+            shapeIterator = shapeList.values().iterator();
+            while (shapeIterator.hasNext())
+                objectsTable.addROIShape(shapeIterator.next());
+        }
+        objectsTable.collapseAll();
+        objectsTable.expandFolders(expandedFolderIds);
+    }
 	
 	/**
 	 * Returns the name of the component.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -369,7 +369,7 @@ public class ROITable
     Set<Long> getExpandedFolders() {
         Set<Long> result = new HashSet<Long>();
         for (ROINode node : nodes) {
-            if (node.isExpanded() && node.isFolderNode() && node.containsROIs())
+            if (node.isExpanded() && node.isFolderNode())
                 result.add(((FolderData) node.getUserObject()).getId());
         }
         return result;
@@ -1368,6 +1368,7 @@ public class ROITable
             FolderData folder = (FolderData) evt.getNewValue();
             if(action == CreationActionType.CREATE_FOLDER && parent!=null) {
                 folder.setParentFolder(parent.asFolder());
+                recentlyModifiedFolders.add(parent);
             }
             
             toSave.add(folder);
@@ -1379,6 +1380,7 @@ public class ROITable
             FolderData folder = getSelectedFolders().get(0);
             FolderData target = (FolderData) evt.getNewValue();
             folder.setParentFolder(target.asFolder());
+            recentlyModifiedFolders.add(target);
             manager.saveROIFolders(Collections.singleton(folder));
         }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
@@ -492,6 +492,9 @@ public class SelectionWizard
             if (CommonsLangUtils.isEmpty(name))
                 return;
             String description = descriptionField.getText();
+            if (DEFAULT_DESCRIPTION.equals(description)) {
+                description = null;
+            }
             FolderData folder = new FolderData();
             folder.setName(name);
             folder.setDescription(description);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
@@ -44,15 +44,26 @@ import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 public class ROIFolderSaver extends BatchCallTree {
+    
+    /**
+     * The actions which this {@link ROIFolderSaver} can handle
+     */
     public enum ROIFolderAction {
-        ADD_TO_FOLDER, REMOVE_FROM_FOLDER, CREATE_FOLDER, DELETE_FOLDER
+        /** Add ROIs to Folder */
+        ADD_TO_FOLDER, 
+        /** Remove ROIs from Folder */
+        REMOVE_FROM_FOLDER, 
+        /** Create Folder */
+        CREATE_FOLDER, 
+        /** Delete Folder */
+        DELETE_FOLDER
     }
 
     /** Call to save the ROIs. */
     private BatchCall saveCall;
 
     /** Was the save successful. */
-    private Collection result;
+    private Collection<ROIData> result;
 
     /**
      * Creates a {@link BatchCall} to load the ROIs.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
@@ -25,13 +25,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import omero.cmd.CmdCallbackI;
 import omero.gateway.SecurityContext;
 import omero.gateway.facility.DataManagerFacility;
 import omero.gateway.facility.ROIFacility;
-import omero.gateway.model.DataObject;
 import omero.gateway.model.FolderData;
 import omero.gateway.model.ROIData;
-import omero.gateway.util.Pojos;
 import omero.model.IObject;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -53,7 +52,7 @@ public class ROIFolderSaver extends BatchCallTree {
     private BatchCall saveCall;
 
     /** Was the save successful. */
-    private Collection<ROIData> result;
+    private Collection result;
 
     /**
      * Creates a {@link BatchCall} to load the ROIs.
@@ -86,7 +85,9 @@ public class ROIFolderSaver extends BatchCallTree {
                     for (FolderData f : folders)
                         ifolders.add((IObject) f.asFolder());
 
-                    dm.delete(ctx, ifolders);
+                    CmdCallbackI cb = dm.delete(ctx, ifolders);
+                    // wait for the delete action to be finished
+                    cb.block(10000);
                 } 
                 result = Collections.EMPTY_LIST;
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
@@ -449,7 +449,7 @@ public class OMETreeTable
 			(MutableTreeTableNode) getTreeTableModel().getRoot();
 		if (root == null) return;
 		for (MutableTreeTableNode node : ((OMETreeNode) root).getChildList())
-			((OMETreeNode) node).setExpanded(true);
+			((OMETreeNode) node).setExpanded(false);
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/model/OMETreeNode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/model/OMETreeNode.java
@@ -91,6 +91,15 @@ public class OMETreeNode
 	 */
 	public boolean isExpanded() { return expanded; }
 	
+    /**
+     * Return <code>true</code> if this node is a root node
+     * 
+     * @return See above.
+     */
+    public boolean isRoot() {
+        return getPath().getPathCount() == 1;
+    }
+	
 	/**
 	 * Sets the current node to expanded.
 	 * 


### PR DESCRIPTION
The next bugfix PR, see [Trello - ROI Folders Insight Bugs](https://trello.com/c/XUI38KAp/27-roi-folders-insight-bugs)

Fixed:
- Changes of folder visibility won't affect orphaned ROIs any more.
- Expanded folders will stay expanded after the ROI table is refreshed (e. g. after a "add folders" action); additionally modified folders (e. g. if ROIs are moved to a folder) will be expanded, too (is this helpful, your thoughts @pwalczysko ? ).
- Deleted folders will immediately be removed from the table
- The column width is preserved after table refresh
- Folders created via 'Add ROIs to Folder" dialog won't have "Description" as Folder description any more.
