### PR TITLE
Roifolders improvements

### DIFF
--- a/components/blitz/src/omero/gateway/model/FolderData.java
+++ b/components/blitz/src/omero/gateway/model/FolderData.java
@@ -160,6 +160,33 @@ public class FolderData extends DataObject {
     }
     
     /**
+     * Get the number of sub folders
+     * 
+     * @return See above.
+     */
+    public int subfolderCount() {
+        return asFolder().sizeOfChildFolders();
+    }
+
+    /**
+     * Get the number of images linked to this folder
+     * 
+     * @return See above.
+     */
+    public int imageCount() {
+        return asFolder().sizeOfImageLinks();
+    }
+
+    /**
+     * Get the number of ROIs linked to this folder
+     * 
+     * @return See above.
+     */
+    public int roiCount() {
+        return asFolder().sizeOfRoiLinks();
+    }
+    
+    /**
      * Copy the list of child folders, see {@link Folder#copyChildFolders()}
      * 
      * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/ROINode.java
@@ -123,6 +123,21 @@ public class ROINode
 		initMaps();
 	}
 	
+    /**
+     * Provides an ID based on the user object's type and it's id.
+     * 
+     * @return See above
+     */
+    public String getUUID() {
+        if (getUserObject() instanceof ROI)
+            return "ROI_" + ((ROI) getUserObject()).getID();
+        if (getUserObject() instanceof ROIShape)
+            return "ROIShape_" + ((ROIShape) getUserObject()).getID();
+        if (getUserObject() instanceof FolderData)
+            return "FolderData_" + ((FolderData) getUserObject()).getId();
+        return "" + hashCode();
+    }
+	
 	/**
 	 * Construct ROINode with ROIShape type.
 	 * @param nodeName see above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -697,7 +697,7 @@ class ObjectManager extends JPanel implements TabPaneInterface {
     }
 
     /** Rebuilds Tree */
