### PR TITLE
Add support for twitter cards (full image viewer only) (rebased onto metadata52)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -506,6 +506,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.public.cache.timeout":
         ["PUBLIC_CACHE_TIMEOUT", 60 * 60 * 24, int, None],
 
+    # Social media integration
+    "omero.web.twitter.enabled":
+        ["TWITTER_ENABLED",
+         "false",
+         parse_boolean,
+         "Enable Twitter cards."],
+    "omero.web.twitter.siteuser":
+        ["TWITTER_SITE_USER",
+         None,
+         leave_none_unset,
+         "Twitter site username."],
+
     # Application configuration
     "omero.web.server_list":
         ["SERVER_LIST",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -514,6 +514,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Dictionary of `server-name: @twitter-site-username`, where "
           "server-name matches a name from `omero.web.server_list`. "
           "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
+    "omero.web.sharing.opengraph":
+        ["SHARING_OPENGRAPH",
+         {},
+         json.loads,
+         ("Dictionary of `server-name: site-name`, where "
+          "server-name matches a name from `omero.web.server_list`. "
+          "For example: ``'{\"omero\": \"Open Microscopy\"}'``")],
 
     # Application configuration
     "omero.web.server_list":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -509,14 +509,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # Social media integration
     "omero.web.sharing.twitter":
         ["SHARING_TWITTER",
-         {},
+         '{}',
          json.loads,
          ("Dictionary of `server-name: @twitter-site-username`, where "
           "server-name matches a name from `omero.web.server_list`. "
           "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
     "omero.web.sharing.opengraph":
         ["SHARING_OPENGRAPH",
-         {},
+         '{}',
          json.loads,
          ("Dictionary of `server-name: site-name`, where "
           "server-name matches a name from `omero.web.server_list`. "

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -507,16 +507,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["PUBLIC_CACHE_TIMEOUT", 60 * 60 * 24, int, None],
 
     # Social media integration
-    "omero.web.twitter.enabled":
-        ["TWITTER_ENABLED",
-         "false",
-         parse_boolean,
-         "Enable Twitter cards."],
-    "omero.web.twitter.siteuser":
-        ["TWITTER_SITE_USER",
-         None,
-         leave_none_unset,
-         "Twitter site username."],
+    "omero.web.sharing.twitter":
+        ["SHARING_TWITTER",
+         {},
+         json.loads,
+         ("Dictionary of `server-name: @twitter-site-username`, where "
+          "server-name matches a name from `omero.web.server_list`. "
+          "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
 
     # Application configuration
     "omero.web.server_list":

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1,5 +1,6 @@
 {% extends "webgateway/core_html.html" %}
 {% load i18n %}
+{% load common_filters %}
 
 {% comment %}
 <!--
@@ -42,6 +43,14 @@
     <link rel="stylesheet" type="text/css" href="{% static "webgateway/css/ome.iehacks.css"|add:url_suffix %}" media="all" />
 <![endif]-->
 
+{% if twitter %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="{{ twitter|escape }}">
+    <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
+    <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
+    <meta name="twitter:creator" content="{{ twitter|escape }}">
+    <meta name="twitter:image" content="{{ twitter_img }}280">
+{% endif %}
 {% endblock %}
 
 {% block script %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -43,14 +43,24 @@
     <link rel="stylesheet" type="text/css" href="{% static "webgateway/css/ome.iehacks.css"|add:url_suffix %}" media="all" />
 <![endif]-->
 
+{% if opengraph %}
+    <meta name="og:title" content="{{ image.getName|escape }}">
+    <meta name="og:type" content="website">
+    <meta name="og:site_name" content="{{ opengraph }}">
+    <meta name="og:description" content="{{ image.getDescription|default:image.getOwner.getName|escape }}">
+    <meta name="og:url" content="{{ page_url }}">
+    <meta name="og:image" content="{{ image_preview }}512">
+{% endif %}
+
 {% if twitter %}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="{{ twitter|escape }}">
     <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
     <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
     <meta name="twitter:creator" content="{{ twitter|escape }}">
-    <meta name="twitter:image" content="{{ twitter_img }}280">
+    <meta name="twitter:image" content="{{ image_preview }}280">
 {% endif %}
+
 {% endblock %}
 
 {% block script %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -49,7 +49,7 @@
     <meta name="og:site_name" content="{{ opengraph }}">
     <meta name="og:description" content="{{ image.getDescription|default:image.getOwner.getName|escape }}">
     <meta name="og:url" content="{{ page_url }}">
-    <meta name="og:image" content="{{ image_preview }}512">
+    <meta name="og:image" content="{{ image_preview }}512/">
 {% endif %}
 
 {% if twitter %}
@@ -58,7 +58,7 @@
     <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
     <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
     <meta name="twitter:creator" content="{{ twitter|escape }}">
-    <meta name="twitter:image" content="{{ image_preview }}280">
+    <meta name="twitter:image" content="{{ image_preview }}280/">
 {% endif %}
 
 {% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1952,6 +1952,20 @@ def full_viewer(request, iid, conn=None, **kwargs):
         if image is None:
             logger.debug("(a)Image %s not found..." % (str(iid)))
             raise Http404
+        twitter = None
+        twitter_img = None
+
+        if settings.TWITTER_ENABLED and hasattr(settings, 'TWITTER_SITE_USER'):
+            twitter = settings.TWITTER_SITE_USER
+        if twitter:
+            prefix = kwargs.get(
+                'thumbprefix', 'webgateway.views.render_thumbnail')
+
+            def urlprefix(iid):
+                return reverse(prefix, args=(iid,))
+
+            twitter_img = request.build_absolute_uri(urlprefix(iid))
+
         d = {'blitzcon': conn,
              'image': image,
              'opts': rid,
@@ -1962,6 +1976,9 @@ def full_viewer(request, iid, conn=None, **kwargs):
              'viewport_server': kwargs.get(
                  # remove any trailing slash
                  'viewport_server', reverse('webgateway')).rstrip('/'),
+
+             'twitter': twitter,
+             'twitter_img': twitter_img,
 
              'object': 'image:%i' % int(iid)}
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1964,7 +1964,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
         if hasattr(settings, 'SHARING_OPENGRAPH'):
             opengraph = settings.SHARING_OPENGRAPH.get(server_name)
-            logger.debug('Open Graph enabled: %s', twitter)
+            logger.debug('Open Graph enabled: %s', opengraph)
 
         if hasattr(settings, 'SHARING_TWITTER'):
             twitter = settings.SHARING_TWITTER.get(server_name)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -45,7 +45,7 @@ from omero import ApiUsageException
 from omero.util.decorators import timeit, TimeIt
 from omeroweb.http import HttpJavascriptResponse, HttpJsonResponse, \
     HttpJavascriptResponseServerError
-from connector import Server
+from omeroweb.connector import Server
 
 import glob
 


### PR DESCRIPTION

This is the same as gh-4260 but rebased onto metadata52.

----

I've had this lurking around since January 2014. Given that we now have a public resource and Twitter no longer require manual approvals I thought it's time to resurrect it. See https://dev.twitter.com/cards/types/summary-large-image

The `title` and `description` fields are mandatory, I'm assuming there will always be a non-empty image name, description is set to the owner's name if empty.

At risk of stating the obvious this can only be tested with a public image on an external server. Open an image in the full image viewer, copy the url into a tweet.

                