### PR TITLE
fix minor graph bugs in acquisition metadata for fake plates

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -134,20 +134,11 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [DI]" p:changes="L:[D]"/>
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].child = [DI]" p:changes="L:[D]"/>
 
-        <!-- Move settings if both holder and underlying object are moved. -->
+        <!-- Move settings if underlying object is moved. -->
 
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[ED], S.detector = [I]"
-                                       p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[ED], S.lightSource = [I]"
-                                       p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[ED], S.objective = [I]"
-                                       p:changes="S:[I]"/>
-
-        <!-- Delete settings if only the underlying object is moved. -->
-
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
 
         <!-- Images may be moved only if doing so would not remove an imaging environment from any of them. -->
 
@@ -442,11 +433,6 @@
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}" p:changes="P:{a}"/>
 
-        <!-- Delete remaining settings if holder object is moved. -->
-
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E]" p:changes="DS:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E]" p:changes="LS:[D]"/>
-
         <!-- Move a stage label only if all the images using it are moved. -->
 
         <bean parent="graphPolicyRule" p:matches="Image[E]{r}.stageLabel = SL:[E]{i}" p:changes="SL:{r}"/>
@@ -465,7 +451,22 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <!-- Move a logical channel only if all its channels are to be moved. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]{i}" p:changes="LC:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[E].logicalChannel = LC:[E]{r}" p:changes="LC:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E]{o}" p:changes="LC:[I]"/>
+
+        <!-- Cannot separate channels from logical channels. -->
+
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].channels = C:[I]"
+                                       p:error="cannot move {C} while {LC} remains"/>
+
+        <!-- Cannot separate channels from logical channels in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="$to_private, LC:LogicalChannel[I].channels =/!o C:[I]"
+                                       p:error="cannot move {LC} to a private group because its {C} is differently owned"/>
 
         <!-- Delete remaining settings if holder object is moved. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -143,6 +143,11 @@
         <bean parent="graphPolicyRule" p:matches="Image[E].stageLabel =/!o SL:[E]"
                                        p:error="cannot downgrade to private as {E} uses differently owned {SL}"/>
 
+        <!-- Cannot downgrade to a private group if the logical channels are owned differently from their channels. -->
+
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].channels =/!o C:[E]"
+                                       p:error="cannot downgrade to private as {LC} is for differently owned {C}"/>
+
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -154,20 +154,11 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I];perms=??-???" p:changes="L:[D]"/>
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].child = [I];perms=??-???" p:changes="L:[D]"/>
 
-        <!-- Give settings if both holder and underlying object are given. -->
+        <!-- Give settings if underlying object is given. -->
 
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = S:[ED], S.detector = [I]"
-                                       p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = S:[ED], S.lightSource = [I]"
-                                       p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = S:[ED], S.objective = [I]"
-                                       p:changes="S:[I]"/>
-
-        <!-- Delete settings if only the underlying object is given in a private group. -->
-
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I];perms=??-???" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I];perms=??-???" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I];perms=??-???" p:changes="S:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
 
         <!-- Images may be given only if doing so would not remove an imaging environment from any of them. -->
 
@@ -480,11 +471,6 @@
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E]{r}, L.child = [E]{a}" p:changes="J:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = P:[E]{r}, L.parent = [E]{a}" p:changes="P:{a}"/>
 
-        <!-- Delete remaining settings if holder object is given but not the settings in a private group. -->
-
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E];perms=??-???" p:changes="DS:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E];perms=??-???" p:changes="LS:[D]"/>
-
         <!-- Give a stage label only if all the images using it are given. -->
 
         <bean parent="graphPolicyRule" p:matches="Image[E]{r}.stageLabel = SL:[E]{i}" p:changes="SL:{r}"/>
