### PR TITLE
upload plugin stdout

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/upload.py
+++ b/components/tools/OmeroPy/src/omero/plugins/upload.py
@@ -64,7 +64,7 @@ class UploadControl(BaseControl):
                              " import")
             else:
                 obj = client.upload(file, type=omero_format)
-                self.ctx.out("Uploaded %s as " % file + str(obj.id.val))
+                self.ctx.out("OriginalFile:%s" % obj.id.val)
                 self.ctx.set("last.upload.id", obj.id.val)
 
 try:


### PR DESCRIPTION
As just discussed in devteam, this makes the output of the upload plugin easier to reuse for subsequent CLI calls (see https://github.com/openmicroscopy/openmicroscopy/pull/4579/commits/34b85e4a839eba8051fa6c425d484d11b29677b3 for usage without this PR)

```
$ bin/omero upload test_file.txt
OriginalFile:49795
```

Also discussed was printing the original message to std err:

self.ctx.err("Uploaded %s as " % file + str(obj.id.val))

```
$ bin/omero upload test_file.txt
OriginalFile:49795
Uploaded robot_file_annotation.txt as 49795
```

However, I haven't added this yet as I wouldn't naturally assume, looking at the example above, that this response contained some stderr and some stdout and that I could just get the stdout with

```
$ X=$(bin/omero upload test_file.txt)
$ echo $X
OriginalFile:49795
```

Is this common practise? Do we do it with our other plugins?
Seems easier to me as a naive user that it's simpler just to have the stdout as in the first example?