### PR TITLE
Full viewer button link

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -287,6 +287,12 @@ Wait Until Right Panel Loads Everything
     
     Run Keyword If                  '${containerType}' == 'Project'        Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Creation Date:')]
     Run Keyword If                  '${containerType}' == 'Dataset'        Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Creation Date:')]
+    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Tags')]
+    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Key-Value Pairs')]
+    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Attachments')]
+    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Ratings')]
+    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Comments')]
+
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Acquisition Date:')]
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Import Date:')]
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Dimensions (XY):')]
@@ -295,13 +301,7 @@ Wait Until Right Panel Loads Everything
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Z-sections/Timepoints:')]
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Channels:')]
     Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'ROI Count:')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Tags')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Key-Value Pairs')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Attachments')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Ratings')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Comments')]
-
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/button/span[contains(text(),'Full viewer')]
+    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/a/span[contains(text(),'Full viewer')]
     Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/div/button[contains(@title,'Publishing Options')]
     Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="show_fs_files_btn"]
     Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="show_image_hierarchy"]

--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -11,7 +11,7 @@ ${orphanedIcon}                 webclient/image/folder_yellow16.png
 ${plateIcon}                    webclient/image/folder_plate16.png
 ${runIcon}                      webclient/image/run16.png
 
-${datasetDetails}               xpath=//*[@id="general_tab"]/h1[contains(@data-name,'details')]/following-sibling::div
+${detailsPane}               xpath=//*[@id="general_tab"]/h1[contains(@data-name,'details')]/following-sibling::div
 *** Keywords ***
 
 Get Dialog Button Xpath
@@ -280,33 +280,34 @@ Wait Until Right Panel Loads
     Wait Until Element Is Visible                           xpath=//tr[contains(@class,'data_heading_id')]/td/strong[(text() = '${containerId}')]
 
 Wait Until Right Panel Loads Everything
-    [Arguments]                     ${containerType}        ${containerId}
+    [Arguments]                         ${containerType}        ${containerId}
 
-    Wait Until Right Panel Loads    ${containerType}        ${containerId}
-    Wait Until Element Is Visible                           xpath=//*[@id="general_tab"]/h1[contains(text(),'${containerType} Details')]
-    
-    Run Keyword If                  '${containerType}' == 'Project'        Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Creation Date:')]
-    Run Keyword If                  '${containerType}' == 'Dataset'        Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Creation Date:')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Tags')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Key-Value Pairs')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Attachments')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Ratings')]
-    Wait Until Element Is Visible                       xpath=//*[@id="general_tab"]/h1[contains(text(),'Comments')]
+    Wait Until Right Panel Loads        ${containerType}        ${containerId}
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'${containerType} Details')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'Tags')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'Key-Value Pairs')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'Attachments')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'Ratings')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/h1[contains(text(),'Comments')]
+    Run Keyword If                      '${containerType}' == 'Project'        Wait Until Element Is Visible     ${detailsPane}//th[contains(text(),'Creation Date:')]
+    Run Keyword If                      '${containerType}' == 'Dataset'        Wait Until Element Is Visible     ${detailsPane}//th[contains(text(),'Creation Date:')]
+    Run Keyword If                      '${containerType}' == 'Image'          Check Right Panel Image
 
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Acquisition Date:')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Import Date:')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Dimensions (XY):')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Pixels Type:')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Pixels Size (XYZ) (µm):')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Z-sections/Timepoints:')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'Channels:')]
-    Run Keyword If                  '${containerType}' == 'Image'          Wait Until Element Is Visible     ${datasetDetails}//th[contains(text(),'ROI Count:')]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/a/span[contains(text(),'Full viewer')]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/div/button[contains(@title,'Publishing Options')]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="show_fs_files_btn"]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="show_image_hierarchy"]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="show_link_btn"]
-    Run Keyword If                  '${containerType}' == 'Image'           Wait Until Element Is Visible     xpath=//*[@id="general_tab"]/div/div/button[contains(@title,'Download Image as...')]
+Check Right Panel Image
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Acquisition Date:')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Import Date:')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Dimensions (XY):')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Pixels Type:')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Pixels Size (XYZ) (µm):')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Z-sections/Timepoints:')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'Channels:')]
+    Wait Until Element Is Visible       ${detailsPane}//th[contains(text(),'ROI Count:')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/div/a/span[contains(text(),'Full viewer')]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/div/div/button[contains(@title,'Publishing Options')]
+    Wait Until Element Is Visible       xpath=//*[@id="show_fs_files_btn"]
+    Wait Until Element Is Visible       xpath=//*[@id="show_image_hierarchy"]
+    Wait Until Element Is Visible       xpath=//*[@id="show_link_btn"]
+    Wait Until Element Is Visible       xpath=//*[@id="general_tab"]/div/div/button[contains(@title,'Download Image as...')]
 
 Wait Until Center Panel Loads
     [Arguments]                     ${containerType}

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -239,9 +239,9 @@ Test Owners Rdef
     
     # Test 'Paste and Save' with right-click on different Image in tree
     # (check thumb refresh by change of src)
-    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/img@src
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/a/img@src
     Right Click Image Rendering Settings    ${imageId_2}            Paste and Save
-    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/img[@src!='${thumbSrc}']
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/a/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Select Image By Id                      ${imageId_2}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
@@ -249,9 +249,9 @@ Test Owners Rdef
     Textfield Value Should Be               wblitz-ch0-cw-end           200
 
     # Test Set Owner's in same way on first Image
-    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img@src
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/a/img@src
     Right Click Image Rendering Settings    ${imageId}            Set Owner's and Save
