### PR TITLE
Get ROI count

### DIFF
--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -96,7 +96,8 @@ public class ROIFacility extends Facility {
     }
     
     /**
-     * Get the number of ROIs for an image
+     * Get the number of ROIs for an image (<code>-1</code>
+     * in case of error)
      * 
      * @param ctx
      *            The {@link SecurityContext}

--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.NotImplementedException;
 
+import omero.RLong;
 import omero.ServerError;
 import omero.api.IQueryPrx;
 import omero.api.IRoiPrx;
@@ -92,6 +93,45 @@ public class ROIFacility extends Facility {
         super(gateway);
         this.dm = gateway.getFacility(DataManagerFacility.class);
         this.browse = gateway.getFacility(BrowseFacility.class);
+    }
+    
+    /**
+     * Get the number of ROIs for an image
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param imageId
+     *            The image Id
+     * @return See above
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public int getROICount(SecurityContext ctx, long imageId)
+            throws DSOutOfServiceException, DSAccessException {
+        try {
+            ParametersI p = new ParametersI();
+            p.addId(imageId);
+            String query = "select count(*) from Roi roi "
+                    + "where roi.image.id = :id";
+            IQueryPrx service = gateway.getQueryService(ctx);
+            List<List<omero.RType>> tmp1 = service.projection(query, p);
+            if (CollectionUtils.isEmpty(tmp1)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            List<omero.RType> tmp2 = tmp1.iterator().next();
+            if (CollectionUtils.isEmpty(tmp2)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            omero.RType result = tmp2.iterator().next();
+            if (!(result instanceof RLong)) {
+                throw new Exception("Unexpected HQL result");
+            }
+            return (int) (((RLong) result).getValue());
+        } catch (Exception e) {
+            handleException(this, e, "Can't load ROI count for image "
+                    + imageId);
+        }
+        return -1;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/measurement/ROIEvent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/measurement/ROIEvent.java
@@ -1,0 +1,67 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
+package org.openmicroscopy.shoola.agents.events.measurement;
+
+import org.openmicroscopy.shoola.env.event.AgentEvent;
+
+/**
+ * Event indicating that ROIs have changed (saved, removed, etc.)
+ * 
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ *
+ */
+public class ROIEvent extends AgentEvent {
+
+    /** The image id */
+    private long imageId = -1;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param imageId
+     *            The image id
+     */
+    public ROIEvent(long imageId) {
+        this.imageId = imageId;
+    }
+
+    /**
+     * Get the image id
+     * 
+     * @return See above
+     */
+    public long getImageId() {
+        return imageId;
+    }
+
+    /**
+     * Set the imageId
+     * 
+     * @param imageId
+     *            The image id
+     */
+    public void setImageId(long imageId) {
+        this.imageId = imageId;
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/ImViewerAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -44,6 +44,7 @@ import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewerState;
 import org.openmicroscopy.shoola.agents.events.measurement.MeasurementToolLoaded;
+import org.openmicroscopy.shoola.agents.events.measurement.ROIEvent;
 import org.openmicroscopy.shoola.agents.events.measurement.SelectChannel;
 import org.openmicroscopy.shoola.agents.events.measurement.SelectPlane;
 import org.openmicroscopy.shoola.agents.events.metadata.ChannelSavedEvent;
@@ -619,6 +620,7 @@ public class ImViewerAgent
         bus.register(this, DisplayModeEvent.class);
         bus.register(this, RndSettingsCopied.class);
         bus.register(this, RndSettingsChanged.class);
+        bus.register(this, ROIEvent.class);
     }
 
     /**
@@ -689,8 +691,16 @@ public class ImViewerAgent
             handleDisplayModeEvent((DisplayModeEvent) e);
         else if (e instanceof RndSettingsCopied)
             handleRndSettingsCopied((RndSettingsCopied) e);
-        else if (e instanceof RndSettingsChanged) {
+        else if (e instanceof RndSettingsChanged) 
             handleRndSettingsChangedEvent((RndSettingsChanged) e);
+        else if (e instanceof ROIEvent) 
+            handleROIEvent((ROIEvent) e);
+    }
+
+    private void handleROIEvent(ROIEvent e) {
+        ImViewer viewer = ImViewerFactory.getImageViewerFromImage(null, e.getImageId());
+        if (viewer != null) {
+            viewer.reloadROICount();
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1330,5 +1330,10 @@ public interface ImViewer
      * @return See above
      */
     ImageAcquisitionData getImageAcquisitionData();
+
+    /**
+     * Reload the ROI count
+     */
+    void reloadROICount();
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -3450,5 +3450,15 @@ class ImViewerComponent
     void onSettingsChanged()
     {
         view.resetDefaults();
+    }
+
+    /**
+     * Implemented as specified by the {@link ImViewer} interface.
+     * 
+     * @see ImViewer#reloadROICount()
+     */
+    @Override
+    public void reloadROICount() {
+        model.reloadROICount();
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -3095,4 +3095,11 @@ class ImViewerModel
     {
         selectedRndDefID = defID;
     }
+
+    /**
+     * Reload the ROI count
+     */
+    public void reloadROICount() {
+        metadataViewer.reloadROICount();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -43,6 +43,7 @@ import org.jhotdraw.draw.AttributeKey;
 import org.jhotdraw.draw.Drawing;
 import org.jhotdraw.draw.Figure;
 import org.openmicroscopy.shoola.agents.events.measurement.MeasurementToolLoaded;
+import org.openmicroscopy.shoola.agents.events.measurement.ROIEvent;
 import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.agents.measurement.util.FileMap;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
@@ -970,6 +971,8 @@ class MeasurementViewerComponent
 										"for "+model.getImageID());
 		}
 		model.fireLoadROIServerOrClient(false);
+		
+		reg.getEventBus().post(new ROIEvent(model.getImageID()));
 	}
 
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerComponent.java
@@ -949,6 +949,7 @@ class MeasurementViewerComponent
                                         "for "+model.getImageID());
         }
         model.fireLoadROIServerOrClient(false);
