### PR TITLE
Extend obj get command

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -358,9 +358,14 @@ class ObjGetTxAction(NonFieldTxAction):
         else:
             try:
                 proxy = current.val
-            except AttributeError, ae:
-                ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
-                    field, self.kls, self.obj.id.val, ae.message))
+            except AttributeError:
+                try:
+                    objId = current.id.val
+                    klass = current.__class__.__name__.rstrip("I")
+                    proxy = klass + ":" + str(objId)
+                except AttributeError, ae:
+                    ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
+                        field, self.kls, self.obj.id.val, ae.message))
 
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -391,16 +391,15 @@ class ObjGetTxAction(NonFieldTxAction):
                 elif hasattr(current, "_value") and hasattr(current, "_unit"):
                     proxy = str(current._value) + " " + str(current._unit)
                 elif isinstance(current, list):
-                    proxy = "["
-                    for item in current:
-                        if isinstance(item, NamedValue):
-                            proxy += ("(" + str(item.name) + ","
-                                      + str(item.value) + ")")
+                    if len(current) == 0:
+                        proxy = ""
+                    else:
+                        if isinstance(current[0], NamedValue):
+                            proxy = ",".join(
+                                ["(" + str(i.name) + "," + str(i.value) + ")"
+                                    for i in current])
                         else:
-                            proxy += str(item)
-                        proxy += ","
-                    proxy = proxy.rstrip(",")
-                    proxy += "]"
+                            proxy = ",".join([str(i) for i in current])
                 else:
                     raise AttributeError(
                         "Error: field '%s' for %s:%s : no val, id or value" % (

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -357,18 +357,21 @@ class ObjGetTxAction(NonFieldTxAction):
             proxy = ""
         else:
             try:
-                if hasattr(current, "_value") and hasattr(current, "_unit"):
-                    proxy = str(current._value) + " " + str(current._unit)
-                else:
+                if hasattr(current, "val"):
                     proxy = current.val
-            except AttributeError:
-                try:
+                elif hasattr(current, "id"):
                     objId = current.id.val
                     klass = current.__class__.__name__.rstrip("I")
                     proxy = klass + ":" + str(objId)
-                except AttributeError, ae:
-                    ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
-                        field, self.kls, self.obj.id.val, ae.message))
+                elif hasattr(current, "_value") and hasattr(current, "_unit"):
+                    proxy = str(current._value) + " " + str(current._unit)
+                else:
+                    raise AttributeError(
+                        "Error: field '%s' for %s:%s : no val, id or value" % (
+                            field, self.kls, self.obj.id.val))
+            except AttributeError, ae:
+                ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
+                    field, self.kls, self.obj.id.val, ae.message))
 
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -357,7 +357,10 @@ class ObjGetTxAction(NonFieldTxAction):
             proxy = ""
         else:
             try:
-                proxy = current.val
+                if hasattr(current, "_value") and hasattr(current, "_unit"):
+                    proxy = str(current._value) + " " + str(current._unit)
+                else:
+                    proxy = current.val
             except AttributeError:
                 try:
                     objId = current.id.val

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2014-2016 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -362,7 +362,7 @@ class ObjGetTxAction(NonFieldTxAction):
                     field = attr.lstrip("_")
                     if hasattr(self.obj, field):
                         try:
