### PR TITLE
Copy ome.api.* documentation to omero.api.* (3)

### DIFF
--- a/components/blitz/resources/omero/api/IRenderingSettings.ice
+++ b/components/blitz/resources/omero/api/IRenderingSettings.ice
@@ -42,7 +42,7 @@ module omero {
                  * Returns the default rendering settings for a given pixels
                  * for the current user.
                  *
-                 * @param pixelsId The Id of the <code>Pixels</code>
+                 * @param pixelsId The Id of the Pixels
                  * @return See above.
                  * @throws ValidationException if the image qualified by
                  * <code>imageId</code> is unlocatable.
@@ -56,12 +56,11 @@ module omero {
                  * @param pixels The Pixels set to link to the rendering
                  *               definition.
                  * @return A new, blank rendering definition and sub-objects.
-                 * <b>NOTE:</b> the linked <code>Pixels</code> has been
-                 * unloaded.
+                 * <b>NOTE:</b> the linked Pixels has been unloaded.
                  **/
                 omero::model::RenderingDef createNewRenderingDef(omero::model::Pixels pixels) throws ServerError;
 
-        /**
+                /**
                  * Resets the given rendering settings to those that are
                  * specified by the rendering engine intelligent <i>pretty
                  * good image (PG)</i> logic for the pixels set linked to that
@@ -71,10 +70,10 @@ module omero {
                  * relies on certain objects being loaded. The rendering
                  * settings are saved upon completion.
                  *
-                 * @param def A <code>RenderingDef</code> to reset. It is
-                 *            expected that def.pixels will be <i>unloaded</i>
-                 *            and that the actual linked Pixels set will be
-                 *            provided in the <code>pixels</code> argument.
+                 * @param def A RenderingDef to reset. It is expected that
+                 *            def.pixels will be <i>unloaded</i> and that the
+                 *            actual linked Pixels set will be provided in the
+                 *            <code>pixels</code> argument.
                  * @param pixels The Pixels set for <code>def</code>.
                  **/
                 void resetDefaults(omero::model::RenderingDef def, omero::model::Pixels pixels) throws ServerError;
@@ -89,10 +88,10 @@ module omero {
                  * relies on certain objects being loaded. The rendering
                  * settings are not saved.
                  *
-                 * @param def A <code>RenderingDef</code> to reset. It is
-                 *            expected that def.pixels will be <i>unloaded</i>
-                 *            and that the actual linked Pixels set will be
-                 *            provided in the <code>pixels</code> argument.
+                 * @param def A RenderingDef to reset. It is expected that
+                 *            def.pixels will be <i>unloaded</i> and that the
+                 *            actual linked Pixels set will be provided in the
+                 *            <code>pixels</code> argument.
                  * @param pixels The Pixels set for <code>def</code>.
                  * @return <code>def</code> with the rendering settings reset.
                  **/
@@ -103,7 +102,7 @@ module omero {
                  * that are specified by the rendering engine intelligent
                  * <i>pretty good image (PG)</i> logic.
                  *
-                 * @param imageId The Id of the <code>Image</code>.
+                 * @param imageId The Id of the Image.
                  * @throws ValidationException if the image qualified by
                  * <code>imageId</code> is unlocatable.
                  **/
@@ -114,7 +113,7 @@ module omero {
                  * that are specified by the rendering engine intelligent
                  * <i>pretty good image (PG)</i> logic.
                  *
-                 * @param pixelsId The Id of the <code>Pixels</code>.
+                 * @param pixelsId The Id of the Pixels.
                  * @throws ValidationException if the Pixels qualified by
                  * <code>pixelsId</code> is unlocatable.
                  **/
@@ -125,7 +124,7 @@ module omero {
                  * are specified by the rendering engine intelligent <i>pretty
                  * good image (PG)</i> logic.
                  *
-                 * @param dataSetId The Id of the <code>DataSet</code>.
+                 * @param dataSetId The Id of the Dataset.
                  * @return A {@link java.util.Set} of image IDs that have had
                  *         their rendering settings reset.
                  * @throws ValidationException if the image qualified by
@@ -154,207 +153,206 @@ module omero {
                  **/
                 omero::sys::LongList resetDefaultsInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
 
-		/**
-		 * Resets the rendering settings of a given group of
+                /**
+                 * Resets the rendering settings of a given group of
                  * containers based on the owner's (essentially a copy).
                  * Supported container types are:
-		 * <ul>
-		 *   <li>{@link omero.model.Project}</li>
-		 *   <li>{@link omero.model.Dataset}</li>
-		 *   <li>{@link omero.model.Image}</li>
-		 *   <li>{@link omero.model.Plate}</li>
-		 *   <li>{@link omero.model.Pixels}</li>
-		 * </ul>
-		 * @param type The type of nodes to handle.
-		 * @param nodeIds Ids of the node type.
-		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * <ul>
+                 *   <li>{@link omero.model.Project}</li>
+                 *   <li>{@link omero.model.Dataset}</li>
+                 *   <li>{@link omero.model.Image}</li>
+                 *   <li>{@link omero.model.Plate}</li>
+                 *   <li>{@link omero.model.Pixels}</li>
+                 * </ul>
+                 * @param type The type of nodes to handle.
+                 * @param nodeIds Ids of the node type.
+                 * @return A {@link omero.sys.LongList} of image IDs that have
                  *         had their rendering settings reset.
-		 * @throws ValidationException if an illegal <code>type</code>
+                 * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
-		 */
+                 */
                 omero::sys::LongList resetDefaultsByOwnerInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
 
-		/**
-		 * Resets a the channel windows for one or many containers
+		        /**
+                 * Resets a the channel windows for one or many containers
                  * back to their global minimum and global maximum for the
                  * channel. Supported container types are:
-		 * <ul>
-		 *   <li>{@link omero.model.Project}</li>
-		 *   <li>{@link omero.model.Dataset}</li>
-		 *   <li>{@link omero.model.Image}</li>
-		 *   <li>{@link omero.model.Plate}</li>
-		 *   <li>{@link omero.model.Pixels}</li>
-		 * </ul>
-		 * @param type The type of nodes to handle.
-		 * @param nodeIds Ids of the node type.
-		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * <ul>
+                 *   <li>{@link omero.model.Project}</li>
+                 *   <li>{@link omero.model.Dataset}</li>
+                 *   <li>{@link omero.model.Image}</li>
+                 *   <li>{@link omero.model.Plate}</li>
+                 *   <li>{@link omero.model.Pixels}</li>
+                 * </ul>
+                 * @param type The type of nodes to handle.
+                 * @param nodeIds Ids of the node type.
+                 * @return A {@link omero.sys.LongList} of image IDs that have
                  *         had their rendering settings reset.
-		 * @throws ValidationException if an illegal <code>type</code>
+                 * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
-		 */
+                 */
                 omero::sys::LongList resetMinMaxInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
 
-		/**
-		 * Applies rendering settings to one or many containers. If a
-                 * container such as <code>Dataset</code> is to be copied to,
-                 * all images within that <code>Dataset</code> will have the
-                 * rendering settings applied. Supported container types are:
-		 * <ul>
-		 *   <li>{@link omero.model.Project}</li>
-		 *   <li>{@link omero.model.Dataset}</li>
-		 *   <li>{@link omero.model.Image}</li>
-		 *   <li>{@link omero.model.Plate}</li>
-		 *   <li>{@link omero.model.Screen}</li>
-		 *   <li>{@link omero.model.Pixels}</li>
-		 * </ul>
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to one or many containers. If a
+                 * container such as Dataset is to be copied to, all images
+                 * within that Dataset will have the rendering settings
+                 * applied. Supported container types are:
+                 * <ul>
+                 *   <li>{@link omero.model.Project}</li>
+                 *   <li>{@link omero.model.Dataset}</li>
+                 *   <li>{@link omero.model.Image}</li>
+                 *   <li>{@link omero.model.Plate}</li>
+                 *   <li>{@link omero.model.Screen}</li>
+                 *   <li>{@link omero.model.Pixels}</li>
+                 * </ul>
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param toType The type of nodes to handle.
-		 * @param nodeIds Ids of the node type.
-		 * @return A map with two boolean keys. The value of the
+                 * @param toType The type of nodes to handle.
+                 * @param nodeIds Ids of the node type.
+                 * @return A map with two boolean keys. The value of the
                  *         <code>TRUE</code> is a collection of images ID, the
                  *         settings were successfully applied to.
-		 *         The value of the <code>FALSE</code> is a collection
+                 *         The value of the <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
-		 * @throws ValidationException if an illegal <code>type</code>
+                 * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
-		 */
+                 */
                 BooleanIdListMap applySettingsToSet(long from, string toType, omero::sys::LongList nodeIds) throws ServerError;
 
-		/**
-		 * Applies rendering settings to all images in all
-                 * <code>Datasets</code> of a given <code>Project</code>.
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to all images in all Datasets of
+                 * a given Project.
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param to The Id of the project container to apply settings
+                 * @param to The Id of the project container to apply settings
                  *           to.
-		 * @return A map with two boolean keys. The value of the
+                 * @return A map with two boolean keys. The value of the
                  *         <code>TRUE</code> is a collection of images ID, the
                  *         settings were successfully applied to.
-		 *         The value of the <code>FALSE</code> is a collection
+                 *         The value of the <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
-		 * @throws ValidationException if the rendering settings
+                 * @throws ValidationException if the rendering settings
                  *         <code>from</code> is unlocatable or the project
                  *         <code>to</code> is unlocatable.
-		 */
+                 */
                 BooleanIdListMap applySettingsToProject(long from, long to) throws ServerError;
 
-		/**
-		 * Applies rendering settings to all images in a given
-                 * <code>Dataset</code>.
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to all images in a given Dataset.
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param to The Id of the dataset container to apply settings
+                 * @param to The Id of the dataset container to apply settings
                  *           to.
-		 * @return A map with two boolean keys. The value of the
+                 * @return A map with two boolean keys. The value of the
                  *         <code>TRUE</code> is a collection of images ID, the
                  *         settings were successfully applied to.
-		 *         The value of the <code>FALSE</code> is a collection
+                 *         The value of the <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
-		 * @throws ValidationException if the rendering settings
+                 * @throws ValidationException if the rendering settings
                  *         <code>from</code> is unlocatable or the dataset
                  *         <code>to</code> is unlocatable.
-		 */
+                 */
                 BooleanIdListMap applySettingsToDataset(long from, long to) throws ServerError;
 
-		/**
-		 * Applies rendering settings to a given <code>Image</code>.
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to a given Image.
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param to The Id of the image container to apply settings
+                 * @param to The Id of the image container to apply settings
                  *           to.
-		 * @return <code>true</code> if the settings were successfully
+                 * @return <code>true</code> if the settings were successfully
                  *         applied, <code>false</code> otherwise.
-		 * @throws ValidationException if the rendering settings
+                 * @throws ValidationException if the rendering settings
                  *         <code>from</code> is unlocatable or the image
                  *         <code>to</code> is unlocatable.
-		 */
+                 */
                 BooleanIdListMap applySettingsToImages(long from, omero::sys::LongList to) throws ServerError;
 
-		/**
-		 * Applies rendering settings to a given <code>Image</code>.
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to a given Image.
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param to The Id of the image container to apply settings
+                 * @param to The Id of the image container to apply settings
                  *           to.
-		 * @return <code>true</code> if the settings were successfully
+                 * @return <code>true</code> if the settings were successfully
                  *         applied, <code>false</code> otherwise.
-		 * @throws ValidationException if the rendering settings
+                 * @throws ValidationException if the rendering settings
                  *         <code>from</code> is unlocatable or the image
                  *         <code>to</code> is unlocatable.
-		 */
+                 */
                 bool applySettingsToImage(long from, long to) throws ServerError;
 
-		/**
-		 * Applies rendering settings to a given <code>Pixels</code>.
-		 *
-		 * @param from The Id of the pixels set to copy the rendering
+		        /**
+                 * Applies rendering settings to a given Pixels.
+                 *
+                 * @param from The Id of the pixels set to copy the rendering
                  *             settings from.
-		 * @param to The Id of the pixels container to apply settings
+                 * @param to The Id of the pixels container to apply settings
                  *           to.
-		 * @return See above.
-		 * @throws ValidationException if the rendering settings
+                 * @return See above.
+                 * @throws ValidationException if the rendering settings
                  *         <code>from</code> is unlocatable or the
                  *         pixels<code>to</code> is unlocatable.
-		 */
+                 */
                 bool applySettingsToPixels(long from, long to) throws ServerError;
 
-		/**
-		 * Resets an image's default rendering settings back to
+		        /**
+                 * Resets an image's default rendering settings back to
                  * channel global minimum and maximum.
-		 *
-		 * @param imageId The Id of the <code>Image</code>.
-		 * @throws ValidationException if the image qualified by
-		 *         <code>imageId</code> is unlocatable.
-		 */
+                 *
+                 * @param imageId The Id of the Image.
+                 * @throws ValidationException if the image qualified by
+                 *         <code>imageId</code> is unlocatable.
+                 */
                 void setOriginalSettingsInImage(long imageId) throws ServerError;
 
-		/**
-		 * Resets an Pixels' default rendering settings back to
+	         	/**
+                 * Resets an Pixels' default rendering settings back to
                  * channel global minimum and maximum.
-		 *
-		 * @param pixelsId The Id of the <code>Pixels</code> set.
-		 * @throws ValidationException if the image qualified by
-		 *         <code>pixelsId</code> is unlocatable.
-		 */
+                 *
+                 * @param pixelsId The Id of the Pixels set.
+                 * @throws ValidationException if the image qualified by
+                 *         <code>pixelsId</code> is unlocatable.
+                 */
                 void setOriginalSettingsForPixels(long pixelsId) throws ServerError;
 
-		/**
-		 * Resets a dataset's rendering settings back to channel global
-		 * minimum and maximum.
+		        /**
+                 * Resets a dataset's rendering settings back to channel global
+                 * minimum and maximum.
                  *
-		 * @param datasetId The id of the dataset to handle.
-		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * @param datasetId The id of the dataset to handle.
+                 * @return A {@link omero.sys.LongList} of image IDs that have
                  *         had their rendering settings reset.
-		 * @throws ValidationException if the image qualified by
-		 *         <code>datasetId</code> is unlocatable.
-		 */
+                 * @throws ValidationException if the image qualified by
+                 *         <code>datasetId</code> is unlocatable.
+                 */
                 omero::sys::LongList setOriginalSettingsInDataset(long dataSetId) throws ServerError;
 
-		/**
-		 * Resets a rendering settings back to channel global minimum
+		        /**
+                 * Resets a rendering settings back to channel global minimum
                  * and maximum for the specified containers. Supported
                  * container types are:
-		 * <ul>
-		 *   <li>{@link omero.model.Project}</li>
-		 *   <li>{@link omero.model.Dataset}</li>
-		 *   <li>{@link omero.model.Image}</li>
-		 *   <li>{@link omero.model.Plate}</li>
-		 *   <li>{@link omero.model.Pixels}</li>
-		 * </ul>
-		 *
-		 * @param type The type of nodes to handle.
-		 * @param nodeIds Ids of the node type.
-		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * <ul>
+                 *   <li>{@link omero.model.Project}</li>
+                 *   <li>{@link omero.model.Dataset}</li>
+                 *   <li>{@link omero.model.Image}</li>
+                 *   <li>{@link omero.model.Plate}</li>
+                 *   <li>{@link omero.model.Pixels}</li>
+                 * </ul>
+                 *
+                 * @param type The type of nodes to handle.
+                 * @param nodeIds Ids of the node type.
+                 * @return A {@link omero.sys.LongList} of image IDs that have
                  *         had their rendering settings reset.
-		 * @throws ValidationException if an illegal <code>type</code>
+                 * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
-		 */
+                 */
                 omero::sys::LongList setOriginalSettingsInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
             };
     };

--- a/components/blitz/resources/omero/api/IRenderingSettings.ice
+++ b/components/blitz/resources/omero/api/IRenderingSettings.ice
@@ -173,7 +173,7 @@ module omero {
                  */
                 omero::sys::LongList resetDefaultsByOwnerInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
 
-		        /**
+                /**
                  * Resets a the channel windows for one or many containers
                  * back to their global minimum and global maximum for the
                  * channel. Supported container types are:
@@ -193,7 +193,7 @@ module omero {
                  */
                 omero::sys::LongList resetMinMaxInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to one or many containers. If a
                  * container such as Dataset is to be copied to, all images
                  * within that Dataset will have the rendering settings
@@ -221,7 +221,7 @@ module omero {
                  */
                 BooleanIdListMap applySettingsToSet(long from, string toType, omero::sys::LongList nodeIds) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to all images in all Datasets of
                  * a given Project.
                  *
@@ -240,7 +240,7 @@ module omero {
                  */
                 BooleanIdListMap applySettingsToProject(long from, long to) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to all images in a given Dataset.
                  *
                  * @param from The Id of the pixels set to copy the rendering
@@ -258,7 +258,7 @@ module omero {
                  */
                 BooleanIdListMap applySettingsToDataset(long from, long to) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to a given Image.
                  *
                  * @param from The Id of the pixels set to copy the rendering
@@ -273,7 +273,7 @@ module omero {
                  */
                 BooleanIdListMap applySettingsToImages(long from, omero::sys::LongList to) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to a given Image.
                  *
                  * @param from The Id of the pixels set to copy the rendering
@@ -288,7 +288,7 @@ module omero {
                  */
                 bool applySettingsToImage(long from, long to) throws ServerError;
 
-		        /**
+                /**
                  * Applies rendering settings to a given Pixels.
                  *
                  * @param from The Id of the pixels set to copy the rendering
@@ -302,7 +302,7 @@ module omero {
                  */
                 bool applySettingsToPixels(long from, long to) throws ServerError;
 
-		        /**
+                /**
                  * Resets an image's default rendering settings back to
                  * channel global minimum and maximum.
                  *
@@ -312,7 +312,7 @@ module omero {
                  */
                 void setOriginalSettingsInImage(long imageId) throws ServerError;
 
-	         	/**
+                /**
                  * Resets an Pixels' default rendering settings back to
                  * channel global minimum and maximum.
                  *
@@ -322,7 +322,7 @@ module omero {
                  */
                 void setOriginalSettingsForPixels(long pixelsId) throws ServerError;
 
-		        /**
+                /**
                  * Resets a dataset's rendering settings back to channel global
                  * minimum and maximum.
                  *
@@ -334,7 +334,7 @@ module omero {
                  */
                 omero::sys::LongList setOriginalSettingsInDataset(long dataSetId) throws ServerError;
 
-		        /**
+                /**
                  * Resets a rendering settings back to channel global minimum
                  * and maximum for the specified containers. Supported
                  * container types are:

--- a/components/blitz/resources/omero/api/IRenderingSettings.ice
+++ b/components/blitz/resources/omero/api/IRenderingSettings.ice
@@ -20,30 +20,341 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IRenderingSettings.html">IRenderingSettings.html</a>
+         * Provides method to apply rendering settings to a collection of
+         * images.
+         * All methods will receive the id of the pixels set to copy the
+         * rendering settings from.
          **/
         ["ami", "amd"] interface IRenderingSettings extends ServiceInterface
             {
+                /**
+                 * Checks if the specified sets of pixels are compatible.
+                 * Returns <code>true</code> if the pixels set is valid,
+                 * <code>false</code> otherwise.
+                 *
+                 * @param pFrom The pixels set to copy the settings from.
+                 * @param pTo The pixels set to copy the settings to.
+                 * @return See above.
+                 **/
                 idempotent bool sanityCheckPixels(omero::model::Pixels pFrom, omero::model::Pixels pTo) throws ServerError;
+
+                /**
+                 * Returns the default rendering settings for a given pixels
+                 * for the current user.
+                 *
+                 * @param pixelsId The Id of the <code>Pixels</code>
+                 * @return See above.
+                 * @throws ValidationException if the image qualified by
+                 * <code>imageId</code> is unlocatable.
+                 **/
                 idempotent omero::model::RenderingDef getRenderingSettings(long pixelsId) throws ServerError;
+
+                /**
+                 * Creates a new rendering definition object along with its
+                 * sub-objects.
+                 *
+                 * @param pixels The Pixels set to link to the rendering
+                 *               definition.
+                 * @return A new, blank rendering definition and sub-objects.
+                 * <b>NOTE:</b> the linked <code>Pixels</code> has been
+                 * unloaded.
+                 **/
                 omero::model::RenderingDef createNewRenderingDef(omero::model::Pixels pixels) throws ServerError;
+
+        /**
+                 * Resets the given rendering settings to those that are
+                 * specified by the rendering engine intelligent <i>pretty
+                 * good image (PG)</i> logic for the pixels set linked to that
+                 * set of rendering settings. <b>NOTE:</b> This method should
+                 * only be used to reset a rendering definition that has been
+                 * retrieved via {@link #getRenderingSettings} as it
+                 * relies on certain objects being loaded. The rendering
+                 * settings are saved upon completion.
+                 *
+                 * @param def A <code>RenderingDef</code> to reset. It is
+                 *            expected that def.pixels will be <i>unloaded</i>
+                 *            and that the actual linked Pixels set will be
+                 *            provided in the <code>pixels</code> argument.
+                 * @param pixels The Pixels set for <code>def</code>.
+                 **/
                 void resetDefaults(omero::model::RenderingDef def, omero::model::Pixels pixels) throws ServerError;
+
+                /**
+                 * Resets the given rendering settings to those that are
+                 * specified by the rendering engine intelligent <i>pretty
+                 * good image (PG)</i> logic for the pixels set linked to that
+                 * set of rendering settings. <b>NOTE:</b> This method should
+                 * only be used to reset a rendering definition that has been
+                 * retrieved via {@link #getRenderingSettings(long)} as it
+                 * relies on certain objects being loaded. The rendering
+                 * settings are not saved.
+                 *
+                 * @param def A <code>RenderingDef</code> to reset. It is
+                 *            expected that def.pixels will be <i>unloaded</i>
+                 *            and that the actual linked Pixels set will be
+                 *            provided in the <code>pixels</code> argument.
+                 * @param pixels The Pixels set for <code>def</code>.
+                 * @return <code>def</code> with the rendering settings reset.
+                 **/
                 omero::model::RenderingDef resetDefaultsNoSave(omero::model::RenderingDef def, omero::model::Pixels pixels) throws ServerError;
+
+                /**
+                 * Resets an image's default rendering settings back to those
+                 * that are specified by the rendering engine intelligent
+                 * <i>pretty good image (PG)</i> logic.
+                 *
+                 * @param imageId The Id of the <code>Image</code>.
+                 * @throws ValidationException if the image qualified by
+                 * <code>imageId</code> is unlocatable.
+                 **/
                 void resetDefaultsInImage(long imageId) throws ServerError;
+
+                /**
+                 * Resets a Pixels' default rendering settings back to those
+                 * that are specified by the rendering engine intelligent
+                 * <i>pretty good image (PG)</i> logic.
+                 *
+                 * @param pixelsId The Id of the <code>Pixels</code>.
+                 * @throws ValidationException if the Pixels qualified by
+                 * <code>pixelsId</code> is unlocatable.
+                 **/
                 void resetDefaultsForPixels(long pixelsId) throws ServerError;
+
+                /**
+                 * Resets a dataset's rendering settings back to those that
+                 * are specified by the rendering engine intelligent <i>pretty
+                 * good image (PG)</i> logic.
+                 *
+                 * @param dataSetId The Id of the <code>DataSet</code>.
+                 * @return A {@link java.util.Set} of image IDs that have had
+                 *         their rendering settings reset.
+                 * @throws ValidationException if the image qualified by
+                 * <code>dataSetId</code> is unlocatable.
+                 **/
                 omero::sys::LongList resetDefaultsInDataset(long dataSetId) throws ServerError;
+
+                /**
+                 * Resets a rendering settings back to one or many containers
+                 * that are specified by the rendering engine intelligent
+                 * <i>pretty good image (PG)</i> logic. Supported container
+                 * types are:
+                 * <ul>
+                 *   <li>{@link omero.model.Project}</li>
+                 *   <li>{@link omero.model.Dataset}</li>
+                 *   <li>{@link omero.model.Image}</li>
+                 *   <li>{@link omero.model.Plate}</li>
+                 *   <li>{@link omero.model.Pixels}</li>
+                 * </ul>
+                 * @param type The type of nodes to handle.
+                 * @param nodeIds Ids of the node type.
+                 * @return A {@link java.util.Set} of image IDs that have had
+                 *         their rendering settings reset.
+                 * @throws ValidationException if an illegal <code>type</code>
+                 *         is used.
+                 **/
                 omero::sys::LongList resetDefaultsInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
+
+		/**
+		 * Resets the rendering settings of a given group of
+                 * containers based on the owner's (essentially a copy).
+                 * Supported container types are:
+		 * <ul>
+		 *   <li>{@link omero.model.Project}</li>
+		 *   <li>{@link omero.model.Dataset}</li>
+		 *   <li>{@link omero.model.Image}</li>
+		 *   <li>{@link omero.model.Plate}</li>
+		 *   <li>{@link omero.model.Pixels}</li>
+		 * </ul>
+		 * @param type The type of nodes to handle.
+		 * @param nodeIds Ids of the node type.
+		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 *         had their rendering settings reset.
+		 * @throws ValidationException if an illegal <code>type</code>
+                 *         is used.
+		 */
                 omero::sys::LongList resetDefaultsByOwnerInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
+
+		/**
+		 * Resets a the channel windows for one or many containers
+                 * back to their global minimum and global maximum for the
+                 * channel. Supported container types are:
+		 * <ul>
+		 *   <li>{@link omero.model.Project}</li>
+		 *   <li>{@link omero.model.Dataset}</li>
+		 *   <li>{@link omero.model.Image}</li>
+		 *   <li>{@link omero.model.Plate}</li>
+		 *   <li>{@link omero.model.Pixels}</li>
+		 * </ul>
+		 * @param type The type of nodes to handle.
+		 * @param nodeIds Ids of the node type.
+		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 *         had their rendering settings reset.
+		 * @throws ValidationException if an illegal <code>type</code>
+                 *         is used.
+		 */
                 omero::sys::LongList resetMinMaxInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
-                BooleanIdListMap applySettingsToSet(long from, string toType, omero::sys::LongList to) throws ServerError;
+
+		/**
+		 * Applies rendering settings to one or many containers. If a
+                 * container such as <code>Dataset</code> is to be copied to,
+                 * all images within that <code>Dataset</code> will have the
+                 * rendering settings applied. Supported container types are:
+		 * <ul>
+		 *   <li>{@link omero.model.Project}</li>
+		 *   <li>{@link omero.model.Dataset}</li>
+		 *   <li>{@link omero.model.Image}</li>
+		 *   <li>{@link omero.model.Plate}</li>
+		 *   <li>{@link omero.model.Screen}</li>
+		 *   <li>{@link omero.model.Pixels}</li>
+		 * </ul>
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param toType The type of nodes to handle.
+		 * @param nodeIds Ids of the node type.
+		 * @return A map with two boolean keys. The value of the
+                 *         <code>TRUE</code> is a collection of images ID, the
+                 *         settings were successfully applied to.
+		 *         The value of the <code>FALSE</code> is a collection
+                 *         of images ID, the settings could not be applied to.
+		 * @throws ValidationException if an illegal <code>type</code>
+                 *         is used.
+		 */
+                BooleanIdListMap applySettingsToSet(long from, string toType, omero::sys::LongList nodeIds) throws ServerError;
+
+		/**
+		 * Applies rendering settings to all images in all
+                 * <code>Datasets</code> of a given <code>Project</code>.
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param to The Id of the project container to apply settings
+                 *           to.
+		 * @return A map with two boolean keys. The value of the
+                 *         <code>TRUE</code> is a collection of images ID, the
+                 *         settings were successfully applied to.
+		 *         The value of the <code>FALSE</code> is a collection
+                 *         of images ID, the settings could not be applied to.
+		 * @throws ValidationException if the rendering settings
+                 *         <code>from</code> is unlocatable or the project
+                 *         <code>to</code> is unlocatable.
+		 */
                 BooleanIdListMap applySettingsToProject(long from, long to) throws ServerError;
+
+		/**
+		 * Applies rendering settings to all images in a given
+                 * <code>Dataset</code>.
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param to The Id of the dataset container to apply settings
+                 *           to.
+		 * @return A map with two boolean keys. The value of the
+                 *         <code>TRUE</code> is a collection of images ID, the
+                 *         settings were successfully applied to.
+		 *         The value of the <code>FALSE</code> is a collection
+                 *         of images ID, the settings could not be applied to.
+		 * @throws ValidationException if the rendering settings
+                 *         <code>from</code> is unlocatable or the dataset
+                 *         <code>to</code> is unlocatable.
+		 */
                 BooleanIdListMap applySettingsToDataset(long from, long to) throws ServerError;
+
+		/**
+		 * Applies rendering settings to a given <code>Image</code>.
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param to The Id of the image container to apply settings
+                 *           to.
+		 * @return <code>true</code> if the settings were successfully
+                 *         applied, <code>false</code> otherwise.
+		 * @throws ValidationException if the rendering settings
+                 *         <code>from</code> is unlocatable or the image
+                 *         <code>to</code> is unlocatable.
+		 */
                 BooleanIdListMap applySettingsToImages(long from, omero::sys::LongList to) throws ServerError;
+
+		/**
+		 * Applies rendering settings to a given <code>Image</code>.
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param to The Id of the image container to apply settings
+                 *           to.
+		 * @return <code>true</code> if the settings were successfully
+                 *         applied, <code>false</code> otherwise.
+		 * @throws ValidationException if the rendering settings
+                 *         <code>from</code> is unlocatable or the image
+                 *         <code>to</code> is unlocatable.
+		 */
                 bool applySettingsToImage(long from, long to) throws ServerError;
+
+		/**
+		 * Applies rendering settings to a given <code>Pixels</code>.
+		 *
+		 * @param from The Id of the pixels set to copy the rendering
+                 *             settings from.
+		 * @param to The Id of the pixels container to apply settings
+                 *           to.
+		 * @return See above.
+		 * @throws ValidationException if the rendering settings
+                 *         <code>from</code> is unlocatable or the
+                 *         pixels<code>to</code> is unlocatable.
+		 */
                 bool applySettingsToPixels(long from, long to) throws ServerError;
+
+		/**
+		 * Resets an image's default rendering settings back to
+                 * channel global minimum and maximum.
+		 *
+		 * @param imageId The Id of the <code>Image</code>.
+		 * @throws ValidationException if the image qualified by
+		 *         <code>imageId</code> is unlocatable.
+		 */
                 void setOriginalSettingsInImage(long imageId) throws ServerError;
+
+		/**
+		 * Resets an Pixels' default rendering settings back to
+                 * channel global minimum and maximum.
+		 *
+		 * @param pixelsId The Id of the <code>Pixels</code> set.
+		 * @throws ValidationException if the image qualified by
+		 *         <code>pixelsId</code> is unlocatable.
+		 */
                 void setOriginalSettingsForPixels(long pixelsId) throws ServerError;
+
+		/**
+		 * Resets a dataset's rendering settings back to channel global
+		 * minimum and maximum.
+                 *
+		 * @param datasetId The id of the dataset to handle.
+		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 *         had their rendering settings reset.
+		 * @throws ValidationException if the image qualified by
+		 *         <code>datasetId</code> is unlocatable.
+		 */
                 omero::sys::LongList setOriginalSettingsInDataset(long dataSetId) throws ServerError;
+
+		/**
+		 * Resets a rendering settings back to channel global minimum
+                 * and maximum for the specified containers. Supported
+                 * container types are:
+		 * <ul>
+		 *   <li>{@link omero.model.Project}</li>
+		 *   <li>{@link omero.model.Dataset}</li>
+		 *   <li>{@link omero.model.Image}</li>
+		 *   <li>{@link omero.model.Plate}</li>
+		 *   <li>{@link omero.model.Pixels}</li>
+		 * </ul>
+		 *
+		 * @param type The type of nodes to handle.
+		 * @param nodeIds Ids of the node type.
+		 * @return A {@link omero.sys.LongList} of image IDs that have
+                 *         had their rendering settings reset.
+		 * @throws ValidationException if an illegal <code>type</code>
+                 *         is used.
+		 */
                 omero::sys::LongList setOriginalSettingsInSet(string type, omero::sys::LongList nodeIds) throws ServerError;
             };
     };

--- a/components/blitz/resources/omero/api/ISession.ice
+++ b/components/blitz/resources/omero/api/ISession.ice
@@ -19,20 +19,41 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ISession.html">ISession.html</a>
-         **/
+         * {@link omero.model.Session} creation service for OMERO. Access to
+         * all other services is dependent upon a properly created and still
+         * active {@link omero.model.Session}.
+         *
+         * The session uuid ({@link omero.model.Session#getUuid}) can be
+         * considered a capability token, or temporary single use password.
+         * Simply by possessing it the client has access to all information
+         * available to the {@link omero.model.Session}.
+         *
+         * Note: Both the RMI <code>ome.system.ServiceFactory</code> as well
+         * as the Ice {@link omero.api.ServiceFactory} use
+         * {@link omero.api.ISession} to acquire a
+         * {@link omero.model.Session}. In the Ice case, Glacier2
+         * contacts {@link omero.api.ISession} itself and returns a
+         * ServiceFactory remote proxy. From both ServiceFactory
+         * instances, it is possible but not necessary to access
+         * {@link omero.api.ISession}.
+         */
         ["ami", "amd"] interface ISession extends ServiceInterface
             {
-
+                /**
+                 * Creates a new session and returns it to the user.
+                 *
+                 * @throws ApiUsageException if principal is null
+                 * @throws SecurityViolation if the password check fails
+                 */
                 omero::model::Session createSession(omero::sys::Principal p, string credentials)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
                 /**
-                 * HasPassword: Requires the session to have been created with a password
-                 * as opposed to with a session uuid (via joinSession). If that's not the
-                 * case, a SecurityViolation will be thrown, in which case
-                 * ServiceFactory.setSecurityPassword can be used.
-                 **/
+                 * Allows a user to open up another session for him/herself with the given
+                 * defaults without needing to re-enter password.
+                 *
+                 * TODO Review the security of this method.
+                 */
                 omero::model::Session createUserSession(long timeToLiveMilliseconds, long timeToIdleMilliseconds, string defaultGroup)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
@@ -40,29 +61,145 @@ module omero {
                 // System users
                 //
 
+                /**
+                 * Allows an admin to create a {@link Session} for the give
+                 * {@link omero.sys.Principal}.
+                 *
+                 * @param principal
+                 *            Non-null {@link omero.sys.Principal} with the
+                 *            target user's name
+                 * @param timeToLiveMilliseconds
+                 *            The time that this {@link omero.model.Session}
+                 *            has until destruction. This is useful to
+                 *            override the server default so that an initial
+                 *            delay before the user is given the token will
+                 *            not be construed as idle time. A value less than
+                 *            1 will cause the default max timeToLive to be
+                 *            used; but timeToIdle will be disabled.
+                 */
                 omero::model::Session createSessionWithTimeout(omero::sys::Principal p, long timeToLiveMilliseconds)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
+                /**
+                 * Allows an admin to create a {@link omero.model.Session} for
+                 * the given {@link omero.sys.Principal}.
+                 *
+                 * @param principal
+                 *            Non-null {@link omero.sys.Principal} with the
+                 *            target user's name
+                 * @param timeToLiveMilliseconds
+                 *            The time that this {@link omero.model.Session}
+                 *            has until destruction. Setting the value to 0
+                 *            will prevent destruction unless the session
+                 *            remains idle.
+                 * @param timeToIdleMilliseconds
+                 *            The time that this {@link omero.model.Session}
+                 *            can remain idle before being destroyed. Setting
+                 *            the value to 0 will prevent idleness based
+                 *            destruction.
+                 */
                 omero::model::Session createSessionWithTimeouts(omero::sys::Principal p, long timeToLiveMilliseconds, long timeToIdleMilliseconds)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
+                /**
+                 * Retrieves the session associated with this uuid, updating
+                 * the last access time as well. Throws a
+                 * {@link RemovedSessionException} if not present, or
+                 * a {@link SessionTimeoutException} if expired.
+                 *
+                 * This method can be used as a {@link Session} ping.
+                 */
                 idempotent omero::model::Session getSession(string sessionUuid) throws ServerError;
+
+                /**
+                 * Retrieves the current reference count for the given uuid.
+                 * Has the same semantics as {@link #getSession}.
+                 */
                 idempotent int getReferenceCount(string sessionUuid) throws ServerError;
+
+                /**
+                 * Closes session and releases all resources. It is preferred
+                 * that all clients call this method as soon as possible to
+                 * free memory, but it is possible to not call close, and
+                 * rejoin a session later.
+                 *
+                 * The current reference count for the session is returned. If
+                 * the session does not exist, -1. If this call caused the
+                 * death of the session, then -2.
+                 */
                 int closeSession(omero::model::Session sess) throws ServerError;
 
                 // Listing
+                /**
+                 * Returns a list of open sessions for the current user. The
+                 * list is ordered by session creation time, so that the last
+                 * item was created last.
+                 */
                 idempotent SessionList getMyOpenSessions() throws ServerError;
+
+                /**
+                 * Like {@link #getMyOpenSessions} but returns only those
+                 * sessions with the given agent string.
+                 */
                 idempotent SessionList getMyOpenAgentSessions(string agent) throws ServerError;
+
+                /**
+                 * Like {@link #getMyOpenSessions} but returns only those
+                 * sessions started by official OMERO clients.
+                 */
                 idempotent SessionList getMyOpenClientSessions() throws ServerError;
 
                 // Environment
+                /**
+                 * Retrieves an entry from the given
+                 * {@link omero.model.Session} input environment.
+                 */
                 idempotent omero::RType getInput(string sess, string key) throws ServerError;
+
+                /**
+                 * Retrieves an entry from the {@link omero.model.Session}
+                 * output environment.
+                 */
                 idempotent omero::RType getOutput(string sess, string key) throws ServerError;
+
+                /**
+                 * Places an entry in the given {@link omero.model.Session}
+                 * input environment.
+                 * If the value is null, the key will be removed.
+                 */
                 idempotent void setInput(string sess, string key, omero::RType value) throws ServerError;
+
+                /**
+                 * Places an entry in the given {@link omero.model.Session}
+                 * output environment. If the value is null, the key will be
+                 * removed.
+                 */
                 idempotent void setOutput(string sess, string key, omero::RType value) throws ServerError;
+
+                /**
+                 * Retrieves all keys in the {@link omero.model.Session} input
+                 * environment.
+                 *
+                 * @return a {@link StringSet} of keys
+                 */
                 idempotent StringSet getInputKeys(string sess) throws ServerError;
+
+                /**
+                 * Retrieves all keys in the {@link omero.model.Session}
+                 * output environment.
+                 */
                 idempotent StringSet getOutputKeys(string sess) throws ServerError;
+
+                /**
+                 * Retrieves all inputs from the given
+                 * {@link omero.model.Session} input environment.
+                 */
                 idempotent omero::RTypeDict getInputs(string sess) throws ServerError;
+
+                /**
+                 * Retrieves all outputs from the given
+                 * {@link omero.model.Session} input environment.
+                 */
                 idempotent omero::RTypeDict getOutputs(string sess) throws ServerError;
             };
 

--- a/components/blitz/resources/omero/api/IShare.ice
+++ b/components/blitz/resources/omero/api/IShare.ice
@@ -18,23 +18,146 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/IShare.html">IShare.html</a>
+         * Provides method for sharing - collaboration process for images,
+         * datasets, projects.
          **/
         ["ami", "amd"] interface IShare extends ServiceInterface
             {
+                /**
+                 * Turns on the access control lists attached to the given
+                 * share for the current session. Warning: this will slow down
+                 * the execution of the current session for all database
+                 * reads. Writing to the database will not be allowed. If
+                 * share does not exist or is not accessible (non-members) or
+                 * is disabled, then an {@link ValidationException} is thrown.
+                 */
                 idempotent void activate(long shareId) throws ServerError;
+
+                /**
+                 * Turns off the access control lists with the current share.
+                 */
                 idempotent void deactivate() throws ServerError;
+
+                /**
+                 * Gets a share as a {@link omero.model.Session} with all
+                 * related: {@link omero.model.Annotation} comments,
+                 * {@link omero.model.Experimenter} members, fully loaded.
+                 * Unlike the other methods on this interface, if the
+                 * sessionId is unknown, does not throw a
+                 * {@link omero.ValidationException}.
+                 *
+                 * @return a {@link omero.model.Session} with id and
+                 *         {@link omero.model.Details} set or null.
+                 *         The owner in the Details object is the true owner,
+                 *         and the group in the Details has all member users
+                 *         linked. {@link omero.model.Annotation} instances
+                 *         of the share are linked to the
+                 *         {@link omero.model.Session}. Missing is a list of
+                 *         share guests.
+                 */
                 idempotent omero::model::Share getShare(long shareId) throws ServerError;
+
+                /**
+                 * Returns a map from share id to the count of total members
+                 * (including the owner). This is represented by
+                 * {@link omero.model.ShareMember} links.
+                 *
+                 * @param shareIds Not null.
+                 * @return Map with all ids present.
+                 * @throws ValidationException if a given share does not exist
+                 */
                 idempotent omero::sys::CountMap getMemberCount(omero::sys::LongList shareIds) throws ServerError;
+
+                /**
+                 * Gets all owned shares for the current
+                 * {@link omero.model.Experimenter}.
+                 *
+                 * @param onlyActive
+                 *            if true, then only shares which can be used for
+                 *            login will be returned. All "draft" shares (see
+                 *            {@link #createShare} and closed shares (see
+                 *            {@link #closeShare}) will be filtered.
+                 * @return set of shares. Never null. May be empty.
+                 */
                 idempotent SessionList getOwnShares(bool active) throws ServerError;
+
+                /**
+                 * Gets all shares where current
+                 * {@link omero.model.Experimenter} is a member.
+                 *
+                 * @param onlyActive
+                 *            if true, then only shares which can be used for
+                 *            login will be returned. All "draft" shares (see
+                 *            {@link #createShare}) and closed shares (see
+                 *            {@link #closeShare}) will be filtered.
+                 * @return set of shares. Never null. May be empty.
+                 */
                 idempotent SessionList getMemberShares(bool active) throws ServerError;
+
+                /**
+                 * Gets all shares owned by the given
+                 * {@link omero.model.Experimenter}.
+                 *
+                 * @param onlyActive
+                 *            if true, then only shares which can be used for
+                 *            login will be returned. All "draft" shares (see
+                 *            {@link #createShare}) and closed shares (see
+                 *            {@link #closeShare}) will be filtered.
+                 * @return set of shares. Never null. May be empty.
+                 */
                 idempotent SessionList getSharesOwnedBy(omero::model::Experimenter user, bool active) throws ServerError;
+
+                /**
+                 * Gets all shares where given
+                 * {@link omero.model.Experimenter} is a member.
+                 *
+                 * @param onlyActive
+                 *            if true, then only shares which can be used for
+                 *            login will be returned. All "draft" shares (see
+                 *            {@link #createShare}) and closed shares (see
+                 *            {@link #closeShare}) will be filtered.
+                 * @return set of shares. Never null. May be empty.
+                 */
                 idempotent SessionList getMemberSharesFor(omero::model::Experimenter user, bool active) throws ServerError;
+
+                /**
+                 * Looks up all {@link omero.model.IObject} items belong to the
+                 * {@link omero.model.Session} share.
+                 *
+                 * @return list of objects. Not null. Probably not empty.
+                 */
                 idempotent IObjectList getContents(long shareId) throws ServerError;
+
+                /**
+                 * Returns a range of items from the share.
+                 *
+                 * @see #getContents
+                 */
                 idempotent IObjectList getContentSubList(long shareId, int start, int finish) throws ServerError;
+
+                /**
+                 * Returns the number of items in the share.
+                 */
                 idempotent int getContentSize(long shareId) throws ServerError;
+
+                /**
+                 * Returns the contents of the share keyed by type.
+                 */
                 idempotent IdListMap getContentMap(long shareId) throws ServerError;
 
+                /**
+                 * Creates {@link omero.model.Session} share with all related:
+                 * {@link omero.model.IObject} itmes,
+                 * {@link omero.model.Experimenter} members, and guests.
+                 *
+                 * @param enabled
+                 *            if true, then the share is immediately available
+                 *            for use. If false, then the share is in draft
+                 *            state. All methods on this interface will work
+                 *            for shares <em>except</em> {@link #activate}.
+                 *            Similarly, the share password cannot be used by
+                 *            guests to login.
+                 */
                 long createShare(string description,
                                  omero::RTime expiration,
                                  IObjectList items,
@@ -44,38 +167,185 @@ module omero {
                 idempotent void setDescription(long shareId, string description) throws ServerError;
                 idempotent void setExpiration(long shareId, omero::RTime expiration) throws ServerError;
                 idempotent void setActive(long shareId, bool active) throws ServerError;
+
+                /**
+                 * Closes {@link omero.model.Session} share. No further logins
+                 * will be possible and all getters (e.g.
+                 * {@link #getMemberShares}, {@link #getOwnShares}, ...) will
+                 * filter these results if {@code onlyActive} is true.
+                 */
                 void closeShare(long shareId) throws ServerError;
 
+                /**
+                 * Adds new {@link omero.model.IObject} items to
+                 * {@link omero.model.Session} share. Conceptually calls
+                 * {@link #addObjects} for every argument passed, but the
+                 * graphs will be merged.
+                 */
                 void addObjects(long shareId, IObjectList iobjects) throws ServerError;
+
+                /**
+                 * Adds new {@link omero.model.IObject} item to
+                 * {@link omero.model.Session} share. The entire object graph
+                 * with the exception of all Details will be loaded into the
+                 * share. If you would like to load a single object, then pass
+                 * an unloaded reference.
+                 */
                 void addObject(long shareId, omero::model::IObject iobject) throws ServerError;
+
+                /**
+                 * Remove existing items from the share.
+                 */
                 void removeObjects(long shareId, IObjectList iobjects) throws ServerError;
+
+                /**
+                 * Removes existing {@link omero.model.IObject} object from the
+                 * {@link omero.model.Session} share.
+                 */
                 void removeObject(long shareId, omero::model::IObject iobject) throws ServerError;
 
+                /**
+                 * Returns a map from share id to comment count.
+                 *
+                 * @param shareIds Not null.
+                 * @return Map with all ids present and 0 if no count exists.
+                 * @throws ValidationException if a given share does not exist
+                 */
                 idempotent omero::sys::CountMap getCommentCount(omero::sys::LongList shareIds) throws ServerError;
+
+                /**
+                 * Looks up all {@link omero.model.Annotation} comments which
+                 * belong to the {@link omero.model.Session} share.
+                 *
+                 * @return list of Annotation
+                 */
                 idempotent AnnotationList getComments(long shareId) throws ServerError;
+
+                /**
+                 * Creates {@link omero.model.TextAnnotation} comment for
+                 * {@link omero.model.Session} share.
+                 */
                 omero::model::TextAnnotation addComment(long shareId, string comment) throws ServerError;
+
+                /**
+                 * Creates {@link omero.model.TextAnnotation} comment which
+                 * replies to an existing comment.
+                 *
+                 * @return the new {@link omero.model.TextAnnotation}
+                 */
                 omero::model::TextAnnotation addReply(long shareId,
                                                       string comment,
                                                       omero::model::TextAnnotation replyTo) throws ServerError;
+
+                /**
+                 * Deletes {@link omero.model.Annotation} comment from the
+                 * database.
+                 */
                 void deleteComment(omero::model::Annotation comment) throws ServerError;
 
+                /**
+                 * Get all {@link omero.model.Experimenter} users who are a
+                 * member of the share.
+                 */
                 idempotent ExperimenterList getAllMembers(long shareId) throws ServerError;
+
+                /**
+                 * Get the email addresses for all share guests.
+                 */
                 idempotent StringSet getAllGuests(long shareId) throws ServerError;
+
+                /**
+                 * Get a single set containing the
+                 * {@link omero.model.Experimenter#getOmeName} login names
+                 * of the users as well email addresses for guests.
+                 *
+                 * @param shareId
+                 * @return a {@link StringSet} containing the login of all
+                 *         users
+                 * @throws ValidationException
+                 *         if there is a conflict between email addresses and
+                 *         user names.
+                 */
                 idempotent StringSet getAllUsers(long shareId) throws ValidationException, ServerError;
+
+                /**
+                 * Adds {@link omero.model.Experimenter} experimenters to
+                 * {@link omero.model.Session} share.
+                 */
                 void addUsers(long shareId, ExperimenterList exps) throws ServerError;
+
+                /**
+                 * Adds guest email addresses to the share.
+                 */
                 void addGuests(long shareId, StringSet emailAddresses) throws ServerError;
+
+                /**
+                 * Removes {@link omero.model.Experimenter} experimenters from
+                 * {@link omero.model.Session} share.
+                 */
                 void removeUsers(long shareId, ExperimenterList exps) throws ServerError;
+
+                /**
+                 * Removes guest email addresses from the share.
+                 */
                 void removeGuests(long shareId, StringSet emailAddresses) throws ServerError;
+
+                /**
+                 * Adds {@link omero.model.Experimenter} experimenter to
+                 * {@link omero.model.Session} share.
+                 */
                 void addUser(long shareId, omero::model::Experimenter exp) throws ServerError;
+
+                /**
+                 * Adds guest email address to the share.
+                 */
                 void addGuest(long shareId, string emailAddress) throws ServerError;
+
+                /**
+                 * Removes {@link omero.model.Experimenter} experimenter from
+                 * {@link omero.model.Session} share.
+                 */
                 void removeUser(long shareId, omero::model::Experimenter exp) throws ServerError;
+
+                /**
+                 * Removes guest email address from share.
+                 */
                 void removeGuest(long shareId, string emailAddress) throws ServerError;
 
                 // Under construction
+                /**
+                 * Gets actual active connections to
+                 * {@link omero.model.Session} share.
+                 *
+                 * @return map of experimenter and IP address
+                 */
                 idempotent UserMap getActiveConnections(long shareId) throws ServerError;
+
+                /**
+                 * Gets previous connections to
+                 * {@link omero.model.Session} share.
+                 *
+                 * @return map of experimenter and IP address
+                 */
                 idempotent UserMap getPastConnections(long shareId) throws ServerError;
+
+                /**
+                 * Makes the connection invalid for
+                 * {@link omero.model.Session} share for specified user.
+                 */
                 void invalidateConnection(long shareId, omero::model::Experimenter exp) throws ServerError;
+
+                /**
+                 * Gets events for {@link omero.model.Session} share per
+                 * {@link omero.model.Experimenter} experimenter for period of
+                 * time.
+                 * @return List of events
+                 */
                 idempotent IObjectList getEvents(long shareId, omero::model::Experimenter exp, omero::RTime from, omero::RTime to) throws ServerError;
+
+                /**
+                 * Notifies via email selected members of share.
+                 */
                 void notifyMembersOfShare(long shareId, string subject, string message, bool html) throws ServerError;
             };
 

--- a/components/blitz/resources/omero/api/IShare.ice
+++ b/components/blitz/resources/omero/api/IShare.ice
@@ -74,7 +74,7 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All "draft" shares (see
+                 *            login will be returned. All ""draft"" shares (see
                  *            {@link #createShare} and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
@@ -87,7 +87,7 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All "draft" shares (see
+                 *            login will be returned. All ""draft"" shares (see
                  *            {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
@@ -100,7 +100,7 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All "draft" shares (see
+                 *            login will be returned. All ""draft"" shares (see
                  *            {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
@@ -113,7 +113,7 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All "draft" shares (see
+                 *            login will be returned. All ""draft"" shares (see
                  *            {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.

--- a/components/blitz/resources/omero/api/ITypes.ice
+++ b/components/blitz/resources/omero/api/ITypes.ice
@@ -19,19 +19,86 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ITypes.html">ITypes.html</a>
+         * Access to reflective type information. Also provides simplified
+         * access to special types like enumerations.
          **/
         ["ami", "amd"] interface ITypes extends ServiceInterface
             {
                 omero::model::IObject createEnumeration(omero::model::IObject newEnum) throws ServerError;
+
+                /**
+                 * Lookup an enumeration value. As with the get-methods of
+                 * {@link omero.api.IQuery} queries returning no results
+                 * will through an exception.
+                 *
+                 * @param type An enumeration class which should be searched.
+                 * @param value The value for which an enumeration should be
+                 *              found.
+                 * @return A managed enumeration. Never null.
+                 * @throws ApiUsageException
+                 *         if {@link omero.model.IEnum} is not found.
+                 */
                 idempotent omero::model::IObject getEnumeration(string type, string value) throws ServerError;
                 idempotent IObjectList allEnumerations(string type) throws ServerError;
+
+                /**
+                 * Updates enumeration value specified by object.
+                 *
+                 * @param oldEnum An enumeration object which should be
+                 *                searched.
+                 * @return A managed enumeration. Never null.
+                 */
                 omero::model::IObject updateEnumeration(omero::model::IObject oldEnum) throws ServerError;
+
+                /**
+                 * Updates enumeration value specified by object.
+                 *
+                 * @param oldEnums An enumeration collection of objects which
+                 *                 should be searched.
+                 */
                 void updateEnumerations(IObjectList oldEnums) throws ServerError;
+
+                /**
+                 * Deletes enumeration value specified by object.
+                 *
+                 * @param oldEnum An enumeration object which should be
+                 *                searched.
+                 */
                 void deleteEnumeration(omero::model::IObject oldEnum) throws ServerError;
+
+                /**
+                 * Gets all metadata classes which are IEnum type.
+                 *
+                 * @return set of classes that extend IEnum
+                 * @throws RuntimeException if Class not found.
+                 */
                 idempotent StringSet getEnumerationTypes() throws ServerError;
+
+                /**
+                 * Returns a list of classes which implement
+                 * {@link omero.model.IAnnotated}. These can
+                 * be used in combination with {@link omero.api.Search}.
+                 *
+                 * @return a {@link StringSet} of
+                 *         {@link omero.model.IAnnotated} implementations
+                 */
                 idempotent StringSet getAnnotationTypes() throws ServerError;
+
+                /**
+                 * Gets all metadata classes which are IEnum type with
+                 * contained objects.
+                 *
+                 * @return map of classes that extend IEnum
+                 * @throws RuntimeExceptionif xml parsing failure.
+                 */
                 idempotent IObjectListMap getEnumerationsWithEntries() throws ServerError;
+
+                /**
+                 * Gets all original values.
+                 *
+                 * @return A list of managed enumerations.
+                 * @throws RuntimeException if xml parsing failure.
+                 */
                 idempotent IObjectList getOriginalEnumerations() throws ServerError;
                 void resetEnumerations(string enumClass) throws ServerError;
             };


### PR DESCRIPTION
See https://trello.com/c/KLCaZX4X/19-copy-ome-api-documentation-to-omero-api

Follow-up of #4547 and https://github.com/openmicroscopy/openmicroscopy/pull/4569, this PR copies more of the ome.api.* Javadoc documentation into the slice classes.

To review this PR, either build the slice documentation via release-slice2html or use the published CI documentation or OMERO.docs* artifacts. Check the links are all working and the method parameters match.