### PR TITLE
Fix tooltips metadata panel

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -199,7 +199,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	private static final String TEXT_TAGS_SELECTION = "Tags Selection";
 
 	/** Text for add tags button */
-	private static final String TOOLTIP_ADD_TAGS = "Add Tags.";
+	private static final String TOOLTIP_ADD_TAGS = "Add tags.";
 
 	/** File naming checkbox text */
 	private static final String TEXT_OVERRIDE_FILE_NAMING =

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -374,14 +374,14 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
                 icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeDocsButton);
         removeDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeDocsButton.setToolTipText("Remove Attachments.");
+        removeDocsButton.setToolTipText("Remove attachment.");
         removeDocsButton.addMouseListener(controller);
         removeDocsButton.setActionCommand("" + EditorControl.REMOVE_DOCS);
         buttons.add(removeDocsButton);
 
         final JButton selectButton = new JButton(icons.getIcon(IconManager.ANALYSIS));
         selectButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        selectButton.setToolTipText("Select Files for Scripts");
+        selectButton.setToolTipText("Select files for scripts");
         selectButton.addMouseListener(new MouseAdapter() {
 
             public void mouseReleased(MouseEvent e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -356,7 +356,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         addDocsButton = new JButton(
                 icons.getIcon(IconManager.PLUS_12));
         addDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        addDocsButton.setToolTipText("Attach a document");
+        addDocsButton.setToolTipText("Attach a file");
         addDocsButton.addMouseListener(new MouseAdapter() {
 
             public void mouseReleased(MouseEvent e) {
@@ -374,7 +374,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
                 icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeDocsButton);
         removeDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeDocsButton.setToolTipText("Remove attachment");
+        removeDocsButton.setToolTipText("Remove file");
         removeDocsButton.addMouseListener(controller);
         removeDocsButton.setActionCommand("" + EditorControl.REMOVE_DOCS);
         buttons.add(removeDocsButton);
@@ -407,14 +407,14 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         if (docSelectionMenu != null)
             return docSelectionMenu;
         docSelectionMenu = new JPopupMenu();
-        JMenuItem item = new JMenuItem("Local document...");
-        item.setToolTipText("Import a local document to the server "
+        JMenuItem item = new JMenuItem("Local file...");
+        item.setToolTipText("Import a local file to the server "
                 + "and attach it.");
         item.addActionListener(controller);
         item.setActionCommand("" + EditorControl.ADD_LOCAL_DOCS);
         docSelectionMenu.add(item);
-        item = new JMenuItem("Uploaded document...");
-        item.setToolTipText("Attach a document already uploaded "
+        item = new JMenuItem("Uploaded file...");
+        item.setToolTipText("Attach a file already uploaded "
                 + "to the server.");
         item.addActionListener(controller);
         item.setActionCommand("" + EditorControl.ADD_UPLOADED_DOCS);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -356,7 +356,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         addDocsButton = new JButton(
                 icons.getIcon(IconManager.PLUS_12));
         addDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        addDocsButton.setToolTipText("Attach a document.");
+        addDocsButton.setToolTipText("Attach a document");
         addDocsButton.addMouseListener(new MouseAdapter() {
 
             public void mouseReleased(MouseEvent e) {
@@ -374,7 +374,7 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
                 icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeDocsButton);
         removeDocsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeDocsButton.setToolTipText("Remove attachment.");
+        removeDocsButton.setToolTipText("Remove attachment");
         removeDocsButton.addMouseListener(controller);
         removeDocsButton.setActionCommand("" + EditorControl.REMOVE_DOCS);
         buttons.add(removeDocsButton);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -530,7 +530,7 @@ class DocComponent
 		unlinkButton.setActionCommand(""+REMOVE);
 		if (data instanceof FileAnnotationData) {
 			FileAnnotationData fa = (FileAnnotationData) data;
-			unlinkButton.setToolTipText("Remove the attachment.");
+			unlinkButton.setToolTipText("Remove the file.");
 			
 			if (fa.getId() > 0) {
 				unlinkButton.setEnabled(deletable);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -672,7 +672,7 @@ class EditorUI
 		if (model.isAdministrator() || model.isGroupLeader()) {
 			if (docMenu == null) {
 				docMenu = new PermissionMenu(PermissionMenu.REMOVE,
-						"Attachments");
+						"Files");
 				docMenu.addPropertyChangeListener(new PropertyChangeListener() {
 					
 					public void propertyChange(PropertyChangeEvent evt) {
@@ -689,8 +689,8 @@ class EditorUI
 		}
 		SwingUtilities.convertPointToScreen(location, src);
 		MessageBox box = new MessageBox(model.getRefFrame(),
-				"Remove All Attachments", 
-				"Are you sure you want to remove all Attachments?");
+				"Remove all files", 
+				"Are you sure you want to remove all files?");
 		Dimension d = box.getPreferredSize();
 		Point p = new Point(location.x-d.width/2, location.y);
 		if (box.showMsgBox(p) == MessageBox.YES_OPTION) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -215,7 +215,7 @@ class GeneralPaneUI extends JPanel
        IconManager icons = IconManager.getInstance();
        annotationsFilter = Filter.SHOW_ALL;
        filterButton = new JButton(annotationsFilter.name);
-       filterButton.setToolTipText("Filter tags and attachments.");
+       filterButton.setToolTipText("Filter annotations by user");
        UIUtilities.unifiedButtonLookAndFeel(filterButton);
        Font font = filterButton.getFont();
        filterButton.setFont(font.deriveFont(font.getStyle(), 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -251,7 +251,7 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         addButton = new JButton(icons.getIcon(IconManager.PLUS));
         UIUtilities.unifiedButtonLookAndFeel(addButton);
         addButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        addButton.setToolTipText("Insert Row");
+        addButton.setToolTipText("Insert row");
         addButton.addMouseListener(ml);
         addButton.setEnabled(false);
         addButton.setFocusable(false);
@@ -260,7 +260,7 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         copyButton = new JButton(icons.getIcon(IconManager.COPY));
         UIUtilities.unifiedButtonLookAndFeel(copyButton);
         copyButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        copyButton.setToolTipText("Copy Rows");
+        copyButton.setToolTipText("Copy rows");
         copyButton.addMouseListener(ml);
         copyButton.setEnabled(false);
         copyButton.setFocusable(false);
@@ -269,7 +269,7 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         pasteButton = new JButton(icons.getIcon(IconManager.PASTE));
         UIUtilities.unifiedButtonLookAndFeel(pasteButton);
         pasteButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        pasteButton.setToolTipText("Paste Rows");
+        pasteButton.setToolTipText("Paste rows");
         pasteButton.addMouseListener(ml);
         pasteButton.setEnabled(false);
         pasteButton.setFocusable(false);
@@ -278,7 +278,7 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         deleteButton = new JButton(icons.getIcon(IconManager.DELETE_12));
         UIUtilities.unifiedButtonLookAndFeel(deleteButton);
         deleteButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        deleteButton.setToolTipText("Delete Rows");
+        deleteButton.setToolTipText("Delete rows");
         deleteButton.addMouseListener(ml);
         deleteButton.setEnabled(false);
         deleteButton.setFocusable(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
@@ -349,7 +349,7 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
                 icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeButton);
         removeButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeButton.setToolTipText("Remove Annotations.");
+        removeButton.setToolTipText("Remove Annotations");
         removeButton.addMouseListener(controller);
         removeButton.setActionCommand(
                 ""+EditorControl.REMOVE_OTHER_ANNOTATIONS);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/PropertiesUI.java
@@ -126,10 +126,10 @@ public class PropertiesUI
     private static final String CREATIONDATE_TEXT = "Creation Date: ";
     
     /** Text indicating to edit the description.*/
-    private static final String EDIT_DESC_TEXT = "Edit the description.";
+    private static final String EDIT_DESC_TEXT = "Edit the description";
     
     /**Text indicating to edit the channels.*/
-    private static final String EDIT_CHANNEL_TEXT = "Edit the channels.";
+    private static final String EDIT_CHANNEL_TEXT = "Edit channel names";
     
     /** The default height of the description.*/
     private static final int HEIGHT = 120;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -151,7 +151,7 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         JButton unrateButton = new JButton(icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(unrateButton);
         unrateButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        unrateButton.setToolTipText("Unrate.");
+        unrateButton.setToolTipText("Delete rating.");
         unrateButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 rating.setValue(0);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -151,7 +151,7 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         JButton unrateButton = new JButton(icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(unrateButton);
         unrateButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        unrateButton.setToolTipText("Delete rating.");
+        unrateButton.setToolTipText("Delete rating");
         unrateButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 rating.setValue(0);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -262,7 +262,7 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         addTagsButton = new JButton(icons.getIcon(IconManager.PLUS_12));
         UIUtilities.unifiedButtonLookAndFeel(addTagsButton);
         addTagsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        addTagsButton.setToolTipText("Add tags.");
+        addTagsButton.setToolTipText("Add tags");
         addTagsButton.addActionListener(controller);
         addTagsButton.setActionCommand(""+EditorControl.ADD_TAGS);
         buttons.add(addTagsButton);
@@ -270,7 +270,7 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         removeTagsButton = new JButton(icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeTagsButton);
         removeTagsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeTagsButton.setToolTipText("Remove tags.");
+        removeTagsButton.setToolTipText("Remove tags");
         removeTagsButton.addMouseListener(controller);
         removeTagsButton.setActionCommand(""+EditorControl.REMOVE_TAGS);
         buttons.add(removeTagsButton);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -262,7 +262,7 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         addTagsButton = new JButton(icons.getIcon(IconManager.PLUS_12));
         UIUtilities.unifiedButtonLookAndFeel(addTagsButton);
         addTagsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        addTagsButton.setToolTipText("Add Tags.");
+        addTagsButton.setToolTipText("Add tags.");
         addTagsButton.addActionListener(controller);
         addTagsButton.setActionCommand(""+EditorControl.ADD_TAGS);
         buttons.add(addTagsButton);
@@ -270,7 +270,7 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         removeTagsButton = new JButton(icons.getIcon(IconManager.MINUS_12));
         UIUtilities.unifiedButtonLookAndFeel(removeTagsButton);
         removeTagsButton.setBackground(UIUtilities.BACKGROUND_COLOR);
-        removeTagsButton.setToolTipText("Remove Tags.");
+        removeTagsButton.setToolTipText("Remove tags.");
         removeTagsButton.addMouseListener(controller);
         removeTagsButton.setActionCommand(""+EditorControl.REMOVE_TAGS);
         buttons.add(removeTagsButton);


### PR DESCRIPTION
Fixes some tooltips of the right hand side metadata panel, see [Trello - Insight - Right Hand Pane tooltip changes + one other issue](https://trello.com/c/POjkfKpE/392-insight-right-hand-pane-tooltip-changes-one-other-issue).

**Test**: Check that the tooltips match the proposed ones on the trello card.

Note: When testing the last point (select files for scripts), I noticed that it doesn't work with @emilroz 's "Populate metadata" script which is deployed on eel. Reason for this is, that the scripts define the FileAnnotation parameter as list of Strings, but it should be a list of Longs instead!

