### PR TITLE
Save last change

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -212,6 +212,11 @@
               syncRDCW(OME.preview_viewport);
             });
 
+            $("#save-last-change").click(function(){
+              OME.preview_viewport.save_last_change();
+              // syncRDCW(OME.preview_viewport);
+            });
+
             var rdefs = {{ rdefsJson|safe }};
             // All button events are delegated, so will also apply to new buttons
             $( "#rdef-buttons" )
@@ -371,7 +376,7 @@
       T: <span id="wblitz-t-curr">1</span>/<span id="wblitz-t-count">1</span>
     </div>
 
-    <ul class="toolbar borderless labels">
+    <ul class="toolbar borderless labels" style="overflow:visible">
       <li>
         <button id="rdef-setdef-btn" class="button button-disabled"
             {% if manager.image.canAnnotate %}
@@ -414,8 +419,14 @@
         <img src="{% static "webclient/image/icon_toolbar_paste.png" %}"/><br>
         Paste
       </button></li>
+      <li><button id="save-last-change" class="button"
+          title="Save last change to all">
+        <img src="{% static 'webclient/image/icon_save.png' %}"/><br>
+        <span>Save Change</span>
+      </button></li>
     </ul>
 
+    <div style="clear: both"></div>
     <div id="rdef-postit">
       <div id="rdef-active-area">
         <input id="rd-wblitz-rmodel" type="checkbox" />

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -98,6 +98,15 @@
 
         $(document).ready(function() {
 
+            {% if manager.well %}
+            // If we're looking at a well we know parent is plate
+              var PARENT_ID = "plate-{{ manager.well.plate.id.val }}";
+            {% else %}
+              // For images in Datasets, we get parent from jsTree, using selected image
+              // E.g. dataset-123
+              var PARENT_ID = OME.getParentId();
+            {% endif %}
+
             // Fix size according to right panel size... NB: this behaviour is also in right_plugin.preview.js
             var vpWidth = $("#right_panel").width() - 50,
               vpHeight = Math.min(vpWidth, $("#preview_tab").height() - 100);
@@ -213,8 +222,8 @@
             });
 
             $("#save-last-change").click(function(){
-              OME.preview_viewport.save_last_change();
-              // syncRDCW(OME.preview_viewport);
+              OME.preview_viewport.save_last_change(PARENT_ID);
+              syncRDCW(OME.preview_viewport);
             });
 
             var rdefs = {{ rdefsJson|safe }};
@@ -289,25 +298,15 @@
 
             {% if manager.image.canAnnotate %}
 