@@ -503,7 +489,17 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].planeInfo = PI:[E]" p:changes="PI:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+
+        <!-- Give a logical channel only if all its channels are to be given. -->
+
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]{i}" p:changes="LC:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[E].logicalChannel = LC:[E]{r}" p:changes="LC:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E]{o}" p:changes="LC:[I]"/>
+
+        <!-- Cannot separate channels from logical channels in a private group. -->
+
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel.channels = C1:[I];perms=??-???, LC.channels = C2:[E]"
+                                       p:error="cannot give {C1} while {C2} remains as they share {LC}"/>
 
         <!-- Delete remaining settings if holder object is given but not the settings in a private group. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -346,8 +346,6 @@
         <!-- If a logical channel is deleted then delete the subgraph below it. -->
 
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].channels = C:[E]" p:changes="C:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].detectorSettings = DS:[E]" p:changes="DS:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].lightSourceSettings = LS:[E]" p:changes="LS:[D]"/>
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[D].lightPath = LP:[E]{i}" p:changes="LP:{r}"/>
 
         <!-- Delete a logical channel if its last associated channel is deleted. -->
@@ -367,7 +365,6 @@
              Delete its rendering settings and thumbnails regardless of permissions.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="Image[D].objectiveSettings = OS:[E]" p:changes="OS:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Image[D].pixels = P:[E]" p:changes="P:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[D].channels = C:[E]" p:changes="C:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[D].planeInfo = PI:[E]" p:changes="PI:[D]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -139,6 +139,12 @@
         <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].lightSource = [I]" p:changes="IN:[I]"/>
         <bean parent="graphPolicyRule" p:matches="IN:Instrument[E].objective = [I]" p:changes="IN:[I]"/>
 
+        <!-- Duplicate objects' settings. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
+
         <!-- Duplicate emission and excitation filter links if both parent and child are duplicated. -->
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
@@ -255,13 +261,20 @@
         <!-- If a logical channel is duplicated then duplicate the subgraph below it. -->
 
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].channels = C:[E]" p:changes="C:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].detectorSettings = DS:[E]" p:changes="DS:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightSourceSettings = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LogicalChannel[I].lightPath = LP:[E]" p:changes="LP:[I]"/>
 
-        <!-- Duplicate a logical channel if its associated channel is duplicated. -->
+        <!-- Duplicate a logical channel only if all its channels are to be duplicated. -->
 
-        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]" p:changes="LC:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[I].logicalChannel = LC:[E]{i}" p:changes="LC:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Channel[E].logicalChannel = LC:[E]{r}" p:changes="LC:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E]{o}" p:changes="LC:[I]"/>
+
+        <!-- Respect linking rules outside private groups. -->
+
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E]/!o.channels = C:[I];perms=??r-??"
+                                       p:error="may not duplicate {C} without {LC} in a read-only group"/>
+        <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E]/!o.channels = C:[I];perms=??ra??"
+                                       p:error="may not duplicate {C} without {LC} in a read-annotate group"/>
 
         <!--
              If an image is duplicated then duplicate the subgraph below it.
@@ -270,7 +283,6 @@
 
         <bean parent="graphPolicyRule" p:matches="Image[I].imagingEnvironment = IE:[E]" p:changes="IE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].instrument = IN:[E]" p:changes="IN:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].objectiveSettings = OS:[E]" p:changes="OS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[E]" p:changes="P:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Image[I].stageLabel = SL:[E]" p:changes="SL:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Pixels[I].channels = C:[E]" p:changes="C:[I]"/>

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1028,6 +1028,9 @@ public class GraphTraversal {
 
         if (details == null) {
             final ome.model.internal.Details objectDetails = planning.detailsNoted.get(object);
+            if (objectDetails == null) {
+                throw new GraphException("cannot read " + object);
+            }
             final Experimenter owner = objectDetails.getOwner();
             final ExperimenterGroup group = objectDetails.getGroup();
             final Long ownerId = owner == null ? null : owner.getId();

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1600,7 +1600,7 @@ public class DuplicationTest extends AbstractServerTest {
     }
 
     /**
-     * Test duplication of a plates that share logical channels.
+     * Test duplication of plates that share logical channels.
      * @throws Exception unexpected
      */
     @Test(groups = "ticket:13199")

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -1092,7 +1092,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
 
         /* add settings to the image's light source */
         LightSource lightSource = (LightSource) iQuery.findByQuery(
-                "SELECT image.instrument.lightSource FROM Image image WHERE image.id = :id", 
+                "SELECT image.instrument.lightSource FROM Image image WHERE image.id = :id",
                 new ParametersI().addId(image.getId())).proxy();
         LightSettings lightSettings = mmFactory.createLightSettings(lightSource);
         lightSettings = (LightSettings) iUpdate.saveAndReturnObject(lightSettings).proxy();

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -15,10 +15,12 @@ import java.util.List;
 import java.util.UUID;
 
 import omero.cmd.Chgrp2;
+import omero.cmd.Chgrp2Response;
 import omero.gateway.util.Requests;
 import omero.grid.Column;
 import omero.grid.LongColumn;
 import omero.grid.TablePrx;
+import omero.model.Arc;
 import omero.model.Channel;
 import omero.model.Dataset;
 import omero.model.DatasetI;
@@ -30,6 +32,8 @@ import omero.model.FileAnnotationI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Instrument;
+import omero.model.LightSettings;
+import omero.model.LightSource;
 import omero.model.LogicalChannel;
 import omero.model.OriginalFile;
 import omero.model.Pixels;
@@ -58,6 +62,7 @@ import omero.model.WellSample;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.*;
@@ -1063,5 +1068,53 @@ public class HierarchyMoveTest extends AbstractServerTest {
         assertNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(original.getId())));
         assertNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(projection.getId())));
         assertNotNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(other.getId())));
