### PR TITLE
Show image.name fix

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -327,6 +327,11 @@ Wait For Image Node Text
     ${nodeId}=                      Get NodeId By Icon And Text       ${imageIcon}          ${text}
     [Return]                        ${nodeId}
 
+Wait For Plate Node Text
+    [Arguments]                     ${text}
+    ${nodeId}=                      Get NodeId By Icon And Text       ${plateIcon}          ${text}
+    [Return]                        ${nodeId}
+
 
 # Methods for querying nodes by ID
 
@@ -364,6 +369,11 @@ Wait For Screen Node
 Wait For Plate Node
     [Arguments]                     ${plateId}
     ${nodeId}=                      Get NodeId By Icon And Id       ${plateIcon}         ${plateId}
+    [Return]                        ${nodeId}
+
+Wait For Run Node
+    [Arguments]                     ${runId}
+    ${nodeId}=                      Get NodeId By Icon And Id       ${runIcon}          ${runId}
     [Return]                        ${nodeId}
 
 # Or checking Nodes don't exist by ID (only checks what's loaded in jsTree)
@@ -445,6 +455,11 @@ Dataset Should Be Selected By Id
     ${nodeId}=                          Wait For Dataset Node       ${datasetId}
     Node Should Be Selected By Id       ${nodeId}                   ${expected}
 
+Run Should Be Selected By Id
+    [Arguments]                         ${runId}                    ${expected}=${true}
+    ${nodeId}=                          Wait For Run Node           ${runId}
+    Node Should Be Selected By Id       ${nodeId}                   ${expected}
+
 User Should Be Selected
     [Arguments]                         ${expected}=${true}
     ${nodeId}=                          Get NodeId By Icon          ${userIcon}
@@ -465,6 +480,17 @@ Node Should Be Selected By Icon
 Dataset Should Be Selected
     ${nodeId}=                  Node Should Be Selected By Icon     ${datasetIcon}
     [Return]                    ${nodeId}
+
+Plate Should Be Selected By Name
+    [Arguments]                         ${text}                     ${expected}=${true}
+    ${nodeId}=                          Wait For Plate Node Text    ${text}
+    Node Should Be Selected By Id       ${nodeId}                   ${expected}
+
+
+# Get the Object Id of the currently seleted Node
+Get Selected Id From Tree
+    ${objectId}=        Get Element Attribute    xpath=//a[contains(@class, 'jstree-clicked')]/parent::li@data-id
+    [Return]            ${objectId}
 
 
 Click Node
@@ -497,6 +523,9 @@ Click Previous Thumbnail
 
 Click Next Thumbnail
     Click Element  xpath=//ul[@id='dataIcons']/li[contains(@class, 'ui-selected')]/following-sibling::li
+
+Click Next Well
+    Click Element  xpath=//td[contains(@class, 'well')][contains(@class, 'ui-selected')]/following-sibling::td/img
 
 
 Thumbnail Should Be Selected

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -76,6 +76,21 @@ plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Use populate_metadata to upload and attach bulk annotation csv
 PYTHONPATH=./lib/python python lib/python/omero/util/populate_metadata.py -s $HOSTNAME -p $PORT -k $key Plate:$plateid $BULK_ANNOTATION_CSV
 
+# Import Plate and rename for test ?show=image.name-NAME
+bin/omero import $PLATE_NAME --debug ERROR > show_import.log 2>&1
+plateid=$(sed -n -e 's/^Plate://p' show_import.log)
+bin/omero obj update Plate:$plateid name=testShowPlate
+# Import Image into Project/Dataset and rename for test
+showP=$(bin/omero obj new Project name='showProject')
+showD=$(bin/omero obj new Dataset name='showDataset')
+bin/omero obj new ProjectDatasetLink parent=$showP child=$showD
+for (( k=1; k<=2; k++ ))
+do
+  bin/omero import -d $showD $IMAGE_NAME --debug ERROR > show_import.log 2>&1
+  imageid=$(sed -n -e 's/^Image://p' show_import.log)
+  bin/omero obj update Image:$imageid name=testShowImage$k
+done
+
 # Create Screen with empty plates for Create Scenario
 scrDs=$(bin/omero obj new Screen name='CreateScenario')
 for (( k=1; k<=6; k++ ))
@@ -100,5 +115,7 @@ echo "omero.pass=$USER_PASSWORD" >> "$CONFIG_FILENAME"
 echo "omero.projectid=${project##*:}" >> "$CONFIG_FILENAME"
 echo "omero.datasetid=${dataset##*:}" >> "$CONFIG_FILENAME"
 
-# Remove fake file
+# Remove fake file and logs
 rm *.fake
+rm plate_import.log
+rm show_import.log

