### PR TITLE
Show image with pagination

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -441,7 +441,7 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
         p = omero.sys.ParametersI()
         so = deepcopy(conn.SERVICE_OPTS)
         so.setOmeroGroup(groupId)
-        if (datasetId is not None):
+        if datasetId is not None:
             p.add('did', rlong(datasetId))
             q = """select image.id from Image image
                 join image.datasetLinks dlink where dlink.parent.id = :did

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -449,7 +449,7 @@ def get_image_ids(conn, datasetId=None, groupId=-1, ownerId=None):
 def paths_to_object(conn, experimenter_id=None, project_id=None,
                     dataset_id=None, image_id=None, screen_id=None,
                     plate_id=None, acquisition_id=None, well_id=None,
-                    group_id=None, page_size=settings.PAGE):
+                    group_id=None, page_size=None):
     """
     Retrieves the parents of an object (E.g. P/D/I for image) as a list
     of paths.
@@ -458,9 +458,10 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
     If object has multiple paths, these can also be filtered by parent_ids.
     E.g. paths to image_id filtered by dataset_id.
 
-    If image is in a Dataset that is paginated (imageCount > page_size)
-    then we include 'childPage', 'childCount' and 'childIndex'
-    in the dataset dict.
+    If image is in a Dataset or Orphaned collection that is paginated
+    (imageCount > page_size) then we include 'childPage', 'childCount'
+    and 'childIndex' in the dataset or orphaned dict.
+    The page_size default is settings.PAGE (omero.web.page_size)
 
     Note on wells:
     Selecting a 'well' is really for selecting well_sample paths
@@ -469,6 +470,8 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
     """
 
     qs = conn.getQueryService()
+    if page_size is None:
+        page_size = settings.PAGE
 
     params = omero.sys.ParametersI()
     service_opts = deepcopy(conn.SERVICE_OPTS)

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -192,6 +192,10 @@ $(function() {
                         if (!node) {
                             return;
                         }
+                        // If we have a 'childPage' greater than 0, need to paginate
+                        if (comp.childPage) {
+                            inst._set_page(node, comp.childPage);
+                        }
 
                         if (index < lastIndex) {
                             inst.open_node(node, function() {

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1076,9 +1076,9 @@ class TestShow(IWebTest):
     @pytest.fixture
     def project_dataset_images(self):
         """
-        Returns a new OMERO Project, linked Dataset and 5 linked Images populated
-        by an L{test.integration.library.ITest} instance with required fields
-        set.
+        Returns a new OMERO Project, linked Dataset and 5 linked Images
+        populated by an L{test.integration.library.ITest} instance with
+        required fields set.
         """
         project = ProjectI()
         project.name = rstring(self.uuid())


### PR DESCRIPTION
This fixes the navigation to an image with the url ``` webclient/?show=image-<id> ``` when that image is not on the first page of a Dataset.

To test:
- find a Dataset with pagination (>200 images)
- browse to the second or other page, click an image and copy the link to it
- paste the url in browser and check that this browses to show the image on the correct page
- Bonus: The same should work for Orphaned images (if you have > 200 orphaned images)

Also added web integration test which should pass!