+    }
+
+    /**
+     * Test to move an image whose light source settings are not referenced by a logical channel.
+     * @throws Exception unexpected
+     */
+    @Test(groups = "ticket:13128")
+    public void testMoveLightSourceSettings() throws Exception {
+        /* prepare a pair of groups for the user */
+        newUserAndGroup("rwr---");
+        final EventContext ctx = iAdmin.getEventContext();
+        final ExperimenterGroup source = iAdmin.getGroup(ctx.groupId);
+        final ExperimenterGroup destination = newGroupAddUser("rwr---", ctx.userId);
+
+        /* start in the source group */
+        loginUser(source);
+
+        /* create an image with a light source */
+        Image image = mmFactory.createImage();
+        image.setInstrument(mmFactory.createInstrument(Arc.class.getName()));
+        image = (Image) iUpdate.saveAndReturnObject(image).proxy();
+
+        /* add settings to the image's light source */
+        LightSource lightSource = (LightSource) iQuery.findByQuery(
+                "SELECT image.instrument.lightSource FROM Image image WHERE image.id = :id", 
+                new ParametersI().addId(image.getId())).proxy();
+        LightSettings lightSettings = mmFactory.createLightSettings(lightSource);
+        lightSettings = (LightSettings) iUpdate.saveAndReturnObject(lightSettings).proxy();
+
+        /* move the image */
+        final Chgrp2Response rsp = (Chgrp2Response) doChange(Requests.chgrp().target(image).toGroup(destination).build());
+
+        /* check that the move reported that light source settings moved and nothing was deleted */
+        Assert.assertTrue(rsp.includedObjects.containsKey(ome.model.acquisition.Arc.class.getName()));
+        Assert.assertTrue(rsp.deletedObjects.isEmpty());
+
+        /* check what remains in the source group */
+        assertNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(image.getId())));
+        assertNull(iQuery.findByQuery("FROM LightSettings WHERE id = :id", new ParametersI().addId(lightSettings.getId())));
+
+        /* switch to the destination group */
+        disconnect();
+        loginUser(destination);
+
+        /* check what was moved to the destination group */
+        assertNotNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(image.getId())));
+        assertNotNull(iQuery.findByQuery("FROM LightSettings WHERE id = :id", new ParametersI().addId(lightSettings.getId())));
+        disconnect();
     }
 }


### PR DESCRIPTION
Fixes:

* http://trac.openmicroscopy.org/ome/ticket/13128 -- Bug: moving fake plate loses light settings
* http://trac.openmicroscopy.org/ome/ticket/13199 -- RFE: improve handling of shared logical channels

Adds corresponding integration tests in:

* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration/DuplicationTest/
* http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-start/lastCompletedBuild/testReport/integration.chgrp/HierarchyMoveTest/

To test manually:

* move a single-plate fake to another group and check that it retains its light source settings
* duplicate individual plates from a multi-plate fake and check that it works

Everything else should still work fine.