### PR TITLE
Fix tests for Ice 3.6

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -718,8 +718,8 @@ public class AbstractServerTest extends AbstractTest {
      */
     protected omero.client disconnect() throws Exception {
         omero.client oldClient = client;
-        client = null;
         clean();
+        client = null;
         return oldClient;
     }
 

--- a/components/tools/OmeroJava/test/integration/ClientUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/ClientUsageTest.java
@@ -26,6 +26,7 @@ import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
 import omero.model.ExperimenterI;
 import omero.model.PermissionsI;
+import omero.sys.EventContext;
 
 import org.testng.annotations.Test;
 
@@ -160,4 +161,24 @@ public class ClientUsageTest extends AbstractServerTest {
         sf.setSecurityContext(new omero.model.ExperimenterGroupI(1L, false));
     }
 
+    public void testJoinSession() throws Exception {
+        
+        //create a new user.
+        EventContext ec = newUserAndGroup("rw----", true);
+        String session = ec.sessionUuid;
+        //delete the active client
+        disconnect();
+        client c = new client();
+        try {
+            c.joinSession(session);
+            if (Ice.Util.intVersion() >= 30600) {
+                fail("The session should have been deleted");
+            }
+        } catch (Exception e) {
+            if (Ice.Util.intVersion() < 30600) {
+                fail("Ice 3.5 do not close the session."
+                        + "An error should not have been thrown");
+            }
+        }
+    }
 }

--- a/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
@@ -419,18 +419,16 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // owner creates the image
         Image img = (Image) iUpdate.saveAndReturnObject(mmFactory
                 .simpleImage());
-
         omero.client owner = disconnect();
 
         // tagger creates tag
-        newUserInGroup(ec);
+        EventContext tagger = newUserInGroup(ec);
 
         TagAnnotation c = new TagAnnotationI();
         c.setTextValue(omero.rtypes.rstring("tag"));
         c = (TagAnnotation) iUpdate.saveAndReturnObject(c);
-        omero.client tagger = disconnect();
-        init(owner);
-
+        disconnect();
+        init(ec);
         // Image's owner tags the image.
         ImageAnnotationLink link = new ImageAnnotationLinkI();
         link.setParent(img);
@@ -466,19 +464,19 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Image img = (Image) iUpdate.saveAndReturnObject(mmFactory
                 .simpleImage());
 
-        omero.client owner = disconnect();
+        disconnect();
 
         // tagger creates tag
-        ec = newUserInGroup(ec);
+        EventContext tagger = newUserInGroup(ec);
         // make the tagger the group owner.
         makeGroupOwner();
 
         TagAnnotation c = new TagAnnotationI();
         c.setTextValue(omero.rtypes.rstring("tag"));
         c = (TagAnnotation) iUpdate.saveAndReturnObject(c);
-        omero.client tagger = disconnect();
+        disconnect();
 
-        init(owner);
+        init(ec);
 
         // Image's owner tags the image with another group's owner tag.
         ImageAnnotationLink link = new ImageAnnotationLinkI();

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -1319,8 +1319,6 @@ public class DuplicationTest extends AbstractServerTest {
             linkOwner = newUserInGroup();
         }
 
-        disconnect();
-
         /* create the model objects */
 
         final IObject container, contained, link;
@@ -1340,7 +1338,6 @@ public class DuplicationTest extends AbstractServerTest {
         }
 
         if (containerOwner != containedOwner) {
-            disconnect();
             loginUser(containedOwner);
         }
 
@@ -1358,7 +1355,6 @@ public class DuplicationTest extends AbstractServerTest {
         }
 
         if (containedOwner != linkOwner) {
-            disconnect();
             loginUser(linkOwner);
         }
 
@@ -1394,7 +1390,6 @@ public class DuplicationTest extends AbstractServerTest {
         /* duplicate the link */
 
         if (linkOwner != duplicator) {
-            disconnect();
             loginUser(duplicator);
         }
 

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -60,8 +60,8 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
             case GROUP_OWNER:
                 makeGroupOwner();
         }
