### PR TITLE
expand integration testing for graphs operations

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
@@ -125,7 +125,7 @@ public class FindChildrenI extends FindChildren implements IRequest {
 
         if (CollectionUtils.isEmpty(typesOfChildren)) {
             final Exception e = new IllegalArgumentException("no types of children specified to find");
-            throw helper.cancel(new ERR(), e, "no-types");
+            throw helper.cancel(new ERR(), e, "bad-options");
         }
 
         classesToFind.addAll(graphHelper.getClassesFromNames(typesOfChildren));
@@ -133,7 +133,12 @@ public class FindChildrenI extends FindChildren implements IRequest {
         final Set<String> targetClassNames = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(targetObjects.keySet()));
         final Set<String> childTypeNames = graphHelper.getTopLevelNames(classesToFind);
         final Set<String> currentStopBefore = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(stopBefore));
-        final Set<String> suggestedStopBefore = StopBeforeHelper.get().getStopBeforeChildren(targetClassNames, childTypeNames);
+        final Set<String> suggestedStopBefore;
+        try {
+            suggestedStopBefore = StopBeforeHelper.get().getStopBeforeChildren(targetClassNames, childTypeNames);
+        } catch (IllegalArgumentException e) {
+            throw helper.cancel(new ERR(), e, "bad-options");
+        }
         final Set<String> extraStopBefore = Sets.difference(suggestedStopBefore, currentStopBefore);
         stopBefore.addAll(extraStopBefore);
         if (!extraStopBefore.isEmpty() && LOGGER.isDebugEnabled()) {

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -125,7 +125,7 @@ public class FindParentsI extends FindParents implements IRequest {
 
         if (CollectionUtils.isEmpty(typesOfParents)) {
             final Exception e = new IllegalArgumentException("no types of parents specified to find");
-            throw helper.cancel(new ERR(), e, "no-types");
+            throw helper.cancel(new ERR(), e, "bad-options");
         }
 
         classesToFind.addAll(graphHelper.getClassesFromNames(typesOfParents));
@@ -133,7 +133,12 @@ public class FindParentsI extends FindParents implements IRequest {
         final Set<String> targetClassNames = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(targetObjects.keySet()));
         final Set<String> parentTypeNames = graphHelper.getTopLevelNames(classesToFind);
         final Set<String> currentStopBefore = graphHelper.getTopLevelNames(graphHelper.getClassesFromNames(stopBefore));
-        final Set<String> suggestedStopBefore = StopBeforeHelper.get().getStopBeforeParents(targetClassNames, parentTypeNames);
+        final Set<String> suggestedStopBefore;
+        try {
+            suggestedStopBefore = StopBeforeHelper.get().getStopBeforeParents(targetClassNames, parentTypeNames);
+        } catch (IllegalArgumentException e) {
+            throw helper.cancel(new ERR(), e, "bad-options");
+        }
         final Set<String> extraStopBefore = Sets.difference(suggestedStopBefore, currentStopBefore);
         stopBefore.addAll(extraStopBefore);
         if (!extraStopBefore.isEmpty() && LOGGER.isDebugEnabled()) {

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1387,7 +1387,7 @@ public class DuplicationTest extends AbstractServerTest {
      * @return group permissions for container permissions test cases
      */
     @DataProvider(name = "container permissions test cases")
-    public Object[][] providePrivateGroupFailureCases() {
+    public Object[][] provideContainerPermissionsCases() {
         int index = 0;
         final int GROUP_PERMS = index++;
         final int MY_CONTAINER = index++;

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1096,6 +1096,7 @@ public class DuplicationTest extends AbstractServerTest {
         assertSameProperties(originalLine, duplicateLine);
         assertSameProperties(originalPoint, duplicatePoint);
 }
+
     /**
      * Test duplication of an annotated image with various annotation types treated differently.
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/FindParentsChildrenTest.java
+++ b/components/tools/OmeroJava/test/integration/FindParentsChildrenTest.java
@@ -682,4 +682,26 @@ public class FindParentsChildrenTest extends AbstractServerTest {
         final FindChildren finder = Requests.findChildren().target(images.get(0)).build();
         doChange(client, factory, finder, false);
     }
+
+    /**
+     * Specify to find image containers that are not all mapped by the finder's hierarchy.
+     * The search should fail.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testUnknownParentTypes() throws Exception {
+        final FindParents finder = Requests.findParents().target(images.get(0)).parentType("Project", "Event").build();
+        doChange(client, factory, finder, false);
+    }
+
+    /**
+     * Specify to find image contents that are not all mapped by the finder's hierarchy.
+     * The search should fail.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testUnknownChildTypes() throws Exception {
+        final FindChildren finder = Requests.findChildren().target(images.get(0)).childType("Detector", "Event").build();
+        doChange(client, factory, finder, false);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -943,7 +943,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Pixels createPixels() throws Exception {
-        return createPixels(SIZE_X, SIZE_Y, SIZE_Y, SIZE_Y,
+        return createPixels(SIZE_X, SIZE_Y, SIZE_Z, SIZE_T,
                 DEFAULT_CHANNELS_NUMBER);
     }
 
@@ -1002,8 +1002,40 @@ public class ModelMockFactory {
      */
     public Plate createPlate(int rows, int columns, int fields,
             int numberOfPlateAcquisition, boolean fullImage) throws Exception {
+        return fullImage ?
+                createPlate(rows, columns, fields, numberOfPlateAcquisition, 1, 1, 1, 1, 1) :
+                createPlate(rows, columns, fields, numberOfPlateAcquisition, 0, 0, 0, 0, 0);
+    }
+
+    /**
+     * Creates a plate.
+     *
+     * @param rows
+     *            The number of rows.
+     * @param columns
+     *            The number of columns.
+     * @param fields
+     *            The number of fields.
+     * @param numberOfPlateAcquisition
+     *            The number of plate acquisitions.
+     * @param sizeX
+     *            The size along the X-axis.
+     * @param sizeY
+     *            The size along the Y-axis.
+     * @param sizeZ
+     *            The number of Z-sections.
+     * @param sizeT
+     *            The number of time-points.
+     * @param sizeC
+     *            The number of channels.
+     * @return See above.
+     */
+    public Plate createPlate(int rows, int columns, int fields,
+            int numberOfPlateAcquisition, int sizeX, int sizeY, int sizeZ, int sizeT,
+            int sizeC) throws Exception {
         if (numberOfPlateAcquisition < 0)
             numberOfPlateAcquisition = 0;
+        final boolean fullImage = sizeX > 0 && sizeY > 0 && sizeZ > 0 && sizeT > 0 && sizeC > 0;
         Plate p = new PlateI();
         p.setRows(omero.rtypes.rint(rows));
         p.setColumns(omero.rtypes.rint(columns));
@@ -1032,7 +1064,7 @@ public class ModelMockFactory {
                     for (int field = 0; field < fields; field++) {
                         sample = new WellSampleI();
                         if (fullImage)
-                            sample.setImage(createImage());
+                            sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC));
                         else
                             sample.setImage(simpleImage());
                         well.addWellSample(sample);
@@ -1044,7 +1076,7 @@ public class ModelMockFactory {
                         for (int field = 0; field < fields; field++) {
                             sample = new WellSampleI();
                             if (fullImage)
-                                sample.setImage(createImage());
+                                sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC));
                             else
                                 sample.setImage(simpleImage());
                             well.addWellSample(sample);

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -10,6 +10,7 @@ import integration.AbstractServerTest;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import ome.testing.ObjectFactory;
 
@@ -24,6 +25,8 @@ import omero.model.AnnotationAnnotationLink;
 import omero.model.AnnotationAnnotationLinkI;
 import omero.model.Dataset;
 import omero.model.DatasetI;
+import omero.model.ExternalInfo;
+import omero.model.ExternalInfoI;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
 import omero.model.IObject;
@@ -591,6 +594,28 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         assertGone(ann);
         assertGone(file);
 
+    }
+
+    /**
+     * Test that deleting an project also deletes its external information.
+     * @throws Exception unexpected
+     */
+    @Test(groups = "ticket:13176")
+    public void testDeleteExternalInfoWithProject() throws Exception {
+        ExternalInfo info = new ExternalInfoI();
+        info.setEntityType(omero.rtypes.rstring("ExternalEntity"));
+        info.setEntityId(omero.rtypes.rlong(0));
+        info.setUuid(omero.rtypes.rstring(UUID.randomUUID().toString()));
+        info = (ExternalInfo) iUpdate.saveAndReturnObject(info).proxy();
+
+        IObject object = mmFactory.simpleProject();
+        object.getDetails().setExternalInfo(info);
+        object = iUpdate.saveAndReturnObject(object).proxy();
+
+        doChange(Requests.delete().target(object).build());
+
+        assertGone(object);
+        assertGone(info);
     }
 
     private FileAnnotationI mockAnnotation()

--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @since 4.4.9
  */
-public class DeleteProjectedImageTest  extends AbstractServerTest {
+public class DeleteProjectedImageTest extends AbstractServerTest {
 
     /** Indicates to delete the source image. */
     private static final int SOURCE_IMAGE = 0;

--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -9,6 +9,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -23,6 +24,7 @@ import omero.model.Pixels;
 import omero.sys.EventContext;
 
 import org.springframework.util.ResourceUtils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -42,6 +44,9 @@ public class DeleteProjectedImageTest extends AbstractServerTest {
 
     /** Indicates to delete the both images. */
     private static final int BOTH_IMAGES = 2;
+
+    /* the IDs of the images left over by the tests */
+    private final List<Long> remainingImageIds = new ArrayList<Long>();
 
     /**
      * Imports the small dv.
@@ -148,16 +153,28 @@ public class DeleteProjectedImageTest extends AbstractServerTest {
             assertNull(iQuery.find(Image.class.getSimpleName(), id));
             //check that the projected image is still there
             assertNotNull(iQuery.find(Image.class.getSimpleName(), projectedID));
+            remainingImageIds.add(projectedID);
             break;
         case PROJECTED_IMAGE:
             assertNull(iQuery.find(Image.class.getSimpleName(), projectedID));
            //check that the original image is still there
             assertNotNull(iQuery.find(Image.class.getSimpleName(), id));
+            remainingImageIds.add(id);
             break;
         case BOTH_IMAGES:
             assertNull(iQuery.find(Image.class.getSimpleName(), projectedID));
             assertNull(iQuery.find(Image.class.getSimpleName(), id));
         }
+    }
+
+    /**
+     * Delete the images left over from the tests.
+     * @throws Exception unexpected
+     */
+    @AfterClass
+    public void cleanUpRemainingImages() throws Exception {
+        doChange(root, root.getSession(), Requests.delete().target("Image").id(remainingImageIds).build(), true);
+        remainingImageIds.clear();
     }
 
     /**


### PR DESCRIPTION
Adds stricter argument checking for `FindParents` and `FindChildren` and extra tests for:

* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration/DuplicationTest/
* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration/FindParentsChildrenTest/
* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.chmod/PermissionsTest/
* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.delete/AdditionalDeleteTest/

CI should remain a pleasing shade of blue.