### PR TITLE
rewrite how to access information on Quartz cron expressions

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -346,9 +346,12 @@ omero.metrics.slf4j_minutes=60
 # .. |cron| replace::
 #   Cron Format: seconds minutes hours day-of-month month day-of-week year
 #   (optional). For example, "0,30 * * * * ?" is equivalent to running every
-#   30 seconds. For more information, see the `CronTrigger Tutorial`_.
+#   30 seconds. For more information download the latest *1.x version* of
+#   the `Quartz Job Scheduler`_ and review
+#   :file:`docs/api/org/quartz/CronExpression.html` within the distribution.
 #
-# .. _CronTrigger Tutorial: http://quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger
+# .. _Quartz Job Scheduler:
+#   http://www.quartz-scheduler.org/downloads/
 #
 # |cron|
 omero.pixeldata.cron=*/4 * * * * ?


### PR DESCRIPTION
Unfortunately the version of Quartz we use is so ancient that one must now dig somewhat to find documentation. Companion to https://github.com/openmicroscopy/ome-documentation/pull/1446.