### PR TITLE
Warn when a 404 occurs due to a SecurityViolation in webgateway.views (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1971,6 +1971,8 @@ def full_viewer(request, iid, conn=None, **kwargs):
         c = Context(request, d)
         rsp = t.render(c)
     except omero.SecurityViolation:
+        logger.warn("SecurityViolation in Image:%s", iid)
+        logger.warn(traceback.format_exc())
         raise Http404
     return HttpResponse(rsp)
 


### PR DESCRIPTION
This is the same as gh-4410 but rebased onto develop.

----

Additional logging to try and debug a mysterious 404, suggested by @aleksandra-tarkowska 

Unfortunately I have no idea how to intentionally trigger this error