### PR TITLE
add request builders to Java gateway

### DIFF
--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -56,7 +56,9 @@ public class Requests {
      * @param includeType the child type to include in the request's operation
      * @param excludeType the child type to exclude from the request's operation
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(String includeType, String excludeType) {
         ChildOptionBuilder builder = option();
         if (includeType != null) {
@@ -73,7 +75,9 @@ public class Requests {
      * @param includeType the child types to include in the request's operation
      * @param excludeType the child types to exclude from the request's operation
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(List<String> includeType, List<String> excludeType) {
         ChildOptionBuilder builder = option();
         if (includeType != null) {
@@ -92,7 +96,9 @@ public class Requests {
      * @param includeNs the annotation namespace to which this option applies
      * @param excludeNs the annotation namespace to which this option does not apply
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(String includeType, String excludeType, String includeNs, String excludeNs) {
         ChildOptionBuilder builder = option();
         if (includeType != null) {
@@ -117,7 +123,9 @@ public class Requests {
      * @param includeNs the annotation namespaces to which this option applies
      * @param excludeNs the annotation namespaces to which this option does not apply
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(String includeType, String excludeType, List<String> includeNs,
             List<String> excludeNs) {
         ChildOptionBuilder builder = option();
@@ -143,7 +151,9 @@ public class Requests {
      * @param includeNs the annotation namespace to which this option applies
      * @param excludeNs the annotation namespace to which this option does not apply
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(List<String> includeType, List<String> excludeType, String includeNs, String excludeNs) {
         ChildOptionBuilder builder = option();
         if (includeType != null) {
@@ -168,7 +178,9 @@ public class Requests {
      * @param includeNs the annotation namespaces to which this option applies
      * @param excludeNs the annotation namespaces to which this option does not apply
      * @return the new instance
+     * @deprecated use {@link Requests.ChildOptionBuilder} from {@link #option()}, see this method for an example
      */
+    @Deprecated
     public static ChildOption option(List<String> includeType, List<String> excludeType, List<String> includeNs,
             List<String> excludeNs) {
         ChildOptionBuilder builder = option();
@@ -193,7 +205,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, long groupId) {
         return chgrp().target(targetClass).id(targetId).toGroup(groupId).build();
     }
@@ -205,7 +219,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, long groupId) {
         return chgrp().target(targetClass).id(targetId).option(childOption).toGroup(groupId).build();
     }
@@ -217,7 +233,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, long groupId) {
         return chgrp().target(targetClass).id(targetId).option(childOptions).toGroup(groupId).build();
     }
@@ -229,7 +247,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, boolean dryRun, long groupId) {
         return chgrp().target(targetClass).id(targetId).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -242,7 +262,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long groupId) {
         return chgrp().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -255,7 +277,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long groupId) {
         return chgrp().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -266,7 +290,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, long groupId) {
         return chgrp().target(targetClass).id(targetIds).toGroup(groupId).build();
     }
@@ -278,7 +304,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, long groupId) {
         return chgrp().target(targetClass).id(targetIds).option(childOption).toGroup(groupId).build();
     }
@@ -290,7 +318,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long groupId) {
         return chgrp().target(targetClass).id(targetIds).option(childOptions).toGroup(groupId).build();
     }
@@ -302,7 +332,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, boolean dryRun, long groupId) {
         return chgrp().target(targetClass).id(targetIds).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -315,7 +347,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long groupId) {
         return chgrp().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -328,7 +362,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             long groupId) {
         return chgrp().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
@@ -339,7 +375,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, long groupId) {
         return chgrp().target(targetObjects).toGroup(groupId).build();
     }
@@ -350,7 +388,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, long groupId) {
         return chgrp().target(targetObjects).option(childOption).toGroup(groupId).build();
     }
@@ -361,7 +401,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long groupId) {
         return chgrp().target(targetObjects).option(childOptions).toGroup(groupId).build();
     }
@@ -372,7 +414,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, boolean dryRun, long groupId) {
         return chgrp().target(targetObjects).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -384,7 +428,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long groupId) {
         return chgrp().target(targetObjects).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
@@ -396,7 +442,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param groupId the destination group ID
      * @return the new request
+     * @deprecated use {@link Requests.Chgrp2Builder} from {@link #chgrp()}, see this method for an example
      */
+    @Deprecated
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             long groupId) {
         return chgrp().target(targetObjects).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
@@ -408,7 +456,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, String permissions) {
         return chmod().target(targetClass).id(targetId).toPerms(permissions).build();
     }
@@ -420,7 +470,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, String permissions) {
         return chmod().target(targetClass).id(targetId).option(childOption).toPerms(permissions).build();
     }
@@ -432,7 +484,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, String permissions) {
         return chmod().target(targetClass).id(targetId).option(childOptions).toPerms(permissions).build();
     }
@@ -444,7 +498,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, boolean dryRun, String permissions) {
         return chmod().target(targetClass).id(targetId).dryRun(dryRun).toPerms(permissions).build();
     }
@@ -457,7 +513,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String permissions) {
         return chmod().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toPerms(permissions).build();
     }
@@ -470,7 +528,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
         return chmod().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
@@ -482,7 +542,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, String permissions) {
         return chmod().target(targetClass).id(targetIds).toPerms(permissions).build();
     }
@@ -494,7 +556,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, String permissions) {
         return chmod().target(targetClass).id(targetIds).option(childOption).toPerms(permissions).build();
     }
@@ -506,7 +570,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String permissions) {
         return chmod().target(targetClass).id(targetIds).option(childOptions).toPerms(permissions).build();
     }
@@ -518,7 +584,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, boolean dryRun, String permissions) {
         return chmod().target(targetClass).id(targetIds).dryRun(dryRun).toPerms(permissions).build();
     }
@@ -531,7 +599,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             String permissions) {
         return chmod().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toPerms(permissions).build();
@@ -545,7 +615,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
         return chmod().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
@@ -556,7 +628,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, String permissions) {
         return chmod().target(targetObjects).toPerms(permissions).build();
     }
@@ -567,7 +641,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, String permissions) {
         return chmod().target(targetObjects).option(childOption).toPerms(permissions).build();
     }
@@ -578,7 +654,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String permissions) {
         return chmod().target(targetObjects).option(childOptions).toPerms(permissions).build();
     }
