### PR TITLE
refactor DuplicateI to copy more complex subgraphs

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -273,12 +273,12 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
         void execute(Function<Object, IObject> mapping) throws GraphException {
             final Object duplicateValue = GraphUtil.copyComplexValue(mapping, value);
             if (duplicateValue != null) {
-            try {
-                PropertyUtils.setNestedProperty(duplicate, property, duplicateValue);
-            } catch (NestedNullException | ReflectiveOperationException e) {
-                throw new GraphException(
-                        "cannot set property " + property + " on duplicate " + duplicate.getClass().getName());
-            }
+                try {
+                    PropertyUtils.setNestedProperty(duplicate, property, duplicateValue);
+                } catch (NestedNullException | ReflectiveOperationException e) {
+                    throw new GraphException(
+                            "cannot set property " + property + " on duplicate " + duplicate.getClass().getName());
+                }
             }
         }
     }

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -19,7 +19,6 @@
 
 package omero.cmd.graphs;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,7 +35,6 @@ import org.apache.commons.beanutils.NestedNullException;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.hibernate.FlushMode;
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.proxy.HibernateProxy;
@@ -44,10 +42,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 
 import ome.model.IObject;
@@ -106,13 +109,15 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     private GraphHelper graphHelper;
     private GraphTraversal graphTraversal;
 
-    private FlushMode flushMode;
     private GraphTraversal.PlanExecutor processor;
 
     private int targetObjectCount = 0;
     private int duplicatedObjectCount = 0;
 
     private final Map<IObject, IObject> originalsToDuplicates = new HashMap<IObject, IObject>();
+    private final Map<Entry<String, Long>, IObject> originalClassIdToDuplicates = new HashMap<Entry<String, Long>, IObject>();
+    private final Multimap<IObject, PropertyUpdate> propertiesToUpdate = ArrayListMultimap.create();
+    private final SetMultimap<IObject, IObject> blockedBy = HashMultimap.create();
 
     /**
      * Given class names provided by the user, find the corresponding set of actual classes.
@@ -179,7 +184,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
         }
 
         this.helper = helper;
-        helper.setSteps(dryRun ? 3 : 6);
+        helper.setSteps(dryRun ? 3 : 8);
         this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         classifier = new SpecificityClassifier<Class<? extends IObject>, Inclusion>(
@@ -218,23 +223,163 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     }
 
     /**
-     * Duplicate model object properties, linking them as appropriate with each other and with other model objects.
+     * Note how to update a specific model object property.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    private static abstract class PropertyUpdate {
+        protected final IObject duplicate;
+        protected final String property;
+
+        /**
+         * Create a note regarding how to update a specific model object property.
+         * @param duplicate the duplicate object holding the property
+         * @param property the name of the property
+         */
+        PropertyUpdate(IObject duplicate, String property) {
+            this.duplicate = duplicate;
+            this.property = property;
+        }
+
+        /**
+         * Update the model object property to which this instance corresponds.
+         * @param mapping the mapping from the original object's links to other objects to those objects' corresponding duplicates,
+         * returns {@code null} if no such duplicate exists so as to avoid stealing links from the original objects
+         * @throws GraphException if the property value could not be updated
+         */
+        abstract void execute(Function<Object, IObject> mapping) throws GraphException;
+    }
+
+    /**
+     * Note how to update a specific model object property that is directly accessible.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    private static class PropertyUpdateAccessible extends PropertyUpdate {
+        protected final Object value;
+
+        /**
+         * Create a note regarding how to update a specific model object property.
+         * @param duplicate the duplicate object holding the property
+         * @param property the name of the property
+         * @param value the property value from the original object
+         */
+        PropertyUpdateAccessible(IObject duplicate, String property, Object value) {
+            super(duplicate, property);
+            this.value = value;
+        }
+
+        @Override
+        void execute(Function<Object, IObject> mapping) throws GraphException {
+            final Object duplicateValue = GraphUtil.copyComplexValue(mapping, value);
+            if (duplicateValue != null) {
+            try {
+                PropertyUtils.setNestedProperty(duplicate, property, duplicateValue);
+            } catch (NestedNullException | ReflectiveOperationException e) {
+                throw new GraphException(
+                        "cannot set property " + property + " on duplicate " + duplicate.getClass().getName());
+            }
+            }
+        }
+    }
+
+    /**
+     * Note how to update a specific model object property that is accessible only via {@code iterate} and {@code add} methods.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.2.3
+     */
+    private static class PropertyUpdateInaccessible extends PropertyUpdate {
+        protected final IObject original;
+        protected final Method reader, writer;
+        protected final boolean isOrdered;
+
+        private Set<IObject> written = new HashSet<IObject>();
+
+        /**
+         * Create a note regarding how to update a specific model object property.
+         * @param original the original object holding the property
+         * @param duplicate the duplicate object holding the property
+         * @param property the name of the property
+         * @param reader the {@code iterate} method for the property
+         * @param writer the {@code add} method for the property
+         * @param isOrdered if the property value is a collection whose order must be preserved on duplication
+         */
+        PropertyUpdateInaccessible(IObject original, IObject duplicate, String property, Method reader, Method writer,
+                boolean isOrdered) {
+            super(duplicate, property);
+            this.original = original;
+            this.reader = reader;
+            this.writer = writer;
+            this.isOrdered = isOrdered;
+        }
+
+        @Override
+        void execute(Function<Object, IObject> mapping) throws GraphException {
+            try {
+                @SuppressWarnings("unchecked")
+                final Iterator<IObject> linkedTos = (Iterator<IObject>) reader.invoke(original);
+                boolean stillWriting = true;
+                while (linkedTos.hasNext()) {
+                    final IObject linkedTo = linkedTos.next();
+                    final IObject duplicateOfLinkedTo = mapping.apply(linkedTo);
+                    if (stillWriting && duplicateOfLinkedTo != null) {
+                        if (written.add(duplicateOfLinkedTo)) {
+                            writer.invoke(duplicate, duplicateOfLinkedTo);
+                        }
+                    } else if (isOrdered) {
+                        /* cannot easily update other than by appending so skip the rest for now */
+                        stillWriting = false;
+                    }
+                }
+            } catch (NestedNullException | ReflectiveOperationException e) {
+                throw new GraphException(
+                        "cannot set property " + property + " on duplicate " + duplicate.getClass().getName());
+            }
+        }
+    }
+
+    /**
+     * Copy simple property values to the duplicate model object.
      * @throws GraphException if duplication failed
      */
