### PR TITLE
refactor disk usage

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -75,6 +75,7 @@
     <import resource="graph-rules/blitz-chmod-rules.xml"/>
     <import resource="graph-rules/blitz-chown-rules.xml"/>
     <import resource="graph-rules/blitz-delete-rules.xml"/>
+    <import resource="graph-rules/blitz-disk-usage-rules.xml"/>
     <import resource="graph-rules/blitz-duplicate-rules.xml"/>
     <import resource="graph-rules/blitz-container-rules.xml"/>
     <import resource="graph-rules/blitz-contained-rules.xml"/>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -367,6 +367,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodTargets"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownTargets"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteTargets"/>
+          <entry key="omero.cmd.graphs.DiskUsageI" value-ref="diskUsageTargets"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateTargets"/>
           <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerTargets"/>
           <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedTargets"/>
@@ -378,6 +379,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodRules"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownRules"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteRules"/>
+          <entry key="omero.cmd.graphs.DiskUsageI" value-ref="diskUsageRules"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateRules"/>
           <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerRules"/>
           <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedRules"/>

--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -367,7 +367,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodTargets"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownTargets"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteTargets"/>
-          <entry key="omero.cmd.graphs.DiskUsageI" value-ref="diskUsageTargets"/>
+          <entry key="omero.cmd.graphs.DiskUsage2I" value-ref="diskUsageTargets"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateTargets"/>
           <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerTargets"/>
           <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedTargets"/>
@@ -379,7 +379,7 @@
           <entry key="omero.cmd.graphs.Chmod2I" value-ref="chmodRules"/>
           <entry key="omero.cmd.graphs.Chown2I" value-ref="chownRules"/>
           <entry key="omero.cmd.graphs.Delete2I" value-ref="deleteRules"/>
-          <entry key="omero.cmd.graphs.DiskUsageI" value-ref="diskUsageRules"/>
+          <entry key="omero.cmd.graphs.DiskUsage2I" value-ref="diskUsageRules"/>
           <entry key="omero.cmd.graphs.DuplicateI" value-ref="duplicateRules"/>
           <entry key="omero.cmd.graphs.FindParentsI" value-ref="containerRules"/>
           <entry key="omero.cmd.graphs.FindChildrenI" value-ref="containedRules"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+#
+# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+
+    <util:list id="diskUsageTargets" value-type="java.lang.String">
+
+        <!-- acquisition -->
+        <value>Instrument</value>
+
+        <!-- annotations -->
+        <value>Annotation</value>
+        <value>IAnnotationLink</value>
+
+        <!-- containers -->
+        <value>Dataset</value>
+        <value>DatasetImageLink</value>
+        <value>Project</value>
+        <value>ProjectDatasetLink</value>
+        <value>Folder</value>
+        <value>FolderImageLink</value>
+        <value>FolderRoiLink</value>
+
+        <!-- core -->
+        <value>Channel</value>
+        <value>Image</value>
+        <value>LogicalChannel</value>
+        <value>OriginalFile</value>
+        <value>Pixels</value>
+        <value>PixelsOriginalFileMap</value>
+        <value>PlaneInfo</value>
+
+        <!-- display -->
+        <value>ChannelBinding</value>
+        <value>CodomainMapContext</value>
+        <value>QuantumDef</value>
+        <value>RenderingDef</value>
+        <value>Thumbnail</value>
+
+        <!-- experiment -->
+        <value>Experiment</value>
+        <value>MicrobeamManipulation</value>
+
+        <!-- fs -->
+        <value>Fileset</value>
+        <value>FilesetEntry</value>
+        <value>FilesetJobLink</value>
+
+        <!-- internal -->
+        <value>Link</value>
+
+        <!-- jobs -->
+        <value>Job</value>
+        <value>JobOriginalFileLink</value>
+
+        <!-- meta -->
+        <value>Experimenter</value>
+        <value>ExperimenterGroup</value>
+        <value>ExternalInfo</value>
+
+        <!-- roi -->
+        <value>Roi</value>
+        <value>Shape</value>
+
+        <!-- screen -->
+        <value>Plate</value>
+        <value>PlateAcquisition</value>
+        <value>Reagent</value>
+        <value>Screen</value>
+        <value>ScreenPlateLink</value>
+        <value>Well</value>
+        <value>WellReagentLink</value>
+        <value>WellSample</value>
+
+        <!-- stats -->
+        <value>StatsInfo</value>
+
+    </util:list>
+
+    <util:list id="diskUsageRules" value-type="ome.services.graphs.GraphPolicyRule">
+
+        <!-- see blitz-graph-rules.xml for rule syntax -->
+
+        <!-- ACQUISITION -->
+
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filter = F:[E]" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LightSettings[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DetectorSettings[I].detector = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ObjectiveSettings[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].detector = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].lightSource = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].objective = [I]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].filterSet = FS:[E]" p:changes="FS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTF[I].objective = O:[E]" p:changes="O:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
+                                       p:changes="L:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
+
+        <!-- ANNOTATIONS -->
+
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].child = A:[E]" p:changes="A:[I]"/>
+
+        <!-- CONTAINERS -->
+
+        <bean parent="graphPolicyRule" p:matches="Folder[I].childFolders = C:[E]" p:changes="C:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I]" p:changes="L:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="ProjectDatasetLink[I].child = D:[E]" p:changes="D:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="DatasetImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderImageLink[I].child = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FolderRoiLink[I].child = ROI:[E]" p:changes="ROI:[I]"/>
+
+        <!-- CORE -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]" p:changes="IE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]" p:changes="IN:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]" p:changes="SL:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].pixelsFileMaps = POFM:[E]" p:changes="POFM:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].settings = RD:[E]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Pixels[I].thumbnails = T:[E]" p:changes="T:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].channels = C:[E]" p:changes="C:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightPath = LP:[E]" p:changes="LP:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="FileAnnotation[I].file = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetEntry[I].originalFile = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PixelsOriginalFileMap[I].parent = OF:[E]" p:changes="OF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].source = OF:[E]" p:changes="OF:[I]"/>
+
+        <!-- DISPLAY -->
+
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+
+        <!-- EXPERIMENT -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].experiment = E:[E]" p:changes="E:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Experiment[I].microbeamManipulation = M:[E]" p:changes="M:[I]"/>
+
+        <!-- FS -->
+
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].images = I:[E]" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].usedFiles = FE:[E]" p:changes="FE:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Fileset[I].jobLinks = L:[E]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="FilesetJobLink[I].child = J:[E]" p:changes="J:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="F:Fileset[E].images = I:[I]" p:changes="F:[I]"/>
+
+        <!-- JOB -->
+
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="JobOriginalFileLink[I].child = OF:[E]" p:changes="OF:[I]"/>
+
+        <!-- META -->
+
+        <bean parent="graphPolicyRule" p:matches="[I].details.externalInfo = EI:[E]" p:changes="EI:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="X:Instrument[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Annotation[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Dataset[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Project[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Folder[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Channel[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Image[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:LogicalChannel[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:OriginalFile[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Pixels[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PixelsOriginalFileMap[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PlaneInfo[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:ChannelBinding[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:CodomainMapContext[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:QuantumDef[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:RenderingDef[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Thumbnail[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Experiment[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:MicrobeamManipulation[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Fileset[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:FilesetEntry[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Job[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:ExternalInfo[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Roi[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Shape[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Plate[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PlateAcquisition[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Reagent[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Screen[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Well[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:WellSample[E].details.owner = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:StatsInfo[E].details.owner = [I]" p:changes="X:[I]"/>
+
+        <bean parent="graphPolicyRule" p:matches="X:Instrument[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Annotation[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Dataset[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Project[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Folder[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Channel[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Image[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:LogicalChannel[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:OriginalFile[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Pixels[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PixelsOriginalFileMap[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PlaneInfo[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:ChannelBinding[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:CodomainMapContext[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:QuantumDef[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:RenderingDef[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Thumbnail[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Experiment[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:MicrobeamManipulation[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Fileset[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:FilesetEntry[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Job[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:ExternalInfo[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Roi[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Shape[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Plate[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:PlateAcquisition[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Reagent[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Screen[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:Well[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:WellSample[E].details.group = [I]" p:changes="X:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="X:StatsInfo[E].details.group = [I]" p:changes="X:[I]"/>
+
+        <!-- ROI -->
+
+        <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- SCREEN -->
+
+        <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[I].child = P:[E]" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].wells = W:[E]" p:changes="W:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = R:[E]" p:changes="R:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:[E]" p:changes="WS:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="WellSample[I].image = I:[E]" p:changes="I:[I]"/>
+
+        <!-- STATS -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].statsInfo = SI:[E]" p:changes="SI:[I]"/>
+
+    </util:list>
+
+</beans>

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -196,6 +196,7 @@ module omero {
          *   Folder, Screen, Plate, Well, WellSample,
          *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
          **/
+        ["deprecated:use omero::cmd::DiskUsage2 instead"]
         class DiskUsage extends Request {
             omero::api::StringSet classes;
             omero::api::StringLongListMap objects;
@@ -213,6 +214,7 @@ module omero {
          *   Thumbnail for the image thumbnails
          * The above map values are broken down by owner-group keys.
          **/
+        ["deprecated:use omero::cmd::DiskUsage2Response instead"]
         class DiskUsageResponse extends Response {
             omero::api::LongPairToStringIntMap fileCountByReferer;
             omero::api::LongPairToStringLongMap bytesUsedByReferer;

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -185,41 +185,6 @@ module omero {
 
         };
 
-        /**
-         * Request to determine the disk usage of the given objects
-         * and their contents. File-system paths used by multiple objects
-         * are de-duplicated in the total count. Specifying a class is
-         * equivalent to specifying all its instances as objects.
-         *
-         * Permissible classes include:
-         *   ExperimenterGroup, Experimenter, Project, Dataset,
-         *   Folder, Screen, Plate, Well, WellSample,
-         *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
-         **/
-        class DiskUsage extends Request {
-            omero::api::StringSet classes;
-            omero::api::StringLongListMap objects;
-        };
-
-        /**
-         * Disk usage report: bytes used and non-empty file counts on the
-         * repository file-system for specific objects. The counts from the
-         * maps may sum to more than the total if different types of object
-         * refer to the same file. Common referers include:
-         *   Annotation for file annotations
-         *   FilesetEntry for OMERO 5 image files (OMERO.fs)
-         *   Job for import logs
-         *   Pixels for pyramids and OMERO 4 images and archived files
-         *   Thumbnail for the image thumbnails
-         * The above map values are broken down by owner-group keys.
-         **/
-        class DiskUsageResponse extends Response {
-            omero::api::LongPairToStringIntMap fileCountByReferer;
-            omero::api::LongPairToStringLongMap bytesUsedByReferer;
-            omero::api::LongPairIntMap totalFileCount;
-            omero::api::LongPairLongMap totalBytesUsed;
-        };
-
     };
 };
 

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -185,6 +185,41 @@ module omero {
 
         };
 
+        /**
+         * Request to determine the disk usage of the given objects
+         * and their contents. File-system paths used by multiple objects
+         * are de-duplicated in the total count. Specifying a class is
+         * equivalent to specifying all its instances as objects.
+         *
+         * Permissible classes include:
+         *   ExperimenterGroup, Experimenter, Project, Dataset,
+         *   Folder, Screen, Plate, Well, WellSample,
+         *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
+         **/
+        class DiskUsage extends Request {
+            omero::api::StringSet classes;
+            omero::api::StringLongListMap objects;
+        };
+
+        /**
+         * Disk usage report: bytes used and non-empty file counts on the
+         * repository file-system for specific objects. The counts from the
+         * maps may sum to more than the total if different types of object
+         * refer to the same file. Common referers include:
+         *   Annotation for file annotations
+         *   FilesetEntry for OMERO 5 image files (OMERO.fs)
+         *   Job for import logs
+         *   Pixels for pyramids and OMERO 4 images and archived files
+         *   Thumbnail for the image thumbnails
+         * The above map values are broken down by owner-group keys.
+         **/
+        class DiskUsageResponse extends Response {
+            omero::api::LongPairToStringIntMap fileCountByReferer;
+            omero::api::LongPairToStringLongMap bytesUsedByReferer;
+            omero::api::LongPairIntMap totalFileCount;
+            omero::api::LongPairLongMap totalBytesUsed;
+        };
+
     };
 };
 

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -367,6 +367,40 @@ module omero {
         };
 
         /**
+         * Request to determine the disk usage of the given objects
+         * and their contents. File-system paths used by multiple objects
+         * are de-duplicated in the total count. Specifying a class is
+         * equivalent to specifying all its instances as objects.
+         *
+         * Permissible classes include:
+         *   ExperimenterGroup, Experimenter, Project, Dataset,
+         *   Folder, Screen, Plate, Well, WellSample,
+         *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
+         **/
+        class DiskUsage extends GraphQuery {
+            omero::api::StringSet targetClasses;
+        };
+
+        /**
+         * Disk usage report: bytes used and non-empty file counts on the
+         * repository file-system for specific objects. The counts from the
+         * maps may sum to more than the total if different types of object
+         * refer to the same file. Common referers include:
+         *   Annotation for file annotations
+         *   FilesetEntry for OMERO 5 image files (OMERO.fs)
+         *   Job for import logs
+         *   Pixels for pyramids and OMERO 4 images and archived files
+         *   Thumbnail for the image thumbnails
+         * The above map values are broken down by owner-group keys.
+         **/
+        class DiskUsageResponse extends Response {
+            omero::api::LongPairToStringIntMap fileCountByReferer;
+            omero::api::LongPairToStringLongMap bytesUsedByReferer;
+            omero::api::LongPairIntMap totalFileCount;
+            omero::api::LongPairLongMap totalBytesUsed;
+        };
+
+        /**
          * Duplicate model objects with some selection of their subgraph.
          * All target model objects must be in the current group context.
          * The extra three data members allow adjustment of the related

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -377,7 +377,7 @@ module omero {
          *   Folder, Screen, Plate, Well, WellSample,
          *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
          **/
-        class DiskUsage extends GraphQuery {
+        class DiskUsage2 extends GraphQuery {
             omero::api::StringSet targetClasses;
         };
 
@@ -393,7 +393,7 @@ module omero {
          *   Thumbnail for the image thumbnails
          * The above map values are broken down by owner-group keys.
          **/
-        class DiskUsageResponse extends Response {
+        class DiskUsage2Response extends Response {
             omero::api::LongPairToStringIntMap fileCountByReferer;
             omero::api::LongPairToStringLongMap bytesUsedByReferer;
             omero::api::LongPairIntMap totalFileCount;

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -238,7 +238,10 @@ public class RequestObjectFactoryRegistry extends
                 new ObjectFactory(DiskUsageI.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        return new DiskUsageI(pixelsService, thumbnailService, graphRequestFactory.getGraphPathBean());
+                        final DiskUsageI request = graphRequestFactory.getRequest(DiskUsageI.class);
+                        request.setPixelsService(pixelsService);
+                        request.setThumbnailService(thumbnailService);
+                        return request;
                     }
                 });
         factories.put(DuplicateI.ice_staticId(),

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -40,6 +40,7 @@ import omero.cmd.graphs.ChownFacadeI;
 import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
 import omero.cmd.graphs.DiskUsage2I;
+import omero.cmd.graphs.DiskUsageI;
 import omero.cmd.graphs.DuplicateI;
 import omero.cmd.graphs.FindChildrenI;
 import omero.cmd.graphs.FindParentsI;
@@ -232,6 +233,13 @@ public class RequestObjectFactoryRegistry extends
                     @Override
                     public Ice.Object create(String name) {
                         return new ManageImageBinariesI(pixelsService, voter);
+                    }
+                });
+        factories.put(DiskUsageI.ice_staticId(),
+                new ObjectFactory(DiskUsageI.ice_staticId()) {
+                    @Override
+                    public Ice.Object create(String name) {
+                        return new DiskUsageI(pixelsService, thumbnailService, graphRequestFactory.getGraphPathBean());
                     }
                 });
         factories.put(DiskUsage2I.ice_staticId(),

--- a/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
+++ b/components/blitz/src/omero/cmd/RequestObjectFactoryRegistry.java
@@ -39,7 +39,7 @@ import omero.cmd.graphs.Chown2I;
 import omero.cmd.graphs.ChownFacadeI;
 import omero.cmd.graphs.Delete2I;
 import omero.cmd.graphs.DeleteFacadeI;
-import omero.cmd.graphs.DiskUsageI;
+import omero.cmd.graphs.DiskUsage2I;
 import omero.cmd.graphs.DuplicateI;
 import omero.cmd.graphs.FindChildrenI;
 import omero.cmd.graphs.FindParentsI;
@@ -234,11 +234,11 @@ public class RequestObjectFactoryRegistry extends
                         return new ManageImageBinariesI(pixelsService, voter);
                     }
                 });
-        factories.put(DiskUsageI.ice_staticId(),
-                new ObjectFactory(DiskUsageI.ice_staticId()) {
+        factories.put(DiskUsage2I.ice_staticId(),
+                new ObjectFactory(DiskUsage2I.ice_staticId()) {
                     @Override
                     public Ice.Object create(String name) {
-                        final DiskUsageI request = graphRequestFactory.getRequest(DiskUsageI.class);
+                        final DiskUsage2I request = graphRequestFactory.getRequest(DiskUsage2I.class);
                         request.setPixelsService(pixelsService);
                         request.setThumbnailService(thumbnailService);
                         return request;

--- a/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
@@ -51,8 +51,8 @@ import ome.services.graphs.GraphTraversal;
 import ome.system.Login;
 import ome.system.Roles;
 import omero.api.LongPair;
-import omero.cmd.DiskUsage;
-import omero.cmd.DiskUsageResponse;
+import omero.cmd.DiskUsage2;
+import omero.cmd.DiskUsage2Response;
 import omero.cmd.HandleI.Cancel;
 import omero.cmd.ERR;
 import omero.cmd.Helper;
@@ -65,11 +65,11 @@ import omero.cmd.Response;
  * @since 5.1.0
  */
 @SuppressWarnings("serial")
-public class DiskUsageI extends DiskUsage implements IRequest {
+public class DiskUsage2I extends DiskUsage2 implements IRequest {
 
     /* FIELDS AND CONSTRUCTORS */
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DiskUsageI.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskUsage2I.class);
 
     private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
@@ -106,7 +106,7 @@ public class DiskUsageI extends DiskUsage implements IRequest {
      * @param targetClasses legal target object classes for the search
      * @param graphPolicy the graph policy to apply for the search
      */
-    public DiskUsageI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+    public DiskUsage2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
             Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
@@ -322,8 +322,8 @@ public class DiskUsageI extends DiskUsage implements IRequest {
         /**
          * @return a disk usage response corresponding to the current usage
          */
-        public DiskUsageResponse getDiskUsageResponse() {
-            return new DiskUsageResponse(countByTypeByWho, sizeByTypeByWho, totalCountByWho, totalSizeByWho);
+        public DiskUsage2Response getDiskUsageResponse() {
+            return new DiskUsage2Response(countByTypeByWho, sizeByTypeByWho, totalCountByWho, totalSizeByWho);
         }
 
         /**

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -63,7 +63,9 @@ import omero.model.OriginalFile;
  * Calculate the disk usage entailed by the given objects.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
+ * @deprecated will be removed in OMERO 5.4, use {@code DiskUsage2} instead
  */
+@Deprecated
 @SuppressWarnings("serial")
 public class DiskUsageI extends DiskUsage implements IRequest {
     /* TODO: This class can be substantially refactored and simplified by using the graph traversal reimplementation. */

--- a/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsageI.java
@@ -1,0 +1,642 @@
+/*
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+
+import ome.api.IQuery;
+import ome.io.bioformats.BfPyramidPixelBuffer;
+import ome.io.nio.PixelsService;
+import ome.io.nio.ThumbnailService;
+import ome.model.IObject;
+import ome.parameters.Parameters;
+import ome.services.graphs.GraphPathBean;
+import ome.system.Login;
+import omero.api.LongPair;
+import omero.cmd.DiskUsage;
+import omero.cmd.DiskUsageResponse;
+import omero.cmd.HandleI.Cancel;
+import omero.cmd.ERR;
+import omero.cmd.Helper;
+import omero.cmd.IRequest;
+import omero.cmd.Response;
+import omero.model.OriginalFile;
+
+/**
+ * Calculate the disk usage entailed by the given objects.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.1.0
+ */
+@SuppressWarnings("serial")
+public class DiskUsageI extends DiskUsage implements IRequest {
+    /* TODO: This class can be substantially refactored and simplified by using the graph traversal reimplementation. */
+
+    /* FIELDS AND CONSTRUCTORS */
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskUsageI.class);
+    private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
+
+    /* <FromClass, Map.Entry<ToClass, HQL>> */
+    private static final ImmutableMultimap<String, Map.Entry<String, String>> TRAVERSAL_QUERIES;
+
+    private static final ImmutableSet<String> OWNED_OBJECTS;
+    private static final ImmutableSet<String> ANNOTATABLE_OBJECTS;
+
+    private static final Map<String, String> classIdProperties = Collections.synchronizedMap(new HashMap<String, String>());
+
+    private final PixelsService pixelsService;
+    private final ThumbnailService thumbnailService;
+    private final GraphPathBean graphPathBean;
+
+    private Helper helper;
+
+    /**
+     * Construct a disk usage request.
+     * @param pixelsService the pixels service
+     * @param thumbnailService the thumbnail service
+     * @param graphPathBean the graph path bean
+     */
+    public DiskUsageI(PixelsService pixelsService, ThumbnailService thumbnailService, GraphPathBean graphPathBean) {
+        this.pixelsService = pixelsService;
+        this.thumbnailService = thumbnailService;
+        this.graphPathBean = graphPathBean;
+    }
+
+    /* NAVIGATION OF MODEL OBJECT GRAPH */
+
+    static {
+        final ImmutableMultimap.Builder<String, Map.Entry<String, String>> builder = ImmutableMultimap.builder();
+
+        builder.put("Project", Maps.immutableEntry("Dataset",
+                "SELECT child.id FROM ProjectDatasetLink WHERE parent.id IN (:ids)"));
+        builder.put("Dataset", Maps.immutableEntry("Image",
+                "SELECT child.id FROM DatasetImageLink WHERE parent.id IN (:ids)"));
+        builder.put("Folder", Maps.immutableEntry("Image",
+                "SELECT child.id FROM FolderImageLink WHERE parent.id IN (:ids)"));
+        builder.put("Folder", Maps.immutableEntry("Roi",
+                "SELECT child.id FROM FolderRoiLink WHERE parent.id IN (:ids)"));
+        builder.put("Folder", Maps.immutableEntry("Folder",
+                "SELECT id FROM Folder WHERE parentFolder.id IN (:ids)"));
+        builder.put("Screen", Maps.immutableEntry("Plate",
+                "SELECT child.id FROM ScreenPlateLink WHERE parent.id IN (:ids)"));
+        builder.put("Plate", Maps.immutableEntry("Well",
+                "SELECT id FROM Well WHERE plate.id IN (:ids)"));
+        builder.put("Plate", Maps.immutableEntry("PlateAcquisition",
+                "SELECT id FROM PlateAcquisition WHERE plate.id IN (:ids)"));
+        builder.put("PlateAcquisition", Maps.immutableEntry("WellSample",
+                "SELECT id FROM WellSample WHERE plateAcquisition.id IN (:ids)"));
+        builder.put("Well", Maps.immutableEntry("WellSample",
+                "SELECT id FROM WellSample WHERE well.id IN (:ids)"));
+        builder.put("Well", Maps.immutableEntry("Reagent",
+                "SELECT child.id FROM WellReagentLink WHERE parent.id IN (:ids)"));
+        builder.put("WellSample", Maps.immutableEntry("Image",
+                "SELECT image.id FROM WellSample WHERE id IN (:ids)"));
+        builder.put("Image", Maps.immutableEntry("Pixels",
+                "SELECT id FROM Pixels WHERE image.id IN (:ids)"));
+        builder.put("Pixels", Maps.immutableEntry("Thumbnail",
+                "SELECT id FROM Thumbnail WHERE pixels.id IN (:ids)"));
+        builder.put("Pixels", Maps.immutableEntry("OriginalFile",
+                "SELECT parent.id FROM PixelsOriginalFileMap WHERE child.id IN (:ids)"));
+        builder.put("Pixels", Maps.immutableEntry("Channel",
+                "SELECT id FROM Channel WHERE pixels.id IN (:ids)"));
+        builder.put("Pixels", Maps.immutableEntry("PlaneInfo",
+                "SELECT id FROM PlaneInfo WHERE pixels.id IN (:ids)"));
+        builder.put("Channel", Maps.immutableEntry("LogicalChannel",
+                "SELECT logicalChannel.id FROM Channel WHERE id IN (:ids)"));
+        builder.put("Image", Maps.immutableEntry("Fileset",
+                "SELECT fileset.id FROM Image WHERE id IN (:ids)"));
+        builder.put("Fileset", Maps.immutableEntry("Job",
+                "SELECT child.id FROM FilesetJobLink WHERE parent.id IN (:ids)"));
+        builder.put("Job", Maps.immutableEntry("OriginalFile",
+                "SELECT child.id FROM JobOriginalFileLink WHERE parent.id IN (:ids)"));
+        builder.put("Fileset", Maps.immutableEntry("Image",
+                "SELECT id FROM Image WHERE fileset.id IN (:ids)"));
+        builder.put("Fileset", Maps.immutableEntry("FilesetEntry",
+                "SELECT id FROM FilesetEntry WHERE fileset.id IN (:ids)"));
+        builder.put("FilesetEntry", Maps.immutableEntry("OriginalFile",
+                "SELECT originalFile.id FROM FilesetEntry WHERE id IN (:ids)"));
+        builder.put("Annotation", Maps.immutableEntry("OriginalFile",
+                "SELECT file.id FROM FileAnnotation WHERE id IN (:ids)"));
+        builder.put("Image", Maps.immutableEntry("Roi",
+                "SELECT id FROM Roi WHERE image.id IN (:ids)"));
+        builder.put("Roi", Maps.immutableEntry("Shape",
+                "SELECT id FROM Shape WHERE roi.id IN (:ids)"));
+        builder.put("Roi", Maps.immutableEntry("OriginalFile",
+                "SELECT source.id FROM Roi WHERE id IN (:ids)"));
+        builder.put("Image", Maps.immutableEntry("Instrument",
+                "SELECT instrument.id FROM Image WHERE id IN (:ids)"));
+        builder.put("Instrument", Maps.immutableEntry("Detector",
+                "SELECT id FROM Detector WHERE instrument.id IN (:ids)"));
+        builder.put("Instrument", Maps.immutableEntry("Dichroic",
+                "SELECT id FROM Dichroic WHERE instrument.id IN (:ids)"));
+        builder.put("Instrument", Maps.immutableEntry("Filter",
+                "SELECT id FROM Filter WHERE instrument.id IN (:ids)"));
+        builder.put("Instrument", Maps.immutableEntry("LightSource",
+                "SELECT id FROM LightSource WHERE instrument.id IN (:ids)"));
+        builder.put("Instrument", Maps.immutableEntry("Objective",
+                "SELECT id FROM Objective WHERE instrument.id IN (:ids)"));
+        builder.put("Dichroic", Maps.immutableEntry("LightPath",
+                "SELECT id FROM LightPath WHERE dichroic.id IN (:ids)"));
+        builder.put("LogicalChannel", Maps.immutableEntry("LightPath",
+                "SELECT lightPath.id FROM LogicalChannel WHERE id IN (:ids)"));
+
+        TRAVERSAL_QUERIES = builder.build();
+    }
+
+    static {
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+
+        builder.add("Annotation");
+        builder.add("Channel");
+        builder.add("Dataset");
+        builder.add("Detector");
+        builder.add("Dichroic");
+        builder.add("Fileset");
+        builder.add("Filter");
+        builder.add("Folder");
+        builder.add("Image");
+        builder.add("LogicalChannel");
+        builder.add("Instrument");
+        builder.add("LightPath");
+        builder.add("LightSource");
+        builder.add("Objective");
+        builder.add("OriginalFile");
+        builder.add("Pixels");
+        builder.add("PlaneInfo");
+        builder.add("PlateAcquisition");
+        builder.add("Plate");
+        builder.add("Project");
+        builder.add("Reagent");
+        builder.add("Roi");
+        builder.add("Screen");
+        builder.add("Shape");
+        builder.add("Well");
+        builder.add("WellSample");
+
+        OWNED_OBJECTS = builder.build();
+    }
+
+    static {
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+
+        builder.add("Annotation");
+        builder.add("Channel");
+        builder.add("Dataset");
+        builder.add("Detector");
+        builder.add("Dichroic");
+        builder.add("Experimenter");
+        builder.add("ExperimenterGroup");
+        builder.add("Fileset");
+        builder.add("Filter");
+        builder.add("Folder");
+        builder.add("Image");
+        builder.add("Instrument");
+        builder.add("LightPath");
+        builder.add("LightSource");
+        builder.add("Objective");
+        builder.add("OriginalFile");
+        builder.add("PlaneInfo");
+        builder.add("PlateAcquisition");
+        builder.add("Plate");
+        builder.add("Project");
+        builder.add("Reagent");
+        builder.add("Roi");
+        builder.add("Screen");
+        builder.add("Shape");
+        builder.add("Well");
+
+        ANNOTATABLE_OBJECTS = builder.build();
+    }
+
+    /* USAGE STATISTICS TRACKING */
+
+    /**
+     * Track the disk usage subtotals and totals. Not thread-safe.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.1.0
+     */
+    private static class Usage {
+        private final Map<LongPair, Map<String, Integer>> countByTypeByWho = new HashMap<LongPair, Map<String, Integer>>();
+        private final Map<LongPair, Map<String, Long>> sizeByTypeByWho = new HashMap<LongPair, Map<String, Long>>();
+
+        private final Map<LongPair, Integer> totalCountByWho = new HashMap<LongPair, Integer>();
+        private final Map<LongPair, Long> totalSizeByWho = new HashMap<LongPair, Long>();
+
+        private boolean bumpTotals = false;
+
+        /**
+         * The next call to {@link #add(String, Long)} may bump {@link #totalCount} and {@link #totalSize}.
+         * @return this instance, for method chaining
+         */
+        Usage bumpTotals() {
+            bumpTotals = true;
+            return this;
+        }
+
+        /**
+         * Adjust counts and sizes according to given ownership, type and size.
+         * Does not adjust anything unless {@code size > 0}.
+         * @see #bumpTotals()
+         * @param owner the ID of an owner
+         * @param group the ID of a group
+         * @param type a type
+         * @param size a size
+         */
+        void add(long owner, long group, String type, Long size) {
+            if (size <= 0) {
+                bumpTotals = false;
+                return;
+            }
+            final LongPair ownership = new LongPair(owner, group);
+            final Map<String, Integer> countByType;
+            final Map<String, Long> sizeByType;
+            if (countByTypeByWho.containsKey(ownership)) {
+                countByType = countByTypeByWho.get(ownership);
+                sizeByType = sizeByTypeByWho.get(ownership);
+            } else {
+                countByType = new HashMap<String, Integer>();
+                sizeByType = new HashMap<String, Long>();
+                countByTypeByWho.put(ownership, countByType);
+                sizeByTypeByWho.put(ownership, sizeByType);
+            }
+            Long sizeThisType = sizeByType.get(type);
+            if (sizeThisType == null) {
+                countByType.put(type, Integer.valueOf(1));
+                sizeByType.put(type, size);
+            } else {
+                countByType.put(type, countByType.get(type) + 1);
+                sizeByType.put(type, sizeThisType + size);
+            }
+            if (bumpTotals) {
+                Integer totalCount = totalCountByWho.get(ownership);
+                Long totalSize = totalSizeByWho.get(ownership);
+                if (totalCount == null) {
+                    totalCount = 0;
+                }
+                if (totalSize == null) {
+                    totalSize = 0L;
+                }
+                totalCount++;
+                totalSize += size;
+                totalCountByWho.put(ownership, totalCount);
+                totalSizeByWho.put(ownership, totalSize);
+                bumpTotals = false;
+            }
+        }
+
+        /**
+         * @return a disk usage response corresponding to the current usage
+         */
+        public DiskUsageResponse getDiskUsageResponse() {
+            return new DiskUsageResponse(countByTypeByWho, sizeByTypeByWho, totalCountByWho, totalSizeByWho);
+        }
+
+        /**
+         * Convert a map into a concise string representation.
+         * @param byWho a map with owner, group keys
+         * @return the string representation
+         */
+        private String toString(Map<LongPair, ?> byWho) {
+            final List<String> asStrings = new ArrayList<String>(byWho.size());
+            final StringBuffer sb = new StringBuffer();
+            for (final Map.Entry<LongPair, ?> entry : byWho.entrySet()) {
+                sb.setLength(0);
+                sb.append(entry.getKey().first);
+                sb.append('/');
+                sb.append(entry.getKey().second);
+                sb.append('=');
+                sb.append(entry.getValue());
+                asStrings.add(sb.toString());
+            }
+            return Joiner.on(", ").join(asStrings);
+        }
+
+        @Override
+        public String toString() {
+            return "files = [" + toString(totalCountByWho) + "], bytes = [" + toString(totalSizeByWho) + "]";
+        }
+    }
+
+    /* CMD REQUEST FRAMEWORK */
+
+    @Override
+    public ImmutableMap<String, String> getCallContext() {
+       return ALL_GROUPS_CONTEXT;
+    }
+
+    @Override
+    public void init(Helper helper) {
+        this.helper = helper;
+        helper.setSteps(1);
+    }
+
+    @Override
+    public DiskUsageResponse step(int step) throws Cancel {
+        helper.assertStep(step);
+        if (step != 0) {
+            throw helper.cancel(new ERR(), new IllegalArgumentException(), "disk usage operation has no step " + step);
+        }
+        try {
+            return getDiskUsage();
+        } catch (Cancel c) {
+            throw c;
+        } catch (Throwable t) {
+            throw helper.cancel(new ERR(), t, "disk usage operation failed");
+        }
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void buildResponse(int step, Object object) {
+        helper.assertResponse(step);
+        if (step == 0) {
+            helper.setResponseIfNull((DiskUsageResponse) object);
+        }
+    }
+
+    @Override
+    public Response getResponse() {
+        return helper.getResponse();
+    }
+
+    /* DISK USAGE CALCULATION */
+
+    /**
+     * Notes the ownership and disk usage of an original file. Immutable.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.1.0
+     */
+    private static class OwnershipAndSize {
+        /** the ID of the owner of the file */
+        public final long owner;
+
+        /** the ID of the group of the file */
+        public final long group;
+
+        /** the size of the file */
+        public final long size;
+
+        /**
+         * Construct a tuple of a file's ownership and disk usage.
+         * @param owner the ID of the owner of the file
+         * @param group the ID of the group of the file
+         * @param size the size of the file
+         */
+        OwnershipAndSize(long owner, long group, long size) {
+            this.owner = owner;
+            this.group = group;
+            this.size = size;
+        }
+    }
+
+    /**
+     * Get the size of the file at the given path, or {@code 0} if it does not exist.
+     * @param path a file path
+     * @return the file's size, or {@code 0} if the file does not exist
+     */
+    private static long getFileSize(String path) {
+        final File file = new File(path);
+        return file.exists() ? file.length() : 0;
+    }
+
+    /**
+     * Look up the identifier property for the given class.
+     * @param className a class name
+     * @return the identifier property, never {@code null}
+     * @throws Cancel if an identifier property could not be found for the given class
+     */
+    private String getIdPropertyFor(String className) throws Cancel {
+        String idProperty = classIdProperties.get(className);
+        if (idProperty == null) {
+            final Class<? extends IObject> actualClass = graphPathBean.getClassForSimpleName(className);
+            if (actualClass == null) {
+                final Exception e = new IllegalArgumentException("class " + className + " is unknown");
+                throw helper.cancel(new ERR(), e, "bad-class");
+            }
+            idProperty = graphPathBean.getIdentifierProperty(actualClass.getName());
+            if (idProperty == null) {
+                final Exception e = new IllegalArgumentException("no identifier property is known for class " + className);
+                throw helper.cancel(new ERR(), e, "bad-class");
+            }
+            classIdProperties.put(className, idProperty);
+        }
+        return idProperty;
+    }
+
+    /**
+     * Calculate the disk usage of the model objects specified in the request.
+     * @return the total usage, in bytes
+     */
+    private DiskUsageResponse getDiskUsage() {
+        final IQuery queryService = helper.getServiceFactory().getQueryService();
+
+        final int batchSize = 256;
+
+        final SetMultimap<String, Long> objectsToProcess = HashMultimap.create();
+        final SetMultimap<String, Long> objectsProcessed = HashMultimap.create();
+        final Usage usage = new Usage();
+
+        /* original file ID to types that refer to them */
+        final SetMultimap<Long, String> typesWithFiles = HashMultimap.create();
+        /* original file ID to file ownership and size */
+        final Map<Long, OwnershipAndSize> fileSizes = new HashMap<Long, OwnershipAndSize>();
+
+        /* note the objects to process */
+
+        for (final String className : classes) {
+            final String hql = "SELECT " + getIdPropertyFor(className) + " FROM " + className;
+            for (final Object[] resultRow : queryService.projection(hql, null)) {
+                if (resultRow != null) {
+                    final Long objectId = (Long) resultRow[0];
+                    objectsToProcess.put(className, objectId);
+                }
+            }
+        }
+
+        for (final Map.Entry<String, List<Long>> objectList : objects.entrySet()) {
+            objectsToProcess.putAll(objectList.getKey(), objectList.getValue());
+
+            if (LOGGER.isDebugEnabled()) {
+                final List<Long> ids = Lists.newArrayList(objectsToProcess.get(objectList.getKey()));
+                Collections.sort(ids);
+                LOGGER.debug("size calculator to process " + objectList.getKey() + " " + Joiner.on(", ").join(ids));
+            }
+        }
+
+        /* check that the objects' class names are valid */
+
+        for (final String className : objectsToProcess.keySet()) {
+            getIdPropertyFor(className);
+        }
+
+        /* iteratively process objects, descending the model graph */
+
+        while (!objectsToProcess.isEmpty()) {
+            /* obtain canonical class name and ID list */
+            final Map.Entry<String, Collection<Long>> nextClass = objectsToProcess.asMap().entrySet().iterator().next();
+            String className = nextClass.getKey();
+            final int lastDot = className.lastIndexOf('.');
+            if (lastDot >= 0) {
+                className = className.substring(lastDot + 1);
+            } else if (className.charAt(0) == '/') {
+                className = className.substring(1);
+            }
+            /* get IDs still to process, and split off a batch of them for this query */
+            final Collection<Long> ids = nextClass.getValue();
+            ids.removeAll(objectsProcessed.get(className));
+            if (ids.isEmpty()) {
+                continue;
+            }
+            final List<Long> idsToQuery = Lists.newArrayList(Iterables.limit(ids, batchSize));
+            ids.removeAll(idsToQuery);
+            objectsProcessed.putAll(className, idsToQuery);
+            final Parameters parameters = new Parameters().addIds(idsToQuery);
+
+            if ("Pixels".equals(className)) {
+                /* Pixels may have /OMERO/Pixels/<id> files */
+                final String hql = "SELECT id, details.owner.id, details.group.id FROM Pixels WHERE id IN (:ids)";
+                for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                    if (resultRow != null) {
+                        final Long pixelsId = (Long) resultRow[0];
+                        final Long ownerId = (Long) resultRow[1];
+                        final Long groupId = (Long) resultRow[2];
+                        final String pixelsPath = pixelsService.getPixelsPath(pixelsId);
+                        usage.bumpTotals().add(ownerId, groupId, className, getFileSize(pixelsPath));
+                        usage.bumpTotals().add(ownerId, groupId, className, getFileSize(pixelsPath + PixelsService.PYRAMID_SUFFIX));
+                        usage.bumpTotals().add(ownerId, groupId, className, getFileSize(pixelsPath + PixelsService.PYRAMID_SUFFIX +
+                                BfPyramidPixelBuffer.PYR_LOCK_EXT));
+                    }
+                }
+            } else if ("Thumbnail".equals(className)) {
+                /* Thumbnails may have /OMERO/Thumbnails/<id> files */
+                final String hql = "SELECT id, details.owner.id, details.group.id FROM Thumbnail WHERE id IN (:ids)";
+                for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                    if (resultRow != null) {
+                        final Long thumbnailId = (Long) resultRow[0];
+                        final Long ownerId = (Long) resultRow[1];
+                        final Long groupId = (Long) resultRow[2];
+                        final String thumbnailPath = thumbnailService.getThumbnailPath(thumbnailId);
+                        usage.bumpTotals().add(ownerId, groupId, className, getFileSize(thumbnailPath));
+                    }
+                }
+            } else if ("OriginalFile".equals(className)) {
+                /* OriginalFiles have their size noted */
+                final String hql = "SELECT id, details.owner.id, details.group.id, size FROM OriginalFile WHERE id IN (:ids)";
+                for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                    if (resultRow != null && resultRow[3] instanceof Long) {
+                        final Long fileId = (Long) resultRow[0];
+                        final Long ownerId = (Long) resultRow[1];
+                        final Long groupId = (Long) resultRow[2];
+                        final Long fileSize = (Long) resultRow[3];
+                        fileSizes.put(fileId, new OwnershipAndSize(ownerId, groupId, fileSize));
+                    }
+                }
+            } else if ("Experimenter".equals(className)) {
+                /* for an experimenter, use the list of owned objects */
+                for (final String resultClassName : OWNED_OBJECTS) {
+                    final String hql = "SELECT " + getIdPropertyFor(resultClassName) + " FROM " + resultClassName +
+                            " WHERE details.owner.id IN (:ids)";
+                    for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                        objectsToProcess.put(resultClassName, (Long) resultRow[0]);
+                    }
+                }
+            } else if ("ExperimenterGroup".equals(className)) {
+                /* for an experimenter group, use the list of owned objects */
+                for (final String resultClassName : OWNED_OBJECTS) {
+                    final String hql = "SELECT " + getIdPropertyFor(resultClassName) + " FROM " + resultClassName +
+                            " WHERE details.group.id IN (:ids)";
+                    for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                        objectsToProcess.put(resultClassName, (Long) resultRow[0]);
+                    }
+                }
+            }
+
+            /* follow the next step from here on the model object graph */
+            for (final Map.Entry<String, String> query : TRAVERSAL_QUERIES.get(className)) {
+                final String resultClassName = query.getKey();
+                final String hql = query.getValue();
+                for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                    if (resultRow != null && resultRow[0] instanceof Long) {
+                        final Long resultId = (Long) resultRow[0];
+                        objectsToProcess.put(resultClassName, resultId);
+                        if ("OriginalFile".equals(resultClassName)) {
+                            typesWithFiles.put(resultId, className);
+                        }
+                    }
+                }
+            }
+            if (ANNOTATABLE_OBJECTS.contains(className)) {
+                /* also watch for annotations on the current objects */
+                final String hql = "SELECT child.id FROM " + className + "AnnotationLink WHERE parent.id IN (:ids)";
+                for (final Object[] resultRow : queryService.projection(hql, parameters)) {
+                    objectsToProcess.put("Annotation", (Long) resultRow[0]);
+                }
+            }
+
+            if (LOGGER.isDebugEnabled()) {
+                Collections.sort(idsToQuery);
+                LOGGER.debug("usage is " + usage + " after processing " + className + " " + Joiner.on(", ").join(idsToQuery));
+            }
+        }
+
+        /* collate file counts and sizes by referer type */
+        for (final Map.Entry<Long, OwnershipAndSize> fileIdSize : fileSizes.entrySet()) {
+            final Long fileId = fileIdSize.getKey();
+            final OwnershipAndSize fileSize = fileIdSize.getValue();
+            Set<String> types = typesWithFiles.get(fileId);
+            if (types.isEmpty()) {
+                types = ImmutableSet.of("OriginalFile");
+            }
+            usage.bumpTotals();
+            for (final String type : types) {
+                usage.add(fileSize.owner, fileSize.group, type, fileSize.size);
+            }
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("usage is " + usage + " after including " + OriginalFile.class.getSimpleName() + " sizes");
+        }
+
+        return usage.getDiskUsageResponse();
+    }
+}

--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -2606,98 +2606,17 @@ public class Requests {
      * @author m.t.b.carroll@dundee.ac.uk
      * @since 5.2.3
      */
-    public static class DiskUsageBuilder extends Builder<DiskUsage> {
-
-        /* the class targeted by calls to the id method */
-        private String targetObjectClass = null;
-
-        /* keep a deduplicated copy of all identified targets to minimize a possibly large argument size */
-        private SetMultimap<String, Long> allTargets = HashMultimap.create();
+    public static class DiskUsageBuilder extends GraphQueryBuilder<DiskUsageBuilder, DiskUsage> {
 
         /**
          * Instantiate a new {@link DiskUsage} and initialize its collection containers.
          */
         DiskUsageBuilder() {
             super(new DiskUsage());
-            assembly.classes = new ArrayList<String>();
-            assembly.objects = new HashMap<String, List<Long>>();
-        }
-
-        /**
-         * Assemble and return the finished object.
-         * @return the built instance
-         */
-        @Override
-        public DiskUsage build() {
-            assembly.objects.clear();
-            for (final Map.Entry<String, Collection<Long>> target : allTargets.asMap().entrySet()) {
-                assembly.objects.put(target.getKey(), new ArrayList<Long>(target.getValue()));
-            }
-            return super.build();
+            assembly.targetClasses = new ArrayList<String>();
         }
 
         /* PROPERTY SETTERS THAT ACT DIRECTLY ON THE INSTANCE BEING ASSEMBLED */
-
-        /**
-         * @param targets target objects for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         */
-        public DiskUsageBuilder target(Map<String, ? extends Iterable<Long>> targets) {
-            for (final Map.Entry<String, ? extends Iterable<Long>> classAndIds : targets.entrySet()) {
-                allTargets.putAll(classAndIds.getKey(), classAndIds.getValue());
-            }
-            return this;
-        }
-
-        /**
-         * @param targetClass a target object type for this operation, required to then use an {@code id} method
-         * @return this builder, for method chaining
-         */
-        public DiskUsageBuilder target(String targetClass) {
-            targetObjectClass = targetClass;
-            return this;
-        }
-
-        /**
-         * @param ids target object IDs for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         * @see #target(String)
-         * @see #target(Class)
-         */
-        public DiskUsageBuilder id(Iterable<Long> ids) {
-            if (targetObjectClass == null) {
-                throw new IllegalStateException("must first use target(String) to set class name");
-            }
-            allTargets.putAll(targetObjectClass, ids);
-            return this;
-        }
-
-        /**
-         * @param ids target object IDs for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         * @see #target(String)
-         * @see #target(Class)
-         */
-        public DiskUsageBuilder id(RLong... ids) {
-            if (targetObjectClass == null) {
-                throw new IllegalStateException("must first use target(String) to set class name");
-            }
-            for (final RLong id : ids) {
-                allTargets.put(targetObjectClass, id.getValue());
-            }
-            return this;
-        }
-
-        /**
-         * @param targets target objects for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         */
-        public DiskUsageBuilder target(IObject... targets) {
-            for (final IObject target : targets) {
-                target(target.getClass()).id(target.getId());
-            }
-            return this;
-        }
 
         /**
          * @param types whole types to target for this operation, does not overwrite previous calls
@@ -2705,7 +2624,7 @@ public class Requests {
          */
         public DiskUsageBuilder type(Iterable<String> types) {
             for (final String type : types) {
-                assembly.classes.add(type);
+                assembly.targetClasses.add(type);
             }
             return this;
         }
@@ -2716,38 +2635,12 @@ public class Requests {
          */
         public final DiskUsageBuilder type(@SuppressWarnings("unchecked") Class<? extends IObject>... types) {
             for (final Class<? extends IObject> type : types) {
-                assembly.classes.add(getModelClassName(type));
+                assembly.targetClasses.add(getModelClassName(type));
             }
             return this;
         }
 
         /* PROPERTY SETTERS THAT SIMPLY WRAP USAGE OF THE ABOVE SETTERS */
-
-        /**
-         * @param targets target objects for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         */
-        public DiskUsageBuilder target(Multimap<String, Long> targets) {
-            return target(targets.asMap());
-        }
-
-        /**
-         * @param targetClass a target object type for this operation, required to then use an {@code id} method
-         * @return this builder, for method chaining
-         */
-        public DiskUsageBuilder target(Class<? extends IObject> targetClass) {
-            return target(getModelClassName(targetClass));
-        }
-
-        /**
-         * @param ids target object IDs for this operation, does not overwrite previous calls
-         * @return this builder, for method chaining
-         * @see #target(String)
-         * @see #target(Class)
-         */
-        public DiskUsageBuilder id(Long... ids) {
-            return id(Arrays.asList(ids));
-        }
 
         /**
          * @param types whole types to target for this operation, does not overwrite previous calls

--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -35,7 +35,7 @@ import omero.cmd.Chgrp2;
 import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
-import omero.cmd.DiskUsage;
+import omero.cmd.DiskUsage2;
 import omero.cmd.Duplicate;
 import omero.cmd.FindChildren;
 import omero.cmd.FindParents;
@@ -2602,17 +2602,17 @@ public class Requests {
     }
 
     /**
-     * A builder for {@link DiskUsage} instances.
+     * A builder for {@link DiskUsage2} instances.
      * @author m.t.b.carroll@dundee.ac.uk
      * @since 5.2.3
      */
-    public static class DiskUsageBuilder extends GraphQueryBuilder<DiskUsageBuilder, DiskUsage> {
+    public static class DiskUsageBuilder extends GraphQueryBuilder<DiskUsageBuilder, DiskUsage2> {
 
         /**
-         * Instantiate a new {@link DiskUsage} and initialize its collection containers.
+         * Instantiate a new {@link DiskUsage2} and initialize its collection containers.
          */
         DiskUsageBuilder() {
-            super(new DiskUsage());
+            super(new DiskUsage2());
             assembly.targetClasses = new ArrayList<String>();
         }
 
@@ -2715,7 +2715,7 @@ public class Requests {
     }
 
     /**
-     * @return a new {@link DiskUsage} builder
+     * @return a new {@link DiskUsage2} builder
      */
     public static DiskUsageBuilder diskUsage() {
         return new DiskUsageBuilder();

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -760,7 +760,7 @@ public class GraphTraversal {
                         }
                     }
                     subclassesQueried = true;
-                } catch (QueryException e) {
+                } catch (NullPointerException | QueryException e) {
                     NO_SUBCLASS_QUERY.add(className);
                 }
             }

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -377,10 +377,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -416,10 +416,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -449,10 +449,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Long) totalAnnotationSize);
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -499,10 +499,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -534,10 +534,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }
@@ -563,10 +563,10 @@ public class DiskUsageTest extends AbstractServerTest {
             final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
-                Assert.assertEquals(byReferer.get("Annotation"), (Integer) annotationIds.size());
+                Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
             }
         } finally {
-            final Delete2 request = Requests.delete().target("Annotation").id(annotationIds).build();
+            final Delete2 request = Requests.delete().target("FileAnnotation").id(annotationIds).build();
             doChange(request);
         }
     }

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -35,8 +35,8 @@ import omero.RType;
 import omero.ServerError;
 import omero.api.LongPair;
 import omero.cmd.Delete2;
-import omero.cmd.DiskUsage;
-import omero.cmd.DiskUsageResponse;
+import omero.cmd.DiskUsage2;
+import omero.cmd.DiskUsage2Response;
 import omero.cmd.ManageImageBinaries;
 import omero.cmd.ManageImageBinariesResponse;
 import omero.cmd.graphs.ChildOption;
@@ -74,7 +74,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Integration tests for the {@link omero.cmd.DiskUsage} request.
+ * Integration tests for the {@link omero.cmd.DiskUsage2} request.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */
@@ -93,9 +93,9 @@ public class DiskUsageTest extends AbstractServerTest {
      * @return the objects' disk usage
      * @throws Exception if thrown during request execution
      */
-    private DiskUsageResponse runDiskUsage(Map<java.lang.String, ? extends Collection<Long>> objects) throws Exception {
-        final DiskUsage request = Requests.diskUsage().target(objects).build();
-        return (DiskUsageResponse) doChange(request);
+    private DiskUsage2Response runDiskUsage(Map<java.lang.String, ? extends Collection<Long>> objects) throws Exception {
+        final DiskUsage2 request = Requests.diskUsage().target(objects).build();
+        return (DiskUsage2Response) doChange(request);
     }
 
     /**
@@ -220,7 +220,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testOwnership() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         final ImmutableList<Map<LongPair, ?>> responseElements = ImmutableList.of(
                         response.bytesUsedByReferer, response.fileCountByReferer, response.totalBytesUsed, response.totalFileCount);
         for (final Map<LongPair, ?> responseElement : responseElements) {
@@ -239,7 +239,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testFileSize() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
         for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
             Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
@@ -271,7 +271,7 @@ public class DiskUsageTest extends AbstractServerTest {
         iUpdate.saveObject(dil);
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Project", Collections.singleton(projectId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Project", Collections.singleton(projectId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
@@ -302,7 +302,7 @@ public class DiskUsageTest extends AbstractServerTest {
         final long parentFolderId = parentFolder.getId().getValue();
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Folder", Collections.singleton(parentFolderId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Folder", Collections.singleton(parentFolderId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FilesetEntry"), fileSize);
@@ -327,7 +327,7 @@ public class DiskUsageTest extends AbstractServerTest {
 
         final long importLogSize = queryForId(query, imageId);
 
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
         for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
             Assert.assertEquals((long) byReferer.get("Job"), importLogSize);
@@ -340,7 +340,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testThumbnailSize() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
         for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
             Assert.assertEquals(byReferer.get("Thumbnail"), thumbnailSize);
@@ -374,7 +374,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(3), annotationIds.get(4));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
@@ -413,7 +413,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(1), annotationIds.get(2));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
@@ -446,7 +446,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(2), annotationIds.get(0));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.bytesUsedByReferer.size(), 1);
             for (final Map<String, Long> byReferer : response.bytesUsedByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Long) totalAnnotationSize);
@@ -463,7 +463,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testCounts() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         Assert.assertEquals(response.fileCountByReferer.size(), 1);
         for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
             Assert.assertEquals(byReferer.size(), 3);
@@ -496,7 +496,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(3), annotationIds.get(4));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
@@ -531,7 +531,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(1), annotationIds.get(2));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
@@ -560,7 +560,7 @@ public class DiskUsageTest extends AbstractServerTest {
         addAnnotation(Annotation.class, annotationIds.get(2), annotationIds.get(0));
 
         try {
-            final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+            final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
             Assert.assertEquals(response.fileCountByReferer.size(), 1);
             for (final Map<String, Integer> byReferer : response.fileCountByReferer.values()) {
                 Assert.assertEquals(byReferer.get("FileAnnotation"), (Integer) annotationIds.size());
@@ -578,7 +578,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testSizeTotals() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         final Map<LongPair, Long> expected = new HashMap<LongPair, Long>();
         for (final Map.Entry<LongPair, Map<String, Long>> byReferer : response.bytesUsedByReferer.entrySet()) {
             long total = 0;
@@ -601,7 +601,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testCountTotals() throws Exception {
-        final DiskUsageResponse response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
+        final DiskUsage2Response response = runDiskUsage(ImmutableMap.of("Image", Collections.singleton(imageId)));
         final Map<LongPair, Integer> expected = new HashMap<LongPair, Integer>();
         for (final Map.Entry<LongPair, Map<String, Integer>> byReferer : response.fileCountByReferer.entrySet()) {
             int total = 0;
@@ -623,7 +623,7 @@ public class DiskUsageTest extends AbstractServerTest {
      */
     @Test
     public void testBadClassName() throws Exception {
-        final DiskUsage request = Requests.diskUsage().target("NoClass").id(1L).build();
+        final DiskUsage2 request = Requests.diskUsage().target("NoClass").id(1L).build();
         doChange(client, factory, request, false, null);
     }
 }

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -759,7 +759,7 @@ Examples:
                 args.obj.append(
                     "ExperimenterGroup:%s" % ",".join(map(str, gids)))
 
-        req.objects, req.classes = self._usage_obj(args.obj)
+        req.targetObjects, req.targetClasses = self._usage_obj(args.obj)
         cb = None
         try:
             rsp, status, cb = self.response(client, req, wait=args.wait)

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -743,10 +743,10 @@ Examples:
     # then the size returned would be identical to:
     bin/omero fs usage Project:1,2 --units M
         """
-        from omero.cmd import DiskUsage
+        from omero.cmd import DiskUsage2
 
         client = self.ctx.conn(args)
-        req = DiskUsage()
+        req = DiskUsage2()
         if not args.obj:
             admin = client.sf.getAdminService()
             uid = admin.getEventContext().userId


### PR DESCRIPTION
Changes the `DiskUsage` request to use the graph machinery instead of its own different implementation of graph traversal. Behavior should be unchanged except for reporting attachments as `FileAnnotation` instead of `Annotation`. Note that this can be accessed from the CLI via the `bin/omero fs usage` subcommand (see the `--report` option).