### PR TITLE
provide new FindParents and FindChildren requests

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -76,5 +76,7 @@
     <import resource="graph-rules/blitz-chown-rules.xml"/>
     <import resource="graph-rules/blitz-delete-rules.xml"/>
     <import resource="graph-rules/blitz-duplicate-rules.xml"/>
+    <import resource="graph-rules/blitz-container-rules.xml"/>
+    <import resource="graph-rules/blitz-contained-rules.xml"/>
 
 </beans>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -368,6 +368,8 @@
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownTargets"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteTargets"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateTargets"/>
+          <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerTargets"/>
+          <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedTargets"/>
         </map>
       </constructor-arg>
       <constructor-arg>
@@ -377,6 +379,8 @@
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownRules"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteRules"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateRules"/>
+          <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerRules"/>
+          <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedRules"/>
         </map>
       </constructor-arg>
       <constructor-arg>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -44,6 +44,9 @@
         <value>DatasetImageLink</value>
         <value>Project</value>
         <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
 
         <!-- core -->
         <value>Channel</value>
@@ -150,10 +153,17 @@
 
         <!-- CONTAINERS -->
 
+        <bean parent="graphPolicyRule" p:matches="Folder[I].childFolders = C:[E]" p:changes="C:[I]"/>
+
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I]" p:changes="L:[I]"/>
+
         <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderRoiLink[I].child = ROI:[E]" p:changes="ROI:[I]"/>
 
         <!-- CORE -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -106,6 +106,8 @@
 
         <!-- see blitz-graph-rules.xml for rule syntax -->
 
+        <!-- adjustments to these should be reflected in StopBeforeHelper.HIERARCHY -->
+
         <!-- ACQUISITION -->
 
         <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+#
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+
+    <util:list id="containedTargets" value-type="java.lang.String">
+
+        <!-- acquisition -->
+        <value>Instrument</value>
+
+        <!-- annotations -->
+        <value>Annotation</value>
+        <value>IAnnotationLink</value>
+
+        <!-- containers -->
+        <value>Dataset</value>
+        <value>DatasetImageLink</value>
+        <value>Project</value>
+        <value>ProjectDatasetLink</value>
+
+        <!-- core -->
+        <value>Channel</value>
+        <value>Image</value>
+        <value>LogicalChannel</value>
+        <value>OriginalFile</value>
+        <value>Pixels</value>
+        <value>PixelsOriginalFileMap</value>
+        <value>PlaneInfo</value>
+
+        <!-- display -->
+        <value>ChannelBinding</value>
+        <value>CodomainMapContext</value>
+        <value>QuantumDef</value>
+        <value>RenderingDef</value>
+        <value>Thumbnail</value>
+
+        <!-- experiment -->
+        <value>Experiment</value>
+        <value>MicrobeamManipulation</value>
+
+        <!-- fs -->
+        <value>Fileset</value>
+        <value>FilesetEntry</value>
+        <value>FilesetJobLink</value>
+
+        <!-- internal -->
+        <value>Link</value>
+
+        <!-- jobs -->
+        <value>Job</value>
+        <value>JobOriginalFileLink</value>
+
+        <!-- meta -->
+        <value>ExternalInfo</value>
+
+        <!-- roi -->
+        <value>Roi</value>
+        <value>Shape</value>
+
+        <!-- screen -->
+        <value>Plate</value>
+        <value>PlateAcquisition</value>
+        <value>Reagent</value>
+        <value>Screen</value>
+        <value>ScreenPlateLink</value>
+        <value>Well</value>
+        <value>WellReagentLink</value>
+        <value>WellSample</value>
+
+        <!-- stats -->
+        <value>StatsInfo</value>
+
+    </util:list>
+
+    <util:list id="containedRules" value-type="ome.services.graphs.GraphPolicyRule">
+
+        <!-- see blitz-graph-rules.xml for rule syntax -->
+
+        <!-- ACQUISITION -->
+
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filter = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LightSettings[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DetectorSettings[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ObjectiveSettings[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].detector = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].lightSource = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].objective = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
+
+        <!-- ANNOTATIONS -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].child = A:[E]" p:changes="A:[I]"/>
+
+        <!-- CONTAINERS -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+
+        <!-- CORE -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]" p:changes="IE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = OS:[E]" p:changes="OS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]" p:changes="SL:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].pixelsFileMaps = POFM:[E]" p:changes="POFM:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].settings = RD:[E]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails = T:[E]" p:changes="T:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E]" p:changes="DS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightPath = LP:[E]" p:changes="LP:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PixelsOriginalFileMap[I].parent = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]" p:changes="OF:[I]"/>
+
+        <!-- DISPLAY -->
+
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+
+        <!-- EXPERIMENT -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment = E:[E]" p:changes="E:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Experiment[I].microbeamManipulation = M:[E]" p:changes="M:[I]"/>
+
+        <!-- FS -->
+
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].images = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].usedFiles = FE:[E]" p:changes="FE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].jobLinks = L:[E]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilesetJobLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].child = J:[E]" p:changes="J:[I]"/>
+
+        <!-- JOB -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="JobOriginalFileLink[I].child = OF:[E]" p:changes="OF:[I]"/>
+
+        <!-- META -->
+
+        <bean parent="graphPolicyRule" p:matches="[I].details.externalInfo = EI:[E]" p:changes="EI:[I]"/>
+
+        <!-- ROI -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- SCREEN -->
+
+        <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[I].child = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].wells = W:[E]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellSample[I].image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- STATS -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].statsInfo = SI:[E]" p:changes="SI:[I]"/>
+
+    </util:list>
+
+</beans>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -159,7 +159,6 @@
 
         <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]" p:changes="IE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]" p:changes="IN:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = OS:[E]" p:changes="OS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]" p:changes="SL:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
@@ -168,8 +167,6 @@
         <bean parent="graphPolicyRule" p:matches="Pixels[I].settings = RD:[E]" p:changes="RD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails = T:[E]" p:changes="T:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].channels = C:[E]" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E]" p:changes="DS:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightPath = LP:[E]" p:changes="LP:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
 
@@ -194,7 +191,6 @@
         <bean parent="graphPolicyRule" p:matches="Fileset[I].images = I:[E]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Fileset[I].usedFiles = FE:[E]" p:changes="FE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Fileset[I].jobLinks = L:[E]" p:changes="L:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilesetJobLink[E].parent = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].child = J:[E]" p:changes="J:[I]"/>
 
         <!-- JOB -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -159,7 +159,6 @@
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E].imagingEnvironment = [I]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E].instrument = [I]" p:changes="I:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="I:Image[E].objectiveSettings = [I]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E].pixels = [I]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="I:Image[E].stageLabel = [I]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="P:Pixels[E].channels = [I]" p:changes="P:[I]"/>
@@ -168,8 +167,6 @@
         <bean parent="graphPolicyRule" p:matches="P:Pixels[E].settings = [I]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="P:Pixels[E].thumbnails = [I]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].channels = [I]" p:changes="LC:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].detectorSettings = [I]" p:changes="LC:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].lightSourceSettings = [I]" p:changes="LC:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].lightPath = [I]" p:changes="LC:[I]"/>
         <bean parent="graphPolicyRule" p:matches="C:Channel[E].logicalChannel = [I]" p:changes="C:[I]"/>
 
@@ -194,7 +191,6 @@
         <bean parent="graphPolicyRule" p:matches="F:Fileset[E].images = [I]" p:changes="F:[I]"/>
         <bean parent="graphPolicyRule" p:matches="F:Fileset[E].usedFiles = [I]" p:changes="F:[I]"/>
         <bean parent="graphPolicyRule" p:matches="F:Fileset[E].jobLinks = [I]" p:changes="F:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].parent = F:[E]" p:changes="F:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:FilesetJobLink[E].child = [I]" p:changes="L:[I]"/>
 
         <!-- JOB -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -44,6 +44,9 @@
         <value>DatasetImageLink</value>
         <value>Project</value>
         <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
 
         <!-- core -->
         <value>Channel</value>
@@ -150,10 +153,17 @@
 
         <!-- CONTAINERS -->
 
