### PR TITLE
Ticket 13202

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.view.MeasurementResults 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -522,7 +522,7 @@ class MeasurementResults
 		String filename = file.getAbsolutePath();
 		MeasurementTableModel tm = (MeasurementTableModel) results.getModel();
 		tm = tm.copy();
-		tm.setShowUnits(true);
+		tm.setShowUnits(false);
 		ExcelWriter writer = new ExcelWriter(filename);
 		writer.openFile();
 		writer.createSheet("Measurement Results");

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
@@ -148,6 +148,11 @@ public class MeasurementTableModel extends AbstractTableModel
                     buffer.append(UIUtilities.formatToDecimal(d));
                     buffer.append(" ");
                 }
+                if (v instanceof Length) {
+                    Length n = (Length) v;
+                    buffer.append(UIUtilities.twoDecimalPlaces(n.getValue()));
+                    buffer.append(" ");
+                }
             }
             if (total > 0) {
                 buffer.append("= "+UIUtilities.formatToDecimal(total));

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -561,7 +561,8 @@ public class MeasureBezierFigure
 
 		for (int i = 0 ; i < path.size(); i++)
 		{
-			pointArrayY.add(new LengthI(path.get(i).getControlPoint(0).getY(), getUnit()));
+		    pointArrayX.add(transformX(path.get(i).getControlPoint(0).getX()));
+		    pointArrayY.add(transformY(path.get(i).getControlPoint(0).getY()));
 		}
 		AnnotationKeys.POINTARRAYX.set(shape, pointArrayX);
 		AnnotationKeys.POINTARRAYY.set(shape, pointArrayY);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/annotation/AnnotationKeys.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/annotation/AnnotationKeys.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -50,15 +50,15 @@ public class AnnotationKeys
 	
 	/** The area of the figure. */
 	public static final AnnotationKey<Length> AREA = 
-		new AnnotationKey<Length>("measurementArea", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementArea", null);
 	
 	/** The perimeter of the figure. */
 	public static final AnnotationKey<Length> PERIMETER = 
-		new AnnotationKey<Length>("measurementPerimeter", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementPerimeter", null);
 	
 	/** The volume of the figure. */
 	public static final AnnotationKey<Length> VOLUME = 
-		new AnnotationKey<Length>("measurementVolume", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementVolume", null);
 	
 	/** A list of angles in the figure, used for bezier, line and 
 	 * line connection figures which can have a number of elbows. 
@@ -88,39 +88,39 @@ public class AnnotationKeys
 	
 	/** The X coord of the centre of the object. */
 	public static final AnnotationKey<Length> CENTREX= 
-		new AnnotationKey<Length>("measurementCentreX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementCentreX", null);
 
 	/** The Y coord of the centre of the object. */
 	public static final AnnotationKey<Length> CENTREY= 
-		new AnnotationKey<Length>("measurementCentreY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementCentreY", null);
 
 	/** The X coord of the start of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> STARTPOINTX= 
-		new AnnotationKey<Length>("measurementStartPointX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementStartPointX", null);
 
 	/** The X coord of the start of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> STARTPOINTY= 
-		new AnnotationKey<Length>("measurementStartPointY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementStartPointY", null);
 	
 	/** The X coord of the end of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> ENDPOINTX= 
-		new AnnotationKey<Length>("measurementEndPointX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementEndPointX", null);
 	
 	/** The Y coord of the end of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> ENDPOINTY= 
-		new AnnotationKey<Length>("measurementEndPointY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementEndPointY", null);
 	
 	/** The width of the figure. */
 	public static final AnnotationKey<Length> WIDTH = 
-		new AnnotationKey<Length>("measurementWidth", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementWidth", null);
 	
 	/** The height of the figure.*/
 	public static final AnnotationKey<Length> HEIGHT = 
-		new AnnotationKey<Length>("measurementHeight", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementHeight", null);
 	
     /** Should the figure show the measurement text. */
     public static final AnnotationKey<Object> TAG =


### PR DESCRIPTION
While investigating [Ticket 13202](https://trac.openmicroscopy.org/ome/ticket/13202#ticket) I fixed some problems with the ResultsTable of the MeasurementTool. This should also fix the error the user reported, although I couldn't reproduce it (but my suspicion is, it was some kind of unit conversion problem).

On that occassion I also made sure, that no unit up or down conversion ("round to reasonable unit") happens and that the ResultTable does not contain any unit symbols (numbers only),therefore the unit is shown in the headers of the table only (if it is a real unit and not in pixels). As far as I remember that was also requested in the past. The numbers in the table should all be of the same dimension so that they are easily comparable. This point might need some further discussion ( /cc @jburel @gusferguson ).

**Test**
- Make sure Coord_List(X) and Coord_List(Y) values are populated for Polygons, in the ResultsTable as well as the exported Excel file.
- Toggle between "calibrated" and "pixel value" display, check that the numbers are reasonable.

Note: I opened the PR agains regions, because this will certainly conflict with upcoming region PRs, although it's actually more a bugfix for develop branch.
