### PR TITLE
TablesFacility

### DIFF
--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -31,7 +31,6 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.AnnotationData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
-import omero.gateway.model.FileData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.MaskData;
 import omero.gateway.model.PlateData;
@@ -432,10 +431,10 @@ public class TablesFacility extends Facility {
      *             If an error occurred while trying to retrieve data from OMERO
      *             service.
      */
-    public Collection<FileData> getAvailableTables(SecurityContext ctx,
-            DataObject parent) throws DSOutOfServiceException,
-            DSAccessException {
-        Collection<FileData> result = new ArrayList<FileData>();
+    public Collection<FileAnnotationData> getAvailableTables(
+            SecurityContext ctx, DataObject parent)
+            throws DSOutOfServiceException, DSAccessException {
+        Collection<FileAnnotationData> result = new ArrayList<FileAnnotationData>();
         try {
             MetadataFacility mf = gateway.getFacility(MetadataFacility.class);
 
@@ -448,9 +447,7 @@ public class TablesFacility extends Facility {
             for (AnnotationData anno : annos) {
                 FileAnnotationData fad = (FileAnnotationData) anno;
                 if (fad.getOriginalMimetype().equals(TABLES_MIMETYPE)) {
-                    long fileId = ((FileAnnotationData) anno).getFileID();
-                    OriginalFile file = new OriginalFileI(fileId, false);
-                    result.add(new FileData(file));
+                    result.add(fad);
                 }
             }
 

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package omero.gateway.facility;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.model.AnnotationData;
+import omero.gateway.model.DataObject;
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.FileData;
+import omero.gateway.model.ImageData;
+import omero.gateway.model.MaskData;
+import omero.gateway.model.PlateData;
+import omero.gateway.model.ROIData;
+import omero.gateway.model.TableData;
+import omero.gateway.model.WellSampleData;
+import omero.grid.BoolColumn;
+import omero.grid.Column;
+import omero.grid.Data;
+import omero.grid.DoubleArrayColumn;
+import omero.grid.DoubleColumn;
+import omero.grid.FileColumn;
+import omero.grid.FloatArrayColumn;
+import omero.grid.ImageColumn;
+import omero.grid.LongArrayColumn;
+import omero.grid.LongColumn;
+import omero.grid.MaskColumn;
+import omero.grid.PlateColumn;
+import omero.grid.RoiColumn;
+import omero.grid.SharedResourcesPrx;
+import omero.grid.StringColumn;
+import omero.grid.TablePrx;
+import omero.grid.WellColumn;
+import omero.model.FileAnnotation;
+import omero.model.FileAnnotationI;
+import omero.model.Image;
+import omero.model.ImageI;
+import omero.model.OriginalFile;
+import omero.model.OriginalFileI;
+import omero.model.Plate;
+import omero.model.PlateI;
+import omero.model.Roi;
+import omero.model.RoiI;
+import omero.model.WellSample;
+import omero.model.WellSampleI;
+
+/**
+ * {@link Facility} to interact with OMERO.tables
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class TablesFacility extends Facility {
+
+    /** The mimetype of an omero tables file */
+    public static final String TABLES_MIMETYPE = "OMERO.tables";
+    
+    /**
+     * Creates a new instance
+     * 
+     * @param gateway
+     *            Reference to the {@link Gateway}
+     */
+    TablesFacility(Gateway gateway) {
+        super(gateway);
+    }
+
+    /**
+     * Adds a new table with the provided data
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param target
+     *            The object to attach the table to
+     * @param name
+     *            A name for the table (can be <code>null</code>)
+     * @param data
+     *            The data
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public void addTable(SecurityContext ctx, DataObject target, String name,
+            TableData data) throws DSOutOfServiceException, DSAccessException {
+        try {
+            if (name == null)
+                name = UUID.randomUUID().toString();
+
+            String[] columnNames = data.getColumnNames() != null ? data
+                    .getColumnNames() : new String[0];
+
+            String[] description = data.getDescriptions() != null ? data
+                    .getDescriptions() : new String[0];
+
+            Column[] columns = new Column[data.getTypes().length];
+            for (int i = 0; i < data.getTypes().length; i++) {
+                String cname = columnNames.length > i ? columnNames[i] : "";
+                String desc = description.length > i ? description[i] : "";
+                Object[] d = data.getData().length > i ? data.getData()[i]
+                        : new Object[0];
+                columns[i] = createColumn(cname, desc, data.getTypes()[i], d);
+            }
+
+            SharedResourcesPrx sr = gateway.getSharedResources(ctx);
+            if (!sr.areTablesEnabled()) {
+                throw new Exception("Tables feature is not enabled on this server!");
+            }
+            long repId = sr.repositories().descriptions.get(0).getId()
+                    .getValue();
+            TablePrx table = sr.newTable(repId, name);
+            table.initialize(columns);
+            table.addData(columns);
+            table.close();
+
+            DataManagerFacility dm = gateway
+                    .getFacility(DataManagerFacility.class);
+            BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
+
+            OriginalFile file = table.getOriginalFile();
+            file = (OriginalFile) browse.findIObject(ctx, file);
+
+            FileAnnotation anno = new FileAnnotationI();
+            anno.setFile(file);
+            FileAnnotationData annotation = new FileAnnotationData(anno);
+            annotation.setDescription(name);
+
+            annotation = (FileAnnotationData) dm.saveAndReturnObject(ctx,
+                    annotation);
+            dm.attachAnnotation(ctx, annotation, target);
+        } catch (Exception e) {
+            handleException(this, e, "Could not add table");
+        }
+    }
+
+    /**
+     * Load the data from a table
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The if of the {@link OriginalFile} which stores the table
+     * @return All data which the table contains
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public TableData getTable(SecurityContext ctx, long fileId)
+            throws DSOutOfServiceException, DSAccessException {
+        try {
+            OriginalFile file = new OriginalFileI(fileId, false);
+            SharedResourcesPrx sr = gateway.getSharedResources(ctx);
+            TablePrx table = sr.openTable(file);
+
+            Column[] columns = table.getHeaders();
+
+            String[] header = new String[columns.length];
+            String[] descriptions = new String[columns.length];
+            Class<?>[] types = new Class<?>[columns.length];
+            long[] colNumbers = new long[columns.length];
+            for (int i = 0; i < columns.length; i++) {
+                header[i] = columns[i].name;
+                descriptions[i] = columns[i].description;
+                colNumbers[i] = i;
+            }
+
+            if (table.getNumberOfRows() == 0) {
+                for (int i = 0; i < columns.length; i++) {
+                    types[i] = Object.class;
+                }
+                return new TableData(header, descriptions, types,
+                        new Object[columns.length][0]);
+            }
+
+            int nRows = (int) table.getNumberOfRows();
+            Object[][] dataArray = new Object[columns.length][nRows];
+            Data data = table.read(colNumbers, 0, table.getNumberOfRows());
+            for (int i = 0; i < data.columns.length; i++) {
+                Column col = data.columns[i];
+                if (col instanceof BoolColumn) {
+                    Boolean[] rowData = new Boolean[nRows];
+                    boolean tableData[] = ((BoolColumn) col).values;
+                    for (int j = 0; j < nRows; j++)
+                        rowData[j] = tableData[j];
+                    dataArray[i] = rowData;
+                    types[i] = Boolean.class;
+                }
+                if (col instanceof DoubleArrayColumn) {
+                    Double[][] rowData = new Double[nRows][];
+                    double tableData[][] = ((DoubleArrayColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Double[] tmp = new Double[tableData[j].length];
+                        for (int k = 0; k < tableData[j].length; k++) {
+                            tmp[k] = tableData[j][k];
+                        }
+                        rowData[j] = tmp;
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = Double[].class;
+                }
+                if (col instanceof DoubleColumn) {
+                    Double[] rowData = new Double[nRows];
+                    double tableData[] = ((DoubleColumn) col).values;
+                    for (int j = 0; j < nRows; j++)
+                        rowData[j] = tableData[j];
+                    dataArray[i] = rowData;
+                    types[i] = Double.class;
+                }
+                if (col instanceof FileColumn) {
+                    FileAnnotationData[] rowData = new FileAnnotationData[nRows];
+                    long tableData[] = ((FileColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        FileAnnotation f = new FileAnnotationI(tableData[j],
+                                false);
+                        rowData[j] = new FileAnnotationData(f);
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = FileAnnotationData.class;
+                }
+                if (col instanceof FloatArrayColumn) {
+                    Float[][] rowData = new Float[nRows][];
+                    float tableData[][] = ((FloatArrayColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Float[] tmp = new Float[tableData[j].length];
+                        for (int k = 0; k < tableData[j].length; k++) {
+                            tmp[k] = tableData[j][k];
+                        }
+                        rowData[j] = tmp;
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = Float[].class;
+                }
+                if (col instanceof ImageColumn) {
+                    ImageData[] rowData = new ImageData[nRows];
+                    long tableData[] = ((ImageColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Image im = new ImageI(tableData[j], false);
+                        rowData[j] = new ImageData(im);
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = ImageData.class;
+                }
+                if (col instanceof LongArrayColumn) {
+                    Long[][] rowData = new Long[nRows][];
+                    long tableData[][] = ((LongArrayColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Long[] tmp = new Long[tableData[j].length];
+                        for (int k = 0; k < tableData[j].length; k++) {
+                            tmp[k] = tableData[j][k];
+                        }
+                        rowData[j] = tmp;
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = Long[].class;
+                }
+                if (col instanceof LongColumn) {
+                    Long[] rowData = new Long[nRows];
+                    long tableData[] = ((LongColumn) col).values;
+                    for (int j = 0; j < nRows; j++)
+                        rowData[j] = tableData[j];
+                    dataArray[i] = rowData;
+                    types[i] = Long.class;
+                }
+                if (col instanceof MaskColumn) {
+                    MaskColumn mc = ((MaskColumn) col);
+                    MaskData[] rowData = new MaskData[nRows];
+                    for (int j = 0; j < nRows; j++) {
+                        MaskData md = new MaskData(mc.x[j], mc.y[j], mc.w[j],
+                                mc.h[j], mc.bytes[j]);
+                        rowData[j] = md;
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = MaskData.class;
+                }
+                if (col instanceof PlateColumn) {
+                    PlateData[] rowData = new PlateData[nRows];
+                    long tableData[] = ((PlateColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Plate p = new PlateI(tableData[j], false);
+                        rowData[j] = new PlateData(p);
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = PlateData.class;
+                }
+                if (col instanceof RoiColumn) {
+                    ROIData[] rowData = new ROIData[nRows];
+                    long tableData[] = ((RoiColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        Roi p = new RoiI(tableData[j], false);
+                        rowData[j] = new ROIData(p);
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = ROIData.class;
+                }
+                if (col instanceof StringColumn) {
+                    String[] rowData = ((StringColumn) col).values;
+                    dataArray[i] = rowData;
+                    types[i] = String.class;
+                }
+                if (col instanceof WellColumn) {
+                    WellSampleData[] rowData = new WellSampleData[nRows];
+                    long tableData[] = ((WellColumn) col).values;
+                    for (int j = 0; j < nRows; j++) {
+                        WellSample p = new WellSampleI(tableData[j], false);
+                        rowData[j] = new WellSampleData(p);
+                    }
+                    dataArray[i] = rowData;
+                    types[i] = ROIData.class;
+                }
+            }
+            return new TableData(header, descriptions, types, dataArray);
+        } catch (Exception e) {
+            handleException(this, e, "Could not load table data");
+        }
+        return null;
+    }
+
+    /**
+     * Get all available tables for a the specified object
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param parent
+     *            The {@link DataObject}
+     * @return See above
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public Collection<FileData> getAvailableTables(SecurityContext ctx,
+            DataObject parent) throws DSOutOfServiceException,
+            DSAccessException {
+        Collection<FileData> result = new ArrayList<FileData>();
+        try {
+            MetadataFacility mf = gateway.getFacility(MetadataFacility.class);
+            
+            List<Class<? extends AnnotationData>> types = new ArrayList<Class<? extends AnnotationData>>(
+                    1);
+            types.add(FileAnnotationData.class);
+
+            List<AnnotationData> annos = mf.getAnnotations(ctx, parent, types,
+                    null);
+            for (AnnotationData anno : annos) {
+                FileAnnotationData fad = (FileAnnotationData) anno;
+                if(fad.getOriginalMimetype().equals(TABLES_MIMETYPE)) {
+                    long fileId = ((FileAnnotationData) anno).getFileID();
+                    OriginalFile file = new OriginalFileI(fileId, false);
+                    result.add(new FileData(file));
+                }
+            }
+
+        } catch (Exception e) {
+            handleException(this, e, "Could not load tables");
+        }
+        return result;
+    }
+
+    /**
+     * Create a {@link Column} with the specified data
+     * 
+     * @param header
+     *            The header (column name)
+     * @param description
+     *            Description
+     * @param type
+     *            The type of data
+     * @param data
+     *            The data
+     * @return The {@link Column}
+     */
+    private Column createColumn(String header, String description,
+            Class<?> type, Object[] data) {
+        Column c = null;
+
+        if (type.equals(Boolean.class)) {
+            boolean[] d = new boolean[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Boolean) data[i];
+            c = new BoolColumn(header, description, d);
+        }
+
+        if (type.equals(Double[].class)) {
+            double[][] d = new double[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Double[] src = (Double[]) data[i];
+                double[] dst = new double[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new DoubleArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(Double.class)) {
+            double[] d = new double[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Double) data[i];
+            c = new DoubleColumn(header, description, d);
+        }
+
+        if (type.equals(FileAnnotationData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((FileAnnotationData) data[i]).getFileID();
+            c = new FileColumn(header, description, d);
+        }
+
+        if (type.equals(Float[].class)) {
+            float[][] d = new float[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Float[] src = (Float[]) data[i];
+                float[] dst = new float[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new FloatArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(ImageData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((ImageData) data[i]).getId();
+            c = new ImageColumn(header, description, d);
+        }
+
+        if (type.equals(Long[].class)) {
+            long[][] d = new long[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Long[] src = (Long[]) data[i];
+                long[] dst = new long[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new LongArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(Long.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Long) data[i];
+            c = new LongColumn(header, description, d);
+        }
+
+        if (type.equals(MaskData.class)) {
+            long[] imageId = new long[data.length];
+            int[] theZ = new int[data.length];
+            int[] theT = new int[data.length];
+            double[] x = new double[data.length];
+            double[] y = new double[data.length];
+            double[] w = new double[data.length];
+            double[] h = new double[data.length];
+            byte[][] bytes = new byte[data.length][];
+
+            for (int i = 0; i < data.length; i++) {
+                MaskData md = (MaskData) data[i];
+                // TODO: Where get the imageId from!?
+                theZ[i] = md.getZ();
+                theT[i] = md.getT();
+                x[i] = md.getX();
+                y[i] = md.getY();
+                w[i] = md.getWidth();
+                h[i] = md.getHeight();
+                bytes[i] = md.getMask();
+            }
+
+            c = new MaskColumn(header, description, imageId, theZ, theT, x, y,
+                    w, h, bytes);
+        }
+
+        if (type.equals(PlateData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((PlateData) data[i]).getId();
+            c = new PlateColumn(header, description, d);
+        }
+
+        if (type.equals(ROIData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((ROIData) data[i]).getId();
+            c = new RoiColumn(header, description, d);
+        }
+
+        if (type.equals(String.class)) {
+            String[] d = new String[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (String) data[i];
+            c = new StringColumn(header, description, Short.MAX_VALUE, d);
+        }
+
+        if (type.equals(WellSampleData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((WellSampleData) data[i]).getId();
+            c = new WellColumn(header, description, d);
+        }
+
+        return c;
+    }
+}

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -253,7 +253,7 @@ public class TablesFacility extends Facility {
             if (rowFrom < 0)
                 rowFrom = 0;
 
-            long maxRow = (int) table.getNumberOfRows() - 1;
+            long maxRow = table.getNumberOfRows() - 1;
 
             if (rowTo < 0)
                 rowTo = rowFrom + DEFAULT_MAX_ROWS_TO_FETCH;
@@ -404,6 +404,7 @@ public class TablesFacility extends Facility {
             TableData result = new TableData(header, dataArray);
             result.setOffset(rowFrom);
             result.setOriginalFileId(fileId);
+            result.setCompleted(rowTo == maxRow);
             return result;
         } catch (Exception e) {
             handleException(this, e, "Could not load table data");

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -122,16 +122,15 @@ public class TablesFacility extends Facility {
             TableDataColumn[] columns = data.getColumns() != null ? data
                     .getColumns() : new TableDataColumn[0];
 
-            String[] description = data.getDescriptions() != null ? data
-                    .getDescriptions() : new String[0];
-
             Column[] gridColumns = new Column[data.getColumns().length];
             for (int i = 0; i < data.getColumns().length; i++) {
                 String cname = columns.length > i ? columns[i].getName() : "";
-                String desc = description.length > i ? description[i] : "";
+                String desc = columns.length > i ? columns[i].getDescription()
+                        : "";
                 Object[] d = data.getData().length > i ? data.getData()[i]
                         : new Object[0];
-                gridColumns[i] = createColumn(cname, desc, data.getColumns()[i].getType(), d);
+                gridColumns[i] = createColumn(cname, desc,
+                        data.getColumns()[i].getType(), d);
             }
 
             SharedResourcesPrx sr = gateway.getSharedResources(ctx);
@@ -182,7 +181,7 @@ public class TablesFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @param fileId
-     *            The if of the {@link OriginalFile} which stores the table
+     *            The id of the {@link OriginalFile} which stores the table
      * @return All data which the table contains
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in
@@ -201,13 +200,13 @@ public class TablesFacility extends Facility {
      * @param ctx
      *            The {@link SecurityContext}
      * @param fileId
-     *            The if of the {@link OriginalFile} which stores the table
+     *            The id of the {@link OriginalFile} which stores the table
      * @param rowFrom
      *            The start row (inclusive)
      * @param rowTo
-     *            The end row (can be <code>-1</code> in which case
+     *            The end row (inclusive) (can be <code>-1</code> in which case
      *            {@link TablesFacility#DEFAULT_MAX_ROWS_TO_FETCH} rows will be
-     *            fetched) (inclusive)
+     *            fetched)
      * @param columns
      *            The columns to take into account (can be left unspecified, in
      *            which case all columns will used)
@@ -229,7 +228,7 @@ public class TablesFacility extends Facility {
                 throw new Exception(
                         "Tables feature is not enabled on this server!");
             }
-            
+
             table = sr.openTable(file);
 
             Column[] cols = table.getHeaders();
@@ -242,17 +241,16 @@ public class TablesFacility extends Facility {
             }
 
             TableDataColumn[] header = new TableDataColumn[columns.length];
-            String[] descriptions = new String[columns.length];
             for (int i = 0; i < columns.length; i++) {
                 int columnIndex = (int) columns[i];
-                header[i] = new TableDataColumn(cols[columnIndex].name, columnIndex,  Object.class);
-                descriptions[i] = cols[columnIndex].description;
+                header[i] = new TableDataColumn(cols[columnIndex].name,
+                        cols[columnIndex].description, columnIndex,
+                        Object.class);
             }
 
-            if (table.getNumberOfRows() == 0) 
-                return new TableData(header, descriptions,
-                        new Object[columns.length][0]);
-            
+            if (table.getNumberOfRows() == 0)
+                return new TableData(header, new Object[columns.length][0]);
+
             if (rowFrom < 0)
                 rowFrom = 0;
 
@@ -404,8 +402,7 @@ public class TablesFacility extends Facility {
                     header[i].setType(ROIData.class);
                 }
             }
-            TableData result = new TableData(header, descriptions,
-                    dataArray);
+            TableData result = new TableData(header, dataArray);
             result.setOffset(rowFrom);
             result.setOriginalFileId(fileId);
             return result;

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -168,6 +168,7 @@ public class TablesFacility extends Facility {
                 try {
                     table.close();
                 } catch (ServerError e) {
+                    logError(this, "Could not close table", e);
                 }
         }
         return data;
@@ -452,6 +453,7 @@ public class TablesFacility extends Facility {
                 try {
                     table.close();
                 } catch (ServerError e) {
+                    logError(this, "Could not close table", e);
                 }
         }
         return null;

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -190,7 +190,7 @@ public class TablesFacility extends Facility {
      */
     public TableData getTable(SecurityContext ctx, long fileId)
             throws DSOutOfServiceException, DSAccessException {
-        return getTable(ctx, fileId, 0, DEFAULT_MAX_ROWS_TO_FETCH);
+        return getTable(ctx, fileId, 0, DEFAULT_MAX_ROWS_TO_FETCH - 1);
     }
 
     /**
@@ -219,9 +219,12 @@ public class TablesFacility extends Facility {
     public TableData getTable(SecurityContext ctx, long fileId, long rowFrom,
             long rowTo, int... columns) throws DSOutOfServiceException,
             DSAccessException {
-        long[] lcolumns = new long[columns.length];
-        for (int i = 0; i < columns.length; i++) {
-            lcolumns[i] = columns[i];
+        long[] lcolumns = null;
+        if (columns != null) {
+            lcolumns = new long[columns.length];
+            for (int i = 0; i < columns.length; i++) {
+                lcolumns[i] = columns[i];
+            }
         }
         return getTable(ctx, fileId, rowFrom, rowTo, lcolumns);
     }

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -175,6 +175,27 @@ public class TablesFacility extends Facility {
     }
 
     /**
+     * Get basic information about a table.
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The id of the {@link OriginalFile} which stores the table
+     * @return An 'empty' {@link TableData} object without the actual table data
+     *         loaded; which only contains information about the columns and the
+     *         size of the table.
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
+    public TableData getTableInfo(SecurityContext ctx, long fileId)
+            throws DSOutOfServiceException, DSAccessException {
+        return getTable(ctx, fileId, 0, 0);
+    }
+    
+    /**
      * Load the data from a table (Note: limited to
      * {@link TablesFacility#DEFAULT_MAX_ROWS_TO_FETCH} number of rows)
      * 

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -79,7 +79,7 @@ public class TablesFacility extends Facility {
     /** The mimetype of an omero tables file */
     public static final String TABLES_MIMETYPE = "OMERO.tables";
 
-    /** Maximum number of rows to fetch */
+    /** Maximum number of rows to fetch if not specified otherwise */
     public static final int DEFAULT_MAX_ROWS_TO_FETCH = 1000;
 
     /**

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -142,7 +142,6 @@ public class TablesFacility extends Facility {
             table = sr.newTable(repId, name);
             table.initialize(gridColumns);
             table.addData(gridColumns);
-            table.close();
 
             DataManagerFacility dm = gateway
                     .getFacility(DataManagerFacility.class);

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -134,7 +134,7 @@ public class TablesFacility extends Facility {
 
             SharedResourcesPrx sr = gateway.getSharedResources(ctx);
             if (!sr.areTablesEnabled()) {
-                throw new Exception(
+                throw new DSAccessException(
                         "Tables feature is not enabled on this server!");
             }
             long repId = sr.repositories().descriptions.get(0).getId()
@@ -282,7 +282,7 @@ public class TablesFacility extends Facility {
             OriginalFile file = new OriginalFileI(fileId, false);
             SharedResourcesPrx sr = gateway.getSharedResources(ctx);
             if (!sr.areTablesEnabled()) {
-                throw new Exception(
+                throw new DSAccessException(
                         "Tables feature is not enabled on this server!");
             }
 

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -203,7 +203,7 @@ public class TablesFacility extends Facility {
      *            The {@link SecurityContext}
      * @param fileId
      *            The id of the {@link OriginalFile} which stores the table
-     * @return All data which the table contains
+     * @return The data which the table contains
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in
      * @throws DSAccessException
@@ -216,7 +216,7 @@ public class TablesFacility extends Facility {
     }
 
     /**
-     * Load the data from a table
+     * Load data from a table
      * 
      * @param ctx
      *            The {@link SecurityContext}
@@ -231,7 +231,7 @@ public class TablesFacility extends Facility {
      * @param columns
      *            The columns to take into account (can be left unspecified, in
      *            which case all columns will used)
-     * @return All data which the table contains
+     * @return The specified data
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in
      * @throws DSAccessException
@@ -252,7 +252,7 @@ public class TablesFacility extends Facility {
     }
     
     /**
-     * Load the data from a table
+     * Load data from a table
      * 
      * @param ctx
      *            The {@link SecurityContext}
@@ -267,7 +267,7 @@ public class TablesFacility extends Facility {
      * @param columns
      *            The columns to take into account (can be left unspecified, in
      *            which case all columns will used)
-     * @return All data which the table contains
+     * @return The specified data
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in
      * @throws DSAccessException

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -160,6 +160,7 @@ public class TablesFacility extends Facility {
             dm.attachAnnotation(ctx, annotation, target);
 
             data.setOriginalFileId(file.getId().getValue());
+            data.setNumberOfRows(table.getNumberOfRows());
         } catch (Exception e) {
             handleException(this, e, "Could not add table");
         } finally {

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -39,9 +39,15 @@ public class TableData {
 
     /** The data types of the columns */
     private Class<?>[] types;
-    
-    /** The offset, if this TableData represents only a subset of the original table */
+
+    /**
+     * The offset, if this TableData represents only a subset of the original
+     * table
+     */
     private long offset = 0;
+
+    /** The Id of the original file */
+    private long originalFileId = -1;
 
     /**
      * Creates a new instance
@@ -110,6 +116,25 @@ public class TableData {
     }
 
     /**
+     * Get the original file id
+     * 
+     * @return See above
+     */
+    public long getOriginalFileId() {
+        return originalFileId;
+    }
+
+    /**
+     * Set the originalfile id
+     * 
+     * @param originalFileId
+     *            The originalfile id
+     */
+    public void setOriginalFileId(long originalFileId) {
+        this.originalFileId = originalFileId;
+    }
+
+    /**
      * Set the row offset (if this {@link TableData} represents only a subset of
      * the original table)
      * 
@@ -124,7 +149,8 @@ public class TableData {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * (int)offset;
+        result = prime + (int) offset;
+        result = prime * result + (int) originalFileId;
         result = prime * result + Arrays.hashCode(columnNames);
         result = prime * result + Arrays.hashCode(types);
         result = prime * result + objectArrayHashCode(data, types);
@@ -141,6 +167,8 @@ public class TableData {
         if (getClass() != obj.getClass())
             return false;
         TableData other = (TableData) obj;
+        if (originalFileId != other.getOriginalFileId())
+            return false;
         if (offset != other.getOffset())
             return false;
         if (Arrays.hashCode(types) != Arrays.hashCode(other.types))
@@ -217,6 +245,5 @@ public class TableData {
 
         return result;
     }
-    
-    
+
 }

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -39,6 +39,9 @@ public class TableData {
 
     /** The data types of the columns */
     private Class<?>[] types;
+    
+    /** The offset, if this TableData represents only a subset of the original table */
+    private long offset = 0;
 
     /**
      * Creates a new instance
@@ -96,10 +99,32 @@ public class TableData {
         return types;
     }
 
+    /**
+     * Get the row offset (if this {@link TableData} represents only a subset of
+     * the original table)
+     * 
+     * @return See above
+     */
+    public long getOffset() {
+        return offset;
+    }
+
+    /**
+     * Set the row offset (if this {@link TableData} represents only a subset of
+     * the original table)
+     * 
+     * @param offset
+     *            The row offset
+     */
+    public void setOffset(long offset) {
+        this.offset = offset;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * (int)offset;
         result = prime * result + Arrays.hashCode(columnNames);
         result = prime * result + Arrays.hashCode(types);
         result = prime * result + objectArrayHashCode(data, types);
@@ -116,6 +141,8 @@ public class TableData {
         if (getClass() != obj.getClass())
             return false;
         TableData other = (TableData) obj;
+        if (offset != other.getOffset())
+            return false;
         if (Arrays.hashCode(types) != Arrays.hashCode(other.types))
             return false;
         if (stringArrayHashCode(columnNames) != stringArrayHashCode(other.columnNames))
@@ -190,4 +217,6 @@ public class TableData {
 
         return result;
     }
+    
+    
 }

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -31,9 +31,6 @@ public class TableData {
     /** The column definitions */
     private TableDataColumn columns[];
 
-    /** Column descriptions */
-    private String descriptions[];
-
     /** The data in form data['column index']['row data'] */
     private Object[][] data;
 
@@ -51,14 +48,11 @@ public class TableData {
      * 
      * @param columns
      *            The headers; can be <code>null</code>
-     * @param descriptions
-     *            Column descriptions; can be <code>null</code>
      * @param data
      *            The data in form data['column index']['row data']
      */
-    public TableData(TableDataColumn[] columns, String[] descriptions, Object[][] data) {
+    public TableData(TableDataColumn[] columns, Object[][] data) {
         this.columns = columns;
-        this.descriptions = descriptions;
         this.data = data;
     }
 
@@ -69,15 +63,6 @@ public class TableData {
      */
     public TableDataColumn[] getColumns() {
         return columns;
-    }
-
-    /**
-     * Get the column descriptions
-     * 
-     * @return See above
-     */
-    public String[] getDescriptions() {
-        return descriptions;
     }
 
     /**
@@ -136,7 +121,6 @@ public class TableData {
         result = prime + (int) offset;
         result = prime * result + (int) originalFileId;
         result = prime * result + Arrays.hashCode(columns);
-        result = prime * result + Arrays.hashCode(descriptions);
         return result;
     }
 
@@ -155,29 +139,10 @@ public class TableData {
             return false;
         if (Arrays.hashCode(columns) != Arrays.hashCode(other.columns))
             return false;
-        if (stringArrayHashCode(descriptions) != stringArrayHashCode(other.descriptions))
-            return false;
         if (objectArrayHashCode(data, columns) != objectArrayHashCode(other.data,
                 other.columns))
             return false;
         return true;
-    }
-
-    /**
-     * Generates a hash code for a String array, ignoring empty and
-     * <code>null</code> Strings
-     * 
-     * @param array
-     *            The String array to generate the hash code for
-     * @return See above.
-     */
-    private int stringArrayHashCode(String[] array) {
-        StringBuilder sb = new StringBuilder();
-        if (array != null) {
-            for (String s : array)
-                sb.append(s);
-        }
-        return sb.toString().hashCode();
     }
 
     /**

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -28,17 +28,14 @@ import java.util.Arrays;
  */
 public class TableData {
 
-    /** The table header */
-    private String columnNames[];
+    /** The column definitions */
+    private TableDataColumn columns[];
 
     /** Column descriptions */
     private String descriptions[];
 
     /** The data in form data['column index']['row data'] */
     private Object[][] data;
-
-    /** The data types of the columns */
-    private Class<?>[] types;
 
     /**
      * The offset, if this TableData represents only a subset of the original
@@ -52,21 +49,17 @@ public class TableData {
     /**
      * Creates a new instance
      * 
-     * @param columnNames
+     * @param columns
      *            The headers; can be <code>null</code>
      * @param descriptions
      *            Column descriptions; can be <code>null</code>
-     * @param types
-     *            The data types of the columns
      * @param data
      *            The data in form data['column index']['row data']
      */
-    public TableData(String[] columnNames, String[] descriptions,
-            Class<?>[] types, Object[][] data) {
-        this.columnNames = columnNames;
+    public TableData(TableDataColumn[] columns, String[] descriptions, Object[][] data) {
+        this.columns = columns;
         this.descriptions = descriptions;
         this.data = data;
-        this.types = types;
     }
 
     /**
@@ -74,8 +67,8 @@ public class TableData {
      * 
      * @return See above
      */
-    public String[] getColumnNames() {
-        return columnNames;
+    public TableDataColumn[] getColumns() {
+        return columns;
     }
 
     /**
@@ -94,15 +87,6 @@ public class TableData {
      */
     public Object[][] getData() {
         return data;
-    }
-
-    /**
-     * Get the data types
-     * 
-     * @return See above
-     */
-    public Class<?>[] getTypes() {
-        return types;
     }
 
     /**
@@ -151,9 +135,7 @@ public class TableData {
         int result = 1;
         result = prime + (int) offset;
         result = prime * result + (int) originalFileId;
-        result = prime * result + Arrays.hashCode(columnNames);
-        result = prime * result + Arrays.hashCode(types);
-        result = prime * result + objectArrayHashCode(data, types);
+        result = prime * result + Arrays.hashCode(columns);
         result = prime * result + Arrays.hashCode(descriptions);
         return result;
     }
@@ -171,14 +153,12 @@ public class TableData {
             return false;
         if (offset != other.getOffset())
             return false;
-        if (Arrays.hashCode(types) != Arrays.hashCode(other.types))
-            return false;
-        if (stringArrayHashCode(columnNames) != stringArrayHashCode(other.columnNames))
+        if (Arrays.hashCode(columns) != Arrays.hashCode(other.columns))
             return false;
         if (stringArrayHashCode(descriptions) != stringArrayHashCode(other.descriptions))
             return false;
-        if (objectArrayHashCode(data, types) != objectArrayHashCode(other.data,
-                other.types))
+        if (objectArrayHashCode(data, columns) != objectArrayHashCode(other.data,
+                other.columns))
             return false;
         return true;
     }
@@ -212,7 +192,7 @@ public class TableData {
      *            the same type (<code>types[i]</code>).
      * @return See above
      */
-    private int objectArrayHashCode(Object[][] objects, Class[] types) {
+    private int objectArrayHashCode(Object[][] objects, TableDataColumn[] columns) {
 
         // The reason for this method is, that we can't use Arrays.hashCode()
         // method on Object[][] arrays, because an Object[][] array can be
@@ -234,8 +214,8 @@ public class TableData {
             Object[] col = objects[i];
 
             for (int j = 0; j < col.length; j++) {
-                Object castedObject = types[i].cast(col[j]);
-                if (types[i].isArray())
+                Object castedObject = columns[i].getType().cast(col[j]);
+                if (columns[i].getType().isArray())
                     result = prime * result
                             + Arrays.hashCode((Object[]) castedObject);
                 else
@@ -250,17 +230,9 @@ public class TableData {
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        if (columnNames != null) {
-            for (int i = 0; i < columnNames.length; i++) {
-                sb.append(columnNames[i]);
-                sb.append('\t');
-            }
-            sb.append('\n');
-        }
-
-        if (types != null) {
-            for (int i = 0; i < types.length; i++) {
-                sb.append(types[i].getSimpleName());
+        if (columns != null) {
+            for (int i = 0; i < columns.length; i++) {
+                sb.append(columns[i]);
                 sb.append('\t');
             }
             sb.append('\n');

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package omero.gateway.model;
+
+import java.util.Arrays;
+
+/**
+ * A simple data 'container' for an OMERO.table
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class TableData {
+
+    /** The table header */
+    private String columnNames[];
+
+    /** Column descriptions */
+    private String descriptions[];
+
+    /** The data in form data['column index']['row data'] */
+    private Object[][] data;
+
+    /** The data types of the columns */
+    private Class<?>[] types;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param columnNames
+     *            The headers; can be <code>null</code>
+     * @param descriptions
+     *            Column descriptions; can be <code>null</code>
+     * @param types
+     *            The data types of the columns
+     * @param data
+     *            The data in form data['column index']['row data']
+     */
+    public TableData(String[] columnNames, String[] descriptions,
+            Class<?>[] types, Object[][] data) {
+        this.columnNames = columnNames;
+        this.descriptions = descriptions;
+        this.data = data;
+        this.types = types;
+    }
+
+    /**
+     * Get the headers
+     * 
+     * @return See above
+     */
+    public String[] getColumnNames() {
+        return columnNames;
+    }
+
+    /**
+     * Get the column descriptions
+     * 
+     * @return See above
+     */
+    public String[] getDescriptions() {
+        return descriptions;
+    }
+
+    /**
+     * Get the data
+     * 
+     * @return See above
+     */
+    public Object[][] getData() {
+        return data;
+    }
+
+    /**
+     * Get the data types
+     * 
+     * @return See above
+     */
+    public Class<?>[] getTypes() {
+        return types;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(columnNames);
+        result = prime * result + Arrays.hashCode(types);
+        result = prime * result + objectArrayHashCode(data, types);
+        result = prime * result + Arrays.hashCode(descriptions);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TableData other = (TableData) obj;
+        if (Arrays.hashCode(types) != Arrays.hashCode(other.types))
+            return false;
+        if (stringArrayHashCode(columnNames) != stringArrayHashCode(other.columnNames))
+            return false;
+        if (stringArrayHashCode(descriptions) != stringArrayHashCode(other.descriptions))
+            return false;
+        if (objectArrayHashCode(data, types) != objectArrayHashCode(other.data,
+                other.types))
+            return false;
+        return true;
+    }
+
+    /**
+     * Generates a hash code for a String array, ignoring empty and
+     * <code>null</code> Strings
+     * 
+     * @param array
+     *            The String array to generate the hash code for
+     * @return See above.
+     */
+    private int stringArrayHashCode(String[] array) {
+        StringBuilder sb = new StringBuilder();
+        if (array != null) {
+            for (String s : array)
+                sb.append(s);
+        }
+        return sb.toString().hashCode();
+    }
+
+    /**
+     * Generates a hash code by iterating over all elements and casting them to
+     * their proposed classes
+     * 
+     * @param objects
+     *            The array to generate the object for
+     * @param types
+     *            The types of the elements in the array; it's assumed that
+     *            every element of a sub array (<code>object[i][]</code>) has
+     *            the same type (<code>types[i]</code>).
+     * @return See above
+     */
+    private int objectArrayHashCode(Object[][] objects, Class[] types) {
+
+        // The reason for this method is, that we can't use Arrays.hashCode()
+        // method on Object[][] arrays, because an Object[][] array can be
+        // for example an array of Object arrays, but also an array of String
+        // arrays, in which case they have a different hash codes and are
+        // *not* equal even if they contain in fact equal elements.
+        // An example for this:
+        // Object[][] test = new String[1][1];
+        // test[0] = new String[1];
+        // test[0][0] = new String("test");
+        // Object[][] test2 = new Object[1][1];
+        // test2[0][0] = new String("test");
+        // --> Arrays.hashCode(test) != Arrays.hashCode(test2)
+
+        final int prime = 31;
+        int result = 1;
+
+        for (int i = 0; i < objects.length; i++) {
+            Object[] col = objects[i];
+
+            for (int j = 0; j < col.length; j++) {
+                Object castedObject = types[i].cast(col[j]);
+                if (types[i].isArray())
+                    result = prime * result
+                            + Arrays.hashCode((Object[]) castedObject);
+                else
+                    result = prime * result + castedObject.hashCode();
+            }
+        }
+
+        return result;
+    }
+}

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -246,4 +246,41 @@ public class TableData {
         return result;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        if (columnNames != null) {
+            for (int i = 0; i < columnNames.length; i++) {
+                sb.append(columnNames[i]);
+                sb.append('\t');
+            }
+            sb.append('\n');
+        }
+
+        if (types != null) {
+            for (int i = 0; i < types.length; i++) {
+                sb.append(types[i].getSimpleName());
+                sb.append('\t');
+            }
+            sb.append('\n');
+        }
+
+        if (data == null || data.length == 0)
+            return sb.toString();
+
+        int nRows = 0;
+        if (data[0] != null)
+            nRows = data[0].length;
+        for (int r = 0; r < nRows; r++) {
+            for (int c = 0; c < data.length; c++) {
+                sb.append(data[c][r]);
+                sb.append('\t');
+            }
+            sb.append('\n');
+        }
+
+        return sb.toString();
+    }
+
 }

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -45,6 +45,12 @@ public class TableData {
     private long originalFileId = -1;
 
     /**
+     * Flag to indicate if this TableData object contains that last available
+     * row
+     */
+    private boolean completed = true;
+
+    /**
      * Creates a new instance
      * 
      * @param columns
@@ -64,7 +70,7 @@ public class TableData {
                 this.data[i][j] = columnData.get(j);
         }
     }
-    
+
     /**
      * Creates a new instance
      * 
@@ -136,11 +142,32 @@ public class TableData {
         this.offset = offset;
     }
 
+    /**
+     * @return <code>true</code> if the last available row is contained,
+     *         <code>false</code> if there's more data available in the original
+     *         table
+     */
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    /**
+     * Set to <code>true</code> if the last available row is contained,
+     * <code>false</code> if there's more data available in the original table
+     * 
+     * @param completed
+     *            See above
+     */
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime + (int) offset;
+        result = prime * result + (completed ? 1231 : 1237);
         result = prime * result + (int) originalFileId;
         result = prime * result + Arrays.hashCode(columns);
         return result;
@@ -159,10 +186,12 @@ public class TableData {
             return false;
         if (offset != other.getOffset())
             return false;
+        if (completed != other.completed)
+            return false;
         if (Arrays.hashCode(columns) != Arrays.hashCode(other.columns))
             return false;
-        if (objectArrayHashCode(data, columns) != objectArrayHashCode(other.data,
-                other.columns))
+        if (objectArrayHashCode(data, columns) != objectArrayHashCode(
+                other.data, other.columns))
             return false;
         return true;
     }
@@ -179,7 +208,8 @@ public class TableData {
      *            the same type (<code>types[i]</code>).
      * @return See above
      */
-    private int objectArrayHashCode(Object[][] objects, TableDataColumn[] columns) {
+    private int objectArrayHashCode(Object[][] objects,
+            TableDataColumn[] columns) {
 
         // The reason for this method is, that we can't use Arrays.hashCode()
         // method on Object[][] arrays, because an Object[][] array can be

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -19,6 +19,7 @@
 package omero.gateway.model;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * A simple data 'container' for an OMERO.table
@@ -47,7 +48,28 @@ public class TableData {
      * Creates a new instance
      * 
      * @param columns
-     *            The headers; can be <code>null</code>
+     *            The column definitions
+     * @param data
+     *            The data in form of List of columns
+     */
+    public TableData(List<TableDataColumn> columns, List<List<Object>> data) {
+        this.columns = new TableDataColumn[columns.size()];
+        this.columns = columns.toArray(this.columns);
+
+        int nRows = !data.isEmpty() ? data.get(0).size() : 0;
+        this.data = new Object[data.size()][nRows];
+        for (int i = 0; i < data.size(); i++) {
+            List<Object> columnData = data.get(i);
+            for (int j = 0; j < columnData.size(); j++)
+                this.data[i][j] = columnData.get(j);
+        }
+    }
+    
+    /**
+     * Creates a new instance
+     * 
+     * @param columns
+     *            The column definitions
      * @param data
      *            The data in form data['column index']['row data']
      */

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -45,10 +45,10 @@ public class TableData {
     private long originalFileId = -1;
 
     /**
-     * Flag to indicate if this TableData object contains that last available
-     * row
+     * Number of rows in the original table (this doesn't have to match
+     * data[x].length, depending on how many rows are loaded)
      */
-    private boolean completed = true;
+    private long numberOfRows = 0;
 
     /**
      * Creates a new instance
@@ -148,18 +148,37 @@ public class TableData {
      *         table
      */
     public boolean isCompleted() {
-        return completed;
+        if (data == null || data.length == 0)
+            return true;
+
+        return (offset + data[0].length) == numberOfRows;
     }
 
     /**
-     * Set to <code>true</code> if the last available row is contained,
-     * <code>false</code> if there's more data available in the original table
+     * Manually set completed state (sets the {@link TableData#numberOfRows} to
+     * the last row in the {@link TableData#data} array)
+     */
+    public void setCompleted() {
+        this.numberOfRows = (data == null || data.length == 0) ? 0 : offset
+                + data[0].length;
+    }
+
+    /**
+     * @return The total number of rows in the original table (this doesn't have
+     *         to match data[x].length, depending on how many rows are loaded)
+     */
+    public long getNumberOfRows() {
+        return numberOfRows;
+    }
+
+    /**
+     * Set the total number of rows in the original table
      * 
-     * @param completed
+     * @param numberOfRows
      *            See above
      */
-    public void setCompleted(boolean completed) {
-        this.completed = completed;
+    public void setNumberOfRows(long numberOfRows) {
+        this.numberOfRows = numberOfRows;
     }
 
     @Override
@@ -167,7 +186,7 @@ public class TableData {
         final int prime = 31;
         int result = 1;
         result = prime + (int) offset;
-        result = prime * result + (completed ? 1231 : 1237);
+        result = prime * result + (int) numberOfRows;
         result = prime * result + (int) originalFileId;
         result = prime * result + Arrays.hashCode(columns);
         return result;
@@ -186,7 +205,7 @@ public class TableData {
             return false;
         if (offset != other.getOffset())
             return false;
-        if (completed != other.completed)
+        if (numberOfRows != other.numberOfRows)
             return false;
         if (Arrays.hashCode(columns) != Arrays.hashCode(other.columns))
             return false;

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -143,12 +143,20 @@ public class TableData {
     }
 
     /**
+     * @return <code>true</code> if this TableData object doesn't contain any
+     *         data, <code>false</code> if it does contain data.
+     */
+    public boolean isEmpty() {
+        return data == null || data.length == 0 || data[0].length == 0;
+    }
+
+    /**
      * @return <code>true</code> if the last available row is contained,
      *         <code>false</code> if there's more data available in the original
      *         table
      */
     public boolean isCompleted() {
-        if (data == null || data.length == 0)
+        if (isEmpty())
             return true;
 
         return (offset + data[0].length) == numberOfRows;
@@ -159,7 +167,7 @@ public class TableData {
      * the last row in the {@link TableData#data} array)
      */
     public void setCompleted() {
-        this.numberOfRows = (data == null || data.length == 0) ? 0 : offset
+        this.numberOfRows = isEmpty() ? 0 : offset
                 + data[0].length;
     }
 
@@ -221,7 +229,7 @@ public class TableData {
      * 
      * @param objects
      *            The array to generate the object for
-     * @param types
+     * @param columns
      *            The types of the elements in the array; it's assumed that
      *            every element of a sub array (<code>object[i][]</code>) has
      *            the same type (<code>types[i]</code>).
@@ -274,7 +282,7 @@ public class TableData {
             sb.append('\n');
         }
 
-        if (data == null || data.length == 0)
+        if (isEmpty())
             return sb.toString();
 
         int nRows = 0;

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -21,6 +21,8 @@ package omero.gateway.model;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
+
 /**
  * A simple data 'container' for an OMERO.table
  * 
@@ -59,15 +61,23 @@ public class TableData {
      *            The data in form of List of columns
      */
     public TableData(List<TableDataColumn> columns, List<List<Object>> data) {
-        this.columns = new TableDataColumn[columns.size()];
-        this.columns = columns.toArray(this.columns);
+        if (CollectionUtils.isNotEmpty(columns)) {
+            this.columns = new TableDataColumn[columns.size()];
+            this.columns = columns.toArray(this.columns);
+        } else {
+            this.columns = new TableDataColumn[0];
+        }
 
-        int nRows = !data.isEmpty() ? data.get(0).size() : 0;
-        this.data = new Object[data.size()][nRows];
-        for (int i = 0; i < data.size(); i++) {
-            List<Object> columnData = data.get(i);
-            for (int j = 0; j < columnData.size(); j++)
-                this.data[i][j] = columnData.get(j);
+        if (CollectionUtils.isNotEmpty(data)) {
+            int nRows = data.get(0).size();
+            this.data = new Object[data.size()][nRows];
+            for (int i = 0; i < data.size(); i++) {
+                List<Object> columnData = data.get(i);
+                for (int j = 0; j < columnData.size(); j++)
+                    this.data[i][j] = columnData.get(j);
+            }
+        } else {
+            this.data = new Object[0][0];
         }
     }
 
@@ -80,8 +90,8 @@ public class TableData {
      *            The data in form data['column index']['row data']
      */
     public TableData(TableDataColumn[] columns, Object[][] data) {
-        this.columns = columns;
-        this.data = data;
+        this.columns = columns != null ? columns : new TableDataColumn[0];
+        this.data = data != null ? data : new Object[0][0];
     }
 
     /**

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -1,0 +1,87 @@
+package omero.gateway.model;
+
+public class TableDataColumn {
+
+    private String name;
+
+    private int index;
+
+    private Class<?> type;
+
+    public TableDataColumn(String name, int index, Class<?> type) {
+        this.name = name;
+        this.index = index;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public void setType(Class<?> type) {
+        this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + index;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result
+                + ((type == null) ? 0 : type.getCanonicalName().hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TableDataColumn other = (TableDataColumn) obj;
+        if (index != other.index)
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.getCanonicalName().equals(
+                other.type.getCanonicalName()))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        String s = name != null ? name : "";
+        if (index > -1) {
+            s += " (" + index + ")";
+        }
+        s += " [" + type.getSimpleName() + "]";
+        return s;
+    }
+
+}

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -32,7 +32,11 @@ public class TableDataColumn {
     /** A description */
     private String description = "";
 
-    /** The index of the column */
+    /**
+     * The index of the column (in the original table; this doesn't have to
+     * match the index in the {@link TableData#columns} or
+     * {@link TableData#data} array, depending on which columns are loaded)
+     */
     private int index = -1;
 
     /** The type of data in this column */

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -1,39 +1,151 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 package omero.gateway.model;
 
+/**
+ * Defines a column for a {@link TableData} object
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
 public class TableDataColumn {
 
-    private String name;
+    /** The header */
+    private String name = "";
 
-    private int index;
+    /** A description */
+    private String description = "";
 
-    private Class<?> type;
+    /** The index of the column */
+    private int index = -1;
 
+    /** The type of data in this column */
+    private Class<?> type = null;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param name
+     *            The header
+     * @param index
+     *            The index
+     * @param type
+     *            The type of data in this column
+     */
     public TableDataColumn(String name, int index, Class<?> type) {
         this.name = name;
         this.index = index;
         this.type = type;
     }
 
+    /**
+     * Creates a new instance
+     * 
+     * @param name
+     *            The header
+     * @param description
+     *            A description
+     * @param index
+     *            The index
+     * @param type
+     *            The type of data in this column
+     */
+    public TableDataColumn(String name, String description, int index,
+            Class<?> type) {
+        this.name = name;
+        this.description = description;
+        this.index = index;
+        this.type = type;
+    }
+
+    /**
+     * Get the header
+     * 
+     * @return See above
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Set the header
+     * 
+     * @param name
+     *            The header
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Get the description
+     * 
+     * @return See description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Set the description
+     * 
+     * @param description
+     *            The description
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Get the index
+     * 
+     * @return See above
+     */
     public int getIndex() {
         return index;
     }
 
+    /**
+     * Set the index
+     * 
+     * @param index
+     *            The index
+     */
     public void setIndex(int index) {
         this.index = index;
     }
 
+    /**
+     * Get the data type
+     * 
+     * @return See above
+     */
     public Class<?> getType() {
         return type;
     }
 
+    /**
+     * Set the data type
+     * 
+     * @param type
+     *            The data type
+     */
     public void setType(Class<?> type) {
         this.type = type;
     }
@@ -42,6 +154,8 @@ public class TableDataColumn {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result
+                + ((description == null) ? 0 : description.hashCode());
         result = prime * result + index;
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         result = prime * result
@@ -58,6 +172,11 @@ public class TableDataColumn {
         if (getClass() != obj.getClass())
             return false;
         TableDataColumn other = (TableDataColumn) obj;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
         if (index != other.index)
             return false;
         if (name == null) {
@@ -76,7 +195,10 @@ public class TableDataColumn {
 
     @Override
     public String toString() {
-        String s = name != null ? name : "";
+        String s = name;
+        if (description.trim().length() > 0)
+            s += " '" + description + "'";
+
         if (index > -1) {
             s += " (" + index + ")";
         }

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -72,8 +72,8 @@ public class TableDataColumn {
      */
     public TableDataColumn(String name, String description, int index,
             Class<?> type) {
-        this.name = name;
-        this.description = description;
+        this.name = name != null ? name : "";
+        this.description = description != null ? description : "";
         this.index = index;
         this.type = type;
     }
@@ -190,6 +190,9 @@ public class TableDataColumn {
             return false;
         if (type == null) {
             if (other.type != null)
+                return false;
+        } else if (other.type == null) {
+            if (type != null)
                 return false;
         } else if (!type.getCanonicalName().equals(
                 other.type.getCanonicalName()))

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -17,6 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 package omero.gateway.model;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Defines a column for a {@link TableData} object
@@ -53,9 +55,7 @@ public class TableDataColumn {
      *            The type of data in this column
      */
     public TableDataColumn(String name, int index, Class<?> type) {
-        this.name = name;
-        this.index = index;
-        this.type = type;
+        this(name, "", index, type);
     }
 
     /**
@@ -200,13 +200,15 @@ public class TableDataColumn {
     @Override
     public String toString() {
         String s = name;
-        if (description.trim().length() > 0)
+        if (StringUtils.isNotEmpty(description))
             s += " '" + description + "'";
 
-        if (index > -1) {
+        if (index > -1) 
             s += " (" + index + ")";
-        }
-        s += " [" + type.getSimpleName() + "]";
+
+        if (type != null)
+            s += " [" + type.getSimpleName() + "]";
+
         return s;
     }
 

--- a/components/tools/OmeroJava/test/gateway.testng.xml
+++ b/components/tools/OmeroJava/test/gateway.testng.xml
@@ -10,6 +10,7 @@
 			<class name="integration.gateway.RawDataFacilityTest" />
 			<class name="integration.gateway.MetadataFacilityTest" />
 			<class name="integration.gateway.ROIFacilityTest" />
+			<class name="integration.gateway.TablesFacilityTest" />
 		</classes>
 	</test>
 </suite>

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
@@ -40,6 +40,7 @@ import omero.gateway.facility.Facility;
 import omero.gateway.facility.ROIFacility;
 import omero.gateway.facility.RawDataFacility;
 import omero.gateway.facility.SearchFacility;
+import omero.gateway.facility.TablesFacility;
 import omero.gateway.facility.TransferFacility;
 import omero.log.SimpleLogger;
 import omero.model.IObject;
@@ -82,7 +83,8 @@ public class GatewayTest {
     TransferFacility transferFacility = null;
     DataManagerFacility datamanagerFacility = null;
     ROIFacility roiFacility = null;
-    
+    TablesFacility tablesFacility = null;
+
     @Test
     public void testConnected() throws DSOutOfServiceException {
         String version = gw.getServerVersion();
@@ -124,6 +126,7 @@ public class GatewayTest {
                 gw);
         roiFacility = Facility.getFacility(ROIFacility.class,
                 gw);
+        tablesFacility = Facility.getFacility(TablesFacility.class, gw);
     }
 
     @AfterClass(alwaysRun = true)

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
@@ -39,6 +39,7 @@ import omero.gateway.facility.DataManagerFacility;
 import omero.gateway.facility.Facility;
 import omero.gateway.facility.ROIFacility;
 import omero.gateway.facility.RawDataFacility;
+import omero.gateway.facility.ROIFacility;
 import omero.gateway.facility.SearchFacility;
 import omero.gateway.facility.TablesFacility;
 import omero.gateway.facility.TransferFacility;

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -50,6 +50,15 @@ public class TablesFacilityTest extends GatewayTest {
     }
 
     @Test(dependsOnMethods = { "testAddTable" })
+    public void testGetTableInfo() throws Exception {
+        FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
+                .iterator().next();
+        TableData data2 = tablesFacility.getTableInfo(rootCtx, tablesFile.getFileID());
+        Assert.assertEquals(data2.getNumberOfRows(), 4);
+        Assert.assertEquals(data2.getColumns(), this.data.getColumns());
+    }
+    
+    @Test(dependsOnMethods = { "testAddTable" })
     public void testGetTable() throws Exception {
         FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.FileData;
 import omero.gateway.model.TableData;
+import omero.gateway.model.TableDataColumn;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -56,19 +57,24 @@ public class TablesFacilityTest extends GatewayTest {
         Assert.assertEquals(data2, data,
                 "The tables data retrieved doesn't match the original");
     }
-    
+
     @Test(dependsOnMethods = { "testAddTable" })
     public void testGetSubsetTable() throws Exception {
         FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
         // get row 1 and 2 with column 1 and 2
-        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(), 1, 2, 1, 2);
-        
+        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(),
+                1, 2, 1, 2);
+
+        TableDataColumn[] header = new TableDataColumn[2];
+        header[0] = new TableDataColumn("column1", 1, Long.class);
+        header[1] = new TableDataColumn("column2", 2, Double.class);
+
         Object[][] expData = new Object[2][2];
-        expData[0] = new Object[] {1l, 2l};
-        expData[1] = new Object[] {1.0d, 2.0d};
-        
-        TableData exp = new TableData(new String[] {"column1", "column2"}, null, new Class<?>[] {Long.class, Double.class}, expData);
+        expData[0] = new Object[] { 1l, 2l };
+        expData[1] = new Object[] { 1.0d, 2.0d };
+
+        TableData exp = new TableData(header, null, expData);
         exp.setOffset(1);
         exp.setOriginalFileId(tablesFile.getId());
         Assert.assertEquals(data2, exp,
@@ -81,11 +87,11 @@ public class TablesFacilityTest extends GatewayTest {
         this.ds = (DatasetData) datamanagerFacility.createDataset(rootCtx, ds,
                 null);
 
-        String[] header = new String[] { "column0", "column1", "column2",
-                "column3" };
-
-        Class<?>[] types = new Class<?>[] { String.class, Long.class,
-                Double.class, Double[].class };
+        TableDataColumn[] header = new TableDataColumn[] {
+                new TableDataColumn("column0", 0, String.class),
+                new TableDataColumn("column1", 1, Long.class),
+                new TableDataColumn("column2", 2, Double.class),
+                new TableDataColumn("column3", 3, Double[].class) };
 
         Object[][] objs = new Object[4][3];
         objs[0] = new Object[] { new String("test0"), new String("test1"),
@@ -96,7 +102,7 @@ public class TablesFacilityTest extends GatewayTest {
         objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },
                 new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 } };
 
-        this.data = new TableData(header, null, types, objs);
+        this.data = new TableData(header, null, objs);
 
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -74,7 +74,7 @@ public class TablesFacilityTest extends GatewayTest {
         expData[0] = new Object[] { 1l, 2l };
         expData[1] = new Object[] { 1.0d, 2.0d };
 
-        TableData exp = new TableData(header, null, expData);
+        TableData exp = new TableData(header, expData);
         exp.setOffset(1);
         exp.setOriginalFileId(tablesFile.getId());
         Assert.assertEquals(data2, exp,
@@ -102,7 +102,7 @@ public class TablesFacilityTest extends GatewayTest {
         objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },
                 new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 } };
 
-        this.data = new TableData(header, null, objs);
+        this.data = new TableData(header, objs);
 
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -21,7 +21,7 @@ package integration.gateway;
 import java.util.UUID;
 
 import omero.gateway.model.DatasetData;
-import omero.gateway.model.FileData;
+import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.TableData;
 import omero.gateway.model.TableDataColumn;
 
@@ -51,7 +51,7 @@ public class TablesFacilityTest extends GatewayTest {
 
     @Test(dependsOnMethods = { "testAddTable" })
     public void testGetTable() throws Exception {
-        FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
+        FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId());
         Assert.assertEquals(data2, data,
@@ -60,7 +60,7 @@ public class TablesFacilityTest extends GatewayTest {
 
     @Test(dependsOnMethods = { "testAddTable" })
     public void testGetSubsetTable() throws Exception {
-        FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
+        FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
         // get row 1 and 2 with column 1 and 2
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(),

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -57,6 +57,7 @@ public class TablesFacilityTest extends GatewayTest {
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getFileID());
         Assert.assertEquals(data2, data,
                 "The tables data retrieved doesn't match the original");
+        Assert.assertTrue(data2.isCompleted());
     }
 
     @Test(dependsOnMethods = { "testAddTable" })
@@ -79,9 +80,10 @@ public class TablesFacilityTest extends GatewayTest {
         TableData exp = new TableData(header, expData);
         exp.setOffset(1);
         exp.setOriginalFileId(tablesFile.getFileID());
-        exp.setCompleted(false);
+        exp.setNumberOfRows(4);
         Assert.assertEquals(data2, exp,
                 "The tables data retrieved doesn't match the original");
+        Assert.assertFalse(data2.isCompleted());
     }
 
     private void initData() throws Exception {
@@ -98,7 +100,7 @@ public class TablesFacilityTest extends GatewayTest {
 
         Object[][] objs = new Object[4][4];
         objs[0] = new Object[] { new String("test0"), new String("test1"),
-                new String("test2") , new String("test4")};
+                new String("test2") , new String("test3")};
         objs[1] = new Object[] { new Long(0), new Long(1), new Long(2), new Long(3) };
         objs[2] = new Object[] { new Double(0.0), new Double(1.0),
                 new Double(2.0), new Double(3.0) };
@@ -106,6 +108,6 @@ public class TablesFacilityTest extends GatewayTest {
                 new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 }, new Double[] { 0.3, 1.3, 2.3 } };
 
         this.data = new TableData(header, objs);
-
+        this.data.setCompleted();
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -65,16 +65,16 @@ public class TablesFacilityTest extends GatewayTest {
         FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
         this.data.setOriginalFileId(tablesFile.getFileID());
-        // get row 1 and 2 with column 1 and 2
+        // get row 1 and 2 with column 0 and 2
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getFileID(),
-                1, 2, 1, 2);
-
+                1, 2, 0, 2);
+        
         TableDataColumn[] header = new TableDataColumn[2];
-        header[0] = new TableDataColumn("column1", 1, Long.class);
+        header[0] = new TableDataColumn("column0", 0, String.class);
         header[1] = new TableDataColumn("column2", 2, Double.class);
 
         Object[][] expData = new Object[2][2];
-        expData[0] = new Object[] { 1l, 2l };
+        expData[0] = new Object[] { "test1", "test2" };
         expData[1] = new Object[] { 1.0d, 2.0d };
 
         TableData exp = new TableData(header, expData);

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -53,7 +53,8 @@ public class TablesFacilityTest extends GatewayTest {
     public void testGetTable() throws Exception {
         FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
-        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId());
+        this.data.setOriginalFileId(tablesFile.getFileID());
+        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getFileID());
         Assert.assertEquals(data2, data,
                 "The tables data retrieved doesn't match the original");
     }
@@ -62,8 +63,9 @@ public class TablesFacilityTest extends GatewayTest {
     public void testGetSubsetTable() throws Exception {
         FileAnnotationData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
+        this.data.setOriginalFileId(tablesFile.getFileID());
         // get row 1 and 2 with column 1 and 2
-        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(),
+        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getFileID(),
                 1, 2, 1, 2);
 
         TableDataColumn[] header = new TableDataColumn[2];
@@ -76,7 +78,8 @@ public class TablesFacilityTest extends GatewayTest {
 
         TableData exp = new TableData(header, expData);
         exp.setOffset(1);
-        exp.setOriginalFileId(tablesFile.getId());
+        exp.setOriginalFileId(tablesFile.getFileID());
+        exp.setCompleted(false);
         Assert.assertEquals(data2, exp,
                 "The tables data retrieved doesn't match the original");
     }
@@ -93,14 +96,14 @@ public class TablesFacilityTest extends GatewayTest {
                 new TableDataColumn("column2", 2, Double.class),
                 new TableDataColumn("column3", 3, Double[].class) };
 
-        Object[][] objs = new Object[4][3];
+        Object[][] objs = new Object[4][4];
         objs[0] = new Object[] { new String("test0"), new String("test1"),
-                new String("test2") };
-        objs[1] = new Object[] { new Long(0), new Long(1), new Long(2) };
+                new String("test2") , new String("test4")};
+        objs[1] = new Object[] { new Long(0), new Long(1), new Long(2), new Long(3) };
         objs[2] = new Object[] { new Double(0.0), new Double(1.0),
-                new Double(2.0) };
+                new Double(2.0), new Double(3.0) };
         objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },
-                new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 } };
+                new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 }, new Double[] { 0.3, 1.3, 2.3 } };
 
         this.data = new TableData(header, objs);
 

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package integration.gateway;
+
+import java.util.UUID;
+
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.FileData;
+import omero.gateway.model.TableData;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TablesFacilityTest extends GatewayTest {
+
+    private DatasetData ds;
+
+    private TableData data;
+
+    @Override
+    @BeforeClass(alwaysRun = true)
+    protected void setUp() throws Exception {
+        super.setUp();
+        initData();
+    }
+
+    @Test
+    public void testAddTable() throws Exception {
+        // just check if it doesn't throw an exception;
+        // verification is done by testGetTable()
+        tablesFacility.addTable(rootCtx, ds, null, data);
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testGetTable() throws Exception {
+        FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
+                .iterator().next();
+        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId());
+        Assert.assertEquals(data, data2,
+                "The tables data retrieved doesn't match the original");
+    }
+
+    private void initData() throws Exception {
+        DatasetData ds = new DatasetData();
+        ds.setName(UUID.randomUUID().toString());
+        this.ds = (DatasetData) datamanagerFacility.createDataset(rootCtx, ds,
+                null);
+
+        String[] header = new String[] { "column0", "column1", "column2",
+                "column3" };
+
+        Class<?>[] types = new Class<?>[] { String.class, Long.class,
+                Double.class, Double[].class };
+
+        Object[][] objs = new Object[4][3];
+        objs[0] = new Object[] { new String("test0"), new String("test1"),
+                new String("test2") };
+        objs[1] = new Object[] { new Long(0), new Long(1), new Long(1) };
+        objs[2] = new Object[] { new Double(0.0), new Double(1.0),
+                new Double(2.0) };
+        objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },
+                new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 } };
+
+        this.data = new TableData(header, null, types, objs);
+
+    }
+}

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -65,11 +65,12 @@ public class TablesFacilityTest extends GatewayTest {
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(), 1, 2, 1, 2);
         
         Object[][] expData = new Object[2][2];
-        expData[0] = new Long[] {1l, 2l};
-        expData[1] = new Double[] {1.0d, 2.0d};
+        expData[0] = new Object[] {1l, 2l};
+        expData[1] = new Object[] {1.0d, 2.0d};
         
         TableData exp = new TableData(new String[] {"column1", "column2"}, null, new Class<?>[] {Long.class, Double.class}, expData);
         exp.setOffset(1);
+        exp.setOriginalFileId(tablesFile.getId());
         Assert.assertEquals(data2, exp,
                 "The tables data retrieved doesn't match the original");
     }

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -53,7 +53,24 @@ public class TablesFacilityTest extends GatewayTest {
         FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
                 .iterator().next();
         TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId());
-        Assert.assertEquals(data, data2,
+        Assert.assertEquals(data2, data,
+                "The tables data retrieved doesn't match the original");
+    }
+    
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testGetSubsetTable() throws Exception {
+        FileData tablesFile = tablesFacility.getAvailableTables(rootCtx, ds)
+                .iterator().next();
+        // get row 1 and 2 with column 1 and 2
+        TableData data2 = tablesFacility.getTable(rootCtx, tablesFile.getId(), 1, 2, 1, 2);
+        
+        Object[][] expData = new Object[2][2];
+        expData[0] = new Long[] {1l, 2l};
+        expData[1] = new Double[] {1.0d, 2.0d};
+        
+        TableData exp = new TableData(new String[] {"column1", "column2"}, null, new Class<?>[] {Long.class, Double.class}, expData);
+        exp.setOffset(1);
+        Assert.assertEquals(data2, exp,
                 "The tables data retrieved doesn't match the original");
     }
 
@@ -72,7 +89,7 @@ public class TablesFacilityTest extends GatewayTest {
         Object[][] objs = new Object[4][3];
         objs[0] = new Object[] { new String("test0"), new String("test1"),
                 new String("test2") };
-        objs[1] = new Object[] { new Long(0), new Long(1), new Long(1) };
+        objs[1] = new Object[] { new Long(0), new Long(1), new Long(2) };
         objs[2] = new Object[] { new Double(0.0), new Double(1.0),
                 new Double(2.0) };
         objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -88,15 +88,10 @@ public class TablesFacilityTest extends GatewayTest {
         }
 
         original = new TableData(header, data);
-        long start = System.currentTimeMillis();
         TableData stored = tablesFacility.addTable(rootCtx, ds, "Big Table",
                 original);
-        long duration = System.currentTimeMillis() - start;
-
+        Assert.assertEquals(stored.getNumberOfRows(), nRows);
         original.setOriginalFileId(stored.getOriginalFileId());
-
-        System.out.println("Storing table with " + (nCols * nRows)
-                + " entries took " + duration + " ms");
     }
 
     @Test(dependsOnMethods = { "testAddTable" })
@@ -138,12 +133,8 @@ public class TablesFacilityTest extends GatewayTest {
         for (int x = 0; x < columns.length; x++)
             columns[x] = rand.nextInt(cols);
 
-        long start = System.currentTimeMillis();
         TableData td2 = tablesFacility.getTable(rootCtx,
                 original.getOriginalFileId(), rowFrom, rowTo, columns);
-        System.out.println("Requested random subset row " + rowFrom + " to "
-                + rowTo + " columns " + Arrays.toString(columns) + ", took "
-                + (System.currentTimeMillis() - start) + " ms");
 
         Object[][] data2 = td2.getData();
 

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -33,94 +33,42 @@ import org.testng.annotations.Test;
 
 public class TablesFacilityTest extends GatewayTest {
 
+    private static Random rand = new Random();
+
+    private static final int nCols = 10;
+
+    private static final int nRows = 100000;
+
     private DatasetData ds;
 
-    private TableData data;
+    private TableData original;
 
-    private long dataFileId = -1;
-    
     @Override
     @BeforeClass(alwaysRun = true)
     protected void setUp() throws Exception {
         super.setUp();
-        initData();
+
+        DatasetData ds = new DatasetData();
+        ds.setName(UUID.randomUUID().toString());
+        this.ds = (DatasetData) datamanagerFacility.createDataset(rootCtx, ds,
+                null);
     }
 
-    @Test
+    @Test(timeOut = 300000)
     public void testAddTable() throws Exception {
-        // just check if it doesn't throw an exception;
-        // verification is done by testGetTable()
-        TableData d = tablesFacility.addTable(rootCtx, ds, null, data);
-        dataFileId = d.getOriginalFileId();
-    }
-
-    @Test(dependsOnMethods = { "testAddTable" })
-    public void testGetTableInfo() throws Exception {
-        TableData data2 = tablesFacility.getTableInfo(rootCtx, dataFileId);
-        Assert.assertEquals(data2.getNumberOfRows(), 4);
-        Assert.assertEquals(data2.getColumns(), this.data.getColumns());
-    }
-    
-    @Test(dependsOnMethods = { "testAddTable" })
-    public void testGetAvailableTables() throws Exception {
-        Collection<FileAnnotationData> tablesFiles = tablesFacility.getAvailableTables(rootCtx, ds);
-        for(FileAnnotationData fa : tablesFiles) {
-            if (fa.getFileID() == dataFileId)
-                return;
-        }
-        Assert.fail("Didn't find the table with getAvailableTables() method");
-    }
-    
-    @Test(dependsOnMethods = { "testAddTable" })
-    public void testGetTable() throws Exception {
-        this.data.setOriginalFileId(dataFileId); // necessary for equals() 
-        TableData data2 = tablesFacility.getTable(rootCtx, dataFileId);
-        Assert.assertEquals(data2, data,
-                "The tables data retrieved doesn't match the original");
-        Assert.assertTrue(data2.isCompleted());
-    }
-
-    @Test(dependsOnMethods = { "testAddTable" })
-    public void testGetSubsetTable() throws Exception {
-        // get row 1 and 2 with column 0 and 2
-        TableData data2 = tablesFacility.getTable(rootCtx, dataFileId,
-                1, 2, 0, 2);
-        
-        TableDataColumn[] header = new TableDataColumn[2];
-        header[0] = new TableDataColumn("column0", 0, String.class);
-        header[1] = new TableDataColumn("column2", 2, Double.class);
-
-        Object[][] expData = new Object[2][2];
-        expData[0] = new Object[] { "test1", "test2" };
-        expData[1] = new Object[] { 1.0d, 2.0d };
-
-        TableData exp = new TableData(header, expData);
-        exp.setOffset(1);
-        exp.setOriginalFileId(dataFileId);  
-        exp.setNumberOfRows(4);
-        Assert.assertEquals(data2, exp,
-                "The tables data retrieved doesn't match the original");
-        Assert.assertFalse(data2.isCompleted());
-    }
-    
-    @Test
-    public void testBigTable() throws Exception {
-        int cols = 10;
-        int rows = 100000;
-        Random rand = new Random();
         Class<?>[] types = new Class<?>[] { String.class, Long.class,
                 Double.class, Double[].class };
-        TableDataColumn[] header = new TableDataColumn[cols];
+        TableDataColumn[] header = new TableDataColumn[nCols];
         for (int i = 0; i < header.length; i++) {
             header[i] = new TableDataColumn("column-" + i, i,
                     types[rand.nextInt(types.length)]);
         }
 
-        Object[][] data = new Object[header.length][rows];
-        for (int c = 0; c < cols; c++) {
-            Object[] column = new Object[rows];
+        Object[][] data = new Object[header.length][nRows];
+        for (int c = 0; c < nCols; c++) {
+            Object[] column = new Object[nRows];
             Class<?> type = header[c].getType();
-            for (int r = 0; r < rows; r++) {
+            for (int r = 0; r < nRows; r++) {
                 if (type.equals(String.class)) {
                     column[r] = "" + rand.nextInt();
                 } else if (type.equals(Long.class)) {
@@ -136,75 +84,90 @@ public class TablesFacilityTest extends GatewayTest {
             }
             data[c] = column;
         }
-        
-        TableData td = new TableData(header, data);
+
+        original = new TableData(header, data);
         long start = System.currentTimeMillis();
-        td = tablesFacility.addTable(rootCtx, ds, "Big Table", td);
+        TableData stored = tablesFacility.addTable(rootCtx, ds, "Big Table",
+                original);
         long duration = System.currentTimeMillis() - start;
-        
-        System.out.println("Storing table with "+(cols*rows)+" entries took "+duration+" ms");
-        
-        duration = 0;
-        int nEntries = 0;
-        for(int i=0; i<10; i++) {
-            // read some random subsets from the table and compare to original data
-            int rowFrom = rand.nextInt(rows-1000); // can't request more than 1000 rows at once
-            int rowTo = rowFrom + rand.nextInt(1000);
-            int[] columns = new int[rand.nextInt(cols)];
-            
-            nEntries += (rowTo - rowFrom) * columns.length;
-            
-            for(int x=0; x<columns.length; x++)
-                columns[x] = rand.nextInt(cols);
-            
-            start = System.currentTimeMillis();
-            TableData td2 = tablesFacility.getTable(rootCtx, td.getOriginalFileId(),
-                    rowFrom, rowTo, columns);
-            duration += System.currentTimeMillis() - start;
-            
-            Object[][] data2 = td2.getData();
-            
-            for(int r=rowFrom; r<rowTo; r++) {
-                for(int c=0; c<columns.length; c++) {
-                    int index = columns[c];
-                    Class<?> type = header[index].getType();
-                    if (type.equals(String.class)) {
-                        Assert.assertEquals((String)data2[c][r-(int)td2.getOffset()], (String)data[index][r]);
-                    } else if (type.equals(Long.class)) {
-                        Assert.assertEquals((Long)data2[c][r-(int)td2.getOffset()], (Long)data[index][r]);
-                    } else if (type.equals(Double.class)) {
-                        Assert.assertEquals((Double)data2[c][r-(int)td2.getOffset()], (Double)data[index][r]);
-                    } else if (type.equals(Double[].class)) {
-                        Assert.assertEquals((Double[])data2[c][r-(int)td2.getOffset()], (Double[])data[index][r]);
-                    }
+
+        original.setOriginalFileId(stored.getOriginalFileId());
+
+        System.out.println("Storing table with " + (nCols * nRows)
+                + " entries took " + duration + " ms");
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testGetTableInfo() throws Exception {
+        TableData info = tablesFacility.getTableInfo(rootCtx,
+                original.getOriginalFileId());
+        Assert.assertEquals(info.getNumberOfRows(), nRows);
+        Assert.assertEquals(info.getColumns(), original.getColumns());
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testGetAvailableTables() throws Exception {
+        Collection<FileAnnotationData> tablesFiles = tablesFacility
+                .getAvailableTables(rootCtx, ds);
+        Assert.assertEquals(1, tablesFiles.size());
+        Assert.assertEquals(tablesFiles.iterator().next().getFileID(),
+                original.getOriginalFileId());
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" }, invocationCount = 10, threadPoolSize = 5)
+    /**
+     * Read a random subset from the table and compare to the original data
+     * 
+     * @throws Exception
+     */
+    public void testReadBigTable() throws Exception {
+        Object[][] origData = original.getData();
+
+        TableData info = tablesFacility.getTableInfo(rootCtx,
+                original.getOriginalFileId());
+        int rows = (int) info.getNumberOfRows();
+        int cols = info.getColumns().length;
+
+        int rowFrom = rand.nextInt(rows - 1000); // can't request more than 1000
+                                                 // rows at once
+        int rowTo = rowFrom + rand.nextInt(1000);
+        int[] columns = new int[rand.nextInt(cols)];
+
+        for (int x = 0; x < columns.length; x++)
+            columns[x] = rand.nextInt(cols);
+
+        long start = System.currentTimeMillis();
+        TableData td2 = tablesFacility.getTable(rootCtx,
+                original.getOriginalFileId(), rowFrom, rowTo, columns);
+        System.out.println("Requesting random subset of size: "
+                + ((rowTo - rowFrom) * columns.length) + " entries, took "
+                + (System.currentTimeMillis() - start) + " ms");
+
+        Object[][] data2 = td2.getData();
+
+        for (int r = rowFrom; r < rowTo; r++) {
+            for (int c = 0; c < columns.length; c++) {
+                int index = columns[c];
+                Class<?> type = info.getColumns()[index].getType();
+                if (type.equals(String.class)) {
+                    Assert.assertEquals(
+                            (String) data2[c][r - (int) td2.getOffset()],
+                            (String) origData[index][r]);
+                } else if (type.equals(Long.class)) {
+                    Assert.assertEquals(
+                            (Long) data2[c][r - (int) td2.getOffset()],
+                            (Long) origData[index][r]);
+                } else if (type.equals(Double.class)) {
+                    Assert.assertEquals(
+                            (Double) data2[c][r - (int) td2.getOffset()],
+                            (Double) origData[index][r]);
+                } else if (type.equals(Double[].class)) {
+                    Assert.assertEquals(
+                            (Double[]) data2[c][r - (int) td2.getOffset()],
+                            (Double[]) origData[index][r]);
                 }
             }
         }
-        System.out.println("Requesting random subsets (average size: "+(nEntries/10)+" entries) took "+(duration/10)+" ms on average");
     }
 
-    private void initData() throws Exception {
-        DatasetData ds = new DatasetData();
-        ds.setName(UUID.randomUUID().toString());
-        this.ds = (DatasetData) datamanagerFacility.createDataset(rootCtx, ds,
-                null);
-
-        TableDataColumn[] header = new TableDataColumn[] {
-                new TableDataColumn("column0", 0, String.class),
-                new TableDataColumn("column1", 1, Long.class),
-                new TableDataColumn("column2", 2, Double.class),
-                new TableDataColumn("column3", 3, Double[].class) };
-
-        Object[][] objs = new Object[4][4];
-        objs[0] = new Object[] { new String("test0"), new String("test1"),
-                new String("test2") , new String("test3")};
-        objs[1] = new Object[] { new Long(0), new Long(1), new Long(2), new Long(3) };
-        objs[2] = new Object[] { new Double(0.0), new Double(1.0),
-                new Double(2.0), new Double(3.0) };
-        objs[3] = new Object[] { new Double[] { 0.0, 1.0, 2.0 },
-                new Double[] { 0.1, 1.1, 2.1 }, new Double[] { 0.2, 1.2, 2.2 }, new Double[] { 0.3, 1.3, 2.3 } };
-
-        this.data = new TableData(header, objs);
-        this.data.setCompleted();
-    }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -56,7 +56,7 @@ public class TablesFacilityTest extends GatewayTest {
                 null);
     }
 
-    @Test(timeOut = 300000)
+    @Test(timeOut = 600000)
     public void testAddTable() throws Exception {
         Class<?>[] types = new Class<?>[] { String.class, Long.class,
                 Double.class, Double[].class };

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -18,6 +18,7 @@
  */
 package integration.gateway;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
@@ -140,8 +141,8 @@ public class TablesFacilityTest extends GatewayTest {
         long start = System.currentTimeMillis();
         TableData td2 = tablesFacility.getTable(rootCtx,
                 original.getOriginalFileId(), rowFrom, rowTo, columns);
-        System.out.println("Requesting random subset of size: "
-                + ((rowTo - rowFrom) * columns.length) + " entries, took "
+        System.out.println("Requested random subset row " + rowFrom + " to "
+                + rowTo + " columns " + Arrays.toString(columns) + ", took "
                 + (System.currentTimeMillis() - start) + " ms");
 
         Object[][] data2 = td2.getData();

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
 
+import omero.gateway.facility.TablesFacility;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.TableData;
@@ -114,13 +115,13 @@ public class TablesFacilityTest extends GatewayTest {
                 original.getOriginalFileId());
     }
 
-    @Test(dependsOnMethods = { "testAddTable" }, invocationCount = 10, threadPoolSize = 5)
+    @Test(dependsOnMethods = { "testAddTable" }, invocationCount = 10)
     /**
      * Read a random subset from the table and compare to the original data
      * 
      * @throws Exception
      */
-    public void testReadBigTable() throws Exception {
+    public void testReadTable() throws Exception {
         Object[][] origData = original.getData();
 
         TableData info = tablesFacility.getTableInfo(rootCtx,
@@ -128,8 +129,8 @@ public class TablesFacilityTest extends GatewayTest {
         int rows = (int) info.getNumberOfRows();
         int cols = info.getColumns().length;
 
-        int rowFrom = rand.nextInt(rows - 1000); // can't request more than 1000
-                                                 // rows at once
+        // request maximum of 1000 rows
+        int rowFrom = rand.nextInt(rows - 1000);
         int rowTo = rowFrom + rand.nextInt(1000);
         int[] columns = new int[rand.nextInt(cols)];
 
@@ -168,6 +169,18 @@ public class TablesFacilityTest extends GatewayTest {
                 }
             }
         }
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    /**
+     * Test that unspecified requests are limited to TablesFacility.DEFAULT_MAX_ROWS_TO_FETCH rows
+     * @throws Exception
+     */
+    public void testThreshold() throws Exception {
+        TableData td = tablesFacility.getTable(rootCtx,
+                original.getOriginalFileId());
+        Assert.assertEquals(td.getData()[0].length,
+                TablesFacility.DEFAULT_MAX_ROWS_TO_FETCH);
     }
 
 }


### PR DESCRIPTION
Resurrected the `TablesFacility` from  #4347 (which was closed and only a subset merged into 5.2.3).

The TablesFacility would provide an easy way for adding and getting table structured data to/from OMERO, this would be very useful for the R gateway (i.e attaching/loading dataframes to/from OME objects, https://github.com/dominikl/rOMERO/blob/dev_5_3/examples/dataframes.R ).

Probably needs some more discussion, but it would be very handy to open up the tables accessibility, so I could create some more realistic R examples.

**Test**
Basically check if the `TablesFacility.java` 'API' makes sense and the according integration test is sufficient and passes. Optional: Run above mentioned `dataframes.R` example code.

**Status**
In my opinion this could be merged. But there was still some discussion going on about the tables mimetype, without coming to a conclusion yet.

/cc @jburel 