-        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].parent = P:[E]" p:changes="P:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].parent = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Folder[E].childFolders = [I]" p:changes="F:[I]"/>
+
         <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].child = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].parent = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].parent = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderImageLink[I].parent = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderRoiLink[I].parent = F:[E]" p:changes="F:[I]"/>
 
         <!-- CORE -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+#
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+
+    <util:list id="containerTargets" value-type="java.lang.String">
+
+        <!-- acquisition -->
+        <value>Instrument</value>
+
+        <!-- annotations -->
+        <value>Annotation</value>
+        <value>IAnnotationLink</value>
+
+        <!-- containers -->
+        <value>Dataset</value>
+        <value>DatasetImageLink</value>
+        <value>Project</value>
+        <value>ProjectDatasetLink</value>
+
+        <!-- core -->
+        <value>Channel</value>
+        <value>Image</value>
+        <value>LogicalChannel</value>
+        <value>OriginalFile</value>
+        <value>Pixels</value>
+        <value>PixelsOriginalFileMap</value>
+        <value>PlaneInfo</value>
+
+        <!-- display -->
+        <value>ChannelBinding</value>
+        <value>CodomainMapContext</value>
+        <value>QuantumDef</value>
+        <value>RenderingDef</value>
+        <value>Thumbnail</value>
+
+        <!-- experiment -->
+        <value>Experiment</value>
+        <value>MicrobeamManipulation</value>
+
+        <!-- fs -->
+        <value>Fileset</value>
+        <value>FilesetEntry</value>
+        <value>FilesetJobLink</value>
+
+        <!-- internal -->
+        <value>Link</value>
+
+        <!-- jobs -->
+        <value>Job</value>
+        <value>JobOriginalFileLink</value>
+
+        <!-- meta -->
+        <value>ExternalInfo</value>
+
+        <!-- roi -->
+        <value>Roi</value>
+        <value>Shape</value>
+
+        <!-- screen -->
+        <value>Plate</value>
+        <value>PlateAcquisition</value>
+        <value>Reagent</value>
+        <value>Screen</value>
+        <value>ScreenPlateLink</value>
+        <value>Well</value>
+        <value>WellReagentLink</value>
+        <value>WellSample</value>
+
+        <!-- stats -->
+        <value>StatsInfo</value>
+
+    </util:list>
+
+    <util:list id="containerRules" value-type="ome.services.graphs.GraphPolicyRule">
+
+        <!-- see blitz-graph-rules.xml for rule syntax -->
+
+        <!-- ACQUISITION -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].detector = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].dichroic = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].filter = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].filterSet = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].lightSource = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].microscope = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].objective = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Instrument[E].otf = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Filter[E].transmittanceRange = [I]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FS:FilterSet[E].dichroic = [I]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:Laser[E].pump = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].detectorSettings = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].lightSourceSettings = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].objectiveSettings = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[E].filterSet = [I]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[E].objective = [I]" p:changes="OTF:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
+
+        <!-- ANNOTATIONS -->
+
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].parent = X:[E]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <!-- CONTAINERS -->
+
+        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].parent = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].parent = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <!-- CORE -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].imagingEnvironment = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].instrument = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].objectiveSettings = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].pixels = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].stageLabel = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].channels = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].pixelsFileMaps = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].planeInfo = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].settings = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].thumbnails = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].channels = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].detectorSettings = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].lightSourceSettings = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].lightPath = [I]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="C:Channel[E].logicalChannel = [I]" p:changes="C:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="FA:FileAnnotation[E].file = [I]" p:changes="FA:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FE:FilesetEntry[E].originalFile = [I]" p:changes="FE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="POFM:PixelsOriginalFileMap[E].parent = [I]" p:changes="POFM:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ROI:Roi[E].source = [I]" p:changes="ROI:[I]"/>
+
+        <!-- DISPLAY -->
+
+        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].quantization = [I]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].spatialDomainEnhancement = [I]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].waveRendering = [I]" p:changes="RD:[I]"/>
+
+        <!-- EXPERIMENT -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].experiment = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="E:Experiment[E].microbeamManipulation = [I]" p:changes="E:[I]"/>
+
+        <!-- FS -->
+
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E].images = [I]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E].usedFiles = [I]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E].jobLinks = [I]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].parent = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilesetJobLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <!-- JOB -->
+
+        <bean parent="graphPolicyRule" p:matches="JobOriginalFileLink[I].parent = J:[E]" p:changes="J:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].child = [I]" p:changes="L:[I]"/>
+
+        <!-- META -->
+
+        <bean parent="graphPolicyRule" p:matches="X:[E].details.externalInfo = [I]" p:changes="X:[I]"/>
+
+        <!-- ROI -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].rois = [I]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ROI:Roi[E].shapes = [I]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[EI]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="M:Mask[E].pixels = P:[EI], P.image = [I]" p:changes="M:[I]"/>
+
+        <!-- SCREEN -->
+
+        <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].parent = W:[E]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ScreenPlateLink[I].parent = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Plate[E].wells = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Plate[E].plateAcquisitions = [I]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PA:PlateAcquisition[E].wellSample = [I]" p:changes="PA:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="W:Well[E].wellSamples = [I]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WS:WellSample[E].image = [I]" p:changes="WS:[I]"/>
+
+        <!-- STATS -->
+
+        <bean parent="graphPolicyRule" p:matches="C:Channel[E].statsInfo = [I]" p:changes="C:[I]"/>
+
+    </util:list>
+
+</beans>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -176,7 +176,7 @@
 
         <!-- If a link to an annotation is duplicated then duplicate the annotation itself. -->
 
-        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].child = A:Annotation[E]" p:changes="A:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].child = A:[E]" p:changes="A:[I]"/>
 
         <!-- If an original file is duplicated then also duplicate the corresponding file annotation -->
 
@@ -356,8 +356,8 @@
 
         <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E]" p:changes="P:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[E], P.image = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- SCREEN -->
 

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -197,16 +197,21 @@ module omero {
         };
 
         /**
-         * Base class for new requests for operating upon the model object
-         * graph.
+         * Base class for new requests for reading the model object graph.
          **/
-        class GraphModify2 extends Request {
+        class GraphQuery extends Request {
 
             /**
              * The model objects upon which to operate.
              * Related model objects may also be targeted.
              **/
             omero::api::StringLongListMap targetObjects;
+        };
+
+        /**
+         * Base class for new requests for modifying the model object graph.
+         **/
+        class GraphModify2 extends GraphQuery {
 
             /**
              * If the request should operate on specific kinds of children.
@@ -400,6 +405,68 @@ module omero {
              * objects that would have been duplicated.
              **/
             omero::api::StringLongListMap duplicates;
+        };
+
+        /**
+         * Identify the parents or containers of model objects.
+         * Traverses the model graph to identify indirect relationships.
+         **/
+        class FindParents extends GraphQuery {
+
+            /**
+             * The types of parents being sought.
+             **/
+            omero::api::StringSet typesOfParents;
+
+            /**
+             * Classes of model objects to exclude from the recursive
+             * search. Can greatly increase efficiency by preventing search
+             * from reaching classes that have many instances but no sought
+             * parents in their subgraphs.
+             **/
+            omero::api::StringSet stopBefore;
+        };
+
+        /**
+         * Result of identifying the parents or containers of model objects.
+         **/
+        class FoundParents extends OK {
+
+            /**
+             * The parents that were identified.
+             **/
+            omero::api::StringLongListMap parents;
+        };
+
+        /**
+         * Identify the children or contents of model objects.
+         * Traverses the model graph to identify indirect relationships.
+         **/
+        class FindChildren extends GraphQuery {
+
+            /**
+             * The types of children being sought.
+             **/
+            omero::api::StringSet typesOfChildren;
+
+            /**
+             * Classes of model objects to exclude from the recursive
+             * search. Can greatly increase efficiency by preventing search
+             * from reaching classes that have many instances but no sought
+             * children in their subgraphs.
+             **/
+            omero::api::StringSet stopBefore;
+        };
+
+        /**
+         * Result of identifying the children or contents of model objects.
+         **/
+        class FoundChildren extends OK {
+
+            /**
+             * The children that were identified.
+             **/
+            omero::api::StringLongListMap children;
         };
 
         /**

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -420,9 +420,9 @@ module omero {
 
             /**
              * Classes of model objects to exclude from the recursive
-             * search. Can greatly increase efficiency by preventing search
-             * from reaching classes that have many instances but no sought
-             * parents in their subgraphs.
+             * search. Search does not include or pass such objects.
+             * For efficiency the server automatically excludes various
+             * classes depending on the other arguments of the request.
              **/
             omero::api::StringSet stopBefore;
         };
@@ -451,9 +451,9 @@ module omero {
 
             /**
              * Classes of model objects to exclude from the recursive
-             * search. Can greatly increase efficiency by preventing search
-             * from reaching classes that have many instances but no sought
-             * children in their subgraphs.
+             * search. Search does not include or pass such objects.
+             * For efficiency the server automatically excludes various
+             * classes depending on the other arguments of the request.
              **/
             omero::api::StringSet stopBefore;
         };

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -41,6 +41,8 @@ import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
 import omero.cmd.graphs.DiskUsageI;
 import omero.cmd.graphs.DuplicateI;
+import omero.cmd.graphs.FindChildrenI;
+import omero.cmd.graphs.FindParentsI;
 import omero.cmd.graphs.GraphRequestFactory;
 import omero.cmd.graphs.LegalGraphTargetsI;
 import omero.cmd.graphs.SkipHeadI;
