### PR TITLE
Load all `omero/plugins` subdirs on the PYTHONPATH

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1348,7 +1348,17 @@ class CLI(cmd.Cmd, Context):
         in the parser
         """
 
-        for plugin_path in self._plugin_paths:
+        paths = set(self._plugin_paths)
+        for x in sys.path:
+            x = path(x)
+            if x.isdir():
+                x = x / "omero" / "plugins"
+                if x.exists():
+                    paths.add(x)
+            else:
+                if self.isdebug:
+                    print "Can't load %s" % x
+        for plugin_path in paths:
             self.loadpath(path(plugin_path))
 
         self.configure_plugins()


### PR DESCRIPTION
During plugin loading, loop over the contents of sys.path
(i.e. PYTHONPATH) and for all directories which contain a
subdirectory `omero/plugin` run the loadpath method as if
it had been passed to `bin/omero` with `--path`.

NB: This currently does not handle plugins packaged as eggs.

See https://github.com/ome/omero-cli-duplicate/pull/1 for an example of how this would be used.

Further explanation is now on https://trello.com/c/qMrZfcoU/78-external-cli-plugins