### PR TITLE
Revert "Cleanup local OME Maven cache for every Travis build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ before_install:
     - scc travis-merge
     - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
-    # Remove OME Maven cache as we are working on a breaking branch
-    - rm -rf ~/.m2/repository/ome
 
 # retries the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507


### PR DESCRIPTION
This reverts commit 70ab7a67c2daa72c40c70550e10f89336505bbbf.

With the large part of the breaking Bio-Formats changes having been included, purging the `ome` directory in the Maven cache should not be necessary anymore. With this change Travis should remain green and upcoming builds should not need to fetch from Artifactory.