-    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img[@src!='${thumbSrc}']
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/a/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
@@ -259,9 +259,9 @@ Test Owners Rdef
     Textfield Value Should Be               wblitz-ch0-cw-end           100
 
     # Test "Set Imported" on first Image
-    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img@src
+    ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/a/img@src
     Right Click Image Rendering Settings    ${imageId}            Set Imported and Save
-    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/img[@src!='${thumbSrc}']
+    Wait Until Page Contains Element        xpath=//li[@id="image_icon-${imageId}"]/div[@class="image"]/a/img[@src!='${thumbSrc}']
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}

--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -39,7 +39,7 @@ Test Open Viewer
     ${nodeId}=                          Wait For Image Node         ${imageId}
     ${imageName}=                       Wait For General Panel And Return Name      Image
     # Open Image Viewer 3 different ways and check
-    Click Element                       xpath=//button[@title='Open full image viewer in new window']
+    Click Element                       xpath=//a[@title='Open full image viewer in new window']
     Check Image Viewer                  ${imageName}
     Double Click Element                xpath=//li[@id='image_icon-${imageId}']//img
     Check Image Viewer                  ${imageName}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -269,17 +269,19 @@
 
 
     {% if image %}
-    <button class="btn silver btn_text" href="#" style="position: absolute; left: 0; height: 20px"
+    <a class="btn silver btn_text" style="position: absolute; left: 0; height: 20px"
             {% if share and not share.share.isOwned %}
+                href="{% url 'web_image_viewer' share.share.id image.id %}"
                 onclick="return OME.openPopup('{% url 'web_image_viewer' share.share.id image.id %}')"
             {% else %}
+                href="{% url 'web_image_viewer' image.id %}"
                 onclick="return OME.openPopup('{% url 'web_image_viewer' image.id %}')"
             {% endif %}
             title="Open full image viewer in new window">
         <span>
             Full viewer
         </span>
-    </button>
+    </a>
     {% endif %}
 
 </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -329,10 +329,9 @@
             {% endif %}
 
 
-            $("#preview_open_viewer").click(function(){
-
-              var url = "{% if share and not share.share.isOwned %}{% url 'web_image_viewer' share.share.id manager.image.id %}{% else %}{% url 'web_image_viewer' manager.image.id %}{% endif %}";
-
+            $("#preview_open_viewer").click(function(event){
+              event.preventDefault();
+              var url = $(this).attr('href');
               var vpQuery = OME.preview_viewport.getQuery();
               // remove &zm=50
               vpQuery = vpQuery.replace("&zm=" + OME.preview_viewport.getZoom(), "");
@@ -351,11 +350,14 @@
 	
 <!-- open-image link -->
 
-			<button id="preview_open_viewer" class="btn silver btn_text" href="#" alt="View" title="Open full viewer" rel="{% content_identifier "preview" manager.image.id %}"> <!-- rel is used by robot framework, do not remove it! -->
+			<a id="preview_open_viewer"
+        href="{% if share and not share.share.isOwned %}{% url 'web_image_viewer' share.share.id manager.image.id %}{% else %}{% url 'web_image_viewer' manager.image.id %}{% endif %}"
+        class="btn silver btn_text" alt="View"
+        title="Open full viewer" rel="{% content_identifier 'preview' manager.image.id %}"> <!-- rel is used by robot framework, do not remove it! -->
 				<span>
                 {% trans "Full viewer" %} 
 				</span>
-			</button>
+			</a>
 
     <div style="clear:both; margin-bottom: 3px"></div>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -24,9 +24,12 @@
             data-owned="">
 
             <div class="image">
-                <img alt="image"
-                    src="<%= webindex %>render_thumbnail/size/96/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>"
-                        title="<%= img.name %>"/>
+                <!-- we wrap img with <a> so you can right-click -> open link in new tab -->
+                <a href="<%= webindex %><% if(img.shareId) {print( img.shareId + '/')} %>img_detail/<%= img.id %>/">
+                    <img alt="image"
+                         src="<%= webindex %>render_thumbnail/size/96/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>"
+                         title="<%= img.name %>"/>
+                </a>
             </div>
             <!-- NB: '#image_icon-123 div.desc' etc is used to update name when changed in right panel via "editinplace" -->
             <div class="desc" valign="middle">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -106,6 +106,7 @@ $(document).ready(function() {
 
         // single click handler on image (container). Selection then update toolbar & metadata pane
         $( "#icon_table" ).on( "click", "li.row", function(event) {
+            event.preventDefault();
             handleClickSelection(event);
         });
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -399,6 +399,8 @@ $(document).ready(function() {
         if (event.target.nodeName.toLowerCase() == 'li') {
             $targetIcon = $(event.target);
         } else if (event.target.nodeName.toLowerCase() == 'img') {
+            $targetIcon = $(event.target).parent().parent().parent();
+        } else if (event.target.nodeName.toLowerCase() == 'a') {
             $targetIcon = $(event.target).parent().parent();
         } else {
             $targetIcon = $(event.target).parent();


### PR DESCRIPTION
See https://trello.com/c/vRHQSsTs/59-full-viewer-button-to-be-link and https://github.com/openmicroscopy/openmicroscopy/issues/4558

This PR makes the thumbnails and the Full Viewer buttons into html ```<a>``` links which means you can right-click and "Open link in new tab".
To test:
 - Right-click on thumbnail -> open link in new tab. Repeat on other thumbnails.
 - Right-click on "Full Viewer" button -> open link in new tab.
 - Test "Full Viewer" button in General tab *and* Preview tab.
 - Check that images have been opened in a series of new tabs.

Also check that other clicks on thumbnails and button are still working OK - E.g. double-click thumb to open image in new window, selecting images, shift-select range of thumbs etc.