### PR TITLE
Import target fixes for regex templates

### DIFF
--- a/components/blitz/src/ome/formats/importer/targets/ServerTemplateImportTarget.java
+++ b/components/blitz/src/ome/formats/importer/targets/ServerTemplateImportTarget.java
@@ -101,7 +101,7 @@ public class ServerTemplateImportTarget extends TemplateImportTarget {
             Dataset dataset;
             List<IObject> datasets = (List<IObject>) query.findAllByQuery(
                 "select o from Dataset as o where o.name = :name"
-                + " order by o.id desc",
+                + " order by o.id " + order,
                 new ParametersI().add("name", rstring(name)));
             if (datasets.size() == 0 || getDiscriminator().startsWith("@")) {
                 dataset = new DatasetI();

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -363,12 +363,15 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             return;
         }
 
+        ome.model.annotations.CommentAnnotation lastCA = null;
+        long maxCAId = 0;
         for (Annotation a : settings.userSpecifiedAnnotationList) {
             if (a == null) {
                 continue;
             }
 
             ome.model.annotations.Annotation ann = null;
+
             String ns = null;
             if (a.isLoaded()) {
                 ns = a.getNs() == null ? null : a.getNs().getValue();
@@ -387,30 +390,36 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             if (NSAUTOCLOSE.value.equals(ns)) {
                 autoClose = true;
             } else if (NSTARGETTEMPLATE.value.equals(ns)) {
-                ome.model.annotations.CommentAnnotation ca =
-                        (ome.model.annotations.CommentAnnotation) ann;
-                if (settings.userSpecifiedTarget != null) {
-                    // TODO: Exception
-                    String kls = settings.userSpecifiedTarget.getClass().getSimpleName();
-                    long id = settings.userSpecifiedTarget.getId().getValue();
-                    log.error("User-specified template target '{}' AND {}:{}",
-                            ca.getTextValue(), kls, id);
-                    continue;
+                ome.model.annotations.CommentAnnotation
+                    ca = (ome.model.annotations.CommentAnnotation) ann;
+                if (ca.getId().longValue() > maxCAId) {
+                    maxCAId = ca.getId().longValue();
+                    lastCA = ca;
                 }
-
+            }
+        }
+        if (lastCA != null) {
+            if (settings.userSpecifiedTarget != null) {
+                // TODO: Exception
+                String kls = settings.userSpecifiedTarget.getClass().getSimpleName();
+                long id = settings.userSpecifiedTarget.getId().getValue();
+                log.error("User-specified template target '{}' AND {}:{}",
+                        lastCA.getTextValue(), kls, id);
+            } else {
                 // Path converted to unix slashes.
-                String path = ca.getDescription();
+                String path = lastCA.getDescription();
                 File file = new File(path);
                 for (int i = 0; i < location.omittedLevels; i++) {
                     file = file.getParentFile();
                 }
                 path = file.toString();
+                log.debug("Using target path {}", path);
                 // Here we use the client-side (but unix-separated) path, since
                 // for simple imports, we don't have any context about the directory
                 // from the client.
                 ServerTemplateImportTarget target = new ServerTemplateImportTarget(path);
-                target.init(ca.getTextValue());
-                settings.userSpecifiedTarget = target.load(store, reader.isSPWReader());
+                target.init(lastCA.getTextValue());
+                    settings.userSpecifiedTarget = target.load(store, reader.isSPWReader());
             }
         }
     }

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -679,6 +679,80 @@ class TestImport(CLITest):
             assert container1.name.val == inner2
             assert container2.name.val == inner1
 
+    @pytest.mark.parametrize("spw", (True, False))
+    @pytest.mark.parametrize("qualifier", ("", "+", "-", "@"))
+    def testMultipleNameTemplateTargetArgument(
+            self, spw, qualifier, tmpdir, capfd):
+
+        outer = "MultipleNameTemplateTargetArgument-Test-" + self.uuid()
+        inner = "MultipleNameTemplateTargetArgument-Test-" + self.uuid()
+        oids = []
+        for i in range(2):
+            if spw:
+                kls = "Screen"
+            else:
+                kls = "Dataset"
+            oid = self.create_object(kls, name=inner)
+            oids.append(oid)
+
+        subdir = tmpdir.mkdir(outer)
+        if spw:
+            fake = ("SPW&screens=0&plates=1&plateRows=1&plateCols=1&"
+                    "fields=1&plateAcqs=1.fake")
+        else:
+            fake = "test.fake"
+        subdir.mkdir(inner).join(fake).write('')
+
+        self.args += ("-T",
+                      ("regex:%sname:^.*%s/(?<Container1>.*)"
+                       % (qualifier, outer)))
+        self.args += [str(tmpdir)]
+
+        # Now, run the import and check that the correct
+        # container is used or created and used.
+        found = self.parse_container(spw, capfd)
+        if qualifier == "-":
+            assert found == min(oids)
+        elif qualifier == "@":
+            assert found not in oids
+        else:
+            assert found == max(oids)
+
+    @pytest.mark.parametrize("spw", (True, False))
+    def testUniqueMultipleNameTemplateTargetArgument(
+            self, spw, tmpdir, capfd):
+
+        outer = "UniqueMultipleNameTemplateTargetArgument-Test-" + self.uuid()
+        inner = "UniqueMultipleNameTemplateTargetArgument-Test-" + self.uuid()
+        oids = []
+        for i in range(2):
+            if spw:
+                kls = "Screen"
+            else:
+                kls = "Dataset"
+            oid = self.create_object(kls, name=inner)
+            oids.append(oid)
+
+        subdir = tmpdir.mkdir(outer)
+        if spw:
+            importType = "Plate"
+            fake = ("SPW&screens=0&plates=1&plateRows=1&plateCols=1&"
+                    "fields=1&plateAcqs=1.fake")
+        else:
+            importType = "Image"
+            fake = "test.fake"
+        subdir.mkdir(inner).join(fake).write('')
+
+        self.args += ("-T", "regex:%%name:^.*%s/(?<Container1>.*)" % outer)
+        self.args += [str(tmpdir)]
+
+        # Now, run the import and check that the imported object
+        # is not in a container.
+        o, e = self.do_import(capfd)
+        obj = self.get_object(e, importType)
+        container = self.get_container(obj.id.val, spw=spw)
+        assert container is None
+
     @pytest.mark.parametrize("kls", ("Project", "Plate", "Image"))
     def testBadTargetArgument(self, kls, tmpdir, capfd):
 


### PR DESCRIPTION
This fixes the behaviour seen in https://trello.com/c/oBRyeuuI/50-multiple-import-targets. It also fixes a bug seen in passing. Integration tests are added for both fixes.

To test a nested import create a folder structure similar to the one below,
```
~/outer/inner-1
~/outer/inner-2
```
with an image or screen or more in each of the inner folders. Then import using a regex template,
```
omero import ~/outer -T "regex:name:^.*outer/(?<Container1>.*?)" 
```
The result should be that the images/screens are imported into two separate Datasets/Plates, inner-1 and inner-2.

The bug noticed was was that the `-name` discriminator was not being respected for Dataset regex imports . This bug arose because I failed to add an integration test when the initial work was done here! That has been rectified in this PR.

To test for this create a number of Datasets with the same name and and import an image from inside a folder of that name. So if the image is under
```
~/outer/inner
```
then create several Datasets called `inner`.
```
omero import ~/outer -T "regex:-name:^.*outer/(?<Container1>.*?)" 
```
should import into the oldest Dataset `inner`, i.e. the one with the smallest id.
```
omero import ~/outer -T "regex:+name:^.*outer/(?<Container1>.*?)" 
```
should still import into the newest dataset called `inner`.

@joshmoore the problem here was that multiple CommentAnnotations are created, one for each Fileset, but only one if picked up server-side. The code here takes the easier option and picks up the most recent server-side which will correspond to the current Fileset. A neater approach might be to only allow one CommentAnnotation with the correct namespace client-side. 
