### PR TITLE
Shape renaming: components/tools review

### DIFF
--- a/components/tools/OmeroM/src/roi/createEllipse.m
+++ b/components/tools/OmeroM/src/roi/createEllipse.m
@@ -1,4 +1,4 @@
-function ellipse = createEllipse(x, y, rx, varargin)
+function ellipse = createEllipse(x, y, radiusx, varargin)
 % CREATEELLIPSE Create a ellipse shape object from a set of coordinates and radii
 %
 %   Examples:
@@ -8,7 +8,7 @@ function ellipse = createEllipse(x, y, rx, varargin)
 %
 % See also: CREATERECTANGLE, SETSHAPECOORDINATES
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2016 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -30,13 +30,13 @@ isposscalar = @(x) isscalar(x) && x > 0;
 ip = inputParser;
 ip.addRequired('x', @isscalar);
 ip.addRequired('y', @isscalar);
-ip.addRequired('rx', isposscalar);
-ip.addOptional('ry', rx, isposscalar);
-ip.parse(x, y, rx, varargin{:});
+ip.addRequired('radiusx', isposscalar);
+ip.addOptional('radiusy', radiusx, isposscalar);
+ip.parse(x, y, radiusx, varargin{:});
 
 % Create an Ellipse shape
 ellipse = omero.model.EllipseI;
 ellipse.setX(rdouble(x));
 ellipse.setY(rdouble(y));
-ellipse.setRadiusX(rdouble(rx));
-ellipse.setRadiusY(rdouble(ip.Results.ry));
+ellipse.setRadiusX(rdouble(radiusx));
+ellipse.setRadiusY(rdouble(ip.Results.radiusy));

--- a/components/tools/OmeroM/test/unit/TestEllipse.m
+++ b/components/tools/OmeroM/test/unit/TestEllipse.m
@@ -3,7 +3,7 @@
 % Require MATLAB xUnit Test Framework to be installed
 % http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
 
-% Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+% Copyright (C) 2013-2016 University of Dundee & Open Microscopy Environment.
 % All rights reserved.
 %
 % This program is free software; you can redistribute it and/or modify
@@ -25,8 +25,8 @@ classdef TestEllipse < TestShape
     properties
         x = 10
         y = 20
-        rx = 5
-        ry = 8
+        radiusx = 5
+        radiusy = 8
     end
     
     methods
@@ -40,9 +40,9 @@ classdef TestEllipse < TestShape
         
         function createEllipse(self, iscircle)
             if nargin<2 || ~iscircle
-                self.shape = createEllipse(self.x, self.y, self.rx, self.ry);
+                self.shape = createEllipse(self.x, self.y, self.radiusx, self.radiusy);
             else
-                self.shape = createEllipse(self.x, self.y, self.rx);
+                self.shape = createEllipse(self.x, self.y, self.radiusx);
             end
         end
         
@@ -50,8 +50,8 @@ classdef TestEllipse < TestShape
             assertTrue(isa(self.shape, 'omero.model.EllipseI'));
             assertEqual(self.shape.getX().getValue(), self.x);
             assertEqual(self.shape.getY().getValue(), self.y);
-            assertEqual(self.shape.getRadiusX().getValue(), self.rx);
-            assertEqual(self.shape.getRadiusY().getValue(), self.ry);
+            assertEqual(self.shape.getRadiusX().getValue(), self.radiusx);
+            assertEqual(self.shape.getRadiusY().getValue(), self.radiusy);
         end
         
         function testCircle(self)
@@ -60,30 +60,30 @@ classdef TestEllipse < TestShape
             assertTrue(isa(self.shape, 'omero.model.EllipseI'));
             assertEqual(self.shape.getX().getValue(), self.x);
             assertEqual(self.shape.getY().getValue(), self.y);
-            assertEqual(self.shape.getRadiusX().getValue(), self.rx);
-            assertEqual(self.shape.getRadiusY().getValue(), self.rx);
+            assertEqual(self.shape.getRadiusX().getValue(), self.radiusx);
+            assertEqual(self.shape.getRadiusY().getValue(), self.radiusx);
         end
         
         function testNegativeRadiusX(self)
