### PR TITLE
Display well label on hover over well

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2170,7 +2170,16 @@ div.paging input.button_pagination {
 #spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}
 #spw table td.ui-selected { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}
 
-
+#spw .well .wellLabel {
+    display: none;
+    position: absolute;
+    background: #eee;
+    padding: 2px;
+    color: black;
+}
+#spw .well:hover .wellLabel {
+    display: block;
+}
 
 
 /** Annotation Styles **/

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -141,11 +141,12 @@ jQuery._WeblitzPlateview = function (container, options) {
           }
           var td = $('<td class="well" id="'+parentPrefix+'well-'+data.grid[i][j].wellId+'">' +
             '<div class="waiting" style="width:'+opts.width+'px;height:'+opts.height+'px;"></div>' +
+            '<div class="wellLabel">' + data.rowlabels[i] + data.collabels[j] + '</div>' +
             '<img id="'+parentPrefix+'image-'+data.grid[i][j].id+'" class="loading" style="width:'+opts.width+'px;height:'+opts.height+'px;" src="'+ data.grid[i][j].thumb_url+'" name="'+(data.rowlabels[i] + data.collabels[j])+'"></td>');
           $('img', td)
             .click(tclick(data.grid[i][j]))
             .load(function() { 
-              $(this).removeClass('loading').siblings().remove();
+              $(this).removeClass('loading').siblings('.waiting').remove();
               _this.self.trigger('thumbLoad', [$(this).parent(), $(this)]);
             })
             .data('wellpos', data.rowlabels[i] + data.collabels[j]);


### PR DESCRIPTION
This is a partial solution to the problem of knowing which wells are which on a large plate when the row and column labels have scrolled off screen.
See https://trello.com/c/TXLXoyeU/64-critical-loss-of-context-when-looking-for-well
We simply show a well label when you hover over each well:

<img width="192" alt="screen shot 2016-03-10 at 21 47 45" src="https://cloud.githubusercontent.com/assets/900055/13685756/07bddc30-e70a-11e5-925e-b6b92094fb30.png">
