### PR TITLE
update uses of Requests to avoid deprecated methods

### DIFF
--- a/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
+++ b/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
@@ -43,7 +43,6 @@ import omero.api.IUpdatePrx;
 import omero.cmd.CmdCallbackI;
 import omero.api.RawFileStorePrx;
 import omero.cmd.Delete2;
-import omero.cmd.Request;
 import omero.cmd.Response;
 import omero.cmd.graphs.ChildOption;
 import omero.gateway.Gateway;
@@ -56,6 +55,7 @@ import omero.gateway.model.ImageData;
 import omero.gateway.util.PojoMapper;
 import omero.gateway.util.Pojos;
 import omero.gateway.util.Requests;
+import omero.gateway.util.Requests.Delete2Builder;
 import omero.model.ChecksumAlgorithm;
 import omero.model.ChecksumAlgorithmI;
 import omero.model.DatasetAnnotationLink;
@@ -226,35 +226,11 @@ public class DataManagerFacility extends Facility {
     public CmdCallbackI delete(SecurityContext ctx, List<IObject> objects)
             throws DSOutOfServiceException, DSAccessException {
         try {
-            /*
-             * convert the list of objects to lists of IDs by OMERO model class
-             * name
-             */
-            final Map<String, List<Long>> objectIds = new HashMap<String, List<Long>>();
+            final Delete2Builder request = Requests.delete();
             for (final IObject object : objects) {
-                /* determine actual model class name for this object */
-                Class<? extends IObject> objectClass = object.getClass();
-                while (true) {
-                    final Class<?> superclass = objectClass.getSuperclass();
-                    if (IObject.class == superclass) {
-                        break;
-                    } else {
-                        objectClass = superclass.asSubclass(IObject.class);
-                    }
-                }
-                final String objectClassName = objectClass.getSimpleName();
-                /* then add the object's ID to the list for that class name */
-                final Long objectId = object.getId().getValue();
-                List<Long> idsThisClass = objectIds.get(objectClassName);
-                if (idsThisClass == null) {
-                    idsThisClass = new ArrayList<Long>();
-                    objectIds.put(objectClassName, idsThisClass);
-                }
-                idsThisClass.add(objectId);
+                request.target(object);
             }
-            /* now delete the objects */
-            final Request request = Requests.delete(objectIds);
-            return gateway.submit(ctx, request);
+            return gateway.submit(ctx, request.build());
         } catch (Throwable t) {
             handleException(this, t, "Cannot delete the object.");
         }
@@ -281,35 +257,11 @@ public class DataManagerFacility extends Facility {
     public Response deleteObjects(SecurityContext ctx, List<IObject> objects)
             throws DSOutOfServiceException, DSAccessException {
         try {
-            /*
-             * convert the list of objects to lists of IDs by OMERO model class
-             * name
-             */
-            final Map<String, List<Long>> objectIds = new HashMap<String, List<Long>>();
+            final Delete2Builder request = Requests.delete();
             for (final IObject object : objects) {
-                /* determine actual model class name for this object */
-                Class<? extends IObject> objectClass = object.getClass();
-                while (true) {
-                    final Class<?> superclass = objectClass.getSuperclass();
-                    if (IObject.class == superclass) {
-                        break;
-                    } else {
-                        objectClass = superclass.asSubclass(IObject.class);
-                    }
-                }
-                final String objectClassName = objectClass.getSimpleName();
-                /* then add the object's ID to the list for that class name */
-                final Long objectId = object.getId().getValue();
-                List<Long> idsThisClass = objectIds.get(objectClassName);
-                if (idsThisClass == null) {
-                    idsThisClass = new ArrayList<Long>();
-                    objectIds.put(objectClassName, idsThisClass);
-                }
-                idsThisClass.add(objectId);
+                request.target(object);
             }
-            /* now delete the objects */
-            final Request request = Requests.delete(objectIds);
-            return gateway.submit(ctx, request).loop(50, 250);
+            return gateway.submit(ctx, request.build()).loop(50, 250);
         } catch (Throwable t) {
             handleException(this, t, "Cannot delete the object.");
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -3648,7 +3648,7 @@ class OMEROGateway
                         case GroupData.PERMISSIONS_PUBLIC_READ:
                             r = "rwrwr-";
                     }
-                    final Chmod2 chmod = Requests.chmod("ExperimenterGroup", group.getId(), r);
+                    final Chmod2 chmod = Requests.chmod().target(group.asGroup()).toPerms(r).build();
                     List<Request> l = new ArrayList<Request>();
                     l.add(chmod);
                     return new RequestCallback(gw.submit(ctx, l, null));
@@ -7253,7 +7253,7 @@ class OMEROGateway
               }
 			}
 			
-			commands.add(Requests.chgrp(objects, target.getGroupID()));
+			commands.add(Requests.chgrp().target(objects).toGroup(target.getGroupID()).build());
 			commands.addAll(saves);
 			
 			return new RequestCallback(gw.submit(ctx, commands, target));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -866,36 +866,20 @@ class OmeroDataServiceImpl
             DataObject data = delo.getObjectToDelete();
 
             if (!CollectionUtils.isEmpty(delo.getAnnotations())) {
-                opts.add(Requests.option(null,
-                        PojoMapper.getGraphType(AnnotationData.class)));
+                opts.add(Requests.option().excludeType(PojoMapper.getGraphType(AnnotationData.class)).build());
             }
 
             if (!delo.deleteContent()) {
                 if (data instanceof DatasetData) {
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(ImageData.class)));
+                    opts.add(Requests.option().excludeType(PojoMapper.getGraphType(ImageData.class)).build());
                 } else if (data instanceof ProjectData) {
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(DatasetData.class)));
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(ImageData.class)));
+                    opts.add(Requests.option().excludeType(PojoMapper.getGraphType(DatasetData.class)).build());
                 } else if (data instanceof ScreenData) {
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(PlateData.class)));
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(WellData.class)));
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(PlateAcquisitionData.class)));
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(ImageData.class)));
+                    opts.add(Requests.option().excludeType(PojoMapper.getGraphType(PlateData.class)).build());
                 } else if (data instanceof PlateData) {
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(PlateAcquisitionData.class)));
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(ImageData.class)));
+                    opts.add(Requests.option().excludeType(PojoMapper.getGraphType(ImageData.class)).build());
                 } else if (data instanceof PlateAcquisitionData) {
-                    opts.add(Requests.option(null,
-                            PojoMapper.getGraphType(ImageData.class)));
+                    opts.add(Requests.option().excludeType(PojoMapper.getGraphType(ImageData.class)).build());
                 }
 
                 else if (data instanceof TagAnnotationData) {
@@ -919,8 +903,7 @@ class OmeroDataServiceImpl
 
         List<Request> cmds = new ArrayList<Request>();
         for (String type : toDelete.keySet()) {
-            cmds.add(Requests.delete(type, toDelete.get(type),
-                    options.get(type)));
+            cmds.add(Requests.delete().target(type).id(toDelete.get(type)).option(options.get(type)).build());
         }
 
         return gateway.submit(cmds, ctx);

--- a/examples/Delete/FileAnnotationDelete.java
+++ b/examples/Delete/FileAnnotationDelete.java
@@ -38,9 +38,8 @@ public class FileAnnotationDelete {
             d.linkAnnotation(fa);
             d = (Dataset) s.getUpdateService().saveAndReturnObject(d);
             fa = (FileAnnotation) d.linkedAnnotationList().get(0);
-            long faID = fa.getId().getValue();
 
-            Delete2 deleteCmd = Requests.delete("Annotation", faID);
+            Delete2 deleteCmd = Requests.delete().target(fa).build();
             Map<String, String> callContext = new HashMap<String, String>();
             CmdCallbackI cb = null;
             try {


### PR DESCRIPTION
With this PR the only remaining uses of deprecated `Requests` methods are in the integration tests. CI should remain green. This probably mostly affects permissions operations from Insight.