### PR TITLE
Roi popupmenu fix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
@@ -22,44 +22,19 @@
  */
 package org.openmicroscopy.shoola.agents.measurement.util.roimenu;
 
-//Java imports
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 
-
-
-
-
-
-
-
-
-//Third-party libraries
-import org.jhotdraw.draw.Figure;
-
-
-
-
-
-
-
-
-
-import omero.gateway.model.DataObject;
-//Application-internal dependencies
 import omero.gateway.model.FolderData;
 
 import org.openmicroscopy.shoola.agents.measurement.util.actions.ROIAction;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROIActionController;
-import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROINode;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROIActionController.CreationActionType;
-import org.openmicroscopy.shoola.agents.treeviewer.actions.CreateAction;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.ROI;
 import org.openmicroscopy.shoola.util.roi.model.ROIShape;
@@ -237,7 +212,9 @@ public class ROIPopupMenu
 
         for (Object obj : selection) {
             if (isROISelection
-                    && !(obj instanceof ROI || obj instanceof ROIShape)) {
+                    && !(obj instanceof ROI || 
+                            obj instanceof ROIShape || 
+                            obj instanceof ROIFigure)) {
                 isROISelection = false;
             }
             if (isFolderSelection && !(obj instanceof FolderData)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -35,6 +36,7 @@ import omero.gateway.model.FolderData;
 import org.openmicroscopy.shoola.agents.measurement.util.actions.ROIAction;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROIActionController;
 import org.openmicroscopy.shoola.agents.measurement.util.roitable.ROIActionController.CreationActionType;
+import org.openmicroscopy.shoola.agents.measurement.view.ROITable;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.ROI;
 import org.openmicroscopy.shoola.util.roi.model.ROIShape;
@@ -73,20 +75,20 @@ public class ROIPopupMenu
 	/** The menubar which holds the menu items. */
 	private JPopupMenu				popupMenu;
 	
-	/** The link to the controller for the pop up menu. */
-	private ROIActionController		controller; 	
-	
 	/** The list of actions. */
 	private List<ROIAction>			actions;
+	
+	/** The link to the controller for the pop up menu. */
+	private ROITable table;
 	
 	/**
 	 * Instantiate the popup menu
 	 * @param controller class which has interface ROIActionController that 
 	 * determines which action to perform depending on menu item selected.
 	 */
-	public ROIPopupMenu(ROIActionController controller)
+	public ROIPopupMenu(ROITable table)
 	{
-		this.controller = controller;
+		this.table = table;
 		actions = new ArrayList<ROIAction>();
 		createPopupMenu();
 	}
@@ -104,7 +106,7 @@ public class ROIPopupMenu
 			ROIActionController.CreationActionType.values();
 		for (int indexCnt = 0 ; indexCnt < values.length ; indexCnt++)
 		{
-			action = new ROIAction(controller, values[indexCnt]);
+			action = new ROIAction(table, values[indexCnt]);
 			actions.add(action);
 			popupMenu.add(new JMenuItem(action));
 		}
@@ -189,8 +191,12 @@ public class ROIPopupMenu
                 Object obj = selection.iterator().next();
                 if (obj instanceof FolderData) {
                     FolderData f = (FolderData) obj;
-                    f.canEdit();
+                    return f.canEdit();
                 }
+                if (obj instanceof ROI)
+                    return ((ROI) obj).canEdit();
+                if (obj instanceof ROIShape)
+                    return ((ROIShape) obj).getROI().canEdit();
             }
             else {
                 for (Object obj : selection) {
@@ -225,6 +231,7 @@ public class ROIPopupMenu
         if (!(isFolderSelection ^ isROISelection))
             return false;
 
+        boolean isInFolder = false;
         int delete = 0;
         int edit = 0;
         int link = 0;
@@ -250,6 +257,8 @@ public class ROIPopupMenu
                 if (obj instanceof ROI) {
                     boolean shapeEdit = true;
                     boolean shapeDel = true;
+                    if (!isInFolder)
+                        isInFolder = !table.findFolders((ROI) obj).isEmpty();
                     for (ROIShape s : ((ROI) obj).getShapes().values()) {
                         roi = s.getFigure();
                         if (shapeEdit && !roi.canEdit())
@@ -265,6 +274,9 @@ public class ROIPopupMenu
                         delete++;
                 }
                 if (obj instanceof ROIShape) {
+                    if (!isInFolder)
+                        isInFolder = !table.findFolders(
+                                ((ROIShape) obj).getROI()).isEmpty();
                     shape = (ROIShape) obj;
                     roi = shape.getFigure();
                     if (!(roi.isReadOnly())) {
@@ -277,6 +289,9 @@ public class ROIPopupMenu
                     }
                 }
                 if (obj instanceof ROIFigure) {
+                    if (!isInFolder)
+                        isInFolder = !table.findFolders(
+                                ((ROIFigure) obj).getROI()).isEmpty();
                     roi = (ROIFigure) obj;
                     if (!(roi.isReadOnly())) {
                         if (roi.canEdit()) {
@@ -303,7 +318,7 @@ public class ROIPopupMenu
         case PROPAGATE:
             return isROISelection && edit == selection.size();
         case REMOVE_FROM_FOLDER:
-            return isROISelection && link == selection.size();
+            return isROISelection && link == selection.size() && isInFolder;
         case SPLIT:
             return isROISelection && edit == selection.size();
         case TAG:

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
@@ -323,10 +323,13 @@ public class ROIPopupMenu
         return false;
     }
 
-	/**
-	 * Returns the popup menu.
-	 * @return see above.
-	 */
-	public JPopupMenu getPopupMenu() { return popupMenu; }
+    /**
+     * Returns the popup menu.
+     * 
+     * @return see above.
+     */
+    public JPopupMenu getPopupMenu() {
+        return popupMenu;
+    }
 	
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roimenu/ROIPopupMenu.java
@@ -78,13 +78,12 @@ public class ROIPopupMenu
 	/** The list of actions. */
 	private List<ROIAction>			actions;
 	
-	/** The link to the controller for the pop up menu. */
+	/** The reference to the {@link ROITable}*/
 	private ROITable table;
 	
 	/**
 	 * Instantiate the popup menu
-	 * @param controller class which has interface ROIActionController that 
-	 * determines which action to perform depending on menu item selected.
+	 * @param table Reference to the {@link ROITable}
 	 */
 	public ROIPopupMenu(ROITable table)
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
@@ -318,10 +318,7 @@ class MeasurementViewerControl
     			setROIFigureStatus(ROIFigure.IDLE);
     			if (!UIUtilities.isWindowsOS()) {
         			if (isRightClick(e)) {
-        				Collection l = 
-        					view.getDrawingView().getSelectedFigures();
-        				if (l != null && l.size() == 1)
-        					view.showROIManagementMenu(e.getX(), e.getY());
+        			    view.showROIManagementMenu(e.getX(), e.getY());
         			}
     			}
     		}
@@ -331,10 +328,7 @@ class MeasurementViewerControl
     			setROIFigureStatus(ROIFigure.IDLE);
     			if (UIUtilities.isWindowsOS()) {
         			if (isRightClick(e)) {
-        				Collection l = 
-        					view.getDrawingView().getSelectedFigures();
-        				if (l != null && l.size() == 1)
-        					view.showROIManagementMenu(e.getX(), e.getY());
+        			    view.showROIManagementMenu(e.getX(), e.getY());
         			}
     			}
     		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -932,7 +932,7 @@ public class ROITable
      * @param roi The ROI
      * @return The folder nodes this ROI is part of
      */
-    Collection<ROINode> findFolders(ROI roi) {
+    public Collection<ROINode> findFolders(ROI roi) {
         if(roi.getFolders().isEmpty())
             return Collections.EMPTY_LIST;
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -545,6 +545,7 @@ public class ROITable
      */
     void showROIManagementMenu(Component c, int x, int y)
     {
+        popupMenu.setActionsEnabled(getSelectedObjects());
     	JPopupMenu menu = popupMenu.getPopupMenu();
     	if (menu.isVisible()) return;
     	menu.show(c, x, y);


### PR DESCRIPTION
The ROI context menu didn't work properly when triggered by right click on the ROIs in the image viewer. See respective point on checklist on the [Trello card - ROI Folders Insight Bugs/RFEs](https://trello.com/c/XUI38KAp/27-roi-folders-insight-bugs-rfes) This PR fixes the problems. 

**Test**: Check that the ROI context menu triggered from the image viewer works like the context menu triggered from the ROI table (and that both work like expected).

