### PR TITLE
Adding omero web config apache24 to message from `web start`

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -504,8 +504,10 @@ class WebControl(BaseControl):
         if deploy in (settings.WSGI,):
             self.ctx.die(609, "You are deploying OMERO.web using apache and"
                          " mod_wsgi. Generate apache config using"
-                         " 'omero web config apache' and reload"
+                         " 'omero web config apache' or"
+                         " 'omero web config apache24' and reload"
                          " web server.")
+
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -188,6 +188,7 @@ class TestWeb(object):
             stderr = (
                 ("You are deploying OMERO.web using apache and mod_wsgi. "
                  "Generate apache config using 'omero web config apache' "
+                 "or 'omero web config apache24' "
                  "and reload web server."))
             assert stderr == e.split(os.linesep)[0]
             assert 1 == len(e.split(os.linesep))-1


### PR DESCRIPTION
cf https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=8012&p=16820#p16820 and https://trello.com/c/aHKgiVXW/36-mention-apache-2-4-in-docs - message from OMERO.web states user should generate web config with "omero web apache" yet user is using Apache 2.4. We're improving docs to include references to the new command for Apache 2.4+, but the output from OMERO.web needs to mention it too.

Test updated.