### PR TITLE
Robot remote driver

### DIFF
--- a/components/tests/ui/plugins/robot.py
+++ b/components/tests/ui/plugins/robot.py
@@ -41,6 +41,9 @@ class RobotControl(BaseControl):
             help="Protocol to use for the OMERO.web robot tests."
             " Default: http")
         config.add_argument(
+            "--webhost", type=str,
+            help="Web host to use for the OMERO.web robot tests.")
+        config.add_argument(
             "--remoteurl", type=str, default="",
             help="The url for a remote selenium server for example"
             " http://selenium_server_host/wd/hub. Default: False")
@@ -82,11 +85,13 @@ class RobotControl(BaseControl):
         d["WEBPREFIX"] = static_prefix
         d["QWEBPREFIX"] = urllib.quote(static_prefix, '')
         d["QSEP"] = urllib.quote('/', '')
-        if settings.APPLICATION_SERVER in settings.WSGI_TYPES:
-            d["WEBHOST"] = d["HOST"]
-        else:
+        if args.webhost:
+            d["WEBHOST"] = args.webhost
+        elif settings.APPLICATION_SERVER not in settings.WSGI_TYPES:
             d["WEBHOST"] = "%s:%s" % (settings.APPLICATION_SERVER_HOST,
                                       settings.APPLICATION_SERVER_PORT)
+        else:
+            d["WEBHOST"] = d["HOST"]
 
         # Read robot.template file and substitute keywords
         c = file(self.ctx.dir / "etc" / "templates" / "robot.template").read()

--- a/components/tests/ui/plugins/robot.py
+++ b/components/tests/ui/plugins/robot.py
@@ -41,9 +41,17 @@ class RobotControl(BaseControl):
             help="Protocol to use for the OMERO.web robot tests."
             " Default: http")
         config.add_argument(
-            "--remoteurl", type=str, default="False",
+            "--remoteurl", type=str, default="",
             help="The url for a remote selenium server for example"
             " http://selenium_server_host/wd/hub. Default: False")
+        config.add_argument(
+            "--dc", type=str, default="",
+            help="If you specify a value for remote you can also specify"
+            " 'desired_capabilities' which is a string in the form"
+            " key1:val1,key2:val2 that will be used to specify"
+            " desired_capabilities to the remote server. This is useful"
+            " for doing things like specify a proxy server or for specify"
+            " browser and os.")
 
     def config(self, args):
         """Generate a configuration file for the Robot framework tests"""
@@ -64,6 +72,7 @@ class RobotControl(BaseControl):
             "ROOTPASS": p.getPropertyWithDefault("omero.rootpass", "omero"),
             "PROTOCOL": args.protocol,
             "REMOTEURL": args.remoteurl,
+            "DC": args.dc,
         }
 
         # Add OMERO.web substitutions

--- a/components/tests/ui/plugins/robot.py
+++ b/components/tests/ui/plugins/robot.py
@@ -40,6 +40,10 @@ class RobotControl(BaseControl):
             "--protocol", type=str, default="http",
             help="Protocol to use for the OMERO.web robot tests."
             " Default: http")
+        config.add_argument(
+            "--remoteurl", type=str, default="False",
+            help="The url for a remote selenium server for example"
+            " http://selenium_server_host/wd/hub. Default: False")
 
     def config(self, args):
         """Generate a configuration file for the Robot framework tests"""
@@ -59,6 +63,7 @@ class RobotControl(BaseControl):
             "PASS": p.getPropertyWithDefault("omero.pass", "omero"),
             "ROOTPASS": p.getPropertyWithDefault("omero.rootpass", "omero"),
             "PROTOCOL": args.protocol,
+            "REMOTEURL": args.remoteurl,
         }
 
         # Add OMERO.web substitutions

--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -19,6 +19,7 @@ ${WEB PREFIX}           %(WEBPREFIX)s
 ${SERVER_ID}            1
 
 ${REMOTE_URL}           %(REMOTEURL)s
+${DC}                   %(DC)s
 ${BROWSER}              Firefox
 ${DELAY}                0
 ${WAIT}                 50

--- a/components/tests/ui/resources/robot.template
+++ b/components/tests/ui/resources/robot.template
@@ -18,6 +18,7 @@ ${WEB HOST}             %(WEBHOST)s
 ${WEB PREFIX}           %(WEBPREFIX)s
 ${SERVER_ID}            1
 
+${REMOTE_URL}           %(REMOTEURL)s
 ${BROWSER}              Firefox
 ${DELAY}                0
 ${WAIT}                 50

--- a/components/tests/ui/resources/web/login.txt
+++ b/components/tests/ui/resources/web/login.txt
@@ -32,7 +32,7 @@ Login Page Should Be Open
 
 Open Browser To Login Page
     [Arguments]                 ${main url}=${LOGIN URL}    ${login url}=${LOGIN URL}     ${title}=OMERO.web - Login
-    Open Browser                ${main url}         ${BROWSER}
+    Open Browser                ${main url}         ${BROWSER}      remote_url=${REMOTE_URL}
     Set Selenium Speed          ${DELAY}
     Login Page Should Be Open   ${login url}        ${title}
 

--- a/components/tests/ui/resources/web/login.txt
+++ b/components/tests/ui/resources/web/login.txt
@@ -32,7 +32,7 @@ Login Page Should Be Open
 
 Open Browser To Login Page
     [Arguments]                 ${main url}=${LOGIN URL}    ${login url}=${LOGIN URL}     ${title}=OMERO.web - Login
-    Open Browser                ${main url}         ${BROWSER}      remote_url=${REMOTE_URL}
+    Open Browser                ${main url}         ${BROWSER}      remote_url=${REMOTE_URL}    desired_capabilities=${DC}
     Set Selenium Speed          ${DELAY}
     Login Page Should Be Open   ${login url}        ${title}
 

--- a/components/tests/ui/resources/web/webadmin.txt
+++ b/components/tests/ui/resources/web/webadmin.txt
@@ -24,7 +24,7 @@ Log In As Root
 
 Open Browser To Login Page
     [Arguments]                 ${main url}     ${login url}
-    Open Browser                ${main url}     ${BROWSER}
+    Open Browser                ${main url}     ${BROWSER}          remote_url=${REMOTE_URL}
     Set Selenium Speed          ${DELAY}
     Page Should Be Open         ${login url}    OMERO.web - Login
 

--- a/components/tests/ui/resources/web/webadmin.txt
+++ b/components/tests/ui/resources/web/webadmin.txt
@@ -24,7 +24,7 @@ Log In As Root
 
 Open Browser To Login Page
     [Arguments]                 ${main url}     ${login url}
-    Open Browser                ${main url}     ${BROWSER}          remote_url=${REMOTE_URL}
+    Open Browser                ${main url}     ${BROWSER}          remote_url=${REMOTE_URL}    desired_capabilities=${DC}
     Set Selenium Speed          ${DELAY}
     Page Should Be Open         ${login url}    OMERO.web - Login
 


### PR DESCRIPTION
Allow running robot tests using selenium remote server

test via selenium hub https://github.com/openmicroscopy/devspace/pull/20

test locally using:

```
dist/bin/omero --path components/tests/ui/plugins robot config --protocol http --webhost 'your_webserver' --remoteurl 'http://develop-seleniumhub.docker.openmicroscopy.org:4444/wd/hub' --dc 'browserName:${BROWSER},javascriptEnabled:True' > components/tests/ui/resources/config.txt

./build.py -f components/tests/ui/build.xml web-firefox -DTEST=view_image.txt
```