-    private void setDuplicatePropertyValues() throws GraphException {
-        /* organize duplicate index by class name and ID */
-        final Map<Entry<String, Long>, IObject> duplicatesByOriginalClassAndId = new HashMap<Entry<String, Long>, IObject>();
+    private void copySimpleProperties() throws GraphException {
         for (final Entry<IObject, IObject> originalAndDuplicate : originalsToDuplicates.entrySet()) {
             final IObject original = originalAndDuplicate.getKey();
-            final String originalClass = Hibernate.getClass(original).getName();
-            final Long originalId = original.getId();
             final IObject duplicate = originalAndDuplicate.getValue();
-            duplicatesByOriginalClassAndId.put(Maps.immutableEntry(originalClass, originalId), duplicate);
+            final String originalClass = Hibernate.getClass(original).getName();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("copying properties from " + originalClass + ":" + original.getId());
+            }
+            try {
+                /* process property values for a given object that is duplicated */
+                for (final String superclassName : graphPathBean.getSuperclassesOfReflexive(originalClass)) {
+                    /* process property values that do not relate to edges in the model object graph */
+                    for (final String property : graphPathBean.getSimpleProperties(superclassName)) {
+                        /* ignore inaccessible properties */
+                        if (!graphPathBean.isPropertyAccessible(superclassName, property)) {
+                            continue;
+                        }
+                        /* copy original property value to duplicate, creating new instances of collections */
+                        final Object value = PropertyUtils.getProperty(original, property);
+                        final Object duplicateValue = GraphUtil.copyComplexValue(Functions.constant(null), value);
+                        PropertyUtils.setProperty(duplicate, property, duplicateValue);
+                    }
+                }
+            } catch (NestedNullException | ReflectiveOperationException e) {
+                throw new GraphException("failed to duplicate " + originalClass + ':' + original.getId());
+            }
         }
+    }
+
+    /**
+     * Note in which order to persist the duplicate model objects and how to copy their properties.
+     * @throws GraphException if duplication failed
+     */
+    private void noteNewPropertyValuesForDuplicates() throws GraphException {
         /* allow lookup regardless of if original is actually a Hibernate proxy object */
-        final Function<Object, Object> duplicateLookup = new Function<Object, Object>() {
+        final Function<Object, IObject> duplicateLookup = new Function<Object, IObject>() {
             @Override
-            public Object apply(Object original) {
+            public IObject apply(Object original) {
                 if (original instanceof IObject) {
                     final String originalClass;
                     if (original instanceof HibernateProxy) {
@@ -243,20 +388,19 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                         originalClass = original.getClass().getName();
                     }
                     final Long originalId = ((IObject) original).getId();
-                    return duplicatesByOriginalClassAndId.get(Maps.immutableEntry(originalClass, originalId));
+                    return originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
                 } else {
                     return null;
                 }
             }
         };
-        /* copy property values into duplicates and link with other model objects */
-        final Session session = helper.getSession();
+        /* note how to copy property values into duplicates and link with other model objects */
         for (final Entry<IObject, IObject> originalAndDuplicate : originalsToDuplicates.entrySet()) {
             final IObject original = originalAndDuplicate.getKey();
             final IObject duplicate = originalAndDuplicate.getValue();
             final String originalClass = Hibernate.getClass(original).getName();
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("copying properties from " + originalClass + ":" + original.getId());
+                LOGGER.debug("noting how to copy properties from " + originalClass + ":" + original.getId());
             }
             try {
                 /* process property values for a given object that is duplicated */
@@ -281,9 +425,9 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                             }
                         }
                         /* check for another accessor for inaccessible properties */
+                        Object value;
                         if (graphPathBean.isPropertyAccessible(superclassName, property)) {
                             /* copy the linking from the original's property over to the duplicate's */
-                            Object value;
                             try {
                                 value = PropertyUtils.getNestedProperty(original, property);
                             } catch (NestedNullException e) {
@@ -312,13 +456,9 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                                     value = null;
                                 }
                             }
-                            /* copy the property value, replacing originals with corresponding duplicates */
-                            final Object duplicateValue = GraphUtil.copyComplexValue(duplicateLookup, value);
-                            try {
-                                PropertyUtils.setNestedProperty(duplicate, property, duplicateValue);
-                            } catch (NestedNullException e) {
-                                throw new GraphException(
-                                        "cannot set property " + superclassName + '.' + property + " on duplicate");
+                            /* note how to copy the property value, replacing originals with corresponding duplicates */
+                            if (value != null) {
+                                propertiesToUpdate.put(duplicate, new PropertyUpdateAccessible(duplicate, property, value));
                             }
                         } else {
                             /* this could be a one-to-many property with direct accessors protected */
@@ -332,18 +472,162 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                                 /* no luck, so ignore this property */
                                 continue;
                             }
-                            /* copy the linking from the original's property over to the duplicate's */
-                            final Iterator<IObject> linkedTos = (Iterator<IObject>) reader.invoke(original);
-                            while (linkedTos.hasNext()) {
-                                final IObject linkedTo = linkedTos.next();
-                                /* copy only links to other duplicates, as otherwise we may steal objects from the original */
-                                final IObject duplicateOfLinkedTo = (IObject) duplicateLookup.apply(linkedTo);
-                                if (duplicateOfLinkedTo != null) {
-                                    writer.invoke(duplicate, duplicateOfLinkedTo);
+                            boolean isOrdered;
+                            try {
+                                linkerClass.getMethod("getPrimary" + linkedClass.getSimpleName());
+                                isOrdered = true;
+                            } catch (NoSuchMethodException | SecurityException e) {
+                                isOrdered = false;
+                            }
+                            value = reader.invoke(original);
+                            /* note how to copy the linking from the original's property over to the duplicate's */
+                            propertiesToUpdate.put(duplicate,
+                                    new PropertyUpdateInaccessible(original, duplicate, property, reader, writer, isOrdered));
+                            if (isOrdered) {
+                                /* ensure that the values are written in order */
+                                IObject previousDuplicate = null;
+                                final Iterator<IObject> valueIterator = (Iterator<IObject>) reader.invoke(original);
+                                while (valueIterator.hasNext()) {
+                                    final IObject nextDuplicate = originalsToDuplicates.get(valueIterator.next());
+                                    if (nextDuplicate != null) {
+                                        if (previousDuplicate != null) {
+                                            blockedBy.put(nextDuplicate, previousDuplicate);
+                                        }
+                                        previousDuplicate = nextDuplicate;
+                                    }
                                 }
                             }
                         }
+                        /* persist the property values before persisting the holder */
+                        final Set<IObject> duplicatesInValue = GraphUtil.filterComplexValue(duplicateLookup, value);
+                        blockedBy.putAll(duplicate, duplicatesInValue);
                     }
+                }
+            } catch (NestedNullException | ReflectiveOperationException e) {
+                throw new GraphException("failed to duplicate " + originalClass + ':' + original.getId());
+            }
+        }
+    }
+
+    /**
+     * Duplicate model object properties, linking them as appropriate with each other and with other model objects.
+     * @throws GraphException if duplication failed
+     */
+    private void persistDuplicatesWithNewPropertyValues() throws GraphException {
+        /* copy property values into duplicates and link with other model objects */
+        final Session session = helper.getSession();
+        final ListMultimap<IObject, IObject> propertyUpdateTriggers = ArrayListMultimap.create();
+        final Set<IObject> persisted = new HashSet<IObject>();
+        final Set<IObject> remainingTransient = new HashSet<IObject>(originalsToDuplicates.values());
+        while (!remainingTransient.isEmpty()) {
+            boolean isProgress = false;
+            final Iterator<IObject> remainingTransientIterator = remainingTransient.iterator();
+            while (remainingTransientIterator.hasNext()) {
+                final IObject duplicate = remainingTransientIterator.next();
+                final Set<IObject> blockers = blockedBy.get(duplicate);
+                blockers.retainAll(remainingTransient);  /* changes to the view affect the underlying map */
+                if (blockers.isEmpty()) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("duplicating an instance of " + duplicate.getClass().getName());
+                    }
+                    /* before persisting an object, fill in its links to other objects */
+                    for (final PropertyUpdate update : propertiesToUpdate.get(duplicate)) {
+                        final Function<Object, IObject> duplicateProxyLookup = new Function<Object, IObject>() {
+                            @Override
+                            public IObject apply(Object original) {
+                                if (original instanceof IObject) {
+                                    final String originalClass;
+                                    if (original instanceof HibernateProxy) {
+                                        originalClass = Hibernate.getClass(original).getName();
+                                    } else {
+                                        originalClass = original.getClass().getName();
+                                    }
+                                    final Long originalId = ((IObject) original).getId();
+                                    final IObject duplicate =
+                                            originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
+                                    if (duplicate == null) {
+                                        return null;
+                                    }
+                                    if (persisted.contains(duplicate)) {
+                                        return duplicate;
+                                    } else {
+                                        /* this value is omitted from the object's property value when it is persisted so we note
+                                         * to update this property when the value is persisted */
+                                        propertyUpdateTriggers.put(duplicate, update.duplicate);
+                                    }
+                                }
+                                return null;
+                            }
+                        };
+                        update.execute(duplicateProxyLookup);
+                    }
+                    /* fill in other objects' links to the object to be persisted, such as back-references */
+                    persisted.add(duplicate);
+                    final Function<Object, IObject> duplicateProxyLookup = new Function<Object, IObject>() {
+                        @Override
+                        public IObject apply(Object original) {
+                            if (original instanceof IObject) {
+                                final String originalClass;
+                                if (original instanceof HibernateProxy) {
+                                    originalClass = Hibernate.getClass(original).getName();
+                                } else {
+                                    originalClass = original.getClass().getName();
+                                }
+                                final Long originalId = ((IObject) original).getId();
+                                final IObject duplicate =
+                                        originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
+                                if (duplicate == null) {
+                                    return null;
+                                }
+                                if (persisted.contains(duplicate)) {
+                                    return duplicate;
+                                }
+                            }
+                            return null;
+                        }
+                    };
+                    for (final IObject objectToUpdate : propertyUpdateTriggers.get(duplicate)) {
+                        for (final PropertyUpdate update : propertiesToUpdate.get(objectToUpdate)) {
+                            update.execute(duplicateProxyLookup);
+                        }
+                    }
+                    propertyUpdateTriggers.removeAll(duplicate);
+                    final Collection<PropertyUpdate> propertiesToUpdateForDuplicate =
+                            new ArrayList<PropertyUpdate>(propertiesToUpdate.get(duplicate));
+                    /* when an object is persisted its hash changes, so move key in persisted and in propertiesToUpdate */
+                    propertiesToUpdate.removeAll(duplicate);
+                    persisted.remove(duplicate);
+                    session.persist(duplicate);
+                    propertiesToUpdate.putAll(duplicate, propertiesToUpdateForDuplicate);
+                    persisted.add(duplicate);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("persisted " + duplicate.getClass().getName() + ":" + duplicate.getId());
+                    }
+                    remainingTransientIterator.remove();
+                    isProgress = true;
+                }
+            }
+            if (!isProgress) {
+                throw new GraphException("internal duplication error: cyclic model graph");
+            }
+        }
+    }
+
+    /**
+     * Link other model objects to the duplicates.
+     * @throws GraphException if duplication failed
+     */
+    private void linkToNewDuplicates() throws GraphException {
+        /* copy property values into duplicates and link with other model objects */
+        final Session session = helper.getSession();
+        for (final IObject original : originalsToDuplicates.keySet()) {
+            final String originalClass = Hibernate.getClass(original).getName();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("adjusting properties of " + originalClass + ":" + original.getId());
+            }
+            try {
+                /* process property values for a given object that is duplicated */
+                for (final String superclassName : graphPathBean.getSuperclassesOfReflexive(originalClass)) {
                     /* process property values that link to the duplicate from other model objects */
                     for (final Entry<String, String> backwardLink : graphPathBean.getLinkedBy(superclassName)) {
                         /* next backward link */
@@ -368,22 +652,22 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                                         session.createQuery(rootQuery).setParameterList("ids", idsBatch).list();
                                 for (final IObject linker : linkers) {
                                     if (originalsToDuplicates.containsKey(linker)) {
-                                        /* ignore linkers that are to be duplicated, those are handled as forward links */
+                                        /* ignore linkers that are to be duplicated, those have already been handled */
                                         continue;
                                     }
                                     /* copy the linking from the original's property over to the duplicate's */
-                                    Object value;
+                                    final Object value;
                                     try {
                                         value = PropertyUtils.getNestedProperty(linker, property);
                                     } catch (NestedNullException e) {
                                         continue;
                                     }
-                                    /* for linkers only adjust collection properties */
+                                    /* for linkers adjust only the collection properties */
                                     if (value instanceof Collection) {
                                         final Collection<IObject> valueCollection = (Collection<IObject>) value;
                                         final Collection<IObject> newDuplicates = new ArrayList<IObject>();
                                         for (final IObject originalLinker : valueCollection) {
-                                            final IObject duplicateOfValue = originalsToDuplicates.get(originalLinker);
+                                            IObject duplicateOfValue = originalsToDuplicates.get(originalLinker);
                                             if (duplicateOfValue != null) {
                                                 /* previous had just original, now include duplicate too */
                                                 newDuplicates.add(duplicateOfValue);
@@ -395,19 +679,9 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                             }
                         }
                     }
-                    /* process property values that do not relate to edges in the model object graph */
-                    for (final String property : graphPathBean.getSimpleProperties(superclassName)) {
-                        /* ignore inaccessible properties */
-                        if (!graphPathBean.isPropertyAccessible(superclassName, property)) {
-                            continue;
-                        }
-                        /* copy original property value to duplicate */
-                        final Object value = PropertyUtils.getProperty(original, property);
-                        PropertyUtils.setProperty(duplicate, property, GraphUtil.copyComplexValue(duplicateLookup, value));
-                    }
                 }
-            } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                throw new GraphException("failed to duplicate " + originalClass + ':' + original.getId());
+            } catch (NestedNullException | ReflectiveOperationException e) {
+                throw new GraphException("failed to adjust " + originalClass + ':' + original.getId());
             }
         }
     }
