### PR TITLE
Prevent deleting temporary files for failing exporter tests

### DIFF
--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -947,6 +947,7 @@ public class ExporterTest extends AbstractServerTest {
     public void testExportAsOMEXMLDowngradeImageWithROI(Target target) throws Exception {
         File f = null;
         File transformed = null;
+        boolean results = false;
         try {
             f = export(OME_XML, IMAGE_ROI);
             //transform
@@ -955,12 +956,18 @@ public class ExporterTest extends AbstractServerTest {
             validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
+            results = true;
         } catch (Throwable e) {
             throw new Exception("Cannot downgrade image: "+target.getSource(),
                     e);
         } finally {
-            if (f != null) f.delete();
-            if (transformed != null) transformed.delete();
+            if (result) {
+                if (f != null) f.delete();
+                if (transformed != null) transformed.delete();
+            } else {
+                System.out.println("Failed file:" + f.getAbsolutePath());
+                System.out.println("Failed transformed file:" + transformed.getAbsolutePath());
+            }
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -947,7 +947,7 @@ public class ExporterTest extends AbstractServerTest {
     public void testExportAsOMEXMLDowngradeImageWithROI(Target target) throws Exception {
         File f = null;
         File transformed = null;
-        boolean results = false;
+        boolean result = false;
         try {
             f = export(OME_XML, IMAGE_ROI);
             //transform
@@ -956,7 +956,7 @@ public class ExporterTest extends AbstractServerTest {
             validate(transformed);
             //import the file
             importFile(transformed, OME_XML);
-            results = true;
+            result = true;
         } catch (Throwable e) {
             throw new Exception("Cannot downgrade image: "+target.getSource(),
                     e);


### PR DESCRIPTION
This temporary PR should simplify the debugging of the failing Java integration tests related to the BinData code generation changes /cc @mtbc @dgault 