@@ -589,7 +667,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, boolean dryRun, String permissions) {
         return chmod().target(targetObjects).dryRun(dryRun).toPerms(permissions).build();
     }
@@ -601,7 +681,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, String permissions) {
         return chmod().target(targetObjects).option(childOption).dryRun(dryRun).toPerms(permissions).build();
     }
@@ -613,7 +695,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param permissions the new permissions
      * @return the new request
+     * @deprecated use {@link Requests.Chmod2Builder} from {@link #chmod()}, see this method for an example
      */
+    @Deprecated
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
         return chmod().target(targetObjects).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
@@ -625,7 +709,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, long userId) {
         return chown().target(targetClass).id(targetId).toUser(userId).build();
     }
@@ -637,7 +723,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, long userId) {
         return chown().target(targetClass).id(targetId).option(childOption).toUser(userId).build();
     }
@@ -649,7 +737,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, long userId) {
         return chown().target(targetClass).id(targetId).option(childOptions).toUser(userId).build();
     }
@@ -661,7 +751,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, boolean dryRun, long userId) {
         return chown().target(targetClass).id(targetId).dryRun(dryRun).toUser(userId).build();
     }
@@ -674,7 +766,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long userId) {
         return chown().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
@@ -687,7 +781,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long userId) {
         return chown().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toUser(userId).build();
     }
@@ -698,7 +794,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, long userId) {
         return chown().target(targetClass).id(targetIds).toUser(userId).build();
     }
@@ -710,7 +808,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, long userId) {
         return chown().target(targetClass).id(targetIds).option(childOption).toUser(userId).build();
     }
@@ -722,7 +822,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long userId) {
         return chown().target(targetClass).id(targetIds).option(childOptions).toUser(userId).build();
     }
@@ -734,7 +836,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, boolean dryRun, long userId) {
         return chown().target(targetClass).id(targetIds).dryRun(dryRun).toUser(userId).build();
     }
@@ -747,7 +851,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long userId) {
         return chown().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
@@ -760,7 +866,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             long userId) {
         return chown().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toUser(userId).build();
@@ -771,7 +879,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, long userId) {
         return chown().target(targetObjects).toUser(userId).build();
     }
@@ -782,7 +892,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, long userId) {
         return chown().target(targetObjects).option(childOption).toUser(userId).build();
     }
@@ -793,7 +905,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long userId) {
         return chown().target(targetObjects).option(childOptions).toUser(userId).build();
     }
@@ -804,7 +918,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, boolean dryRun, long userId) {
         return chown().target(targetObjects).dryRun(dryRun).toUser(userId).build();
     }
@@ -816,7 +932,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long userId) {
         return chown().target(targetObjects).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
@@ -828,7 +946,9 @@ public class Requests {
      * @param dryRun if this request is a dry run
      * @param userId the destination user ID
      * @return the new request
+     * @deprecated use {@link Requests.Chown2Builder} from {@link #chown()}, see this method for an example
      */
+    @Deprecated
     public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             long userId) {
         return chown().target(targetObjects).option(childOptions).dryRun(dryRun).toUser(userId).build();
@@ -839,7 +959,9 @@ public class Requests {
      * @param targetClass the target object class
      * @param targetId the target object ID
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId) {
         return delete().target(targetClass).id(targetId).build();
     }
@@ -850,7 +972,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param childOption how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption) {
         return delete().target(targetClass).id(targetId).option(childOption).build();
     }
@@ -861,7 +985,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param childOptions how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions) {
         return delete().target(targetClass).id(targetId).option(childOptions).build();
     }
@@ -872,7 +998,9 @@ public class Requests {
      * @param targetId the target object ID
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId, boolean dryRun) {
         return delete().target(targetClass).id(targetId).dryRun(dryRun).build();
     }
@@ -884,7 +1012,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption, boolean dryRun) {
         return delete().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).build();
     }
@@ -896,7 +1026,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun) {
         return delete().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).build();
     }
@@ -906,7 +1038,9 @@ public class Requests {
      * @param targetClass the target object class
      * @param targetIds the target object IDs
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds) {
         return delete().target(targetClass).id(targetIds).build();
     }
@@ -917,7 +1051,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param childOption how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption) {
         return delete().target(targetClass).id(targetIds).option(childOption).build();
     }
@@ -928,7 +1064,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param childOptions how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions) {
         return delete().target(targetClass).id(targetIds).option(childOptions).build();
     }
@@ -939,7 +1077,9 @@ public class Requests {
      * @param targetIds the target object IDs
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds, boolean dryRun) {
         return delete().target(targetClass).id(targetIds).dryRun(dryRun).build();
     }
@@ -951,7 +1091,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun) {
         return delete().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).build();
     }
@@ -963,7 +1105,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun) {
         return delete().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).build();
     }
@@ -972,7 +1116,9 @@ public class Requests {
      * Create a new {@link Delete2} request.
      * @param targetObjects the target objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects) {
         return delete().target(targetObjects).build();
     }
@@ -982,7 +1128,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param childOption how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption) {
         return delete().target(targetObjects).option(childOption).build();
     }
@@ -992,7 +1140,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param childOptions how to process child objects
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions) {
         return delete().target(targetObjects).option(childOptions).build();
     }
@@ -1002,7 +1152,9 @@ public class Requests {
      * @param targetObjects the target objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects, boolean dryRun) {
         return delete().target(targetObjects).dryRun(dryRun).build();
     }
@@ -1013,7 +1165,9 @@ public class Requests {
      * @param childOption how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun) {
         return delete().target(targetObjects).option(childOption).dryRun(dryRun).build();
     }
@@ -1024,7 +1178,9 @@ public class Requests {
      * @param childOptions how to process child objects
      * @param dryRun if this request is a dry run
      * @return the new request
+     * @deprecated use {@link Requests.Delete2Builder} from {@link #delete()}, see this method for an example
      */
+    @Deprecated
     public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun) {
         return delete().target(targetObjects).option(childOptions).dryRun(dryRun).build();
     }
@@ -1036,7 +1192,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).startFrom(startFrom).request(request).build();
     }
@@ -1049,7 +1207,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOption).startFrom(startFrom).request(request).build();
@@ -1063,7 +1223,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1077,7 +1239,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
@@ -1091,7 +1255,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOption).dryRun(dryRun)
@@ -1107,7 +1273,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun)
@@ -1121,7 +1289,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).startFrom(startFrom).request(request).build();
     }
