### PR TITLE
Measurementtool DnD

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -183,32 +183,6 @@ public class ROINode
         return getUserObject() instanceof ROIShape;
     }
 
-    /**
-     * Checks if this node exclusively contains ROI child nodes
-     * 
-     * @return <code>false</code> if it does not, <code>true</code> otherwise
-     *         (also if it does not contain any child nodes)
-     */
-    public boolean containsROIs() {
-        for (int i = 0; i < getChildCount(); i++)
-            if (!((ROINode) getChildAt(i)).isROINode())
-                return false;
-        return true;
-    }
-    
-    /**
-     * Checks if this node exclusively contains Folder child nodes
-     * 
-     * @return <code>false</code> if it does not, <code>true</code> otherwise
-     *         (also if it does not contain any child nodes)
-     */
-    public boolean containsFolders() {
-        for (int i = 0; i < getChildCount(); i++)
-            if (!((ROINode) getChildAt(i)).isFolderNode())
-                return false;
-        return true;
-    }
-    
 	/**
 	 * Get the point in the parent where a child with coordinate should be 
 	 * inserted.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -27,14 +27,24 @@ package org.openmicroscopy.shoola.agents.measurement.util.roitable;
 //Java imports
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 
+
+
+
 //Third-party libraries
 import org.jdesktop.swingx.treetable.MutableTreeTableNode;
+
+import javax.swing.tree.MutableTreeNode;
 import javax.swing.tree.TreePath;
+
+
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
@@ -221,6 +231,34 @@ public class ROINode
 		return index;
 	}
 	
+    /**
+     * Get the point in the parent where a child should be inserted.
+     * 
+     * @param f
+     *            see above.
+     * @return see above.
+     */
+    public int getInsertionPoint(FolderData f) {
+        int index = 0;
+
+        if (f == null)
+            return index;
+
+        for (MutableTreeTableNode n : children) {
+            ROINode r = (ROINode) n;
+            if (r.getUserObject() == null)
+                continue;
+            if (r.isFolderNode()) {
+                if (((FolderData) r.getUserObject()).getName()
+                        .compareToIgnoreCase(f.getName()) > 0)
+                    break;
+            }
+            index++;
+        }
+
+        return index;
+    }
+    
 	/** Initializes the maps for the child nodes. */
 	private void initMaps()
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -558,6 +558,8 @@ public class ROINode
                 // therefore take a step of length 2 to get the folder node
                 ROINode folder = (ROINode) path.getPathComponent(path
                         .getPathCount() - 3);
+                if (folder.isRoot())
+                    return shape.isVisible();
                 if (b == null)
                     b = folder.isVisible();
                 else

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -27,24 +27,14 @@ package org.openmicroscopy.shoola.agents.measurement.util.roitable;
 //Java imports
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
-
-
-
+import javax.swing.tree.TreePath;
 
 //Third-party libraries
 import org.jdesktop.swingx.treetable.MutableTreeTableNode;
-
-import javax.swing.tree.MutableTreeNode;
-import javax.swing.tree.TreePath;
-
-
-
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
@@ -597,6 +587,57 @@ public class ROINode
         for (MutableTreeTableNode n : this.getChildList()) {
             gatherNodes((ROINode) n, nodes);
         }
