### PR TITLE
Prefix linkify_element with OME.

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -116,6 +116,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                 $mapAnnContainer.html(html);
 
                 // Finish up...
+                OME.linkify_element($( "table.keyValueTable tbody tr td" ));
                 OME.filterAnnotationsAddedBy();
                 $(".tooltip", $mapAnnContainer).tooltip_init();
             });

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -81,9 +81,6 @@
                 OME.linkify_element($( "#image_desc" ));
                 {% endif %}
 
-                // Temporary hack to get links to show in MapAnnotations
-                OME.linkify_element($( "table.keyValueTable tbody tr td" ));
-
                 var acquisition_load = false;
                 var preview_load = false;
                 var hierarchy_load = false;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -82,7 +82,7 @@
                 {% endif %}
 
                 // Temporary hack to get links to show in MapAnnotations
-                linkify_element($( "table.keyValueTable tbody tr td" ));
+                OME.linkify_element($( "table.keyValueTable tbody tr td" ));
 
                 var acquisition_load = false;
                 var preview_load = false;


### PR DESCRIPTION
A rebase issue, this left many parts of the UI unusable
(link button, k/v dropdown, etc) after certain operations.

See: https://trello.com/c/gmCgOvwU/326-metadata52-web-problems