### PR TITLE
Auto load single run

### DIFF
--- a/components/tests/ui/testcases/web/spw_test.txt
+++ b/components/tests/ui/testcases/web/spw_test.txt
@@ -24,6 +24,13 @@ Bulk Annotation Should Contain Row
 
 *** Test Cases ***
 
+Test Auto Load Single Run
+    [Documentation]     Selecting Plate with single Run should load plate
+
+    Select Experimenter
+    Select First Plate
+    Click Well By Name                      A1
+
 Test Bulk Annotations
     [Documentation]     Test display of bulk annotations added in setup
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -23,6 +23,16 @@ $(function() {
 
     // Select jstree and then cascade handle events and setup the tree.
     var jstree = $("#dataTree")
+    .on('load_node.jstree', function(event, data){
+        // If we load a Plate with only a single Child 'Run',
+        // we automatically select it to load the Plate itself
+        var node = data.node;
+        if (node.type === "plate" && node.children.length === 1) {
+            var inst = data.instance;
+            inst.deselect_all();
+            inst.select_node(node.children[0]);
+        }
+    })
     .on('changed.jstree', function (e, data) {
         var inst = data.instance;
         buttonsShowHide(inst.get_selected(true), inst);

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -23,16 +23,6 @@ $(function() {
 
     // Select jstree and then cascade handle events and setup the tree.
     var jstree = $("#dataTree")
-    .on('load_node.jstree', function(event, data){
-        // If we load a Plate with only a single Child 'Run',
-        // we automatically select it to load the Plate itself
-        var node = data.node;
-        if (node.type === "plate" && node.children.length === 1) {
-            var inst = data.instance;
-            inst.deselect_all();
-            inst.select_node(node.children[0]);
-        }
-    })
     .on('changed.jstree', function (e, data) {
         var inst = data.instance;
         buttonsShowHide(inst.get_selected(true), inst);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -756,8 +756,8 @@ $(document).ready(function() {
                 //     url += 'load_data/' + nodeType + '/?view=icon' + "&page="+newPage;
                 //     break;
                 case 'plate':
-                    // Only load plates if it does not have child acquisitions
-                    if (!inst.is_parent(node)) {
+                    // Only load plates if it has a single 'Run' (or none)
+                    if (node.children.length < 2) {
                         url += 'load_data/' + nodeType + '/' + nodeId + '/';
                         if (show) {
                             url += "?show=" + show;


### PR DESCRIPTION
When a Plate is selected, the centre panel will display it if the Plate has only a single Run (or none).
Same behaviour as Insight.
See https://trello.com/c/vR04i5uF/63-minor-auto-load-single-runs

To test:
 - Browse to Plate in tree.
 - If it has a single Run, this will load in centre panel without needing to select the Run.