### PR TITLE
RoiTable DnD Scrolling

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -26,8 +26,13 @@ package org.openmicroscopy.shoola.agents.measurement.view;
 
 //Java imports
 import java.awt.Component;
+import java.awt.Insets;
 import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.dnd.DnDConstants;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -49,6 +54,10 @@ import javax.swing.DropMode;
 import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
 import javax.swing.ListSelectionModel;
+import javax.swing.Scrollable;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.ToolTipManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -60,7 +69,6 @@ import javax.swing.tree.TreePath;
 //Third-party libraries
 import org.jdesktop.swingx.JXTreeTable;
 import org.jhotdraw.draw.Figure;
-import org.apache.commons.collections.CollectionUtils;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -160,6 +168,86 @@ public class ROITable
 	    ROIS, SHAPES, FOLDERS, MIXED
 	}
 	
+	// DnD Scroll
+	
+	/** DnD autoscroll insets (this defines the scroll sensitive area) */
+    private static final int AUTOSCROLL_INSET = 10;
+    
+	/** DnD autoscroll timer */
+    private Timer timer;
+	
+	/** Track the last mouse drag position */
+    private Point lastPosition;
+    
+	/** outer DnD autoscroll rectable */
+    private Rectangle outer;
+
+    /** inner DnD autoscroll rectable */
+    private Rectangle inner;
+    
+	/**
+     * Autoscroll to position
+     */
+    private void autoscroll(Point position) {
+        Scrollable s = (Scrollable) this;
+        if (position.y < inner.y) {
+            // scroll upwards
+            int dy = s.getScrollableUnitIncrement(outer,
+                    SwingConstants.VERTICAL, -1);
+            Rectangle r = new Rectangle(inner.x, outer.y - dy, inner.width, dy);
+            scrollRectToVisible(r);
+        } else if (position.y > (inner.y + inner.height)) {
+            // scroll downwards
+            int dy = s.getScrollableUnitIncrement(outer,
+                    SwingConstants.VERTICAL, 1);
+            Rectangle r = new Rectangle(inner.x, outer.y + outer.height,
+                    inner.width, dy);
+            scrollRectToVisible(r);
+        }
+
+        if (position.x < inner.x) {
+            // scroll left
+            int dx = s.getScrollableUnitIncrement(outer,
+                    SwingConstants.HORIZONTAL, -1);
+            Rectangle r = new Rectangle(outer.x - dx, inner.y, dx, inner.height);
+            scrollRectToVisible(r);
+        } else if (position.x > (inner.x + inner.width)) {
+            // scroll right
+            int dx = s.getScrollableUnitIncrement(outer,
+                    SwingConstants.HORIZONTAL, 1);
+            Rectangle r = new Rectangle(outer.x + outer.width, inner.y, dx,
+                    inner.height);
+            scrollRectToVisible(r);
+        }
+    }
+    
+    /**
+     * Updates inner/outer autoscroll regions
+     */
+    private void updateRegion() {
+        // compute the outer
+        Rectangle visible = getVisibleRect();
+        outer.setBounds(visible.x, visible.y, visible.width, visible.height);
+
+        // compute the insets
+        Insets i = new Insets(0, 0, 0, 0);
+        if (this instanceof Scrollable) {
+            int minSize = 2 * AUTOSCROLL_INSET;
+
+            if (visible.width >= minSize) {
+                i.left = i.right = AUTOSCROLL_INSET;
+            }
+
+            if (visible.height >= minSize) {
+                i.top = i.bottom = AUTOSCROLL_INSET;
+            }
+        }
+
+        // set the inner from the insets
+        inner.setBounds(visible.x + i.left, visible.y + i.top, visible.width
+                - (i.left + i.right), visible.height - (i.top + i.bottom));
+    }
+    
 	/**
 	 * Returns <code>true</code> if all the roishapes in the shapelist 
 	 * have the same id, <code>false</code> otherwise.
@@ -283,6 +371,35 @@ public class ROITable
                     previousSelectionIndices = getSelectedRows();
             }
         });
+        
+        // DnD Scroll
+        
+        outer = new Rectangle();
+        inner = new Rectangle();
+
+        Toolkit t = Toolkit.getDefaultToolkit();
+        Integer prop;
+
+        ActionListener al = new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                updateRegion();
+                Point componentPosition = new Point(lastPosition);
+                SwingUtilities.convertPointFromScreen(componentPosition,
+                        ROITable.this);
+                if (outer.contains(componentPosition)
+                        && !inner.contains(componentPosition)) {
+                    autoscroll(componentPosition);
+                }
+            }
+        };
+
+        prop = (Integer) t.getDesktopProperty("DnD.Autoscroll.interval");
+        timer = new Timer(prop == null ? 100 : prop.intValue(), al);
+
+        prop = (Integer) t.getDesktopProperty("DnD.Autoscroll.initialDelay");
+        timer.setInitialDelay(prop == null ? 100 : prop.intValue());
 	}
 	
     /**
@@ -1629,7 +1746,6 @@ public class ROITable
             return new MouseInputHandler() {
 
                 public void mousePressed(MouseEvent e) {
-
                     Point origin = e.getPoint();
                     int row = table.rowAtPoint(origin);
                     int column = table.columnAtPoint(origin);
@@ -1642,9 +1758,17 @@ public class ROITable
 
                 @Override
                 public void mouseDragged(MouseEvent e) {
+                    lastPosition = e.getLocationOnScreen();
+                    if (!timer.isRunning())
+                        timer.start();
 
                     table.getTransferHandler().exportAsDrag(table, e,
                             DnDConstants.ACTION_MOVE);
+                }
+                
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    timer.stop();
                 }
             };
         }


### PR DESCRIPTION
Workaround to enable auto scrolling when dragging items on the ROITable.

**Test**: Select a few ROIs somewhere in the middle of the table, try to drag them to a position which currently lies outside of the visible part of the table by moving the cursor close to the upper or lower edge of the table. Make sure the table automatically scrolls up or down. 

Note: **This might not work on OSX**. Might be fixed in newer JDK version (see http://mail.openjdk.java.net/pipermail/awt-dev/2013-September/005643.html ), but couldn't confirm yet. Suggest to test with Windows.
