### PR TITLE
Bugfix: Moving multiple folders via context menu didn't work

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -1627,17 +1627,62 @@ public class ROITable
         }
         
         if (SelectionDialog.OBJECT_SELECTION_PROPERTY.equals(name)) {
-            FolderData folder = getSelectedFolders().get(0);
+            // exclude child nodes
+            Set<Long> excludeIds = new HashSet<Long>();
+            for (FolderData f : getSelectedFolders()) {
+                if (excludeIds.contains(f.getId()))
+                    continue;
+
+                ROINode fnode = findFolderNode(f);
+                Collection<ROINode> subNodes = new ArrayList<ROINode>();
+                fnode.getAllDecendants(subNodes);
+                for (ROINode subNode : subNodes)
+                    if (subNode.isFolderNode())
+                        excludeIds.add(((FolderData) subNode.getUserObject())
+                                .getId());
+
+                excludeIds.remove(f.getId());
+            }
+
             FolderData target = (FolderData) evt.getNewValue();
-            folder.setParentFolder(target.asFolder());
             addRecentlyModifiedFolder(target);
-            manager.saveROIFolders(Collections.singleton(folder));
+
+            Collection<FolderData> toSave = new ArrayList<FolderData>();
+            for (FolderData folder : getSelectedFolders()) {
+                if (!excludeIds.contains(folder.getId())) {
+                    folder.setParentFolder(target.asFolder());
+                    toSave.add(folder);
+                }
+            }
+            manager.saveROIFolders(toSave);
         }
 
         if (SelectionDialog.NONE_SELECTION_PROPERTY.equals(name)) {
-            FolderData folder = getSelectedFolders().get(0);
-            folder.setParentFolder(null);
-            manager.saveROIFolders(Collections.singleton(folder));
+            // exclude child nodes
+            Set<Long> excludeIds = new HashSet<Long>();
+            for (FolderData f : getSelectedFolders()) {
+                if (excludeIds.contains(f.getId()))
+                    continue;
+
+                ROINode fnode = findFolderNode(f);
+                Collection<ROINode> subNodes = new ArrayList<ROINode>();
+                fnode.getAllDecendants(subNodes);
+                for (ROINode subNode : subNodes)
+                    if (subNode.isFolderNode())
+                        excludeIds.add(((FolderData) subNode.getUserObject())
+                                .getId());
+
+                excludeIds.remove(f.getId());
+            }
+
+            Collection<FolderData> toSave = new ArrayList<FolderData>();
+            for (FolderData folder : getSelectedFolders()) {
+                if (!excludeIds.contains(folder.getId())) {
+                    folder.setParentFolder(null);
+                    toSave.add(folder);
+                }
+            }
+            manager.saveROIFolders(toSave);
         }
     }
 


### PR DESCRIPTION
**Test**: Select multiple folders (also nested ones), move them to another folder (*via context menu*). All of them should be moved (before: only the first one was). For nested folders: Their hierarchy should be preserved. E. g. "B" is a sub folder of "A". Select "A" and "B", move them to folder "C", then "B" should still be a sub folder of "A" (this is just to make sure that I did not reintroduce a bug I fixed earlier).

