### PR TITLE
fix method name for Chown2Builder.toGroup

### DIFF
--- a/components/blitz/src/omero/gateway/util/Requests.java
+++ b/components/blitz/src/omero/gateway/util/Requests.java
@@ -2210,8 +2210,18 @@ public class Requests {
          * @param user the user to which to give the target objects, does overwrite previous calls
          * @return this builder, for method chaining
          */
-        public Chown2Builder toGroup(Experimenter user) {
+        public Chown2Builder toUser(Experimenter user) {
             return toUser(user.getId());
+        }
+
+        /**
+         * @param user the user to which to give the target objects, does overwrite previous calls
+         * @return this builder, for method chaining
+         * @deprecated use {@link #toUser(Experimenter)}
+         */
+        @Deprecated
+        public Chown2Builder toGroup(Experimenter user) {
+            return toUser(user);
         }
     }
 


### PR DESCRIPTION
This is a simple code PR that fixes a copy-and-paste slip in method naming. CI should remain green.

(As this affects gateway API it is a 5.2 backport candidate; I've no idea where/how we note those.)