### PR TITLE
Adding BF version for 5.2.2 history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -40,6 +40,9 @@ System administrator updates include:
    experimental solution to resolve download issues
 -  documentation of hard-linking issues for in-place import on linux systems
 
+This release also upgrades the version of Bio-Formats which OMERO uses to
+5.1.8.
+
 Note that the OMERO Virtual Appliance has been discontinued and will not be
 updated for version 5.2.2 or any later releases.
 


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/4494 this point was added to the release announcement but not the history page in the docs.