### PR TITLE
Show tag tagset

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -55,7 +55,7 @@ class Show(object):
     """
 
     # List of prefixes that are at the top level of the tree
-    TOP_LEVEL_PREFIXES = ('project', 'screen')
+    TOP_LEVEL_PREFIXES = ('project', 'screen', 'tagset')
 
     # List of supported object types
     SUPPORTED_OBJECT_TYPES = (
@@ -357,13 +357,13 @@ class Show(object):
                         self._initially_select = ['well.id-%s' % p.getId()]
                         return self._find_first_selected()
                     if first_obj == "tag":
-                        # Parents of tags must be tags (no OMERO_CLASS)
-                        self._initially_open.insert(0, "tag-%s" % p.getId())
+                        # Parents of tags must be tagset (no OMERO_CLASS)
+                        self._initially_open.insert(0, "tagset-%s" % p.getId())
                     else:
                         self._initially_open.insert(
                             0, "%s-%s" % (p.OMERO_CLASS.lower(), p.getId())
                         )
-                        self._initially_open_owner = p.details.owner.id.val
+                    self._initially_open_owner = p.details.owner.id.val
                 m = self.PATH_REGEX.match(self._initially_open[0])
                 if m.group('object_type') == 'image':
                     self._initially_open.insert(0, "orphaned-0")

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -60,7 +60,7 @@ class Show(object):
     # List of supported object types
     SUPPORTED_OBJECT_TYPES = (
         'project', 'dataset', 'image', 'screen', 'plate', 'tag',
-        'acquisition', 'run', 'well'
+        'acquisition', 'run', 'well', 'tagset'
     )
 
     # Regular expression which declares the format for a "path" used either
@@ -259,7 +259,7 @@ class Show(object):
         @type attributes L{dict}
         """
         first_selected = None
-        if first_obj == "tag":
+        if first_obj in ["tag", "tagset"]:
             first_selected = self._load_tag(attributes)
         elif first_obj == "well":
             first_selected = self._load_well(attributes)
@@ -328,7 +328,7 @@ class Show(object):
             return None
         first_obj = m.group('object_type')
         # if we're showing a tag, make sure we're on the tags page...
