### PR TITLE
fix #13197: allow Duplicate to be used with SkipHead

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -78,7 +78,6 @@ public class SkipHeadI extends SkipHead implements IRequest {
      * Construct a new <q>skip-head</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param graphPathBean the graph path bean to use
      * @param graphRequestFactory a means of instantiating the sub-request
-     * @throws GraphException if the request was not of an appropriate type
      */
     public SkipHeadI(GraphPathBean graphPathBean, GraphRequestFactory graphRequestFactory) {
         this.graphPathBean = graphPathBean;

--- a/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
+++ b/components/blitz/src/omero/cmd/graphs/SkipHeadI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 
@@ -37,7 +36,6 @@ import ome.model.IObject;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
-import ome.system.Login;
 import omero.cmd.HandleI.Cancel;
 import omero.cmd.ERR;
 import omero.cmd.Helper;
@@ -57,8 +55,6 @@ import omero.cmd.Status;
 public class SkipHeadI extends SkipHead implements IRequest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SkipHeadI.class);
-
-    private static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     private static final ImmutableSet<State> REQUEST_FAILURE_FLAGS = ImmutableSet.of(State.CANCELLED, State.FAILURE);
 
@@ -86,7 +82,7 @@ public class SkipHeadI extends SkipHead implements IRequest {
 
     @Override
     public Map<String, String> getCallContext() {
-        return new HashMap<String, String>(ALL_GROUPS_CONTEXT);
+        return ((IRequest) request).getCallContext();
     }
 
     @Override

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -57,7 +57,7 @@ import ome.tools.hibernate.HibernateUtils;
  * 
  * This information is stored in a Details object, but unlike Details which
  * assumes that an empty value signifies increased security levels, empty values
- * here signifiy reduced security levels. E.g.,
+ * here signify reduced security levels. E.g.,
  * 
  * Details: user == null ==> object belongs to root CurrentDetails: user == null
  * ==> current user is "nobody" (anonymous)

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -152,7 +152,7 @@ public class DuplicationTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = Requests.delete("Image", testImages);
+        final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1249,7 +1249,8 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* duplicate the image via SkipHead */
 
-        final SkipHead dup = Requests.skipHead().target("Dataset").id(originalDatasetId).startFrom("Image").request(Duplicate.class).build();
+        final SkipHead dup =
+                Requests.skipHead().target("Dataset").id(originalDatasetId).startFrom("Image").request(Duplicate.class).build();
         final DuplicateResponse response = (DuplicateResponse) doChange(dup);
 
         /* check that the response includes duplication of only the image */


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/13197 and is checked by https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/DuplicationTest/testDuplicateImageViaSkipHead/.

Enthusiastic manual testers may wish to read @ximenesuk's description in the ticket and avail themselves of #4574.