@@ -258,6 +260,20 @@ public class RequestObjectFactoryRegistry extends
                     @Override
                     public Ice.Object create(String name) {
                     	return new ResetPasswordRequestI(mailUtil, passwordUtil, sec, passwordProvider);
+                    }
+                });
+        factories.put(FindParentsI.ice_staticId(),
+                new ObjectFactory(FindParentsI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return graphRequestFactory.getRequest(FindParentsI.class);
+                    }
+                });
+        factories.put(FindChildrenI.ice_staticId(),
+                new ObjectFactory(FindChildrenI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return graphRequestFactory.getRequest(FindChildrenI.class);
                     }
                 });
         /* request parameters */

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -115,30 +115,6 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     private final Map<IObject, IObject> originalsToDuplicates = new HashMap<IObject, IObject>();
 
     /**
-     * Given class names provided by the user, find the corresponding set of actual classes.
-     * @param classNames names of model object classes
-     * @return the named classes
-     */
-    private Set<Class<? extends IObject>> getClassesFromNames(Collection<String> classNames) {
-        if (CollectionUtils.isEmpty(classNames)) {
-            return Collections.emptySet();
-        }
-        final Set<Class<? extends IObject>> classes = new HashSet<Class<? extends IObject>>();
-        for (String className : classNames) {
-            final int lastDot = className.lastIndexOf('.');
-            if (lastDot > 0) {
-                className = className.substring(lastDot + 1);
-            }
-            final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
-            if (actualClass == null) {
-                throw new IllegalArgumentException("unknown model object class named: " + className);
-            }
-            classes.add(actualClass);
-        }
-        return classes;
-    }
-
-    /**
      * Construct a new <q>duplicate</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
@@ -190,9 +166,9 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                     }});
 
         try {
-            classifier.addClass(Inclusion.DUPLICATE, getClassesFromNames(typesToDuplicate));
-            classifier.addClass(Inclusion.REFERENCE, getClassesFromNames(typesToReference));
-            classifier.addClass(Inclusion.IGNORE,    getClassesFromNames(typesToIgnore));
+            classifier.addClass(Inclusion.DUPLICATE, graphHelper.getClassesFromNames(typesToDuplicate));
+            classifier.addClass(Inclusion.REFERENCE, graphHelper.getClassesFromNames(typesToReference));
+            classifier.addClass(Inclusion.IGNORE,    graphHelper.getClassesFromNames(typesToIgnore));
         } catch (IllegalArgumentException e) {
             throw helper.cancel(new ERR(), e, "bad-class");
         }

--- a/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+
+import ome.model.IObject;
+import ome.security.ACLVoter;
+import ome.security.SystemTypes;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPathBean;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphTraversal;
+import ome.system.Login;
+import ome.system.Roles;
+import omero.cmd.FindChildren;
+import omero.cmd.FoundChildren;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+
+/**
+ * Request to identify children or contents of model objects, whether direct or indirect.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.3
+ */
+public class FindChildrenI extends FindChildren implements IRequest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FindChildrenI.class);
+
+    private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
+
+    private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
+
+    private final ACLVoter aclVoter;
+    private final SystemTypes systemTypes;
+    private final GraphPathBean graphPathBean;
+    private final Set<Class<? extends IObject>> targetClasses;
+    private final GraphPolicy graphPolicy;
+
+    private final Set<Class<? extends IObject>> classesToFind = new HashSet<Class<? extends IObject>>();
+
+    private Helper helper;
+    private GraphHelper graphHelper;
+    private GraphTraversal graphTraversal;
+
+    private int targetObjectCount = 0;
+    private int foundObjectCount = 0;
+
+    /**
+     * Construct a new <q>find-children</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
+     * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
+     * @param systemTypes for identifying the system types
+     * @param graphPathBean the graph path bean to use
+     * @param targetClasses legal target object classes for the search
+     * @param graphPolicy the graph policy to apply for the search
+     */
+    public FindChildrenI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
+        this.aclVoter = aclVoter;
+        this.systemTypes = systemTypes;
+        this.graphPathBean = graphPathBean;
+        this.targetClasses = targetClasses;
+        this.graphPolicy = graphPolicy;
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+       return new HashMap<String, String>(ALL_GROUPS_CONTEXT);
+    }
+
+    @Override
+    public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("typesOfChildren", typesOfChildren);
+            arguments.addParameter("stopBefore", stopBefore);
+            LOGGER.debug("request: " + arguments);
+        }
+
+        this.helper = helper;
+        helper.setSteps(1);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
+
+        if (CollectionUtils.isEmpty(typesOfChildren)) {
+            final Exception e = new IllegalArgumentException("no types of children specified to find");
+            throw helper.cancel(new ERR(), e, "no-types");
+        }
+
+        classesToFind.addAll(graphHelper.getClassesFromNames(typesOfChildren));
+
+        final Iterable<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters;
+        if (CollectionUtils.isEmpty(stopBefore)) {
+            graphPolicyAdjusters = Collections.emptySet();
+        } else {
+            final Set<Class<? extends IObject>> typesToStopBefore = graphHelper.getClassesFromNames(stopBefore);
+            final Function<GraphPolicy, GraphPolicy> graphPolicyAdjuster = new Function<GraphPolicy, GraphPolicy>() {
+                @Override
+                public GraphPolicy apply(GraphPolicy graphPolicy) {
+                    return SkipTailPolicy.getSkipTailPolicy(graphPolicy, GraphUtil.getPredicateFromClasses(typesToStopBefore));
+                }
+            };
+            graphPolicyAdjusters = Collections.singleton(graphPolicyAdjuster);
+        }
+
+        graphTraversal = graphHelper.prepareGraphTraversal(null, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
+                aclVoter, systemTypes, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+        try {
+            switch (step) {
+            case 0:
+                final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
+                targetObjectCount += targetMultimap.size();
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                if (!plan.getValue().isEmpty()) {
+                    final Exception e = new IllegalStateException("querying the model graph does not delete any objects");
+                    helper.cancel(new ERR(), e, "graph-fail");
+                }
+                return plan.getKey();
+            default:
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
+            }
+        } catch (Cancel c) {
+            throw c;
+        } catch (GraphException ge) {
+            final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
+            graphERR.message = ge.message;
+            throw helper.cancel(graphERR, ge, "graph-fail");
+        } catch (Throwable t) {
+            throw helper.cancel(new ERR(), t, "graph-fail");
+        }
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (step == 0) {
+            SetMultimap<String, Long> result = (SetMultimap<String, Long>) object;
+            result = Multimaps.filterKeys(result, new Predicate<String>() {
+                @Override
+                public boolean apply(String foundClassName) {
+                    final Class<? extends IObject> foundClass;
+                    try {
+                        foundClass = Class.forName(foundClassName).asSubclass(IObject.class);
+                    } catch (ClassCastException | ClassNotFoundException e) {
+                        throw helper.cancel(new ERR(), e, "graph-fail");
+                    }
+                    for (final Class<? extends IObject> classToFind : classesToFind) {
+                        if (classToFind.isAssignableFrom(foundClass)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }});
+            final Map<String, List<Long>> foundObjects = GraphUtil.copyMultimapForResponse(result);
+            foundObjectCount += result.size();
+            final FoundChildren response = new FoundChildren(foundObjects);
+            helper.setResponseIfNull(response);
+            helper.info("in finding children of " + targetObjectCount +
+                    ", found " + foundObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("children", response.children);
+                LOGGER.debug("response: " + arguments);
+            }
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+
+import ome.model.IObject;
+import ome.security.ACLVoter;
+import ome.security.SystemTypes;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPathBean;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphTraversal;
+import ome.system.Login;
+import ome.system.Roles;
+import omero.cmd.FindParents;
+import omero.cmd.FoundParents;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+
+/**
+ * Request to identify parents or containers of model objects, whether direct or indirect.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.2.3
+ */
+public class FindParentsI extends FindParents implements IRequest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FindParentsI.class);
+
+    private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
+
+    private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
+
+    private final ACLVoter aclVoter;
+    private final SystemTypes systemTypes;
+    private final GraphPathBean graphPathBean;
+    private final Set<Class<? extends IObject>> targetClasses;
+    private final GraphPolicy graphPolicy;
+
+    private final Set<Class<? extends IObject>> classesToFind = new HashSet<Class<? extends IObject>>();
+
+    private Helper helper;
+    private GraphHelper graphHelper;
+    private GraphTraversal graphTraversal;
+
+    private int targetObjectCount = 0;
+    private int foundObjectCount = 0;
+
+    /**
+     * Construct a new <q>find-parents</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
+     * @param aclVoter ACL voter for permissions checking
+     * @param securityRoles the security roles
+     * @param systemTypes for identifying the system types
+     * @param graphPathBean the graph path bean to use
+     * @param targetClasses legal target object classes for the search
+     * @param graphPolicy the graph policy to apply for the search
+     */
+    public FindParentsI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
+        this.aclVoter = aclVoter;
+        this.systemTypes = systemTypes;
+        this.graphPathBean = graphPathBean;
+        this.targetClasses = targetClasses;
+        this.graphPolicy = graphPolicy;
+    }
+
+    @Override
+    public Map<String, String> getCallContext() {
+       return new HashMap<String, String>(ALL_GROUPS_CONTEXT);
+    }
+
+    @Override
+    public void init(Helper helper) {
+        if (LOGGER.isDebugEnabled()) {
+            final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+            arguments.addParameter("targetObjects", targetObjects);
+            arguments.addParameter("typesOfParents", typesOfParents);
+            arguments.addParameter("stopBefore", stopBefore);
+            LOGGER.debug("request: " + arguments);
+        }
+
+        this.helper = helper;
+        helper.setSteps(1);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
+
+        if (CollectionUtils.isEmpty(typesOfParents)) {
+            final Exception e = new IllegalArgumentException("no types of parents specified to find");
+            throw helper.cancel(new ERR(), e, "no-types");
+        }
+
+        classesToFind.addAll(graphHelper.getClassesFromNames(typesOfParents));
+
+        final Iterable<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters;
+        if (CollectionUtils.isEmpty(stopBefore)) {
+            graphPolicyAdjusters = Collections.emptySet();
+        } else {
+            final Set<Class<? extends IObject>> typesToStopBefore = graphHelper.getClassesFromNames(stopBefore);
+            final Function<GraphPolicy, GraphPolicy> graphPolicyAdjuster = new Function<GraphPolicy, GraphPolicy>() {
+                @Override
+                public GraphPolicy apply(GraphPolicy graphPolicy) {
+                    return SkipTailPolicy.getSkipTailPolicy(graphPolicy, GraphUtil.getPredicateFromClasses(typesToStopBefore));
+                }
+            };
+            graphPolicyAdjusters = Collections.singleton(graphPolicyAdjuster);
+        }
+
+        graphTraversal = graphHelper.prepareGraphTraversal(null, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
+                aclVoter, systemTypes, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
+    }
+
+    @Override
+    public Object step(int step) throws Cancel {
+        helper.assertStep(step);
+        try {
+            switch (step) {
+            case 0:
+                final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
+                targetObjectCount += targetMultimap.size();
+                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                if (!plan.getValue().isEmpty()) {
+                    final Exception e = new IllegalStateException("querying the model graph does not delete any objects");
+                    helper.cancel(new ERR(), e, "graph-fail");
+                }
+                return plan.getKey();
+            default:
+                final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
+                throw helper.cancel(new ERR(), e, "bad-step");
+            }
+        } catch (Cancel c) {
+            throw c;
+        } catch (GraphException ge) {
+            final omero.cmd.GraphException graphERR = new omero.cmd.GraphException();
+            graphERR.message = ge.message;
+            throw helper.cancel(graphERR, ge, "graph-fail");
+        } catch (Throwable t) {
+            throw helper.cancel(new ERR(), t, "graph-fail");
+        }
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (step == 0) {
+            SetMultimap<String, Long> result = (SetMultimap<String, Long>) object;
+            result = Multimaps.filterKeys(result, new Predicate<String>() {
+                @Override
+                public boolean apply(String foundClassName) {
+                    final Class<? extends IObject> foundClass;
+                    try {
+                        foundClass = Class.forName(foundClassName).asSubclass(IObject.class);
+                    } catch (ClassCastException | ClassNotFoundException e) {
+                        throw helper.cancel(new ERR(), e, "graph-fail");
+                    }
+                    for (final Class<? extends IObject> classToFind : classesToFind) {
+                        if (classToFind.isAssignableFrom(foundClass)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }});
+            final Map<String, List<Long>> foundObjects = GraphUtil.copyMultimapForResponse(result);
+            foundObjectCount += result.size();
+            final FoundParents response = new FoundParents(foundObjects);
+            helper.setResponseIfNull(response);
+            helper.info("in finding parents of " + targetObjectCount +
+                    ", found " + foundObjectCount + " in total");
+
+            if (LOGGER.isDebugEnabled()) {
+                final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
+                arguments.addParameter("parents", response.parents);
+                LOGGER.debug("response: " + arguments);
+            }
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -32,11 +32,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 
 import ome.model.IObject;
 import ome.security.ACLVoter;
@@ -58,7 +61,7 @@ import omero.cmd.Response;
 /**
  * Request to identify parents or containers of model objects, whether direct or indirect.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.2.3
+ * @since 5.3.0
  */
 public class FindParentsI extends FindParents implements IRequest {
 
@@ -126,6 +129,16 @@ public class FindParentsI extends FindParents implements IRequest {
         }
 
         classesToFind.addAll(graphHelper.getClassesFromNames(typesOfParents));
+
+        final Set<String> targetClassNames = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(targetObjects.keySet()));
+        final Set<String> parentTypeNames = graphHelper.getTopLevelNames(classesToFind);
+        final Set<String> currentStopBefore = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(stopBefore));
+        final Set<String> suggestedStopBefore = StopBeforeHelper.get().getStopBeforeParents(targetClassNames, parentTypeNames);
+        final Set<String> extraStopBefore = Sets.difference(suggestedStopBefore, currentStopBefore);
+        stopBefore.addAll(extraStopBefore);
+        if (!extraStopBefore.isEmpty() && LOGGER.isDebugEnabled()) {
+            LOGGER.debug("to stopBefore added: " + Joiner.on(',').join(Ordering.natural().sortedCopy(extraStopBefore)));
+        }
 
         final Iterable<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters;
         if (CollectionUtils.isEmpty(stopBefore)) {

--- a/components/blitz/src/omero/cmd/graphs/GraphHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphHelper.java
@@ -158,4 +158,25 @@ public class GraphHelper {
         }
         return targetMultimap;
     }
+
+    /**
+     * Get the simple names of the top-level superclasses of the given classes.
+     * @param modelClasses some model classes
+     * @return the simple names of their top-level classes
+     */
+    public Set<String> getTopLevelNames(Iterable<Class<? extends IObject>> modelClasses) {
+        final Set<String> classNames = new HashSet<String>();
+        for (Class<?> modelClass : modelClasses) {
+            while (true) {
+                final Class<?> superclass = modelClass.getSuperclass();
+                if (superclass == Object.class) {
+                    break;
+                } else {
+                    modelClass = superclass;
+                }
+            }
+            classNames.add(modelClass.getSimpleName());
+        }
+        return classNames;
+    }
 }

--- a/components/blitz/src/omero/cmd/graphs/GraphHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphHelper.java
@@ -20,10 +20,14 @@
 package omero.cmd.graphs;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
@@ -39,7 +43,7 @@ import omero.cmd.ERR;
 import omero.cmd.Helper;
 
 /**
- * Factors common code out of {@link omero.cmd.GraphModify2} implementations for reuse.
+ * Factors common code out of {@link omero.cmd.GraphQuery} implementations for reuse.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.2.3
  */
@@ -59,7 +63,31 @@ public class GraphHelper {
     }
 
     /**
-     * Construct a graph traversal manager for a {@link omero.cmd.GraphModify2} request.
+     * Given class names provided by the user, find the corresponding set of actual classes.
+     * @param classNames names of model object classes
+     * @return the named classes
+     */
+    public Set<Class<? extends IObject>> getClassesFromNames(Collection<String> classNames) {
+        if (CollectionUtils.isEmpty(classNames)) {
+            return Collections.emptySet();
+        }
+        final Set<Class<? extends IObject>> classes = new HashSet<Class<? extends IObject>>();
+        for (String className : classNames) {
+            final int lastDot = className.lastIndexOf('.');
+            if (lastDot > 0) {
+                className = className.substring(lastDot + 1);
+            }
+            final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
+            if (actualClass == null) {
+                throw new IllegalArgumentException("unknown model object class named: " + className);
+            }
+            classes.add(actualClass);
+        }
+        return classes;
+    }
+
+    /**
+     * Construct a graph traversal manager for a {@link omero.cmd.GraphQuery} request.
      * @param childOptions the child options set on the request
      * @param requiredPermissions the abilities that the user must have to operate upon an object for it to be included
      * @param graphPolicy the graph policy for the request

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -34,6 +34,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.hibernate.Session;
 
+import ome.model.IObject;
 import ome.model.core.OriginalFile;
 import ome.model.internal.Details;
 import ome.services.graphs.GraphException;
@@ -46,6 +47,7 @@ import omero.cmd.Request;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
@@ -511,5 +513,24 @@ public class GraphUtil {
         public String toString() {
             return Joiner.on(", ").join(parameters);
         }
+    }
+
+    /**
+     * Construct a predicate to test if an object's class is of any of the given classes.
+     * @param matchTypes model object classes
+     * @return a predicate for testing membership of those classes
+     */
+    public static Predicate<Class<? extends IObject>> getPredicateFromClasses(final Iterable<Class<? extends IObject>> matchTypes) {
+        return new Predicate<Class<? extends IObject>>() {
+            @Override
+            public boolean apply(Class<? extends IObject> subjectType) {
+                for (final Class<? extends IObject> matchType : matchTypes) {
+                    if (matchType.isAssignableFrom(subjectType)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
     }
 }

--- a/components/blitz/src/omero/cmd/graphs/NullGraphTraversalProcessor.java
+++ b/components/blitz/src/omero/cmd/graphs/NullGraphTraversalProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collection;
+import java.util.Set;
+
+import ome.model.internal.Details;
+import ome.services.graphs.GraphException;
+import ome.services.graphs.GraphPolicy.Ability;
+import ome.services.graphs.GraphPolicy;
+import ome.services.graphs.GraphTraversal;
+
+/**
+ * A {@link ome.services.graphs.GraphTraversal.Processor} that does nothing whatsoever.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.0
+ */
+public class NullGraphTraversalProcessor implements GraphTraversal.Processor {
+
+    private final Set<GraphPolicy.Ability> requiredAbilities;
+
+    /**
+     * Construct a {@link ome.services.graphs.GraphTraversal.Processor} that does nothing whatsoever.
+     * @param requiredAbilities the {@link Ability} set to be returned by {@link #getRequiredPermissions()}
+     */
+    public NullGraphTraversalProcessor(Set<Ability> requiredAbilities) {
+        this.requiredAbilities = requiredAbilities;
+    }
+
+    @Override
+    public void nullProperties(String className, String propertyName, Collection<Long> ids) { }
+
+    @Override
+    public void deleteInstances(String className, Collection<Long> ids) { }
+
+    @Override
+    public void processInstances(String className, Collection<Long> ids) { }
+
+    @Override
+    public Set<Ability> getRequiredPermissions() {
+        return requiredAbilities;
+    }
+
+    @Override
+    public void assertMayProcess(String className, long id, Details details) throws GraphException { }
+}

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadPolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -85,15 +85,11 @@ public class SkipHeadPolicy {
                 ImmutableSet.copyOf(Collections2.transform(startFrom, getClassFromName));
 
         final Predicate<IObject> isStartFrom = new Predicate<IObject>() {
+            private final Predicate<Class<? extends IObject>> tester = GraphUtil.getPredicateFromClasses(startFromClasses);
+
             @Override
             public boolean apply(IObject subject) {
-                final Class<? extends IObject> subjectClass = subject.getClass();
-                for (final Class<? extends IObject> startFromClass : startFromClasses) {
-                    if (startFromClass.isAssignableFrom(subjectClass)) {
-                        return true;
-                    }
-                }
-                return false;
+                return tester.apply(subject.getClass());
             }
         };
 

--- a/components/blitz/src/omero/cmd/graphs/StopBeforeHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/StopBeforeHelper.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+/**
+ * Calculates suggestions for the {@code stopBefore} property of {@link omero.cmd.FindParents} and {@link omero.cmd.FindChildren}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.3.0
+ * @param <X> the type with which model types are represented
+ */
+public class StopBeforeHelper<X> {
+
+    /**
+     * @return the singleton {@code stopBefore} helper
+     */
+    static StopBeforeHelper<String> get() {
+        return STOP_BEFORE_HELPER;
+    }
+
+    /**
+     * Represents a model class hierarchy with a sense of direction. The directed graph may be cyclic.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.3.0
+     * @param <X> the type used to represent node identities
+     */
+    private static class Hierarchy<X> {
+        private final SetMultimap<X, X> directlyBeyond = HashMultimap.create();
+        private final SetMultimap<X, X> allBeyond = HashMultimap.create();
+        private boolean dirty = false;
+
+        /**
+         * Add an edge to the hierarchy.
+         * @param from the <q>from</q> node
+         * @param to the <q>to</q> node
+         */
+        private void addEdge(X from, X to) {
+            if (directlyBeyond.put(from, to)) {
+                dirty = true;
+            }
+        }
+
+        /**
+         * Find all nodes beyond the given <q>current</q> nodes. The return value includes those current nodes.
+         * @param current the nodes to start from
+         * @param all the nodes known to be beyond those nodes
+         * @return all nodes beyond the current nodes
+         */
+        private Set<X> getAllBeyond(Set<X> current, Set<X> all) {
+            all.addAll(current);
+            final Set<X> next = new HashSet<X>();
+            for (final X node : current) {
+                next.addAll(directlyBeyond.get(node));
+            }
+            next.removeAll(all);
+            return next.isEmpty() ? all : getAllBeyond(next, all);
+        }
+
+        /**
+         * Compute {@link allBeyond} as the transitive closure of {@link directlyBeyond}. It is also reflexive.
+         */
+        private void computeAllBeyond() {
+            for (final X from : directlyBeyond.keySet()) {
+                for (final X to : getAllBeyond(Collections.singleton(from), new HashSet<X>())) {
+                    allBeyond.put(from, to);
+                }
+            }
+            dirty = false;
+        }
+
+        /**
+         * Get the nodes beyond the given nodes.
+         * @param beyonds the map of <q>beyondness</q> to use
+         * @param nodes some nodes
+         * @return the nodes beyond those nodes
+         */
+        private Set<X> beyond(SetMultimap<X, X> beyonds, Collection<X> nodes) {
+            if (dirty) {
+                computeAllBeyond();
+            }
+            final Set<X> beyond = new HashSet<X>();
+            for (final X node : nodes) {
+                beyond.addAll(beyonds.get(node));
+            }
+            return beyond;
+        }
+
+        /**
+         * Get the nodes immediately beyond the given nodes.
+         * @param nodes some nodes
+         * @return the next nodes beyond those nodes
+         */
+        private Set<X> directlyBeyond(Collection<X> nodes) {
+            return beyond(directlyBeyond, nodes);
+        }
+
+        /**
+         * Get all the nodes <em>including</em> and beyond the given nodes, whether directly or indirectly.
+         * @param nodes some nodes
+         * @return all nodes beyond those nodes
+         */
+        private Set<X> allBeyond(Collection<X> nodes) {
+            return beyond(allBeyond, nodes);
+        }
+    }
+
+    private final Hierarchy<X> aboves = new Hierarchy<X>();
+    private final Hierarchy<X> belows = new Hierarchy<X>();
+
+    /**
+     * Add an edge to the hierarchy.
+     * @param above the node <q>above</q> the other
+     * @param below the node <q>below</q> the other
+     */
+    private void addEdge(X above, X below) {
+        belows.addEdge(above, below);
+        aboves.addEdge(below, above);
+    }
+
+    /**
+     * Get suggested values for {@link omero.cmd.FindParents#stopBefore}.
+     * @param startFrom simple top-level class names for the objects from which to start searching
+     * @param sought simple top-level class names for the objects that are sought
+     * @return simple top-level class names for objects to ignore in the graph because the subtree beyond contains nothing sought
+     */
+    Set<X> getStopBeforeParents(Set<X> startFrom, Set<X> sought) {
+        final Set<X> pathNodes = aboves.allBeyond(startFrom);
+        pathNodes.retainAll(belows.allBeyond(sought));
+        final Set<X> beyonds = aboves.directlyBeyond(pathNodes);
+        beyonds.removeAll(pathNodes);
+        return beyonds;
+    }
+
+    /**
+     * Get suggested values for {@link omero.cmd.FindChildren#stopBefore}.
+     * @param startFrom simple top-level class names for the objects from which to start searching
+     * @param sought simple top-level class names for the objects that are sought
+     * @return simple top-level class names for objects to ignore in the graph because the subtree beyond contains nothing sought
+     */
+    Set<X> getStopBeforeChildren(Set<X> startFrom, Set<X> sought) {
+        final Set<X> pathNodes = belows.allBeyond(startFrom);
+        pathNodes.retainAll(aboves.allBeyond(sought));
+        final Set<X> beyonds = belows.directlyBeyond(pathNodes);
+        beyonds.removeAll(pathNodes);
+        return beyonds;
+    }
+
+    /**
+     * The model graph containment hierarchy, each subarray being a parent followed by directly contained children.
+     * Multiple lines for the same parent are combined. This names only top-level classes, not any of their subclasses.
+     * The hierarchy reflects the policy rules encoded in <tt>blitz-contained-rules.xml</tt>.
+     */
+    private static String[][] HIERARCHY = new String[][]{
+        {"Instrument", "Detector", "Dichroic", "Filter", "FilterSet", "LightSource", "Microscope", "Objective", "OTF"},
+        {"Filter", "TransmittanceRange"},
+        {"FilterSet", "Dichroic"},
+        {"LightSource", "LightSource"},
+        {"LogicalChannel", "DetectorSettings", "LightSettings"},
+        {"Image", "ObjectiveSettings"},
+        {"LightSettings", "LightSource"},
+        {"DetectorSettings", "Detector"},
+        {"ObjectiveSettings", "Objective"},
+        {"Detector", "Instrument"},
+        {"LightSource", "Instrument"},
+        {"Objective", "Instrument"},
+        {"OTF", "FilterSet", "Objective"},
+        {"FilterSet", "FilterSetEmissionFilterLink", "FilterSetExcitationFilterLink"},
+        {"LightPath", "LightPathEmissionFilterLink", "LightPathExcitationFilterLink"},
+        {"Project", "ProjectDatasetLink"},
+        {"Dataset", "DatasetImageLink"},
+        {"Folder", "Folder", "FolderImageLink", "FolderRoiLink"},
+        {"DatasetImageLink", "Image"},
+        {"ProjectDatasetLink", "Dataset"},
+        {"FolderImageLink", "Image"},
+        {"FolderRoiLink", "Roi"},
+        {"Image", "ImagingEnvironment", "Instrument", "ObjectiveSettings", "Pixels", "StageLabel"},
+        {"Pixels", "Channel", "PixelsOriginalFileMap","PlaneInfo", "RenderingDef", "Thumbnail"},
+        {"LogicalChannel", "Channel", "LightPath"},
+        {"Channel", "LogicalChannel"},
+        {"Annotation", "OriginalFile"},
+        {"FilesetEntry", "OriginalFile"},
+        {"PixelsOriginalFileMap", "OriginalFile"},
+        {"Roi", "OriginalFile"},
+        {"RenderingDef", "QuantumDef", "CodomainMapContext", "ChannelBinding"},
+        {"Image", "Experiment"},
+        {"Experiment", "MicrobeamManipulation"},
+        {"Fileset", "Image", "FilesetEntry", "FilesetJobLink"},
+        {"FilesetJobLink", "Job"},
+        {"Job", "JobOriginalFileLink"},
+        {"JobOriginalFileLink", "OriginalFile"},
+        {"Image", "Roi"},
+        {"Roi", "Shape"},
+        {"Shape", "Image"},
+        {"Screen", "Reagent"},
+        {"Well", "WellReagentLink"},
+        {"WellReagentLink", "Reagent"},
+        {"Screen", "ScreenPlateLink"},
+        {"ScreenPlateLink", "Plate"},
+        {"Plate", "Well", "PlateAcquisition"},
+        {"PlateAcquisition", "WellSample"},
+        {"Well", "WellSample"},
+        {"WellSample", "Image"},
+        {"Channel", "StatsInfo"}
+    };
+
+    /**
+     * The singleton instance of the helper.
+     */
+    private static final StopBeforeHelper<String> STOP_BEFORE_HELPER;
+
+    /* populate the singleton instance with the hierarchy, plus annotation subgraphs */
+    static {
+        STOP_BEFORE_HELPER = new StopBeforeHelper<String>();
+        for (final String[] parentThenChildren : HIERARCHY) {
+            for (int index = 1; index < parentThenChildren.length; index++) {
+                STOP_BEFORE_HELPER.addEdge(parentThenChildren[0], parentThenChildren[index]);
+            }
+        }
+        for (final String annotatable : new String[]{
+                "Annotation", "Channel", "Dataset", "Detector", "Dichroic", "Fileset", "Filter", "Folder", "Image",
+                "Instrument", "LightPath", "LightSource", "Objective", "OriginalFile", "PlaneInfo", "PlateAcquisition", "Plate",
+                "Project", "Reagent", "Roi", "Screen", "Shape", "Well"}) {
+            final String link = annotatable + "AnnotationLink";
+            STOP_BEFORE_HELPER.addEdge(annotatable, link);
+            STOP_BEFORE_HELPER.addEdge(link, "Annotation");
+        }
+    }
+}

--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -1928,7 +1928,7 @@ public class Requests {
     /**
      * A builder for {@link GraphQuery} instances.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since 5.2.3
+     * @since 5.3.0
      * @param <B> the type of the builder
      * @param <R> the type of the object to be built
      */
@@ -2371,7 +2371,7 @@ public class Requests {
     /**
      * A builder for {@link FindParents} instances.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since 5.2.3
+     * @since 5.3.0
      */
     public static class FindParentsBuilder extends GraphQueryBuilder<FindParentsBuilder, FindParents> {
 
@@ -2452,7 +2452,7 @@ public class Requests {
     /**
      * A builder for {@link FindChildren} instances.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since 5.2.3
+     * @since 5.3.0
      */
     public static class FindChildrenBuilder extends GraphQueryBuilder<FindChildrenBuilder, FindChildren> {
 

--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -37,7 +37,10 @@ import omero.cmd.Chown2;
 import omero.cmd.Delete2;
 import omero.cmd.DiskUsage;
 import omero.cmd.Duplicate;
+import omero.cmd.FindChildren;
+import omero.cmd.FindParents;
 import omero.cmd.GraphModify2;
+import omero.cmd.GraphQuery;
 import omero.cmd.SkipHead;
 import omero.cmd.graphs.ChildOption;
 import omero.model.Experimenter;
@@ -1923,13 +1926,13 @@ public class Requests {
     }
 
     /**
-     * A builder for {@link GraphModify2} instances.
+     * A builder for {@link GraphQuery} instances.
      * @author m.t.b.carroll@dundee.ac.uk
      * @since 5.2.3
      * @param <B> the type of the builder
      * @param <R> the type of the object to be built
      */
-    private static abstract class GraphModify2Builder<B extends GraphModify2Builder<B, R>, R extends GraphModify2>
+    private static abstract class GraphQueryBuilder<B extends GraphQueryBuilder<B, R>, R extends GraphQuery>
         extends Builder<R> {
 
         /*
@@ -1944,12 +1947,12 @@ public class Requests {
         private SetMultimap<String, Long> allTargets = HashMultimap.create();
 
         /**
-         * Initialize a new {@link GraphModify2}'s collection containers.
+         * Initialize a new {@link GraphQuery}'s collection containers.
+         * @param assembly the new instance to assemble
          */
-        GraphModify2Builder(R assembly) {
+        GraphQueryBuilder(R assembly) {
             super(assembly);
             assembly.targetObjects = new HashMap<String, List<Long>>();
-            assembly.childOptions = new ArrayList<ChildOption>();
         }
 
         /**
@@ -2033,28 +2036,6 @@ public class Requests {
             return (B) this;
         }
 
-        /**
-         * @param options child options for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         */
-        @SuppressWarnings("unchecked")
-        public B option(Iterable<ChildOption> options) {
-            for (final ChildOption option : options) {
-                assembly.childOptions.add(option);
-            }
-            return (B) this;
-        }
-
-        /**
-         * @param dryRun if this operation is a dry run, does overwrite previous calls
-         * @return this builder, for method chaining
-         */
-        @SuppressWarnings("unchecked")
-        public B dryRun(boolean dryRun) {
-            assembly.dryRun = dryRun;
-            return (B) this;
-        }
-
         /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
 
         /**
@@ -2082,6 +2063,52 @@ public class Requests {
         public B id(Long... ids) {
             return id(Arrays.asList(ids));
         }
+    }
+
+    /**
+     * A builder for {@link GraphModify2} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     * @param <B> the type of the builder
+     * @param <R> the type of the object to be built
+     */
+    private static abstract class GraphModify2Builder<B extends GraphModify2Builder<B, R>, R extends GraphModify2>
+        extends GraphQueryBuilder<B, R> {
+
+        /**
+         * Initialize a new {@link GraphModify2}'s collection containers.
+         * @param assembly the new instance to assemble
+         */
+        GraphModify2Builder(R assembly) {
+            super(assembly);
+            assembly.childOptions = new ArrayList<ChildOption>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param options child options for this operation, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B option(Iterable<ChildOption> options) {
+            for (final ChildOption option : options) {
+                assembly.childOptions.add(option);
+            }
+            return (B) this;
+        }
+
+        /**
+         * @param dryRun if this operation is a dry run, does overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        @SuppressWarnings("unchecked")
+        public B dryRun(boolean dryRun) {
+            assembly.dryRun = dryRun;
+            return (B) this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
 
         /**
          * @param options child options for this operation, does not overwrite previous calls
@@ -2340,6 +2367,168 @@ public class Requests {
             return ignoreType(Arrays.asList(types));
         }
     }
+
+    /**
+     * A builder for {@link FindParents} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class FindParentsBuilder extends GraphQueryBuilder<FindParentsBuilder, FindParents> {
+
+        /**
+         * Instantiate a new {@link FindParents} and initialize its collection containers.
+         */
+        public FindParentsBuilder() {
+            super(new FindParents());
+            assembly.typesOfParents = new ArrayList<String>();
+            assembly.stopBefore = new ArrayList<String>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param types the types of parents to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindParentsBuilder parentType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.typesOfParents.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types of parents to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final FindParentsBuilder parentType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.typesOfParents.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindParentsBuilder stopBefore(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.stopBefore.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final FindParentsBuilder stopBefore(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.stopBefore.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param types the types of parents to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindParentsBuilder parentType(String... types) {
+            return parentType(Arrays.asList(types));
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindParentsBuilder stopBefore(String... types) {
+            return stopBefore(Arrays.asList(types));
+        }
+    }
+
+    /**
+     * A builder for {@link FindChildren} instances.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    public static class FindChildrenBuilder extends GraphQueryBuilder<FindChildrenBuilder, FindChildren> {
+
+        /**
+         * Instantiate a new {@link FindChildren} and initialize its collection containers.
+         */
+        public FindChildrenBuilder() {
+            super(new FindChildren());
+            assembly.typesOfChildren = new ArrayList<String>();
+            assembly.stopBefore = new ArrayList<String>();
+        }
+
+        /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
+
+        /**
+         * @param types the types of children to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindChildrenBuilder childType(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.typesOfChildren.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types of children to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final FindChildrenBuilder childType(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.typesOfChildren.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindChildrenBuilder stopBefore(Iterable<String> types) {
+            for (final String type : types) {
+                assembly.stopBefore.add(type);
+            }
+            return this;
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public final FindChildrenBuilder stopBefore(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
+            for (final Class<? extends IObject> type : types) {
+                assembly.stopBefore.add(getModelClassName(type));
+            }
+            return this;
+        }
+
+        /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
+
+        /**
+         * @param types the types of children to find, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindChildrenBuilder childType(String... types) {
+            return childType(Arrays.asList(types));
+        }
+
+        /**
+         * @param types the types to exclude from the search, does not overwrite previous calls
+         * @return this builder, for method chaining
+         */
+        public FindChildrenBuilder stopBefore(String... types) {
+            return stopBefore(Arrays.asList(types));
+        }
+}
 
     /**
      * A builder for {@link SkipHead} instances.
@@ -2609,6 +2798,20 @@ public class Requests {
      */
     public static DuplicateBuilder duplicate() {
         return new DuplicateBuilder();
+    }
+
+    /**
+     * @return a new {@link FindParents} builder
+     */
+    public static FindParentsBuilder findParents() {
+        return new FindParentsBuilder();
+    }
+
+    /**
+     * @return a new {@link FindChildren} builder
+     */
+    public static FindChildrenBuilder findChildren() {
+        return new FindChildrenBuilder();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/FindParentsChildrenTest.java
+++ b/components/tools/OmeroJava/test/integration/FindParentsChildrenTest.java
@@ -1,0 +1,685 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import omero.ServerError;
+import omero.cmd.FindChildren;
+import omero.cmd.FindParents;
+import omero.cmd.FoundChildren;
+import omero.cmd.FoundParents;
+import omero.gateway.util.Requests;
+import omero.gateway.util.Requests.Delete2Builder;
+import omero.model.CommentAnnotation;
+import omero.model.CommentAnnotationI;
+import omero.model.Dataset;
+import omero.model.DatasetImageLink;
+import omero.model.DatasetImageLinkI;
+import omero.model.Folder;
+import omero.model.FolderImageLink;
+import omero.model.FolderImageLinkI;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.ImageAnnotationLink;
+import omero.model.ImageAnnotationLinkI;
+import omero.model.Plate;
+import omero.model.Roi;
+import omero.model.RoiAnnotationLink;
+import omero.model.RoiAnnotationLinkI;
+import omero.model.RoiI;
+import omero.model.TagAnnotation;
+import omero.model.TagAnnotationI;
+
+/**
+ * Test the requests for finding the parents and children of model objects.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.3.0
+ */
+public class FindParentsChildrenTest extends AbstractServerTest {
+    private final List<Dataset> datasets = new ArrayList<Dataset>();
+    private final List<Folder> folders = new ArrayList<Folder>();
+    private final List<Plate> plates = new ArrayList<Plate>();
+    private final List<Image> images = new ArrayList<Image>();
+    private final List<Roi> rois = new ArrayList<Roi>();
+    private final List<CommentAnnotation> comments = new ArrayList<CommentAnnotation>();
+    private final List<TagAnnotation> tags = new ArrayList<TagAnnotation>();
+
+    /**
+     * Persist the given objects and replace their list elements with the corresponding proxy object.
+     * @param objects new model objects
+     * @throws ServerError unexpected
+     */
+    private <X extends IObject> void saveObjects(List<X> objects) throws ServerError {
+        for (int index = 0; index < objects.size(); index++) {
+            objects.set(index, (X) iUpdate.saveAndReturnObject(objects.get(index)).proxy());
+        }
+    }
+
+    /**
+     * Create a linked graph of model objects to use in testing.
+     * Creates two datasets, three folders, and three images:
+     * the first and second images in the first dataset and folder, the second and third images in the second dataset and folder.
+     * The third folder contains the other two folders.
+     * Each image has two ROIs. Each image has a comment and each ROI has a tag.
+     * @throws Exception unexpected
+     */
+    @BeforeClass
+    public void setup() throws Exception {
+        newUserAndGroup("rw----");
+
+        for (int count = 2; count > 0; count--) {
+            datasets.add(mmFactory.simpleDataset());
+        }
+        for (int count = datasets.size() + 1; count > 0; count--) {
+            folders.add(mmFactory.simpleFolder());
+        }
+        for (int count = datasets.size() + 1; count > 0; count--) {
+            images.add(mmFactory.simpleImage());
+        }
+        for (int count = images.size() * 2; count > 0; count--) {
+            rois.add(new RoiI());
+        }
+        for (int count = images.size(); count > 0; count--) {
+            comments.add(new CommentAnnotationI());
+        }
+        for (int count = rois.size(); count > 0; count--) {
+            tags.add(new TagAnnotationI());
+        }
+
+        saveObjects(datasets);
+        saveObjects(folders);
+        saveObjects(images);
+        saveObjects(rois);
+        saveObjects(comments);
+        saveObjects(tags);
+
+        final List<IObject> links = new ArrayList<IObject>();
+
+        for (int datasetIndex = 0; datasetIndex < datasets.size(); datasetIndex++) {
+            for (int childOffset = 0; childOffset < 2; childOffset++) {
+                final DatasetImageLink dil = new DatasetImageLinkI();
+                dil.setParent(datasets.get(datasetIndex));
+                dil.setChild(images.get(datasetIndex + childOffset));
+                links.add(dil);
+            }
+        }
+
+        for (int folderIndex = 0; folderIndex < datasets.size(); folderIndex++) {
+            for (int childOffset = 0; childOffset < 2; childOffset++) {
+                final FolderImageLink fil = new FolderImageLinkI();
+                fil.setParent(folders.get(folderIndex));
+                fil.setChild(images.get(folderIndex + childOffset));
+                links.add(fil);
+            }
+        }
+
+        for (int roiIndex = 0; roiIndex < rois.size(); roiIndex++) {
+            final Roi roi = (Roi) iQuery.get("Roi", rois.get(roiIndex).getId().getValue());
+            roi.setImage(images.get(roiIndex / 2));
+            links.add(roi);
+        }
+
+        for (int imageIndex = 0; imageIndex < images.size(); imageIndex++) {
+            final ImageAnnotationLink ial = new ImageAnnotationLinkI();
+            ial.setParent(images.get(imageIndex));
+            ial.setChild(comments.get(imageIndex));
+            links.add(ial);
+        }
+
+        for (int roiIndex = 0; roiIndex < rois.size(); roiIndex++) {
+            final RoiAnnotationLink ral = new RoiAnnotationLinkI();
+            ral.setParent(rois.get(roiIndex));
+            ral.setChild(tags.get(roiIndex));
+            links.add(ral);
+        }
+
+        iUpdate.saveCollection(links);
+
+        for (int folderIndex = 0; folderIndex < datasets.size(); folderIndex++) {
+            final Folder folder = (Folder) iQuery.get("Folder", folders.get(folderIndex).getId().getValue());
+            folder.setParentFolder(folders.get(datasets.size()));
+            iUpdate.saveObject(folder);
+        }
+    }
+
+    /**
+     * Delete the model objects created by {@link #setup()} once the tests are finished.
+     * @throws Exception unexpected
+     */
+    @AfterClass
+    public void teardown() throws Exception {
+        final Delete2Builder deleter = Requests.delete();
+        for (final List<? extends IObject> objects : Arrays.asList(datasets, folders, plates, images, rois, comments, tags)) {
+            for (final IObject object : objects) {
+                deleter.target(object);
+            }
+        }
+        doChange(deleter.build());
+    }
+
+    /**
+     * Find the image that a ROI is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImageOfRoiSingle() throws Exception {
+        final FindParents finder = Requests.findParents().target(rois.get(5)).parentType("Image").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundImages = found.parents.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(2).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the ROIs of an image.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindRoisOfImageSingle() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(2)).childType("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundRois = found.children.remove(ome.model.roi.Roi.class.getName());
+        Assert.assertNotNull(foundRois);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundRois, Arrays.asList(rois.get(4).getId().getValue(),
+                                                                                     rois.get(5).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the images that ROIs are in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImageOfRoiMultiple() throws Exception {
+        final FindParents finder = Requests.findParents().target(rois.get(1), rois.get(2)).parentType("Image").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundImages = found.parents.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(0).getId().getValue(),
+                                                                                       images.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the ROIs of images.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindRoisOfImageMultiple() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(0), images.get(2)).childType("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundRois = found.children.remove(ome.model.roi.Roi.class.getName());
+        Assert.assertNotNull(foundRois);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundRois, Arrays.asList(rois.get(0).getId().getValue(),
+                                                                                     rois.get(1).getId().getValue(),
+                                                                                     rois.get(4).getId().getValue(),
+                                                                                     rois.get(5).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that an image is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfImageSingle() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(1)).parentType("Dataset").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundDatasets = found.parents.remove(ome.model.containers.Dataset.class.getName());
+        Assert.assertNotNull(foundDatasets);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundDatasets, Arrays.asList(datasets.get(0).getId().getValue(),
+                                                                                         datasets.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images of a dataset.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInDatasetSingle() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(1)).childType("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(1).getId().getValue(),
+                                                                                       images.get(2).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that images are in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfImageMultiple() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(0), images.get(1)).parentType("Dataset").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundDatasets = found.parents.remove(ome.model.containers.Dataset.class.getName());
+        Assert.assertNotNull(foundDatasets);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundDatasets, Arrays.asList(datasets.get(0).getId().getValue(),
+                                                                                         datasets.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images of datasets.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInDatasetMultiple() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(0), datasets.get(1)).childType("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(0).getId().getValue(),
+                                                                                       images.get(1).getId().getValue(),
+                                                                                       images.get(2).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that an image is in.
+     * Ignore any ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfImageStopBeforeRoi() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(1)).parentType("Dataset").stopBefore("Roi").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundDatasets = found.parents.remove(ome.model.containers.Dataset.class.getName());
+        Assert.assertNotNull(foundDatasets);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundDatasets, Arrays.asList(datasets.get(0).getId().getValue(),
+                                                                                         datasets.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images of a dataset.
+     * Ignore any ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInDatasetStopBeforeRoi() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(1)).childType("Image").stopBefore("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(1).getId().getValue(),
+                                                                                       images.get(2).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that an image is in.
+     * Ignore any datasets.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfImageStopBeforeDataset() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(1)).parentType("Dataset").stopBefore("Dataset").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images of a dataset.
+     * Ignore any images.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInDatasetStopBeforeImage() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(1)).childType("Image").stopBefore("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that a ROI is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfRoi() throws Exception {
+        final FindParents finder = Requests.findParents().target(rois.get(3)).parentType("Dataset").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundDatasets = found.parents.remove(ome.model.containers.Dataset.class.getName());
+        Assert.assertNotNull(foundDatasets);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundDatasets, Arrays.asList(datasets.get(0).getId().getValue(),
+                                                                                         datasets.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find a dataset's ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindRoisInDataset() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(0)).childType("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.roi.Roi.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(rois.get(0).getId().getValue(),
+                                                                                       rois.get(1).getId().getValue(),
+                                                                                       rois.get(2).getId().getValue(),
+                                                                                       rois.get(3).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that a ROI is in.
+     * Ignore any images.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfRoiStopBeforeImage() throws Exception {
+        final FindParents finder = Requests.findParents().target(rois.get(3)).parentType("Dataset").stopBefore("Image").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find a dataset's ROIs.
+     * Ignore any images.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindRoisInDatasetStopBeforeImage() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(0)).childType("Roi").stopBefore("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the datasets that a comment is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindDatasetsOfComment() throws Exception {
+        final FindParents finder = Requests.findParents().target(comments.get(2)).parentType("Dataset").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundDatasets = found.parents.remove(ome.model.containers.Dataset.class.getName());
+        Assert.assertNotNull(foundDatasets);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundDatasets, Arrays.asList(datasets.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find a dataset's comments.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindCommentsOfDataset() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(datasets.get(0)).childType("CommentAnnotation").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundComments = found.children.remove(ome.model.annotations.CommentAnnotation.class.getName());
+        Assert.assertNotNull(foundComments);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundComments, Arrays.asList(comments.get(0).getId().getValue(),
+                                                                                         comments.get(1).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the images that a comment is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesOfComment() throws Exception {
+        final FindParents finder = Requests.findParents().target(comments.get(1)).parentType("Image").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundImages = found.parents.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images that a tag is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesOfTag() throws Exception {
+        final FindParents finder = Requests.findParents().target(tags.get(1)).parentType("Image").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundImages = found.parents.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(0).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find an image's annotations.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindAnnotationsOfImage() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(1)).childType("Annotation").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundComments = found.children.remove(ome.model.annotations.CommentAnnotation.class.getName());
+        Assert.assertNotNull(foundComments);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundComments, Arrays.asList(comments.get(1).getId().getValue())));
+        final List<Long> foundTags = found.children.remove(ome.model.annotations.TagAnnotation.class.getName());
+        Assert.assertNotNull(foundTags);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundTags, Arrays.asList(tags.get(2).getId().getValue(),
+                                                                                     tags.get(3).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the images that a comment is in.
+     * Ignore any ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesOfCommentStopBeforeRoi() throws Exception {
+        final FindParents finder = Requests.findParents().target(comments.get(1)).parentType("Image").stopBefore("Roi").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundImages = found.parents.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(1).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images that a tag is in.
+     * Ignore any ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesOfTagStopBeforeRoi() throws Exception {
+        final FindParents finder = Requests.findParents().target(tags.get(1)).parentType("Image").stopBefore("Roi").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find an image's annotations.
+     * Ignore any ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindAnnotationsOfImageStopBeforeRoi() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(1)).childType("Annotation").stopBefore("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundComments = found.children.remove(ome.model.annotations.CommentAnnotation.class.getName());
+        Assert.assertNotNull(foundComments);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundComments, Arrays.asList(comments.get(1).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find various components of plate structure: contained by a plate; containing the fields' images.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindVariousInPlate() throws Exception {
+        List<Long> foundPlates, foundRuns, foundWells, foundFields, foundImages;
+        plates.add((Plate) iUpdate.saveAndReturnObject(mmFactory.createPlate(2, 2, 2, 2, false)).proxy());
+
+        final FindChildren childFinder = Requests.findChildren().target(plates.get(0))
+                .childType("PlateAcquisition", "Well", "WellSample", "Image").build();
+        final FoundChildren foundChildren = (FoundChildren) doChange(childFinder);
+        foundRuns = foundChildren.children.remove(ome.model.screen.PlateAcquisition.class.getName());
+        Assert.assertNotNull(foundRuns);
+        Assert.assertEquals(foundRuns.size(), 2);
+        foundWells = foundChildren.children.remove(ome.model.screen.Well.class.getName());
+        Assert.assertNotNull(foundWells);
+        Assert.assertEquals(foundWells.size(), 4);
+        foundFields = foundChildren.children.remove(ome.model.screen.WellSample.class.getName());
+        Assert.assertNotNull(foundFields);
+        Assert.assertEquals(foundFields.size(), 16);
+        foundImages = foundChildren.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertEquals(foundImages.size(), 16);
+        Assert.assertTrue(foundChildren.children.isEmpty());
+
+        final FindParents parentFinder = Requests.findParents().target("Image").id(foundImages)
+                .parentType("Plate", "PlateAcquisition", "Well", "WellSample").build();
+        final FoundParents foundParents = (FoundParents) doChange(parentFinder);
+        foundPlates = foundParents.parents.remove(ome.model.screen.Plate.class.getName());
+        Assert.assertNotNull(foundPlates);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundPlates, Arrays.asList(plates.get(0).getId().getValue())));
+        foundRuns = foundParents.parents.remove(ome.model.screen.PlateAcquisition.class.getName());
+        Assert.assertNotNull(foundRuns);
+        Assert.assertEquals(foundRuns.size(), 2);
+        foundWells = foundParents.parents.remove(ome.model.screen.Well.class.getName());
+        Assert.assertNotNull(foundWells);
+        Assert.assertEquals(foundWells.size(), 4);
+        foundFields = foundParents.parents.remove(ome.model.screen.WellSample.class.getName());
+        Assert.assertNotNull(foundFields);
+        Assert.assertEquals(foundFields.size(), 16);
+        Assert.assertTrue(foundParents.parents.isEmpty());
+    }
+
+    /**
+     * Find the folders that an image is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindFoldersOfImage() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(1)).parentType("Folder").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundFolders = found.parents.remove(ome.model.containers.Folder.class.getName());
+        Assert.assertNotNull(foundFolders);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundFolders, Arrays.asList(folders.get(0).getId().getValue(),
+                                                                                        folders.get(1).getId().getValue(),
+                                                                                        folders.get(2).getId().getValue())));
+
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find the images of a folder.
+     * The images are in the given folder.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInFolderDirect() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(folders.get(1)).childType("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(1).getId().getValue(),
+                                                                                       images.get(2).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the images of a folder.
+     * The images are in subfolders of the given folder.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindImagesInFolderRecursive() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(folders.get(2)).childType("Image").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.core.Image.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(images.get(0).getId().getValue(),
+                                                                                       images.get(1).getId().getValue(),
+                                                                                       images.get(2).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Find the folders that a ROI is in.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindFoldersOfRoi() throws Exception {
+        final FindParents finder = Requests.findParents().target(rois.get(3)).parentType("Folder").build();
+        final FoundParents found = (FoundParents) doChange(finder);
+        final List<Long> foundFolders = found.parents.remove(ome.model.containers.Folder.class.getName());
+        Assert.assertNotNull(foundFolders);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundFolders, Arrays.asList(folders.get(0).getId().getValue(),
+                                                                                        folders.get(1).getId().getValue(),
+                                                                                        folders.get(2).getId().getValue())));
+        Assert.assertTrue(found.parents.isEmpty());
+    }
+
+    /**
+     * Find a folder's ROIs.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testFindRoisInFolder() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(folders.get(0)).childType("Roi").build();
+        final FoundChildren found = (FoundChildren) doChange(finder);
+        final List<Long> foundImages = found.children.remove(ome.model.roi.Roi.class.getName());
+        Assert.assertNotNull(foundImages);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(foundImages, Arrays.asList(rois.get(0).getId().getValue(),
+                                                                                       rois.get(1).getId().getValue(),
+                                                                                       rois.get(2).getId().getValue(),
+                                                                                       rois.get(3).getId().getValue())));
+        Assert.assertTrue(found.children.isEmpty());
+    }
+
+    /**
+     * Do not specify which types of image container to find.
+     * The search should fail.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testMissingParentTypes() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(0)).build();
+        doChange(client, factory, finder, false);
+    }
+
+    /**
+     * Do not specify which types of image contents to find.
+     * The search should fail.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testMissingChildTypes() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(0)).build();
+        doChange(client, factory, finder, false);
+    }
+}


### PR DESCRIPTION
These are generic model graph traversal requests for finding the parents and children of model objects. Integration tests are provided. They are intended to be useful for existing code such as https://github.com/openmicroscopy/openmicroscopy/commit/dd532abb92ec82803df97983ea999d0759756816 and will be even more useful with arbitrarily nested folders for single-query traversal.

Beyond #4519 this PR adds Folder support and automatic assistance with `stopBefore`.

Integration tests are provided at http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration/FindParentsChildrenTest/ and the curious could turn on debug logging for `omero.cmd.graphs` to see the extra `stopBefore` classes being added.

I am certainly happy to assist with the creation of Java gateway methods.  These may want to use `stopBefore(Mask.class)` so that folder contents queries do not include images or ROIs that are not directly in folders but instead relate to masks of those that are.

--no-rebase as introduction of `GraphQuery` superclass breaks Blitz API