### PR TITLE
inline singly used test method

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -45,7 +45,6 @@ import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
-import omero.cmd.Chmod2;
 import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
 import omero.cmd.Delete2Response;
@@ -58,7 +57,6 @@ import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.State;
 import omero.cmd.Status;
-import omero.gateway.util.Requests;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
 import omero.model.BooleanAnnotation;
@@ -334,21 +332,6 @@ public class AbstractServerTest extends AbstractTest {
         g.getDetails().setPermissions(perms);
         g = new ExperimenterGroupI(rootAdmin.createGroup(g), false);
         return newUserInGroup(g, owner);
-    }
-
-    /**
-     * Changes the permissions of the group.
-     *
-     * @param perms
-     *            The permissions level.
-     * @param groupId
-     *            The identifier of the group to handle.
-     * @throws Exception
-     *             Thrown if an error occurred.
-     */
-    protected void resetGroupPerms(String perms, long groupId) throws Exception {
-        final Chmod2 chmod = Requests.chmod().target("ExperimenterGroup").id(groupId).toPerms(perms).build();
-        doChange(root, root.getSession(), chmod, true);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import omero.api.IRenderingSettingsPrx;
+import omero.cmd.Chmod2;
+import omero.gateway.util.Requests;
 import omero.model.ChannelBinding;
 import omero.model.IObject;
 import omero.model.Image;
@@ -319,7 +321,8 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         disconnect();
         init(ctx);
 
-        resetGroupPerms(modified, ctx.groupId);
+        final Chmod2 chmod = Requests.chmod().target("ExperimenterGroup").id(ctx.groupId).toPerms(modified).build();
+        doChange(root, root.getSession(), chmod, true);
         // method already tested
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
         long pix2 = image2.getPrimaryPixels().getId().getValue();


### PR DESCRIPTION
Inlines a short method that is used only once in integration tests. CI should remain green.

Suggested by https://github.com/openmicroscopy/openmicroscopy/pull/4634#issuecomment-217374147.