--- a/components/tests/ui/testcases/web/show_test.txt
+++ b/components/tests/ui/testcases/web/show_test.txt
@@ -1,0 +1,103 @@
+*** Settings ***
+Library         String
+
+Resource          ../../resources/config.txt
+Resource          ../../resources/web/login.txt
+Resource          ../../resources/web/tree.txt
+
+Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Teardown      Close all browsers
+
+*** Variables ***
+
+${imageName1}                       testShowImage1
+${imageName2}                       testShowImage2
+${plateName}                        testShowPlate
+# Full Well name may make test fragile?
+${wellName}                         test&plates=1&plateAcqs=1&plateRows=2&plateCols=3&fields=1&screens=1.fake [test]
+${runName}                          PlateAcquisition Name 0
+
+*** Keywords ***
+
+Wait For Right Panel
+    [Arguments]                             ${dataType}       ${dataName}
+    Wait Until Page Contains Element        xpath=//tr[contains(@class,'data_heading_id')]//th[contains(text(),'${dataType} ID:')]
+    Wait Until Page Contains Element        xpath=//div[contains(@class,'data_heading')]//span[contains(text(),'${dataName}')]
+    ${dataId}=                              Get Text                css=tr.data_heading_id strong
+    [Return]                                ${dataId}   
+
+Check Well Selected
+    [Arguments]                             ${wellName}       ${wellId}
+    Wait Until Page Contains Element        xpath=//td[@id='well-${wellId}'][contains(@class,'well')][contains(@class,'ui-selected')]
+    Wait Until Page Contains Element        xpath=//td[@id='well-${wellId}']/img[@name='${wellName}']
+
+Get Link Button Url
+    Click Element                           id=show_link_btn
+    ${linkUrl}=                             Get Value               xpath=//div[@id='link_info_popup']//input
+    [Return]                                ${linkUrl}
+
+*** Test Cases ***
+
+Test Show Plate
+    [Documentation]     Tests that ?show functionality works on pre-imported Plates
+
+    # Load the Plate by show
+    Go To                               ${WELCOME URL}?show=plate.name-testShowPlate
+    ${plateId}=                         Wait For Right Panel            Plate               ${plateName}
+    ${nodeId}=                          Plate Should Be Selected By Name                    ${plateName}
+    # Check URL from the Link button
+    ${plateUrl}=                        Get Link Button Url
+    Should Be Equal                     ${plateUrl}                     ${WELCOME URL}?show=plate-${plateId}
+
+    #Load Well by path
+    Go To                               ${WELCOME URL}?path=plate.name-${plateName}|well.name-A1
+    ${wellId}=                          Wait For Right Panel            Well                ${wellName}     
+    Check Well Selected                 A1                              ${wellId}
+    ${runId}=                           Get Selected Id From Tree
+    # Check URL from the Link button
+    ${wellUrl}=                         Get Link Button Url
+    Should Be Equal                     ${wellUrl}                      ${WELCOME URL}?show=well-${wellId}
+    
+    # Get Next Well IDs to Test multi-selection of Wells
+    ${well-id-A2}=                      Get Element Attribute           xpath=//td[contains(@class, 'well')][descendant::img[@name='A2']]@id
+    ${w}    ${wellA2Id}=                Split String                    ${well-id-A2}    -
+    Go To                               ${WELCOME URL}?show=well-${wellId}|well-${wellA2Id}
+    Wait Until Page Contains Element    id=batch_ann_title
+    Check Well Selected                 A1                              ${wellId}
+    Check Well Selected                 A2                              ${wellA2Id}
+    Xpath Should Match X Times          //td[contains(@class, 'well')][contains(@class,'ui-selected')]        2
+
+    # Load Run by run.id
+    Go To                               ${WELCOME URL}?show=run.id-${runId}
+    Wait For Right Panel                Run                             ${runName}
+    Run Should Be Selected By Id        ${runId}
+
+    # Load the Plate by ID
+    Go To                               ${WELCOME URL}?show=plate-${plateId}
+    Wait For Right Panel                Plate                           ${plateName}
+    ${nodeId}=                          Wait For Plate Node Text        ${plateName}
+    Node Should Be Selected By Id       ${nodeId}
+
+
+Test Show PDI
+    [Documentation]     Tests that ?show functionality works on Images in Project/Dataset
+    # show image.name
+    Go To                               ${WELCOME URL}?show=image.name-${imageName1}
+    ${imageId1}=                        Wait For Right Panel                Image               ${imageName1}
+    Thumbnail Should Be Selected        ${imageId1}
+
+    # path image.name
+    Go To                               ${WELCOME URL}?path=image.name-${imageName2}
+    ${imageId2}=                        Wait For Right Panel                Image               ${imageName2}
+    Thumbnail Should Be Selected        ${imageId2}
+
+    # show Multiple images by ID
+    Go To                               ${WELCOME URL}?show=image-${imageId1}|image-${imageId2}
+    Wait Until Page Contains Element    id=batch_ann_title
+    Xpath Should Match X Times          //li[contains(@class, 'row')][contains(@class,'ui-selected')]        2
+
+
+
+
+
+

--- a/components/tests/ui/testcases/web/show_test.txt
+++ b/components/tests/ui/testcases/web/show_test.txt
@@ -14,7 +14,7 @@ ${imageName1}                       testShowImage1
 ${imageName2}                       testShowImage2
 ${plateName}                        testShowPlate
 # Full Well name may make test fragile?
