### PR TITLE
Update guava CacheBuilderSpec link in config

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -258,7 +258,7 @@ omero.scripts.cache.cron=0 0 0 * * ?
 # for how long.
 #
 # For more information, see
-# https://github.com/google/guava/blob/master/guava/src/com/google/common/cache/CacheBuilderSpec.java
+# http://google.github.io/guava/releases/17.0/api/docs/com/google/common/cache/CacheBuilderSpec.html
 omero.scripts.cache.spec=maximumSize=1000
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -258,7 +258,7 @@ omero.scripts.cache.cron=0 0 0 * * ?
 # for how long.
 #
 # For more information, see
-# http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html
+# https://github.com/google/guava/blob/master/guava/src/com/google/common/cache/CacheBuilderSpec.java
 omero.scripts.cache.spec=maximumSize=1000
 
 #############################################


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/343/warnings3Result/ - docs build was unstable this morning because this link is broken. I'm not sure if it's temporary but the `/git/javadoc/com/google/common/cache/CacheBuilderSpec.html` bit is giving a 404 and the `http://docs.guava-libraries.googlecode.com` domain is redirecting to this github repo instead so I've changed the link to point directly at the code.

Will need the autogen docs build to run before this will feed through into the docs page.