-        if first_obj == "tag" and self.menu != "usertags":
+        if first_obj in ["tag", "tagset"] and self.menu != "usertags":
             # redirect to usertags/?show=tag-123
             raise IncorrectMenuError(
                 reverse(viewname="load_template", args=['usertags']) +

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -412,116 +412,6 @@ class Show(object):
         return self._initially_open_owner
 
 
-def paths_to_tag(conn, experimenter_id=None, tagset_id=None, tag_id=None):
-    """
-    Finds tag for tag_id, also looks for parent tagset in path.
-    If tag_id and tagset_id are given, only return paths that have both.
-    If no tagset/tag paths are found, simply look for tags with tag_id.
-    """
-    params = omero.sys.ParametersI()
-    service_opts = deepcopy(conn.SERVICE_OPTS)
-    where_clause = []
-
-    if experimenter_id is not None:
-        params.add('eid', rlong(experimenter_id))
-        where_clause.append(
-            'coalesce(tsowner.id, towner.id) = :eid')
-
-    if tag_id is not None:
-        params.add('tid', rlong(tag_id))
-        where_clause.append(
-            'ttlink.child.id = :tid')
-
-    if tagset_id is not None:
-        params.add('tsid', rlong(tagset_id))
-        where_clause.append(
-            'tagset.id = :tsid')
-
-    if tag_id is None and tagset_id is None:
-        return []
-
-    qs = conn.getQueryService()
-    paths = []
-
-    # Look for tag in a tagset...
-    if tag_id is not None:
-        q = '''
-            select coalesce(tsowner.id, towner.id),
-                   tagset.id,
-                   ttlink.child.id
-            from TagAnnotation tagset
-            left outer join tagset.details.owner tsowner
-            left outer join tagset.annotationLinks ttlink
-            left outer join ttlink.child.details.owner towner
-            where %s
-        ''' % ' and '.join(where_clause)
-
-        tagsets = qs.projection(q, params, service_opts)
-        for e in tagsets:
-            path = []
-            # Experimenter is always found
-            path.append({
-                'type': 'experimenter',
-                'id': e[0].val
-            })
-            path.append({
-                'type': 'tagset',
-                'id': e[1].val
-            })
-            path.append({
-                'type': 'tag',
-                'id': e[2].val
-            })
-            paths.append(path)
-
-    # If we haven't found tag in tagset, just look for tags with matching IDs
-    if len(paths) == 0:
-
-        where_clause = []
-
-        if experimenter_id is not None:
-            # params.add('eid', rlong(experimenter_id))
-            where_clause.append(
-                'coalesce(tsowner.id, towner.id) = :eid')
-
-        if tag_id is not None:
-            # params.add('tid', rlong(tag_id))
-            where_clause.append(
-                'tag.id = :tid')
-
-        elif tagset_id is not None:
-            # params.add('tsid', rlong(tagset_id))
-            where_clause.append(
-                'tag.id = :tsid')
-
-        q = '''
-            select towner.id, tag.id
-            from TagAnnotation tag
-            left outer join tag.details.owner towner
-            where %s
-        ''' % ' and '.join(where_clause)
-
-        tagsets = qs.projection(q, params, service_opts)
-        for e in tagsets:
-            path = []
-            # Experimenter is always found
-            path.append({
-                'type': 'experimenter',
-                'id': e[0].val
-            })
-            if tag_id is not None:
-                t = 'tag'
-            else:
-                t = 'tagset'
-            path.append({
-                'type': t,
-                'id': e[1].val
-            })
-            paths.append(path)
-
-    return paths
-
-
 def paths_to_object(conn, experimenter_id=None, project_id=None,
                     dataset_id=None, image_id=None, screen_id=None,
                     plate_id=None, acquisition_id=None, well_id=None,
@@ -930,5 +820,115 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
         })
 
         paths.append(path)
