### PR TITLE
NPE Importer Dialog

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -366,6 +366,8 @@ class LocationDialog extends JDialog implements ActionListener,
 		        model.getImportFor());
 		
 		addPropertyChangeListener(this);
+		
+		addButton.setEnabled(true);
 	}
 
 	/** 
@@ -508,6 +510,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		addButton.setToolTipText(TOOLTIP_QUEUE_ITEMS);
 		addButton.addActionListener(this);
 		addButton.setActionCommand("" + CMD_ADD);
+		addButton.setEnabled(false);
 		
 		closeButton = new JButton(TEXT_CLOSE);
 		closeButton.setToolTipText(TOOLTIP_CLOSE_DIALOGUE);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1404,6 +1404,7 @@ class LocationDialog extends JDialog implements ActionListener,
                 || ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
             busyLabel.setBusy(true);
             busyLabel.setVisible(true);
+            addButton.setEnabled(false);
             Object value = evt.getNewValue();
             if(value != null && value instanceof ImportLocationDetails) {
                 ImportLocationDetails details = (ImportLocationDetails) evt
@@ -1696,6 +1697,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	    this.container = container;
 	    this.busyLabel.setBusy(false);
 	    this.busyLabel.setVisible(false);
+	    this.addButton.setEnabled(true);
 	    populateUIWithDisplayData(findWithId(groups, currentGroupId), userID);
 	    setInputsEnabled(true);
 	}


### PR DESCRIPTION
This wee PR should fix [QA 17060](https://www.openmicroscopy.org/qa2/qa/feedback/17060/). I couldn't reproduce the issue, but the only explanation for the NPE is that the "Add to Queue" button must have been hit before the dialog was fully initialized (in particular before the user/group boxes have been populated). With this PR the button is only enabled after full UI initialization.
**Review**: Check if code makes sense; test if you can still add files to the import queue.
