### PR TITLE
Get ROI count

### DIFF
--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -22,18 +22,16 @@ package omero.gateway.facility;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.collections.CollectionUtils;
 
+import omero.RLong;
 import omero.ServerError;
 import omero.api.IQueryPrx;
 import omero.api.IRoiPrx;
@@ -47,7 +45,6 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.ROIResult;
 import omero.gateway.util.ModelMapper;
 import omero.gateway.util.PyTablesUtils;
-import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageI;
 import omero.model.Line;
@@ -82,6 +79,45 @@ public class ROIFacility extends Facility {
     ROIFacility(Gateway gateway) throws ExecutionException {
         super(gateway);
         this.dm = gateway.getFacility(DataManagerFacility.class);
+    }
+    
+    /**
+     * Get the number of ROIs for an image
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param imageId
+     *            The image Id
+     * @return See above
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public int getROICount(SecurityContext ctx, long imageId)
+            throws DSOutOfServiceException, DSAccessException {
+        try {
+            ParametersI p = new ParametersI();
+            p.addId(imageId);
+            String query = "select count(*) from Roi roi "
+                    + "where roi.image.id = :id";
+            IQueryPrx service = gateway.getQueryService(ctx);
+            List<List<omero.RType>> tmp1 = service.projection(query, p);
+            if (CollectionUtils.isEmpty(tmp1)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            List<omero.RType> tmp2 = tmp1.iterator().next();
+            if (CollectionUtils.isEmpty(tmp2)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            omero.RType result = tmp2.iterator().next();
+            if (!(result instanceof RLong)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            return (int) (((RLong) result).getValue());
+        } catch (Exception e) {
+            handleException(this, e, "Can't load ROI count for image "
+                    + imageId);
+        }
+        return -1;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1413,8 +1413,7 @@ public class PropertiesUI
          * Starts an asyc. call to load the number of ROIs
          */
         void loadROICount(ImageData image) {
-            ExperimenterData exp = MetadataViewerAgent.getUserDetails();
-            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId(), exp.getId());
+            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId());
             l.load();
         }
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -387,6 +387,20 @@ public interface ImageDataView
 	 */
 	public CallHandle loadROIFromServer(SecurityContext ctx, long imageID,
 			long userID, AgentEventListener observer);
+	
+    /**
+     * Load the number of ROIs for a specific image
+     * 
+     * @param ctx
+     *            The security context.
+     * @param imageID
+     *            The image's id.
+     * @param observer
+     *            Call-back handler.
+     * @return See above
+     */
+    public CallHandle getROICount(SecurityContext ctx, long imageID,
+            AgentEventListener observer);
 	
 	/**
 	 * Renders the image with the overlays if the passed map is not 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -49,6 +49,7 @@ import org.openmicroscopy.shoola.env.data.views.calls.OverlaysRenderer;
 import org.openmicroscopy.shoola.env.data.views.calls.PixelsDataLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.PlaneInfoLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ProjectionSaver;
+import org.openmicroscopy.shoola.env.data.views.calls.ROICountLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ROILoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ResultsSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.SaveAsLoader;
@@ -371,7 +372,7 @@ class ImageDataViewImpl
 
 	/**
      * Implemented as specified by the view interface.
-     * @see ImageDataView#loadROIFromServer(long, Long, AgentEventListener)
+     * @see ImageDataView#loadROIFromServer(SecurityContext, long, long, AgentEventListener)
      */
 	public CallHandle loadROIFromServer(SecurityContext ctx, long imageID,
 			long userID, AgentEventListener observer)
@@ -379,6 +380,16 @@ class ImageDataViewImpl
 		BatchCallTree cmd = new ServerSideROILoader(ctx, imageID, userID);
 		return cmd.exec(observer);
 	}
+	
+	/**
+     * Implemented as specified by the view interface.
+     * @see ImageDataView#getROICount(SecurityContext, long, AgentEventListener)
+     */
+    public CallHandle getROICount(SecurityContext ctx, long imageID, AgentEventListener observer)
+    {
+        BatchCallTree cmd = new ROICountLoader(ctx, imageID);
+        return cmd.exec(observer);
+    }
 
 	/**
      * Implemented as specified by the view interface.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
@@ -1,0 +1,85 @@
+/*
+ * org.openmicroscopy.shoola.env.data.views.calls.ServerSideROILoader
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ * 	This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.data.views.calls;
+
+import omero.gateway.SecurityContext;
+import omero.gateway.facility.ROIFacility;
+
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
+/**
+ * Loads the number of ROIs for a specific image
+ *
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ROICountLoader extends BatchCallTree {
+
+    /** The result of the query. */
+    private Object results;
+
+    /** Call to load the ROIs. */
+    private BatchCall loadCall;
+
+    private BatchCall makeLoadCalls(final SecurityContext ctx,
+            final long imageID) {
+        return new BatchCall("Load ROI count from Server") {
+            public void doCall() throws Exception {
+                results = context.getGateway().getFacility(ROIFacility.class)
+                        .getROICount(ctx, imageID);
+            }
+        };
+    }
+
+    /**
+     * Adds the {@link #loadCall} to the computation tree.
+     * 
+     * @see BatchCallTree#buildTree()
+     */
+    protected void buildTree() {
+        add(loadCall);
+    }
+
+    /**
+     * Returns the root node of the requested tree.
+     * 
+     * @see BatchCallTree#getResult()
+     */
+    protected Object getResult() {
+        return results;
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param ctx
+     *            The security context.
+     * @param imageID
+     *            The image's ID.
+     */
+    public ROICountLoader(SecurityContext ctx, long imageID) {
+        loadCall = makeLoadCalls(ctx, imageID);
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -86,6 +86,13 @@ public class ROIFacilityTest extends GatewayTest {
         return roiData;
     }
 
+    @Test(dependsOnMethods = { "testSaveROIs" })
+    public void testGetROICount() throws DSOutOfServiceException,
+            DSAccessException {
+        int n = roifac.getROICount(rootCtx, img.getId());
+        Assert.assertEquals(2, n);
+    }
+    
     @Test(dependsOnMethods = { "testSaveROIs" })
     public void testLoadROIs() throws DSOutOfServiceException,
             DSAccessException {


### PR DESCRIPTION
At the moment Insight loads all ROIs and counts them on the client side for showing the number of ROIs in the right hand side meta data panel. This PR adds a method for directly getting the number of ROIs via an HQL query.

**Test**: Check some images with ROIs, make sure the ROI count (right hand side metadata panel) is correct.