-            {% if manager.well %}
-            // If we're looking at a well we know parent is plate
-              var pid = "plate-{{ manager.well.plate.id.val }}";
-            {% else %}
-              // For images in Datasets, we get parent from jsTree, using selected image
-              // E.g. dataset-123
-              var pid = OME.getParentId();
-            {% endif %}
-
-
-            if (pid) {
+            if (PARENT_ID) {
               $("#rdef-save-all")
-                .attr('title', "Apply and Save settings to all images in " + pid)
+                .attr('title', "Apply and Save settings to all images in " + PARENT_ID)
                 .removeAttr('disabled').removeClass("button-disabled")
                 .click(function(){
                   var $span = $('span', this),
                     spanTxt = $span.text();
                   $span.text("Saving...");
-                  var typeId = pid.split("-");
+                  var typeId = PARENT_ID.split("-");
                   var rdefQry = OME.preview_viewport.getQuery();
                   // need to paste current settings to all images...
                   var url = "{% url 'webgateway.views.copy_image_rdef_json' %}"+ "?" + rdefQry;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -222,7 +222,7 @@
             });
 
             $("#save-last-change").click(function(){
-              OME.preview_viewport.save_last_change(PARENT_ID);
+              OME.preview_viewport.save_unsaved_changes_to_all(PARENT_ID);
               syncRDCW(OME.preview_viewport);
             });
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -322,5 +322,7 @@ urlpatterns = patterns(
 
     url(r'^api/shares/$', views.api_share_list, name='api_shares'),
 
+    url(r'^api/rendering_def/$', views.api_rendering_def,
+        name='api_rendering_def'),
 
 )

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -927,6 +927,56 @@ jQuery._WeblitzViewport = function (container, server, options) {
     }
   };
 
+  // get difference between last 2 states in undo queue
+  this.get_last_change = function() {
+
+    if (channels_undo_stack_ptr === 0) {
+      return false;
+    }
+
+    var e1 = channels_undo_stack[channels_undo_stack_ptr - 1],
+      e2 = channels_undo_stack[channels_undo_stack_ptr];
+
+    var diff = {};
+    if (e1.model != e2.model) {
+      diff.model = e2.model;
+    }
+    var diffChannels = {},
+      ch1, ch2,
+      chdiff;
+    for (var i=0; i<e1.channels.length; i++) {
+      ch1 = e1.channels[i];
+      ch2 = e2.channels[i];
+      chdiff = {};
+      if (ch1.active != ch2.active) {
+        chdiff.active = ch2.active;
+      }
+      if (OME.rgbToHex(ch1.color) != OME.rgbToHex(ch2.color)) {
+        chdiff.color = ch2.color;
+      }
+      if (ch1.windowStart != ch2.windowStart) {
+        chdiff.windowStart = ch2.windowStart;
+      }
+      if (ch1.windowEnd != ch2.windowEnd) {
+        chdiff.windowEnd = ch2.windowEnd;
+      }
+      if (ch1.metalabel != ch2.metalabel) {
+        chdiff.metalabel = ch2.metalabel;
+      }
+      if (_.size(chdiff) > 0) {
+        diffChannels['' + i] = chdiff;
+      }
+    }
+    if (_.size(diffChannels) > 0) {
+      diff.channels = diffChannels;
+    }
+    return diff;
+  };
+
+  this.save_last_change = function() {
+
+  };
+
   this.undo_channels = function (redo) {
     if (channels_undo_stack_ptr >= 0) {
 //      if (channels_undo_stack.length-1 == channels_undo_stack_ptr && !redo) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -888,11 +888,11 @@ jQuery._WeblitzViewport = function (container, server, options) {
 
   var sizeOfObject = function (obj) {
     var count = 0;
-    for (k in obj) {
+    for (var k in obj) {
       if (obj.hasOwnProperty(k)) count++;
     }
     return count;
-  }
+  };
 
   var channels_undo_stack = [];
   var channels_undo_stack_ptr = -1;
@@ -936,13 +936,17 @@ jQuery._WeblitzViewport = function (container, server, options) {
   };
 
   // get difference between last 2 states in undo queue
-  this.get_last_change = function() {
+  this.get_unsaved_changes = function() {
 
+    console.log('saved_undo_stack_ptr, channels_undo_stack_ptr', saved_undo_stack_ptr, channels_undo_stack_ptr);
     if (channels_undo_stack_ptr === 0) {
       return false;
     }
+    if (saved_undo_stack_ptr === channels_undo_stack_ptr) {
+      return false;
+    }
 
-    var e1 = channels_undo_stack[channels_undo_stack_ptr - 1],
+    var e1 = channels_undo_stack[saved_undo_stack_ptr],
       e2 = channels_undo_stack[channels_undo_stack_ptr];
 
     var diff = {};
@@ -977,11 +981,12 @@ jQuery._WeblitzViewport = function (container, server, options) {
     if (sizeOfObject(diffChannels) > 0) {
       diff.channels = diffChannels;
     }
+    console.log('unsaved changes', diff);
     return diff;
   };
 
-  this.save_last_change = function(parentId) {
-    var diff = this.get_last_change();
+  this.save_unsaved_changes_to_all = function(parentId) {
+    var diff = this.get_unsaved_changes();
 
     // E.g dataset-123
     if (!parentId) return;
@@ -996,6 +1001,8 @@ jQuery._WeblitzViewport = function (container, server, options) {
     .done(function(data){
         OME.refreshThumbnails({'ignorePreview': true});
     });
+
+    this.setSaved();
   };
 
   this.undo_channels = function (redo) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -886,6 +886,14 @@ jQuery._WeblitzViewport = function (container, server, options) {
    * Undo / Redo support
    */
 
+  var sizeOfObject = function (obj) {
+    var count = 0;
+    for (k in obj) {
+      if (obj.hasOwnProperty(k)) count++;
+    }
+    return count;
+  }
+
   var channels_undo_stack = [];
   var channels_undo_stack_ptr = -1;
   var saved_undo_stack_ptr = 0;   // channels_undo_stack_ptr will start off here
@@ -962,11 +970,11 @@ jQuery._WeblitzViewport = function (container, server, options) {
       if (ch1.metalabel != ch2.metalabel) {
         chdiff.metalabel = ch2.metalabel;
       }
-      if (_.size(chdiff) > 0) {
+      if (sizeOfObject(chdiff) > 0) {
         diffChannels['' + i] = chdiff;
       }
     }
-    if (_.size(diffChannels) > 0) {
+    if (sizeOfObject(diffChannels) > 0) {
       diff.channels = diffChannels;
     }
     return diff;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -952,12 +952,11 @@ jQuery._WeblitzViewport = function (container, server, options) {
         chdiff.active = ch2.active;
       }
       if (OME.rgbToHex(ch1.color) != OME.rgbToHex(ch2.color)) {
-        chdiff.color = ch2.color;
+        chdiff.color = OME.rgbToHex(ch2.color);
       }
-      if (ch1.windowStart != ch2.windowStart) {
+      // If start OR end has changed, return both
+      if (ch1.windowStart != ch2.windowStart || ch1.windowEnd != ch2.windowEnd) {
         chdiff.windowStart = ch2.windowStart;
-      }
-      if (ch1.windowEnd != ch2.windowEnd) {
         chdiff.windowEnd = ch2.windowEnd;
       }
       if (ch1.metalabel != ch2.metalabel) {
@@ -973,8 +972,22 @@ jQuery._WeblitzViewport = function (container, server, options) {
     return diff;
   };
 
-  this.save_last_change = function() {
+  this.save_last_change = function(parentId) {
+    var diff = this.get_last_change();
 
+    // E.g dataset-123
+    if (!parentId) return;
+    parentId = parentId.replace('-', '=');
+
+    $.ajax({
+        url: server + "/api/rendering_def/?" + parentId,
+        type: "POST",
+        data: JSON.stringify(diff),
+        dataType: 'json'
+    })
+    .done(function(data){
+        OME.refreshThumbnails({'ignorePreview': true});
+    });
   };
 
   this.undo_channels = function (redo) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -212,38 +212,31 @@
         var canSaveRdef = viewport.loadedImg.perms.canAnnotate;
         if (viewport.getSaved() || !canSaveRdef) {
             $("#rdef-setdef-btn").attr("disabled", "disabled").addClass("button-disabled");
+            $('#save-last-change').attr("disabled", "disabled").addClass("button-disabled");
         } else {
             $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
+            $('#save-last-change').removeAttr('disabled').removeClass("button-disabled");
         }
 
         // update 'save last change' button according to diff between last changes
-        if (viewport.has_channels_undo()) {
-            $('#save-last-change').removeAttr('disabled').removeClass("button-disabled");
-        } else {
-            $('#save-last-change').attr("disabled", "disabled").addClass("button-disabled");
-        }
-        var diff = viewport.get_last_change();
-        var btnHtml = "Save Change<br>to All";
-        var btnTooltip = "Save last change to all images";
-        var chCount = 0;
-        if (diff.channels) {
-            for (var ch in diff.channels) {
-                if (diff.channels.hasOwnProperty(ch)){
-                    chCount++;
-                    for (var attr in diff.channels[ch]) {
-                        btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
-                        btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
-                        // windowStart /End -> Slider Start /End
-                        attr = attr.replace('window', 'Slider ');
-                        btnTooltip += attr + " to all images";
-                    }
-                }
-            }
-        }
-        if (chCount > 1) {
-            btnHtml = "Save Changes<br> to All";
-            btnTooltip = "Save last changes to all images";
-        }
+        var diff = viewport.get_unsaved_changes();
+        var btnHtml = "Save Changes<br>to All";
+        var btnTooltip = "Save unsaved changes to all images";
+        // var chCount = 0;
+        // if (diff.channels) {
+        //     for (var ch in diff.channels) {
+        //         if (diff.channels.hasOwnProperty(ch)){
+        //             chCount++;
+        //             for (var attr in diff.channels[ch]) {
+        //                 btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
+        //                 btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
+        //                 // windowStart /End -> Slider Start /End
+        //                 attr = attr.replace('window', 'Slider ');
+        //                 btnTooltip += attr + " to all images";
+        //             }
+        //         }
+        //     }
+        // }
         $('#save-last-change').attr('title', btnTooltip);
         $('#save-last-change span').html(btnHtml);
     };

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -148,7 +148,7 @@
         }
         //var t = $('#rd-wblitz-ch'+idx).get(0);
         //if (t != undefined) t.checked=ch.active;
-        var rgb = OME.hexToRgb(ch.color)
+        var rgb = OME.hexToRgb(ch.color);
         $('#wblitz-ch'+idx).css('background-color', 'rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')').attr('title', ch.label);
     };
 
@@ -215,6 +215,38 @@
         } else {
             $("#rdef-setdef-btn").removeAttr('disabled').removeClass("button-disabled");
         }
+
+        // update 'save last change' button according to diff between last changes
+        if (viewport.has_channels_undo()) {
+            $('#save-last-change').removeAttr('disabled').removeClass("button-disabled");
+        } else {
+            $('#save-last-change').attr("disabled", "disabled").addClass("button-disabled");
+        }
+        var diff = viewport.get_last_change();
+        var btnHtml = "Save Change<br>to All";
+        var btnTooltip = "Save last change to all images";
+        if (diff.channels) {
+            if (_.size(diff.channels) > 1) {
+                btnHtml = "Save Changes<br>to all";
+            } else if (_.size(diff.channels) === 1) {
+                for (var ch in diff.channels) {
+                    if (diff.channels.hasOwnProperty(ch)){
+                        for (var attr in diff.channels[ch]) {
+                            btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
+
+                            btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
+                            if (attr === "windowStart" || attr === "windowEnd"){
+                                btnTooltip += 'slider to all images';
+                            } else {
+                                btnTooltip += attr + " to all images";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        $('#save-last-change').attr('title', btnTooltip);
+        $('#save-last-change span').html(btnHtml);
     };
 
     var on_batchCopyRDefs = false;
@@ -325,8 +357,9 @@
                 updateUndoRedo(viewport);
             };
         };
+        var rgb;
         for (i=0; i<channels.length; i++) {
-            var rgb = OME.hexToRgb(channels[i].color)
+            rgb = OME.hexToRgb(channels[i].color);
             $('<button id="wblitz-ch'+i+
                 '"class="squared' + (channels[i].active?' pressed':'') +
                 '"style="background-color: rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')' +
@@ -465,7 +498,7 @@
             if (lbl.length > 7) {
                 lbl = lbl.slice(0, 5) + "...";
             }
-            var rgb = OME.hexToRgb(channels[i].color)
+            rgb = OME.hexToRgb(channels[i].color);
             tmp.after(template
                 .replace(/\$class/g, btnClass)
                 .replace(/\$col/g, 'rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')')

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -225,22 +225,24 @@
         var diff = viewport.get_last_change();
         var btnHtml = "Save Change<br>to All";
         var btnTooltip = "Save last change to all images";
+        var chCount = 0;
         if (diff.channels) {
-            if (_.size(diff.channels) > 1) {
-                btnHtml = "Save Changes<br>to all";
-            } else if (_.size(diff.channels) === 1) {
-                for (var ch in diff.channels) {
-                    if (diff.channels.hasOwnProperty(ch)){
-                        for (var attr in diff.channels[ch]) {
-                            btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
-                            btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
-                            // windowStart /End -> Slider Start /End
-                            attr = attr.replace('window', 'Slider ');
-                            btnTooltip += attr + " to all images";
-                        }
+            for (var ch in diff.channels) {
+                if (diff.channels.hasOwnProperty(ch)){
+                    chCount++;
+                    for (var attr in diff.channels[ch]) {
+                        btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
+                        btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
+                        // windowStart /End -> Slider Start /End
+                        attr = attr.replace('window', 'Slider ');
+                        btnTooltip += attr + " to all images";
                     }
                 }
             }
+        }
+        if (chCount > 1) {
+            btnHtml = "Save Changes<br> to All";
+            btnTooltip = "Save last changes to all images";
         }
         $('#save-last-change').attr('title', btnTooltip);
         $('#save-last-change span').html(btnHtml);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -233,13 +233,10 @@
                     if (diff.channels.hasOwnProperty(ch)){
                         for (var attr in diff.channels[ch]) {
                             btnHtml = "Save Ch-" + (parseInt(ch, 10) + 1) + " " + "<br>to all";
-
                             btnTooltip = "Save Ch-" + (parseInt(ch, 10) + 1) + " ";
-                            if (attr === "windowStart" || attr === "windowEnd"){
-                                btnTooltip += 'slider to all images';
-                            } else {
-                                btnTooltip += attr + " to all images";
-                            }
+                            // windowStart /End -> Slider Start /End
+                            attr = attr.replace('window', 'Slider ');
+                            btnTooltip += attr + " to all images";
                         }
                     }
                 }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -926,11 +926,11 @@
 	    {% endif %}-->{% endcomment %}
             <br />
             <label>Rendering Settings</label><br />
-            <button id="rdef-copy-btn" class="btn silver btn_text" title="Copy Rendering Settings">
+            <button id="wblitz-copyRdef" class="btn silver btn_text" title="Copy Rendering Settings">
                 <span>Copy</span>
             </button>
 
-            <button id="rdef-paste-btn" class="btn silver btn_text" title="Paste Rendering Settings">
+            <button id="wblitz-pasteRdef" class="btn silver btn_text" title="Paste Rendering Settings">
                 <span>Paste</span>
             </button>
           </div>
@@ -1183,11 +1183,11 @@
     });
 
     var copy_paste_rdef_url = "{% url 'webgateway.views.copy_image_rdef_json' %}";
-    $("#rdef-copy-btn").click(function() {
+    $("#rdef-copy-btn, #wblitz-copyRdef").click(function() {
         copyRdefs(viewport);
     });
 
-    $("#rdef-paste-btn").click(function() {
+    $("#rdef-paste-btn, #wblitz-pasteRdef").click(function() {
         pasteRdefs(viewport);
     });
 


### PR DESCRIPTION
This is a prototype for https://trello.com/c/mpUSdeUU/43-rendering-settings-applytoall

Investigation on how to apply limited rendering settings (last change) to all images in Dataset.
To test:
 - Select image from Dataset - open Preview panel
 - Adjust sliders or pick colour or change greyscale/colour
 - The 'Save Last Change' button will become enabled with change of text - tooltip gives more info
 - Clicking this button will apply last change to other images in Dataset.