@@ -415,14 +689,13 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     @Override
     public Object step(int step) throws Cancel {
         helper.assertStep(step);
-        final Session session = helper.getSession();
         try {
             switch (step) {
             case 0:
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(session, targetMultimap, true, true);
+                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
                 if (plan.getValue().isEmpty()) {
                     graphTraversal.assertNoUnlinking();
                 } else {
@@ -440,17 +713,16 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                 processor.execute();
                 return null;
             case 4:
-                /* prevent premature flush triggered by duplication queries */
-                flushMode = session.getFlushMode();
-                session.setFlushMode(FlushMode.COMMIT);
-                setDuplicatePropertyValues();
+                copySimpleProperties();
                 return null;
             case 5:
-                for (final IObject duplicate : originalsToDuplicates.values()) {
-                    session.persist(duplicate);
-                }
-                session.flush();
-                session.setFlushMode(flushMode);
+                noteNewPropertyValuesForDuplicates();
+                return null;
+            case 6:
+                persistDuplicatesWithNewPropertyValues();
+                return null;
+            case 7:
+                linkToNewDuplicates();
                 return null;
             default:
                 final Exception e = new IllegalArgumentException("model object graph operation has no step " + step);
@@ -482,7 +754,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
             final DuplicateResponse response = new DuplicateResponse(duplicatedObjects);
             helper.setResponseIfNull(response);
             helper.info("in mock duplication of " + targetObjectCount + ", duplicated " + duplicatedObjectCount + " in total");
-        } else if (!dryRun && step == 5) {
+        } else if (!dryRun && step == 6) {
             final Map<String, List<Long>> duplicatedObjects = new HashMap<String, List<Long>>();
             for (final IObject duplicate : originalsToDuplicates.values()) {
                 final String className = duplicate.getClass().getName();
@@ -530,7 +802,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
 
     @Override
     public int getStepProvidingCompleteResponse() {
-        return dryRun ? 0 : 5;
+        return dryRun ? 0 : 6;
     }
 
     @Override
@@ -568,6 +840,9 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                     } catch (InstantiationException | IllegalAccessException e) {
                         throw new GraphException("cannot create a duplicate of " + original);
                     }
+                    final String originalClass = Hibernate.getClass(original).getName();
+                    final Long originalId = original.getId();
+                    originalClassIdToDuplicates.put(Maps.immutableEntry(originalClass, originalId), duplicate);
                     originalsToDuplicates.put(original, duplicate);
                 }
             }

--- a/components/blitz/src/omero/cmd/graphs/GraphUtil.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphUtil.java
@@ -357,12 +357,46 @@ public class GraphUtil {
     }
 
     /**
+     * Filter the given value to return only objects from the mapping. If a collection type, recurse into filtering the elements.
+     * @param mapping a mapping of non-collection elements to replace with others
+     * @param value the value to filter, may be {@code null}
+     * @return the mapped objects for the objects found in the given value, never {@code null}
+     */
+    static <X> Set<X> filterComplexValue(Function<Object, X> mapping, Object value) {
+        return value == null ? Collections.<X>emptySet() : filterComplexValue(new HashSet<X>(), mapping, value);
+    }
+
+    private static <X> Set<X> filterComplexValue(Set<X> sought, Function<Object, X> mapping, Object value) {
+        if (value instanceof Iterable) {
+            @SuppressWarnings("unchecked")
+            final Iterable<Object> iterable = (Iterable<Object>) value;
+            for (final Object element : iterable) {
+                filterComplexValue(sought, mapping, element);
+            }
+            return sought;
+        } else if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<Object, Object> map = (Map<Object, Object>) value;
+            for (final Map.Entry<Object, Object> element : map.entrySet()) {
+                filterComplexValue(sought, mapping, element.getKey());
+                filterComplexValue(sought, mapping, element.getValue());
+            }
+        } else if (value != null) {
+            final X mapped = mapping.apply(value);
+            if (mapped != null) {
+                sought.add(mapped);
+            }
+        }
+        return sought;
+    }
+
+    /**
      * Copy the given value. If a collection type, recurse into copying the elements.
      * @param mapping a mapping of non-collection elements to replace with others in the copy
      * @param value the value to copy, may be {@code null}
      * @return a copy of the value with newly instantiated lists, sets and maps
      */
-    static Object copyComplexValue(Function<Object, Object> mapping, Object value) {
+    static Object copyComplexValue(Function<Object, ? extends Object> mapping, Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof List) {


### PR DESCRIPTION
`DuplicateI` failed in duplicating `ome/data_repo/curated/mias/frans/siRNA_PRIM1_03102008/001-365700055641`. This PR adjusts for Hibernate so as to,

* not rely on deferring flushes
* never persist an object whose properties contain transient instances
* never try to reorder an existing collection
* fill in back-references before persisting objects.

Fixes http://trac.openmicroscopy.org/ome/ticket/13171. Will probably conflict with regions so I will do that rebasing myself. (I have kept most graphs changes to regions, but this is a bugfix.)

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/DuplicationTest/ should continue to pass. Also feel free to try submitting `DuplicateI` requests yourself, including for the above plate. Graph structure should be duplicated *except* for anything relating to files on disk, such as thumbnails and pixel data: see https://trello.com/c/8GbXbGqx/6-duplicate-original-files.