### PR TITLE
get better message for status when using apache

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -58,6 +58,12 @@ Example IIS usage:
 
 """
 
+APACHE_MOD_WSGI_ERR = ("[ERROR] You are deploying OMERO.web using Apache and"
+                       " mod_wsgi. OMERO.web does not provide any management"
+                       " for ‘daemon’ process which communicate with Apache"
+                       " child processes using UNIX sockets to handle"
+                       " a request. Please check Apache directly.")
+
 
 def config_required(func):
     """Decorator validating Django dependencies and omeroweb/settings.py"""
@@ -513,11 +519,10 @@ class WebControl(BaseControl):
         deploy = getattr(settings, 'APPLICATION_SERVER')
 
         if deploy in (settings.WSGI,):
-            self.ctx.die(609, "You are deploying OMERO.web using apache and"
-                         " mod_wsgi. Generate apache config using"
+            self.ctx.die(609, "%s\nGenerate apache config using"
                          " 'omero web config apache' or"
                          " 'omero web config apache24' and reload"
-                         " web server.")
+                         " web server." % APACHE_MOD_WSGI_ERR)
 
         else:
             self.ctx.out("Starting OMERO.web... ", newline=False)
@@ -602,12 +607,7 @@ class WebControl(BaseControl):
             else:
                 self.ctx.err("[NOT STARTED]")
         elif deploy in (settings.WSGI,):
-            self.ctx.err("You are deploying OMERO.web using Apache and"
-                         " mod_wsgi. OMERO.web does not provide any "
-                         " management for ‘daemon’ process which "
-                         " communicate with Apache child processes"
-                         " using UNIX sockets to handle a request."
-                         " Please check Apache directly.")
+            self.ctx.err(APACHE_MOD_WSGI_ERR)
         elif deploy in (settings.DEVELOPMENT,):
             self.ctx.err(
                 "DEVELOPMENT: You will have to kill processes by hand!")

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -60,9 +60,9 @@ Example IIS usage:
 
 APACHE_MOD_WSGI_ERR = ("[ERROR] You are deploying OMERO.web using Apache and"
                        " mod_wsgi. OMERO.web does not provide any management"
-                       " for ‘daemon’ process which communicate with Apache"
-                       " child processes using UNIX sockets to handle"
-                       " a request. Please check Apache directly.")
+                       " for the daemon process which communicates with"
+                       " Apache child processes using UNIX sockets to handle"
+                       " a request.")
 
 
 def config_required(func):
@@ -607,7 +607,8 @@ class WebControl(BaseControl):
             else:
                 self.ctx.err("[NOT STARTED]")
         elif deploy in (settings.WSGI,):
-            self.ctx.err(APACHE_MOD_WSGI_ERR)
+            self.ctx.err("%s Please check Apache "
+                         "directly." % APACHE_MOD_WSGI_ERR)
         elif deploy in (settings.DEVELOPMENT,):
             self.ctx.err(
                 "DEVELOPMENT: You will have to kill processes by hand!")

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -602,8 +602,12 @@ class WebControl(BaseControl):
             else:
                 self.ctx.err("[NOT STARTED]")
         elif deploy in (settings.WSGI,):
-            self.ctx.err("You are deploying OMERO.web using apache and"
-                         " mod_wsgi. Cannot check status.")
+            self.ctx.err("You are deploying OMERO.web using Apache and"
+                         " mod_wsgi. OMERO.web does not provide any "
+                         " management for ‘daemon’ process which "
+                         " communicate with Apache child processes"
+                         " using UNIX sockets to handle a request."
+                         " Please check Apache directly.")
         elif deploy in (settings.DEVELOPMENT,):
             self.ctx.err(
                 "DEVELOPMENT: You will have to kill processes by hand!")

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -185,13 +185,17 @@ class TestWeb(object):
         csout = "Clearing expired sessions. This may take some time... [OK]"
         assert csout == o.split(os.linesep)[0]
         if app_server in ('wsgi',):
-            stderr = (
-                ("You are deploying OMERO.web using apache and mod_wsgi. "
-                 "Generate apache config using 'omero web config apache' "
-                 "or 'omero web config apache24' "
-                 "and reload web server."))
-            assert stderr == e.split(os.linesep)[0]
-            assert 1 == len(e.split(os.linesep))-1
+            stderr0 = ("[ERROR] You are deploying OMERO.web using Apache and"
+                       " mod_wsgi. OMERO.web does not provide any management"
+                       " for the daemon process which communicates"
+                       " with Apache child processes using UNIX sockets"
+                       " to handle a request.")
+            stderr1 = ("Generate apache config using"
+                       " 'omero web config apache' or"
+                       " 'omero web config apache24' and reload web server.")
+            assert stderr0 == e.split(os.linesep)[0]
+            assert stderr1 == e.split(os.linesep)[1]
+            assert 2 == len(e.split(os.linesep))-1
         elif app_server in ('wsgi-tcp',):
             startout = "Starting OMERO.web... [OK]"
             assert startout == o.split(os.linesep)[1]


### PR DESCRIPTION
https://trello.com/c/SOvbfoLq/57-docs-pr-omero-web-pr-re-web-start-stop-gunicorn
To test:

- `bin/omero config set omero.web.application_server wsgi`
- `bin/omero web start|status`

```
$ dist/bin/omero web start
Post-processed 'omeroweb.viewer.min.css' as 'omeroweb.viewer.min.css'
Post-processed 'omeroweb.viewer.min.js' as 'omeroweb.viewer.min.js'

0 static files copied to '/Users/ola/OMERO/ome.git/dist/lib/python/omeroweb/static', 616 unmodified, 2 post-processed.
Clearing expired sessions. This may take some time... [OK]
[ERROR] You are deploying OMERO.web using Apache and mod_wsgi. OMERO.web does not provide any management for daemon process which communicate with Apache child processes using UNIX sockets to handle a request. Please check Apache directly.
Generate apache config using 'omero web config apache' or 'omero web config apache24' and reload web server.

$ dist/bin/omero web status
OMERO.web status... [ERROR] You are deploying OMERO.web using Apache and mod_wsgi. OMERO.web does not provide any management for daemon process which communicate with Apache child processes using UNIX sockets to handle a request. Please check Apache directly.

```
