### PR TITLE
Shape renaming: insight review

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -265,20 +265,20 @@ class InputServerStrategy
 	 */
 	private MeasureEllipseFigure createEllipseFigure(EllipseData data)
 	{
-		double cx = data.getX();
-		double cy = data.getY();
-		double rx = data.getRadiusX();
-		double ry = data.getRadiusY();
+		double x = data.getX();
+		double y = data.getY();
+		double radiusx = data.getRadiusX();
+		double radiusy = data.getRadiusY();
 		
-		double x = cx-rx;
-		double y = cy-ry;
-		double width = rx*2d;
-		double height = ry*2d;
+		double x0 = x-radiusx;
+		double y0 = y-radiusy;
+		double width = radiusx*2d;
+		double height = radiusy*2d;
 		MeasureEllipseFigure fig = new MeasureEllipseFigure(data.getText(), 
-				x, y, width, height, data.isReadOnly(), 
+				x0, y0, width, height, data.isReadOnly(),
 					data.isClientObject(), data.canEdit(), data.canDelete(), 
 					data.canAnnotate());
-		fig.setEllipse(x, y, width, height);
+		fig.setEllipse(x0, y0, width, height);
 		fig.setText(data.getText());
 		addShapeSettings(fig, data.getShapeSettings());
 		AffineTransform transform;

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -101,10 +101,10 @@ public class ROIReader {
     private EllipseData convertEllipse(OvalRoi shape)
     {
         Rectangle bounds = shape.getBounds();
-        double rx = bounds.getWidth();
-        double ry = bounds.getHeight();
-        EllipseData r = new EllipseData(bounds.getX()+rx/2, bounds.getY()+ry/2,
-                rx/2, ry/2);
+        double width = bounds.getWidth();
+        double height = bounds.getHeight();
+        EllipseData r = new EllipseData(
+            bounds.getX()+width/2, bounds.getY()+height/2, width/2, height/2);
         r.setText(shape.getName());
         if (formatShape(shape, r)) {
             return r;


### PR DESCRIPTION
See https://trello.com/c/LW8l7U8x/20-shape-attribute-renaming-cleanup

This PR reviews the variable/methods used when retrieving Point and Ellipse attributes in the Insight component. In particular the following grep should return nothing

```
$ git grep -I [sg]et[RrCc][xy] -- examples
```

and the output of the following one should be reviewed:

```
$ git grep -I [^a-zA-Z][RrCc][XxYy] -- components/insight
```

All remaining usages of the variables above should either used in the context of JHotDraw or SVG  elements or have a different meaning e.g. ratio along x.