-    void rebuildTable() {    
+    void rebuildTable() {
         if (objectsTable.getIDFilter().isEmpty()
                 && (selectAll == null || !selectAll.isChecked())) {
             // setup initial folder selection (only show folders

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -184,6 +184,12 @@ class ObjectManager extends JPanel implements TabPaneInterface {
      */
     private TreeSelectionListener treeSelectionListener;
 
+    /**
+     * Flag to indicate that the filter menu selection has to be set to default
+     * state
+     */
+    private boolean initFilterMenuSelection = true;
+    
     /** Initializes the components composing the display. */
     private void initComponents() {
         ROINode root = new ROINode("root");
@@ -698,13 +704,13 @@ class ObjectManager extends JPanel implements TabPaneInterface {
 
     /** Rebuilds Tree */
     void rebuildTable() {
-        if (objectsTable.getIDFilter().isEmpty()
-                && (selectAll == null || !selectAll.isChecked())) {
+        if (initFilterMenuSelection) {
             // setup initial folder selection (only show folders
             // which contain ROIs for the current image)
             for (FolderData f : model.getUsedFolders()) {
                 objectsTable.getIDFilter().add(f.getId());
             }
+            initFilterMenuSelection = false;
         }
         
         Set<Long> expandedFolderIds = objectsTable.getExpandedFolders();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectManager.java
@@ -697,7 +697,7 @@ class ObjectManager extends JPanel implements TabPaneInterface {
     }
 
     /** Rebuilds Tree */
-    void rebuildTable() {
+    void rebuildTable() {    
         if (objectsTable.getIDFilter().isEmpty()
                 && (selectAll == null || !selectAll.isChecked())) {
             // setup initial folder selection (only show folders
@@ -707,28 +707,28 @@ class ObjectManager extends JPanel implements TabPaneInterface {
             }
         }
         
-        TreeMap<Long, ROI> roiList = model.getROI();
-        Iterator<ROI> iterator = roiList.values().iterator();
-        ROI roi;
-        TreeMap<Coord3D, ROIShape> shapeList;
-        Iterator<ROIShape> shapeIterator;
         Set<Long> expandedFolderIds = objectsTable.getExpandedFolders();
         expandedFolderIds.addAll(Pojos.extractIds(objectsTable
                 .getRecentlyModifiedFolders()));
         objectsTable.clear();
         objectsTable.initFolders(getFolders());
-        while (iterator.hasNext()) {
-            roi = iterator.next();
-            shapeList = roi.getShapes();
-            shapeIterator = shapeList.values().iterator();
-            while (shapeIterator.hasNext())
-                objectsTable.addROIShape(shapeIterator.next());
-        }
+        objectsTable.addROIShapeList(extractShapes(model.getROI().values()));
         objectsTable.collapseAll();
         objectsTable.expandFolders(expandedFolderIds);
         objectsTable.setAutoCreateColumnsFromModel(false);
     }
 
+    List<ROIShape> extractShapes(Collection<ROI> rois) {
+        List<ROIShape> result = new ArrayList<ROIShape>();
+        Iterator<ROI> iterator = rois.iterator();
+        while (iterator.hasNext()) {
+            ROI roi = iterator.next();
+            TreeMap<Coord3D, ROIShape> shapeList = roi.getShapes();
+            result.addAll(shapeList.values());
+        }
+        return result;
+    }
+    
     /**
      * Returns the name of the component.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -813,12 +813,15 @@ public class ROITable
     
     private ROINode findFolderNode(FolderData folder) {
         Collection<ROINode> tmp = nodesMap.get(getUUID(folder));
-        if (tmp.size() == 1)
-            return tmp.iterator().next();
-        if (CollectionUtils.isEmpty(tmp))
+        switch (tmp.size()) {
+        case 0:
             return null;
-        throw new RuntimeException("Multiple ROINodes found for "
-                + getUUID(folder));
+        case 1:
+            return tmp.iterator().next();
+        default:
+            throw new RuntimeException("Multiple ROINodes found for "
+                    + getUUID(folder));
+        }
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -710,9 +710,11 @@ public class ROITable
 	    Collection<ROINode> nodes = findNodes(shape.getROI());
         for(ROINode node : nodes) {
     		ROINode child = node.findChild(shape);
-    		node.remove(child);
-    		if (node.getChildCount() == 0)
+    		if (child != null) {
+        		node.remove(child);
+        		if (node.getChildCount() == 0)
     			node.getParent().remove(node);
+    		}
         }
 		this.setTreeTableModel(new ROITableModel(root, columnNames));
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -57,12 +57,12 @@ import javax.swing.plaf.basic.BasicTableUI;
 import javax.swing.table.TableColumn;
 import javax.swing.tree.TreePath;
 
-
-
-
 //Third-party libraries
 import org.jdesktop.swingx.JXTreeTable;
 import org.jhotdraw.draw.Figure;
+import org.apache.commons.collections.CollectionUtils;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.util.roimenu.ROIPopupMenu;
@@ -117,8 +117,8 @@ public class ROITable
 	/** Column names of the table. */
 	private Vector<String>	columnNames;
     
-	/** References to all ROINodes */
-    private Collection<ROINode> nodes;
+    /** References to all ROINodes */
+    private ListMultimap<String, ROINode> nodesMap;
     
 	/** The tree model. */
 	private ROITableModel	model;
@@ -245,7 +245,7 @@ public class ROITable
 		ToolTipManager.sharedInstance().registerComponent(this);
 		this.setAutoResizeMode(JXTreeTable.AUTO_RESIZE_ALL_COLUMNS);
 		this.setRowHeight(25);
-		this.nodes = new ArrayList<ROINode>();
+		this.nodesMap = ArrayListMultimap.create();
 		for (int i = 0 ; i < model.getColumnCount() ; i++)
 			getColumn(i).setResizable(true);
 		
@@ -396,7 +396,7 @@ public class ROITable
      */
     Set<Long> getExpandedFolders() {
         Set<Long> result = new HashSet<Long>();
-        for (ROINode node : nodes) {
+        for (ROINode node : nodesMap.values()) {
             if (node.isExpanded() && node.isFolderNode())
                 result.add(((FolderData) node.getUserObject()).getId());
         }
@@ -410,7 +410,7 @@ public class ROITable
      *            The folder IDs
      */
     void expandFolders(Collection<Long> ids) {
-        for (ROINode node : nodes) {
+        for (ROINode node : nodesMap.values()) {
             if (node.isFolderNode()
                     && ids.contains(((FolderData) node.getUserObject()).getId()))
                 expandPath(node.getPath());
@@ -424,7 +424,7 @@ public class ROITable
 		for (int i = 0 ; i < childCount ; i++ )
 			root.remove(0);
 		this.setTreeTableModel(new ROITableModel(root, columnNames));
-		this.nodes.clear();
+		this.nodesMap.clear();
 		this.recentlyModifiedFolders.clear();
 		this.invalidate();
 		this.repaint();
@@ -526,15 +526,7 @@ public class ROITable
         root.getAllDecendants(tmp);
         for (ROINode n : tmp) {
             if (n.isExpanded()) {
-                Object uo = n.getUserObject();
-                if (uo != null) {
-                    if (uo instanceof ROI)
-                        expandedNodeIds.add("ROI_"+((ROI) uo).getID());
-                    else if (uo instanceof ROIShape)
-                        expandedNodeIds.add("Shape_"+((ROIShape) uo).getID());
-                    else if (uo instanceof FolderData)
-                        expandedNodeIds.add("Folder_"+((FolderData) uo).getId());
-                }
+                expandedNodeIds.add(n.getUUID());
             }
         }
         
@@ -553,7 +545,7 @@ public class ROITable
 	            {
 	                parent = new ROINode(shape.getROI());
 	                parent.setExpanded(true);
-	                this.nodes.add(parent);
+	                this.nodesMap.put(parent.getUUID(), parent);
 	                childCount = root.getChildCount();
 	                root.insert(parent, childCount);
 	            }
@@ -565,7 +557,7 @@ public class ROITable
 	            roiShapeNode = parent.findChild(shape.getCoord3D());
 	            newNode = new ROINode(shape);
 	            newNode.setExpanded(true);
-	            this.nodes.add(newNode);
+	            this.nodesMap.put(newNode.getUUID(), newNode);
 	            if (roiShapeNode != null)
 	            {
 	                index = parent.getIndex(roiShapeNode);
@@ -588,7 +580,7 @@ public class ROITable
                         parent = new ROINode(shape.getROI());
                         parent.setExpanded(true);
                         nodes.add(parent);
-                        this.nodes.add(parent);
+                        this.nodesMap.put(parent.getUUID(), parent);
                         childCount = folder.getChildCount();
                         folder.insert(parent, childCount);
 		            }
@@ -600,7 +592,7 @@ public class ROITable
 		            roiShapeNode = parent.findChild(shape.getCoord3D());
 		            newNode = new ROINode(shape);
 		            newNode.setExpanded(true);
-		            this.nodes.add(newNode);
+		            this.nodesMap.put(newNode.getUUID(), newNode);
 		            if (roiShapeNode != null)
 		            {
 		                index = parent.getIndex(roiShapeNode);
@@ -620,21 +612,9 @@ public class ROITable
         tmp.clear();
         root.getAllDecendants(tmp);
         for (ROINode n : tmp) {
-            Object uo = n.getUserObject();
-            if (uo != null) {
-                String id = "";
-                if (uo instanceof ROI)
-                    id = "ROI_"+((ROI) uo).getID();
-                else if (uo instanceof ROIShape)
-                    id = "Shape_"+((ROIShape) uo).getID();
-                else if (uo instanceof FolderData)
-                    id = "Folder_"+((FolderData) uo).getId();
-
-                if (expandedNodeIds.contains(id))
-                    expandNode(n);
-            }
+            if (expandedNodeIds.contains(n.getUUID()))
+                expandNode(n);
         }
-		
 	}
 
 	/** 
@@ -757,15 +737,7 @@ public class ROITable
 	 * @return See above
 	 */
 	Collection<ROINode> findNodes(ROI roi) {
-	    Collection<ROINode> result = new ArrayList<ROINode>();
-	    for(ROINode node: nodes) {
-	        if(node.isROINode()) {
-	            ROI nodeRoi = (ROI) node.getUserObject();
-	            if(nodeRoi.getID() == roi.getID())
-	                result.add(node);
-	        }
-	    }
-	    return result;
+	    return nodesMap.get(getUUID(roi));
 	}
 	
     /**
@@ -798,10 +770,10 @@ public class ROITable
         
         for (FolderData f : roi.getFolders()) {
             if (displayFolder(f)) {
-                ROINode node = findFolderNode(nodes, f);
+                ROINode node = findFolderNode(f);
                 if (node == null) {
                     node = new ROINode(f);
-                    nodes.add(node);
+                    nodesMap.put(node.getUUID(), node);
                     handleParentFolderNodes(node);
                 }
                 insertInto.add(node);
@@ -809,16 +781,6 @@ public class ROITable
         }
         
         return insertInto;
-    }
-    
-    private ROINode getFolderNode(FolderData f) {
-        for (ROINode node : nodes) {
-            if (node.isFolderNode()) {
-                if (((FolderData) node.getUserObject()).getId() == f.getId())
-                    return node;
-            }
-        }
-        return null;
     }
     
     /**
@@ -837,10 +799,10 @@ public class ROITable
             return;
         }
 
-        ROINode parent = findFolderNode(nodes, parentFolder);
+        ROINode parent = findFolderNode(parentFolder);
         if (parent == null) {
             parent = new ROINode(parentFolder);
-            nodes.add(parent);
+            nodesMap.put(parent.getUUID(), parent);
             parent.insert(node, 0);
             handleParentFolderNodes(parent);
         } else if (parent.findChild((FolderData) node.getUserObject()) == null) {
@@ -849,25 +811,36 @@ public class ROITable
         }
     }
     
-    /** 
-     * Find the {@link ROINode} for a certain {@link FolderData} within a
-     * collection of {@link ROINode}s
+    private ROINode findFolderNode(FolderData folder) {
+        Collection<ROINode> tmp = nodesMap.get(getUUID(folder));
+        if (tmp.size() == 1)
+            return tmp.iterator().next();
+        if (CollectionUtils.isEmpty(tmp))
+            return null;
+        throw new RuntimeException("Multiple ROINodes found for "
+                + getUUID(folder));
+    }
+
+    /**
+     * See {@link ROINode#getUUID()}
      * 
-     * @param nodes
-     *            The collection to search through
-     * @param folder
-     *            The folder to look for
-     * @return The ROINode representing the folder or <code>null</code> if it
-     *         can't be found
+     * @param roi
+     *            The ROI
+     * @return See above
      */
-    private ROINode findFolderNode(Collection<ROINode> nodes, FolderData folder) {
-        for (ROINode n : nodes) {
-            Object obj = n.getUserObject();
-            if (obj instanceof FolderData
-                    && ((FolderData) obj).getId() == folder.getId())
-                return n;
-        }
-        return null;
+    private String getUUID(ROI roi) {
+        return "ROI_" + roi.getID();
+    }
+
+    /**
+     * See {@link ROINode#getUUID()}
+     * 
+     * @param folder
+     *            The Folder
+     * @return See above
+     */
+    private String getUUID(FolderData folder) {
+        return "FolderData_" + folder.getId();
     }
     
     /**
@@ -879,10 +852,10 @@ public class ROITable
     public void initFolders(Collection<FolderData> folders) {
         for (FolderData f : folders) {
             if (displayFolder(f)) {
-                ROINode node = findFolderNode(nodes, f);
+                ROINode node = findFolderNode(f);
                 if (node == null) {
                     node = new ROINode(f);
-                    nodes.add(node);
+                    nodesMap.put(node.getUUID(), node);
                     handleParentFolderNodes(node);
                 }
             }
@@ -1387,7 +1360,7 @@ public class ROITable
             excludeIds.add(f.getId());
             if (f.getParentFolder() != null)
                 excludeIds.add(f.getParentFolder().getId());
-            ROINode fnode = getFolderNode(f);
+            ROINode fnode = findFolderNode(f);
             Collection<ROINode> subNodes = new ArrayList<ROINode>();
             fnode.getAllDecendants(subNodes);
             for (ROINode subNode : subNodes)

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import junit.framework.Assert;
 import omero.api.IPixelsPrx;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
@@ -42,6 +41,7 @@ import omero.model.IObject;
 import omero.model.PixelsType;
 import omero.model.Roi;
 
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -87,10 +87,22 @@ public class ROIFacilityTest extends GatewayTest {
 
         Assert.assertEquals(rois.size(), 2);
         for (ROIData roi : rois) {
-            Assert.assertTrue("ROI doesn't have an ID!", roi.getId() >= 0);
+            Assert.assertTrue(roi.getId() >= 0);
         }
     }
 
+    @Test
+    public void testSaveImagelessROIs() throws DSOutOfServiceException,
+            DSAccessException {
+        ROIData r = createRectangleROI(11, 11, 10, 10);
+        Collection<ROIData> result = roifac.saveROIs(rootCtx, -1, Collections.singleton(r));
+
+        Assert.assertEquals(result.size(), 1);
+        r = result.iterator().next();
+        Assert.assertTrue(r.getId() >= 0);
+        Assert.assertNull(r.getImage() );
+    }
+    
     private ROIData createRectangleROI(int x, int y, int w, int h) {
         ROIData roiData = new ROIData();
         RectangleData rectangle = new RectangleData(x, y, w, h);
@@ -118,8 +130,7 @@ public class ROIFacilityTest extends GatewayTest {
             }
         }
 
-        Assert.assertTrue("Loaded ROIs don't match saved ROIs!",
-                myRois.isEmpty());
+        Assert.assertTrue(myRois.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
This PR...
- enables the saving of imageless ROIs; **Test**: Just check integration test (`testSaveImagelessROIs`); it doesn't have a real significance in the client, yet.
- adds some performance tweaks to the ROITable/ObjectManager; **Test**: Check that the ROI/Folder table performs well with images with many ROIs. For example each ROI/Folder action (e. g. add ROI to folder, via menu or DnD, doesn't matter) as well as putting folders on display via the filter menu, refreshes the table. The refresh lag should not be too long, so that you're still able to interact with the table in a reasonable way.
- fixes the bug that it was not possible to deselect all folders for display (filter popup menu). **Test**: Select some folders for display, successively deselect them again (*not* via the 'Select All' menu item). It should be possible to also deselect the last one, with the result that no folders are on display at all.

IMHO even the interactions with the 1000 ROIs fake image work pretty well. Is that already close to a "real world" example? Looking forward to test the ROI tool with an IDR example...
