### PR TITLE
deletebutton fileset check

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -14,12 +14,17 @@ ${runIcon}                      webclient/image/run16.png
 ${datasetDetails}               xpath=//*[@id="general_tab"]/h1[contains(@data-name,'details')]/following-sibling::div
 *** Keywords ***
 
-Click Dialog Button
+Get Dialog Button Xpath
     [Arguments]     ${buttonText}
     # Confirm dialog (make sure we pick the currently visible dialog)
     # jQuery UI buttons sometimes are <button>text and sometimes <button><span>text so we use *
-    Wait Until Page Contains Element    xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//div[contains(@class, 'ui-dialog-buttonset')]//*[contains(text(), '${buttonText}')]
-    Click Element                       xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//div[contains(@class, 'ui-dialog-buttonset')]//*[contains(text(), '${buttonText}')]
+    [Return]        //div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//div[contains(@class, 'ui-dialog-buttonset')]//*[contains(text(), '${buttonText}')]
+
+Click Dialog Button
+    [Arguments]     ${buttonText}
+    ${xpath}=                       Get Dialog Button Xpath     ${buttonText}
+    Wait Until Element Is Visible   xpath=${xpath}
+    Click Element                   xpath=${xpath}
 
 Xpath Should Have Class
     [Arguments]                     ${identifier}       ${className}
@@ -220,6 +225,13 @@ Select First Image
     ${imageId}=                     Select Node By Icon      ${imageIcon}
     Wait Until Right Panel Loads    Image                    ${imageId}
     [Return]                        ${imageId}
+
+Select First Image With Name
+    [Arguments]                     ${ImageName}
+    ${nodeId}=                      Wait For Image Node Text        ${ImageName}
+    Click Node                      ${nodeId}
+    Wait For General Panel          Image
+    [Return]                        ${nodeId}
 
 Select First Orphaned Image
     ${nodeId}                       Select Orphaned Images Section

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -18,6 +18,7 @@ USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-robot_ice.config}
 IMAGE_NAME=${IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00&sizeZ=3&sizeT=10.fake}
 TINY_IMAGE_NAME=${TINY_IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00.fake}
+MIF_IMAGE_NAME=${MIF_IMAGE_NAME:-test&series=3.fake}
 PLATE_NAME=${PLATE_NAME:-test&plates=1&plateAcqs=1&plateRows=2&plateCols=3&fields=1&screens=0.fake}
 BULK_ANNOTATION_CSV=${BULK_ANNOTATION_CSV:-bulk_annotation.csv}
 
@@ -33,6 +34,7 @@ bin/omero logout
 touch $IMAGE_NAME
 touch $TINY_IMAGE_NAME
 touch $PLATE_NAME
+touch $MIF_IMAGE_NAME
 
 # Create batch annotation csv
 echo "Well,Well Type,Concentration" > "$BULK_ANNOTATION_CSV"
@@ -68,6 +70,13 @@ delDs=$(bin/omero obj new Dataset name='Delete')
 for (( k=1; k<=10; k++ ))
 do
   bin/omero import -d $delDs $TINY_IMAGE_NAME --debug ERROR
+done
+
+# Create Dataset with MIF images
+mifDs=$(bin/omero obj new Dataset name='MIF Images')
+for (( k=1; k<=2; k++ ))
+do
+  bin/omero import -d $mifDs $MIF_IMAGE_NAME --debug ERROR
 done
 
 # Import Plate

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -20,6 +20,17 @@ Clear Activity
     Click Element           id=launch_activities
     Click Element           id=clear_activities
 
+Check Fileset Delete Warning
+    Wait Until Element Is Visible           id=delete-dialog-form
+    Wait Until Element Is Visible           xpath=//div[@class='split_filesets_info']
+    # For some reason, fails to find full text: 'Multi-image filesets cannot be partially deleted'
+    Wait Until Page Contains                partially deleted
+    # Should be 3 thumbnails shown for this fileset
+    Xpath Should Match X Times              //div[@class='split_fileset']//img[@class='fileset_image']        3
+    # Yes button shouldn't be visible
+    ${xpath}=                               Get Dialog Button Xpath     Yes
+    Element Should Not Be Visible           xpath=${xpath}
+
 *** Test Cases ***
 
 Test Delete Project
@@ -84,6 +95,28 @@ Test Delete Images in Dataset
     # ...Need to check that centre panel doesn't reload and show image during delete: #12866
     Sleep                                   5
     Xpath Should Match X Times              ${thumbnailsXpath}   ${delThumbCount}
+
+
+Test Delete MIF Images
+    [Documentation]     Checks warnings when trying to delete Multi-Image-Fileset images
+
+    Clear Activity
+    Select Experimenter
+    # Click on Dataset named "MIF Images"
+    Select First Dataset With Name          MIF Images
+    ${nodeId}=                              Select First Image With Name            test&series=3.fake [test]
+    Wait Until Element Is Visible           xpath=//ul[@id='dataIcons']//li[contains(@class, 'fs-selected')]
+    Xpath Should Match X Times              //ul[@id='dataIcons']//li[contains(@class, 'fs-selected')]       3
+    # Check warning is generated via toolbar button...
+    Click Element                           id=deleteButton
+    Check Fileset Delete Warning
+    Click Dialog Button                     Cancel
+    # ...and from right-click menu
+    Open Context Menu                       xpath=//li[@id='${nodeId}']/a
+    Wait Until Element Is Visible           xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), 'Delete')]
+    Click Element                           xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), 'Delete')]
+    Check Fileset Delete Warning
+    Click Dialog Button                     Cancel
 
 
 Test Delete Images in Share

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -683,7 +683,7 @@
 
         $('#deleteButton').click(function() {
             var deleteUrl = "{% url 'manage_action_containers' 'deletemany' %}",
-                filesetCheckUrl = "{% url 'fileset_check' 'delete' %}?";
+                filesetCheckUrl = "{% url 'fileset_check' 'delete' %}";
             OME.handleDelete(deleteUrl, filesetCheckUrl, {{ ome.user.id }});
         });
 


### PR DESCRIPTION
This fixes a tiny bug where deleting with the toolbar Delete button doesn't properly check for partially deleted filesets. 

To test:
 - Pick a single image from a MIF, try deleting with the toolbar button.
 - Should get the appropriate split-MIF warning that prevents you from going ahead with delete.