### PR TITLE
Re-enable saving of ExternalInfo

### DIFF
--- a/components/model/src/ome/model/internal/Details.java
+++ b/components/model/src/ome/model/internal/Details.java
@@ -151,6 +151,7 @@ public abstract class Details implements Filterable, Serializable {
         setContexts(copy.contexts);
         setContext(copy.getContext());
         possiblySetPermissions(copy);
+        setExternalInfo(copy.getExternalInfo());
         setCreationEvent(copy.getCreationEvent());
         setOwner(copy.getOwner());
         setGroup(copy.getGroup());


### PR DESCRIPTION
At some point (either during the move to blitz or later
during the hiding of Details implementations), the copying
of ExternalInfo objects from one Details to the next was
lost. Since then, no ExternalInfo objects could have been
linked to any IObject, and it's even unlikely that they
could have been created at all.