### PR TITLE
Fix potential class cast/NPE for unknown metadata key

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/LightSourceComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/LightSourceComponent.java
@@ -302,7 +302,10 @@ class LightSourceComponent
             else {
             	area = UIUtilities.createComponent(OMETextArea.class, null);
             	((OMETextArea) area).setEditable(false);
-            	((OMETextArea) area).setText((String) value);
+                if (value != null)
+                    ((OMETextArea) area).setText(value.toString());
+                else
+                    ((OMETextArea) area).setText("N/A");
             	((OMETextArea) area).setEditedColor(
             			UIUtilities.EDITED_COLOR);
             }


### PR DESCRIPTION
Fixes a potential class cast and NPE if metadata contains an unknown entry.

**Test**: Import fake plate `PW&plates=2&plateRows=1&plateCols=1&fields=1&plateAcqs=2.fake`, select a well, view all metadata (i. e. expand all tabs) in right hand side metadata panel.