@@ -1134,7 +1304,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOption).startFrom(startFrom).request(request).build();
@@ -1148,7 +1320,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1162,7 +1336,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1177,7 +1353,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOption).dryRun(dryRun)
@@ -1193,7 +1371,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun)
@@ -1207,7 +1387,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).startFrom(startFrom).request(request).build();
     }
@@ -1220,7 +1402,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOption).startFrom(startFrom).request(request).build();
@@ -1234,7 +1418,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1248,7 +1434,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1263,7 +1451,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun)
@@ -1279,7 +1469,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun)
@@ -1293,7 +1485,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).startFrom(startFrom).request(request).build();
     }
@@ -1306,7 +1500,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOption).startFrom(startFrom).request(request).build();
@@ -1320,7 +1516,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1334,7 +1532,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1349,7 +1549,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun)
@@ -1365,7 +1567,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun)
@@ -1378,7 +1582,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, String startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).startFrom(startFrom).request(request).build();
     }
@@ -1390,7 +1596,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOption).startFrom(startFrom).request(request).build();
@@ -1403,7 +1611,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1416,7 +1626,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, String startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
@@ -1429,7 +1641,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
             String startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOption).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1443,7 +1657,9 @@ public class Requests {
      * @param startFrom the class from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOptions).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1455,7 +1671,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).startFrom(startFrom).request(request).build();
     }
@@ -1467,7 +1685,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOption).startFrom(startFrom).request(request).build();
@@ -1480,7 +1700,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOptions).startFrom(startFrom).request(request).build();
@@ -1493,7 +1715,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
         return skipHead().target(targetObjects).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1507,7 +1731,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOption).dryRun(dryRun).startFrom(startFrom).request(request).build();