-                            proxy += (field + ": "
+                            proxy += (field + "="
                                       + str(self.get_field(field)) + "\n")
                         except AttributeError:
                             pass

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -35,6 +35,7 @@ import fileinput
 from omero_ext.argparse import SUPPRESS
 from omero.cli import BaseControl, CLI, ExceptionHandler
 from omero.rtypes import rlong
+from omero.model import NamedValue
 
 
 class TxField(object):
@@ -389,6 +390,17 @@ class ObjGetTxAction(NonFieldTxAction):
                     proxy = klass + ":" + str(objId)
                 elif hasattr(current, "_value") and hasattr(current, "_unit"):
                     proxy = str(current._value) + " " + str(current._unit)
+                elif isinstance(current, list):
+                    proxy = "["
+                    for item in current:
+                        if isinstance(item, NamedValue):
+                            proxy += ("(" + str(item.name) + ","
+                                      + str(item.value) + ")")
+                        else:
+                            proxy += str(item)
+                        proxy += ","
+                    proxy = proxy.rstrip(",")
+                    proxy += "]"
                 else:
                     raise AttributeError(
                         "Error: field '%s' for %s:%s : no val, id or value" % (

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -343,14 +343,29 @@ class ObjGetTxAction(NonFieldTxAction):
 
     def on_go(self, ctx, args):
 
-        if len(self.tx_cmd.arg_list) != 3:
-            ctx.die(335, "usage: get OBJ FIELD")
+        if len(self.tx_cmd.arg_list) not in (2, 3):
+            ctx.die(335, "usage: get OBJ [FIELD]")
 
-        field = self.tx_cmd.arg_list[2]
-        try:
-            proxy = self.get_field(field)
-        except AttributeError, ae:
-            ctx.die(336, ae.message)
+        if len(self.tx_cmd.arg_list) == 3:
+            field = self.tx_cmd.arg_list[2]
+            try:
+                proxy = self.get_field(field)
+            except AttributeError, ae:
+                ctx.die(336, ae.message)
+        else:
+            proxy = ""
+            for attr in dir(self.obj):
+                if (attr.startswith("_") and
+                        not (attr.startswith("__")
+                             or attr.startswith("_op_")
+                             or attr.endswith("oaded"))):
+                    field = attr.lstrip("_")
+                    if hasattr(self.obj, field):
+                        try:
+                            proxy += (field + ": "
+                                      + str(self.get_field(field)) + "\n")
+                        except AttributeError:
+                            pass
 
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -348,9 +348,18 @@ class ObjGetTxAction(NonFieldTxAction):
 
         field = self.tx_cmd.arg_list[2]
         try:
+            proxy = self.get_field(field)
+        except AttributeError, ae:
+            ctx.die(336, ae.message)
+
+        self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
+
+    def get_field(self, field):
+
+        try:
             current = getattr(self.obj, field)
         except AttributeError:
-            ctx.die(336, "Unknown field '%s' for %s:%s" % (
+            raise AttributeError("Unknown field '%s' for %s:%s" % (
                 field, self.kls, self.obj.id.val))
 
         if current is None:
@@ -370,10 +379,10 @@ class ObjGetTxAction(NonFieldTxAction):
                         "Error: field '%s' for %s:%s : no val, id or value" % (
                             field, self.kls, self.obj.id.val))
             except AttributeError, ae:
-                ctx.die(336, "Error: field '%s' for %s:%s : %s" % (
+                raise AttributeError("Error: field '%s' for %s:%s : %s" % (
                     field, self.kls, self.obj.id.val, ae.message))
 
-        self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
+        return proxy
 
 
 class TxState(object):

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -477,7 +477,7 @@ class TxState(object):
 
 
 class ObjControl(BaseControl):
-    """Create and Update OMERO objects
+    """Create, Update and Query OMERO objects
 
 The obj command allows inserting any objects into the OMERO
 database as well as updating and querying existing ones. This
@@ -487,22 +487,31 @@ Examples:
 
     $ bin/omero obj new Dataset name=foo
     Dataset:123
-
     $ bin/omero obj update Dataset:123 description=bar
     Dataset:123
-
+    $ bin/omero obj get Dataset:123 name
+    foo
+    $ bin/omero obj get Dataset:123
+    description=bar
+    id=123
+    name=foo
+    version=
     $ bin/omero obj null Dataset:123 description
     Dataset:123
-
     $ bin/omero obj get Dataset:123 description
-    A dataset
 
     $ bin/omero obj new MapAnnotation ns=example.com
     MapAnnotation:456
-    $ bin/omero obj map-set MapAnnotation mapValue foo bar
+    $ bin/omero obj map-set MapAnnotation:456 mapValue foo bar
     MapAnnotation:456
-    $ bin/omero obj map-get MapAnnotation mapValue foo
+    $ bin/omero obj map-set MapAnnotation:456 mapValue fu baa
+    MapAnnotation:456
+    $ bin/omero obj map-get MapAnnotation:456 mapValue foo
     bar
+    $ bin/omero obj get MapAnnotation:456 mapValue
+    (foo,bar),(fu,baa)
+    $ bin/omero obj list-get MapAnnotation:456 mapValue 0
+    (foo,bar)
 
 Bash examples:
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -166,7 +166,7 @@ class TxAction(object):
                 kls = kls[0:-1]
             return obj, kls
         except AttributeError:
-            ctx.die(102, "No class named '%s'" % self.class_name())
+            ctx.die(102, "No class named '%s'" % self.class_name(ctx))
 
 
 class NewObjectTxAction(TxAction):

--- a/components/tools/OmeroPy/src/omero_model_ElectricPotentialI.py
+++ b/components/tools/OmeroPy/src/omero_model_ElectricPotentialI.py
@@ -889,6 +889,7 @@ class ElectricPotentialI(_omero_model.ElectricPotential, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettav"))  # nopep8
     CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
         Mul(Pow(10, 42), Sym("zettav"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ATTOVOLT"] = "aV"

--- a/components/tools/OmeroPy/src/omero_model_FrequencyI.py
+++ b/components/tools/OmeroPy/src/omero_model_FrequencyI.py
@@ -889,6 +889,7 @@ class FrequencyI(_omero_model.Frequency, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettahz"))  # nopep8
     CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
         Mul(Pow(10, 42), Sym("zettahz"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ATTOHERTZ"] = "aHz"

--- a/components/tools/OmeroPy/src/omero_model_LengthI.py
+++ b/components/tools/OmeroPy/src/omero_model_LengthI.py
@@ -2033,6 +2033,7 @@ class LengthI(_omero_model.Length, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettam"))  # nopep8
     CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ZEPTOMETER] = \
         Mul(Pow(10, 42), Sym("zettam"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ANGSTROM"] = "Å"

--- a/components/tools/OmeroPy/src/omero_model_PowerI.py
+++ b/components/tools/OmeroPy/src/omero_model_PowerI.py
@@ -889,6 +889,7 @@ class PowerI(_omero_model.Power, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettaw"))  # nopep8
     CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.ZEPTOWATT] = \
         Mul(Pow(10, 42), Sym("zettaw"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ATTOWATT"] = "aW"

--- a/components/tools/OmeroPy/src/omero_model_PressureI.py
+++ b/components/tools/OmeroPy/src/omero_model_PressureI.py
@@ -2033,6 +2033,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettapa"))  # nopep8
     CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
         Mul(Pow(10, 42), Sym("zettapa"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ATMOSPHERE"] = "atm"

--- a/components/tools/OmeroPy/src/omero_model_TemperatureI.py
+++ b/components/tools/OmeroPy/src/omero_model_TemperatureI.py
@@ -73,6 +73,7 @@ class TemperatureI(_omero_model.Temperature, UnitBase):
         Add(Sym("r"), Rat(Int(-45967), Int(100)))  # nopep8
     CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.KELVIN] = \
         Mul(Rat(Int(5), Int(9)), Sym("r"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["CELSIUS"] = "°C"

--- a/components/tools/OmeroPy/src/omero_model_TimeI.py
+++ b/components/tools/OmeroPy/src/omero_model_TimeI.py
@@ -1153,6 +1153,7 @@ class TimeI(_omero_model.Time, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("zettas"))  # nopep8
     CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.ZEPTOSECOND] = \
         Mul(Pow(10, 42), Sym("zettas"))  # nopep8
+    del val
 
     SYMBOLS = dict()
     SYMBOLS["ATTOSECOND"] = "as"

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -145,6 +145,31 @@ class TestObj(CLITest):
         state = self.go()
         assert state.get_row(0) == desc
 
+    def test_new_and_get_obj(self):
+        pname = "foo"
+        dname = "bar"
+        self.args = self.login_args() + [
+            "obj", "new", "Project", "name=%s" % pname]
+        state = self.go()
+        project = state.get_row(0)
+        self.args = self.login_args() + [
+            "obj", "new", "Dataset", "name=%s" % dname]
+        state = self.go()
+        dataset = state.get_row(0)
+        self.args = self.login_args() + [
+            "obj", "new", "ProjectDatasetLink",
+            "parent=%s" % project, "child=%s" % dataset]
+        state = self.go()
+        link = state.get_row(0)
+        self.args = self.login_args() + [
+            "obj", "get", link, "parent"]
+        state = self.go()
+        assert state.get_row(0) == project
+        self.args = self.login_args() + [
+            "obj", "get", link, "child"]
+        state = self.go()
+        assert state.get_row(0) == dataset
+
     def test_map_mods(self):
         self.args = self.login_args() + [
             "obj", "new", "MapAnnotation", "ns=test"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -170,6 +170,14 @@ class TestObj(CLITest):
         state = self.go()
         assert state.get_row(0) == dataset
 
+    def test_get_unit_and_value(self):
+        # units defaults to MICROMETER
+        img = self.importSingleImage(physicalSizeX=1.0)
+        self.args = self.login_args() + [
+            "obj", "get", "Pixels:%s" % img.id.val, "physicalSizeX"]
+        state = self.go()
+        assert state.get_row(0) == "1.0 MICROMETER"
+
     def test_map_mods(self):
         self.args = self.login_args() + [
             "obj", "new", "MapAnnotation", "ns=test"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -206,9 +206,9 @@ class TestObj(CLITest):
             "obj", "get", project]
         state = self.go()
         lines = state.get_row(0).split("\n")
-        assert "id: %s" % project.split(":")[1] in lines
-        assert "name: %s" % name in lines
-        assert "description: %s" % desc in lines
+        assert "id=%s" % project.split(":")[1] in lines
+        assert "name=%s" % name in lines
+        assert "description=%s" % desc in lines
 
     def test_map_mods(self):
         self.args = self.login_args() + [

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -223,19 +223,19 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "get", "MapAnnotation:%s" % a.id.val, "mapValue"]
         state = self.go()
-        assert state.get_row(0) == "[]"
+        assert state.get_row(0) == ""
         a.setMapValue([NV("name1", "value1")])
         a = updateService.saveAndReturnObject(a)
         self.args = self.login_args() + [
             "obj", "get", "MapAnnotation:%s" % a.id.val, "mapValue"]
         state = self.go()
-        assert state.get_row(0) == "[(name1,value1)]"
+        assert state.get_row(0) == "(name1,value1)"
         a.setMapValue([NV("name1", "value1"), NV("name2", "value2")])
         a = updateService.saveAndReturnObject(a)
         self.args = self.login_args() + [
             "obj", "get", "MapAnnotation:%s" % a.id.val, "mapValue"]
         state = self.go()
-        assert state.get_row(0) == "[(name1,value1),(name2,value2)]"
+        assert state.get_row(0) == "(name1,value1),(name2,value2)"
 
         # Test for a list of strings
         n = NamespaceI()
@@ -244,19 +244,19 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "get", "Namespace:%s" % n.id.val, "keywords"]
         state = self.go()
-        assert state.get_row(0) == "[]"
+        assert state.get_row(0) == ""
         n.setKeywords(["keyword1"])
         n = updateService.saveAndReturnObject(n)
         self.args = self.login_args() + [
             "obj", "get", "Namespace:%s" % n.id.val, "keywords"]
         state = self.go()
-        assert state.get_row(0) == "[keyword1]"
+        assert state.get_row(0) == "keyword1"
         n.setKeywords(["keyword1", "keyword2"])
         n = updateService.saveAndReturnObject(n)
         self.args = self.login_args() + [
             "obj", "get", "Namespace:%s" % n.id.val, "keywords"]
         state = self.go()
-        assert state.get_row(0) == "[keyword1,keyword2]"
+        assert state.get_row(0) == "keyword1,keyword2"
 
     def test_list_get(self):
         updateService = self.root.getSession().getUpdateService()

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -172,9 +172,10 @@ class TestObj(CLITest):
 
     def test_get_unit_and_value(self):
         # units defaults to MICROMETER
-        img = self.importSingleImage(physicalSizeX=1.0)
+        fake = create_path("image", "&physicalSizeX=1.0.fake")
+        pixIds = self.import_image(filename=fake.abspath())
         self.args = self.login_args() + [
-            "obj", "get", "Pixels:%s" % img.id.val, "physicalSizeX"]
+            "obj", "get", "Pixels:%s" % pixIds[0], "physicalSizeX"]
         state = self.go()
         assert state.get_row(0) == "1.0 MICROMETER"
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -194,6 +194,22 @@ class TestObj(CLITest):
         with pytest.raises(NonZeroReturnCode):
                 state = self.go()
 
+    def test_get_fields(self):
+        name = "foo"
+        desc = "bar"
+        self.args = self.login_args() + [
+            "obj", "new", "Project", "name=%s" % name,
+            "description=%s" % desc]
+        state = self.go()
+        project = state.get_row(0)
+        self.args = self.login_args() + [
+            "obj", "get", project]
+        state = self.go()
+        lines = state.get_row(0).split("\n")
+        assert "id: %s" % project.split(":")[1] in lines
+        assert "name: %s" % name in lines
+        assert "description: %s" % desc in lines
+
     def test_map_mods(self):
         self.args = self.login_args() + [
             "obj", "new", "MapAnnotation", "ns=test"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -179,6 +179,21 @@ class TestObj(CLITest):
         state = self.go()
         assert state.get_row(0) == "1.0 MICROMETER"
 
+    def test_get_unknown_and_empty_field(self):
+        name = "foo"
+        self.args = self.login_args() + [
+            "obj", "new", "Project", "name=%s" % name]
+        state = self.go()
+        project = state.get_row(0)
+        self.args = self.login_args() + [
+            "obj", "get", project, "description"]
+        state = self.go()
+        assert state.get_row(0) == ""
+        self.args = self.login_args() + [
+            "obj", "get", project, "bar"]
+        with pytest.raises(NonZeroReturnCode):
+                state = self.go()
+
     def test_map_mods(self):
         self.args = self.login_args() + [
             "obj", "new", "MapAnnotation", "ns=test"]


### PR DESCRIPTION
This was a quick fix for the issue raised by @mtbc in https://trello.com/c/sBjOWOWT/588-omero-obj-follow-up  If the requested field has an `id` rather than a `val` return the result in the form `Klass:id`. It now extends the command to handle fields that have units, returning the value and the units. It also adds the more general form to get all reasonable OMERO fields and values for a given object. 

Testing should use fields that have ids. For instance import an image from the command line and then use the returned Pixels id to get linked object ids:
```
$ bin/omero obj get Pixels:101 image
Image:101
$ bin/omero obj get Image:101 fileset
Fileset:51
```

To test a field with units import a fake, e.g.:
```
$ omero import ~/Work/images/fakes/image\&physicalSizeX\=123.fake
Imported pixels:
251
Other imported objects:
Fileset:251
Image:251
$ omero obj get Pixels:251 physicalSizeX
123.0 MICROMETER
```

existing value fields should still work:
```
$ bin/omero obj get Image:101 name
IAGFP-Noc01_R3D.dv
```

Test getting all fields:
```
$ bin/omero obj new Project name=foo description=bar
Project:251
$ bin/omero obj get Project:251
description: bar
id: 251
name: foo
version:

$ omero obj get Pixels:251
dimensionOrder: DimensionOrder:1
id: 251
image: Image:251
methodology:
physicalSizeX: 123.0 MICROMETER
physicalSizeY:
physicalSizeZ:
pixelsType: PixelsType:5
relatedTo:
sha1: ecb315eecb4feab2a177494b656e1653cb6d76f1
significantBits: 8
sizeC: 1
sizeT: 1
sizeX: 512
sizeY: 512
sizeZ: 1
timeIncrement:
version:
waveIncrement:
waveStart:
```

Test list fields, whole and by index value:
```
$ omero obj get ExperimenterGroup:260 config
[(name1,value1),(name2,value2),(name3,value3)]
$ omero obj get ExperimenterGroup:1 config
[]
$ omero obj list-get ExperimenterGroup:260 config 1
(name2,value2)
$ omero obj list-get ExperimenterGroup:260 config -1
(name3,value3)
$ omero obj list-get ExperimenterGroup:260 config 3
Error: field 'config[3]' for ExperimenterGroup:260, list index out of range
$ omero obj list-get ExperimenterGroup:260 name 1
Field 'name' for ExperimenterGroup:260 is not a list
```

Integration tests have been added to https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_obj.py the whole of which should still pass.