### PR TITLE
Add keepalive for root connection

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -116,6 +116,18 @@ class ITest(object):
         cls.root = None
         cls.__clients.__del__()
 
+    def keepRootAlive(self):
+        """
+        Keeps root connection alive.
+        """
+        try:
+            if self.root.sf is None:
+                assert self.root.connect()
+            else:
+                self.root.sf.keepAlive(None)
+        except Exception:
+            raise
+
     @classmethod
     def omeropydir(self):
         count = 10

--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -122,7 +122,9 @@ class ITest(object):
         """
         try:
             if self.root.sf is None:
-                assert self.root.connect()
+                p = Ice.createProperties(sys.argv)
+                rootpass = p.getProperty("omero.rootpass")
+                self.root.createSession("root", rootpass)
             else:
                 self.root.sf.keepAlive(None)
         except Exception:

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -120,6 +120,7 @@ class TestImport(CLITest):
         self.cli.register("import", plugin.ImportControl, "TEST")
         self.args += ["import"]
         self.add_client_dir()
+        self.keepRootAlive()
 
     def set_conn_args(self):
         host = self.root.getProperty("omero.host")


### PR DESCRIPTION
This an attempt to fix the three fails record on the card https://trello.com/c/EavoXnp4/649-importas-and-multigroup-cli-tests

This adds a `keepAlive` for the root connection so that the connection is still available when these three tests need it. This is the most minimal solution and appears to work when testing locally against a remote server - it needs this latency for the tests to take long enough for the connection to be lost, see below. 

Testing
-------

The tests on Jenkins should pass, though given the intermittency the tests will need to be checked for a number of runs.

Local testing is possible though dependent on a slower connection. Set ice.config to point at `eel.openmicroscopy.org:24064` and then:

```
./setup.py test -t test/integration/clitest/test_import.py -m "not broken" -k "not Symlink" -v
```

should pass cleanly.