### PR TITLE
Revert Bio-Formats version to 5.2.0-SNAPSHOT for next milestone development

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -976,4 +976,4 @@ versions.bufr=1.1.00
 ###
 
 # Override BIo-Formats version for the model work
-versions.bioformats=5.2.0-m3
+versions.bioformats=5.2.0-SNAPSHOT


### PR DESCRIPTION
This should allow OMERO 5.3 to consume the development SNAPSHOT of Bio-Formats.