### PR TITLE
Shape attributes cleanup

### DIFF
--- a/components/blitz/src/ome/services/roi/GeomTool.java
+++ b/components/blitz/src/ome/services/roi/GeomTool.java
@@ -153,18 +153,18 @@ public class GeomTool {
         return pt;
     }
 
-    public Ellipse ellipse(double cx, double cy, double rx, double ry) {
+    public Ellipse ellipse(double x, double y, double radiusx, double radiusy) {
         SmartEllipseI ellipse = new SmartEllipseI();
-        ellipse.setX(rdouble(cx));
-        ellipse.setY(rdouble(cy));
-        ellipse.setRadiusX(rdouble(rx));
-        ellipse.setRadiusY(rdouble(ry));
+        ellipse.setX(rdouble(x));
+        ellipse.setY(rdouble(y));
+        ellipse.setRadiusX(rdouble(radiusx));
+        ellipse.setRadiusY(rdouble(radiusy));
         return ellipse;
     }
 
-    public Ellipse ellipse(double cx, double cy, double rx, double ry, int t,
+    public Ellipse ellipse(double x, double y, double radiusx, double radiusy, int t,
             int z) {
-        Ellipse ellipse = ellipse(cx, cy, rx, ry);
+        Ellipse ellipse = ellipse(x, y, radiusx, radiusy);
         ellipse.setTheT(rint(t));
         ellipse.setTheZ(rint(z));
         return ellipse;

--- a/components/blitz/src/omero/gateway/model/EllipseData.java
+++ b/components/blitz/src/omero/gateway/model/EllipseData.java
@@ -62,18 +62,18 @@ public class EllipseData
     /**
      * Creates a new instance of the EllipseData.
      *
-     * @param cx The x-coordinate of the center of the Ellipse.
-     * @param cy The y-coordinate of the center of the Ellipse.
-     * @param rx The radius along the X-axis.
-     * @param ry The radius along the Y-axis.
+     * @param x The x-coordinate of the center of the Ellipse.
+     * @param y The y-coordinate of the center of the Ellipse.
+     * @param radiusx The radius along the X-axis.
+     * @param radiusy The radius along the Y-axis.
      */
-    public EllipseData(double cx, double cy, double rx, double ry)
+    public EllipseData(double x, double y, double radiusx, double radiusy)
     {
         super(new EllipseI(), true);
-        setX(cx);
-        setY(cy);
-        setRadiusX(rx);
-        setRadiusY(ry);
+        setX(x);
+        setY(y);
+        setRadiusX(radiusx);
+        setRadiusY(radiusy);
     }
 
     /**

--- a/components/blitz/src/omero/model/SmartEllipseI.java
+++ b/components/blitz/src/omero/model/SmartEllipseI.java
@@ -32,14 +32,14 @@ public class SmartEllipseI extends omero.model.EllipseI implements SmartShape {
 
     public Shape asAwtShape() {
         try {
-            double cx = getX().getValue();
-            double cy = getY().getValue();
-            double rx = getRadiusX().getValue();
-            double ry = getRadiusY().getValue();
-            double height = ry * 2;
-            double width = rx * 2;
-            double cornerX = cx - rx;
-            double cornerY = cy - ry;
+            double x = getX().getValue();
+            double y = getY().getValue();
+            double radiusx = getRadiusX().getValue();
+            double radiusy = getRadiusY().getValue();
+            double height = radiusy * 2;
+            double width = radiusx * 2;
+            double cornerX = x - radiusx;
+            double cornerY = y - radiusy;
             Ellipse2D.Double e = new Ellipse2D.Double(cornerX, cornerY, width,
                     height);
             return e;

--- a/components/blitz/src/omero/model/SmartPolygonI.java
+++ b/components/blitz/src/omero/model/SmartPolygonI.java
@@ -43,12 +43,12 @@ public class SmartPolygonI extends omero.model.PolygonI implements SmartShape {
             StringBuilder sb = new StringBuilder();
             int sz = random.nextInt(20) + 1;
             for (int i = 0; i < sz; i++) {
-                int cx = random.nextInt(100);
-                int cy = random.nextInt(100);
+                int x = random.nextInt(100);
+                int y = random.nextInt(100);
                 if (i > 0) {
                     sb.append(",");
                 }
-                Util.appendSvgPoint(sb, cx, cy);
+                Util.appendSvgPoint(sb, x, y);
             }
             this.points = rstring(sb.toString());
         } else {

--- a/components/blitz/src/omero/model/SmartPolylineI.java
+++ b/components/blitz/src/omero/model/SmartPolylineI.java
@@ -45,12 +45,12 @@ public class SmartPolylineI extends omero.model.PolylineI implements SmartShape 
             StringBuilder sb = new StringBuilder();
             int sz = random.nextInt(20) + 1;
             for (int i = 0; i < sz; i++) {
-                int cx = random.nextInt(100);
-                int cy = random.nextInt(100);
+                int x = random.nextInt(100);
+                int y = random.nextInt(100);
                 if (i > 0) {
                     sb.append(",");
                 }
-                Util.appendSvgPoint(sb, cx, cy);
+                Util.appendSvgPoint(sb, x, y);
             }
             this.points = rstring(sb.toString());
         } else {

--- a/components/blitz/src/omero/model/SmartShape.java
+++ b/components/blitz/src/omero/model/SmartShape.java
@@ -69,11 +69,11 @@ public interface SmartShape {
             appendDbPoint(sb, p.x.getValue(), p.y.getValue());
         }
 
-        public static void appendDbPoint(StringBuilder sb, double cx, double cy) {
+        public static void appendDbPoint(StringBuilder sb, double x, double y) {
             sb.append("(");
-            sb.append(cx);
+            sb.append(x);
             sb.append(",");
-            sb.append(cy);
+            sb.append(y);
             sb.append(")");
         }
 
@@ -81,24 +81,24 @@ public interface SmartShape {
             appendSvgPoint(sb, p.x.getValue(), p.y.getValue());
         }
 
-        public static void appendSvgPoint(StringBuilder sb, double cx, double cy) {
-            sb.append(cx);
+        public static void appendSvgPoint(StringBuilder sb, double x, double y) {
+            sb.append(x);
             sb.append(",");
-            sb.append(cy);
+            sb.append(y);
             sb.append(" ");
         }
 
-        public static boolean appendSegement(StringBuilder sb, boolean first,
-                double cx, double cy) {
+        public static boolean appendSegment(StringBuilder sb, boolean first,
+                double x, double y) {
             if (first) {
                 sb.append("M ");
                 first = false;
             } else {
                 sb.append("L ");
             }
-            sb.append(cx);
+            sb.append(x);
             sb.append(" ");
-            sb.append(cy);
+            sb.append(y);
             sb.append(" ");
             return first;
         }
@@ -107,9 +107,9 @@ public interface SmartShape {
             StringBuilder sb = new StringBuilder(points.size() * 16);
             boolean first = true;
             for (Point point : points) {
-                double cx = point.getX().getValue();
-                double cy = point.getY().getValue();
-                first = appendSegement(sb, first, cx, cy);
+                double x = point.getX().getValue();
+                double y = point.getY().getValue();
+                first = appendSegment(sb, first, x, y);
             }
             if (close) {
                 sb.append("Z");
@@ -124,7 +124,7 @@ public interface SmartShape {
             PointsParser pp = new PointsParser();
             PointsHandler ph = new DefaultPointsHandler() {
                 public void point(float x, float y) throws ParseException {
-                    first[0] = appendSegement(sb, first[0], x, y);
+                    first[0] = appendSegment(sb, first[0], x, y);
                 }
             };
             pp.setPointsHandler(ph);

--- a/components/tools/OmeroM/src/roi/createPoint.m
+++ b/components/tools/OmeroM/src/roi/createPoint.m
@@ -32,5 +32,5 @@ ip.parse(x, y);
 
 % Create Point shape
 point = omero.model.PointI;
-point.setCx(rdouble(x));
-point.setCy(rdouble(y));
+point.setX(rdouble(x));
+point.setY(rdouble(y));


### PR DESCRIPTION
See https://trello.com/c/LW8l7U8x/20-shape-attribute-renaming-cleanup

Following the [Shape property renaming](https://github.com/openmicroscopy/openmicroscopy/pull/4481), this PR reviews the usages of `cx,` `cy`, `rx` and `ry` variables in the server components and fixes one of the MATLAB functions to use the new methods.

To test this PR, check the changes make sense and there are no more occurences of `[cC][xy]` and `[rR][xy]` in the modified components.