### PR TITLE
Shape renaming: examples review

### DIFF
--- a/examples/RegionsOfInterest/Main.cpp
+++ b/examples/RegionsOfInterest/Main.cpp
@@ -8,5 +8,5 @@ using namespace omero::rtypes;
 int main() {
         RoiPtr roi = new RoiI();
         EllipsePtr ellipse = new EllipseI();
-        ellipse->setCx(rdouble(1));
+        ellipse->setX(rdouble(1));
 }

--- a/examples/RegionsOfInterest/Main.java
+++ b/examples/RegionsOfInterest/Main.java
@@ -55,18 +55,18 @@ public class Main {
 
         // A real ellipse
         Ellipse ellipse = new EllipseI();
-        ellipse.setCx(rdouble(1));
-        ellipse.setCy(rdouble(1));
-        ellipse.setRx(rdouble(1));
-        ellipse.setRy(rdouble(2));
+        ellipse.setX(rdouble(1));
+        ellipse.setY(rdouble(1));
+        ellipse.setRadiusX(rdouble(1));
+        ellipse.setRadiusY(rdouble(2));
         roi.addShape(ellipse);
 
         // A circle as an ellipse
         Ellipse circle = new EllipseI();
-        circle.setCx(rdouble(5));
-        circle.setCy(rdouble(8));
-        circle.setRx(rdouble(1));
-        circle.setRy(rdouble(1)); // Same radius
+        circle.setX(rdouble(5));
+        circle.setY(rdouble(8));
+        circle.setRadiusX(rdouble(1));
+        circle.setRadiusY(rdouble(1)); // Same radius
         roi.addShape(circle);
 
         // Making a grouping of lines
@@ -131,8 +131,8 @@ public class Main {
         mask.setPixels(new PixelsI(0, false));
 
         Point point = new PointI();
-        point.setCx(rdouble(75.0));
-        point.setCy(rdouble(75.0));
+        point.setX(rdouble(75.0));
+        point.setY(rdouble(75.0));
         // Point.r should be removed
         point.setTransform(null);
         roi.addShape(point);

--- a/examples/RegionsOfInterest/Main.py
+++ b/examples/RegionsOfInterest/Main.py
@@ -6,4 +6,4 @@ from omero.rtypes import rdouble
 
 roi = omero.model.RoiI()
 ellipse = omero.model.EllipseI()
-ellipse.setCx(rdouble(1))
+ellipse.setX(rdouble(1))

--- a/examples/Training/java/src/training/ROIs.java
+++ b/examples/Training/java/src/training/ROIs.java
@@ -147,10 +147,10 @@ public class ROIs
         roi.addShape(rect); //Add the shape
         //Create an ellipse.
         Ellipse ellipse = new EllipseI();
-        ellipse.setCx(omero.rtypes.rdouble(10));
-        ellipse.setCy(omero.rtypes.rdouble(10));
-        ellipse.setRx(omero.rtypes.rdouble(10));
-        ellipse.setRy(omero.rtypes.rdouble(10));
+        ellipse.setX(omero.rtypes.rdouble(10));
+        ellipse.setY(omero.rtypes.rdouble(10));
+        ellipse.setRadiusX(omero.rtypes.rdouble(10));
+        ellipse.setRadiusY(omero.rtypes.rdouble(10));
         ellipse.setTheZ(omero.rtypes.rint(1));
         ellipse.setTheT(omero.rtypes.rint(0));
         ellipse.setTextValue(omero.rtypes.rstring("ellipse text"));
@@ -167,8 +167,8 @@ public class ROIs
         roi.addShape(line);
         //Create a point
         Point point = new PointI();
-        point.setCx(omero.rtypes.rdouble(75.0));
-        point.setCy(omero.rtypes.rdouble(75.0));
+        point.setX(omero.rtypes.rdouble(75.0));
+        point.setY(omero.rtypes.rdouble(75.0));
         point.setTheZ(omero.rtypes.rint(0));
         point.setTheT(omero.rtypes.rint(0));
         point.setTransform(null);

--- a/examples/Training/matlab/ROIs.m
+++ b/examples/Training/matlab/ROIs.m
@@ -119,25 +119,25 @@ try
             y = shape.getY().getValue();
             width = shape.getWidth().getValue();
             height = shape.getHeight().getValue();
-            fprintf(1, '  Rectangle x: %g, y: %g, width: %g, height: %g\n',...
+            fprintf(1, '  Rectangle X: %g, Y: %g, Width: %g, Height: %g\n',...
                 x, y, width, height);      
         elseif (isa(shape, 'omero.model.Ellipse'))
-            cx = shape.getX().getValue();
-            cy = shape.getY().getValue();
-            rx = shape.getRadiusX().getValue();
-            ry = shape.getRadiusY().getValue();
-            fprintf(1, '  Ellipse x: %g, y: %g, rx: %g, ry: %g\n',...
-                cx, cy, rx, ry);
+            x = shape.getX().getValue();
+            y = shape.getY().getValue();
+            radiusx = shape.getRadiusX().getValue();
+            radiusy = shape.getRadiusY().getValue();
+            fprintf(1, '  Ellipse X: %g, Y: %g, RadiusX: %g, RadiusY: %g\n',...
+                x, y, radiusx, radiusy);
         elseif (isa(shape, 'omero.model.Point'))
-            cx = shape.getX().getValue();
-            cy = shape.getY().getValue();
-            fprintf(1, '  Point x: %g, y: %g\n', cx, cy);
+            x = shape.getX().getValue();
+            y = shape.getY().getValue();
+            fprintf(1, '  Point X: %g, Y: %g\n', x, y);
         elseif (isa(shape, 'omero.model.Line'))
             x1 = shape.getX1().getValue();
             x2 = shape.getX2().getValue();
             y1 = shape.getY1().getValue();
             y2 = shape.getY2().getValue();
-            fprintf(1, '  Line (x1, y1): (%g, %g), (x2, y2): (%g, %g)\n',...
+            fprintf(1, '  Line (X1, Y1): (%g, %g), (X2, Y2): (%g, %g)\n',...
                 x1, y1, x2, y2);
         elseif isa(shape, 'omero.model.Polyline')
             points = shape.getPoints().getValue();

--- a/examples/Training/python/Advanced/Simple_FRAP.py
+++ b/examples/Training/python/Advanced/Simple_FRAP.py
@@ -36,7 +36,8 @@ image = conn.getObject('Image', imageId)
 # =================================================================
 def getEllipses(conn, imageId):
     """
-    Returns the a dict of tIndex: {'cx':cx, 'cy':cy, 'rx':rx, 'ry':ry, 'z':z}
+    Returns the a dict of tIndex:
+    {'x':x, 'y':y, 'radiusX':radiusX, 'radiusY':radiusY, 'z':z}
     NB: Assume only 1 ellipse per time point
 
     @param conn:    BlitzGateway connection
@@ -50,36 +51,38 @@ def getEllipses(conn, imageId):
     for roi in result.rois:
         for shape in roi.copyShapes():
             if type(shape) == omero.model.EllipseI:
-                cx = int(shape.getX().getValue())
-                cy = int(shape.getY().getValue())
-                rx = int(shape.getRadiusX().getValue())
-                ry = int(shape.getRadiusY().getValue())
+                x = int(shape.getX().getValue())
+                y = int(shape.getY().getValue())
+                radiusX = int(shape.getRadiusX().getValue())
+                radiusY = int(shape.getRadiusY().getValue())
                 z = int(shape.getTheZ().getValue())
                 t = int(shape.getTheT().getValue())
-                ellipses[t] = {'cx': cx, 'cy': cy, 'rx': rx, 'ry': ry, 'z': z}
+                ellipses[t] = {'x': x, 'y': y, 'radiusX': radiusX,
+                               'radiusY': radiusY, 'z': z}
     return ellipses
 
 
 def getEllipseData(image, ellipses):
     """ Returns a dict of t:averageIntensity for all ellipses.
 
-    @param ellipse:     The ellipse defined as a tuple (cx, cy, rx, ry, z, t)
+    @param ellipse:     The ellipse defined as a tuple
+                        (x, y, radiusX, radiusY, z, t)
     @returns:           A list of (x,y) points for the ellipse
     """
     data = {}
     for t, e in ellipses.items():
-        cx = e['cx']
-        cy = e['cy']
-        rx = e['rx']
-        ry = e['ry']
+        x = e['x']
+        y = e['y']
+        radiusX = e['radiusX']
+        radiusY = e['radiusY']
 
         # find bounding box of ellipse
-        xStart = cx - rx
-        xEnd = cx + rx
-        yStart = cy - ry
-        yEnd = cy + ry
-        width = rx * 2
-        height = ry * 2
+        xStart = x - radiusX
+        xEnd = x + radiusX
+        yStart = y - radiusY
+        yEnd = y + radiusY
+        width = radiusX * 2
+        height = radiusY * 2
 
         # get pixel data for the 'tile'
         tileData = image.getPrimaryPixels().getTile(
@@ -87,11 +90,12 @@ def getEllipseData(image, ellipses):
 
         # find the pixels within the ellipse
         pixelValues = []
-        for x in range(xStart, xEnd):
-            for y in range(yStart, yEnd):
-                dx = x - e['cx']
-                dy = y - e['cy']
-                r = float(dx*dx)/float(rx*rx) + float(dy*dy)/float(ry*ry)
+        for x0 in range(xStart, xEnd):
+            for y0 in range(yStart, yEnd):
+                dx = x0 - e['x']
+                dy = y0 - e['y']
+                r = (float(dx*dx)/float(radiusX*radiusX) +
+                     float(dy*dy)/float(radiusY*radiusY))
                 if r <= 1:
                     pixelValues.append(tileData[dx][dy])
         # get the average intensity

--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -218,14 +218,14 @@ for roi in result.rois:
             shape['height'] = s.getHeight().getValue()
         elif type(s) == omero.model.EllipseI:
             shape['type'] = 'Ellipse'
-            shape['cx'] = s.getX().getValue()
-            shape['cy'] = s.getY().getValue()
-            shape['rx'] = s.getRadiusX().getValue()
-            shape['ry'] = s.getRadiusY().getValue()
+            shape['x'] = s.getX().getValue()
+            shape['y'] = s.getY().getValue()
+            shape['radiusX'] = s.getRadiusX().getValue()
+            shape['radiusY'] = s.getRadiusY().getValue()
         elif type(s) == omero.model.PointI:
             shape['type'] = 'Point'
-            shape['cx'] = s.getX().getValue()
-            shape['cy'] = s.getY().getValue()
+            shape['x'] = s.getX().getValue()
+            shape['y'] = s.getY().getValue()
         elif type(s) == omero.model.LineI:
             shape['type'] = 'Line'
             shape['x1'] = s.getX1().getValue()


### PR DESCRIPTION
See https://trello.com/c/LW8l7U8x/20-shape-attribute-renaming-cleanup

This PR reviews the variable/methods used when retrieving Point and Ellipse attributes in the `examples` directory. In particular the output of the two following greps should return nothing:

```
$ git grep -I [sg]et[RrCc][xy] -- examples
$ git grep -I [^a-zA-Z][RrCc][XxYy] -- examples
```