### PR TITLE
Fix the zoom input in the main image viewer. See #13175

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -137,7 +137,7 @@
    * Zoom input box change event handler.
    */
   function zoomCheck (i) {
-    var percent = parseFloat($(i).attr('value').replace(/%/, ''));
+    var percent = parseFloat($(i).val());
     if (isNaN(percent)) {
       percent = 100;
     }
@@ -1023,7 +1023,7 @@
 
     /* Bind zoom changes to the zoom button */
     viewport.bind('zoom', function(e, percent) {
-      $("#wblitz-zoom").attr('value', ''+percent /*+'%'*/);
+      $("#wblitz-zoom").val(''+percent);
       $(".popped").removeClass('popped');
     });
 


### PR DESCRIPTION
Fixes the zoom input in the main image viewer.
See http://trac.openmicroscopy.org/ome/ticket/13175

To test:
 - Zoom the image, check the zoom input value updates
 - Change the zoom input by typing in a number & Enter or with the up/down buttons - image should zoom.