+
+    return paths
+
+
+def paths_to_tag(conn, experimenter_id=None, tagset_id=None, tag_id=None):
+    """
+    Finds tag for tag_id, also looks for parent tagset in path.
+    If tag_id and tagset_id are given, only return paths that have both.
+    If no tagset/tag paths are found, simply look for tags with tag_id.
+    """
+    params = omero.sys.ParametersI()
+    service_opts = deepcopy(conn.SERVICE_OPTS)
+    where_clause = []
+
+    if experimenter_id is not None:
+        params.add('eid', rlong(experimenter_id))
+        where_clause.append(
+            'coalesce(tsowner.id, towner.id) = :eid')
+
+    if tag_id is not None:
+        params.add('tid', rlong(tag_id))
+        where_clause.append(
+            'ttlink.child.id = :tid')
+
+    if tagset_id is not None:
+        params.add('tsid', rlong(tagset_id))
+        where_clause.append(
+            'tagset.id = :tsid')
+
+    if tag_id is None and tagset_id is None:
+        return []
+
+    qs = conn.getQueryService()
+    paths = []
+
+    # Look for tag in a tagset...
+    if tag_id is not None:
+        q = '''
+            select coalesce(tsowner.id, towner.id),
+                   tagset.id,
+                   ttlink.child.id
+            from TagAnnotation tagset
+            left outer join tagset.details.owner tsowner
+            left outer join tagset.annotationLinks ttlink
+            left outer join ttlink.child.details.owner towner
+            where %s
+        ''' % ' and '.join(where_clause)
+
+        tagsets = qs.projection(q, params, service_opts)
+        for e in tagsets:
+            path = []
+            # Experimenter is always found
+            path.append({
+                'type': 'experimenter',
+                'id': e[0].val
+            })
+            path.append({
+                'type': 'tagset',
+                'id': e[1].val
+            })
+            path.append({
+                'type': 'tag',
+                'id': e[2].val
+            })
+            paths.append(path)
+
+    # If we haven't found tag in tagset, just look for tags with matching IDs
+    if len(paths) == 0:
+
+        where_clause = []
+
+        if experimenter_id is not None:
+            # params.add('eid', rlong(experimenter_id))
+            where_clause.append(
+                'coalesce(tsowner.id, towner.id) = :eid')
+
+        if tag_id is not None:
+            # params.add('tid', rlong(tag_id))
+            where_clause.append(
+                'tag.id = :tid')
+
+        elif tagset_id is not None:
+            # params.add('tsid', rlong(tagset_id))
+            where_clause.append(
+                'tag.id = :tsid')
+
+        q = '''
+            select towner.id, tag.id
+            from TagAnnotation tag
+            left outer join tag.details.owner towner
+            where %s
+        ''' % ' and '.join(where_clause)
+
+        tagsets = qs.projection(q, params, service_opts)
+        for e in tagsets:
+            path = []
+            # Experimenter is always found
+            path.append({
+                'type': 'experimenter',
+                'id': e[0].val
+            })
+            if tag_id is not None:
+                t = 'tag'
+            else:
+                t = 'tagset'
+            path.append({
+                'type': t,
+                'id': e[1].val
+            })
+            paths.append(path)
 
     return paths

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -139,19 +139,6 @@ $(function() {
         if (!param) {
             // If not found, just select root node
             inst.select_node('ul > li:first');
-        } else if (param.split("-")[0] === "tag") {
-            // Tags not yet supported by paths_to_object lookup
-            // So, we only support top-level tags (not under TagSet)
-            // Tree root may be experimenter or 'All members' (this supports both)
-            var root = inst.get_node('ul > li:first');
-            inst.open_node(root, function() {
-                var node = inst.locate_node(param, root)[0];
-                if (!node) return;
-                inst.select_node(node);
-                inst.open_node(node);
-                // we also focus the node, to scroll to it and setup hotkey events
-                $("#" + node.id).children('.jstree-anchor').focus();
-            });
         } else {
             // Gather data for request
             // Might have multiple objects separated by |

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -84,7 +84,8 @@ from omeroweb.feedback.views import handlerInternalError
 from omeroweb.http import HttpJsonResponse
 from omeroweb.webclient.decorators import login_required
 from omeroweb.webclient.decorators import render_response
-from omeroweb.webclient.show import Show, IncorrectMenuError, paths_to_object
+from omeroweb.webclient.show import Show, IncorrectMenuError, \
+    paths_to_object, paths_to_tag
 from omeroweb.connector import Connector
 from omeroweb.decorators import ConnCleaningHttpResponse, parse_url
 from omeroweb.decorators import get_client_ip
@@ -1007,13 +1008,19 @@ def api_paths_to_object(request, conn=None, **kwargs):
         acquisition_id = get_long_or_default(request, 'acquisition',
                                              acquisition_id)
         well_id = request.GET.get('well', None)
+        tag_id = get_long_or_default(request, 'tag', None)
+        tagset_id = get_long_or_default(request, 'tagset', None)
         group_id = get_long_or_default(request, 'group', None)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
-    paths = paths_to_object(conn, experimenter_id, project_id, dataset_id,
-                            image_id, screen_id, plate_id, acquisition_id,
-                            well_id, group_id)
+    if tag_id is not None or tagset_id is not None:
+        paths = paths_to_tag(conn, experimenter_id, tagset_id, tag_id)
+
+    else:
+        paths = paths_to_object(conn, experimenter_id, project_id,
+                                dataset_id, image_id, screen_id, plate_id,
+                                acquisition_id, well_id, group_id)
     return HttpJsonResponse({'paths': paths})
 
 

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -329,6 +329,22 @@ class TestShow(IWebTest):
         }
 
     @pytest.fixture
+    def tagset_show_request(self, tag):
+        """
+        Returns a simple GET request object with the 'show' query string
+        variable set in the ("tagset-id") form.
+        """
+        as_string = 'tagset-%d' % tag.id.val
+        initially_select = ['tagset-%d' % tag.id.val]
+        initially_open = ['tagset-%d' % tag.id.val]
+        return {
+            'request': self.request_factory.get(
+                self.path, data={'show': as_string}),
+            'initially_select': initially_select,
+            'initially_open': initially_open
+        }
+
+    @pytest.fixture
     def tagset_tag_path_request(self, tagset_tag):
         """
         Returns a simple GET request object with the 'path' query string
@@ -338,7 +354,27 @@ class TestShow(IWebTest):
         as_string = 'tag=%d|tag=%d' % (tagset_tag.id.val, tag.id.val)
         initially_select = ['tag-%d' % tag.id.val]
         initially_open = [
-            'tag-%d' % tagset_tag.id.val,
+            'tagset-%d' % tagset_tag.id.val,
+            'tag-%d' % tag.id.val
+        ]
+        return {
+            'request': self.request_factory.get(
+                self.path, data={'path': as_string}),
+            'initially_select': initially_select,
+            'initially_open': initially_open
+        }
+
+    @pytest.fixture
+    def tagset_tag_show_request(self, tagset_tag):
+        """
+        Returns a simple GET request object with the 'show' query string
+        variable of 'tag-id' as the child tag of a tagset.
+        """
+        tag, = tagset_tag.linkedAnnotationList()
+        as_string = 'tag-%s' % (tag.id.val)
+        initially_select = ['tag-%d' % tag.id.val]
+        initially_open = [
+            'tagset-%d' % tagset_tag.id.val,
             'tag-%d' % tag.id.val
         ]
         return {
@@ -738,6 +774,14 @@ class TestShow(IWebTest):
             show.first_selected
         assert excinfo.value.uri is not None
 
+    def test_tagset_redirect(self, tagset_show_request):
+        show = Show(self.conn, tagset_show_request['request'], None)
+        self.assert_instantiation(show)
+
+        with pytest.raises(IncorrectMenuError) as excinfo:
+            show.first_selected
+        assert excinfo.value.uri is not None
+
     def test_tag_legacy_path(self, tag_path_request, tag):
         show = Show(self.conn, tag_path_request['request'], 'usertags')
         self.assert_instantiation(show)
@@ -931,6 +975,24 @@ class TestShow(IWebTest):
         assert show._first_selected == first_selected
         assert len(show.initially_select) == \
             len(tag_by_textvalue_path_request['initially_select'])
+
+    def test_tagset_tag_by_id(
+            self, tagset_tag_path_request, tagset_tag):
+        show = Show(self.conn, tagset_tag_path_request['request'], 'usertags')
+        self.assert_instantiation(show)
+
+        tag, = tagset_tag.linkedAnnotationList()
+        first_selected = show.first_selected
+        assert first_selected is not None
+        assert isinstance(first_selected, TagAnnotationWrapper)
+        assert first_selected.getId() == tag.id.val
+        assert show.initially_open == \
+            tagset_tag_path_request['initially_open']
+        assert show.initially_open_owner == \
+            tag.details.owner.id.val
+        assert show._first_selected == first_selected
+        assert show.initially_select == \
+            tagset_tag_path_request['initially_select']
 
     def test_multiple_well_by_id(
             self, wells_by_id_show_request, screen_plate_run_well):


### PR DESCRIPTION
This fixes the links to "show" tag when tag is under a tagset or to show tagset.

To test:
 - Browse to Tag under a Tag set, copy link to it ```/webclient/?show=tag-801```, paste to a different browser (not logged in), log in as a different user (who can access the tag) and check you are taken to the tag in tag tree.
 - Repeat with a Tag set. ```/webclient/?show=tagset-801```
 - When combined with #4540 this should also work for tags (in tagset or orphaned) ```webclient/usertags/?show=tag.textValue-Bod1```
 - Also test with a Tag NOT under a Tag set.