### PR TITLE
Customize server_name

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -161,6 +161,9 @@ class WebControl(BaseControl):
             "--http", type=int,
             help="HTTP port for web server")
         nginx_group.add_argument(
+            "--servername", type=str, default='$hostname',
+            help="Nginx virtual server name")
+        nginx_group.add_argument(
             "--max-body-size", type=str, default='0',
             help="Maximum allowed size of the client request body."
             "Default: 0 (disabled)")
@@ -271,6 +274,8 @@ class WebControl(BaseControl):
             port = 8080
         else:
             port = 80
+        if args.servername:
+            servername = args.servername
 
         if settings.APPLICATION_SERVER in settings.WSGITCP:
             if settings.APPLICATION_SERVER_PORT == port:
@@ -291,6 +296,7 @@ class WebControl(BaseControl):
 
         if server in ("nginx", "nginx-development",):
             d["MAX_BODY_SIZE"] = args.max_body_size
+            d["SERVERNAME"] = servername
 
         # FORCE_SCRIPT_NAME always has a starting /, and will not have a
         # trailing / unless there is no prefix (/)

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-withoptions.conf
@@ -4,7 +4,7 @@ upstream omeroweb_test {
 
 server {
     listen 1234;
-    server_name $hostname;
+    server_name omeroweb.host;
 
     sendfile on;
     client_max_body_size 2m;

--- a/etc/templates/web/nginx.conf.template
+++ b/etc/templates/web/nginx.conf.template
@@ -4,7 +4,7 @@ upstream omeroweb%(PREFIX_NAME)s {
 
 server {
     listen %(HTTPPORT)d;
-    server_name $hostname;
+    server_name %(SERVERNAME)s;
 
     sendfile on;
     client_max_body_size %(MAX_BODY_SIZE)s;


### PR DESCRIPTION
This PR allow custom virtual server name in nginx config

see https://github.com/openmicroscopy/devspace/issues/35

to test:
- `bin/omero web config nginx` and check if 

 ```
server {
    listen 80;
    server_name $hostname;
 ```
- `bin/omero web config nginx --servername "mydomain.com"` and check if 

 ```
server {
    listen 80;
    server_name mydomain.com;
 ```