### PR TITLE
have AbstractServerTest.resetGroupPerms use Chmod2

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -45,6 +45,7 @@ import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
+import omero.cmd.Chmod2;
 import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
@@ -57,6 +58,7 @@ import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.State;
 import omero.cmd.Status;
+import omero.gateway.util.Requests;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
 import omero.model.BooleanAnnotation;
@@ -345,10 +347,8 @@ public class AbstractServerTest extends AbstractTest {
      *             Thrown if an error occurred.
      */
     protected void resetGroupPerms(String perms, long groupId) throws Exception {
-        IAdminPrx rootAdmin = root.getSession().getAdminService();
-        ExperimenterGroup g = rootAdmin.getGroup(groupId);
-        g.getDetails().setPermissions(new PermissionsI(perms));
-        rootAdmin.updateGroup(g);
+        final Chmod2 chmod = Requests.chmod().target("ExperimenterGroup").id(groupId).toPerms(perms).build();
+        doChange(root, root.getSession(), chmod, true);
     }
 
     /**


### PR DESCRIPTION
Attempts to correct failing tests in `RenderingSettingsServicePermissionsTest`.