### PR TITLE
warn about Windows deprecation

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -60,8 +60,10 @@ def config_required(func):
     def import_django_settings(func):
         def wrapper(self, *args, **kwargs):
             if self._isWindows():
-                self.ctx.err("Windows platform will not longer be supported"
-                             " since OMERO 5.3.")
+                self.ctx.err("Support for Windows will be removed in"
+                             " OMERO 5.3, see http://blog.openmicroscopy.org/"
+                             "tech-issues/future-plans/deployment/2016/03/22/"
+                             "windows-support/")
             try:
                 import django  # NOQA
             except:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -19,7 +19,7 @@ from functools import wraps
 from omero_ext.argparse import SUPPRESS
 
 HELP = "OMERO.web configuration/deployment tools"
-WINDOWS_WARNING = ("Support for Windows will be removed in"
+WINDOWS_WARNING = ("WARNING: Support for Windows will be removed in"
                    " OMERO 5.3, see http://blog.openmicroscopy.org/"
                    "tech-issues/future-plans/deployment/2016/03/22/"
                    "windows-support/")

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -19,7 +19,13 @@ from functools import wraps
 from omero_ext.argparse import SUPPRESS
 
 HELP = "OMERO.web configuration/deployment tools"
+WINDOWS_WARNING = ("Support for Windows will be removed in"
+                   " OMERO 5.3, see http://blog.openmicroscopy.org/"
+                   "tech-issues/future-plans/deployment/2016/03/22/"
+                   "windows-support/")
 
+if platform.system() == 'Windows':
+    HELP += ("\n\n%s" % WINDOWS_WARNING)
 
 LONGHELP = """OMERO.web configuration/deployment tools
 
@@ -60,10 +66,7 @@ def config_required(func):
     def import_django_settings(func):
         def wrapper(self, *args, **kwargs):
             if self._isWindows():
-                self.ctx.err("Support for Windows will be removed in"
-                             " OMERO 5.3, see http://blog.openmicroscopy.org/"
-                             "tech-issues/future-plans/deployment/2016/03/22/"
-                             "windows-support/")
+                self.ctx.err(WINDOWS_WARNING)
             try:
                 import django  # NOQA
             except:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -59,6 +59,9 @@ def config_required(func):
     """Decorator validating Django dependencies and omeroweb/settings.py"""
     def import_django_settings(func):
         def wrapper(self, *args, **kwargs):
+            if self._isWindows():
+                self.ctx.err("Windows platform will not longer be supported"
+                             " since OMERO 5.3.")
             try:
                 import django  # NOQA
             except:


### PR DESCRIPTION
Following https://github.com/openmicroscopy/ome-documentation/pull/1437 web plugin should also warn

To test:
- `bin\omero web -h`
- `bin\omero web help`

try other commands from help
- `bin\omero web config ...`

they should contain:

```
bin\omero web config nginx
WARNING: Support for Windows will be removed in OMERO 5.3, see http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/
```

cc: @jburel 