### PR TITLE
use new request builders in DiskUsage and Duplicate tests

### DIFF
--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -70,10 +70,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 /**
  * Integration tests for the {@link omero.cmd.DiskUsage} request.
@@ -90,25 +88,13 @@ public class DiskUsageTest extends AbstractServerTest {
     private Long thumbnailSize;
 
     /**
-     * Convert a {@code Collection<Long>} to a {@code List<Long>}.
-     */
-    private static Function<Collection<Long>, List<Long>> LONG_COLLECTION_TO_LIST =
-            new Function<Collection<Long>, List<Long>>() {
-        @Override
-        public List<Long> apply(Collection<Long> ids) {
-            return new ArrayList<Long>(ids);
-        }
-    };
-
-    /**
      * Submit a disk usage request for the given objects and return the server's response.
      * @param objects the target objects
      * @return the objects' disk usage
      * @throws Exception if thrown during request execution
      */
     private DiskUsageResponse runDiskUsage(Map<java.lang.String, ? extends Collection<Long>> objects) throws Exception {
-        final DiskUsage request = new DiskUsage();
-        request.objects = Maps.transformValues(objects, LONG_COLLECTION_TO_LIST);
+        final DiskUsage request = Requests.diskUsage().target(objects).build();
         return (DiskUsageResponse) doChange(request);
     }
 
@@ -223,7 +209,7 @@ public class DiskUsageTest extends AbstractServerTest {
     @AfterClass
     public void teardown() throws Exception {
         if (imageId != null) {
-            final Delete2 request = Requests.delete("Image", imageId);
+            final Delete2 request = Requests.delete().target("Image").id(imageId).build();
             doChange(request);
         }
     }
@@ -291,8 +277,8 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
             }
         } finally {
-            final ChildOption option = Requests.option(null, "Image");
-            final Delete2 request = Requests.delete("Project", projectId, option);
+            final ChildOption option = Requests.option().excludeType("Image").build();
+            final Delete2 request = Requests.delete().target("Project").id(projectId).option(option).build();
             doChange(request);
         }
     }
@@ -322,8 +308,8 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
             }
         } finally {
-            final ChildOption option = Requests.option(null, "Image");
-            final Delete2 request = Requests.delete("Folder", parentFolderId, option);
+            final ChildOption option = Requests.option().excludeType("Image").build();
+            final Delete2 request = Requests.delete().target("Folder").id(parentFolderId).option(option).build();
             doChange(request);
         }
     }
@@ -394,7 +380,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -433,7 +419,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -466,7 +452,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -516,7 +502,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -551,7 +537,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -580,7 +566,7 @@ public class DiskUsageTest extends AbstractServerTest {
                 Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete("Annotation", annotationIds);
+            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -637,8 +623,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testBadClassName() throws Exception {
-        final DiskUsage request = new DiskUsage();
-        request.objects = ImmutableMap.of("NoClass", Collections.singletonList(1L));
+        final DiskUsage request = Requests.diskUsage().target("NoClass").id(1L).build();
         doChange(client, factory, request, false, null);
     }
 }

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -20,7 +20,6 @@
 package integration;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,7 +100,6 @@ import org.testng.annotations.Test;
 import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
@@ -167,7 +165,7 @@ public class DuplicationTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = Requests.delete("Image", testImages);
+        final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }
@@ -396,8 +394,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* find out which objects the duplication claims to have created */
@@ -511,9 +508,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image in dry-run mode */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
-        dup.dryRun = true;
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).dryRun().build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* find out which objects the duplication reports as being targets for processing */
@@ -565,8 +560,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image, link, and annotation */
@@ -633,9 +627,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
-        dup.typesToReference = ImmutableList.of("TextAnnotation");
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).referenceType("TextAnnotation").build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image and link, but not an annotation */
@@ -691,9 +683,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
-        dup.typesToIgnore = ImmutableList.of("IAnnotationLink");
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).ignoreType("IAnnotationLink").build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image and link, but not an annotation */
@@ -744,8 +734,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image and link, but not the attachment */
@@ -824,8 +813,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image and annotations and the links among them */
@@ -915,8 +903,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the images */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", (List<Long>) new ArrayList<Long>(originalImageIds));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageIds).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of the images, links, and annotations */
@@ -1048,8 +1035,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image, link, and annotation */
@@ -1147,10 +1133,9 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
-        dup.typesToDuplicate = ImmutableList.of("BasicAnnotation", "XmlAnnotation");
-        dup.typesToReference = ImmutableList.of("DoubleAnnotation", "TextAnnotation");
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId)
+                .duplicateType("BasicAnnotation", "XmlAnnotation")
+                .referenceType("DoubleAnnotation", "TextAnnotation").build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of an image, annotations and their links */
@@ -1226,8 +1211,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image with contradictory instructions */
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects = ImmutableMap.of("Image", Arrays.asList(originalImageId));
+        final Duplicate dup = Requests.duplicate().target("Image").id(originalImageId).build();
 
         for (int i = 0; i < 4; i++) {
             dup.typesToDuplicate = i == 0 ? null : ImmutableList.of("IAnnotationLink");
@@ -1361,9 +1345,7 @@ public class DuplicationTest extends AbstractServerTest {
 
         final boolean expectSuccess = myContainer || "rwrw--".equals(groupPerms);
 
-        final Duplicate dup = new Duplicate();
-        dup.targetObjects =
-                ImmutableMap.of(link.getClass().getSuperclass().getSimpleName(), Arrays.asList(link.getId().getValue()));
+        final Duplicate dup = Requests.duplicate().target(link).build();
         final Response response = doChange(client, factory, dup, expectSuccess);
 
         if (expectSuccess) {

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1192,7 +1192,7 @@ public class DuplicationTest extends AbstractServerTest {
     }
 
     /**
-     * Test duplication of an annotated image with contradictory treatments for the same annotation typs.
+     * Test duplication of an annotated image with contradictory treatments for the same annotation types.
      * @throws Exception unexpected
      */
     @Test


### PR DESCRIPTION
Add use of the new builders for `DiskUsage` and `Duplicate` so that those builders actually get some automated testing. On `regions` instead of `develop` because those test classes have already diverged to include folders.