-            self.rx = -1;
+            self.radiusx = -1;
             assertExceptionThrown(@() self.createEllipse(),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
         
         function testNegativeRadiusY(self)
-            self.ry = -1;
+            self.radiusy = -1;
             assertExceptionThrown(@() self.createEllipse(),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
         
         function testZeroRadiusX(self)
-            self.rx = 0;
+            self.radiusx = 0;
             assertExceptionThrown(@() self.createEllipse(),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
         
         function testZeroRadiusY(self)
-            self.ry = 0;
+            self.radiusy = 0;
             assertExceptionThrown(@() self.createEllipse(),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end

--- a/components/tools/OmeroPy/src/omero/util/OmeroPopo.py
+++ b/components/tools/OmeroPy/src/omero/util/OmeroPopo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+# Copyright (C) 2006-2016 University of Dundee. All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -671,96 +671,96 @@ class EllipseData(ShapeData):
         ShapeData.__init__(self)
         if(shape is None):
             self.setValue(EllipseI())
-            self.setCx(0)
-            self.setCy(0)
-            self.setRx(0)
-            self.setRy(0)
+            self.setX(0)
+            self.setY(0)
+            self.setRadiusX(0)
+            self.setRadiusY(0)
         else:
             self.setValue(shape)
 
     ##
     # Set the centre x coord of the Ellipse
-    # @param cx See above.
-    def setCx(self, cx):
+    # @param x See above.
+    def setX(self, x):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        shape.setX(rdouble(cx))
+        shape.setX(rdouble(x))
 
     ##
     # Get the centre x coord of the Ellipse
     # @return See Above.
-    def getCx(self):
+    def getX(self):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        cx = shape.getX()
-        if(cx is None):
+        x = shape.getX()
+        if(x is None):
             return 0
-        return cx.getValue()
+        return x.getValue()
 
     ##
     # Set the centre y coord of the Ellipse
-    # @param cy See above.
-    def setCy(self, cy):
+    # @param y See above.
+    def setY(self, y):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        shape.setY(rdouble(cy))
+        shape.setY(rdouble(y))
 
     ##
     # Get the centre y coord of the Ellipse
     # @return See Above.
-    def getCy(self):
+    def getY(self):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        cy = shape.getY()
-        if(cy is None):
+        y = shape.getY()
+        if(y is None):
             return 0
-        return cy.getValue()
+        return y.getValue()
 
     ##
     # Set the radius on the x-axis of the Ellipse
-    # @param rx See above.
-    def setRx(self, rx):
+    # @param radiusx See above.
+    def setRadiusX(self, radiusx):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        shape.setRadiusX(rdouble(rx))
+        shape.setRadiusX(rdouble(radiusx))
 
     ##
     # Get the radius of the x-axis of the Ellipse
     # @return See Above.
-    def getRx(self):
+    def getRadiusX(self):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        rx = shape.getRadiusX()
-        if(rx is None):
+        radiusx = shape.getRadiusX()
+        if(radiusx is None):
             return 0
-        return rx.getValue()
+        return radiusx.getValue()
 
     ##
     # Set the radius on the y-axis of the Ellipse
-    # @param rx See above.
-    def setRy(self, ry):
+    # @param radiusy See above.
+    def setRadiusY(self, radiusy):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        shape.setRadiusY(rdouble(ry))
+        shape.setRadiusY(rdouble(radiusy))
 
     ##
     # Get the radius of the y-axis of the Ellipse
     # @return See Above.
-    def getRy(self):
+    def getRadiusY(self):
         shape = self.asIObject()
         if(shape is None):
             raise Exception("No Shape specified.")
-        ry = shape.getRadiusY()
-        if(ry is None):
+        radiusy = shape.getRadiusY()
+        if(radiusy is None):
             return 0
-        return ry.getValue()
+        return radiusy.getValue()
 
     ##
     # Transform the point by the affineTransform transform.
@@ -777,19 +777,19 @@ class EllipseData(ShapeData):
     # @return See above.
     #
     def containsPoints(self):
-        cx = self.getCx()
-        cy = self.getCy()
-        rx = self.getRx()
-        ry = self.getRy()
+        x = self.getX()
+        y = self.getY()
+        radiusx = self.getRadiusX()
+        radiusy = self.getRadiusY()
         transform = self.transformToMatrix(self.getTransform())
-        point = numpy.matrix((cx, cy, 1)).transpose()
+        point = numpy.matrix((x, y, 1)).transpose()
         centre = transform * point
-        BL = numpy.matrix((cx - rx, cy + ry, 1)).transpose()
-        BR = numpy.matrix((cx + rx, cy + ry, 1)).transpose()
-        TL = numpy.matrix((cx - rx, cy - ry, 1)).transpose()
-        TR = numpy.matrix((cx + rx, cy - ry, 1)).transpose()
-        MajorAxisLeft = numpy.matrix((cx - rx, cy, 1)).transpose()
-        MajorAxisRight = numpy.matrix((cx + rx, cy, 1)).transpose()
+        BL = numpy.matrix((x - radiusx, y + radiusy, 1)).transpose()
+        BR = numpy.matrix((x + radiusx, y + radiusy, 1)).transpose()
+        TL = numpy.matrix((x - radiusx, y - radiusy, 1)).transpose()
+        TR = numpy.matrix((x + radiusx, y - radiusy, 1)).transpose()
+        MajorAxisLeft = numpy.matrix((x - radiusx, y, 1)).transpose()
+        MajorAxisRight = numpy.matrix((x + radiusx, y, 1)).transpose()
         lb = transform * BL
         rb = transform * BR
         lt = transform * TL
@@ -815,15 +815,16 @@ class EllipseData(ShapeData):
         cy = float(centre[1])
         xrange = range(centredBoundingBox[0][0], centredBoundingBox[1][0])
         yrange = range(centredBoundingBox[0][1], centredBoundingBox[1][1])
-        for x in xrange:
-            for y in yrange:
-                newX = x * math.cos(majorAxisAngle) + y * \
+        for dx in xrange:
+            for dy in yrange:
+                newX = dx * math.cos(majorAxisAngle) + dy * \
                     math.sin(majorAxisAngle)
-                newY = -x * math.sin(majorAxisAngle) + \
-                    y * math.cos(majorAxisAngle)
-                val = (newX * newX) / (rx * rx) + (newY * newY) / (ry * ry)
+                newY = -dx * math.sin(majorAxisAngle) + \
+                    dy * math.cos(majorAxisAngle)
+                val = (newX * newX) / (radiusx * radiusx) + \
+                    (newY * newY) / (radiusy * radiusy)
                 if(val <= 1):
-                    points[(int(x + cx), int(y + cy))] = 1
+                    points[(int(dx + cx), int(dy + cy))] = 1
         return points
 
 ##

--- a/components/tools/OmeroPy/src/omero/util/ROIDrawingUtils.py
+++ b/components/tools/OmeroPy/src/omero/util/ROIDrawingUtils.py
@@ -3,7 +3,7 @@
 #
 #
 # ------------------------------------------------------------------------------
-#  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+#  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
 #
 #
 #   This program is free software; you can redistribute it and/or modify
@@ -159,22 +159,24 @@ class DrawingCanvas:
         return shapeSettings[0][1]
 
     ##
-    # Draw an ellipse at (cx, cy) with major and minor axis (rx,ry).
-    # @param cx See above.
-    # @param cy See above.
-    # @param rx See above.
-    # @param ry See above.
+    # Draw an ellipse at (x, y) with major and minor axis (radiusx, radiusy).
+    # @param x See above.
+    # @param y See above.
+    # @param radiusx See above.
+    # @param radiusy See above.
     # @param shapeSettings The shapes display properties(colour,etc).
     # @param affineTransform The affine transform that the shape has to
     #                        undergo before drawing.
-    def drawEllipse(self, cx, cy, rx, ry, shapeSettings, affineTransform=None):
-        x = cx - rx
-        y = cy - ry
-        w = x + rx * 2
-        h = y + ry * 2
+    def drawEllipse(self, x, y, radiusx, radiusy, shapeSettings,
+                    affineTransform=None):
+        x0 = x - radiusx
+        y0 = y - radiusx
+        x1 = x0 + radiusx * 2
+        y1 = y0 + radiusy * 2
         fillColour = self.getFillColour(shapeSettings)
         strokeColour = self.getStrokeColour(shapeSettings)
-        self.draw.ellipse((x, y, w, h), fill=fillColour, outline=strokeColour)
+        self.draw.ellipse((x0, y0, x1, y1), fill=fillColour,
+                          outline=strokeColour)
 
     ##
     # Draw a rectangle at (x, y) with width, height (width, height).
@@ -294,7 +296,7 @@ class DrawingCanvas:
             self.image.paste(newImage)
 
     ##
-    # Draw text at (x, y) with major and minor axis (rx,ryr).
+    # Draw text at (x, y).
     # @param x See above.
     # @param y See above.
     # @param text The text to draw.

--- a/components/tools/OmeroPy/src/omero/util/ROIDrawingUtils.py
+++ b/components/tools/OmeroPy/src/omero/util/ROIDrawingUtils.py
@@ -170,7 +170,7 @@ class DrawingCanvas:
     def drawEllipse(self, x, y, radiusx, radiusy, shapeSettings,
                     affineTransform=None):
         x0 = x - radiusx
-        y0 = y - radiusx
+        y0 = y - radiusy
         x1 = x0 + radiusx * 2
         y1 = y0 + radiusy * 2
         fillColour = self.getFillColour(shapeSettings)

--- a/components/tools/OmeroPy/src/omero/util/ROI_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/ROI_utils.py
@@ -3,7 +3,7 @@
 #
 #
 # ------------------------------------------------------------------------------
-#  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+#  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
 #
 #
 #   This program is free software; you can redistribute it and/or modify
@@ -360,17 +360,18 @@ class EllipseData(ShapeData, ROIDrawingI):
     ##
     # Constructor for EllipseData object.
     # @param roicoord The ROICoordinate of the object (default: 0,0)
-    # @param cx The centre x coordinate of the ellipse.
-    # @param cy The centre y coordinate of the ellipse.
-    # @param rx The major axis of the ellipse.
-    # @param ry The minor axis of the ellipse.
+    # @param x The centre x coordinate of the ellipse.
+    # @param y The centre y coordinate of the ellipse.
+    # @param radiusX The major axis of the ellipse.
+    # @param radiusY The minor axis of the ellipse.
 
-    def __init__(self, roicoord=ROICoordinate(), cx=0, cy=0, rx=0, ry=0):
+    def __init__(self, roicoord=ROICoordinate(), x=0, y=0, radiusX=0,
+                 radiusY=0):
         ShapeData.__init__(self)
-        self.cx = rdouble(cx)
-        self.cy = rdouble(cy)
-        self.rx = rdouble(rx)
-        self.ry = rdouble(ry)
+        self.x = rdouble(x)
+        self.y = rdouble(y)
+        self.radiusX = rdouble(radiusX)
+        self.radiusY = rdouble(radiusY)
         self.setCoord(roicoord)
 
     ##
@@ -379,19 +380,19 @@ class EllipseData(ShapeData, ROIDrawingI):
     def setROIGeometry(self, ellipse):
         ellipse.setTheZ(self.coord.theZ)
         ellipse.setTheT(self.coord.theZ)
-        ellipse.setX(self.cx)
-        ellipse.setY(self.cy)
-        ellipse.setRadiusX(self.rx)
-        ellipse.setRadiusY(self.ry)
+        ellipse.setX(self.x)
+        ellipse.setY(self.y)
+        ellipse.setRadiusX(self.radiusX)
+        ellipse.setRadiusY(self.radiusY)
 
     ##
     # overridden, @See ShapeData#getGeometryFromROI
     #
     def getGeometryFromROI(self, roi):
-        self.cx = roi.getX()
-        self.cy = roi.getY()
-        self.rx = roi.getRadiusX()
-        self.ry = roi.getRadiusY()
+        self.x = roi.getX()
+        self.y = roi.getY()
+        self.radiusX = roi.getRadiusX()
+        self.radiusY = roi.getRadiusY()
 
     ##
     # overridden, @See ShapeData#createBaseType
@@ -404,8 +405,8 @@ class EllipseData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         visitor.drawEllipse(
-            self.cx.getValue(), self.cy.getValue(), self.rx.getValue(),
-            self.ry.getValue(), self.shapeSettings.getSettings())
+            self.x.getValue(), self.y.getValue(), self.radiusX.getValue(),
+            self.radiusY.getValue(), self.shapeSettings.getSettings())
 
 ##
 # The RectangleData class contains all the manipulation and creation of

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2012-2014 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2012-2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -258,10 +258,10 @@ def shapeMarshal(shape):
         # TODO: support for mask
     elif shape_type == omero.model.EllipseI:
         rv['type'] = 'Ellipse'
-        rv['cx'] = shape.getX().getValue()
-        rv['cy'] = shape.getY().getValue()
-        rv['rx'] = shape.getRadiusX().getValue()
-        rv['ry'] = shape.getRadiusY().getValue()
+        rv['x'] = shape.getX().getValue()
+        rv['y'] = shape.getY().getValue()
+        rv['radiusX'] = shape.getRadiusX().getValue()
+        rv['radiusY'] = shape.getRadiusY().getValue()
     elif shape_type == omero.model.PolylineI:
         rv['type'] = 'PolyLine'
         rv['points'] = stringToSvg(shape.getPoints().getValue())
@@ -273,8 +273,8 @@ def shapeMarshal(shape):
         rv['y2'] = shape.getY2().getValue()
     elif shape_type == omero.model.PointI:
         rv['type'] = 'Point'
-        rv['cx'] = shape.getX().getValue()
-        rv['cy'] = shape.getY().getValue()
+        rv['x'] = shape.getX().getValue()
+        rv['y'] = shape.getY().getValue()
     elif shape_type == omero.model.PolygonI:
         rv['type'] = 'Polygon'
         # z = closed line

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roidisplay.js
@@ -108,13 +108,13 @@ $.fn.roi_display = function(options) {
               newShape = paper.image(src, shape['x'], shape['y'], shape['width'], shape['height']);
             }
             if (shape['type'] == 'Ellipse') {
-              newShape = paper.ellipse(shape['cx'], shape['cy'], shape['rx'], shape['ry']);
+              newShape = paper.ellipse(shape['x'], shape['y'], shape['radiusX'], shape['radiusY']);
             }
             else if (shape['type'] == 'Rectangle') {
               newShape = paper.rect(shape['x'], shape['y'], shape['width'], shape['height']);
             }
             else if (shape['type'] == 'Point') {
-              newShape = paper.ellipse( shape['cx'], shape['cy'], 2, 2);
+              newShape = paper.ellipse( shape['x'], shape['y'], 2, 2);
             }
             else if (shape['type'] == 'Line') {
               // define line as 'path': Move then Line: E.g. "M10 10L90 90"
@@ -164,14 +164,14 @@ $.fn.roi_display = function(options) {
         var get_tool_tip = function(shape) {
             var toolTip = "";
             if (shape['type'] == 'Ellipse') {
-              toolTip = "cx:"+ shape['cx'] +" cy:"+ shape['cy'] +" rx:"+ shape['rx'] + " ry: "+  shape['ry'];
+              toolTip = "x:"+ shape['x'] +" y:"+ shape['y'] +" radiusX:"+ shape['radiusX'] + " radiusY: "+  shape['radiusY'];
             }
             else if (shape['type'] == 'Rectangle') {
               toolTip = "x:"+ shape['x'] +" y:"+ shape['y'] +
                 " width:"+ shape['width'] + " height: "+  shape['height'];
             }
             else if (shape['type'] == 'Point') {
-              toolTip = "cx:"+ shape['cx'] +" cy:"+ shape['cy'];
+              toolTip = "x:"+ shape['x'] +" y:"+ shape['y'];
             }
             else if (shape['type'] == 'Line') {
               toolTip = "x1:"+ shape['x1'] +" y1:"+ shape['y1'] +" x2:"+ shape['x2'] +" y2:"+ shape['y2'];

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roiutils.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.roiutils.js
@@ -87,8 +87,8 @@ $.fn.get_ome_point = function(center_x, center_y, z_plane, t_plane, transform, s
     var shape_config = typeof shape_config !== "undefined" ? shape_config : $.fn.get_shape_config();
 
     var point_conf = {
-        "cx": center_x,
-        "cy": center_y
+        "x": center_x,
+        "y": center_y
     };
 
     $.extend(point_conf, $.fn.get_generic_shape(transform, z_plane, t_plane, "Point"));
@@ -104,8 +104,8 @@ $.fn.get_ome_ellipse = function(center_x, center_y, radius_x, radius_y, z_plane,
     var shape_config = typeof shape_config !== "undefined" ? shape_config : $.fn.get_shape_config();
 
     var ellipse_conf = {
-        "rx": radius_x,
-        "ry": radius_y
+        "radiusX": radius_x,
+        "radiusY": radius_y
     };
 
     $.extend(ellipse_conf, $.fn.get_ome_point(center_x, center_y, z_plane, t_plane,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -476,12 +476,12 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
         # TODO: support for mask
     elif type(s) == omero.model.EllipseI:
         shape['type'] = 'Ellipse'
-        shape['cx'] = int(s.getX().getValue())
-        shape['cy'] = int(s.getY().getValue())
-        shape['rx'] = int(s.getRadiusX().getValue())
-        shape['ry'] = int(s.getRadiusY().getValue())
-        bBox = (shape['cx']-shape['rx'], shape['cy']-shape['ry'],
-                2*shape['rx'], 2*shape['ry'])
+        shape['x'] = int(s.getX().getValue())
+        shape['y'] = int(s.getY().getValue())
+        shape['radiusX'] = int(s.getRadiusX().getValue())
+        shape['radiusY'] = int(s.getRadiusY().getValue())
+        bBox = (shape['x']-shape['radiusX'], shape['y']-shape['radiusY'],
+                2*shape['radiusX'], 2*shape['radiusY'])
     elif type(s) == omero.model.PolylineI:
         shape['type'] = 'PolyLine'
         shape['xyList'] = pointsStringToXYlist(s.getPoints().getValue())
@@ -498,9 +498,9 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
                 max(shape['y1'], shape['y2'])-y)
     elif type(s) == omero.model.PointI:
         shape['type'] = 'Point'
-        shape['cx'] = s.getX().getValue()
-        shape['cy'] = s.getY().getValue()
-        bBox = (shape['cx']-50, shape['cy']-50, 100, 100)
+        shape['x'] = s.getX().getValue()
+        shape['y'] = s.getY().getValue()
+        bBox = (shape['x']-50, shape['y']-50, 100, 100)
     elif type(s) == omero.model.PolygonI:
         shape['type'] = 'Polygon'
         shape['xyList'] = pointsStringToXYlist(s.getPoints().getValue())

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -90,7 +90,7 @@ def basic_point(default_id):
     shape = omero.model.PointI()
     shape.id = rlong(default_id)
     shape.x = rdouble(0.0)
-    shape.y = rdouble(0.0)
+    shape.y = rdouble(.1)
     return shape
 
 
@@ -99,9 +99,9 @@ def basic_ellipse(default_id):
     shape = omero.model.EllipseI()
     shape.id = rlong(default_id)
     shape.x = rdouble(0.0)
-    shape.y = rdouble(0.0)
-    shape.radiusX = rdouble(5.0)
-    shape.radiusY = rdouble(5.0)
+    shape.y = rdouble(.1)
+    shape.radiusX = rdouble(1.0)
+    shape.radiusY = rdouble(.5)
     return shape
 
 
@@ -140,12 +140,12 @@ class TestShapeMarshal(object):
         marshaled = shapeMarshal(basic_point)
         self.assert_marshal(marshaled, 'Point')
         assert 0.0 == marshaled['x']
-        assert 0.0 == marshaled['y']
+        assert 0.1 == marshaled['y']
 
     def test_ellipse_marshal(self, basic_ellipse):
         marshaled = shapeMarshal(basic_ellipse)
         self.assert_marshal(marshaled, 'Ellipse')
         assert 0.0 == marshaled['x']
-        assert 0.0 == marshaled['y']
-        assert 5.0 == marshaled['radiusX']
-        assert 5.0 == marshaled['radiusY']
+        assert 0.1 == marshaled['y']
+        assert 1.0 == marshaled['radiusX']
+        assert 0.5 == marshaled['radiusY']

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -21,7 +21,7 @@
 import pytest
 import omero
 import omero.clients
-from omero.rtypes import rlong, rstring
+from omero.rtypes import rlong, rstring, rdouble
 from omeroweb.webgateway.marshal import shapeMarshal
 
 
@@ -85,6 +85,26 @@ def empty_polygon(default_id):
     return shape
 
 
+@pytest.fixture(scope='function')
+def basic_point(default_id):
+    shape = omero.model.PointI()
+    shape.id = rlong(default_id)
+    shape.x = rdouble(0.0)
+    shape.y = rdouble(0.0)
+    return shape
+
+
+@pytest.fixture(scope='function')
+def basic_ellipse(default_id):
+    shape = omero.model.EllipseI()
+    shape.id = rlong(default_id)
+    shape.x = rdouble(0.0)
+    shape.y = rdouble(0.0)
+    shape.radiusX = rdouble(5.0)
+    shape.radiusY = rdouble(5.0)
+    return shape
+
+
 class TestShapeMarshal(object):
     """
     Tests to ensure that OME-XML model and OMERO.insight shape point
@@ -93,29 +113,39 @@ class TestShapeMarshal(object):
 
     DEFAULT_ID = 1L
 
-    def assert_polyline(self, marshaled):
-        assert marshaled['type'] == 'PolyLine'
+    def assert_marshal(self, marshaled, type):
+        assert marshaled['type'] == type
         assert marshaled['id'] == self.DEFAULT_ID
 
-    def assert_polygon(self, marshaled):
-        assert marshaled['type'] == 'Polygon'
-        assert marshaled['id'] == self.DEFAULT_ID
-
-    def test_ployline_marshal(self, basic_polyline):
+    def test_polyline_marshal(self, basic_polyline):
         marshaled = shapeMarshal(basic_polyline)
-        self.assert_polyline(marshaled)
+        self.assert_marshal(marshaled, 'PolyLine')
         assert 'M 1 2 L 2 3 L 4 5' == marshaled['points']
 
     def test_polyline_float_marshal(self, float_polyline):
         marshaled = shapeMarshal(float_polyline)
-        self.assert_polyline(marshaled)
+        self.assert_marshal(marshaled, 'PolyLine')
         assert 'M 1.5 2.5 L 2 3 L 4.1 5.1' == marshaled['points']
 
     def test_polygon_marshal(self, basic_polygon):
         marshaled = shapeMarshal(basic_polygon)
-        self.assert_polygon(marshaled)
+        self.assert_marshal(marshaled, 'Polygon')
         assert 'M 1 2 L 2 3 L 4 5 z' == marshaled['points']
 
     def test_unrecognised_roi_shape_points_string(self, empty_polygon):
         marshaled = shapeMarshal(empty_polygon)
         assert ' z' == marshaled['points']
+
+    def test_point_marshal(self, basic_point):
+        marshaled = shapeMarshal(basic_point)
+        self.assert_marshal(marshaled, 'Point')
+        assert 0.0 == marshaled['x']
+        assert 0.0 == marshaled['y']
+
+    def test_ellipse_marshal(self, basic_ellipse):
+        marshaled = shapeMarshal(basic_ellipse)
+        self.assert_marshal(marshaled, 'Ellipse')
+        assert 0.0 == marshaled['x']
+        assert 0.0 == marshaled['y']
+        assert 5.0 == marshaled['radiusX']
+        assert 5.0 == marshaled['radiusY']


### PR DESCRIPTION
See https://trello.com/c/LW8l7U8x/20-shape-attribute-renaming-cleanup

This PR reviews the variable/methods used when retrieving `Point` and `Ellipse` attributes in the `component/tools` directory. In particular the output of the two following greps should be reviewed with this PR included:

```
$ git grep -I [sg]et[RrCc][xy] -- $(git ls-files components/tools/ | grep -v 3rdparty | grep -v gtest)
$ git grep -I [^a-zA-Z][RrCc][XxYy] -- $(git ls-files components/tools/ | grep -v 3rdparty | grep -v gtest)
```

Additionally:
- review the breaking changes proposed in `webgateway/marshal.py` and the associated unit tests /cc @will-moore @chris-allan 
- check all Python/Web integration tests keep passing
- check the shape rendering in OMERO.web client is unmodified