### PR TITLE
cached thumbnail size is 96

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1372,7 +1372,7 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
     except ValueError:
         field = 0
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
-    thumbsize = int(request.GET.get('size', 64))
+    thumbsize = int(request.GET.get('size', 96))
     logger.debug(thumbsize)
     server_id = kwargs['server_id']
 


### PR DESCRIPTION
This PR change default thumbnail size loaded to plate grid to 96. This is because cached thumbnails in `omero.data.dir` are 96 not 64. There is no point to render them again

Should we also change default in https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroWeb/omeroweb/webgateway/views.py#L308 ? If so in 5.3 if that is ok?

@chris-allan @will-moore do you see any implications?

To test:
 - open plate and inspect thumbnail URL