+        reg.getEventBus().post(new ROIEvent(model.getImageID()));
     }
     
 	/** 
@@ -971,7 +972,6 @@ class MeasurementViewerComponent
 										"for "+model.getImageID());
 		}
 		model.fireLoadROIServerOrClient(false);
-		
 		reg.getEventBus().post(new ROIEvent(model.getImageID()));
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerFactory.java
@@ -27,16 +27,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import org.openmicroscopy.shoola.agents.events.iviewer.MeasurementTool;
+import org.openmicroscopy.shoola.agents.events.measurement.ROIEvent;
 import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.agents.measurement.actions.ActivationAction;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.ui.TaskBar;
+
 import omero.gateway.model.ChannelData;
 import omero.gateway.model.PixelsData;
 
@@ -268,6 +273,7 @@ public class MeasurementViewerFactory
 			if (comp.hasROIToSave())
 				comp.saveROIToServer(false);
 		}
+		MeasurementAgent.getRegistry().getEventBus().post(new ROIEvent(imageID));
 	}
 
 	/** All the tracked components. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -28,8 +28,8 @@ import java.util.List;
 import ome.model.units.BigResult;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsCopied;
+import org.openmicroscopy.shoola.agents.events.measurement.ROIEvent;
 import org.openmicroscopy.shoola.agents.events.metadata.ChannelSavedEvent;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DisplayModeEvent;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
@@ -44,11 +44,14 @@ import org.openmicroscopy.shoola.env.data.AdminService;
 import org.openmicroscopy.shoola.env.data.events.ReconnectedEvent;
 import org.openmicroscopy.shoola.env.data.events.UserGroupSwitched;
 import org.openmicroscopy.shoola.env.data.util.AgentSaveInfo;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.AgentEvent;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.rnd.RenderingControl;
+
 import omero.gateway.model.ChannelData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
@@ -383,6 +386,7 @@ public class MetadataViewerAgent
         bus.register(this, RndSettingsCopied.class);
         bus.register(this, CopyRndSettings.class);
         bus.register(this, RndSettingsPasted.class);
+        bus.register(this, ROIEvent.class);
     }
 
     /**
@@ -431,6 +435,17 @@ public class MetadataViewerAgent
                    	 handleCopyRndSettings((CopyRndSettings) e);
 		else if (e instanceof RndSettingsPasted) 
                     	handleRndSettingsPasted((RndSettingsPasted) e);
+        else if (e instanceof ROIEvent)
+            handleROIEvent((ROIEvent) e);
 	}
+
+    private void handleROIEvent(ROIEvent e) {
+        MetadataViewer viewer = MetadataViewerFactory.getViewerFromId(
+                ImageData.class.getName(), e.getImageId());
+        if (viewer != null) {
+            viewer.reloadROICount();
+        }
+        
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -563,5 +563,10 @@ public interface Editor
      * @return See above
      */
     public Collection<FileAnnotationData> getSelectedFileAnnotations();