-${wellName}                         test&plates=1&plateAcqs=1&plateRows=2&plateCols=3&fields=1&screens=1.fake [test]
+${wellName}                         test&plates=1&plateAcqs=1&plateRows=2&plateCols=3&fields=1&screens=0.fake [test]
 ${runName}                          PlateAcquisition Name 0
 
 *** Keywords ***

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -298,22 +298,20 @@ class Show(object):
                 "%s-%s" % (first_obj, first_selected.getId())
             ]
             first_selected = parent_node
-            self._initially_select = self._initially_open[:]
         else:
             # Tree hierarchy open to first selected object.
             self._initially_open = [
                 '%s-%s' % (first_obj, first_selected.getId())
             ]
-            # support for multiple objects selected by ID,
-            # E.g. show=image-1|image-2
-            if 'id' in attributes.keys() and len(self._initially_select) > 1:
-                # 'image.id-1' -> 'image-1'
-                self._initially_select = [
-                    i.replace(".id", "") for i in self._initially_select]
-            else:
-                # Only select a single object
-                self._initially_select = self._initially_open[:]
-
+        # support for multiple objects selected by ID,
+        # E.g. show=image-1|image-2
+        if 'id' in attributes.keys() and len(self._initially_select) > 1:
+            # 'image.id-1' -> 'image-1'
+            self._initially_select = [
+                i.replace(".id", "") for i in self._initially_select]
+        else:
+            # Only select a single object
+            self._initially_select = self._initially_open[:]
         self._initially_open_owner = first_selected.details.owner.id.val
         return first_selected
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -134,29 +134,13 @@ $(function() {
         */
         var inst = data.instance;
 
-        // Introspect the URL to get the show parameter
-        var param = OME.getURLParameter('show');
-        if (!param) {
+        // Global variable specifies what to select
+        var nodeIds = WEBCLIENT.initially_select;
+        if (nodeIds.length === 0) {
             // If not found, just select root node
             inst.select_node('ul > li:first');
-        } else if (param.split("-")[0] === "tag") {
-            // Tags not yet supported by paths_to_object lookup
-            // So, we only support top-level tags (not under TagSet)
-            // Tree root may be experimenter or 'All members' (this supports both)
-            var root = inst.get_node('ul > li:first');
-            inst.open_node(root, function() {
-                var node = inst.locate_node(param, root)[0];
-                if (!node) return;
-                inst.select_node(node);
-                inst.open_node(node);
-                // we also focus the node, to scroll to it and setup hotkey events
-                $("#" + node.id).children('.jstree-anchor').focus();
-            });
         } else {
-            // Gather data for request
-            // Might have multiple objects separated by |
-            // We just use the first
-            var nodeIds = param.split('|');
+            // We load hierachy for first item...
             var paramSplit = nodeIds[0].split('-');
 
             var payload = {};

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -76,6 +76,9 @@
     WEBCLIENT.URLS.copy_image_rdef_json = "{% url 'webgateway.views.copy_image_rdef_json' %}";
     WEBCLIENT.URLS.reset_owners_rdef_json = "{% url 'reset_owners_rdef_json' %}";
     WEBCLIENT.URLS.reset_rdef_json = "{% url 'reset_rdef_json' %}";
+    // jsTree code in ome.tree.js and center panel code in center_plugin.thumbs.js.html uses initially_select
+    // instead of browser URL since URL may be /webclient/?path=plate.name-barcode|well.name-A1
+    WEBCLIENT.initially_select = [{% for o in initially_select %}"{{ o }}"{% if not forloop.last %},{% endif %}{% endfor %}];
 
     {% ifequal menu 'usertags' %}
         WEBCLIENT.URLS.tree_top_level = WEBCLIENT.URLS.api_tags_and_tagged;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -746,7 +746,7 @@ $(document).ready(function() {
             node = inst.get_node(node);
             var nodeType = node.type;
             var nodeId = node.data.obj.id;
-            var show = OME.getURLParameter('show');
+            var show = WEBCLIENT.initially_select.join("|");
 
             switch(nodeType) {
                 // case 'dataset':

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -551,8 +551,8 @@ class TestShow(IWebTest):
         plate_acquisition = ws_a.plateAcquisition
         as_string = 'well-%d|well-%d' % (well_a.id.val, well_b.id.val)
         initially_select = [
-            'acquisition-%d' % plate_acquisition.id.val,
-            'well-%d' % well_a.id.val
+            'well-%d' % well_a.id.val,
+            'well-%d' % well_b.id.val
         ]
         initially_open = [
             'screen-%d' % screen_plate_run_well.id.val,


### PR DESCRIPTION
This fixes a lot of "show" functionality that was broken with the new jsTree in 5.2.x as noticed in https://github.com/openmicroscopy/openmicroscopy/pull/4534#issuecomment-200354950

To test:
 - check that all the examples in https://github.com/openmicroscopy/openmicroscopy/pull/2611 are working, that urls load and select the specified items.
 - Select multiple wells in Plate, copy link url, paste in browser and check that it loads and selects the same wells.
 - Repeat for multiple Images in a Dataset

I will also add Robot tests to this PR...