### PR TITLE
remove obsolete database check

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -103,28 +103,6 @@ BEGIN
     RETURN ur || uw || gr || gw || wr || ww;
 END;' LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION omero_43_check_pg_advisory_lock() RETURNS void AS '
-DECLARE
-    txt text;
-BEGIN
-      BEGIN
-        PERFORM pg_advisory_lock(1, 1);
-        PERFORM pg_advisory_unlock(1, 1);
-      EXCEPTION
-        WHEN undefined_function THEN
-         txt := chr(10) ||
-            ''====================================================================================='' || chr(10) ||
-            ''pg_advisory_lock does not exist!'' || chr(10) || chr(10) ||
-            ''You must upgrade to PostgreSQL 8.2 or above'' || chr(10) ||
-            ''====================================================================================='' || chr(10) || chr(10);
-         -- 8.1 is unsupported starting with OMERO4.3 (See #4902)
-         RAISE EXCEPTION ''%%'', txt;
-      END;
-END;' LANGUAGE plpgsql;
-SELECT omero_43_check_pg_advisory_lock();
-DROP FUNCTION omero_43_check_pg_advisory_lock();
-
-
 
 set constraints all deferred;
 

--- a/sql/psql/OMERO5.3DEV__3/psql-footer.sql
+++ b/sql/psql/OMERO5.3DEV__3/psql-footer.sql
@@ -729,28 +729,6 @@ BEGIN
     RETURN ur || uw || gr || gw || wr || ww;
 END;' LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION omero_43_check_pg_advisory_lock() RETURNS void AS '
-DECLARE
-    txt text;
-BEGIN
-      BEGIN
-        PERFORM pg_advisory_lock(1, 1);
-        PERFORM pg_advisory_unlock(1, 1);
-      EXCEPTION
-        WHEN undefined_function THEN
-         txt := chr(10) ||
-            ''====================================================================================='' || chr(10) ||
-            ''pg_advisory_lock does not exist!'' || chr(10) || chr(10) ||
-            ''You must upgrade to PostgreSQL 8.2 or above'' || chr(10) ||
-            ''====================================================================================='' || chr(10) || chr(10);
-         -- 8.1 is unsupported starting with OMERO4.3 (See #4902)
-         RAISE EXCEPTION ''%%'', txt;
-      END;
-END;' LANGUAGE plpgsql;
-SELECT omero_43_check_pg_advisory_lock();
-DROP FUNCTION omero_43_check_pg_advisory_lock();
-
-
 
 set constraints all deferred;
 


### PR DESCRIPTION
Remove check for `pg_advisory_lock` which has been available since PostgreSQL 8.2.