### PR TITLE
Copy ome.api.* documentation to omero.api.* (2)

### DIFF
--- a/components/blitz/resources/omero/api/IMetadata.ice
+++ b/components/blitz/resources/omero/api/IMetadata.ice
@@ -24,8 +24,8 @@ module omero {
         ["ami", "amd"] interface IMetadata extends ServiceInterface
             {
                 /**
-                 * Loads the <code>logical channels</code> and the acquisition
-                 * metadata related to them.
+                 * Loads the logical channels and the acquisition metadata
+                 * related to them.
                  *
                  * @param ids The collection of logical channel's ids.
                  * 		      Mustn't be <code>null</code>.
@@ -91,11 +91,11 @@ module omero {
                 //idempotent omero::metadata::TagContainerList loadTags(long id, bool withObjects, omero::sys::Parameters options) throws ServerError;
 
                 /**
-                 * Loads the Tag Set if the id is specified otherwise loads
-                 * all the Tag Set.
+                 * Loads the TagSet if the id is specified otherwise loads
+                 * all the TagSet.
                  *
                  * @param ids The id of the tag to load or <code>-1</code>.
-                 * @return Map whose key is a <code>Tag/Tag Set</code> and the
+                 * @return Map whose key is a <code>Tag/TagSet</code> and the
                  *         value either a Map or a list of related
                  *         <code>DataObject</code>.
                  **/
@@ -106,7 +106,7 @@ module omero {
                  * <code>AnnotationAnnotatioLink</code> objects and, if the
                  * <code>orphan</code> parameters is <code>true</code>, the
                  * <code>TagAnnotation</code> object.
-                 * Note that the difference between a Tag Set and a Tag is made
+                 * Note that the difference between a TagSet and a Tag is made
                  * using the NS_INSIGHT_TAG_SET namespace.
                  *
                  * @param options The POJO options.

--- a/components/blitz/resources/omero/api/IMetadata.ice
+++ b/components/blitz/resources/omero/api/IMetadata.ice
@@ -18,37 +18,212 @@ module omero {
 
     module api {
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IMetadata.html">IMetadata.html</a>
+         * Provides method to interact with acquisition metadata and
+         * annotations.
          **/
         ["ami", "amd"] interface IMetadata extends ServiceInterface
             {
+                /**
+                 * Loads the <code>logical channels</code> and the acquisition
+                 * metadata related to them.
+                 *
+                 * @param ids The collection of logical channel's ids.
+                 * 		      Mustn't be <code>null</code>.
+                 * @return The collection of loaded logical channels.
+                 **/
                 idempotent LogicalChannelList loadChannelAcquisitionData(omero::sys::LongList ids) throws ServerError;
+
+                /**
+                 * Loads all the annotations of given types, that have been
+                 * attached to the specified <code>rootNodes</code> for the
+                 * specified <code>annotatorIds</code>.
+                 * If no types specified, all annotations will be loaded.
+                 * This method looks for the annotations that have been
+                 * attached to each of the specified objects. It then maps
+                 * each <code>rootId</code> onto the set of annotations
+                 * that were found for that node. If no annotations were found
+                 * for that node, then the entry will be <code>null</code>.
+                 * Otherwise it will be a <code>Map</code> containing
+                 * {@link omero.model.Annotation} objects.
+                 *
+                 * @param rootType
+                 *      The type of the nodes the annotations are linked to.
+                 *      Mustn't be <code>null</code>.
+                 * @param rootIds
+                 *      Ids of the objects of type <code>rootType</code>.
+                 * 		Mustn't be <code>null</code>.
+                 * @param annotationType
+                 *      The types of annotation to retrieve. If
+                 *      <code>null</code> all annotations will be loaded.
+                 *      String of the type
+                 *      <code>omero.model.annotations.*</code>.
+                 * @param annotatorIds
+                 *      Ids of the users for whom annotations should be
+                 *      retrieved. If <code>null</code>, all annotations
+                 *      returned.
+                 * @param options
+                 * @return A map whose key is rootId and value the
+                 *         <code>Map</code> of all annotations for that node
+                 *         or <code>null</code>.
+                 **/
                 idempotent LongIObjectListMap loadAnnotations(string rootType, omero::sys::LongList rootIds,
                                                          omero::api::StringSet annotationTypes, omero::sys::LongList annotatorIds,
                                                          omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Loads all the annotations of a given type.
+                 * It is possible to filter the annotations by including or
+                 * excluding name spaces set on the annotations.
+                 *
+                 * @param annotationType The type of annotations to load.
+                 * @param include
+                 *      Include the annotations with the specified name spaces.
+                 * @param exclude
+                 *      Exclude the annotations with the specified name spaces.
+                 * @param options   The POJO options.
+                 * @return          A collection of found annotations.
+                 **/
                 idempotent AnnotationList loadSpecifiedAnnotations(string annotationType,
                                                                    omero::api::StringSet include,
                                                                    omero::api::StringSet exclude,
                                                                    omero::sys::Parameters options) throws ServerError;
                 //idempotent omero::metadata::TagSetContainerList loadTagSets(long id, bool withObjects, omero::sys::Parameters options) throws ServerError;
                 //idempotent omero::metadata::TagContainerList loadTags(long id, bool withObjects, omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Loads the Tag Set if the id is specified otherwise loads
+                 * all the Tag Set.
+                 *
+                 * @param ids The id of the tag to load or <code>-1</code>.
+                 * @return Map whose key is a <code>Tag/Tag Set</code> and the
+                 *         value either a Map or a list of related
+                 *         <code>DataObject</code>.
+                 **/
                 idempotent LongIObjectListMap loadTagContent(omero::sys::LongList ids, omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Loads all the tag Sets. Returns a collection of
+                 * <code>AnnotationAnnotatioLink</code> objects and, if the
+                 * <code>orphan</code> parameters is <code>true</code>, the
+                 * <code>TagAnnotation</code> object.
+                 * Note that the difference between a Tag Set and a Tag is made
+                 * using the NS_INSIGHT_TAG_SET namespace.
+                 *
+                 * @param options The POJO options.
+                 * @return See above.
+                 **/
                 idempotent IObjectList loadTagSets(omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Returns a map whose key is a tag id and the value the
+                 * number of Projects, Datasets, and Images linked to that tag.
+                 *
+                 * @param ids The collection of ids.
+                 * @param options The POJO options.
+                 * @return See above.
+                 **/
                 idempotent omero::sys::CountMap getTaggedObjectsCount(omero::sys::LongList ids, omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Counts the number of annotation of a given type.
+                 *
+                 * @param annotationType The type of annotations to load.
+                 * @param include   The collection of name space, one of the
+                 *                  constants defined by this class.
+                 * @param exclude   The collection of name space, one of the
+                 *                  constants defined by this class.
+                 * @param options	The POJO options.
+                 * @return See above.
+                 **/
                 omero::RLong countSpecifiedAnnotations(string annotationType,
                                                        omero::api::StringSet include,
                                                        omero::api::StringSet exclude,
                                                        omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Loads the specified annotations.
+                 *
+                 * @param annotationIds The collection of annotation ids.
+                 * @return              See above.
+                 */
                 idempotent AnnotationList loadAnnotation(omero::sys::LongList annotationIds) throws ServerError;
+
+                /**
+                 * Loads the instrument and its components i.e. detectors,
+                 * objectives, etc.
+                 *
+                 * @param id    The id of the instrument to load.
+                 * @return      See above
+                 */
                 idempotent omero::model::Instrument loadInstrument(long id) throws ServerError;
+
+                /**
+                 * Loads the annotations of a given type used by the specified
+                 * user but not owned by the user.
+                 *
+                 * @param annotationType    The type of annotations to load.
+                 * @param userID            The identifier of the user.
+                 * @return                  See above.
+                 */
                 idempotent IObjectList loadAnnotationsUsedNotOwned(string annotationType, long userID) throws ServerError;
+
+                /**
+                 * Counts the number of annotation of a given type used by the
+                 * specified user but not owned by the user.
+                 *
+                 * @param annotationType    The type of annotations to load.
+                 * @param userID            The identifier of the user.
+                 * @return                  See above.
+                 */
                 omero::RLong countAnnotationsUsedNotOwned(string annotationType, long userID) throws ServerError;
+
+                /**
+                 * Loads the annotations of a given type linked to the
+                 * specified objects. It is possible to filter the annotations
+                 * by including or excluding name spaces set on the
+                 * annotations.
+                 *
+                 * This method looks for the annotations that have been
+                 * attached to each of the specified objects. It then maps
+                 * each <code>rootNodeId</code> onto the set of annotations
+                 * that were found for that node. If no annotations were found
+                 * for that node, the map will not contain an entry for that
+                 * node. Otherwise it will be a <code>Set</code> containing
+                 * {@link omero.model.Annotation} objects.
+                 * The <code>rootNodeType</code> supported are:
+                 * Project, Dataset, Image, Pixels, Screen, Plate,
+                 * PlateAcquisition, Well, Fileset.
+                 *
+                 * @param annotationType  The type of annotations to load.
+                 * @param include
+                 *      Include the annotations with the specified name spaces.
+                 * @param exclude
+                 *      Exclude the annotations with the specified name spaces.
+                 * @param rootNodeType
+                 *      The type of objects the annotations are linked to.
+                 * @param rootNodeIds   The identifiers of the objects.
+                 * @param options       The POJO options.
+                 * @return              A collection of found annotations.
+                 */
                 idempotent LongAnnotationListMap loadSpecifiedAnnotationsLinkedTo(string annotationType,
                                                                    omero::api::StringSet include,
                                                                    omero::api::StringSet exclude,
                                                                    string rootNodeType,
                                                                    omero::sys::LongList rootNodeIds,
                                                                    omero::sys::Parameters options) throws ServerError;
+
+                /**
+                 * Finds the original file IDs for the import logs
+                 * corresponding to the given Image or Fileset IDs.
+                 *
+                 * @param rootNodeType
+                 *       the root node type, may be {@link omero.model.Image}
+                 *       or {@link omero.model.Fileset}
+                 * @param ids
+                 *       the IDs of the entities for which the import log
+                 *       original file IDs are required
+                 * @return the original file IDs of the import logs
+                 **/
                 idempotent LongIObjectListMap loadLogFiles(string rootType, omero::sys::LongList ids) throws ServerError;
             };
 

--- a/components/blitz/resources/omero/api/IMetadata.ice
+++ b/components/blitz/resources/omero/api/IMetadata.ice
@@ -102,7 +102,7 @@ module omero {
                 idempotent LongIObjectListMap loadTagContent(omero::sys::LongList ids, omero::sys::Parameters options) throws ServerError;
 
                 /**
-                 * Loads all the tag Sets. Returns a collection of
+                 * Loads all the TagSets. Returns a collection of
                  * <code>AnnotationAnnotatioLink</code> objects and, if the
                  * <code>orphan</code> parameters is <code>true</code>, the
                  * <code>TagAnnotation</code> object.

--- a/components/blitz/resources/omero/api/IPixels.ice
+++ b/components/blitz/resources/omero/api/IPixels.ice
@@ -153,7 +153,7 @@ module omero {
                  *
                  * @param enumClass Enumeration class.
                  * @return List of all enumeration objects for the
-                 *         <i>klass</i>.
+                 *         <i>enumClass</i>.
                  **/
                 idempotent IObjectList getAllEnumerations(string enumClass) throws ServerError;
 
@@ -178,9 +178,11 @@ module omero {
                  * @param sizeX The new size across the X-axis.
                  *              <code>null</code> if the copy should maintain
                  *              the same size.
-                 * @param sizeY The new size across the Y-axis.                                 *              <code>null</code> if the copy should maintain
+                 * @param sizeY The new size across the Y-axis.
+                 *              <code>null</code> if the copy should maintain
                  *              the same size.
-                 * @param sizeZ The new size across the Z-axis.                                 *              <code>null</code> if the copy should maintain
+                 * @param sizeZ The new size across the Z-axis.
+                 *              <code>null</code> if the copy should maintain
                  *              the same size.
                  * @param sizeT The new number of timepoints.
                  *              <code>null</code> if the copy should maintain

--- a/components/blitz/resources/omero/api/IPixels.ice
+++ b/components/blitz/resources/omero/api/IPixels.ice
@@ -16,19 +16,190 @@ module omero {
 
     module api {
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IPixels.html">IPixels.html</a>
+         * Metadata gateway for the {@link omero.api.RenderingEngine} and
+         * clients. This service provides all DB access that the rendering
+         * engine needs as well as Pixels services to a client. It also allows
+         * the rendering  engine to also be run external to the server (e.g.
+         * client-side).
+         *
          **/
         ["ami", "amd"] interface IPixels extends ServiceInterface
             {
+                /**
+                 * Retrieves the pixels metadata. The following objects are
+                 * pre-linked:
+                 * <ul>
+                 * <li>pixels.pixelsType</li>
+                 * <li>pixels.pixelsDimensions</li>
+                 * <li>pixels.channels</li>
+                 * <li>pixels.channnels.statsInfo</li>
+                 * <li>pixels.channnels.colorComponent</li>
+                 * <li>pixels.channnels.logicalChannel</li>
+                 * <li>pixels.channnels.logicalChannel.photometricInterpretation</li>
+                 * </ul>
+                 *
+                 * @param pixId Pixels id.
+                 * @return Pixels object which matches <code>id</code>.
+                 **/
                 idempotent omero::model::Pixels retrievePixDescription(long pixId) throws ServerError;
+
+                /**
+                 * Retrieves the rendering settings for a given pixels set and
+                 * the currently logged in user. If the current user has no
+                 * {@link omero.model.RenderingDef}, and the user is an
+                 * administrator, then a {@link omero.model.RenderingDef} may
+                 * be returned for the owner of the
+                 *{@link omero.model.Pixels}. This matches the behavior of the
+                 * Rendering service.
+                 *
+                 * The following objects will be pre-linked:
+                 * <ul>
+                 * <li>renderingDef.quantization</li>
+                 * <li>renderingDef.model</li>
+                 * <li>renderingDef.waveRendering</li>
+                 * <li>renderingDef.waveRendering.color</li>
+                 * <li>renderingDef.waveRendering.family</li>
+                 * <li>renderingDef.spatialDomainEnhancement</li>
+                 * </ul>
+                 *
+                 * @param pixId Pixels id.
+                 * @return Rendering definition.
+                 */
                 idempotent omero::model::RenderingDef retrieveRndSettings(long pixId) throws ServerError;
+
+                /**
+                 * Retrieves the rendering settings for a given pixels set and
+                 * the passed user. The following objects are pre-linked:
+                 * <ul>
+                 * <li>renderingDef.quantization</li>
+                 * <li>renderingDef.model</li>
+                 * <li>renderingDef.waveRendering</li>
+                 * <li>renderingDef.waveRendering.color</li>
+                 * <li>renderingDef.waveRendering.family</li>
+                 * <li>renderingDef.spatialDomainEnhancement</li>
+                 * </ul>
+                 *
+                 * @param pixId Pixels id.
+                 * @param userID  The id of the user.
+                 * @return Rendering definition.
+                 **/
                 idempotent omero::model::RenderingDef retrieveRndSettingsFor(long pixId, long userId) throws ServerError;
+
+                /**
+                 * Retrieves all the rendering settings for a given pixels set
+                 * and the passed user. The following objects are pre-linked:
+                 * <ul>
+                 * <li>renderingDef.quantization</li>
+                 * <li>renderingDef.model</li>
+                 * <li>renderingDef.waveRendering</li>
+                 * <li>renderingDef.waveRendering.color</li>
+                 * <li>renderingDef.waveRendering.family</li>
+                 * <li>renderingDef.spatialDomainEnhancement</li>
+                 * </ul>
+                 *
+                 * @param pixId    Pixels id.
+                 * @param userId   The id of the user.
+                 * @return Rendering definition.
+                 **/
                 idempotent IObjectList retrieveAllRndSettings(long pixId, long userId) throws ServerError;
+
+                /**
+                 * Loads a specific set of rendering settings. The
+                 * following objects are pre-linked:
+                 * <ul>
+                 * <li>renderingDef.quantization</li>
+                 * <li>renderingDef.model</li>
+                 * <li>renderingDef.waveRendering</li>
+                 * <li>renderingDef.waveRendering.color</li>
+                 * <li>renderingDef.waveRendering.family</li>
+                 * <li>renderingDef.spatialDomainEnhancement</li>
+                 * </ul>
+                 *
+                 * @param renderingSettingsId Rendering definition id.
+                 * @throws ValidationException If no <code>RenderingDef</code>
+                 * matches the ID <code>renderingDefId</code>.
+                 * @return Rendering definition.
+                 **/
                 idempotent omero::model::RenderingDef loadRndSettings(long renderingSettingsId) throws ServerError;
+
+                /**
+                 * Saves the specified rendering settings.
+                 *
+                 * @param rndSettings Rendering settings.
+                 **/
                 void saveRndSettings(omero::model::RenderingDef rndSettings) throws ServerError;
+
+                /**
+                 * Bit depth for a given pixel type.
+                 *
+                 * @param type Pixels type.
+                 * @return Bit depth in bits.
+                 **/
                 idempotent int getBitDepth(omero::model::PixelsType type) throws ServerError;
+
+                /**
+                 * Retrieves a particular enumeration for a given enumeration
+                 * class.
+                 *
+                 * @param enumClass Enumeration class.
+                 * @param value Enumeration string value.
+                 * @return Enumeration object.
+                 **/
                 idempotent omero::model::IObject getEnumeration(string enumClass, string value) throws ServerError;
+
+                /**
+                 * Retrieves the exhaustive list of enumerations for a given
+                 * enumeration class.
+                 *
+                 * @param enumClass Enumeration class.
+                 * @return List of all enumeration objects for the
+                 *         <i>klass</i>.
+                 **/
                 idempotent IObjectList getAllEnumerations(string enumClass) throws ServerError;
+
+                /**
+                 * Copies the metadata, and <b>only</b> the metadata linked to
+                 * a Pixels object into a new Pixels object of equal or
+                 * differing size across one or many of its three physical
+                 * dimensions or temporal dimension.
+                 * It is beyond the scope of this method to handle updates or
+                 * changes to the raw pixel data available through
+                 * {@link omero.api.RawPixelsStore} or to add
+                 * and link {@link omero.model.PlaneInfo} and/or other Pixels
+                 * set specific metadata.
+                 * It is also assumed that the caller wishes the pixels
+                 * dimensions and {@link omero.model.PixelsType} to remain the
+                 * same; changing these is outside the scope of this method.
+                 * <b>NOTE:</b> As {@link omero.model.Channel} objects are
+                 * only able to apply to a single set of Pixels any
+                 * annotations or linkage to these objects will be lost.
+                 *
+                 * @param pixelsId The source Pixels set id.
+                 * @param sizeX The new size across the X-axis.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeY The new size across the Y-axis.                                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeZ The new size across the Z-axis.                                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeT The new number of timepoints.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same number.
+                 * @param channelList The channels that should be copied into
+                 *                    the new Pixels set.
+                 * @param methodology An optional string signifying the
+                 *                    methodology that will be used to produce
+                 *                    this new Pixels set.
+                 * @param copyStats Whether or not to copy the
+                 *                  {@link omero.model.StatsInfo} for each
+                 *                  channel.
+                 * @return Id of the new Pixels object on success or
+                 *         <code>null</code> on failure.
+                 * @throws ValidationException If the X, Y, Z, T or
+                 *         channelList dimensions are out of bounds or the
+                 *         Pixels object corresponding to
+                 *         <code>pixelsId</code> is unlocatable.
+                 **/
                 omero::RLong copyAndResizePixels(long pixelsId,
                                                  omero::RInt sizeX,
                                                  omero::RInt sizeY,
@@ -37,6 +208,50 @@ module omero {
                                                  omero::sys::IntList channelList,
                                                  string methodology,
                                                  bool copyStats) throws ServerError;
+
+                /**
+                 * Copies the metadata, and <b>only</b> the metadata linked to
+                 * a Image object into a new Image object of equal or
+                 * differing size across one or many of its three physical
+                 * dimensions or temporal dimension.
+                 * It is beyond the scope of this method to handle updates or
+                 * changes to  the raw pixel data available through
+                 * {@link omero.api.RawPixelsStore} or to add
+                 * and link {@link omero.model.PlaneInfo} and/or other Pixels
+                 * set specific metadata.
+                 * It is also assumed that the caller wishes the pixels
+                 * dimensions and {@link omero.model.PixelsType} to remain the
+                 * same; changing these is outside the scope of this method.
+                 * <b>NOTE:</b> As {@link omero.model.Channel} objects are
+                 * only able to apply to a single set of Pixels any
+                 * annotations or linkage to these objects will be lost.
+                 *
+                 * @param imageId The source Image id.
+                 * @param sizeX The new size across the X-axis.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeY The new size across the Y-axis.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeZ The new size across the Z-axis.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same size.
+                 * @param sizeT The new number of timepoints.
+                 *              <code>null</code> if the copy should maintain
+                 *              the same number.
+                 * @param channelList The channels that should be copied into
+                 *                    the new Pixels set.
+                 * @param methodology The name of the new Image.
+                 * @param copyStats Whether or not to copy the
+                 *                  {@link omero.model.StatsInfo} for each
+                 *                  channel.
+                 * @return Id of the new Pixels object on success or
+                 *         <code>null</code> on failure.
+                 * @throws ValidationException If the X, Y, Z, T or
+                 *         channelList dimensions are out of bounds or the
+                 *         Pixels object corresponding to
+                 *         <code>pixelsId</code> is unlocatable.
+                 */
                 omero::RLong copyAndResizeImage(long imageId,
                                                 omero::RInt sizeX,
                                                 omero::RInt sizeY,
@@ -45,10 +260,44 @@ module omero {
                                                 omero::sys::IntList channelList,
                                                 string methodology,
                                                 bool copyStats) throws ServerError;
+
+                /**
+                 * Creates the metadata, and <b>only</b> the metadata linked
+                 * to an Image object. It is beyond the scope of this method
+                 * to handle updates or changes to the raw pixel data
+                 * available through {@link omero.api.RawPixelsStore} or to
+                 * add and link {@link omero.model.PlaneInfo} or
+                 * {@link omero.model.StatsInfo} objects and/or other Pixels
+                 * set specific metadata. It is also up to the caller to
+                 * update the pixels dimensions.
+                 *
+                 * @param sizeX The new size across the X-axis.
+                 * @param sizeY The new size across the Y-axis.
+                 * @param sizeZ The new size across the Z-axis.
+                 * @param sizeT The new number of timepoints.
+                 * @param pixelsType The pixelsType
+                 * @param name The name of the new Image.
+                 * @param description The description of the new Image.
+                 * @return Id of the new Image object on success or
+                 *         <code>null</code> on failure.
+                 * @throws ValidationException If the channel list is
+                 *         <code>null</code> or of size == 0.
+                 **/
                 omero::RLong createImage(int sizeX, int sizeY, int sizeZ, int sizeT,
                                          omero::sys::IntList channelList,
                                          omero::model::PixelsType pixelsType,
                                          string name, string description) throws ServerError;
+
+                /**
+                 * Sets the channel global (all 2D optical sections
+                 * corresponding to a particular channel) minimum and maximum
+                 * for a Pixels set.
+                 *
+                 * @param pixelsId The source Pixels set id.
+                 * @param channelIndex The channel index within the Pixels set.
+                 * @param min The channel global minimum.
+                 * @param max The channel global maximum.
+                 **/
                 void setChannelGlobalMinMax(long pixelsId, int channelIndex, double min, double max) throws ServerError;
             };
     };

--- a/components/blitz/resources/omero/api/IProjection.ice
+++ b/components/blitz/resources/omero/api/IProjection.ice
@@ -20,15 +20,121 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IProjection.html">IProjection.html</a>
+         * Provides methods for performing projections of Pixels sets.
          **/
         ["ami", "amd"] interface IProjection extends ServiceInterface
             {
+                /**
+                 * Performs a projection through the optical sections of a
+                 * particular wavelength at a given time point of a Pixels set.
+                 * @param pixelsId The source Pixels set Id.
+                 * @param pixelsType The destination Pixels type. If
+                 *                   <code>null</code>, the source Pixels set
+                 *                   pixels type will be used.
+                 * @param algorithm <code>MAXIMUM_INTENSITY</code>,
+                 *                  <code>MEAN_INTENSITY</code> or
+                 *                  <code>SUM_INTENSITY</code>. <b>NOTE:</b>
+                 *                  When performing a
+                 *                  <code>SUM_INTENSITY</code> projection,
+                 *                  pixel values will be <i>pinned</i> to the
+                 *                  maximum pixel value of the destination
+                 *                  Pixels type.
+                 * @param timepoint Timepoint to perform the projection.
+                 * @param channelIndex Index of the channel to perform the
+                 *                     projection.
+                 * @param stepping Stepping value to use while calculating the
+                 *                 projection.
+                 *                 For example, <code>stepping=1</code> will
+                 *                 use every optical section from
+                 *                 <code>start</code> to <code>end</code> where
+                 *                 <code>stepping=2</code> will use every
+                 *                 other section from <code>start</code> to
+                 *                 <code>end</code> to perform the projection.
+                 * @param start Optical section to start projecting from.
+                 * @param end Optical section to finish projecting.
+                 * @return A byte array of projected pixel values whose length
+                 *         is equal to the Pixels set
+                 8         <code>sizeX * sizeY * bytesPerPixel</code> in
+                 *         big-endian format.
+                 * @throws ValidationException Where:
+                 * <ul>
+                 *   <li><code>algorithm</code> is unknown</li>
+                 *   <li><code>timepoint</code> is out of range</li>
+                 *   <li><code>channelIndex</code> is out of range</li>
+                 *   <li><code>start</code> is out of range</li>
+                 *   <li><code>end</code> is out of range</li>
+                 *   <li><code>start > end</code></li>
+                 *   <li>the Pixels set qualified by <code>pixelsId</code> is
+                 *       unlocatable.</li>
+                 * </ul>
+                 * @see #projectPixels
+                 **/
                 Ice::ByteSeq projectStack(long pixelsId,
                                           omero::model::PixelsType pixelsType,
                                           omero::constants::projection::ProjectionType algorithm,
                                           int timepoint, int channelIndex, int stepping,
                                           int start, int end) throws ServerError;
+
+                /**
+                 * Performs a projection through selected optical sections and
+                 * optical sections for a given set of time points of a Pixels
+                 * set. The Image which is linked to the Pixels set will be
+                 * copied using
+                 * {@link omero.api.IPixels#copyAndResizeImage}.
+                 *
+                 * @param pixelsId The source Pixels set Id.
+                 * @param pixelsType The destination Pixels type. If
+                 *                   <code>null</code>, the source Pixels set
+                 *                   pixels type will be used.
+                 * @param algorithm <code>MAXIMUM_INTENSITY</code>,
+                 *                  <code>MEAN_INTENSITY</code> or
+                 *                  <code>SUM_INTENSITY</code>. <b>NOTE:</b>
+                 *                  When performing a
+                 *                  <code>SUM_INTENSITY</code> projection,
+                 *                  pixel values will be <i>pinned</i> to the
+                 *                  maximum pixel value of the destination
+                 *                  Pixels type.
+                 * @param tStart Timepoint to start projecting from.
+                 * @param tEnd Timepoint to finish projecting.
+                 * @param channels List of the channel indexes to use while
+                 *                 calculating the projection.
+                 * @param stepping Stepping value to use while calculating the
+                 *                 projection. For example,
+                 *                 <code>stepping=1</code> will use every
+                 *                 optical section from <code>start</code> to
+                 *                 <code>end</code> where
+                 *                 <code>stepping=2</code> will use every
+                 *                 other section from <code>start</code> to
+                 *                 <code>end</code> to perform the projection.
+                 * @param zStart Optical section to start projecting from.
+                 * @param zEnd Optical section to finish projecting.
+                 * @param name Name for the newly created image. If
+                 *             <code>null</code> the name of the Image linked
+                 *             to the Pixels qualified by
+                 *             <code>pixelsId</code> will be used with a
+                 *             "Projection" suffix. For example,
+                 *             <i>GFP-H2B Image of HeLa Cells</i> will have an
+                 *             Image name of
+                 *             <i>GFP-H2B Image of HeLa Cells Projection</i>
+                 *             used for the projection.
+                 * @return The Id of the newly created Image which has been
+                 *         projected.
+                 * @throws ValidationException Where:
+                 * <ul>
+                 *   <li><code>algorithm</code> is unknown</li>
+                 *   <li><code>tStart</code> is out of range</li>
+                 *   <li><code>tEnd</code> is out of range</li>
+                 *   <li><code>tStart > tEnd</code></li>
+                 *   <li><code>channels</code> is null or has indexes out of
+                 *       range</li>
+                 *   <li><code>zStart</code> is out of range</li>
+                 *   <li><code>zEnd</code> is out of range</li>
+                 *   <li><code>zStart > zEnd</code></li>
+                 *   <li>the Pixels set qualified by <code>pixelsId</code> is
+                 *       unlocatable.</li>
+                 * </ul>
+                 * @see #projectStack
+                 **/
                 long projectPixels(long pixelsId, omero::model::PixelsType pixelsType,
                                    omero::constants::projection::ProjectionType algorithm,
                                    int tStart, int tEnd,

--- a/components/blitz/resources/omero/api/IQuery.ice
+++ b/components/blitz/resources/omero/api/IQuery.ice
@@ -20,32 +20,218 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IQuery.html">IQuery.html</a>
+         * Provides methods for directly querying object graphs. As far as is
+         * possible, IQuery should be considered the lowest level DB-access
+         * (SELECT) interface.
+         * Unlike the {@link omero.api.IUpdate} interface, using other methods
+         * will most likely not leave the database in an inconsistent state,
+         * but may provide stale data in some situations.
+         *
+         * By convention, all methods that begin with <code>get</code> will
+         * never return a null or empty {@link java.util.Collection}, but
+         * instead will throw a {@link omero.ValidationException}.
+         *
          **/
         ["ami", "amd"] interface IQuery extends ServiceInterface
             {
+
+                /**
+                 * Looks up an entity by class and id. If no such object
+                 * exists, an exception will be thrown.
+                 *
+                 * @param klass the type of the entity. Not null.
+                 * @param id the entity's id
+                 * @return an initialized entity
+                 * @throws ValidationException if the id doesn't exist.
+                 **/
                 idempotent omero::model::IObject get(string klass, long id) throws ServerError;
+
+
+                /**
+                 * Looks up an entity by class and id. If no such objects
+                 * exists, return a <code>null</code>.
+                 *
+                 * @param klass klass the type of the entity. Not null.
+                 * @param id the entity's id
+                 * @return an initialized entity or null if id doesn't exist.
+                 **/
                 idempotent omero::model::IObject find(string klass, long id) throws ServerError;
+
+                /**
+                 * Looks up all entities that belong to this class and match
+                 * filter.
+                 *
+                 * @param klass entity type to be searched. Not null.
+                 * @param filter filters the result set. Can be null.
+                 * @return a collection if initialized entities or an empty
+                 *         List if none exist.
+                 **/
                 idempotent IObjectList           findAll(string klass, omero::sys::Filter filter) throws ServerError;
+
+                /**
+                 * Searches based on provided example entity. The example
+                 * entity should <em>uniquely</em> specify the entity or an
+                 * exception will be thrown.
+                 *
+                 * Note: findByExample does not operate on the <code>id</code>
+                 * field. For that, use {@link #find}, {@link #get},
+                 * {@link #findByQuery}, or {@link #findAllByQuery}.
+                 *
+                 * @param example Non-null example object.
+                 * @return Possibly null IObject result.
+                 * @throws ApiUsageException if more than one result is return.
+                 **/
                 idempotent omero::model::IObject findByExample(omero::model::IObject example) throws ServerError;
+
+                /**
+                 * Searches based on provided example entity. The returned
+                 * entities will be limited by the {@link omero.sys.Filter}
+                 * object.
+                 *
+                 * Note: findAllbyExample does not operate on the
+                 * <code>id</code> field.
+                 * For that, use {@link #find}, {@link #get},
+                 * {@link #findByQuery}, or {@link #findAllByQuery}
+                 *
+                 *
+                 * @param example Non-null example object.
+                 * @param filter filters the result set. Can be null.
+                 * @return Possibly empty List of IObject results.
+                 **/
                 idempotent IObjectList           findAllByExample(omero::model::IObject example, omero::sys::Filter filter) throws ServerError;
+
+                /**
+                 * Searches a given field matching against a String. Method
+                 * does <em>not</em> allow for case sensitive or insensitive
+                 * searching since this is essentially a lookup. The existence
+                 * of more than one result will result in an exception.
+                 *
+                 * @param klass type of entity to be searched
+                 * @param field the name of the field, either as simple string
+                 *              or as public final static from the entity
+                 *              class, e.g. {@link omero.model.Project#NAME}
+                 * @param value String used for search.
+                 * @return found entity or possibly null.
+                 * @throws ome.conditions.ApiUsageException
+                 *             if more than one result.
+                 **/
                 idempotent omero::model::IObject findByString(string klass, string field, string value) throws ServerError;
+
+                /**
+                 * Searches a given field matching against a String. Method
+                 * allows for case sensitive or insensitive searching using
+                 * the (I)LIKE comparators. Result set will be reduced by the
+                 * {@link omero.sys.Filter} instance.
+                 *
+                 * @param klass type of entity to be searched. Not null.
+                 * @param field the name of the field, either as simple string
+                 *              or as public final static from the entity
+                 *              class, e.g. {@link omero.model.Project#NAME}.
+                 *              Not null.
+                 * @param value String used for search. Not null.
+                 * @param caseSensitive whether to use LIKE or ILIKE
+                 * @param filter filters the result set. Can be null.
+                 * @return A list (possibly empty) with the results.
+                 **/
                 idempotent IObjectList           findAllByString(string klass, string field, string value, bool caseSensitive, omero::sys::Filter filter) throws ServerError;
+
+                /**
+                 * Executes the stored query with the given name. If a query
+                 * with the name cannot be found, an exception will be thrown.
+                 *
+                 * The queryName parameter can be an actual query String if the
+                 * StringQuerySource is configured on the server and the user
+                 * running the query has proper permissions.
+                 *
+                 * @param query Query to execute
+                 * @param params
+                 * @return Possibly null IObject result.
+                 * @throws ValidationException
+                 **/
                 idempotent omero::model::IObject findByQuery(string query, omero::sys::Parameters params) throws ServerError;
+
+                /**
+                 * Executes the stored query with the given name. If a query
+                 * with the name cannot be found, an exception will be thrown.
+                 *
+                 * The queryName parameter can be an actual query String if the
+                 * StringQuerySource is configured on the server and the user
+                 * running the query has proper permissions.
+                 *
+                 * Queries can only return lists of
+                 * {@link omero.model.IObject} instances. This means
+                 * all must be of the form:
+                 *
+                 * <pre>
+                 * select this from SomeModelClass this ...
+                 * </pre>
+                 *
+                 * though the alias "this" is unimportant. Do not try to
+                 * return multiple classes in one call like:
+                 *
+                 * <pre>
+                 * select this, that from SomeClass this, SomeOtherClass that ...
+                 * </pre>
+                 *
+                 * nor to project values out of an object:
+                 *
+                 * <pre>
+                 * select this.name from SomeClass this ...
+                 * </pre>
+                 *
+                 * If a page is desired, add it to the query parameters.
+                 *
+                 * @param query Query to execute. Not null.
+                 * @param params
+                 * @return Possibly empty List of IObject results.
+                 */
                 idempotent IObjectList           findAllByQuery(string query, omero::sys::Parameters params) throws ServerError;
+
+                /**
+                 * Executes a full text search based on Lucene. Each term in
+                 * the query can also be prefixed by the name of the field to
+                 * which is should be restricted.
+                 *
+                 * Examples:
+                 * <ul>
+                 * <li>owner:root AND annotation:someTag</li>
+                 * <li>file:xml AND name:*hoechst*</li>
+                 * </ul>
+                 *
+                 * For more information, see
+                 * <a href="http://lucene.apache.org/java/docs/queryparsersyntax.html">Query Parser Syntax</a>
+                 *
+                 * The return values are first filtered by the security system.
+                 *
+                 * @param klass A non-null class specification of which type
+                 *             should be searched.
+                 * @param query A non-null query string. An empty string will
+                 *              return no results.
+                 * @param params
+                 *            Currently the parameters themselves are unused.
+                 *            But the {@link omero.sys.Parameters#theFilter}
+                 *            can be used to limit the number of results
+                 *            returned ({@link omero.sys.Filter#limit}) or the
+                 *            user for who the results will be found
+                 *            ({@link omero.sys.Filter#ownerId}).
+                 * @return A list of loaded {@link omero.model.IObject}
+                 *         instances. Never null.
+                 **/
                 idempotent IObjectList           findAllByFullText(string klass, string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
                  * Return a sequence of {@link omero.RType} sequences.
                  *
                  * <p>
-                 * Each element of the outer sequence is one row in the return value.
-                 * Each element of the inner sequence is one column specified in the HQL.
+                 * Each element of the outer sequence is one row in the return
+                 * value.
+                 * Each element of the inner sequence is one column specified
+                 * in the HQL.
                  * </p>
                  *
                  * <p>
                  * {@link omero.model.IObject} instances are returned wrapped
-                 * in an {@link omero.rtype.RObject} instance. Primitives are
+                 * in an {@link omero.RObject} instance. Primitives are
                  * mapped to the expected {@link omero.RType} subclass. Types
                  * without an {@link omero.RType} mapper if returned will
                  * throw an exception if present in the select except where a
@@ -54,17 +240,20 @@ module omero {
                  *
                  * <ul>
                  * <li>
-                 *     {@link omero.model.Permissions} instances are serialized to an {@link omero.RMap}
-                 *     containing the keys: perms, canAnnotate, canEdit, canLink, canDelete
+                 *     {@link omero.model.Permissions} instances are
+                 *     serialized to an {@link omero.RMap} containing the
+                 *     keys: perms, canAnnotate, canEdit, canLink, canDelete
                  * </li>
                  * <li>
-                 *     The quantity types like {@link omero.model.Length} are serialized
-                 *     to an {@link omero.RMap} containing the keys: value, unit, symbol
+                 *     The quantity types like {@link omero.model.Length} are
+                 *     serialized to an {@link omero.RMap} containing the
+                 *     keys: value, unit, symbol
                  * </li>
                  * </ul>
                  *
                  * <p>
-                 * As with SQL, if an aggregation statement is used, a group by clause must be added.
+                 * As with SQL, if an aggregation statement is used, a group
+                 * by clause must be added.
                  * </p>
                  *
                  * <p>
@@ -81,6 +270,22 @@ module omero {
                  **/
                 idempotent RTypeSeqSeq           projection(string query, omero::sys::Parameters params) throws ServerError;
 
+                /**
+                 * Refreshes an entire {@link omero.model.IObject} graph,
+                 * recursive loading all data for the managed instances in the
+                 * graph from the database. If any non-managed entities are
+                 * detected (e.g. without ids), an
+                 * {@link omero.ApiUsageException} will be thrown.
+                 *
+                 * @param iObject Non-null managed {@link omero.model.IObject}
+                 *                graph which should have all values
+                 *                re-assigned from the database
+                 * @return a similar {@link omero.model.IObject} graph (with
+                 *         possible additions and deletions) which is in-sync
+                 *         with the database.
+                 * @throws ApiUsageException if any non-managed entities are
+                 *         found.
+                 **/
                 idempotent omero::model::IObject refresh(omero::model::IObject iObject) throws ServerError;
             };
 

--- a/components/blitz/resources/omero/api/IRepositoryInfo.ice
+++ b/components/blitz/resources/omero/api/IRepositoryInfo.ice
@@ -19,14 +19,70 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IRepositoryInfo.html">IRepositoryInfo.html</a>
+         * Provides methods for obtaining information for server repository
+         * disk space allocation. Could be used generically to obtain usage
+         * information for any mount point, however, this interface is
+         * prepared for the API to provide methods to obtain usage info for
+         * the server filesystem containing the image uploads. For the OMERO
+         * server base this is /OMERO. For this implementation it could be
+         * anything e.g. /Data1.
+         *
+         * Methods that fail or cannot execute on the server will throw an
+         * InternalException. This would not be normal and would indicate some
+         * server or disk failure.
          **/
         ["ami", "amd"] interface IRepositoryInfo extends ServiceInterface
             {
+                /**
+                 * Returns the total space in bytes for this file system
+                 * including nested subdirectories.
+                 *
+                 * @return Total space used on this file system.
+                 * @throws ResourceError If there is a problem retrieving disk
+                 *         space used.
+                 **/
                 idempotent long getUsedSpaceInKilobytes() throws ServerError;
+
+                /**
+                 * Returns the free or available space on this file system
+                 * including nested subdirectories.
+                 *
+                 * @return Free space on this file system in KB.
+                 * @throws ResourceError If there is a problem retrieving disk
+                 *         space free.
+                 **/
                 idempotent long getFreeSpaceInKilobytes() throws ServerError;
+
+                /**
+                 * Returns a double of the used space divided by the free
+                 * space.
+                 * This method will be called by a client to watch the
+                 * repository filesystem so that it doesn't exceed 95% full.
+                 *
+                 * @return Fraction of used/free.
+                 * @throws ResourceError If there is a problem calculating the
+                 *         usage fraction.
+                 **/
                 idempotent double getUsageFraction() throws ServerError;
+
+                /**
+                 * Checks that image data repository has not exceeded 95% disk
+                 * space use level.
+                 * @throws ResourceError If the repository usage has exceeded
+                 *         95%.
+                 * @throws InternalException If there is a critical failure
+                 *         while sanity checking the repository.
+                 **/
                 void sanityCheckRepository() throws ServerError;
+
+                /**
+                 * Removes all files from the server that do not have an
+                 * OriginalFile complement in the database, all the Pixels
+                 * that do not have a complement in the database and all the
+                 * Thumbnail's that do not have a complement in the database.
+                 *
+                 * @throws ResourceError If deletion fails.
+                 **/
                 void removeUnusedFiles() throws ServerError;
             };
 


### PR DESCRIPTION
See https://trello.com/c/KLCaZX4X/19-copy-ome-api-documentation-to-omero-api

Follow-up of https://github.com/openmicroscopy/openmicroscopy/pull/4547, this PR copies more of the ome.api.*  Javadoc documentation into the slice classes.

To review this PR, either build the slice documentation via `release-slice2html` or use the published CI documentation or `OMERO.docs*` artifacts. Check the links are all working and the method parameters match.
