### PR TITLE
Re-enable saving of ExternalInfo (rebased onto dev_5_1)

### DIFF
--- a/components/model/src/ome/model/internal/Details.java
+++ b/components/model/src/ome/model/internal/Details.java
@@ -153,6 +153,7 @@ public abstract class Details implements Filterable, Serializable {
         setContexts(copy.contexts);
         setContext(copy.getContext());
         possiblySetPermissions(copy);
+        setExternalInfo(copy.getExternalInfo());
         setCreationEvent(copy.getCreationEvent());
         setOwner(copy.getOwner());
         setGroup(copy.getGroup());


### PR DESCRIPTION

This is the same as gh-4532 but rebased onto dev_5_1.

----

At some point (either during the move to blitz or later
during the hiding of Details implementations), the copying
of ExternalInfo objects from one Details to the next was
lost. Since then, no ExternalInfo objects could have been
linked to any IObject, and it's even unlikely that they
could have been created at all.

                