### PR TITLE
Set Bio-Formats version to 5.2.0-m3 for upcoming development milestone

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -976,4 +976,4 @@ versions.bufr=1.1.00
 ###
 
 # Override BIo-Formats version for the model work
-versions.bioformats=5.2.0-SNAPSHOT
+versions.bioformats=5.2.0-m3


### PR DESCRIPTION
This should be the last dependency bump in preparation of OMERO 5.3.0-m2. To test PR, check that

```
touch test.fake
bin/omero import -f test.fake
```

reports the correct version/revision for Bio-Formats