### PR TITLE
CLI duplicate command

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/duplicate.py
+++ b/components/tools/OmeroPy/src/omero/plugins/duplicate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+   Startup plugin for command-line duplicates
+
+   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+
+"""
+
+import sys
+
+from omero.cli import CLI, GraphControl
+
+HELP = """Duplicate OMERO data.
+
+Duplicate entire graphs of data based on the ID of the top-node.
+
+Examples:
+
+    # Duplicate a dataset
+    omero duplicate Datset:50
+    # Do the same reporting all the new duplicate objects
+    omero duplicate Dataset:50 --report
+
+    # Do a dry run of a duplicate reporting the outcome
+    # if the duplicate had been run
+    omero duplicate Dataset:53 --dry-run
+    # Do a dry run of a duplicate, reporting all the objects
+    # that would have been duplicated
+    omero duplicate Dataset:53 --dry-run --report
+
+"""
+
+
+class DuplicateControl(GraphControl):
+
+    def cmd_type(self):
+        import omero
+        import omero.all
+        return omero.cmd.Duplicate
+
+    def print_detailed_report(self, req, rsp, status):
+        import omero
+        if isinstance(rsp, omero.cmd.DoAllRsp):
+            for response in rsp.responses:
+                if isinstance(response, omero.cmd.DuplicateResponse):
+                    self.print_duplicate_response(response)
+        elif isinstance(rsp, omero.cmd.DuplicateResponse):
+            self.print_duplicate_response(rsp)
+
+    def print_duplicate_response(self, rsp):
+        if rsp.duplicates:
+            self.ctx.out("Duplicates")
+            objIds = self._get_object_ids(rsp.duplicates)
+            for k in objIds:
+                self.ctx.out("  %s:%s" % (k, objIds[k]))
+
+try:
+    register("duplicate", DuplicateControl, HELP)
+except NameError:
+    if __name__ == "__main__":
+        cli = CLI()
+        cli.register("duplicate", DuplicateControl, HELP)
+        cli.invoke(sys.argv[1:])

--- a/components/tools/OmeroPy/src/omero/plugins/duplicate.py
+++ b/components/tools/OmeroPy/src/omero/plugins/duplicate.py
@@ -25,6 +25,7 @@
 """
 
 import sys
+import os
 
 from omero.cli import CLI, GraphControl
 
@@ -77,7 +78,8 @@ class DuplicateControl(GraphControl):
                 self.ctx.out("  %s:%s" % (k, objIds[k]))
 
 try:
-    register("duplicate", DuplicateControl, HELP)
+    if "OMERO_DEV_PLUGINS" in os.environ:
+        register("duplicate", DuplicateControl, HELP)
 except NameError:
     if __name__ == "__main__":
         cli = CLI()

--- a/components/tools/OmeroPy/src/omero/plugins/duplicate.py
+++ b/components/tools/OmeroPy/src/omero/plugins/duplicate.py
@@ -32,10 +32,14 @@ HELP = """Duplicate OMERO data.
 
 Duplicate entire graphs of data based on the ID of the top-node.
 
+Note that no underlying binary data will be duplicated. For example,
+a duplicated Image will refer to the same underlying image files on
+the file system as the original image.
+
 Examples:
 
     # Duplicate a dataset
-    omero duplicate Datset:50
+    omero duplicate Dataset:50
     # Do the same reporting all the new duplicate objects
     omero duplicate Dataset:50 --report
 

--- a/components/tools/OmeroPy/src/omero/plugins/duplicate.py
+++ b/components/tools/OmeroPy/src/omero/plugins/duplicate.py
@@ -33,9 +33,10 @@ HELP = """Duplicate OMERO data.
 
 Duplicate entire graphs of data based on the ID of the top-node.
 
-Note that no underlying binary data will be duplicated. For example,
-a duplicated Image will refer to the same underlying image files on
-the file system as the original image.
+Note that no object that corresponds to a file on disk will be duplicated.
+In some circumstances a duplicate object may reference an original object that
+does have associated binary data but a duplicated image should not be expected
+to include any pixel data.
 
 Examples:
 

--- a/components/tools/OmeroPy/src/omero/plugins/duplicate.py
+++ b/components/tools/OmeroPy/src/omero/plugins/duplicate.py
@@ -1,10 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-   Startup plugin for command-line duplicates
 
-   Copyright 2009-2015 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+   Plugin for duplicating object graphs
 
 """
 


### PR DESCRIPTION
This PR adds a basic duplicate command to the CLI, this should duplicate simple objects and hierarchies. It includes integration tests for simple objects.

## Testing
See:
```
$ omero duplicate --help
...
Examples:

    # Duplicate a dataset
    omero duplicate Dataset:50
    # Do the same reporting all the new duplicate objects
    omero duplicate Dataset:50 --report

    # Do a dry run of a duplicate reporting the outcome
    # if the duplicate had been run
    omero duplicate Dataset:53 --dry-run
    # Do a dry run of a duplicate, reporting all the objects
    # that would have been duplicated
    omero duplicate Dataset:53 --dry-run --report
```
Multiple IDs and objects should also work:
```
$ omero duplicate Dataset:263,264
$ omero duplicate Dataset:263 Dataset:264
```
In addition hierarchies (P/D/I for example) and other complex objects should be duplicated. Create a simple P/D/I structure or import a Screen, then:
```
$ omero duplicate Project:123 --report
$ omero duplicate Screen:321 --report
```
the `--report` option is useful here to check the graph duplication.

To do
-----

Once this PR is merged @pwalczysko plans to add further tests for multiple arguments, simple hierarchies (P/D/I) and complex objects (Screen).

The command itself needs improving to deal with the options in @mtbc's underlying command.
