### PR TITLE
Roi table improvements

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/roitable/TableRowTransferHandler.java
@@ -106,6 +106,8 @@ public class TableRowTransferHandler extends TransferHandler {
      * Check if the current selection is draggable
      */
     private boolean checkDragSource() {
+        if (table.getSelectedColumn() > 0)
+            return false;
         int[] selection = table.getSelectedRows();
         for (int i = 0; i < selection.length; i++) {
             ROINode n = (ROINode) ((ROITable) table).getNodeAtRow(selection[i]);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -73,11 +73,14 @@ import javax.swing.plaf.basic.BasicTableUI;
 import javax.swing.table.TableColumn;
 import javax.swing.tree.TreePath;
 
+
 //Third-party libraries
 import org.jdesktop.swingx.JXTreeTable;
 import org.jhotdraw.draw.Figure;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.measurement.util.roimenu.ROIPopupMenu;
@@ -196,7 +199,6 @@ public class ROITable
      * Autoscroll to position
      */
     private void autoscroll(Point position) {
-        System.out.println("autoscroll "+position);
         Scrollable s = (Scrollable) this;
         if (position.y < inner.y) {
             // scroll upwards

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -920,13 +920,42 @@ public class ROITable
      * @return See above.
      */
     private boolean displayFolder(FolderData folder) {
-        return ignoreFilters
-                || ((onlyShowFolderIds == null || onlyShowFolderIds
-                        .contains(folder.getId())) && folder.getName()
-                        .toLowerCase().contains(folderNameFilter));
+        return ignoreFilters || checkIDFilter(folder)
+                || checkNameFilter(folder);
     }
 
-	/**
+    /**
+     * Checks if the folder's ID is in the list of folders to display
+     * 
+     * @param folder
+     *            The {@link FolderData} to check
+     * @return <code>true</code> if the list of folders to display contains the
+     *         folder's id or if the list doesn't exist
+     */
+    private boolean checkIDFilter(FolderData folder) {
+        return onlyShowFolderIds == null
+                || onlyShowFolderIds.contains(folder.getId());
+    }
+
+    /**
+     * Checks if the folder's (or one of its parent folder's) name contains the
+     * name filter String.
+     * 
+     * @param folder
+     *            The {@link FolderData} to check
+     * @return <code>true</code> if the folder's (or one of its parent folder's)
+     *         name contains the name filter String.
+     */
+    private boolean checkNameFilter(FolderData folder) {
+        boolean match = folder.getName().toLowerCase()
+                .contains(folderNameFilter);
+        if (match || folder.getParentFolder() == null)
+            return match;
+
+        return checkNameFilter(folder.getParentFolder());
+    }
+    
+ 	/**
      * Finds the ROI Folder nodes of the ROI.
      * Folders which don't exist yet, will be created.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ROITable.java
@@ -920,8 +920,8 @@ public class ROITable
      * @return See above.
      */
     private boolean displayFolder(FolderData folder) {
-        return ignoreFilters || checkIDFilter(folder)
-                || checkNameFilter(folder);
+        return ignoreFilters
+                || (checkIDFilter(folder) && checkNameFilter(folder));
     }
 
     /**


### PR DESCRIPTION
Some more improvements/bug fixes with respect to ROI Folders handling, see [Trello - ROI Folders Insight Bugs/RFEs](https://trello.com/c/XUI38KAp/27-roi-folders-insight-bugs-rfes).

* Enable Drag/Drop only on the first column of the ROI table
* If a Folder name matches the filter expression, don't filter the sub folders, always show them.