### PR TITLE
have tooltip not add units to file size

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DocComponent.java
@@ -488,7 +488,7 @@ class DocComponent
 		    FileAnnotationData fa = (FileAnnotationData) data;
 		    long size = ((FileAnnotationData) annotation).getFileSize();
 		    tt.addLine("File ID", ""+fa.getFileID(), true);
-		    tt.addLine("Size", UIUtilities.formatFileSize(size)+"kb", true);
+		    tt.addLine("Size", UIUtilities.formatFileSize(size), true);
 			checkAnnotators(tt, annotation);
 		} else if (data instanceof TagAnnotationData || data instanceof
 				XMLAnnotationData || data instanceof TermAnnotationData ||


### PR DESCRIPTION
Attach files to data in Insight. Check that when you hover over the filename in the metadata pane then the tooltip sensibly reports the file size. (It would previously use units like `KBkb`.)