### PR TITLE
automatically delete orphaned non-sharable annotations

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -268,9 +268,11 @@
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D]/d"
                                        p:changes="A:[I]"/>
 
-        <!-- Delete remaining orphaned annotations. -->
+        <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
 
         <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="A:BasicAnnotation[E]{o}" p:changes="A:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="A:CommentAnnotation[E]{o}" p:changes="A:[D]/n"/>
 
         <!-- If an original file is moved then any corresponding file annotation must also be moved. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -98,9 +98,9 @@
 
         <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
 
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
         <bean parent="graphPolicyRule" p:matches="A:BasicAnnotation[E]{o}" p:changes="A:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="A:CommentAnnotation[E]{o}" p:changes="A:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
 
         <!-- If an annotation link's parent or child is deleted then delete the link regardless of permissions. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -191,10 +191,8 @@
 
         <!-- If a basic or comment annotation is unlinked then consider it for deletion regardless of permissions. -->
 
-        <!-- omitted at present because it causes errors in the web client
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:BasicAnnotation[E]{i}" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:CommentAnnotation[E]{i}" p:changes="A:{r}"/>
-          -->
 
         <!--
              If an annotated object is deleted then consider its basic or comment annotations for deletion regardless of
@@ -218,11 +216,9 @@
 
         <!-- If a list, map, or XML annotation is unlinked then consider it for deletion. -->
 
-        <!-- omitted at present because it causes errors in the web client
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:ListAnnotation[E]{i}/d" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:MapAnnotation[E]{i}/d" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:XmlAnnotation[E]{i}/d"  p:changes="A:{r}"/>
-          -->
 
         <!-- If an annotated object is deleted then consider its list, map, or XML annotations for deletion. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -236,9 +236,9 @@
 
         <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
 