@@ -1521,7 +1747,9 @@ public class Requests {
      * @param startFrom the classes from which to start the actual processing
      * @param request the processor to use
      * @return the new request
+     * @deprecated use {@link Requests.SkipHeadBuilder} from {@link #skipHead()}, see this method for an example
      */
+    @Deprecated
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
         return skipHead().target(targetObjects).option(childOptions).dryRun(dryRun).startFrom(startFrom).request(request).build();

--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,18 +19,30 @@
 
 package omero.gateway.util;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+
+import omero.RLong;
 import omero.cmd.Chgrp2;
 import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
+import omero.cmd.DiskUsage;
+import omero.cmd.Duplicate;
 import omero.cmd.GraphModify2;
 import omero.cmd.SkipHead;
 import omero.cmd.graphs.ChildOption;
+import omero.model.Experimenter;
+import omero.model.ExperimenterGroup;
+import omero.model.IObject;
 
 /**
  * A utility class of factory methods with various signatures for clients to use in generating requests for graph operations.
@@ -46,9 +58,14 @@ public class Requests {
      * @return the new instance
      */
     public static ChildOption option(String includeType, String excludeType) {
-        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
-        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
-        return new ChildOption(includeTypeList, excludeTypeList, null, null);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        return builder.build();
     }
 
     /**
@@ -58,7 +75,14 @@ public class Requests {
      * @return the new instance
      */
     public static ChildOption option(List<String> includeType, List<String> excludeType) {
-        return new ChildOption(includeType, excludeType, null, null);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        return builder.build();
     }
 
     /**
@@ -70,11 +94,20 @@ public class Requests {
      * @return the new instance
      */
     public static ChildOption option(String includeType, String excludeType, String includeNs, String excludeNs) {
-        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
-        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
-        final List<String> includeNsList = includeNs == null ? null : Collections.singletonList(includeNs);
-        final List<String> excludeNsList = excludeNs == null ? null : Collections.singletonList(excludeNs);
-        return new ChildOption(includeTypeList, excludeTypeList, includeNsList, excludeNsList);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        if (includeNs != null) {
+            builder = builder.includeNs(includeNs);
+        }
+        if (excludeNs != null) {
+            builder = builder.excludeNs(excludeNs);
+        }
+        return builder.build();
     }
 
     /**
@@ -87,9 +120,20 @@ public class Requests {
      */
     public static ChildOption option(String includeType, String excludeType, List<String> includeNs,
             List<String> excludeNs) {
-        final List<String> includeTypeList = includeType == null ? null : Collections.singletonList(includeType);
-        final List<String> excludeTypeList = excludeType == null ? null : Collections.singletonList(excludeType);
-        return new ChildOption(includeTypeList, excludeTypeList, includeNs, excludeNs);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        if (includeNs != null) {
+            builder = builder.includeNs(includeNs);
+        }
+        if (excludeNs != null) {
+            builder = builder.excludeNs(excludeNs);
+        }
+        return builder.build();
     }
 
     /**
@@ -101,9 +145,20 @@ public class Requests {
      * @return the new instance
      */
     public static ChildOption option(List<String> includeType, List<String> excludeType, String includeNs, String excludeNs) {
-        final List<String> includeNsList = includeNs == null ? null : Collections.singletonList(includeNs);
-        final List<String> excludeNsList = excludeNs == null ? null : Collections.singletonList(excludeNs);
-        return new ChildOption(includeType, excludeType, includeNsList, excludeNsList);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        if (includeNs != null) {
+            builder = builder.includeNs(includeNs);
+        }
+        if (excludeNs != null) {
+            builder = builder.excludeNs(excludeNs);
+        }
+        return builder.build();
     }
 
     /**
@@ -116,7 +171,20 @@ public class Requests {
      */
     public static ChildOption option(List<String> includeType, List<String> excludeType, List<String> includeNs,
             List<String> excludeNs) {
-        return new ChildOption(includeType, excludeType, includeNs, excludeNs);
+        ChildOptionBuilder builder = option();
+        if (includeType != null) {
+            builder = builder.includeType(includeType);
+        }
+        if (excludeType != null) {
+            builder = builder.excludeType(excludeType);
+        }
+        if (includeNs != null) {
+            builder = builder.includeNs(includeNs);
+        }
+        if (excludeNs != null) {
+            builder = builder.excludeNs(excludeNs);
+        }
+        return builder.build();
     }
 
     /**
@@ -127,9 +195,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+        return chgrp().target(targetClass).id(targetId).toGroup(groupId).build();
     }
 
     /**
@@ -141,9 +207,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+        return chgrp().target(targetClass).id(targetId).option(childOption).toGroup(groupId).build();
     }
 
     /**
@@ -155,9 +219,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, childOptions, false, groupId);
+        return chgrp().target(targetClass).id(targetId).option(childOptions).toGroup(groupId).build();
     }
 
     /**
@@ -169,9 +231,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, boolean dryRun, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+        return chgrp().target(targetClass).id(targetId).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -184,9 +244,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+        return chgrp().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -199,9 +257,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+        return chgrp().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -212,9 +268,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+        return chgrp().target(targetClass).id(targetIds).toGroup(groupId).build();
     }
 
     /**
@@ -226,9 +280,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+        return chgrp().target(targetClass).id(targetIds).option(childOption).toGroup(groupId).build();
     }
 
     /**
@@ -240,9 +292,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, childOptions, false, groupId);
+        return chgrp().target(targetClass).id(targetIds).option(childOptions).toGroup(groupId).build();
     }
 
     /**
@@ -254,9 +304,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, boolean dryRun, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+        return chgrp().target(targetClass).id(targetIds).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -269,9 +317,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+        return chgrp().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -285,9 +331,7 @@ public class Requests {
      */
     public static Chgrp2 chgrp(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             long groupId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+        return chgrp().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -297,7 +341,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, long groupId) {
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, false, groupId);
+        return chgrp().target(targetObjects).toGroup(groupId).build();
     }
 
     /**
@@ -308,7 +352,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, long groupId) {
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), false, groupId);
+        return chgrp().target(targetObjects).option(childOption).toGroup(groupId).build();
     }
 
     /**
@@ -319,7 +363,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long groupId) {
-        return new Chgrp2(targetObjects, childOptions, false, groupId);
+        return chgrp().target(targetObjects).option(childOptions).toGroup(groupId).build();
     }
 
     /**
@@ -330,7 +374,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, boolean dryRun, long groupId) {
-        return new Chgrp2(targetObjects, (List<ChildOption>) null, dryRun, groupId);
+        return chgrp().target(targetObjects).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -342,7 +386,7 @@ public class Requests {
      * @return the new request
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long groupId) {
-        return new Chgrp2(targetObjects, Collections.singletonList(childOption), dryRun, groupId);
+        return chgrp().target(targetObjects).option(childOption).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -355,7 +399,7 @@ public class Requests {
      */
     public static Chgrp2 chgrp(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             long groupId) {
-          return new Chgrp2(targetObjects, childOptions, dryRun, groupId);
+        return chgrp().target(targetObjects).option(childOptions).dryRun(dryRun).toGroup(groupId).build();
     }
 
     /**
@@ -366,9 +410,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, Long targetId, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+        return chmod().target(targetClass).id(targetId).toPerms(permissions).build();
     }
 
     /**
@@ -380,9 +422,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+        return chmod().target(targetClass).id(targetId).option(childOption).toPerms(permissions).build();
     }
 
     /**
@@ -394,9 +434,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, childOptions, false, permissions);
+        return chmod().target(targetClass).id(targetId).option(childOptions).toPerms(permissions).build();
     }
 
     /**
@@ -408,9 +446,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, Long targetId, boolean dryRun, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+        return chmod().target(targetClass).id(targetId).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -423,9 +459,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+        return chmod().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -439,9 +473,7 @@ public class Requests {
      */
     public static Chmod2 chmod(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chmod2(targetObjects, childOptions, dryRun, permissions);
+        return chmod().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -452,9 +484,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+        return chmod().target(targetClass).id(targetIds).toPerms(permissions).build();
     }
 
     /**
@@ -466,9 +496,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+        return chmod().target(targetClass).id(targetIds).option(childOption).toPerms(permissions).build();
     }
 
     /**
@@ -480,9 +508,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, childOptions, false, permissions);
+        return chmod().target(targetClass).id(targetIds).option(childOptions).toPerms(permissions).build();
     }
 
     /**
@@ -494,9 +520,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, boolean dryRun, String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+        return chmod().target(targetClass).id(targetIds).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -510,9 +534,7 @@ public class Requests {
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+        return chmod().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -526,9 +548,7 @@ public class Requests {
      */
     public static Chmod2 chmod(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chmod2(targetObjects, childOptions, dryRun, permissions);
+        return chmod().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -538,7 +558,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, String permissions) {
-        return new Chmod2(targetObjects, (List<ChildOption>) null, false, permissions);
+        return chmod().target(targetObjects).toPerms(permissions).build();
     }
 
     /**
@@ -549,7 +569,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, String permissions) {
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), false, permissions);
+        return chmod().target(targetObjects).option(childOption).toPerms(permissions).build();
     }
 
     /**
@@ -560,7 +580,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String permissions) {
-        return new Chmod2(targetObjects, childOptions, false, permissions);
+        return chmod().target(targetObjects).option(childOptions).toPerms(permissions).build();
     }
 
     /**
@@ -571,7 +591,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, boolean dryRun, String permissions) {
-        return new Chmod2(targetObjects, (List<ChildOption>) null, dryRun, permissions);
+        return chmod().target(targetObjects).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -583,7 +603,7 @@ public class Requests {
      * @return the new request
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, String permissions) {
-        return new Chmod2(targetObjects, Collections.singletonList(childOption), dryRun, permissions);
+        return chmod().target(targetObjects).option(childOption).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -596,7 +616,7 @@ public class Requests {
      */
     public static Chmod2 chmod(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             String permissions) {
-          return new Chmod2(targetObjects, childOptions, dryRun, permissions);
+        return chmod().target(targetObjects).option(childOptions).dryRun(dryRun).toPerms(permissions).build();
     }
 
     /**
@@ -607,9 +627,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+        return chown().target(targetClass).id(targetId).toUser(userId).build();
     }
 
     /**
@@ -621,9 +639,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+        return chown().target(targetClass).id(targetId).option(childOption).toUser(userId).build();
     }
 
     /**
@@ -635,9 +651,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, childOptions, false, userId);
+        return chown().target(targetClass).id(targetId).option(childOptions).toUser(userId).build();
     }
 
     /**
@@ -649,9 +663,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, boolean dryRun, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+        return chown().target(targetClass).id(targetId).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -664,9 +676,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+        return chown().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -679,9 +689,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Chown2(targetObjects, childOptions, dryRun, userId);
+        return chown().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -692,9 +700,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+        return chown().target(targetClass).id(targetIds).toUser(userId).build();
     }
 
     /**
@@ -706,9 +712,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+        return chown().target(targetClass).id(targetIds).option(childOption).toUser(userId).build();
     }
 
     /**
@@ -720,9 +724,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, childOptions, false, userId);
+        return chown().target(targetClass).id(targetIds).option(childOptions).toUser(userId).build();
     }
 
     /**
@@ -734,9 +736,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, boolean dryRun, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+        return chown().target(targetClass).id(targetIds).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -749,9 +749,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun, long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+        return chown().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -765,9 +763,7 @@ public class Requests {
      */
     public static Chown2 chown(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             long userId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Chown2(targetObjects, childOptions, dryRun, userId);
+        return chown().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -777,7 +773,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, long userId) {
-        return new Chown2(targetObjects, (List<ChildOption>) null, false, userId);
+        return chown().target(targetObjects).toUser(userId).build();
     }
 
     /**
@@ -788,7 +784,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, long userId) {
-        return new Chown2(targetObjects, Collections.singletonList(childOption), false, userId);
+        return chown().target(targetObjects).option(childOption).toUser(userId).build();
     }
 
     /**
@@ -799,7 +795,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, long userId) {
-        return new Chown2(targetObjects, childOptions, false, userId);
+        return chown().target(targetObjects).option(childOptions).toUser(userId).build();
     }
 
     /**
@@ -810,7 +806,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, boolean dryRun, long userId) {
-        return new Chown2(targetObjects, (List<ChildOption>) null, dryRun, userId);
+        return chown().target(targetObjects).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -822,7 +818,7 @@ public class Requests {
      * @return the new request
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun, long userId) {
-        return new Chown2(targetObjects, Collections.singletonList(childOption), dryRun, userId);
+        return chown().target(targetObjects).option(childOption).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -835,7 +831,7 @@ public class Requests {
      */
     public static Chown2 chown(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             long userId) {
-          return new Chown2(targetObjects, childOptions, dryRun, userId);
+        return chown().target(targetObjects).option(childOptions).dryRun(dryRun).toUser(userId).build();
     }
 
     /**
@@ -845,9 +841,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+        return delete().target(targetClass).id(targetId).build();
     }
 
     /**
@@ -858,9 +852,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+        return delete().target(targetClass).id(targetId).option(childOption).build();
     }
 
     /**
@@ -871,9 +863,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, childOptions, false);
+        return delete().target(targetClass).id(targetId).option(childOptions).build();
     }
 
     /**
@@ -884,9 +874,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+        return delete().target(targetClass).id(targetId).dryRun(dryRun).build();
     }
 
     /**
@@ -898,9 +886,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId, ChildOption childOption, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+        return delete().target(targetClass).id(targetId).option(childOption).dryRun(dryRun).build();
     }
 
     /**
@@ -912,9 +898,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new Delete2(targetObjects, childOptions, dryRun);
+        return delete().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun).build();
     }
 
     /**
@@ -924,9 +908,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+        return delete().target(targetClass).id(targetIds).build();
     }
 
     /**
@@ -937,9 +919,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+        return delete().target(targetClass).id(targetIds).option(childOption).build();
     }
 
     /**
@@ -950,9 +930,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, childOptions, false);
+        return delete().target(targetClass).id(targetIds).option(childOptions).build();
     }
 
     /**
@@ -963,9 +941,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+        return delete().target(targetClass).id(targetIds).dryRun(dryRun).build();
     }
 
     /**
@@ -977,9 +953,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+        return delete().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun).build();
     }
 
     /**
@@ -991,9 +965,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new Delete2(targetObjects, childOptions, dryRun);
+        return delete().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun).build();
     }
 
     /**
@@ -1002,7 +974,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects) {
-        return new Delete2(targetObjects, (List<ChildOption>) null, false);
+        return delete().target(targetObjects).build();
     }
 
     /**
@@ -1012,7 +984,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption) {
-        return new Delete2(targetObjects, Collections.singletonList(childOption), false);
+        return delete().target(targetObjects).option(childOption).build();
     }
 
     /**
@@ -1022,7 +994,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions) {
-        return new Delete2(targetObjects, childOptions, false);
+        return delete().target(targetObjects).option(childOptions).build();
     }
 
     /**
@@ -1032,7 +1004,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects, boolean dryRun) {
-        return new Delete2(targetObjects, (List<ChildOption>) null, dryRun);
+        return delete().target(targetObjects).dryRun(dryRun).build();
     }
 
     /**
@@ -1043,7 +1015,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun) {
-        return new Delete2(targetObjects, Collections.singletonList(childOption), dryRun);
+        return delete().target(targetObjects).option(childOption).dryRun(dryRun).build();
     }
 
     /**
@@ -1054,7 +1026,7 @@ public class Requests {
      * @return the new request
      */
     public static Delete2 delete(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun) {
-          return new Delete2(targetObjects, childOptions, dryRun);
+        return delete().target(targetObjects).option(childOptions).dryRun(dryRun).build();
     }
 
     /**
@@ -1066,9 +1038,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(String targetClass, Long targetId, String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetId).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1082,10 +1052,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetClass).id(targetId).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1099,9 +1066,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetId).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1114,9 +1079,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetId).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1131,10 +1094,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetClass).id(targetId).option(childOption).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1149,9 +1110,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1163,9 +1123,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(String targetClass, Long targetId, List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1179,9 +1137,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1195,9 +1151,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, List<String> startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1211,9 +1165,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1228,9 +1180,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).option(childOption).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1245,9 +1196,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, Long targetId, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, Collections.singletonList(targetId));
-        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetId).option(childOptions).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1259,9 +1209,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetIds).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1275,10 +1223,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetClass).id(targetIds).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1292,9 +1237,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetIds).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1308,9 +1251,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, String startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetIds).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1325,10 +1266,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1343,9 +1282,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1357,9 +1295,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1373,9 +1309,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1389,9 +1323,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions,
             List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1405,9 +1337,7 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1422,9 +1352,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).option(childOption).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1439,9 +1368,8 @@ public class Requests {
      */
     public static SkipHead skipHead(String targetClass, List<Long> targetIds, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        final Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
-        targetObjects.put(targetClass, targetIds);
-        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+        return skipHead().target(targetClass).id(targetIds).option(childOptions).dryRun(dryRun)
+                .startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1452,7 +1380,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, String startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetObjects).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1465,8 +1393,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, String startFrom,
             GraphModify2 request) {
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetObjects).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1479,7 +1406,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, String startFrom,
             GraphModify2 request) {
-        return new SkipHead(targetObjects, childOptions, false, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetObjects).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1491,7 +1418,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, String startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetObjects).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1505,8 +1432,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
             String startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, Collections.singletonList(startFrom),