-        factory.getRenderingSettingsService();
-        prx.setOriginalSettingsInSet(Image.class.getName(),
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Image.class.getName(),
                 Arrays.asList(image.getId().getValue()));
         List<Long> ids = new ArrayList<Long>();
         ids.add(image.getId().getValue());
@@ -169,14 +169,16 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         ids.clear();
         ids.add(image2.getId().getValue());
         // Change the settings of image 2
-        prx.applySettingsToSet(id, Image.class.getName(), ids);
+        factory.getRenderingSettingsService().applySettingsToSet(id,
+                Image.class.getName(), ids);
         RenderingDef def2 = factory.getPixelsService()
                 .retrieveRndSettings(pix2);
 
         cb = def2.getChannelBinding(0);
         assertEquals(cb.getActive().getValue(), !b);
         ids.add(image.getId().getValue());
-        prx.applySettingsToSet(id, Image.class.getName(), ids);
+        factory.getRenderingSettingsService().applySettingsToSet(id,
+                Image.class.getName(), ids);
     }
 
     /**
@@ -229,7 +231,8 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         ids.clear();
         ids.add(image2.getId().getValue());
         // Change the settings of image 2
-        prx.applySettingsToSet(id, Image.class.getName(), ids);
+        factory.getRenderingSettingsService().applySettingsToSet(id,
+                Image.class.getName(), ids);
         RenderingDef def2 = factory.getPixelsService()
                 .retrieveRndSettings(pix2);
 
@@ -311,6 +314,7 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
 
         disconnect();
         EventContext ctx2 = newUserInGroup(ctx);
+        prx = factory.getRenderingSettingsService();
         prx.setOriginalSettingsInSet(Image.class.getName(), Arrays.asList(id));
         disconnect();
         init(ctx);
@@ -327,7 +331,8 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         ids.clear();
         ids.add(image2.getId().getValue());
         // apply the settings of image1 to image2 and 3
-        prx.applySettingsToSet(id, Image.class.getName(), ids);
+        factory.getRenderingSettingsService().applySettingsToSet(id,
+                Image.class.getName(), ids);
         RenderingDef def2 = factory.getPixelsService()
                 .retrieveRndSettings(pix2);
         cb = def2.getChannelBinding(0);

--- a/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/AnnotationMoveTest.java
@@ -57,7 +57,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
 
         List<Long> annotationIdsUser1 = createNonSharableAnnotation(img, null);
 
-        omero.client clientUser1 = disconnect();
+        disconnect();
         // Add a user to that group
         EventContext ctx2 = newUserInGroup(ctx);
         init(ctx2);
@@ -71,7 +71,7 @@ public class AnnotationMoveTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(dest, users);
 
         // reconnect as user1
-        init(clientUser1);
+        init(ctx);
         // now move the image.
         final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -852,8 +852,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         Assert.assertNull(returnFolder(bottomFolder));
 
-        disconnect();
-
         /* work in second group */
 
         loginUser(toGroup);
@@ -870,8 +868,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         bottomFolder = returnFolder(bottomFolder);
         Assert.assertEquals(bottomFolder.getParentFolder().getId().getValue(), middleFolder.getId().getValue());
         Assert.assertTrue(bottomFolder.copyChildFolders().isEmpty());
