### PR TITLE
Fixed ClassCastException

### DIFF
--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -1162,7 +1162,7 @@ public class BrowseFacility extends Facility {
         } catch (Throwable t) {
             logError(this, "Could not load orphaned images", t);
         }
-        return Collections.emptyList();
+        return Collections.emptySet();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterImageLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterImageLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  */
 package org.openmicroscopy.shoola.agents.treeviewer;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -171,7 +172,7 @@ public class ExperimenterImageLoader
     public void handleResult(Object result)
     {
         if (viewer.getState() == Browser.DISCARDED) return;  //Async cancel.
-        viewer.setLeaves((Set) result, smartFolderNode, expNode); 
+        viewer.setLeaves((Collection) result, smartFolderNode, expNode); 
     }
     
 }


### PR DESCRIPTION
Tiny bugfix for [QA 17191](https://www.openmicroscopy.org/qa2/qa/feedback/17191/) to prevent potential ClassCastException (`result` object is not guaranteed to be an instance of Set, e.g. see https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/blitz/src/omero/gateway/facility/BrowseFacility.java#L1008 ).

**Test**: Code review should be sufficient. Don't know how to easily replicate the bug. Would need an experimenter without user image set, but all experimenters actually have this user icon as default user image.