-                request);
+        return skipHead().target(targetObjects).option(childOption).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1520,7 +1446,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             String startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, childOptions, dryRun, Collections.singletonList(startFrom), request);
+        return skipHead().target(targetObjects).option(childOptions).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1531,7 +1457,7 @@ public class Requests {
      * @return the new request
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<String> startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, (List<ChildOption>) null, false, startFrom, request);
+        return skipHead().target(targetObjects).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1544,7 +1470,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, List<String> startFrom,
             GraphModify2 request) {
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), false, startFrom, request);
+        return skipHead().target(targetObjects).option(childOption).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1557,7 +1483,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, List<String> startFrom,
             GraphModify2 request) {
-        return new SkipHead(targetObjects, childOptions, false, startFrom, request);
+        return skipHead().target(targetObjects).option(childOptions).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1570,7 +1496,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, boolean dryRun, List<String> startFrom,
             GraphModify2 request) {
-        return new SkipHead(targetObjects, (List<ChildOption>) null, dryRun, startFrom, request);
+        return skipHead().target(targetObjects).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1584,7 +1510,7 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, ChildOption childOption, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, Collections.singletonList(childOption), dryRun, startFrom, request);
+        return skipHead().target(targetObjects).option(childOption).dryRun(dryRun).startFrom(startFrom).request(request).build();
     }
 
     /**
@@ -1598,6 +1524,876 @@ public class Requests {
      */
     public static SkipHead skipHead(Map<String, List<Long>> targetObjects, List<ChildOption> childOptions, boolean dryRun,
             List<String> startFrom, GraphModify2 request) {
-        return new SkipHead(targetObjects, childOptions, dryRun, startFrom, request);
+        return skipHead().target(targetObjects).option(childOptions).dryRun(dryRun).startFrom(startFrom).request(request).build();
+    }
+
+    /**
+     * From a model object class determine its simple name suitable for HQL queries or request arguments.
+     * @param modelClass a model object class
+     * @return a good name for that class
+     */
+    private static String getModelClassName(Class<? extends IObject> modelClass) {
+        if (modelClass != IObject.class) {
+            while (true) {
+                /* find a direct subclass of IObject */
+                final Class<? extends IObject> superclass = modelClass.getSuperclass().asSubclass(IObject.class);
+                if (superclass == IObject.class) {
+                    break;
+                }
+                modelClass = superclass;
+            }
+        }
+        return modelClass.getSimpleName();
+    }
+
+    /**
+     * A general superclass for the builders.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     * @param <X> the type of object to be built
+     */
+    private static abstract class Builder<X> {
+
+        protected X assembly;
+
+        /**
+         * Construct a new builder for the given object.
+         * @param newAssembly the object to be built
+         */
+        Builder(X newAssembly) {
+            this.assembly = newAssembly;
+        }
+
+        /**
+         * Assemble and return the finished object.
+         * @return the built instance
+         */
+        public X build() {
+            return assembly;
+        }
+    }
+
+    /**
+     * A builder for {@link ChildOption} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class ChildOptionBuilder extends Builder<ChildOption> {
+
+        /**
+         * Instantiate a new {@link ChildOption} and initialize its collection containers.
+         */
+        private ChildOptionBuilder() {
+            super(new ChildOption());
+            assembly.includeType = new ArrayList<String>();
+            assembly.excludeType = new ArrayList<String>();
+            assembly.includeNs = new ArrayList<String>();
+            assembly.excludeNs = new ArrayList<String>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param types types of children to include in the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder includeType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.includeType.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types of children to include in the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder includeType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.includeType.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param types types of children to exclude from the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder excludeType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.excludeType.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types of children to exclude from the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final ChildOptionBuilder excludeType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.excludeType.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param namespaces annotation namespaces to which to this option applies, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder includeNs(Iterable<String> namespaces) {
+            for (final String namespace : namespaces) {
+                assembly.includeNs.add(namespace);
+            }
+            return this;
+        }
+
+        /**
+         * @param namespaces annotation namespaces to which to this option does not apply, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder excludeNs(Iterable<String> namespaces) {
+            for (final String namespace : namespaces) {
+                assembly.excludeNs.add(namespace);
+            }
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param types types of children to include in the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder includeType(String... types) {
+            return includeType(Arrays.asList(types));
+        }
+
+        /**
+         * @param types types of children to exclude from the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder excludeType(String... types) {
+            return excludeType(Arrays.asList(types));
+        }
+
+        /**
+         * @param namespaces annotation namespaces to which to this option applies, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder includeNs(String... namespaces) {
+            return includeNs(Arrays.asList(namespaces));
+        }
+
+        /**
+         * @param namespaces annotation namespaces to which to this option does not apply, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public ChildOptionBuilder excludeNs(String... namespaces) {
+            return excludeNs(Arrays.asList(namespaces));
+        }
+    }
+
+    /**
+     * A builder for {@link GraphModify2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     * @param <B> the type of the builder
+     * @param <R> the type of the object to be built
+     */
+    private static abstract class GraphModify2Builder<B extends GraphModify2Builder<B, R>, R extends GraphModify2>
+        extends Builder<R> {
+
+        /*
+         * The @SuppressWarnings and omitted methods in this class are from Java's painfully primitive type system,
+         * including lack of proper generics, let alone anything modern like associated type families.
+         */
+
+        /* the class targeted by calls to the id method */
+        private String targetObjectClass = null;
+
+        /* keep a deduplicated copy of all identified targets to minimize a possibly large argument size */
+        private SetMultimap<String, Long> allTargets = HashMultimap.create();
+
+        /**
+         * Initialize a new {@link GraphModify2}'s collection containers.
+         */
+        GraphModify2Builder(R assembly) {
+            super(assembly);
+            assembly.targetObjects = new HashMap<String, List<Long>>();
+            assembly.childOptions = new ArrayList<ChildOption>();
+        }
+
+        /**
+         * Assemble and return the finished object.
+         * @return the built instance
+         */
+        @Override
+        public R build() {
+            assembly.targetObjects.clear();
+            for (final Map.Entry<String, Collection<Long>> target : allTargets.asMap().entrySet()) {
+                assembly.targetObjects.put(target.getKey(), new ArrayList<Long>(target.getValue()));
+            }
+            return super.build();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B target(Map<String, ? extends Iterable<Long>> targets) {
+            for (final Map.Entry<String, ? extends Iterable<Long>> classAndIds : targets.entrySet()) {
+                allTargets.putAll(classAndIds.getKey(), classAndIds.getValue());
+            }
+            return (B) this;
+        }
+
+        /**
+         * @param targetClass a target object type for this operation, required to then use an {@code id} method
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B target(String targetClass) {
+            targetObjectClass = targetClass;
+            return (B) this;
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        @SuppressWarnings("unchecked")
+        public B id(Iterable<Long> ids) {
+            if (targetObjectClass == null) {
+                throw new IllegalStateException("must first use target(String) to set class name");
+            }
+            allTargets.putAll(targetObjectClass, ids);
+            return (B) this;
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        @SuppressWarnings("unchecked")
+        public B id(RLong... ids) {
+            if (targetObjectClass == null) {
+                throw new IllegalStateException("must first use target(String) to set class name");
+            }
+            for (final RLong id : ids) {
+                allTargets.put(targetObjectClass, id.getValue());
+            }
+            return (B) this;
+        }
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B target(IObject... targets) {
+            for (final IObject target : targets) {
+                target(target.getClass()).id(target.getId());
+            }
+            return (B) this;
+        }
+
+        /**
+         * @param options child options for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B option(Iterable<ChildOption> options) {
+            for (final ChildOption option : options) {
+                assembly.childOptions.add(option);
+            }
+            return (B) this;
+        }
+
+        /**
+         * @param dryRun if this operation is a dry run, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B dryRun(boolean dryRun) {
+            assembly.dryRun = dryRun;
+            return (B) this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public B target(Multimap<String, Long> targets) {
+            return target(targets.asMap());
+        }
+
+        /**
+         * @param targetClass a target object type for this operation, required to then use an {@code id} method
+         * @return this builder, for method chaining
+         */
+        public B target(Class<? extends IObject> targetClass) {
+            return target(getModelClassName(targetClass));
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        public B id(Long... ids) {
+            return id(Arrays.asList(ids));
+        }
+
+        /**
+         * @param options child options for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public B option(ChildOption... options) {
+            return option(Arrays.asList(options));
+        }
+
+        /**
+         * Set that this operation is a dry run.
+         * @return this builder, for method chaining
+         */
+        public B dryRun() {
+            return dryRun(true);
+        }
+    }
+
+    /**
+     * A builder for {@link Chgrp2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class Chgrp2Builder extends GraphModify2Builder<Chgrp2Builder, Chgrp2> {
+
+        /**
+         * Instantiate a new {@link Chgrp2}.
+         */
+        public Chgrp2Builder() {
+            super(new Chgrp2());
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param id the group to which to move the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chgrp2Builder toGroup(long id) {
+            assembly.groupId = id;
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param id the group to which to move the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chgrp2Builder toGroup(RLong id) {
+            return toGroup(id.getValue());
+        }
+
+        /**
+         * @param group the group to which to move the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chgrp2Builder toGroup(ExperimenterGroup group) {
+            return toGroup(group.getId());
+        }
+    }
+
+    /**
+     * A builder for {@link Chown2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class Chown2Builder extends GraphModify2Builder<Chown2Builder, Chown2> {
+
+        /**
+         * Instantiate a new {@link Chown2}.
+         */
+        public Chown2Builder() {
+            super(new Chown2());
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param id the user to which to give the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chown2Builder toUser(long id) {
+            assembly.userId = id;
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param id the user to which to give the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chown2Builder toUser(RLong id) {
+            return toUser(id.getValue());
+        }
+
+        /**
+         * @param user the user to which to give the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chown2Builder toGroup(Experimenter user) {
+            return toUser(user.getId());
+        }
+    }
+
+    /**
+     * A builder for {@link Chmod2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class Chmod2Builder extends GraphModify2Builder<Chmod2Builder, Chmod2> {
+
+        /**
+         * Instantiate a new {@link Chmod2}.
+         */
+        public Chmod2Builder() {
+            super(new Chmod2());
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param permissions the permissions to which to set the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public Chmod2Builder toPerms(String permissions) {
+            assembly.permissions = permissions;
+            return this;
+        }
+    }
+
+    /**
+     * A builder for {@link Delete2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class Delete2Builder extends GraphModify2Builder<Delete2Builder, Delete2> {
+
+        /**
+         * Instantiate a new {@link Delete2}.
+         */
+        public Delete2Builder() {
+            super(new Delete2());
+        }
+    }
+
+    /**
+     * A builder for {@link Duplicate} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class DuplicateBuilder extends GraphModify2Builder<DuplicateBuilder, Duplicate> {
+
+        /**
+         * Instantiate a new {@link Duplicate} and initialize its collection containers.
+         */
+        public DuplicateBuilder() {
+            super(new Duplicate());
+            assembly.typesToDuplicate = new ArrayList<String>();
+            assembly.typesToReference = new ArrayList<String>();
+            assembly.typesToIgnore    = new ArrayList<String>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param types types to duplicate, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder duplicateType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.typesToDuplicate.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types to duplicate, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final DuplicateBuilder duplicateType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.typesToDuplicate.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param types types to reference from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder referenceType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.typesToReference.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types to reference from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final DuplicateBuilder referenceType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.typesToReference.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param types types to keep separate from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder ignoreType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.typesToIgnore.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types to keep separate from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final DuplicateBuilder ignoreType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.typesToIgnore.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param types types to duplicate, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder duplicateType(String... types) {
+            return duplicateType(Arrays.asList(types));
+        }
+
+        /**
+         * @param types types to reference from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder referenceType(String... types) {
+            return referenceType(Arrays.asList(types));
+        }
+
+        /**
+         * @param types types to keep separate from duplicates, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DuplicateBuilder ignoreType(String... types) {
+            return ignoreType(Arrays.asList(types));
+        }
+    }
+
+    /**
+     * A builder for {@link SkipHead} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class SkipHeadBuilder extends GraphModify2Builder<SkipHeadBuilder, SkipHead> {
+
+        /**
+         * Instantiate a new {@link SkipHead} and initialize its collection containers.
+         */
+        public SkipHeadBuilder() {
+            super(new SkipHead());
+            assembly.startFrom = new ArrayList<String>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param types types from which to start the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public SkipHeadBuilder startFrom(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.startFrom.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types types from which to start the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final SkipHeadBuilder startFrom(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.startFrom.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param request the operation to perform once target objects are identified, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final SkipHeadBuilder request(GraphModify2 request) {
+            assembly.request = request;
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param types types from which to start the operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public SkipHeadBuilder startFrom(String... types) {
+            return startFrom(Arrays.asList(types));
+        }
+
+        /**
+         * @param request the operation to perform once target objects are identified, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final SkipHeadBuilder request(Class<? extends GraphModify2> request) {
+            try {
+                return request(request.newInstance());
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalArgumentException("invalid request class", e);
+            }
+        }
+    }
+
+    /**
+     * A builder for {@link DiskUsage} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class DiskUsageBuilder extends Builder<DiskUsage> {
+
+        /* the class targeted by calls to the id method */
+        private String targetObjectClass = null;
+
+        /* keep a deduplicated copy of all identified targets to minimize a possibly large argument size */
+        private SetMultimap<String, Long> allTargets = HashMultimap.create();
+
+        /**
+         * Instantiate a new {@link DiskUsage} and initialize its collection containers.
+         */
+        DiskUsageBuilder() {
+            super(new DiskUsage());
+            assembly.classes = new ArrayList<String>();
+            assembly.objects = new HashMap<String, List<Long>>();
+        }
+
+        /**
+         * Assemble and return the finished object.
+         * @return the built instance
+         */
+        @Override
+        public DiskUsage build() {
+            assembly.objects.clear();
+            for (final Map.Entry<String, Collection<Long>> target : allTargets.asMap().entrySet()) {
+                assembly.objects.put(target.getKey(), new ArrayList<Long>(target.getValue()));
+            }
+            return super.build();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder target(Map<String, ? extends Iterable<Long>> targets) {
+            for (final Map.Entry<String, ? extends Iterable<Long>> classAndIds : targets.entrySet()) {
+                allTargets.putAll(classAndIds.getKey(), classAndIds.getValue());
+            }
+            return this;
+        }
+
+        /**
+         * @param targetClass a target object type for this operation, required to then use an {@code id} method
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder target(String targetClass) {
+            targetObjectClass = targetClass;
+            return this;
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        public DiskUsageBuilder id(Iterable<Long> ids) {
+            if (targetObjectClass == null) {
+                throw new IllegalStateException("must first use target(String) to set class name");
+            }
+            allTargets.putAll(targetObjectClass, ids);
+            return this;
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        public DiskUsageBuilder id(RLong... ids) {
+            if (targetObjectClass == null) {
+                throw new IllegalStateException("must first use target(String) to set class name");
+            }
+            for (final RLong id : ids) {
+                allTargets.put(targetObjectClass, id.getValue());
+            }
+            return this;
+        }
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder target(IObject... targets) {
+            for (final IObject target : targets) {
+                target(target.getClass()).id(target.getId());
+            }
+            return this;
+        }
+
+        /**
+         * @param types whole types to target for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder type(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.classes.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types whole types to target for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final DiskUsageBuilder type(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.classes.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param targets target objects for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder target(Multimap<String, Long> targets) {
+            return target(targets.asMap());
+        }
+
+        /**
+         * @param targetClass a target object type for this operation, required to then use an {@code id} method
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder target(Class<? extends IObject> targetClass) {
+            return target(getModelClassName(targetClass));
+        }
+
+        /**
+         * @param ids target object IDs for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         * @see #target(String)
+         * @see #target(Class)
+         */
+        public DiskUsageBuilder id(Long... ids) {
+            return id(Arrays.asList(ids));
+        }
+
+        /**
+         * @param types whole types to target for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public DiskUsageBuilder type(String... types) {
+            return type(Arrays.asList(types));
+        }
+    }
+
+    /**
+     * @return a new {@link ChildOption} builder
+     */
+    public static ChildOptionBuilder option() {
+        return new ChildOptionBuilder();
+    }
+
+    /**
+     * @return a new {@link Chgrp2} builder
+     */
+    public static Chgrp2Builder chgrp() {
+        return new Chgrp2Builder();
+    }
+
+    /**
+     * @return a new {@link Chown2} builder
+     */
+    public static Chown2Builder chown() {
+        return new Chown2Builder();
+    }
+
+    /**
+     * @return a new {@link Chmod2} builder
+     */
+    public static Chmod2Builder chmod() {
+        return new Chmod2Builder();
+    }
+
+    /**
+     * @return a new {@link Delete2} builder
+     */
+    public static Delete2Builder delete() {
+        return new Delete2Builder();
+    }
+
+    /**
+     * @return a new {@link Duplicate} builder
+     */
+    public static DuplicateBuilder duplicate() {
+        return new DuplicateBuilder();
+    }
+
+    /**
+     * @return a new {@link SkipHead} builder
+     */
+    public static SkipHeadBuilder skipHead() {
+        return new SkipHeadBuilder();
+    }
+
+    /**
+     * @return a new {@link DiskUsage} builder
+     */
+    public static DiskUsageBuilder diskUsage() {
+        return new DiskUsageBuilder();
     }
 }


### PR DESCRIPTION
Adds request builders to the Java gateway utility class `Requests`. Testing is largely via CI already using these builders in the new implementation (hence plenty of examples) of the now-deprecated previous helper methods for creating graph requests. (Deprecation due to that they are a pain to create and maintain and already falling behind the requests now offered.) Do feel free to try out the builders yourself too and let me know if you want working examples for disk usage and duplicate (helpers newly offered in this PR so without automated indirect testing).

Not changing much of our existing code to use the new builders until `dev_5_2` is branched to avoid conflicts with `regions`.

--no-rebase