-
-        disconnect();
     }
 
     /**
@@ -882,7 +878,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
      */
     private void assertObjectInGroup(IObject object, ExperimenterGroup group) throws Exception {
         if (iAdmin.getEventContext().groupId != group.getId().getValue()) {
-            disconnect();
             loginUser(group);
         }
         Class <? extends IObject> objectClass = object.getClass();
@@ -923,7 +918,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         Folder parentFolder = (Folder) saveAndReturnFolder(mmFactory.simpleFolder()).proxy();
 
         if (!myChildFolder) {
-            disconnect();
             loginUser(myChildFolder ? mover : other, fromGroup);
         }
 
@@ -932,7 +926,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         childFolder = (Folder) saveAndReturnFolder(childFolder).proxy();
 
         if (myChildFolder != myRoi) {
-            disconnect();
             loginUser(myRoi ? mover : other, fromGroup);
         }
 
@@ -956,7 +949,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         /* perform the specified move */
 
         if (!myRoi) {
-            disconnect();
             loginUser(mover, fromGroup);
         }
 
@@ -1149,8 +1141,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
             Assert.assertEquals(countInstances(Folder.class, folderIds), expectedRemainingFolderCount);
             Assert.assertEquals(countInstances(Image.class, imageIds), expectedRemainingImageCount);
 
-            disconnect();
-
             /* work in second group */
 
             loginUser(toGroup);
@@ -1161,8 +1151,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
             Assert.assertEquals(countInstances(Folder.class, folderIds), expectedMovedFolderCount);
             Assert.assertEquals(countInstances(Image.class, imageIds), expectedMovedImageCount);
         }
