### PR TITLE
Remove link to deleted windows server install page

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -137,9 +137,8 @@ editor.
     ``"[\\"foo\\", \\"bar\\"]"``) or wrap with ``'`` (e.g. ``'["foo",
     "bar"]'``).
 
-Examples of doing this are on the main :doc:`Unix <unix/server-installation>`
-and :doc:`Windows <windows/server-installation>` pages, as well as the
-:doc:`LDAP installation <server-ldap>` page.
+Examples of doing this are on the main :doc:`server installation <unix/server-installation>`
+page, as well as the :doc:`LDAP installation <server-ldap>` page.
 
 .. _core_configuration:
 

--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -137,8 +137,9 @@ editor.
     ``"[\\"foo\\", \\"bar\\"]"``) or wrap with ``'`` (e.g. ``'["foo",
     "bar"]'``).
 
-Examples of doing this are on the main :doc:`server installation <unix/server-installation>`
-page, as well as the :doc:`LDAP installation <server-ldap>` page.
+Examples of doing this are on the
+:doc:`server installation page <unix/server-installation>`, as well as the
+:doc:`LDAP installation <server-ldap>` page.
 
 .. _core_configuration:
 


### PR DESCRIPTION
See https://github.com/openmicroscopy/ome-documentation/pull/1481 this line remaining in the code was trying to reintroduce deleted windows server installation page links into the docs.