### PR TITLE
Enable Plate download

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
@@ -24,21 +24,25 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+
 import javax.swing.Action;
 import javax.swing.JFrame;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.dataBrowser.DataBrowserAgent;
 import org.openmicroscopy.shoola.agents.dataBrowser.IconManager;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageDisplay;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.agents.events.hiviewer.DownloadEvent;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.util.PojosUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
 
@@ -74,14 +78,12 @@ public class DownloadAction
         if (CollectionUtils.isNotEmpty(list)) {
             Iterator<DataObject> i = list.iterator();
             DataObject d;
+
             while (i.hasNext()) {
                 d = i.next();
-                if (d instanceof ImageData) {
-                    ImageData data = (ImageData) d;
-                    if (data.isArchived()) {
-                        enabled = true;
-                        break;
-                    }
+                if (PojosUtil.isDownloadable(d)) {
+                    enabled = true;
+                    break;
                 }
             }
         }
@@ -113,6 +115,10 @@ public class DownloadAction
         if (node == null)
             return;
         
+        List<DataObject> selection = new ArrayList<DataObject>();
+        selection.add((DataObject)node.getHierarchyObject());
+        
+        
         JFrame f = DataBrowserAgent.getRegistry().getTaskBar().getFrame();
 
         int type = FileChooser.FOLDER_CHOOSER;
@@ -131,7 +137,7 @@ public class DownloadAction
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
                     String path = (String) evt.getNewValue();
                     EventBus bus = DataBrowserAgent.getRegistry().getEventBus();
-                    bus.post(new DownloadEvent(new File(path), src.isOverride()));
+                    bus.post(new DownloadEvent(new File(path), src.isOverride(), selection));
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/actions/DownloadAction.java
@@ -115,7 +115,7 @@ public class DownloadAction
         if (node == null)
             return;
         
-        List<DataObject> selection = new ArrayList<DataObject>();
+        final List<DataObject> selection = new ArrayList<DataObject>();
         selection.add((DataObject)node.getHierarchyObject());
         
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/events/hiviewer/DownloadEvent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/events/hiviewer/DownloadEvent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,8 @@
 package org.openmicroscopy.shoola.agents.events.hiviewer;
 
 import java.io.File;
-
+import java.util.List;
+import omero.gateway.model.DataObject;
 import org.openmicroscopy.shoola.env.event.RequestEvent;
 
 
@@ -41,16 +42,25 @@ public class DownloadEvent
     /**  Flag indicating to override the existing file if it exists.*/
     private boolean override;
 
+    /** The objects to download */
+    private List<DataObject> selection;
+    
     /**
      * Creates a new instance.
      *
-     * @param folder where to download the objects
-     * @param override Indicate to override or not the name if it already exits.
+     * @param folder
+     *            where to download the objects
+     * @param override
+     *            Indicate to override or not the name if it already exits.
+     * @param selection
+     *            The objects to download (can be <code>null</code> in which case
+     *            the receiver of this event has to figure it out itself)
      */
-    public DownloadEvent(File folder, boolean override)
-    {
+    public DownloadEvent(File folder, boolean override,
+            List<DataObject> selection) {
         this.folder = folder;
         this.override = override;
+        this.selection = selection;
     }
 
     /**
@@ -67,4 +77,14 @@ public class DownloadEvent
      * @return See above.
      */
     public File getFolder() { return folder; }
+
+    /**
+     * Get the objects to download
+     * @return See above
+     */
+    public List<DataObject> getSelection() {
+        return selection;
+    }
+    
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -53,7 +53,6 @@ import javax.swing.SwingUtilities;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXBusyLabel;
-
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.util.FilesetInfoDialog;
@@ -63,6 +62,7 @@ import org.openmicroscopy.shoola.agents.util.ui.ScriptSubMenu;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.FigureParam;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
+import org.openmicroscopy.shoola.util.PojosUtil;
 import org.openmicroscopy.shoola.util.filter.file.CppFilter;
 import org.openmicroscopy.shoola.util.filter.file.CustomizedFileFilter;
 import org.openmicroscopy.shoola.util.filter.file.JavaFilter;
@@ -178,7 +178,7 @@ class ToolBar
         if (!CollectionUtils.isEmpty(nodes)) {
             Iterator<DataObject> i = nodes.iterator();
             while (i.hasNext()) {
-                if (model.isArchived(i.next())) {
+                if (PojosUtil.isDownloadable(i.next())) {
                     b = true;
                     break;
                 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -508,7 +508,7 @@ public class TreeViewerAgent
         if (exp == null) 
             return;
         TreeViewer viewer = TreeViewerFactory.getTreeViewer(exp);
-        viewer.download(evt.getFolder(), evt.isOverride());
+        viewer.download(evt.getFolder(), evt.isOverride(), evt.getSelection());
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/DownloadAction.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -35,12 +35,12 @@ import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
+import org.openmicroscopy.shoola.util.PojosUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
-import omero.gateway.model.ImageData;
 
 /** 
  * Action to download the selected file.
@@ -90,25 +90,25 @@ public class DownloadAction
             setEnabled(false);
             return;
         }
-        setEnabled(false);
+        enabled = false;
         Object ho = selectedDisplay.getUserObject();
+        
         if (ho instanceof FileAnnotationData) {
             setEnabled(true);
-        } else if (ho instanceof ImageData) {
+        } else {
             Browser browser = model.getSelectedBrowser();
             List<DataObject> list = browser.getSelectedDataObjects();
             Iterator<DataObject> i = list.iterator();
             DataObject data;
-            boolean enabled = false;
             while (i.hasNext()) {
                 data = i.next();
-                if (data instanceof ImageData) {
-                    ImageData img = (ImageData) data;
-                    if (img.isArchived()) enabled = true;
+                if (PojosUtil.isDownloadable(data)) {
+                    enabled = true;
+                    break;
                 }
             }
-            setEnabled(enabled);
         }
+        setEnabled(enabled);
     }
 
     /**
@@ -158,7 +158,7 @@ public class DownloadAction
                 FileChooser src = (FileChooser) evt.getSource();
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
                     String path = (String) evt.getNewValue();
-                    model.download(new File(path), src.isOverride());
+                    model.download(new File(path), src.isOverride(), null);
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -886,14 +886,19 @@ public interface TreeViewer
 	 */
 	void onActivityProcessed(ActivityComponent activity, boolean finished);
 
-	/**
-	 * Downloads the currently selected files to the specified folder.
-	 * 
-	 * @param folder The folder where to download the files.
-	 * @param override Flag indicating to override the existing file if it
-     *                 exists, <code>false</code> otherwise.
-	 */
-	void download(File folder, boolean override);
+    /**
+     * Downloads the currently selected files to the specified folder.
+     * 
+     * @param folder
+     *            The folder where to download the files.
+     * @param override
+     *            Flag indicating to override the existing file if it exists,
+     *            <code>false</code> otherwise.
+     * @param selection
+     *            The objects to download (can be <code>null</code> in which
+     *            case the current TreeViewer selection will be used)
+     */
+    void download(File folder, boolean override, List<DataObject> selection);
 
 	/**
 	 * Sets the collection of archived files.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -47,6 +47,7 @@ import javax.swing.JFrame;
 import org.apache.commons.collections.CollectionUtils;
 
 import omero.model.OriginalFile;
+import omero.model.PlateAcquisition;
 
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowserFactory;
@@ -3646,18 +3647,21 @@ class TreeViewerComponent
 
 	/**
 	 * Implemented as specified by the {@link TreeViewer} interface.
-	 * @see TreeViewer#download(File, boolean)
+	 * @see TreeViewer#download(File, boolean, List)
 	 */
-	public void download(File folder, boolean override)
+	public void download(File folder, boolean override, List<DataObject> selection)
 	{
-	    if (model.getState() == DISCARDED) return;
-	    Browser browser = model.getSelectedBrowser();
-	    if (browser == null) return;
-	    List l = browser.getSelectedDataObjects();
+        if (model.getState() == DISCARDED)
+            return;
+        Browser browser = model.getSelectedBrowser();
+        if (browser == null)
+            return;
+        List l = selection == null ? browser.getSelectedDataObjects()
+                : selection;
 	    if (l == null) return;
 	    Iterator i = l.iterator();
 	    Object object;
-	    List<ImageData> archived = new ArrayList<ImageData>();
+	    List<DataObject> archived = new ArrayList<DataObject>();
 	    List<Long> filesetIds = new ArrayList<Long>();
 	    ImageData image;
 	    long id;
@@ -3677,6 +3681,29 @@ class TreeViewerComponent
 	            downloadFile(folder, override, (FileAnnotationData) object,
 	                    null);
 	        }
+	        else if (object instanceof PlateAcquisitionData
+                    && PojosUtil.isDownloadable((DataObject) object)) {
+                PlateData p = new PlateData(
+                        ((PlateAcquisition) (((DataObject) object).asIObject()))
+                                .getPlate());
+                archived.add(p);
+            } else if (object instanceof PlateData
+                    && PojosUtil.isDownloadable((DataObject) object)) {
+                archived.add((PlateData) object);
+            }
+            else if (object instanceof WellSampleData
+                    && PojosUtil.isDownloadable((DataObject) object)) {
+                
+                image = ((WellSampleData)object).getImage();
+                if (image.isArchived()) {
+                    id = image.getFilesetId();
+                    if (id < 0) archived.add(image);
+                    else if (!filesetIds.contains(id)) {
+                        archived.add(image);
+                        filesetIds.add(id);
+                    }
+                }
+            }
 	    }
 	    if (archived.size() > 0) {
             UserNotifier un = MetadataViewerAgent.getRegistry()

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -26,8 +26,6 @@ import java.util.List;
 
 import javax.swing.Icon;
 
-import omero.gateway.model.ImageData;
-
 /** 
  * Hosts the parameters required to download the archived image.
  *
@@ -48,7 +46,7 @@ public class DownloadArchivedActivityParam
     private File location;
     
     /** The collection of archived images to download. */
-    private List<ImageData> images;
+    private List<omero.gateway.model.DataObject> images;
     
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
@@ -66,7 +64,7 @@ public class DownloadArchivedActivityParam
      * @param images The archived images to download.
      * @param icon The icon associated to the parameters.
      */
-    public DownloadArchivedActivityParam(File location, List<ImageData> images,
+    public DownloadArchivedActivityParam(File location, List<omero.gateway.model.DataObject> images,
     		Icon icon)
     {
     	this.location = location;
@@ -110,7 +108,7 @@ public class DownloadArchivedActivityParam
      * 
      * @return See above.
      */
-    public List<ImageData> getImages() { return images; }
+    public List<omero.gateway.model.DataObject> getImages() { return images; }
 
     /**
      * Returns if the downloaded images should be zipped

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -291,10 +291,10 @@ public interface MetadataHandlerView
 		Collection<Long> pixelsID, AgentEventListener observer);
 	
 	/**
-	 * Loads the archived files related to the specified image.
+	 * Loads the archived files related to the specified objects (images or plates).
 	 * 
 	 * @param ctx The security context.
-	 * @param imageIDs The ids of the pixels set related to the image.
+	 * @param objects The objects to download the original image files for
 	 * @param location The location where to store the files.
 	 * @param override Flag indicating to override the existing file if it
 	 *                 exists, <code>false</code> otherwise.
@@ -303,10 +303,10 @@ public interface MetadataHandlerView
 	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
-	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
+	public CallHandle loadArchivedImage(SecurityContext ctx, List<DataObject> objects,
 		File location, boolean override, boolean zip, boolean keepOriginalPaths,
 		AgentEventListener observer);
-	
+    
 	/**
 	 * Filters by annotation.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -234,20 +234,21 @@ class MetadataHandlerViewImpl
 		return cmd.exec(observer);
 	}
 
-	/**
-	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadArchivedImage(SecurityContext, List, File,
-	 * String, boolean, boolean, boolean AgentEventListener)
-	 */
-	public CallHandle loadArchivedImage(SecurityContext ctx, List<Long> imageIDs,
-			File path, boolean override, boolean zip, boolean keepOriginalPaths,
-			AgentEventListener observer)
-	{
-		BatchCallTree cmd = new ArchivedImageLoader(ctx, imageIDs, path,
-		        override, zip, keepOriginalPaths);
-		return cmd.exec(observer);
-	}
-
+    /**
+     * Implemented as specified by the view interface.
+     * 
+     * @see MetadataHandlerView#loadArchivedImage(SecurityContext , List, File ,
+     *      boolean , boolean , boolean , AgentEventListener )
+     */
+    public CallHandle loadArchivedImage(SecurityContext ctx,
+            List<DataObject> objects, File location,
+            boolean override, boolean zip, boolean keepOriginalPaths,
+            AgentEventListener observer) {
+        BatchCallTree cmd = new ArchivedImageLoader(ctx, objects, location,
+                override, zip, keepOriginalPaths);
+        return cmd.exec(observer);
+    }
+    
 	/**
 	 * Implemented as specified by the view interface.
 	 * @see MetadataHandlerView#loadRatings(SecurityContext, Class, List, long,

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -33,8 +33,6 @@ import org.openmicroscopy.shoola.env.config.Registry;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 import omero.gateway.model.DataObject;
-import omero.gateway.model.ImageData;
-import omero.gateway.model.PlateData;
 
 /** 
  * Loads the image.
@@ -88,7 +86,7 @@ public class ArchivedLoader
      *               Mustn't be <code>null</code>.
      * @param registry Convenience reference for subclasses.
      * @param ctx The security context.
-     * @param objects The images to export.
+     * @param objects The objects to export.
      * @param file The location where to download the image.
      * @param override Flag indicating to override the existing file if it
      *                 exists, <code>false</code> otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -29,11 +29,12 @@ import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
-
 import org.openmicroscopy.shoola.env.config.Registry;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
+import omero.gateway.model.PlateData;
 
 /** 
  * Loads the image.
@@ -53,7 +54,7 @@ public class ArchivedLoader
     private CallHandle handle;
 
     /** The archived images to load. */
-    private List<ImageData> images;
+    private List<DataObject> objects;
 
     /** The file where to download the content of the image. */
     private File file;
@@ -87,7 +88,7 @@ public class ArchivedLoader
      *               Mustn't be <code>null</code>.
      * @param registry Convenience reference for subclasses.
      * @param ctx The security context.
-     * @param images The images to export.
+     * @param objects The images to export.
      * @param file The location where to download the image.
      * @param override Flag indicating to override the existing file if it
      *                 exists, <code>false</code> otherwise.
@@ -96,32 +97,31 @@ public class ArchivedLoader
      * @param activity The activity associated to this loader.
      */
 	public ArchivedLoader(UserNotifier viewer, Registry registry,
-			SecurityContext ctx, List<ImageData> images, File file,
+			SecurityContext ctx, List<DataObject> objects, File file,
 			boolean override, boolean zip, boolean keepOriginalPaths, ActivityComponent activity)
 	{
 		super(viewer, registry, ctx, activity);
-		if (images == null)
-			throw new IllegalArgumentException("Image not valid.");
-		this.images = images;
+		if (objects == null)
+			throw new IllegalArgumentException("No objects provided.");
+		this.objects = objects;
 		this.file = file;
 		this.override = override;
 		this.zip = zip;
 		this.keepOriginalPaths = keepOriginalPaths;
 	}
+    
+    /**
+     * Downloads the archived image.
+     * 
+     * @see UserNotifierLoader#load()
+     */
+    public void load() {
+        if (CollectionUtils.isEmpty(objects))
+            return;
 
-	/**
-	 * Downloads the archived image.
-	 * @see UserNotifierLoader#load()
-	 */
-	public void load()
-	{
-	    List<Long> imageIds = new ArrayList<Long>(images.size());
-	    for(ImageData d : images)
-	        imageIds.add(d.getId());
-	    
-	    handle = mhView.loadArchivedImage(ctx, imageIds, file,
-	            override, zip, keepOriginalPaths, this);
-	}
+        handle = mhView.loadArchivedImage(ctx, objects, file, override, zip,
+                keepOriginalPaths, this);
+    }
 
 	/**
 	 * Cancels the ongoing data retrieval.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
@@ -23,10 +23,14 @@ package org.openmicroscopy.shoola.util;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
+import omero.gateway.model.ImageData;
 import omero.gateway.model.PlateAcquisitionData;
 import omero.gateway.model.PlateData;
 import omero.gateway.model.ProjectData;
 import omero.gateway.model.ScreenData;
+import omero.gateway.model.WellData;
+import omero.gateway.model.WellSampleData;
+import omero.model.PlateAcquisition;
 
 /**
  * Provides some static utility methods for dealing the with Gateway
@@ -52,4 +56,68 @@ public class PojosUtil {
                 || PlateAcquisitionData.class.equals(type);
     }
 
+    /**
+     * Checks the permissions if the object (image, plate or well) can be
+     * downloaded.
+     * 
+     * @param obj
+     *            The object to check.
+     *            
+     * @return Returns <code>true</code> if the object can be downloaded,
+     *         <code>false</code> otherwise.
+     */
+    public static boolean isDownloadable(DataObject obj) {
+        if (obj instanceof ImageData) {
+            ImageData img = (ImageData) obj;
+            return img.isArchived()
+                    && !img.asIObject()
+                            .getDetails()
+                            .getPermissions()
+                            .isRestricted(
+                                    omero.constants.permissions.BINARYACCESS.value);
+        }
+
+        if (obj instanceof PlateData) {
+            PlateData p = (PlateData) obj;
+            return !p
+                    .asIObject()
+                    .getDetails()
+                    .getPermissions()
+                    .isRestricted(
+                            omero.constants.permissions.BINARYACCESS.value);
+        }
+        if (obj instanceof PlateAcquisitionData) {
+            PlateAcquisitionData p = (PlateAcquisitionData) obj;
+            PlateAcquisition pa = (PlateAcquisition) p.asIObject();
+            return !pa
+                    .getPlate()
+                    .getDetails()
+                    .getPermissions()
+                    .isRestricted(
+                            omero.constants.permissions.BINARYACCESS.value);
+        }
+        if (obj instanceof WellSampleData) {
+            WellSampleData w = (WellSampleData) obj;
+            return w.getImage().isArchived()
+                    && !w.asWellSample()
+                            .getPlateAcquisition()
+                            .getPlate()
+                            .getDetails()
+                            .getPermissions()
+                            .isRestricted(
+                                    omero.constants.permissions.BINARYACCESS.value);
+        }
+        if (obj instanceof WellData) {
+            WellData w = (WellData) obj;
+            return w.getWellSamples().iterator().next().getImage().isArchived()
+                    && !w.getPlate()
+                            .asIObject()
+                            .getDetails()
+                            .getPermissions()
+                            .isRestricted(
+                                    omero.constants.permissions.BINARYACCESS.value);
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Enable Plate download, taking the `omero.policy.binary_access` property into account, [Trello - Allow SPW download in Insight](https://trello.com/c/ydtmsP1Z/75-allow-spw-download-in-insight)

**Test** : Add Plates to the `binary_access` property: `./omero config set omero.policy.binary_access "+read,+write,+image,+plate"` (restart server). Make sure you can download plates on the plate, plate acquisition ("Run") and well level, by the context menu on the treeviewer and central databrowser and download menu in the right hand side metadata panel. Note: This will always download the whole plate even if just specific wells are selected. That should probably raise a warning dialog, as it's not intuitively expected. What are your thoughts about that?

