### PR TITLE
bring BinData changes into OMERO

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -86,6 +86,7 @@ import ome.util.LSID;
 import ome.xml.meta.MetadataRoot;
 import ome.xml.model.AffineTransform;
 import ome.xml.model.MapPair;
+import ome.xml.model.enums.Compression;
 import ome.xml.model.enums.FillRule;
 import ome.xml.model.enums.FontFamily;
 import ome.xml.model.enums.FontStyle;
@@ -5128,6 +5129,21 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
+    public void setMaskBinDataBigEndian(Boolean arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setMaskBinDataCompression(Compression arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setMaskBinDataLength(NonNegativeLong arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
     public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex) {
         final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
         o.setMapValue(IceMapper.convertMapPairs(value));
@@ -5666,9 +5682,14 @@ public class OMEROMetadataStoreClient
      * @see loci.formats.meta.MetadataStore#setPixelsBigEndian(java.lang.Boolean,int)
      */
     @Override
-    public void  setPixelsBigEndian(Boolean value,  int index)
+    public void setPixelsBigEndian(Boolean value, int index)
     {
         ignoreUnneeded("setPixelsBigEndian", value, index);
+    }
+
+    @Override
+    public void setPixelsBinData(byte[] arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
     }
 
     /* (non-Javadoc)
@@ -5679,6 +5700,16 @@ public class OMEROMetadataStoreClient
             int binDataIndex)
     {
         ignoreUnneeded("setPixelsBinDataBigEndian", bigEndian, imageIndex);
+    }
+
+    @Override
+    public void setPixelsBinDataCompression(Compression arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setPixelsBinDataLength(NonNegativeLong arg0, int arg1, int arg2) {
+        // TODO Auto-generated method stub
     }
 
     /* (non-Javadoc)
@@ -8150,6 +8181,26 @@ public class OMEROMetadataStoreClient
     public void setPlateFieldIndex(NonNegativeInteger fieldIndex, int plateIndex)
     {
         ignoreMissing("setPlateFieldIndex", fieldIndex, plateIndex);
+    }
+
+    @Override
+    public void setBinaryFileBinData(byte[] arg0, int arg1) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setBinaryFileBinDataBigEndian(Boolean arg0, int arg1) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setBinaryFileBinDataCompression(Compression arg0, int arg1) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setBinaryFileBinDataLength(NonNegativeLong arg0, int arg1) {
+        // TODO Auto-generated method stub
     }
 
     /* (non-Javadoc)

--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -5129,18 +5129,18 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setMaskBinDataBigEndian(Boolean arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setMaskBinDataBigEndian(Boolean isBigEndian, int roiIndex, int shapeIndex) {
+        ignoreMissing("setMaskBinDataBigEndian", isBigEndian, roiIndex, shapeIndex);
     }
 
     @Override
-    public void setMaskBinDataCompression(Compression arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setMaskBinDataCompression(Compression compression, int roiIndex, int shapeIndex) {
+        ignoreMissing("setMaskBinDataCompression", compression, roiIndex, shapeIndex);
     }
 
     @Override
-    public void setMaskBinDataLength(NonNegativeLong arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setMaskBinDataLength(NonNegativeLong length, int roiIndex, int shapeIndex) {
+        ignoreMissing("setMaskBinDataLength", length, roiIndex, shapeIndex);
     }
 
     /* (non-Javadoc)
@@ -5682,8 +5682,8 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setPixelsBinData(byte[] arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setPixelsBinData(byte[] binData, int imageIndex, int binDataIndex) {
+        ignoreMissing("setPixelsBinData", imageIndex, binDataIndex);
     }
 
     /* (non-Javadoc)
@@ -5697,13 +5697,13 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setPixelsBinDataCompression(Compression arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setPixelsBinDataCompression(Compression compression, int imageIndex, int binDataIndex) {
+        ignoreMissing("setPixelsBinDataCompression", compression, imageIndex, binDataIndex);
     }
 
     @Override
-    public void setPixelsBinDataLength(NonNegativeLong arg0, int arg1, int arg2) {
-        // TODO Auto-generated method stub
+    public void setPixelsBinDataLength(NonNegativeLong length, int imageIndex, int binDataIndex) {
+        ignoreMissing("setPixelsBinDataLength", length, imageIndex, binDataIndex);
     }
 
     /* (non-Javadoc)
@@ -8184,23 +8184,23 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setBinaryFileBinData(byte[] arg0, int arg1) {
-        // TODO Auto-generated method stub
+    public void setBinaryFileBinData(byte[] binData, int fileAnnotationIndex) {
+        ignoreMissing("setBinaryFileBinData", fileAnnotationIndex);
     }
 
     @Override
-    public void setBinaryFileBinDataBigEndian(Boolean arg0, int arg1) {
-        // TODO Auto-generated method stub
+    public void setBinaryFileBinDataBigEndian(Boolean isBigEndian, int fileAnnotationIndex) {
+        ignoreMissing("setBinaryFileBinDataBigEndian", isBigEndian, fileAnnotationIndex);
     }
 
     @Override
-    public void setBinaryFileBinDataCompression(Compression arg0, int arg1) {
-        // TODO Auto-generated method stub
+    public void setBinaryFileBinDataCompression(Compression compression, int fileAnnotationIndex) {
+        ignoreMissing("setBinaryFileBinDataCompression", compression, fileAnnotationIndex);
     }
 
     @Override
-    public void setBinaryFileBinDataLength(NonNegativeLong arg0, int arg1) {
-        // TODO Auto-generated method stub
+    public void setBinaryFileBinDataLength(NonNegativeLong length, int fileAnnotationIndex) {
+        ignoreMissing("setBinaryFileBinDataLength", length, fileAnnotationIndex);
     }
 
     /* (non-Javadoc)

--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -5143,12 +5143,6 @@ public class OMEROMetadataStoreClient
         // TODO Auto-generated method stub
     }
 
-    @Override
-    public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex) {
-        final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
-        o.setMapValue(IceMapper.convertMapPairs(value));
-    }
-
     /* (non-Javadoc)
      * @see loci.formats.meta.MetadataStore#setMaskText(java.lang.String, int, int)
      */
@@ -7977,6 +7971,12 @@ public class OMEROMetadataStoreClient
     public void setMapAnnotationNamespace(String namespace, int mapAnnotationIndex) {
         final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
         o.setNs(toRType(namespace));
+    }
+
+    @Override
+    public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex) {
+        final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
+        o.setMapValue(IceMapper.convertMapPairs(value));
     }
 
     /**


### PR DESCRIPTION
Stubs new BinData methods so that OMERO still works and metadata mapping to-do's are logged.

See https://github.com/openmicroscopy/bioformats/pull/2319.