-
-        disconnect();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
@@ -79,7 +79,6 @@ public class HierarchyMoveCombinedDataTest extends AbstractServerTest {
         Image img1 = (Image) iUpdate.saveAndReturnObject(mmFactory
                 .createImage());
         long user1 = img1.getDetails().getOwner().getId().getValue();
-        disconnect();
 
         // Step 2
         // create a new user and add it to the group
@@ -111,14 +110,11 @@ public class HierarchyMoveCombinedDataTest extends AbstractServerTest {
 
         long user2 = d.getDetails().getOwner().getId().getValue();
         assertTrue(user1 != user2);
-        disconnect();
-
+        
         // Step 3
         // Create a new group, the user is now a member of the new group.
         ExperimenterGroup g = newGroupAddUser(target, ctx.userId);
         loginUser(g);
-
-        disconnect();
 
         // Step 4
         // reconnect to the source group.
@@ -150,9 +146,6 @@ public class HierarchyMoveCombinedDataTest extends AbstractServerTest {
         sql = "select i from Image as i where i.id in (:ids)";
         List<IObject> results = iQuery.findAllByQuery(sql, param);
         assertEquals(results.size(), 0);
-
-        // log out from source group
-        disconnect();
 
         // Step 5
         // log into source group to perform the move

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
@@ -105,9 +105,6 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         Dataset d = (Dataset) iUpdate.saveAndReturnObject(mmFactory
                 .simpleDatasetData().asIObject());
 
-        // log out
-        disconnect();
-
         // Create a new group, the user is now a member of the new group.
         ExperimenterGroup g = newGroupAddUser(target, ctx.userId);
 
@@ -117,9 +114,6 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         // Create project in the new group.
         Project p = (Project) iUpdate.saveAndReturnObject(mmFactory
                 .simpleProjectData().asIObject());
-
-        // log out
-        disconnect();
 
         // Step 2: log into source group to perform the move // No. See below.
         switch (memberLevel) {
@@ -193,9 +187,6 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         param.addId(d.getId().getValue());
         String sql = "select i from Dataset as i where i.id = :id";
         assertNull(iQuery.findByQuery(sql, param));
-
-        // log out from source group
-        disconnect();
 
         // Step 3:
 

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
@@ -77,7 +77,7 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
         long originalImageId = image.getId().getValue();
 
         // change to another user in source group
-        EventContext roiUserContext = newUserInGroup();
+        EventContext roiUserContext = newUserInGroup(imageOwnerContext);
 
         // get the image from the roi user's perspective
         Image roiUserImage = getImageWithId(image.getId().getValue());
@@ -92,20 +92,17 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
             Shape shape = serverROI.getShape(i);
             shapeIds.add(shape.getId().getValue());
         }
-
-        disconnect();
-
+        // switch back to the original user
+        loginUser(imageOwnerContext);
         // create the target group
         ExperimenterGroup targetGroup = newGroupAddUser(targetGroupPermissions,
-                imageOwnerContext.userId, false);
+                imageOwnerContext.userId);
+        iAdmin.getEventContext();
 
         if (roiOwnerInTargetGroup) {
             addUserToGroup(roiUserContext.userId, targetGroup);
         }
-
-        // switch back to the original user
-        loginUser(imageOwnerContext);
-
+        iAdmin.getEventContext();
         // Perform the move operation as original user
         final Chgrp2 dc = Requests.chgrp("Image", originalImageId, targetGroup.getId().getValue());
         callback(true, client, dc);
@@ -117,8 +114,6 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
         // check the shapes have moved to target group
         List<IObject> orginalShapes = getShapesWithIds(shapeIds);
         assertEquals(0, orginalShapes.size());
-
-        disconnect();
 
         // Move the user into the target group!
         loginUser(targetGroup);
@@ -285,7 +280,7 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
      */
     private void addUserToGroup(long userId, ExperimenterGroup targetGroup)
             throws Exception {
-        addUsers(targetGroup, Arrays.asList(userId), false);
+        addUsers(targetGroup, Arrays.asList(userId), true);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -1109,12 +1109,10 @@ public class HierarchyMoveTest extends AbstractServerTest {
         assertNull(iQuery.findByQuery("FROM LightSettings WHERE id = :id", new ParametersI().addId(lightSettings.getId())));
 
         /* switch to the destination group */
-        disconnect();
         loginUser(destination);
 
         /* check what was moved to the destination group */
         assertNotNull(iQuery.findByQuery("FROM Image WHERE id = :id", new ParametersI().addId(image.getId())));
         assertNotNull(iQuery.findByQuery("FROM LightSettings WHERE id = :id", new ParametersI().addId(lightSettings.getId())));
-        disconnect();
     }
 }

--- a/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
@@ -238,8 +238,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     	Response rsp = doChange(client, factory, mv, true);
     	OK err = (OK) rsp;
     	assertNotNull(err);
-    	disconnect();
-    	
+
     	// Reconnect in second group to check group.id for all objects in graph
     	long gid2 = secondGroup.getId().getValue();
     	loginUser(new ExperimenterGroupI(secondGroup.getId().getValue(),
@@ -422,7 +421,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
         final Chgrp2 dc = Requests.chgrp("Dataset", dataset.getId().getValue(), secondGroup.getId().getValue());
 
     	doAllChanges(client, factory, true, dc);
-    	disconnect();
+
     	loginUser(new ExperimenterGroupI(secondGroup.getId().getValue(),
     			false));
     	//load the dataset

--- a/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
@@ -90,7 +90,6 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(target, ctx.userId);
         iAdmin.getEventContext(); // Refresh
 
-        disconnect();
         loginUser(ctx);
         //login is as root
         if (moveMemberRole == AbstractServerTest.ADMIN) {
@@ -108,11 +107,9 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
         settings = svc.retrieveAllRndSettings(pixelsID, -1);
         assertEquals(settings.size(), 0);
 
-        disconnect();
         // Log in to other group
         if (moveMemberRole == AbstractServerTest.ADMIN) {
             loginUser(ctx); //require if log as root.
-            disconnect();
         }
         loginUser(g);
 

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -211,7 +211,6 @@ public class PermissionsTest extends AbstractServerTest {
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
         ownerAnnotations = annotateImage(imageId);
-        disconnect();
 
         /* perhaps have another user annotate the image */
 
@@ -220,7 +219,6 @@ public class PermissionsTest extends AbstractServerTest {
         } else {
             init(annotator);
             otherAnnotations = annotateImage(image.getId().getValue());
-            disconnect();
         }
 
         /* perform the chmod */
@@ -228,7 +226,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(chmodder);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
-        disconnect();
 
         if (!isExpectSuccess) {
             return;
@@ -272,7 +269,6 @@ public class PermissionsTest extends AbstractServerTest {
         } else {
             assertAllExist(otherAnnotations);
         }
-        disconnect();
     }
 
     /**
@@ -368,7 +364,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(containerOwner);
         IObject container = isInDataset ? mmFactory.simpleDataset() : mmFactory.simpleFolder();
         container = iUpdate.saveAndReturnObject(container).proxy();
-        disconnect();
 
         /* create an image */
 
@@ -376,7 +371,6 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        disconnect();
 
         /* move the image into the container */
 
@@ -393,14 +387,12 @@ public class PermissionsTest extends AbstractServerTest {
             linkFI.setChild(image);
             link = iUpdate.saveAndReturnObject(linkFI);
         }
-        disconnect();
 
         /* perform the chmod */
 
         init(chmodder);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, "rw----");
         doChange(client, factory, chmod, true);
-        disconnect();
 
         /* check that exactly the expected object deletions have occurred */
 
@@ -412,7 +404,6 @@ public class PermissionsTest extends AbstractServerTest {
         } else {
             assertDoesNotExist(link);
         }
-        disconnect();
     }
 
     /**
@@ -469,13 +460,11 @@ public class PermissionsTest extends AbstractServerTest {
         init(alice);
         Folder topFolder = mmFactory.simpleFolder();
         topFolder = (Folder) iUpdate.saveAndReturnObject(topFolder).proxy();
-        disconnect();
 
         init(bob);
         Folder bottomFolder = mmFactory.simpleFolder();
         bottomFolder.setParentFolder(topFolder);
         bottomFolder = (Folder) iUpdate.saveAndReturnObject(bottomFolder).proxy();
-        disconnect();
 
         /* check that the hierarchy is correctly constructed */
 
@@ -498,7 +487,6 @@ public class PermissionsTest extends AbstractServerTest {
         Assert.assertEquals(aliceFolder.getDetails().getOwner().getId().getValue(), alice.userId);
         Assert.assertEquals(bobFolder.getDetails().getOwner().getId().getValue(), bob.userId);
         Assert.assertNull(bobFolder.getParentFolder());  /* currently fails to unlink */
-        disconnect();
     }
 
     /**
@@ -532,7 +520,6 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(imageId);
         final Instrument instrument = (Instrument) image.getInstrument().proxy();
         image = (Image) image.proxy();
-        disconnect();
 
         /* another user projects the image */
 
@@ -543,7 +530,6 @@ public class PermissionsTest extends AbstractServerTest {
         final long projectionId = projection.getId().getValue();
         testImages.add(projectionId);
         projection = (Image) projection.proxy();
-        disconnect();
 
         /* perform the chmod */
 
@@ -552,7 +538,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(chmodder);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
-        disconnect();
 
         if (!isExpectSuccess) {
             return;
@@ -564,7 +549,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertExists(image);
         assertExists(projection);
         assertExists(instrument);
-        disconnect();
     }
 
 
@@ -599,7 +583,6 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(imageId);
         final Experiment experiment = (Experiment) image.getExperiment().proxy();
         image = (Image) image.proxy();
-        disconnect();
 
         /* another user's image is part of the same experiment */
 
@@ -610,7 +593,6 @@ public class PermissionsTest extends AbstractServerTest {
         final long otherImageId = otherImage.getId().getValue();
         testImages.add(otherImageId);
         otherImage = (Image) otherImage.proxy();
-        disconnect();
 
         /* perform the chmod */
 
@@ -619,7 +601,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(chmodder);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
-        disconnect();
 
         if (!isExpectSuccess) {
             return;
@@ -631,7 +612,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertExists(image);
         assertExists(otherImage);
         assertExists(experiment);
-        disconnect();
     }
 
     /**
@@ -671,7 +651,6 @@ public class PermissionsTest extends AbstractServerTest {
             final Long imageId = ((RLong) result.get(0)).getValue();
             imageIds.add(imageId);
         }
-        disconnect();
 
         /* the images should be owned by the dataset owner */
 
@@ -683,7 +662,6 @@ public class PermissionsTest extends AbstractServerTest {
             image.getDetails().setOwner(datasetOwnerActual);
         }
         iUpdate.saveCollection(images);
-        disconnect();
 
         /* create the dataset and link the images to it */
 
@@ -698,7 +676,6 @@ public class PermissionsTest extends AbstractServerTest {
             link.setChild((Image) image.proxy());
             links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
         }
-        disconnect();
 
         /* perform the chmod */
 
@@ -707,7 +684,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(chmodder);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
         doChange(client, factory, chmod, isExpectSuccess);
-        disconnect();
 
         logRootIntoGroup(dataGroupId);
 
@@ -728,7 +704,6 @@ public class PermissionsTest extends AbstractServerTest {
                 "Dataset", Collections.singletonList(datasetId),
                 "Plate", Collections.singletonList(plateId));
         doChange(client, factory, delete, true);
-        disconnect();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -259,14 +259,12 @@ public class PermissionsTest extends AbstractServerTest {
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
         }
-        disconnect();
 
         /* perform the chown */
 
         init(chowner);
         final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, isExpectSuccess);
-        disconnect();
 
         if (!isExpectSuccess) {
             return;
@@ -296,7 +294,6 @@ public class PermissionsTest extends AbstractServerTest {
         final List<List<RType>> results = iQuery.projection(query, params);
         final long remainingLinkCount = ((RLong) results.get(0).get(0)).getValue();
         Assert.assertEquals(remainingLinkCount, imageLinkIds.size() - tagLinksOnOtherImage.size());
-        disconnect();
     }
 
     /**
@@ -347,20 +344,17 @@ public class PermissionsTest extends AbstractServerTest {
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
         ownerAnnotations = annotateImage(image);
-        disconnect();
 
         /* have another user annotate the image */
 
         init(annotator);
         otherAnnotations = annotateImage(image);
-        disconnect();
 
         /* perform the chown */
 
         init(chowner);
         final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, isExpectSuccess);
-        disconnect();
 
         if (!isExpectSuccess) {
             return;
@@ -372,7 +366,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(image, recipient);
         assertOwnedBy(ownerAnnotations, importer);
         assertOwnedBy(otherAnnotations, annotator);
-        disconnect();
     }
 
     /**
@@ -453,7 +446,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(containerOwner);
         IObject container = isInDataset ? mmFactory.simpleDataset() : mmFactory.simpleFolder();
         container = iUpdate.saveAndReturnObject(container).proxy();
-        disconnect();
 
         /* create an image */
 
@@ -461,7 +453,6 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        disconnect();
 
         /* move the image into the container */
 
@@ -478,14 +469,12 @@ public class PermissionsTest extends AbstractServerTest {
             linkFI.setChild(image);
             link = iUpdate.saveAndReturnObject(linkFI);
         }
-        disconnect();
 
         /* perform the chown */
 
         init(imageOwner);
         final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
-        disconnect();
 
         /* check that the objects' ownership is all as expected */
 
@@ -499,7 +488,6 @@ public class PermissionsTest extends AbstractServerTest {
         } else {
             assertDoesNotExist(link);
         }
-        disconnect();
     }
 
     /**
@@ -539,7 +527,6 @@ public class PermissionsTest extends AbstractServerTest {
         init(containerOwner);
         IObject container = isInDataset ? mmFactory.simpleDataset() : mmFactory.simpleFolder();
         container = iUpdate.saveAndReturnObject(container).proxy();
-        disconnect();
 
         /* create an image */
 
@@ -547,7 +534,6 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        disconnect();
 
         /* move the image into the container */
 
@@ -564,14 +550,12 @@ public class PermissionsTest extends AbstractServerTest {
             linkFI.setChild(image);
             link = iUpdate.saveAndReturnObject(linkFI);
         }
-        disconnect();
 
         /* perform the chown */
 
         init(containerOwner);
         final Chown2 chown = Requests.chown(isInDataset ? "Dataset" : "Folder", container.getId().getValue(), recipient.userId);
         doChange(client, factory, chown, true);
-        disconnect();
 
         /* check that the objects' ownership is all as expected */
 
@@ -579,7 +563,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(container, recipient);
         assertOwnedBy(image, isImageOwner ? recipient : imageOwner);
         assertOwnedBy(link, isImageOwner ? recipient : linkOwner);
-        disconnect();
     }
 
     /**
@@ -653,7 +636,6 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(imageId);
         final Instrument instrument = (Instrument) image.getInstrument().proxy();
         image = (Image) image.proxy();
-        disconnect();
 
         /* another user projects the image */
 
@@ -664,21 +646,18 @@ public class PermissionsTest extends AbstractServerTest {
         final long projectionId = projection.getId().getValue();
         testImages.add(projectionId);
         projection = (Image) projection.proxy();
-        disconnect();
 
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
         doChange(client, factory, chmod, true);
-        disconnect();
 
         /* perform the chown */
 
         init(imageOwner);
         final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
-        disconnect();
 
         /* check that the objects' ownership is all as expected */
 
@@ -686,7 +665,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(image, recipient);
         assertOwnedBy(projection, projectionOwner);
         assertOwnedBy(instrument, imageOwner);
-        disconnect();
     }
 
     /**
@@ -720,7 +698,6 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(imageId);
         final Experiment experiment = (Experiment) image.getExperiment().proxy();
         image = (Image) image.proxy();
-        disconnect();
 
         /* another user's image is part of the same experiment */
 
@@ -731,21 +708,18 @@ public class PermissionsTest extends AbstractServerTest {
         final long otherImageId = otherImage.getId().getValue();
         testImages.add(otherImageId);
         otherImage = (Image) otherImage.proxy();
-        disconnect();
 
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
         final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
         doChange(client, factory, chmod, true);
-        disconnect();
 
         /* perform the chown */
 
         init(imageOwner);
         final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
         doChange(client, factory, chown, true);
-        disconnect();
 
         /* check that the objects' ownership is all as expected */
 
@@ -753,7 +727,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(image, recipient);
         assertOwnedBy(otherImage, otherImageOwner);
         assertOwnedBy(experiment, imageOwner);
-        disconnect();
     }
 
     /**
@@ -819,7 +792,6 @@ public class PermissionsTest extends AbstractServerTest {
             final Long imageId = ((RLong) result.get(0)).getValue();
             imageIds.add(imageId);
         }
-        disconnect();
 
         /* the images should be owned by the dataset owner */
 
@@ -831,7 +803,6 @@ public class PermissionsTest extends AbstractServerTest {
             image.getDetails().setOwner(datasetOwnerActual);
         }
         iUpdate.saveCollection(images);
-        disconnect();
 
         /* create the dataset and link the images to it */
 
@@ -846,7 +817,6 @@ public class PermissionsTest extends AbstractServerTest {
             link.setChild((Image) image.proxy());
             links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
         }
-        disconnect();
 
         /* check that the objects' ownership is all as expected */
 
@@ -855,7 +825,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(images, datasetOwner);
         assertOwnedBy(links, datasetOwner);
         assertOwnedBy(plate, plateOwner);
-        disconnect();
 
         /* perform the chown */
 
@@ -878,7 +847,6 @@ public class PermissionsTest extends AbstractServerTest {
         }
 
         doChange(client, factory, chown, true);
-        disconnect();
 
         logRootIntoGroup(dataGroupId);
 
@@ -912,8 +880,6 @@ public class PermissionsTest extends AbstractServerTest {
                 "Dataset", Collections.singletonList(datasetId),
                 "Plate", Collections.singletonList(plateId));
         doChange(client, factory, delete, true);
-
-        disconnect();
 }
 
     /**


### PR DESCRIPTION
Rebases @jburel's work from #4594 and removes extra `disconnect()`s in tests that either I added recently or that @sbesson accuses. Should improve integration test situation in CI without further regressions.