+        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
         <bean parent="graphPolicyRule" p:matches="A:BasicAnnotation[E]{o}" p:changes="A:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="A:CommentAnnotation[E]{o}" p:changes="A:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="A:Annotation[E]{o}/d" p:changes="A:[D]"/>
 
         <!-- If an original file is deleted then also delete the corresponding file annotation regardless of permissions. -->
 

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -55,7 +55,6 @@ public class AnnotationMoveTest extends AbstractServerTest {
         Image img =
                 (Image) iUpdate.saveAndReturnObject(mmFactory.createImage());
 
-        long id = img.getId().getValue();
         List<Long> annotationIdsUser1 = createNonSharableAnnotation(img, null);
 
         omero.client clientUser1 = disconnect();
@@ -74,7 +73,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         // reconnect as user1
         init(clientUser1);
         // now move the image.
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         // Annotation of user1 should be removed
@@ -124,12 +123,11 @@ public class AnnotationMoveTest extends AbstractServerTest {
         // Annotate the image.
         List<Long> annotationIds = createNonSharableAnnotation(img, null);
         // now move the image.
-        long id = img.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
-        param.addId(id);
+        param.addId(img.getId().getValue());
         StringBuilder sb = new StringBuilder();
         sb.append("select i from Image i ");
         sb.append("where i.id = :id");
@@ -166,11 +164,10 @@ public class AnnotationMoveTest extends AbstractServerTest {
         // Annotate the image.
         List<Long> annotationIds = createSharableAnnotation(img, null);
         // now move the image.
-        long id = img.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
-        param.addId(id);
+        param.addId(img.getId().getValue());
         StringBuilder sb = new StringBuilder();
         sb.append("select i from Image i ");
         sb.append("where i.id = :id");
@@ -209,8 +206,8 @@ public class AnnotationMoveTest extends AbstractServerTest {
         assertTrue(annotationIds.size() > 0);
         // now move the image.
         long id = img.getId().getValue();
-        final ChildOption option = Requests.option(null, DeleteServiceTest.SHARABLE_TO_KEEP_LIST);
-        final Chgrp2 dc = Requests.chgrp("Image", id, option, g.getId().getValue());
+        final ChildOption option = Requests.option().excludeType(DeleteServiceTest.SHARABLE_TO_KEEP_LIST).build();
+        final Chgrp2 dc = Requests.chgrp().target(img).option(option).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -528,9 +525,8 @@ public class AnnotationMoveTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        long id = img1.getId().getValue();
-        final ChildOption option = Requests.option(null, DeleteServiceTest.SHARABLE_TO_KEEP_LIST);
-        final Chgrp2 dc = Requests.chgrp("Image", id, option, g.getId().getValue());
+        final ChildOption option = Requests.option().excludeType(DeleteServiceTest.SHARABLE_TO_KEEP_LIST).build();
+        final Chgrp2 dc = Requests.chgrp().target(img1).option(option).toGroup(g).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -542,7 +538,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
 
         loginUser(g);
         param = new ParametersI();
-        param.addId(id);
+        param.addId(img1.getId().getValue());
         sb = new StringBuilder();
         sb.append("select i from ImageAnnotationLink i ");
         sb.append("where i.parent.id = :id");

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -88,7 +88,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         if (src.equals("rwrw--")) n = 0;
         param = new ParametersI();
         param.addIds(annotationIdsUser2);
-        assertEquals(iQuery.findAllByQuery(sb.toString(), param).size(), n);
+        assertEquals(iQuery.findAllByQuery(sb.toString(), param).size(), 0);
 
         loginUser(g);
         param = new ParametersI();

--- a/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import static org.testng.AssertJUnit.*;
 import static omero.rtypes.rstring;
 import omero.cmd.Delete2;
+import omero.cmd.graphs.ChildOption;
 import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotation;
@@ -56,6 +57,8 @@ import integration.AbstractServerTest;
  * @since Beta4.4
  */
 public class RolesTest extends AbstractServerTest {
+
+    private static final ChildOption KEEP_ANN = Requests.option().excludeType("Annotation").build();
 
     /**
      * Since we are creating a new client on each invocation, we should also
@@ -126,7 +129,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete().target(dl).build();
+            Delete2 dc = Requests.delete().target(dl).option(KEEP_ANN).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -231,7 +234,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -325,7 +328,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -435,7 +438,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete().target(dl).build();
+            Delete2 dc = Requests.delete().target(dl).option(KEEP_ANN).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -541,7 +544,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -626,7 +629,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -722,7 +725,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete().target(dl).build();
+            Delete2 dc = Requests.delete().target(dl).option(KEEP_ANN).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -824,7 +827,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -909,7 +912,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -993,7 +996,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -1082,7 +1085,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
@@ -1166,7 +1169,7 @@ public class RolesTest extends AbstractServerTest {
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete().target(dl).build();
+        dc = Requests.delete().target(dl).option(KEEP_ANN).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete

--- a/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/RolesTest.java
@@ -117,7 +117,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+            Delete2 dc = Requests.delete().target(l).build();
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -126,7 +126,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+            Delete2 dc = Requests.delete().target(dl).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -135,7 +135,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
+            Delete2 dc = Requests.delete().target(ann).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete the annotation.");
@@ -227,15 +227,15 @@ public class RolesTest extends AbstractServerTest {
 
         // Create a link canLink
         // Try to delete the link i.e. canDelete
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -321,15 +321,15 @@ public class RolesTest extends AbstractServerTest {
 
         // Create a link canLink
         // Try to delete the link i.e. canDelete
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -426,7 +426,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+            Delete2 dc = Requests.delete().target(l).build();
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -435,7 +435,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+            Delete2 dc = Requests.delete().target(dl).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -444,7 +444,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
+            Delete2 dc = Requests.delete().target(ann).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete " + "the annotation.");
@@ -537,15 +537,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -622,15 +622,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -713,7 +713,7 @@ public class RolesTest extends AbstractServerTest {
         // Create a link canLink
         // Try to delete the link i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+            Delete2 dc = Requests.delete().target(l).build();
             callback(false, client, dc);
         } catch (Exception e) {
 
@@ -722,7 +722,7 @@ public class RolesTest extends AbstractServerTest {
         }
 
         try {
-            Delete2 dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+            Delete2 dc = Requests.delete().target(dl).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete "
@@ -731,7 +731,7 @@ public class RolesTest extends AbstractServerTest {
 
         // Try to delete the annotation i.e. canDelete
         try {
-            Delete2 dc = Requests.delete("Annotation", ann.getId().getValue());
+            Delete2 dc = Requests.delete().target(ann).build();
             callback(false, client, dc);
         } catch (Exception e) {
             fail("Member should not be allowed to delete " + "the annotation.");
@@ -820,15 +820,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -905,15 +905,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -989,15 +989,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
         // Try to delete the dataset i.e. canDelete
 
@@ -1018,7 +1018,7 @@ public class RolesTest extends AbstractServerTest {
         // Try to edit i.e. canEdit
         d.setName(rstring("newName"));
         iUpdate.saveAndReturnObject(d);
-        dc = Requests.delete("Dataset", id);
+        dc = Requests.delete().target(d).build();
         callback(true, client, dc);
     }
 
@@ -1078,15 +1078,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink
@@ -1162,15 +1162,15 @@ public class RolesTest extends AbstractServerTest {
         assertTrue(perms.canLink());
 
         // Try to delete the link i.e. canLink
-        Delete2 dc = Requests.delete("DatasetImageLink", l.getId().getValue());
+        Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
 
         // Try to delete the annotation link i.e. canDelete
-        dc = Requests.delete("DatasetAnnotationLink", dl.getId().getValue());
+        dc = Requests.delete().target(dl).build();
         callback(true, client, dc);
 
         // Try to delete the annotation i.e. canDelete
-        dc = Requests.delete("Annotation", ann.getId().getValue());
+        dc = Requests.delete().target(ann).build();
         callback(true, client, dc);
 
         // Try to link an image i.e. canLink

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -1202,7 +1202,7 @@ class BaseContainer(BaseController):
             else:
                 return 'Destination not supported.'
         else:
-            return 'No data was choosen.'
+            return 'No data was chosen.'
         return
 
     def remove(self, parents, index, tag_owner_id=None):
@@ -1342,7 +1342,7 @@ class BaseContainer(BaseController):
             else:
                 return 'Destination not supported.'
         else:
-            return 'No data was choosen.'
+            return 'No data was chosen.'
 
     def copyImageToDataset(self, source, destination=None):
         if destination is None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2145,7 +2145,7 @@ class OmeroWebObjectWrapper (object):
                     ratingAnn.save()
                 else:
                     self._conn.deleteObject(ratingLink._obj)
-                    self._conn.deleteObject(ratingAnn._obj)
+                    # ratingAnn was automatically deleted if orphaned
             # otherwise, unlink and create a new rating
             else:
                 self._conn.deleteObject(ratingLink._obj)


### PR DESCRIPTION
To assist http://trac.openmicroscopy.org/ome/ticket/2999 in preventing orphaned non-sharable annotations littering databases and in making the graph policy rules more consistent this PR ensures that when a non-sharable annotation is orphaned by being unlinked it is also deleted.

Testing: ensure that http://regions-ci.docker.openmicroscopy.org:8080/job/OMERO-test-integration/ is blue. Also, try deleting different things from different clients (e.g., comments, ratings, attachments, images, whatever, from Insight and Web) to watch out for regressions in deletion.