### PR TITLE
Temporarily exclude the downgrade tests with ROIs

### DIFF
--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -943,7 +943,7 @@ public class ExporterTest extends AbstractServerTest {
      * Test the export of an image with ROI as OME-XML. Downgrade it.
      * @throws Exception Thrown if an error occurred.
      */
-    @Test(dataProvider = "createTransform")
+    // @Test(dataProvider = "createTransform")
     public void testExportAsOMEXMLDowngradeImageWithROI(Target target) throws Exception {
         File f = null;
         File transformed = null;


### PR DESCRIPTION
In order to estimate the impact of the BinData code generation PR, this PR excludes the OMERO tests downgrading and re-importing OME-XML with ROIs.