### PR TITLE
try harder to guess MIME type

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1069,7 +1070,16 @@ public class client {
         }
 
         if (fileObject.getMimetype() == null) {
-            fileObject.setMimetype(rstring("application/octet-stream"));
+            String mimeType = null;
+            try {
+                mimeType = Files.probeContentType(file.toPath());
+            } catch (IOException | SecurityException e) {
+                /* can't guess */
+            }
+            if (mimeType == null) {
+                mimeType = "application/octet-stream";
+            }
+            fileObject.setMimetype(rstring(mimeType));
         }
 
         IUpdatePrx up = sf.getUpdateService();

--- a/components/blitz/src/omero/gateway/model/FileAnnotationData.java
+++ b/components/blitz/src/omero/gateway/model/FileAnnotationData.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -18,10 +18,12 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package omero.gateway.model;
 
-
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import static omero.rtypes.rstring;
 import omero.RString;
@@ -346,6 +348,14 @@ public class FileAnnotationData extends AnnotationData {
                 format.equals(MS_POWER_POINT_SHOW) ||
                 format.equals(MS_POWER_POINT_X)) {
             return SERVER_MS_POWERPOINT;
+        }
+        try {
+            final String guessedMimeType = Files.probeContentType(attachedFile.toPath());
+            if (guessedMimeType != null) {
+                return guessedMimeType;
+            }
+        } catch (IOException | SecurityException e) {
+            /* can't guess */
         }
         return SERVER_OCTET_STREAM;
     }


### PR DESCRIPTION
Has OMERO's Java code use file content to guess MIME type before falling back to `application/octet-stream`. To test, try attaching files from your local system *using Insight* and check their resulting "mimetype" property. For instance, for an attachment with Annotation ID 123, from the CLI one can do,
```
$ bin/omero hql "SELECT file.mimetype FROM FileAnnotation WHERE id = 123"
```
Generally you should find that sensible things happen for common file extensions like ".pdf". However, where you have files with unknown or no extension, named "myfile" or "foo.bar.wibble" or whatever, with this PR you should now find that they still tend to get a sensible MIME type guessed according to their content: PDF, ASCII text, whatever. Also try a really random file (e.g., `head -c 64 </dev/urandom >/tmp/foo`) to make sure that `application/octet-stream` does remain the fallback if the file content is unrecognizable.

Assists https://trac.openmicroscopy.org/ome/ticket/12041.

--no-rebase