### PR TITLE
web start --foreground

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -137,6 +137,9 @@ class WebControl(BaseControl):
 
         for x in (start, restart):
             x.add_argument(
+                "--foreground", action="store_true",
+                help="Start OMERO.web in foreground mode (no daemon/service)")
+            x.add_argument(
                 "--workers", type=int, help=SUPPRESS)
             x.add_argument(
                 "--worker-connections", type=int, help=SUPPRESS)
@@ -469,7 +472,7 @@ class WebControl(BaseControl):
         return d_args
 
     def _build_run_cmd(self, settings):
-        cmd = "gunicorn -D -p %(base)s/var/django.pid"
+        cmd = "gunicorn %(daemon)s -p %(base)s/var/django.pid"
         cmd += " --bind %(host)s:%(port)d"
         cmd += " --workers %(workers)d "
 
@@ -549,10 +552,12 @@ class WebControl(BaseControl):
                 pass
 
             # wrap all deprecated args
+            daemon = "-D" if not args.foreground else ""
             d_args = self._deprecated_args(args, settings)
             cmd = self._build_run_cmd(settings)
 
             runserver = (cmd % {
+                'daemon': daemon,
                 'base': self.ctx.dir,
                 'host': settings.APPLICATION_SERVER_HOST,
                 'port': settings.APPLICATION_SERVER_PORT,

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -568,6 +568,11 @@ class WebControl(BaseControl):
             }).split()
             if args.foreground:
                 rv = self.ctx.call(args=runserver, cwd=location)  # popen
+                pid_path = self._get_django_pid_path()
+                if pid_path.exists():
+                    pid_path.remove()
+                    self.ctx.out("Removed stale %s" % pid_path)
+                return 0
             else:
                 rv = self.ctx.popen(args=runserver, cwd=location)  # popen
         else:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -566,7 +566,10 @@ class WebControl(BaseControl):
                 'timeout': settings.WSGI_TIMEOUT,
                 'wsgi_args': d_args['wsgi_args']
             }).split()
-            rv = self.ctx.popen(args=runserver, cwd=location)  # popen
+            if args.foreground:
+                rv = self.ctx.call(args=runserver, cwd=location)  # popen
+            else:
+                rv = self.ctx.popen(args=runserver, cwd=location)  # popen
         else:
             runserver = [sys.executable, "manage.py", "runserver", link,
                          "--noreload", "--nothreading"]


### PR DESCRIPTION
This PR allows starting OMERO.web without daemon, in docker web won't start otherwise 

```
$bin/omero web start --foreground
... gunicorn -p ...
```

```
$bin/omero web start
... gunicorn -D -p ...
```