+
+    /**
+     * Reload the ROI count
+     */
+    public void reloadROICount();
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1242,5 +1242,14 @@ class EditorComponent
      */
     public Collection<FileAnnotationData> getSelectedFileAnnotations() {
         return view.getSelectedFileAnnotations();
+    }
+    
+    /** 
+     * Implemented as specified by the {@link Editor} interface.
+     * @see Editor#reloadROICount()
+     */
+    @Override
+    public void reloadROICount() {
+        view.reloadROICount();
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -58,9 +58,7 @@ import org.openmicroscopy.shoola.agents.metadata.util.FigureDialog;
 import org.openmicroscopy.shoola.agents.util.ui.DowngradeChooser;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptingDialog;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
-import org.openmicroscopy.shoola.agents.util.DataComponent;
 import org.openmicroscopy.shoola.agents.util.SelectionWizard;
-import org.openmicroscopy.shoola.agents.util.editorpreview.PreviewPanel;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptMenuItem;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
@@ -871,4 +869,10 @@ class EditorControl
 	 */
 	public void mousePressed(MouseEvent e) {}
 
+	/**
+	 * Reload the ROI count
+	 */
+	public void reloadROICount() {
+	    
+	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1049,5 +1049,14 @@ class EditorUI
      */
 	public Collection<FileAnnotationData> getSelectedFileAnnotations() { 
 	    return generalPane.getSelectedFileAnnotations();
+	}
+	
+	/**
+	 * Reload the ROI count
+	 */
+	public void reloadROICount() {
+	    if(model.getRefObject() instanceof ImageData) {
+	        generalPane.getPropertiesUI().loadROICount((ImageData) model.getRefObject());
+	    }
 	}
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -55,7 +55,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
@@ -63,7 +62,6 @@ import javax.swing.event.DocumentListener;
 
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.jdesktop.swingx.JXTaskPane;
-
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.events.treeviewer.DataObjectSelectionEvent;
@@ -86,7 +84,6 @@ import omero.gateway.model.AnnotationData;
 import omero.gateway.model.ChannelData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
-import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FileData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1413,8 +1413,7 @@ public class PropertiesUI
          * Starts an asyc. call to load the number of ROIs
          */
         void loadROICount(ImageData image) {
-            ExperimenterData exp = MetadataViewerAgent.getUserDetails();
-            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId(), exp.getId());
+            ROICountLoader l = new ROICountLoader(new SecurityContext(image.getGroupId()), this, image.getId());
             l.load();
         }
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -714,4 +714,9 @@ public interface MetadataViewer
 	 * @return See above.
 	 */
 	RndProxyDef getAlternativeRenderingSettings();
+
+	/**
+	 * Reload the ROI count
+	 */
+    void reloadROICount();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1352,4 +1352,13 @@ class MetadataViewerComponent
 	public RndProxyDef getAlternativeRenderingSettings() {
 	    return model.getAlternativeRenderingSettings();
 	}
+
+	/**
+     * Implemented as specified by the {@link MetadataViewer} interface.
+     * @see MetadataViewer#reloadROICount()
+     */
+    @Override
+    public void reloadROICount() {
+        model.getEditor().reloadROICount();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataView.java
@@ -415,6 +415,20 @@ public interface ImageDataView
 	public CallHandle loadROIFromServer(SecurityContext ctx, long imageID,
 			long userID, AgentEventListener observer);
 	
+    /**
+     * Load the number of ROIs for a specific image
+     * 
+     * @param ctx
+     *            The security context.
+     * @param imageID
+     *            The image's id.
+     * @param observer
+     *            Call-back handler.
+     * @return See above
+     */
+    public CallHandle getROICount(SecurityContext ctx, long imageID,
+            AgentEventListener observer);
+	
 	/**
 	 * Renders the image with the overlays if the passed map is not 
 	 * <code>null</code>, renders the image without the overlays if 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/ImageDataViewImpl.java
@@ -51,6 +51,7 @@ import org.openmicroscopy.shoola.env.data.views.calls.PlaneInfoLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ProjectionSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.ROIFolderSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.ROIFolderSaver.ROIFolderAction;
+import org.openmicroscopy.shoola.env.data.views.calls.ROICountLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ROILoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ResultsSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.SaveAsLoader;
@@ -390,7 +391,7 @@ class ImageDataViewImpl
 
 	/**
      * Implemented as specified by the view interface.
-     * @see ImageDataView#loadROIFromServer(long, Long, AgentEventListener)
+     * @see ImageDataView#loadROIFromServer(SecurityContext, long, long, AgentEventListener)
      */
 	public CallHandle loadROIFromServer(SecurityContext ctx, long imageID,
 			long userID, AgentEventListener observer)
@@ -398,6 +399,16 @@ class ImageDataViewImpl
 		BatchCallTree cmd = new ServerSideROILoader(ctx, imageID, userID);
 		return cmd.exec(observer);
 	}
+	
+	/**
+     * Implemented as specified by the view interface.
+     * @see ImageDataView#getROICount(SecurityContext, long, AgentEventListener)
+     */
+    public CallHandle getROICount(SecurityContext ctx, long imageID, AgentEventListener observer)
+    {
+        BatchCallTree cmd = new ROICountLoader(ctx, imageID);
+        return cmd.exec(observer);
+    }
 
 	/**
      * Implemented as specified by the view interface.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
@@ -1,0 +1,85 @@
+/*
+ * org.openmicroscopy.shoola.env.data.views.calls.ServerSideROILoader
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ * 	This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.data.views.calls;
+
+import omero.gateway.SecurityContext;
+import omero.gateway.facility.ROIFacility;
+
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
+/**
+ * Loads the number of ROIs for a specific image
+ *
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class ROICountLoader extends BatchCallTree {
+
+    /** The result of the query. */
+    private Object results;
+
+    /** Call to load the ROIs. */
+    private BatchCall loadCall;
+
+    private BatchCall makeLoadCalls(final SecurityContext ctx,
+            final long imageID) {
+        return new BatchCall("Load ROI count from Server") {
+            public void doCall() throws Exception {
+                results = context.getGateway().getFacility(ROIFacility.class)
+                        .getROICount(ctx, imageID);
+            }
+        };
+    }
+
+    /**
+     * Adds the {@link #loadCall} to the computation tree.
+     * 
+     * @see BatchCallTree#buildTree()
+     */
+    protected void buildTree() {
+        add(loadCall);
+    }
+
+    /**
+     * Returns the root node of the requested tree.
+     * 
+     * @see BatchCallTree#getResult()
+     */
+    protected Object getResult() {
+        return results;
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param ctx
+     *            The security context.
+     * @param imageID
+     *            The image's ID.
+     */
+    public ROICountLoader(SecurityContext ctx, long imageID) {
+        loadCall = makeLoadCalls(ctx, imageID);
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -111,6 +111,13 @@ public class ROIFacilityTest extends GatewayTest {
     }
 
     @Test(dependsOnMethods = { "testSaveROIs" })
+    public void testGetROICount() throws DSOutOfServiceException,
+            DSAccessException {
+        int n = roifac.getROICount(rootCtx, img.getId());
+        Assert.assertEquals(2, n);
+    }
+    
+    @Test(dependsOnMethods = { "testSaveROIs" })
     public void testLoadROIs() throws DSOutOfServiceException,
             DSAccessException {
         List<ROIResult> roiResults = roifac.loadROIs(rootCtx, img.getId());


### PR DESCRIPTION
At the moment Insight loads all ROIs and counts them on the client side for showing the number of ROIs in the right hand side meta data panel. This PR adds a method for directly getting the number of ROIs via an HQL query.

Test: Check some images with ROIs, make sure the ROI count (right hand side metadata panel) is correct.

(based on #4549 to avoid merge conflicts)