### PR TITLE
choose server id

### DIFF
--- a/components/tests/ui/resources/web/login.txt
+++ b/components/tests/ui/resources/web/login.txt
@@ -12,6 +12,7 @@ Library           Selenium2Library
 *** Keywords ***
 User "${username}" logs in with password "${password}"
     Open Browser To Login Page
+    Select Server     ${SERVER_ID}
     Input username    ${username}
     Input password    ${password}
     Submit credentials


### PR DESCRIPTION
Allow choosing robot server id from the drop down menu on login page.

This is available in webadmin tests but not in webclient