+    }
+    
+    /**
+     * Indicates if the node can be annotated if <code>true</code>,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean canAnnotate() {
+        if (isFolderNode())
+            return ((FolderData) getUserObject()).canAnnotate();
+        if (isROINode())
+            return ((ROI) getUserObject()).canAnnotate();
+        if (isShapeNode())
+            return ((ROIShape) getUserObject()).getROI().canAnnotate();
+
+        return false;
+    }
+
+    /**
+     * Indicates if the node can be deleted if <code>true</code>,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean canDelete() {
+        if (isFolderNode())
+            return ((FolderData) getUserObject()).canDelete();
+        if (isROINode())
+            return ((ROI) getUserObject()).canDelete();
+        if (isShapeNode())
+            return ((ROIShape) getUserObject()).getROI().canDelete();
+
+        return false;
+    }
+
+    /**
+     * Indicates if the node can be edited if <code>true</code>,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean canEdit() {
+        if (isFolderNode())
+            return ((FolderData) getUserObject()).canEdit();
+        if (isROINode())
+            return ((ROI) getUserObject()).canEdit();
+        if (isShapeNode())
+            return ((ROIShape) getUserObject()).getROI().canEdit();
+
+        return false;
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
@@ -1,0 +1,133 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
+package org.openmicroscopy.shoola.agents.measurement.util.roitable;
+
+import java.awt.Cursor;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DragSource;
+
+import javax.activation.DataHandler;
+import javax.swing.JComponent;
+import javax.swing.JTable;
+import javax.swing.TransferHandler;
+
+import omero.log.LogMessage;
+
+import org.openmicroscopy.shoola.agents.measurement.view.ROITable;
+import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
+
+/**
+ * TransferHandler for reordering rows in a JTable
+ * 
+ * Based on a stackoverflow post by Aaron Davidson:
+ * http://stackoverflow.com/questions
+ * /638807/how-do-i-drag-and-drop-a-row-in-a-jtable
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class TableRowTransferHandler extends TransferHandler {
+
+    /** Reference to the table */
+    private JTable table = null;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param table
+     *            Reference to the table
+     */
+    public TableRowTransferHandler(JTable table) {
+        this.table = table;
+    }
+
+    @Override
+    protected Transferable createTransferable(JComponent c) {
+        // Just use String as transfer object to keep it simple
+        return new DataHandler(intArrayToString(table.getSelectedRows()),
+                DataFlavor.stringFlavor.getMimeType());
+    }
+
+    @Override
+    public boolean canImport(TransferHandler.TransferSupport info) {
+        boolean b = info.getComponent() == table && info.isDrop()
+                && info.isDataFlavorSupported(DataFlavor.stringFlavor);
+        table.setCursor(b ? DragSource.DefaultMoveDrop
+                : DragSource.DefaultMoveNoDrop);
+        return b;
+    }
+
+    @Override
+    public int getSourceActions(JComponent c) {
+        return TransferHandler.MOVE;
+    }
+
+    @Override
+    public boolean importData(TransferHandler.TransferSupport info) {
+        if (!info.isDrop())
+            return false;
+        ROITable target = (ROITable) info.getComponent();
+        JTable.DropLocation dl = (JTable.DropLocation) info.getDropLocation();
+        int index = dl.getRow();
+        int max = table.getModel().getRowCount();
+        if (index < 0 || index > max)
+            index = max;
+        target.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+        try {
+            String value = (String) info.getTransferable().getTransferData(
+                    DataFlavor.stringFlavor);
+            int[] rowsToMove = stringToIntArray(value);
+            target.handleDragAndDrop(rowsToMove, index);
+            return true;
+        } catch (Exception e) {
+            LogMessage msg = new LogMessage("DnD action failed", e);
+            MetadataViewerAgent.getRegistry().getLogger().warn(this, msg);
+        }
+        return false;
+    }
+
+    @Override
+    protected void exportDone(JComponent c, Transferable t, int act) {
+        if (act == TransferHandler.MOVE || act == TransferHandler.NONE) {
+            table.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+        }
+    }
+
+    private String intArrayToString(int[] array) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < array.length; i++) {
+            sb.append(array[i]);
+            if (i < array.length - 1)
+                sb.append(',');
+        }
+        return sb.toString();
+    }
+
+    private int[] stringToIntArray(String s) {
+        String[] tmp = s.split(",");
+        int[] result = new int[tmp.length];
+        for (int i = 0; i < result.length; i++)
+            result[i] = Integer.parseInt(tmp[i]);
+        return result;
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
@@ -71,15 +71,44 @@ public class TableRowTransferHandler extends TransferHandler {
     @Override
     public boolean canImport(TransferHandler.TransferSupport info) {
         boolean b = info.getComponent() == table && info.isDrop()
-                && info.isDataFlavorSupported(DataFlavor.stringFlavor);
+                && info.isDataFlavorSupported(DataFlavor.stringFlavor)
+                && checkDropTarget(info);
+
         table.setCursor(b ? DragSource.DefaultMoveDrop
                 : DragSource.DefaultMoveNoDrop);
+
         return b;
+    }
+
+    /**
+     * Check if the drop target is valid
+     */
+    private boolean checkDropTarget(TransferHandler.TransferSupport info) {
+        JTable.DropLocation dl = (JTable.DropLocation) info.getDropLocation();
+        int index = dl.getRow();
+        ROINode n = (ROINode) ((ROITable) table).getNodeAtRow(index);
+        return n.canEdit() && n.isFolderNode();
+    }
+
+    /**
+     * Check if the current selection is draggable
+     */
+    private boolean checkDragSource() {
+        int[] selection = table.getSelectedRows();
+        for (int i = 0; i < selection.length; i++) {
+            ROINode n = (ROINode) ((ROITable) table).getNodeAtRow(selection[i]);
+            if (!n.canEdit())
+                return false;
+        }
+        return true;
     }
 
     @Override
     public int getSourceActions(JComponent c) {
-        return TransferHandler.MOVE;
+        if (checkDragSource())
+            return TransferHandler.MOVE;
+        else
+            return TransferHandler.NONE;
     }
 
     @Override

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -1222,6 +1222,27 @@ class MeasurementViewerModel
     }
     
     /**
+     * Move ROIs to Folders
+     * 
+     * @param allROIs
+     *            All ROIs
+     * @param selectedObjects
+     *            The ROIs
+     * @param folders
+     *            The Folders
+     */
+    void moveROIsToFolder(Collection<ROIData> allROIs,
+            Collection<ROIData> selectedObjects, Collection<FolderData> folders) {
+        ExperimenterData exp = (ExperimenterData) MeasurementAgent
+                .getUserDetails();
+        currentSaver = new ROIFolderSaver(component, getSecurityContext(),
+                getImageID(), exp.getId(), allROIs, selectedObjects, folders,
+                ROIFolderAction.MOVE_TO_FOLDER);
+        currentSaver.load();
+        state = MeasurementViewer.SAVING_ROI;
+    }
+    
+    /**
      * Delete Folders
      * 
      * @param folders

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -97,6 +97,7 @@ import omero.gateway.model.GroupData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.model.ROIData;
+import omero.gateway.util.Pojos;
 import ome.model.units.BigResult;
 import omero.model.Length;
 import omero.model.LengthI;
@@ -1228,6 +1229,16 @@ class MeasurementViewerModel
      *            The Folders
      */
     void deleteFolders(Collection<FolderData> folders) {
+        // remove from the local data model
+        Collection<Long> ids = Pojos.extractIds(folders);
+        Iterator<FolderData> it = this.folders.iterator();
+        while(it.hasNext()) {
+            FolderData f = it.next();
+            if(ids.contains(f.getId()))
+                it.remove();
+        }
+        
+        // delete on the server
         ExperimenterData exp = (ExperimenterData) MeasurementAgent
                 .getUserDetails();
         currentSaver = new ROIFolderSaver(component, getSecurityContext(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -1229,16 +1229,6 @@ class MeasurementViewerModel
      *            The Folders
      */
     void deleteFolders(Collection<FolderData> folders) {
-        // remove from the local data model
-        Collection<Long> ids = Pojos.extractIds(folders);
-        Iterator<FolderData> it = this.folders.iterator();
-        while(it.hasNext()) {
-            FolderData f = it.next();
-            if(ids.contains(f.getId()))
-                it.remove();
-        }
-        
-        // delete on the server
         ExperimenterData exp = (ExperimenterData) MeasurementAgent
                 .getUserDetails();
         currentSaver = new ROIFolderSaver(component, getSecurityContext(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -97,7 +97,6 @@ import omero.gateway.model.GroupData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.model.ROIData;
-import omero.gateway.util.Pojos;
 import ome.model.units.BigResult;
 import omero.model.Length;
 import omero.model.LengthI;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -123,7 +123,7 @@ class MeasurementViewerUI
 	static final String DEFAULT_MSG = "";
 	
 	/** The default size of the window. */
-	private static final Dimension DEFAULT_SIZE = new Dimension(400, 300);
+	private static final Dimension DEFAULT_SIZE = new Dimension(500, 300);
 
 	/** The title for the measurement tool main window. */
 	private static final String WINDOW_TITLE = "";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -114,7 +114,7 @@ class ObjectManager
 	
 	static{
 		COLUMN_WIDTHS = new HashMap<String, Integer>();
-        COLUMN_WIDTHS.put(COLUMN_NAMES.get(0), 80);
+        COLUMN_WIDTHS.put(COLUMN_NAMES.get(0), 180);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(1), 36);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(2), 36);
         COLUMN_WIDTHS.put(COLUMN_NAMES.get(3), 36);
@@ -284,6 +284,7 @@ class ObjectManager
         }
         objectsTable.collapseAll();
         objectsTable.expandFolders(expandedFolderIds);
+        objectsTable.setAutoCreateColumnsFromModel( false );
     }
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
 
@@ -41,10 +42,6 @@ import javax.swing.JScrollPane;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.TreeSelectionModel;
-
-
-
-
 
 
 //Third-party libraries
@@ -72,6 +69,7 @@ import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FolderData;
 import omero.gateway.model.ROIData;
+import omero.gateway.util.Pojos;
 import omero.log.LogMessage;
 
 /** 
@@ -265,26 +263,28 @@ class ObjectManager
     	objectsTable.showROIManagementMenu(view.getDrawingView(), x, y);
     }
     
-	/** Rebuilds Tree */
-	void rebuildTable()
-	{
-		TreeMap<Long, ROI> roiList = model.getROI();
-		Iterator<ROI> iterator = roiList.values().iterator();
-		ROI roi;
-		TreeMap<Coord3D, ROIShape> shapeList;
-		Iterator<ROIShape> shapeIterator;
-		objectsTable.clear();
-		objectsTable.initFolders(getFolders());
-		while(iterator.hasNext())
-		{
-			roi = iterator.next();
-			shapeList = roi.getShapes();
-			shapeIterator = shapeList.values().iterator();
-			while (shapeIterator.hasNext())
-				objectsTable.addROIShape(shapeIterator.next());
-		}
-		objectsTable.collapseAll();
-	}
+    /** Rebuilds Tree */
+    void rebuildTable() {
+        TreeMap<Long, ROI> roiList = model.getROI();
+        Iterator<ROI> iterator = roiList.values().iterator();
+        ROI roi;
+        TreeMap<Coord3D, ROIShape> shapeList;
+        Iterator<ROIShape> shapeIterator;
+        Set<Long> expandedFolderIds = objectsTable.getExpandedFolders();
+        expandedFolderIds.addAll(Pojos.extractIds(objectsTable
+                .getRecentlyModifiedFolders()));
+        objectsTable.clear();
+        objectsTable.initFolders(getFolders());
+        while (iterator.hasNext()) {
+            roi = iterator.next();
+            shapeList = roi.getShapes();
+            shapeIterator = shapeList.values().iterator();
+            while (shapeIterator.hasNext())
+                objectsTable.addROIShape(shapeIterator.next());
+        }
+        objectsTable.collapseAll();
+        objectsTable.expandFolders(expandedFolderIds);
+    }
 	
 	/**
 	 * Returns the name of the component.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -154,8 +154,6 @@ class ObjectManager
 	    objectsTable = new ROITable(new ROITableModel(root, COLUMN_NAMES), 
 	    		COLUMN_NAMES, this);
 	    objectsTable.setRootVisible(false);
-	    objectsTable.setColumnSelectionAllowed(true);
-	    objectsTable.setRowSelectionAllowed(true);
 	    treeSelectionListener = new TreeSelectionListener()
 	    {
 			
@@ -575,6 +573,28 @@ class ObjectManager
             }
         }
         model.addROIsToFolder(allRois, selectedRois.values(), folders);
+    }
+    
+    /**
+     * Move ROIs to Folders
+     * 
+     * @param selectedObjects
+     *            The ROIs
+     * @param folders
+     *            The Folders
+     */
+    public void moveROIsToFolder(Collection<ROIShape> selectedObjects,
+            Collection<FolderData> folders) {
+        List<ROIData> allRois = model.getROIData();
+        Map<Long, ROIData> selectedRois = new HashMap<Long, ROIData>();
+        for (ROIShape shape : selectedObjects) {
+            if (!selectedRois.containsKey(shape.getID())) {
+                ROIData rd = findROI(allRois, shape.getROI());
+                if (rd != null)
+                    selectedRois.put(shape.getID(), rd);
+            }
+        }
+        model.moveROIsToFolder(allRois, selectedRois.values(), folders);
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -369,7 +369,7 @@ public class ROITable
     Set<Long> getExpandedFolders() {
         Set<Long> result = new HashSet<Long>();
         for (ROINode node : nodes) {
-            if (node.isExpanded() && node.isFolderNode() && node.containsROIs())
+            if (node.isExpanded() && node.isFolderNode())
                 result.add(((FolderData) node.getUserObject()).getId());
         }
         return result;
@@ -1368,6 +1368,7 @@ public class ROITable
             FolderData folder = (FolderData) evt.getNewValue();
             if(action == CreationActionType.CREATE_FOLDER && parent!=null) {
                 folder.setParentFolder(parent.asFolder());
+                recentlyModifiedFolders.add(parent);
             }
             
             toSave.add(folder);
@@ -1379,6 +1380,7 @@ public class ROITable
             FolderData folder = getSelectedFolders().get(0);
             FolderData target = (FolderData) evt.getNewValue();
             folder.setParentFolder(target.asFolder());
+            recentlyModifiedFolders.add(target);
             manager.saveROIFolders(Collections.singleton(folder));
         }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -26,6 +26,8 @@ package org.openmicroscopy.shoola.agents.measurement.view;
 
 //Java imports
 import java.awt.Component;
+import java.awt.Point;
+import java.awt.dnd.DnDConstants;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -42,14 +44,19 @@ import java.util.TreeMap;
 import java.util.Vector;
 import java.util.Map.Entry;
 
+import javax.swing.DropMode;
 import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
 import javax.swing.ListSelectionModel;
 import javax.swing.ToolTipManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+import javax.swing.event.MouseInputListener;
+import javax.swing.plaf.basic.BasicTableUI;
 import javax.swing.table.TableColumn;
 import javax.swing.tree.TreePath;
+
+
 
 
 //Third-party libraries
@@ -62,6 +69,7 @@ import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROIActionContr
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROINode;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROITableCellRenderer;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROITableModel;
+import org.openmicroscopy.shoola.agents.measurement.util.roitable.TableRowTransferHandler;
 import org.openmicroscopy.shoola.agents.measurement.util.ui.ShapeRenderer;
 import org.openmicroscopy.shoola.agents.util.SelectionWizard;
 import org.openmicroscopy.shoola.agents.util.ui.EditorDialog;
@@ -235,6 +243,15 @@ public class ROITable
 		popupMenu = new ROIPopupMenu(this);
 		reset = false;
 		
+	    setColumnSelectionAllowed(false);
+	    setRowSelectionAllowed(true);
+		
+	    // enable DnD
+	    setUI(new CustomTableUI());
+		setDragEnabled(true);
+        setDropMode(DropMode.ON);
+        setTransferHandler(new TableRowTransferHandler(this));
+
 		// make sure either shapes or folders can be selected, not both
         selectionModel.addListSelectionListener(new ListSelectionListener() {
             boolean active = true;
@@ -1390,7 +1407,119 @@ public class ROITable
             manager.saveROIFolders(Collections.singleton(folder));
         }
     }
+
+    /**
+     * Handles drag and drop actions
+     * 
+     * @param rows
+     *            The dragged rows
+     * @param destination
+     *            The location where the rows had been dragged to
+     */
+    public void handleDragAndDrop(int[] rows, int destination) {
+        List<ROINode> objects = new ArrayList<ROINode>();
+        for (int i = 0; i < rows.length; i++) {
+            if (rows[i] == destination)
+                return;
+            objects.add((ROINode) getNodeAtRow(rows[i]));
+        }
+
+        ROINode target = (ROINode) getNodeAtRow(destination);
+        if (target == null) {
+            if (objects.iterator().next().isFolderNode()) {
+                Collection<FolderData> toSave = new ArrayList<FolderData>();
+                for (ROINode n : objects) {
+                    FolderData folder = (FolderData) n.getUserObject();
+                    folder.setParentFolder(null);
+                    toSave.add(folder);
+                }
+                manager.saveROIFolders(toSave);
+            } else if (objects.iterator().next().isShapeNode()) {
+                List<ROIShape> rois = new ArrayList<ROIShape>();
+                for (ROINode n : objects) {
+                    rois.add((ROIShape) n.getUserObject());
+                }
+                manager.moveROIsToFolder(rois, Collections.EMPTY_LIST);
+            } else if (objects.iterator().next().isROINode()) {
+                List<ROIShape> rois = new ArrayList<ROIShape>();
+                for (ROINode n : objects) {
+                    ROI r = (ROI) n.getUserObject();
+                    rois.addAll(r.getShapes().values());
+                }
+                manager.moveROIsToFolder(rois, Collections.EMPTY_LIST);
+            }
+            return;
+        }
+        
+        if (!target.isFolderNode())
+            return;
+
+        FolderData targetFolder = (FolderData) target.getUserObject();
+
+        if (objects.iterator().next().isFolderNode()) {
+
+            List<FolderData> folders = new ArrayList<FolderData>(objects.size());
+            for (ROINode n : objects) {
+                FolderData f = (FolderData) n.getUserObject();
+                f.setParentFolder(targetFolder.asFolder());
+                folders.add(f);
+            }
+            recentlyModifiedFolders.add(targetFolder);
+            manager.saveROIFolders(folders);
+        } else if (objects.iterator().next().isShapeNode()) {
+            List<ROIShape> rois = new ArrayList<ROIShape>();
+            for (ROINode n : objects) {
+                rois.add((ROIShape) n.getUserObject());
+            }
+            recentlyModifiedFolders.add(targetFolder);
+            manager.moveROIsToFolder(rois,
+                    Collections.singletonList(targetFolder));
+        } else if (objects.iterator().next().isROINode()) {
+            List<ROIShape> rois = new ArrayList<ROIShape>();
+            for (ROINode n : objects) {
+                ROI r = (ROI) n.getUserObject();
+                rois.addAll(r.getShapes().values());
+            }
+            recentlyModifiedFolders.add(targetFolder);
+            manager.moveROIsToFolder(rois,
+                    Collections.singletonList(targetFolder));
+        }
+    }
     
+    /**
+     * The default drag behavior - if multiselection is enabled - is to extend
+     * the selection. To prevent that, we have to override the TableUI. This
+     * workaround is based on the forum post:
+     * https://community.oracle.com/thread/1361004
+     */
+    class CustomTableUI extends BasicTableUI {
+
+        @Override
+        protected MouseInputListener createMouseInputListener() {
+            return new MouseInputHandler() {
+
+                public void mousePressed(MouseEvent e) {
+
+                    Point origin = e.getPoint();
+                    int row = table.rowAtPoint(origin);
+                    int column = table.columnAtPoint(origin);
+                    if (row != -1 && column != -1) {
+                        if (!table.isCellSelected(row, column)) {
+                            super.mousePressed(e);
+                        }
+                    }
+                }
+
+                @Override
+                public void mouseDragged(MouseEvent e) {
+
+                    table.getTransferHandler().exportAsDrag(table, e,
+                            DnDConstants.ACTION_MOVE);
+                }
+            };
+        }
+
+    }
     
 }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -763,15 +763,18 @@ public class ROITable
     }
     
     /**
-     * Adds the node to the parent; will create the parent hierarchy
-     * if it doesn't exist yet.
-     * @param node The Node
+     * Adds the node to the parent; will create the parent hierarchy if it
+     * doesn't exist yet.
+     * 
+     * @param node
+     *            The Node
      */
     void handleParentFolderNodes(ROINode node) {
         FolderData parentFolder = ((FolderData) node.getUserObject())
                 .getParentFolder();
         if (parentFolder == null) {
-            root.insert(node, 0);
+            root.insert(node,
+                    root.getInsertionPoint((FolderData) node.getUserObject()));
             return;
         }
 
@@ -782,7 +785,8 @@ public class ROITable
             parent.insert(node, 0);
             handleParentFolderNodes(parent);
         } else if (parent.findChild((FolderData) node.getUserObject()) == null) {
-            parent.insert(node, 0);
+            parent.insert(node,
+                    parent.getInsertionPoint((FolderData) node.getUserObject()));
         }
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -1238,11 +1238,8 @@ public class ROITable
     public void addToFolder() {
         action = CreationActionType.ADD_TO_FOLDER;
         Collection<Object> tmp = new ArrayList<Object>();
-        for(FolderData folder : manager.getFolders()) {
-            ROINode folderNode = getFolderNode(folder);
-            if((folderNode.isLeaf() || folderNode.containsROIs()) && folder.canLink())
+        for(FolderData folder : manager.getFolders()) 
                 tmp.add(folder);
-        }
         SelectionWizard wiz = new SelectionWizard(null, tmp, FolderData.class, manager.canEdit(), MeasurementAgent.getUserDetails());
         wiz.setTitle("Add to ROI Folders", "Select the Folders to add the ROI(s) to", IconManager.getInstance().getIcon(IconManager.ROIFOLDER));
         wiz.addPropertyChangeListener(this);
@@ -1321,9 +1318,7 @@ public class ROITable
 
         Collection<DataObject> tmp = new ArrayList<DataObject>();
         for (FolderData folder : manager.getFolders()) {
-            ROINode folderNode = getFolderNode(folder);
-            if (!excludeIds.contains(folder.getId()) && folder.canLink()
-                    && (folderNode.isLeaf() || folderNode.containsFolders()))
+            if (!excludeIds.contains(folder.getId()) && folder.canLink())
                 tmp.add(folder);
         }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/SelectionWizard.java
@@ -492,6 +492,9 @@ public class SelectionWizard
             if (CommonsLangUtils.isEmpty(name))
                 return;
             String description = descriptionField.getText();
+            if (DEFAULT_DESCRIPTION.equals(description)) {
+                description = null;
+            }
             FolderData folder = new FolderData();
             folder.setName(name);
             folder.setDescription(description);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewerSorter.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ViewerSorter.java
@@ -208,6 +208,10 @@ public class ViewerSorter
      */
     private int compareDataObjects(DataObject o1, DataObject o2)
     {
+        if ((o1 instanceof FolderData) && (o2 instanceof FolderData)) {
+            return ((FolderData) o1).getFolderPathString().compareToIgnoreCase(
+                    ((FolderData) o2).getFolderPathString());
+        }
     	if (o1 instanceof ChannelData) {
     		ChannelData c1 = (ChannelData) o1;
     		ChannelData c2 = (ChannelData) o2;
@@ -255,10 +259,6 @@ public class ViewerSorter
     {
         Object ob1 = o1.getUserObject();
         Object ob2 = o2.getUserObject();
-        if ((ob1 instanceof FolderData) && (ob2 instanceof FolderData)) {
-        	return ((FolderData) ob1).getFolderPathString().compareTo(
-        	        ((FolderData) ob2).getFolderPathString());
-        }
         if ((ob1 instanceof DataObject) && (ob2 instanceof DataObject)) {
             return compareDataObjects((DataObject) ob1, (DataObject) ob2);
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
@@ -44,15 +44,26 @@ import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 public class ROIFolderSaver extends BatchCallTree {
+    
+    /**
+     * The actions which this {@link ROIFolderSaver} can handle
+     */
     public enum ROIFolderAction {
-        ADD_TO_FOLDER, REMOVE_FROM_FOLDER, CREATE_FOLDER, DELETE_FOLDER
+        /** Add ROIs to Folder */
+        ADD_TO_FOLDER, 
+        /** Remove ROIs from Folder */
+        REMOVE_FROM_FOLDER, 
+        /** Create Folder */
+        CREATE_FOLDER, 
+        /** Delete Folder */
+        DELETE_FOLDER
     }
 
     /** Call to save the ROIs. */
     private BatchCall saveCall;
 
     /** Was the save successful. */
-    private Collection result;
+    private Collection<ROIData> result;
 
     /**
      * Creates a {@link BatchCall} to load the ROIs.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
@@ -25,13 +25,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import omero.cmd.CmdCallbackI;
 import omero.gateway.SecurityContext;
 import omero.gateway.facility.DataManagerFacility;
 import omero.gateway.facility.ROIFacility;
-import omero.gateway.model.DataObject;
 import omero.gateway.model.FolderData;
 import omero.gateway.model.ROIData;
-import omero.gateway.util.Pojos;
 import omero.model.IObject;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -53,7 +52,7 @@ public class ROIFolderSaver extends BatchCallTree {
     private BatchCall saveCall;
 
     /** Was the save successful. */
-    private Collection<ROIData> result;
+    private Collection result;
 
     /**
      * Creates a {@link BatchCall} to load the ROIs.
@@ -86,7 +85,9 @@ public class ROIFolderSaver extends BatchCallTree {
                     for (FolderData f : folders)
                         ifolders.add((IObject) f.asFolder());
 
-                    dm.delete(ctx, ifolders);
+                    CmdCallbackI cb = dm.delete(ctx, ifolders);
+                    // wait for the delete action to be finished
+                    cb.block(10000);
                 } 
                 result = Collections.EMPTY_LIST;
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROIFolderSaver.java
@@ -44,7 +44,7 @@ import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 public class ROIFolderSaver extends BatchCallTree {
-    
+
     /**
      * The actions which this {@link ROIFolderSaver} can handle
      */
@@ -53,6 +53,8 @@ public class ROIFolderSaver extends BatchCallTree {
         ADD_TO_FOLDER, 
         /** Remove ROIs from Folder */
         REMOVE_FROM_FOLDER, 
+        /** Move ROIs to Folder */
+        MOVE_TO_FOLDER,
         /** Create Folder */
         CREATE_FOLDER, 
         /** Delete Folder */
@@ -85,7 +87,14 @@ public class ROIFolderSaver extends BatchCallTree {
                     if (!notSelected.isEmpty())
                         svc.saveROIs(ctx, imageID, notSelected);
                     svc.addRoisToFolders(ctx, imageID, roiList, folders);
-                } else if (action == ROIFolderAction.REMOVE_FROM_FOLDER) {
+                } else if (action == ROIFolderAction.MOVE_TO_FOLDER) {
+                    Collection<ROIData> notSelected = relativeComplement(
+                            roiList, allROIs);
+                    if (!notSelected.isEmpty())
+                        svc.saveROIs(ctx, imageID, notSelected);
+                    svc.addRoisToFolders(ctx, imageID, roiList, folders, true);
+                }  
+                else if (action == ROIFolderAction.REMOVE_FROM_FOLDER) {
                     svc.removeRoisFromFolders(ctx, imageID, roiList, folders);
                 } else if (action == ROIFolderAction.CREATE_FOLDER) {
                     for (FolderData folder : folders)

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
@@ -449,7 +449,7 @@ public class OMETreeTable
 			(MutableTreeTableNode) getTreeTableModel().getRoot();
 		if (root == null) return;
 		for (MutableTreeTableNode node : ((OMETreeNode) root).getChildList())
-			((OMETreeNode) node).setExpanded(true);
+			((OMETreeNode) node).setExpanded(false);
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/model/OMETreeNode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/model/OMETreeNode.java
@@ -91,6 +91,15 @@ public class OMETreeNode
 	 */
 	public boolean isExpanded() { return expanded; }
 	
+    /**
+     * Return <code>true</code> if this node is a root node
+     * 
+     * @return See above.
+     */
+    public boolean isRoot() {
+        return getPath().getPathCount() == 1;
+    }
+	
 	/**
 	 * Sets the current node to expanded.
 	 * 


### PR DESCRIPTION
This PR adds drag and drop support to the ROI table. There's just a little flaw, with drag and drop enabled the CTRL click multi selection sometimes doesn't work properly when clicked in the first column of the table (but fine when the other columns are used). Not sure if this is just an OSX issue. Will check with other platforms, too.

Other points fixed in this PR:
- Folders are now alphabetically sorted
- Folders can now contain sub folders as well as ROIs

(based on PR #4497)
