### PR TITLE
Metadata column column types and datasets

### DIFF
--- a/components/blitz/resources/omero/Tables.ice
+++ b/components/blitz/resources/omero/Tables.ice
@@ -61,6 +61,10 @@ module omero {
             omero::api::LongArray values;
         };
 
+        class DatasetColumn extends Column {
+            omero::api::LongArray values;
+        };
+
         class RoiColumn extends Column {
             omero::api::LongArray values;
         };

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -415,20 +415,9 @@ class ValueResolver(object):
 
         self.images_by_id[self.target_object.id.val] = images_by_id
         self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_dataset(
+        self.parse_by_name(
             self.target_name, images_by_id, images_by_name, data
         )
-
-    def parse_dataset(self, dname, images_by_id, images_by_name, data):
-        for iid, iname in data:
-            images_by_id[iid] = iname
-            if iname in images_by_name:
-                log.warn("Image named %s(id=%d) present. Skipping %s" % (
-                    iname, images_by_name[iname], iid
-                ))
-            else:
-                images_by_name[iname] = iid
-        log.debug('Completed parsing dataset: %s' % dname)
 
     def load_project(self):
         query_service = self.client.getSession().getQueryService()
@@ -468,20 +457,18 @@ class ValueResolver(object):
 
         self.images_by_id[self.target_object.id.val] = images_by_id
         self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_project(
+        self.parse_by_name(
             self.target_name, images_by_id, images_by_name, data
         )
 
-    def parse_project(self, pname, images_by_id, images_by_name, data):
-        # TODO: idential to parse_dataset
+    def parse_by_name(self, name, images_by_id, images_by_name, data):
         for iid, iname in data:
             images_by_id[iid] = iname
             if iname in images_by_name:
-                log.warn("Image named %s(id=%d) present. Skipping %s" % (
+                raise Exception("Image named %s(id=%d) present. Skipping %s" % (
                     iname, images_by_name[iname], iid
                 ))
-            else:
-                images_by_name[iname] = iid
+            images_by_name[iname] = iid
         log.debug('Completed parsing dataset: %s' % pname)
 
     def resolve(self, column, value, row):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -447,7 +447,7 @@ class ParsingContext(object):
     """Generic parsing context for CSV files."""
 
     def __init__(self, client, target_object, file=None, fileid=None,
-                 cfg=None, cfgid=None, attach=False):
+                 cfg=None, cfgid=None, attach=False, column_types=None):
         '''
         This lines should be handled outside of the constructor:
 
@@ -464,6 +464,7 @@ class ParsingContext(object):
         self.client = client
         self.target_object = target_object
         self.file = file
+        self.column_types = column_types
         self.value_resolver = ValueResolver(self.client, self.target_object)
 
     def create_annotation_link(self):
@@ -507,7 +508,8 @@ class ParsingContext(object):
         for h in rows[0]:
             if not h:
                 raise Exception('Empty column header in CSV: %s' % rows[0])
-        self.header_resolver = HeaderResolver(self.target_object, rows[0])
+        self.header_resolver = HeaderResolver(
+            self.target_object, rows[0], column_types=self.column_types)
         self.columns = self.header_resolver.create_columns()
         log.debug('Columns: %r' % self.columns)
 
@@ -1108,7 +1110,8 @@ if __name__ == "__main__":
 
         log.debug('Creating pool of %d threads' % thread_count)
         thread_pool = ThreadPool(thread_count)
-        ctx = context_class(client, target_object, file)
+        ctx = context_class(
+            client, target_object, file, column_types=column_types)
         ctx.parse()
         if not info:
             ctx.write_to_omero()

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -67,17 +67,21 @@ Usage: %s [options] <target_object> <file>
 Runs metadata population code for a given object.
 
 Options:
-  -s    OMERO hostname to use [defaults to "localhost"]
-  -p    OMERO port to use [defaults to 4064]
-  -u    OMERO username to use
-  -w    OMERO password
-  -k    OMERO session key to use
-  -i    Dump measurement information and exit (no population)
-  -d    Print debug statements
-  -c    Use an alternative context (for expert users only)
+  -s            OMERO hostname to use [defaults to "localhost"]
+  -p            OMERO port to use [defaults to 4064]
+  -u            OMERO username to use
+  -w            OMERO password
+  -k            OMERO session key to use
+  --columns     Column configuration, Specify as comma separated list.
+                Supported types: plate, well, image, roi,
+                                 d (double), l (long), s (string), b (boolean)
+                Supported Boolean True Values: "yes", "true", "t", "1".
+  -i            Dump measurement information and exit (no population)
+  -d            Print debug statements
+  -c            Use an alternative context (for expert users only)
 
 Examples:
-  %s -s localhost -p 14064 -u bob Plate:6 metadata.csv
+  %s -s localhost -p 14064 -u bob --columns l,image,d,l Plate:6 metadata.csv
 
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd)
     sys.exit(2)
@@ -1005,7 +1009,7 @@ def parse_target_object(target_object):
 
 if __name__ == "__main__":
     try:
-        options, args = getopt(sys.argv[1:], "s:p:u:w:k:c:id")
+        options, args = getopt(sys.argv[1:], "s:p:u:w:k:c:id", ["columns="])
     except GetoptError, (msg, opt):
         usage(msg)
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -435,7 +435,7 @@ class ValueResolver(object):
         if StringColumn is column_class:
             return value
         if LongColumn is column_class:
-            return int(value)
+            return long(value)
         if DoubleColumn is column_class:
             return float(value)
         if BoolColumn is column_class:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -135,10 +135,11 @@ class HeaderResolver(object):
         'plate': PlateColumn,
     }, **plate_keys)
 
-    def __init__(self, target_object, headers):
+    def __init__(self, target_object, headers, column_types=None):
         self.target_object = target_object
         self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
+        self.types = column_types
 
     def create_columns(self):
         target_class = self.target_object.__class__
@@ -179,12 +180,15 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            try:
-                column = self.screen_keys[header_as_lower](name, description,
-                                                           list())
-            except KeyError:
-                column = StringColumn(name, description,
-                                      self.DEFAULT_COLUMN_SIZE, list())
+            if self.types is not None:
+                column = COLUMN_TYPES[self.types[i]](name, description, list())
+            else:
+                try:
+                    column = self.screen_keys[header_as_lower](
+                        name, description, list())
+                except KeyError:
+                    column = StringColumn(
+                        name, description, self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:
@@ -214,12 +218,15 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            try:
-                column = self.plate_keys[header_as_lower](name, description,
-                                                          list())
-            except KeyError:
-                column = StringColumn(name, description,
-                                      self.DEFAULT_COLUMN_SIZE, list())
+            if self.types is not None:
+                column = COLUMN_TYPES[self.types[i]](name, description, list())
+            else:
+                try:
+                    column = self.plate_keys[header_as_lower](
+                        name, description, list())
+                except KeyError:
+                    column = StringColumn(
+                        name, description, self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -168,6 +168,9 @@ class HeaderResolver(object):
         log.debug('Sanity check passed')
 
     def create_columns_screen(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
@@ -210,6 +213,9 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_plate(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
@@ -252,6 +258,9 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_dataset(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         raise Exception('To be implemented!')
 
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -182,7 +182,11 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            if self.types is not None:
+            if self.types is not None and \
+                    COLUMN_TYPES[self.types[i]] is StringColumn:
+                column = COLUMN_TYPES[self.types[i]](
+                    name, description, self.DEFAULT_COLUMN_SIZE, list())
+            elif self.types is not None:
                 column = COLUMN_TYPES[self.types[i]](name, description, list())
             else:
                 try:
@@ -220,7 +224,11 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            if self.types is not None:
+            if self.types is not None and \
+                    COLUMN_TYPES[self.types[i]] is StringColumn:
+                column = COLUMN_TYPES[self.types[i]](
+                    name, description, self.DEFAULT_COLUMN_SIZE, list())
+            elif self.types is not None:
                 column = COLUMN_TYPES[self.types[i]](name, description, list())
             else:
                 try:
@@ -545,7 +553,8 @@ class ParsingContext(object):
                     break
                 values.append(value)
                 try:
-                    if value.__class__ is not long:
+                    log.debug("Value's class: %s" % value.__class__)
+                    if value.__class__ is str:
                         column.size = max(column.size, len(value))
                 except TypeError:
                     log.error('Original value "%s" now "%s" of bad type!' % (

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -90,6 +90,8 @@ Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd)
 thread_pool = None
 
 # Special column names we may add depending on the data type
+BOOLEAN_TRUE = ["yes", "true", "t", "1"]
+
 PLATE_NAME_COLUMN = 'Plate Name'
 WELL_NAME_COLUMN = 'Well Name'
 IMAGE_NAME_COLUMN = 'Image Name'
@@ -432,6 +434,12 @@ class ValueResolver(object):
                 return long(self.AS_ALPHA.index(value.lower()))
         if StringColumn is column_class:
             return value
+        if LongColumn is column_class:
+            return int(value)
+        if DoubleColumn is column_class:
+            return float(value)
+        if BoolColumn is column_class:
+            return value.lower() in BOOLEAN_TRUE
         raise MetadataError('Unsupported column class: %s' % column_class)
 
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -102,6 +102,8 @@ COLUMN_TYPES = {
     'b': BoolColumn
 }
 
+REGEX_HEADER_SPECIFIER = r'# header '
+
 
 class Skip(object):
     """Instance to denote a row skip request."""
@@ -142,6 +144,23 @@ class HeaderResolver(object):
         self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
         self.types = column_types
+
+    @staticmethod
+    def is_row_column_types(row):
+        if "# header" in row[0]:
+            return True
+        return False
+
+    @staticmethod
+    def get_column_types(row):
+        if "# header" not in row[0]:
+            return None
+        get_first_type = re.compile(REGEX_HEADER_SPECIFIER)
+        column_types = [get_first_type.sub('', row[0])]
+        for column in row[1:]:
+            column_types.append(column)
+        column_types = parse_column_types(column_types)
+        return column_types
 
     def create_columns(self):
         target_class = self.target_object.__class__

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1021,8 +1021,8 @@ def parse_column_types(column_type_list):
             column_types.append(column_type.lower())
         else:
             column_types = []
-            message = "\nColumn type '%s' unknown.\nChoose from following: %s" \
-                % (column_type, ",".join(COLUMN_TYPES.keys()))
+            message = "\nColumn type '%s' unknown.\nChoose from following: " \
+                "%s" % (column_type, ",".join(COLUMN_TYPES.keys()))
             raise MetadataError(message)
     return column_types
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -187,7 +187,7 @@ class HeaderResolver(object):
         log.debug('Sanity check passed')
 
     def create_columns_screen(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         columns = list()
@@ -232,7 +232,7 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_plate(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         columns = list()
@@ -277,7 +277,7 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_dataset(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         raise Exception('To be implemented!')

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -34,11 +34,11 @@ from omero.api import RoiOptions
 from omero.grid import ImageColumn
 from omero.grid import RoiColumn
 from omero.grid import StringColumn
-from omero.model import PlateI, WellI, WellSampleI, OriginalFileI
+from omero.model import OriginalFileI
 from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
 from omero.model import RoiI, PointI, ScreenI
-from omero.rtypes import rdouble, rint, rstring, unwrap
+from omero.rtypes import rdouble, rstring, unwrap
 from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
@@ -72,11 +72,14 @@ def coord2offset(coord):
     return r - 1, c - 1
 
 
-class BasePopulate(lib.ITest):
+class Fixture(object):
+
+    def init(self, test):
+        self.test = test
 
     def setName(self, obj, name):
-        q = self.client.sf.getQueryService()
-        up = self.client.sf.getUpdateService()
+        q = self.test.client.sf.getQueryService()
+        up = self.test.client.sf.getUpdateService()
         obj = q.get(obj.__class__.__name__, obj.id.val)
         obj.setName(rstring(name))
         return up.saveAndReturnObject(obj)
@@ -98,83 +101,136 @@ class BasePopulate(lib.ITest):
         return str(csvFileName)
 
     def createDataset(self, names=("A1", "A2")):
-        ds = self.make_dataset()
+        ds = self.test.make_dataset()
         for name in names:
-            img = self.importSingleImage(name=name)
+            img = self.test.importSingleImage(name=name)
             # Name must match exactly. No ".fake"
             img = self.setName(img, name)
-            self.link(ds, img)
+            self.test.link(ds, img)
         return ds.proxy()
 
     def createScreen(self, rowCount, colCount):
-        plate1 = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)[0]
-        plate2 = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)[0]
+        plate1 = self.test.importPlates(plateRows=rowCount,
+                                        plateCols=colCount)[0]
+        plate2 = self.test.importPlates(plateRows=rowCount,
+                                        plateCols=colCount)[0]
         plate1 = self.setName(plate1, "P001")
         plate2 = self.setName(plate2, "P002")
         screen = ScreenI()
         screen.name = rstring("Screen")
         screen.linkPlate(plate1.proxy())
         screen.linkPlate(plate2.proxy())
-        return self.client.sf.getUpdateService().saveAndReturnObject(screen)
+        return self.test.client.sf.getUpdateService().\
+            saveAndReturnObject(screen)
 
     def createPlate(self, rowCount, colCount):
-        plates = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)
+        plates = self.test.importPlates(plateRows=rowCount,
+                                        plateCols=colCount)
         return plates[0]
 
-    def createPlate1(self, rowCount, colCount):
-        uuid = self.ctx.sessionUuid
+    def get_csv(self):
+        return self.csv
 
-        def createWell(row, column):
-            well = WellI()
-            well.row = rint(row)
-            well.column = rint(column)
-            ws = WellSampleI()
-            image = self.new_image(name=uuid)
-            ws.image = image
-            well.addWellSample(ws)
-            return well
-
-        plate = PlateI()
-        plate.name = rstring("TestPopulateMetadata%s" % uuid)
-        for row in range(rowCount):
-            for col in range(colCount):
-                well = createWell(row, col)
-                plate.addWell(well)
-        return self.client.sf.getUpdateService().saveAndReturnObject(plate)
+    def assert_rows(self, rows):
+        assert rows == self.rowCount * self.colCount
 
 
-class TestPopulateMetadata(BasePopulate):
+class Screen2Plates(Fixture):
 
-    def setup_method(self, method):
-        self.screen_csv = self.createCsv(
+    def __init__(self):
+        self.count = 6
+        self.annCount = 4
+        self.rowCount = 1
+        self.colCount = 2
+        self.csv = self.createCsv(
             colNames="Plate,Well,Well Type,Concentration",
             rowData=("P001,A1,Control,0", "P001,A2,Treatment,10",
                      "P002,A1,Control,0", "P002,A2,Treatment,10"))
-        self.plate_csv = self.createCsv()
-        self.dataset_csv = self.createCsv(
-            colNames="Image Name,Type,Concentration",
-        )
-        self.rowCount = 1
-        self.colCount = 2
         self.screen = None
-        self.plate = None
-        self.dataset = None
-        self.images = []
 
-    def get_screen(self):
+    def assert_rows(self, rows):
+        """
+        Double the number of rows due to 2 plates.
+        """
+        assert rows == 2 * self.rowCount * self.colCount
+
+    def get_target(self):
         if not self.screen:
             self.screen = self.createScreen(self.rowCount, self.colCount)
         return self.screen
 
-    def get_plate(self):
+    def get_annotations(self):
+        query = """select s from Screen s
+            left outer join fetch s.annotationLinks links
+            left outer join fetch links.child
+            where s.id=%s""" % self.screen.id.val
+        qs = self.test.client.sf.getQueryService()
+        screen = qs.findByQuery(query, None)
+        anns = screen.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        query = """
+            SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+            FROM WellAnnotationLink wal join wal.parent well
+                    join well.plate p join p.screenLinks l join l.parent s
+            WHERE s.id=%d""" % self.screen.id.val
+        qs = self.test.client.sf.getQueryService()
+        was = unwrap(qs.projection(query, None))
+        return was
+
+
+class Plate2Wells(Fixture):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 2
+        self.rowCount = 1
+        self.colCount = 2
+        self.csv = self.createCsv()
+        self.plate = None
+
+    def get_target(self):
         if not self.plate:
             self.plate = self.createPlate(self.rowCount, self.colCount)
         return self.plate
 
-    def get_dataset(self):
+    def get_annotations(self):
+        query = """select p from Plate p
+            left outer join fetch p.annotationLinks links
+            left outer join fetch links.child
+            where p.id=%s""" % self.plate.id.val
+        qs = self.test.client.sf.getQueryService()
+        plate = qs.findByQuery(query, None)
+        anns = plate.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        query = """
+            SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+            FROM WellAnnotationLink wal
+            WHERE wal.parent.plate.id=%d""" % self.plate.id.val
+        qs = self.test.client.sf.getQueryService()
+        was = unwrap(qs.projection(query, None))
+        return was
+
+
+class Dataset2Images(Fixture):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 2
+        self.csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+        )
+        self.dataset = None
+        self.images = None
+
+    def assert_rows(self, rows):
+        # Hard-coded in createCsv's arguments
+        assert rows == 2
+
+    def get_target(self):
         if not self.dataset:
             self.dataset = self.createDataset()
             self.images = self.get_dataset_images()
@@ -187,40 +243,20 @@ class TestPopulateMetadata(BasePopulate):
             left outer join fetch i.datasetLinks links
             left outer join fetch links.parent d
             where d.id=%s""" % self.dataset.id.val
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         return qs.findAllByQuery(query, None)
 
-    def get_screen_annotations(self):
-        query = """select s from Screen s
-            left outer join fetch s.annotationLinks links
-            left outer join fetch links.child
-            where s.id=%s""" % self.screen.id.val
-        qs = self.client.sf.getQueryService()
-        screen = qs.findByQuery(query, None)
-        anns = screen.linkedAnnotationList()
-        return anns
-
-    def get_plate_annotations(self):
-        query = """select p from Plate p
-            left outer join fetch p.annotationLinks links
-            left outer join fetch links.child
-            where p.id=%s""" % self.plate.id.val
-        qs = self.client.sf.getQueryService()
-        plate = qs.findByQuery(query, None)
-        anns = plate.linkedAnnotationList()
-        return anns
-
-    def get_dataset_annotations(self):
+    def get_annotations(self):
         query = """select d from Dataset d
             left outer join fetch d.annotationLinks links
             left outer join fetch links.child
             where d.id=%s""" % self.dataset.id.val
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         ds = qs.findByQuery(query, None)
         anns = ds.linkedAnnotationList()
         return anns
 
-    def get_image_annotations(self):
+    def get_child_annotations(self):
         if not self.images:
             return []
         params = ParametersI()
@@ -229,39 +265,21 @@ class TestPopulateMetadata(BasePopulate):
             left outer join i.annotationLinks links
             left outer join links.child as a
             where i.id in (:ids) and a <> null"""
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         return qs.findAllByQuery(query, params)
 
-    def get_well_annotations(self):
-        if self.plate:
-            query = """
-                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
-                FROM WellAnnotationLink wal
-                WHERE wal.parent.plate.id=%d""" % self.plate.id.val
-            qs = self.client.sf.getQueryService()
-            was = unwrap(qs.projection(query, None))
-            return was
-        elif self.screen:
-            query = """
-                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
-                FROM WellAnnotationLink wal join wal.parent well
-                     join well.plate p join p.screenLinks l join l.parent s
-                WHERE s.id=%d""" % self.screen.id.val
-            qs = self.client.sf.getQueryService()
-            was = unwrap(qs.projection(query, None))
-            return was
-        else:
-            return []
 
-    METADATA_TESTS = (
-        ("screen", 6, 4),
-        ("plate", 4, 2),
-        ("dataset", 4, 2)
+class TestPopulateMetadata(lib.ITest):
+
+    METADATA_FIXTURES = (
+        Screen2Plates(),
+        Plate2Wells(),
+        Dataset2Images(),
     )
-    METADATA_IDS = [x[0] for x in METADATA_TESTS]
+    METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 
-    @mark.parametrize("data", METADATA_TESTS, ids=METADATA_IDS)
-    def testPopulateMetadata(self, data):
+    @mark.parametrize("fixture", METADATA_FIXTURES, ids=METADATA_IDS)
+    def testPopulateMetadata(self, fixture):
         """
         We should really test each of the parsing contexts in separate tests
         but in practice each one uses data created by the others, so for
@@ -272,25 +290,26 @@ class TestPopulateMetadata(BasePopulate):
             print yaml, "found"
         except Exception:
             skip("PyYAML not installed.")
-        type, count, anns = data
-        self._test_parsing_context(type, count)
-        self._test_bulk_to_map_annotation_context(type, anns)
-        self._test_delete_map_annotation_context(type, anns)
 
-    def _test_parsing_context(self, type, count):
+        fixture.init(self)
+        self._test_parsing_context(fixture)
+        self._test_bulk_to_map_annotation_context(fixture)
+        self._test_delete_map_annotation_context(fixture)
+
+    def _test_parsing_context(self, fixture):
         """
             Create a small csv file, use populate_metadata.py to parse and
             attach to Plate. Then query to check table has expected content.
         """
 
-        target = getattr(self, "get_%s" % type)()
-        csv = getattr(self, "%s_csv" % type)
+        target = fixture.get_target()
+        csv = fixture.get_csv()
         ctx = ParsingContext(self.client, target, file=csv)
         ctx.parse()
         ctx.write_to_omero()
 
         # Get file annotations
-        anns = getattr(self, "get_%s_annotations" % type)()
+        anns = fixture.get_annotations()
         # Only expect a single annotation which is a 'bulk annotation'
         assert len(anns) == 1
         tableFileAnn = anns[0]
@@ -302,14 +321,11 @@ class TestPopulateMetadata(BasePopulate):
         t = r.openTable(OriginalFileI(fileid), None)
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
-        if self.screen:
-            assert rows == 2 * self.rowCount * self.colCount
-        else:
-            assert rows == self.rowCount * self.colCount
+        fixture.assert_rows(rows)
         for hit in range(rows):
             rowValues = [col.values[0] for col in t.read(range(len(cols)),
                                                          hit, hit+1).columns]
-            assert len(rowValues) == count
+            assert len(rowValues) == fixture.count
             # Unsure where the lower-casing is happening
             if "A1" in rowValues or "a1" in rowValues:
                 assert "Control" in rowValues
@@ -319,37 +335,26 @@ class TestPopulateMetadata(BasePopulate):
                 assert False, \
                     "Row does not contain 'a1' or 'a2': %s" % rowValues
 
-    def _test_bulk_to_map_annotation_context(self, type, ann_count):
+    def _test_bulk_to_map_annotation_context(self, fixture):
         # self._testPopulateMetadataPlate()
-        assert len(self.get_well_annotations()) == 0
-        assert len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
         cfg = os.path.join(
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
 
-        target = getattr(self, "get_%s" % type)()
-        anns = getattr(self, "get_%s_annotations" % type)()
+        target = fixture.get_target()
+        anns = fixture.get_annotations()
         fileid = anns[0].file.id.val
         ctx = BulkToMapAnnotationContext(
             self.client, target, fileid=fileid, cfg=cfg)
         ctx.parse()
-        assert len(self.get_well_annotations()) == 0
-        assert len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
         ctx.write_to_omero()
-        was = self.get_well_annotations()
-        ias = self.get_image_annotations()
+        oas = fixture.get_child_annotations()
+        assert len(oas) == fixture.annCount
 
-        if len(was) == ann_count:
-            assert len(ias) == 0
-            oas = was
-        elif len(ias) == ann_count:
-            assert len(was) == 0
-            oas = ias
-        else:
-            assert False, "W:%s & I:%s" % (len(was), len(ias))
-
-        for ma, wid, wr, wc in was:
+        for ma, wid, wr, wc in oas:
             assert isinstance(ma, MapAnnotationI)
             assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
             mv = ma.getMapValueAsMap()
@@ -362,20 +367,17 @@ class TestPopulateMetadata(BasePopulate):
                 assert mv['Well Type'] == 'Treatment'
                 assert mv['Concentration'] == '10'
 
-    def _test_delete_map_annotation_context(self, type, ann_count):
+    def _test_delete_map_annotation_context(self, fixture):
         # self._test_bulk_to_map_annotation_context()
-        assert len(self.get_well_annotations()) == ann_count or \
-               len(self.get_image_annotations()) == ann_count
+        assert len(fixture.get_child_annotations()) == fixture.annCount
 
-        target = getattr(self, type)
+        target = fixture.get_target()
         ctx = DeleteMapAnnotationContext(self.client, target)
         ctx.parse()
-        assert len(self.get_well_annotations()) == ann_count or \
-               len(self.get_image_annotations()) == ann_count
+        assert len(fixture.get_child_annotations()) == fixture.annCount
 
         ctx.write_to_omero()
-        assert len(self.get_well_annotations()) == 0 and \
-               len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):
@@ -495,7 +497,27 @@ class MockPlateAnalysisCtx(AbstractPlateAnalysisCtx):
         return 1
 
 
-class TestPopulateRois(BasePopulate):
+class ROICSV(Fixture):
+
+    def __init__(self):
+        self.count = 1
+        self.annCount = 2
+        self.csvName = self.createCsv(
+            colNames="Well,Field,X,Y,Type",
+            rowData=("A1,0,15,15,Test",))
+
+        self.rowCount = 1
+        self.colCount = 1
+        self.plate = None
+
+    def get_target(self):
+        if not self.plate:
+            self.plate = self.createPlate(
+                self.rowCount, self.colCount)
+        return self.plate
+
+
+class TestPopulateRois(lib.ITest):
 
     def testPopulateRoisPlate(self):
         """
@@ -503,17 +525,13 @@ class TestPopulateRois(BasePopulate):
             attach to Plate. Then query to check table has expected content.
         """
 
-        csvName = self.createCsv(
-            colNames="Well,Field,X,Y,Type",
-            rowData=("A1,0,15,15,Test",))
-
-        rowCount = 1
-        colCount = 1
-        plate = self.createPlate(rowCount, colCount)
+        fixture = ROICSV()
+        fixture.init(self)
+        plate = fixture.get_target()
 
         # As opposed to the ParsingContext, here we are expected
         # to link the file ourselves
-        ofile = self.client.upload(csvName).proxy()
+        ofile = self.client.upload(fixture.csvName).proxy()
         ann = FileAnnotationI()
         ann.file = ofile
         link = PlateAnnotationLinkI()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -106,7 +106,8 @@ class Fixture(object):
         prj.setName(rstring(name))
         for x in datasets:
             ds = self.createDataset(names=images)
-            prj.linkDataset(ds)
+            ds = self.setName(ds, x)
+            prj.linkDataset(ds.proxy())
         return self.test.client.sf.getUpdateService().saveAndReturnObject(prj)
 
     def createDataset(self, names=("A1", "A2")):


### PR DESCRIPTION
This PR carries on from work by @emilroz  (PR 120) which makes it possible to specify the column types for OMERO.tables when using populate_metadata.py to parse the csv files and adds support for datasets and projects as the target object for a metadata table.