### PR TITLE
remove rank and sort by name regardless of node type

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -254,6 +254,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.ui.tree.type_order">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -136,13 +136,17 @@ class render_response(omeroweb.decorators.render_response):
             context['ome']['email'] = request.session.get(
                 'server_settings').get('email', False)
             if request.session.get('server_settings').get('ui'):
-                context.setdefault('ui', {})  # don't overwrite existing ui
+                # don't overwrite existing ui
+                context.setdefault('ui', {'tree': {}})
                 context['ui']['orphans'] = \
                     request.session.get('server_settings').get('ui', {}) \
                     .get('tree', {}).get('orphans')
                 context['ui']['dropdown_menu'] = \
                     request.session.get('server_settings').get('ui', {}) \
                     .get('menu', {}).get('dropdown')
+                context['ui']['tree']['type_order'] = \
+                    request.session.get('server_settings').get('ui', {}) \
+                    .get('tree', {}).get('type_order')
 
         self.load_settings(request, context, conn)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1066,8 +1066,6 @@ $(function() {
             var inst = this;
             var node1 = inst.get_node(nodeId1);
             var node2 = inst.get_node(nodeId2);
-            var name1 = node1.text.toLowerCase();
-            var name2 = node2.text.toLowerCase();
 
             function getRanking(node) {
                 // return rank based on 'omero.client.ui.tree.type_order' list
@@ -1081,8 +1079,9 @@ $(function() {
                 return WEBCLIENT.UI.TREE.type_order.length + 1;
             }
 
-            // if sorting list is turned off mix object and sort by name
-            if (WEBCLIENT.UI.TREE.type_order.indexOf('false') > -1) {
+            function sortingStrategy(node1, node2) {
+                // sorting strategy
+
                 if(node1.type === 'experimenter') {
                     if (node1.data.obj.id === WEBCLIENT.USER.id) {
                         return -1;
@@ -1090,27 +1089,24 @@ $(function() {
                         return 1;
                     }
                 }
+                var name1 = node1.text.toLowerCase();
+                var name2 = node2.text.toLowerCase();
+
                 // If names are same, sort by ID
                 if (name1 === name2) {
                     return node1.data.obj.id <= node2.data.obj.id ? -1 : 1;
                 }
                 return name1 <= name2 ? -1 : 1;
             }
+
+            // if sorting list is turned off mix object and sort by name
+            if (WEBCLIENT.UI.TREE.type_order.indexOf('false') > -1) {
+                return sortingStrategy(node1, node2);
+            }
             // If the nodes are the same type then just compare lexicographically
             if (node1.type === node2.type && node1.text && node2.text) {
                 // Unless they are experimenters and one of them is the current user.
-                if(node1.type === 'experimenter') {
-                    if (node1.data.obj.id === WEBCLIENT.USER.id) {
-                        return -1;
-                    } else if (node2.data.obj.id === WEBCLIENT.USER.id) {
-                        return 1;
-                    }
-                }
-                // If names are same, sort by ID
-                if (name1 === name2) {
-                    return node1.data.obj.id <= node2.data.obj.id ? -1 : 1;
-                }
-                return name1 <= name2 ? -1 : 1;
+                return sortingStrategy(node1, node2);
             // Otherwise explicitly order the type that might be siblings
             } else {
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1070,27 +1070,31 @@ $(function() {
             var name2 = node2.text.toLowerCase();
 
             function getRanking(node) {
-                if (node.type === 'tagset') {
-                    return 1;
-                } else if (node.type === 'tag') {
-                    return 2;
-                } else if (node.type === 'project') {
-                    return 3;
-                } else if (node.type === 'dataset') {
-                    return 4;
-                } else if (node.type === 'screen') {
-                    return 5;
-                } else if (node.type === 'plate') {
-                    return 6;
-                } else if (node.type === 'orphaned') {
-                    return 7;
-                } else if (node.type === 'image') {
-                    return 8;
-                } else if (node.type === 'acquisition') {
-                    return 9;
-                } else {
-                    return 10;
+                // return rank based on 'omero.client.ui.tree.type_order' list
+                // first type is ranked 1 (the highest), last  is the lowest
+                var rank = WEBCLIENT.UI.TREE.type_order.indexOf(node.type);
+                if (rank > -1) {
+                    return rank;
                 }
+                // types not specified in 'omero.client.ui.tree.type_order'
+                // are sorted as loaded to jquery based on sql
+                return WEBCLIENT.UI.TREE.type_order.length + 1;
+            }
+
+            // if sorting list is turned off mix object and sort by name
+            if (WEBCLIENT.UI.TREE.type_order.indexOf('false') > -1) {
+                if(node1.type === 'experimenter') {
+                    if (node1.data.obj.id === WEBCLIENT.USER.id) {
+                        return -1;
+                    } else if (node2.data.obj.id === WEBCLIENT.USER.id) {
+                        return 1;
+                    }
+                }
+                // If names are same, sort by ID
+                if (name1 === name2) {
+                    return node1.data.obj.id <= node2.data.obj.id ? -1 : 1;
+                }
+                return name1 <= name2 ? -1 : 1;
             }
             // If the nodes are the same type then just compare lexicographically
             if (node1.type === node2.type && node1.text && node2.text) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -192,6 +192,10 @@
         WEBCLIENT.URLS.api_experimenter = "{% url 'api_experimenter' active_user.id %}";
         {% endif %}
 
+        WEBCLIENT.UI = {};
+        WEBCLIENT.UI.TREE = {};
+        WEBCLIENT.UI.TREE.type_order = "{{ui.tree.type_order}}".toLowerCase().split(",").filter(function(e){return e});
+
         {% if page_size %}
             var PAGE_SIZE = {{ page_size }};
         {% endif %}

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -862,6 +862,12 @@ omero.client.download_as.max_size=144000000
 # Client viewers roi limit.
 omero.client.viewer.roi_limit=2000
 
+# Client tree type order rank list
+# first type is ranked 1 (the highest), last is the lowest
+# if set to 'false' empty list allows mixing all types and
+# sorting them by default client ordering strategy
+omero.client.ui.tree.type_order=tagset,tag,project,dataset,screen,plate,acquisition,image
+
 #############################################
 ## Ice overrides
 ##


### PR DESCRIPTION
this PR adds ability to sort client tree nodes by type. 

`omero.client.ui.tree.type_order`by default is `tagset,tag,project,dataset,screen,plate,acquisition,image`

to mix types in a tree and sort them by default sorting strategy impleented in client set `omero.client.ui.tree.type_order false`

Note: removing type from the list won't turn off appearance of nodes, it only allows to order them

![firefoxscreensnapz026](https://cloud.githubusercontent.com/assets/1065155/15044131/b097c654-12ca-11e6-8e6d-35568d8dca3b.png)

**Testing: if you update server configuration you must logout from web (even public user) to pick up changes, server config is stored in session and loaded only for the first time when connection is created**