### PR TITLE
Lens tool compressed image bugfix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/lens/LensModel.java
@@ -179,6 +179,13 @@ class LensModel
 					break;
     		}
     	}
+		
+        if (dataBufferType == DataBuffer.TYPE_BYTE
+                && zoomedDataBuffer.getSize() < (w * h * 3))
+            // if type==byte (i.e. compressed images) the buffer size has to be
+            // w * h * 3 at least
+            zoomedDataBuffer = new DataBufferByte((w * h * 3), 1);
+		
 		SampleModel sm = colorModel.createCompatibleSampleModel(w, h);
         return Raster.createWritableRaster(sm, zoomedDataBuffer, null);			
  	}


### PR DESCRIPTION
Bugfix for [QA 17054](https://www.openmicroscopy.org/qa2/qa/feedback/17054/)

**Test**: Open an image. Set compression level to high. Open lens tool. Set zoom to > 800%. 
