### PR TITLE
update uses of Requests in tests to avoid deprecated methods

### DIFF
--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -1327,8 +1327,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
         permissions = g.getDetails().getPermissions();
@@ -1368,8 +1367,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwra--";
 
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
         permissions = g.getDetails().getPermissions();
@@ -1409,8 +1407,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwrw--";
 
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
         permissions = g.getDetails().getPermissions();
@@ -1448,8 +1445,7 @@ public class AdminServiceTest extends AbstractServerTest {
         // change permissions
         representation = "rwr---";
 
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
         permissions = g.getDetails().getPermissions();
@@ -1481,8 +1477,7 @@ public class AdminServiceTest extends AbstractServerTest {
         Permissions permissions = g.getDetails().getPermissions();
         // change permissions and promote the group
         representation = "rwrw--";
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
 
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1517,8 +1512,7 @@ public class AdminServiceTest extends AbstractServerTest {
 
         // change permissions and promote the group
         representation = "rwr---";
-        Request mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        Request mod = Requests.chmod().target(g).toPerms(representation).build();
 
         doChange(root, root.getSession(), mod, true);
         g = prx.getGroup(id);
@@ -1528,8 +1522,7 @@ public class AdminServiceTest extends AbstractServerTest {
         g = prx.getGroup(id);
         // now try to turn it back to rw----
         representation = "rw----";
-        mod = Requests.chmod(REF_GROUP, g.getId().getValue(),
-                representation);
+        mod = Requests.chmod().target(g).toPerms(representation).build();
 
         doChange(root, root.getSession(), mod, true);
     }

--- a/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceFilesTest.java
@@ -479,7 +479,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have been created and then deleted.
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(pix.getId().getValue(), REF_PIXELS);
         assertEquals(report.deletedObjects.get(REF_PIXELS).size(), 1);
@@ -499,7 +499,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have been created and then deleted.
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
@@ -522,7 +522,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(pix.getId().getValue(), REF_PIXELS);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
@@ -549,7 +549,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
                 PyramidFileType.PYRAMID_LOCK);
         assertOtherPixelsFileExists(pix.getId().getValue(),
                 PyramidFileType.PYRAMID_TMP);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertOtherPixelsFileDoesNotExist(pix.getId().getValue(),
                 PyramidFileType.PYRAMID);
@@ -594,7 +594,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         // Now check that the files have been created and then deleted.
         assertFileExists(ofId, REF_ORIGINAL_FILE);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertFileDoesNotExist(ofId, REF_ORIGINAL_FILE);
         assertNoUndeletedBinaries(report);
@@ -628,7 +628,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the files have NOT been created and then deleted.
         assertFileDoesNotExist(pixId, REF_PIXELS);
         assertFileDoesNotExist(ofId, REF_ORIGINAL_FILE);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
         assertNoUndeletedBinaries(report);
     }
@@ -658,7 +658,6 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         long id = pixels.getId().getValue();
         List<Long> ids = new ArrayList<Long>();
         ids.add(id);
-        long imageID = pixels.getImage().getId().getValue();
 
         ThumbnailStorePrx svc = factory.createThumbnailStore();
         // make sure we have a thumbnail on disk
@@ -684,7 +683,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         }
 
         // delete the image.
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(pixels.getImage()).build();
         Delete2Response report = deleteWithReport(dc);
 
         assertNoUndeletedBinaries(report);
@@ -724,7 +723,6 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         List<Long> ids = new ArrayList<Long>();
         ids.add(id);
 
-        long imageID = pixels.getImage().getId().getValue();
         ThumbnailStorePrx svc = factory.createThumbnailStore();
         // make sure we have a thumbnail on disk
         // request a different size to make sure all thumbnails are deleted.
@@ -765,7 +763,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         loginUser(ownerCtx);
         // Now try to delete the image.
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(pixels.getImage()).build();
         Delete2Response report = deleteWithReport(dc);
         Iterator<Long> j = thumbIds.iterator();
         while (j.hasNext()) {
@@ -800,7 +798,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         ds2.linkImage(img);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
+        Delete2 dc = Requests.delete().target(ds2).build();
         delete(client, dc);
 
         assertDoesNotExist(ds2);
@@ -838,7 +836,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(pix1.getId().getValue(), REF_PIXELS);
         assertFileExists(pix2.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = Requests.delete("Dataset", ds.getId().getValue());
+        Delete2 dc = Requests.delete().target(ds).build();
         Delete2Response report = deleteWithReport(dc);
 
         assertNoUndeletedBinaries(report);
@@ -888,7 +886,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         assertFileExists(of1.getId().getValue(), REF_ORIGINAL_FILE);
         assertFileExists(of2.getId().getValue(), REF_ORIGINAL_FILE);
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
 
         assertNoneExist(img, of1, of2);
@@ -923,7 +921,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
         // Now check that the file has been created.
         assertFileExists(pix.getId().getValue(), REF_PIXELS);
 
-        Delete2 dc = Requests.delete("Dataset", ds.getId().getValue());
+        Delete2 dc = Requests.delete().target(ds).build();
         Delete2Response report = deleteWithReport(dc);
 
         // The dataset should be gone but nothing else.
@@ -953,7 +951,7 @@ public class DeleteServiceFilesTest extends AbstractServerTest {
 
         // create another user and try to delete the image
         newUserInGroup();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         Delete2Response report = deleteWithReport(dc);
 
         // check the image exists as the owner

--- a/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
@@ -107,16 +107,11 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(user1Ctx);
 
         List<Request> commands = new ArrayList<Request>();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
-        commands.add(dc);
-        dc = Requests.delete("Dataset", d.getId().getValue());
-        commands.add(dc);
-        dc = Requests.delete("Project", p.getId().getValue());
-        commands.add(dc);
-        dc = Requests.delete("Screen", s.getId().getValue());
-        commands.add(dc);
-        dc = Requests.delete("Plate", plate.getId().getValue());
-        commands.add(dc);
+        commands.add(Requests.delete().target(img).build());
+        commands.add(Requests.delete().target(d).build());
+        commands.add(Requests.delete().target(p).build());
+        commands.add(Requests.delete().target(s).build());
+        commands.add(Requests.delete().target(plate).build());
 
         DoAll all = new DoAll();
         all.requests = commands;
@@ -149,11 +144,10 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // create an owner who then creates the image
         Image img = (Image) iUpdate.saveAndReturnObject(mmFactory
                 .simpleImage());
-        long imageID = img.getId().getValue();
 
         // create another user and try to delete the image
         newUserInGroup();
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(false, client, dc);
 
         // check the image exists as the owner
@@ -178,7 +172,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Log the admin into that users group
         logRootIntoGroup();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -215,7 +209,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -241,7 +235,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ownerEc);
         makeGroupOwner();
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img); // Deletion permitted in 4.4
@@ -266,7 +260,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
         assertDoesNotExist(img);
     }
@@ -304,8 +298,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // owner deletes image
         loginUser(ec);
-        long id = image.getId().getValue();
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
 
         // image and annotations are all gone
@@ -355,7 +348,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // owner deletes their image
         loginUser(ec);
         long id = imageOwner.getId().getValue();
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(imageOwner).build();
         callback(true, client, dc);
 
         // image is gone but other image and annotations remain
@@ -395,8 +388,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // owner tries to delete image.
         loginUser(ec);
-        long id = img.getId().getValue();
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -437,7 +429,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Tag's owner now deletes the tag.
         init(tagger);
-        Delete2 dc = Requests.delete("Annotation", c.getId().getValue());
+        Delete2 dc = Requests.delete().target(c).build();
         callback(false, client, dc);
         assertExists(c);
         assertExists(link);
@@ -487,7 +479,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         // Tag's owner now deletes the tag.
         init(tagger);
-        Delete2 dc = Requests.delete("Annotation", c.getId().getValue());
+        Delete2 dc = Requests.delete().target(c).build();
         callback(true, client, dc);
 
         assertNoneExist(c, link);
@@ -530,7 +522,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // Delete the image.
         loginUser(ownerCtx);
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         assertNoneExist(image, ownerDef, otherDef);
     }
@@ -563,7 +555,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
         makeGroupOwner();
         // Now try to delete the project.
-        Delete2 dc = Requests.delete("Project", project.getId().getValue());
+        Delete2 dc = Requests.delete().target(project).build();
         callback(true, client, dc);
         assertDoesNotExist(project);
         assertDoesNotExist(dataset);
@@ -595,7 +587,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setParent((Project) project.proxy());
         link = (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
         // Now try to delete the dataset.
-        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
+        Delete2 dc = Requests.delete().target(dataset).build();
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertExists(project);
@@ -632,7 +624,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(user2Ctx);
         // Now try to delete the dataset.
-        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
+        Delete2 dc = Requests.delete().target(dataset).build();
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertExists(project);
@@ -672,7 +664,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         // now try to delete the dataset
         loginUser(ctx);
-        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
+        Delete2 dc = Requests.delete().target(dataset).build();
         callback(true, client, dc);
         assertDoesNotExist(dataset);
         assertDoesNotExist(image1);
@@ -703,7 +695,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setParent((Dataset) dataset.proxy());
         iUpdate.saveAndReturnObject(link);
         // Now try to delete the image
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
 
         assertDoesNotExist(image);
@@ -740,7 +732,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // now try to delete the image
         loginUser(user2Ctx);
 
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
 
         assertDoesNotExist(image);
@@ -774,7 +766,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
 
         // Now try to delete the screen
-        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
+        Delete2 dc = Requests.delete().target(screen).build();
         callback(false, client, dc);
 
         assertExists(screen);
@@ -809,7 +801,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         newUserInGroup(ctx);
         makeGroupOwner();
         // Now try to delete the screen
-        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
+        Delete2 dc = Requests.delete().target(screen).build();
         callback(true, client, dc);
 
         assertDoesNotExist(screen);
@@ -841,7 +833,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         link.setParent((Screen) screen.proxy());
         link = (ScreenPlateLink) iUpdate.saveAndReturnObject(link);
         // Now try to delete the plate
-        Delete2 dc = Requests.delete("Plate", plate.getId().getValue());
+        Delete2 dc = Requests.delete().target(plate).build();
         callback(true, client, dc);
 
         assertDoesNotExist(plate);
@@ -879,7 +871,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(user2Ctx);
         // Now try to delete the plate
-        Delete2 dc = Requests.delete("Plate", plate.getId().getValue());
+        Delete2 dc = Requests.delete().target(plate).build();
         callback(true, client, dc);
 
         assertDoesNotExist(plate);
@@ -919,7 +911,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         disconnect();
         loginUser(ctx);
         // Now try to delete the dataset
-        Delete2 dc = Requests.delete("Dataset", dataset.getId().getValue());
+        Delete2 dc = Requests.delete().target(dataset).build();
         callback(true, client, dc);
 
         assertDoesNotExist(dataset);
@@ -946,7 +938,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -971,7 +963,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         // admin deletes the object.
         logRootIntoGroup();
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);
@@ -1006,7 +998,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         // Image should be deleted.
@@ -1030,7 +1022,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // group owner deletes it
         disconnect();
         newUserInGroup(ownerEc);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(false, client, dc);
 
         assertExists(img);
@@ -1053,7 +1045,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         // group owner deletes it
         disconnect();
         newUserInGroup(ownerEc);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(false, client, dc);
 
         assertExists(img);
@@ -1088,7 +1080,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         Permissions perms = img.getDetails().getPermissions();
         assertTrue(perms.canDelete());
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         assertDoesNotExist(img);

--- a/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
@@ -403,7 +403,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleImage());
         assertNotNull(img);
         long id = img.getId().getValue();
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -427,7 +427,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .createInstrument());
         assertNotNull(ins);
         long id = ins.getId().getValue();
-        Delete2 dc = Requests.delete("Instrument", id);
+        Delete2 dc = Requests.delete().target(ins).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -469,7 +469,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertNotNull(detector);
 
         // delete detector
-        Delete2 dc = Requests.delete("Detector", id);
+        Delete2 dc = Requests.delete().target(detector).build();
         callback(true, client, dc);
 
         // fail to find detector
@@ -489,7 +489,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simplePlateData().asIObject());
         assertNotNull(p);
         long id = p.getId().getValue();
-        Delete2 dc = Requests.delete("Plate", id);
+        Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -547,7 +547,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 }
             }
             // Now delete the plate
-            Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+            Delete2 dc = Requests.delete().target(p).build();
             callback(true, client, dc);
 
             param = new ParametersI();
@@ -647,7 +647,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 }
             }
             // Now delete the plate
-            Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+            Delete2 dc = Requests.delete().target(p).build();
             callback(true, client, dc);
 
             // check the plate
@@ -721,7 +721,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        Delete2 dc = Requests.delete("Dataset", d.getId().getValue());
+        Delete2 dc = Requests.delete().target(d).build();
         callback(true, client, dc);
 
         // Check if objects have been deleted
@@ -774,7 +774,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        Delete2 dc = Requests.delete("Project", p.getId().getValue());
+        Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
 
         // Check if objects have been deleted
@@ -823,7 +823,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
+        Delete2 dc = Requests.delete().target(screen).build();
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -880,7 +880,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             infos.add(info.getId().getValue());
         }
 
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -965,7 +965,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             infos.add(info.getId().getValue());
         }
 
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1036,7 +1036,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> settings = iQuery.findAllByQuery(sql, param);
         // now delete the image
         assertTrue(settings.size() > 0);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         // check if the settings have been deleted.
@@ -1076,7 +1076,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> settings = iQuery.findAllByQuery(sql, param);
         // now delete the image
         assertTrue(settings.size() > 0);
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
         // check if the settings have been deleted.
         Iterator<IObject> i = settings.iterator();
@@ -1171,7 +1171,7 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         // Now we try to delete the image.
 
-        Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
         // Follow the section with acquisition data.
         // Now check if the settings are still there.
@@ -1261,7 +1261,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         // Delete the image.
 
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         // check if the objects have been delete.
 
@@ -1310,7 +1310,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             shapeIds.add(shape.getId().getValue());
         }
 
-        Delete2 dc = Requests.delete("Roi", serverROI.getId().getValue());
+        Delete2 dc = Requests.delete().target(serverROI).build();
         callback(true, client, dc);
 
         // make sure we still have the image
@@ -1355,8 +1355,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             id = obj.getId().getValue();
             annotationIds = createNonSharableAnnotation(obj, null);
 
-
-            Delete2 dc = Requests.delete(type, id);
+            Delete2 dc = Requests.delete().target(type).id(id).build();
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -1396,11 +1395,11 @@ public class DeleteServiceTest extends AbstractServerTest {
                 id = obj.getId().getValue();
                 annotationIds = createSharableAnnotation(obj, null);
                 if (values[j]) {
-                    final ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-                    final Delete2 dc = Requests.delete(type, id, co);
+                    final ChildOption co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+                    final Delete2 dc = Requests.delete().target(type).id(id).option(co).build();
                     callback(true, client, dc);
                 } else {
-                    final Delete2 dc = Requests.delete(type, id);
+                    final Delete2 dc = Requests.delete().target(type).id(id).build();
                     callback(true, client, dc);
                 }
 
@@ -1475,7 +1474,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             }
         }
         // Now delete the plate
-        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+        final Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1576,8 +1575,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(il);
         iUpdate.saveAndReturnArray(links);
 
-        final ChildOption co = Requests.option(null, "FileAnnotation");
-        final Delete2 dc = Requests.delete("Plate", p.getId().getValue(), co);
+        final ChildOption co = Requests.option().excludeType("FileAnnotation").build();
+        final Delete2 dc = Requests.delete().target(p).option(co).build();
         callback(true, client, dc);
         // Shouldn't have measurements
         ParametersI param = new ParametersI();
@@ -1653,11 +1652,11 @@ public class DeleteServiceTest extends AbstractServerTest {
                         annotationIds.addAll(r);
                 }
                 if (annotations[k]) {
-                    final ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue(), co);
+                    final ChildOption co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+                    final Delete2 dc = Requests.delete().target(p).option(co).build();
                     callback(true, client, dc);
                 } else {
-                    final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+                    final Delete2 dc = Requests.delete().target(p).build();
                     callback(true, client, dc);
                 }
 
@@ -1740,7 +1739,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         l.link(new DatasetI(d.getId().getValue(), false), img2);
         iUpdate.saveAndReturnObject(l);
 
-        final Delete2 dc = Requests.delete("Dataset", d.getId().getValue());
+        final Delete2 dc = Requests.delete().target(d).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1791,7 +1790,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         pl.link(new ProjectI(p.getId().getValue(), false), d2);
         iUpdate.saveAndReturnObject(pl);
 
-        final Delete2 dc = Requests.delete("Project", p.getId().getValue());
+        final Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -1844,7 +1843,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             link.link(screen, plate);
             iUpdate.saveAndReturnObject(link);
 
-            final Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
+            final Delete2 dc = Requests.delete().target(screen).build();
             callback(true, client, dc);
 
             param = new ParametersI();
@@ -1889,8 +1888,8 @@ public class DeleteServiceTest extends AbstractServerTest {
 
         long id = fa.getId().getValue();
 
-        final ChildOption co = Requests.option(null, "FileAnnotation");
-        final Delete2 dc = Requests.delete("Image", img.getId().getValue(), co);
+        final ChildOption co = Requests.option().excludeType("FileAnnotation").build();
+        final Delete2 dc = Requests.delete().target(img).option(co).build();
         callback(true, client, dc);
 
         // File annotation should be deleted even if
@@ -1920,8 +1919,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<Long> ids = createSharableAnnotation(img1, img2);
         assertEquals(n, ids.size());
         // now delete the image 1.
-        ChildOption co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-        Delete2 dc = Requests.delete("Image", img1.getId().getValue(), co);
+        ChildOption co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+        Delete2 dc = Requests.delete().target(img1).option(co).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addIds(ids);
@@ -1936,8 +1935,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleDatasetData().asIObject());
         ids = createSharableAnnotation(d1, d2);
         // now delete the dataset 1.
-        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-        dc = Requests.delete("Dataset", d1.getId().getValue(), co);
+        co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+        dc = Requests.delete().target(d1).option(co).build();
         callback(true, client, dc);
         param = new ParametersI();
         param.addIds(ids);
@@ -1951,8 +1950,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleProjectData().asIObject());
         ids = createSharableAnnotation(p1, p2);
         // now delete the project 1.
-        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-        dc = Requests.delete("Project", p1.getId().getValue(), co);
+        co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+        dc = Requests.delete().target(p1).option(co).build();
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1967,8 +1966,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleScreenData().asIObject());
         ids = createSharableAnnotation(s1, s2);
         // now delete the screen 1.
-        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-        dc = Requests.delete("Screen", s1.getId().getValue(), co);
+        co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+        dc = Requests.delete().target(s1).option(co).build();
         callback(true, client, dc);
 
         param = new ParametersI();
@@ -1983,8 +1982,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simplePlateData().asIObject());
         ids = createSharableAnnotation(plate1, plate2);
         // now delete the plate 1.
-        co = Requests.option(null, SHARABLE_TO_KEEP_LIST);
-        dc = Requests.delete("Plate", plate1.getId().getValue(), co);
+        co = Requests.option().excludeType(SHARABLE_TO_KEEP_LIST).build();
+        dc = Requests.delete().target(plate1).option(co).build();
         callback(true, client, dc);
         param = new ParametersI();
         param.addIds(ids);
@@ -2039,7 +2038,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = Requests.delete("Annotation", tagId);
+        Delete2 dc = Requests.delete().target(tag).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2121,7 +2120,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = Requests.delete("Annotation", tagId);
+        Delete2 dc = Requests.delete().target(tag).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2205,7 +2204,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         links.add(platel);
         iUpdate.saveAndReturnArray(links);
         // delete the tag
-        Delete2 dc = Requests.delete("Annotation", tagId);
+        Delete2 dc = Requests.delete().target(tag).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -2274,7 +2273,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        Delete2 dc = Requests.delete("Screen", screenId);
+        Delete2 dc = Requests.delete().target(s).build();
         callback(true, client, dc);
 
         sql = "select r from Screen as r ";
@@ -2330,7 +2329,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        Delete2 dc = Requests.delete("Plate", plateID);
+        Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
 
         sql = "select r from Screen as r ";
@@ -2377,7 +2376,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         pa = (PlateAcquisition) iQuery.findByQuery(sb.toString(), param);
         annotationIds.addAll(createSharableAnnotation(pa, null));
 
-        Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+        Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
         // Check if annotations have been deleted.
         param = new ParametersI();
@@ -2416,8 +2415,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             annotationIds = createNonSharableAnnotation(obj, null);
             annotationIdsNS = createNonSharableAnnotation(obj, NAMESPACE);
 
-            final ChildOption co = Requests.option(null, "Annotation", NAMESPACE, null);
-            final Delete2 dc = Requests.delete(type, id, co);
+            final ChildOption co = Requests.option().excludeType("Annotation").includeNs(NAMESPACE).build();
+            final Delete2 dc = Requests.delete().target(obj).option(co).build();
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -2468,11 +2467,8 @@ public class DeleteServiceTest extends AbstractServerTest {
             annotationIdsNS.addAll(createNonSharableAnnotation(obj, NAMESPACE));
             annotationIdsNS
                     .addAll(createNonSharableAnnotation(obj, NAMESPACE_2));
-            List<String> ns = new ArrayList<String>();
-            ns.add(NAMESPACE);
-            ns.add(NAMESPACE_2);
-            final ChildOption co = Requests.option(null, "Annotation", ns, null);
-            final Delete2 dc = Requests.delete(type, id, co);
+            final ChildOption co = Requests.option().excludeType("Annotation").includeNs(NAMESPACE, NAMESPACE_2).build();
+            final Delete2 dc = Requests.delete().target(obj).option(co).build();
             callback(true, client, dc);
 
             assertDoesNotExist(obj);
@@ -2572,7 +2568,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
 
         // Now we try to delete the image.
-        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        final Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         // Follow the section with acquisition data.
@@ -2727,7 +2723,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
 
         // Now we try to delete the image.
-        final Delete2 dc = Requests.delete("Image", img.getId().getValue());
+        final Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
 
         // Follow the section with acquisition data.
@@ -2817,7 +2813,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<IObject> wellSamples = iQuery.findAllByQuery(sql, param);
         assertEquals(wellSamples.size(), fields);
 
-        Delete2 dc = Requests.delete("PlateAcquisition", id);
+        Delete2 dc = Requests.delete().target(pas.get(0)).build();
         callback(true, client, dc);
 
         sql = "select pa from PlateAcquisition as pa ";
@@ -2859,7 +2855,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertEquals(imageIds.size(), fields);
         assertTrue(annotationIds.size() > 0);
         // now delete the plate acquisition
-        dc = Requests.delete("PlateAcquisition", id);
+        dc = Requests.delete().target(pa).build();
         callback(true, client, dc);
 
         // Annotation should be gone
@@ -2900,12 +2896,8 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .getId().getValue(), false));
         iUpdate.saveAndReturnObject(dl);
         // Now delete the project
-        List<String> options = new ArrayList<String>();
-        options.add(Dataset.class.getSimpleName());
-        options.add(Image.class.getSimpleName());
-        long id = p.getId().getValue();
-        ChildOption co = Requests.option(null, options);
-        Delete2 dc = Requests.delete("Project", id, co);
+        ChildOption co = Requests.option().excludeType("Dataset").build();
+        Delete2 dc = Requests.delete().target(p).option(co).build();
         callback(true, client, dc);
 
         assertDoesNotExist(p);
@@ -2937,9 +2929,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         iUpdate.saveAndReturnObject(l);
 
         // Now delete the screen
-        long id = s.getId().getValue();
-        ChildOption co = Requests.option(null, "Plate");
-        Delete2 dc = Requests.delete("Screen", id, co);
+        ChildOption co = Requests.option().excludeType("Plate").build();
+        Delete2 dc = Requests.delete().target(s).option(co).build();
         callback(true, client, dc);
 
         assertDoesNotExist(s);
@@ -2967,9 +2958,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         iUpdate.saveAndReturnObject(l);
 
         // Now delete the dataset
-        long id = d.getId().getValue();
-        ChildOption co = Requests.option(null, "Image");
-        Delete2 dc = Requests.delete("Dataset", id, co);
+        ChildOption co = Requests.option().excludeType("Image").build();
+        Delete2 dc = Requests.delete().target(d).option(co).build();
         callback(true, client, dc);
 
         assertDoesNotExist(d);
@@ -3056,7 +3046,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             lcs.add(lc);
         }
         iUpdate.saveAndReturnArray(lcs);
-        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
+        Delete2 dc = Requests.delete().target(img1, img2).build();
         // Now delete the image.
         doChange(client, factory, dc, true, null);
         List<Long> ids = new ArrayList<Long>();
@@ -3212,7 +3202,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             lcs.add(lc);
         }
         iUpdate.saveAndReturnArray(lcs);
-        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
+        Delete2 dc = Requests.delete().target(img1, img2).build();
         doChange(client, factory, dc, true, null);
         // Now delete the image.
         List<Long> ids = new ArrayList<Long>();
@@ -3331,7 +3321,7 @@ public class DeleteServiceTest extends AbstractServerTest {
             l.add(channel);
         }
         iUpdate.saveAndReturnArray(l);
-        Delete2 dc = Requests.delete("Image", Arrays.asList(img1.getId().getValue(), img2.getId().getValue()));
+        Delete2 dc = Requests.delete().target(img1, img2).build();
         doChange(client, factory, dc, true, null);
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
@@ -3373,7 +3363,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         assertTrue(images.size() > 0);
         try {
-            Delete2 dc = Requests.delete("Image", images.get(0).getId().getValue());
+            Delete2 dc = Requests.delete().target(images.get(0)).build();
             callback(true, client, dc);
             fail("Should not be allowed.");
         } catch (AssertionError afe) {
@@ -3396,12 +3386,12 @@ public class DeleteServiceTest extends AbstractServerTest {
         img1 = (Image) iUpdate.saveAndReturnObject(img1);
         Image img2 = mmFactory.createImage();
         img2 = (Image) iUpdate.saveAndReturnObject(img2);
+        Delete2 dc = Requests.delete().target(img1, img2).build();
+        callback(true, client, dc);
+
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
-        Delete2 dc = Requests.delete("Image", ids);
-        callback(true, client, dc);
-
         ParametersI param = new ParametersI();
         param.addIds(ids);
 
@@ -3459,7 +3449,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .simpleImage());
         List<Long> ids = createSharableAnnotation(img1, img2);
         assertTrue(ids.size() > 0);
-        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
+        Delete2 dc = Requests.delete().target(img1).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -3488,8 +3478,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         FileAnnotation fa = new FileAnnotationI();
         fa.setFile(of);
         Annotation data = (Annotation) iUpdate.saveAndReturnObject(fa);
-        long id = data.getId().getValue();
-        Delete2 dc = Requests.delete("Annotation", id);
+        Delete2 dc = Requests.delete().target(data).build();
         callback(true, client, dc);
         assertDoesNotExist(data);
         assertDoesNotExist(of);
@@ -3543,7 +3532,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         link1.link(image1, fa);
         link1 = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link1);
 
-        Delete2 dc = Requests.delete("Image", image0.getId().getValue());
+        Delete2 dc = Requests.delete().target(image0).build();
         callback(true, client, dc);
         //
         // Check results
@@ -3597,8 +3586,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         m.setParent(f);
         m = (PixelsOriginalFileMapI) iUpdate.saveAndReturnObject(m);
 
-        long imageID = image.getId().getValue();
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         sql = "select i from Pixels i where i.id = :id";
         param = new ParametersI();
@@ -3623,9 +3611,8 @@ public class DeleteServiceTest extends AbstractServerTest {
         thumbnail.setPixels(pixels);
         thumbnail = (Thumbnail) iUpdate.saveAndReturnObject(thumbnail);
         assertNotNull(thumbnail);
-        long imageID = image.getId().getValue();
         long thumbnailID = thumbnail.getId().getValue();
-        Delete2 dc = Requests.delete("Image", imageID);
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         String sql = "select i from Thumbnail i where i.id = :id";
         ParametersI param = new ParametersI();
@@ -3658,7 +3645,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertEquals(fileset, image1.getFileset());
 
         try {
-            Delete2 dc = Requests.delete("Image", image0.getId().getValue());
+            Delete2 dc = Requests.delete().target(image0).build();
             callback(true, client, dc);
             fail("Should throw on constraint violation");
         } catch (AssertionError e) {
@@ -3685,7 +3672,7 @@ public class DeleteServiceTest extends AbstractServerTest {
     public void testSlowDeleteOfOriginalFile() throws Exception {
         OriginalFile of = (OriginalFile) iUpdate.saveAndReturnObject(mmFactory
                 .createOriginalFile());
-        Delete2 dc = Requests.delete("OriginalFile", of.getId().getValue());
+        Delete2 dc = Requests.delete().target(of).build();
         callback(true, client, dc);
         assertDoesNotExist(of);
     }
@@ -3701,7 +3688,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         OriginalFile of = (OriginalFile) iUpdate.saveAndReturnObject(mmFactory
                 .createOriginalFile());
         createSharableAnnotation(of, null);
-        Delete2 dc = Requests.delete("OriginalFile", of.getId().getValue());
+        Delete2 dc = Requests.delete().target(of).build();
         callback(true, client, dc);
         assertDoesNotExist(of);
     }
@@ -3716,8 +3703,7 @@ public class DeleteServiceTest extends AbstractServerTest {
     public void testDeleteTwice() throws Exception {
         Image img = (Image) iUpdate
                 .saveAndReturnObject(mmFactory.createImage());
-        long id = img.getId().getValue();
-        Delete2 dc = Requests.delete("Image", id);
+        Delete2 dc = Requests.delete().target(img).build();
         callback(true, client, dc);
         callback(false, client, dc);
     }
@@ -3735,7 +3721,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 .createImage());
 
         List<Long> ids = createNonSharableAnnotation(image, null);
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         String sql = "select a from Annotation as a where a.id in (:ids)";
         ParametersI p = new ParametersI();
@@ -3761,7 +3747,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         planeInfo = (PlaneInfo) iUpdate.saveAndReturnObject(planeInfo);
         // now Delete the image.
         assertExists(planeInfo);
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         assertDoesNotExist(image);
         assertDoesNotExist(pixels);
@@ -3858,7 +3844,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         List<OTF> otfs = instrument.copyOtf();
 
         // Delete the image.
-        Delete2 dc = Requests.delete("Image", image.getId().getValue());
+        Delete2 dc = Requests.delete().target(image).build();
         callback(true, client, dc);
         assertDoesNotExist(image);
         assertDoesNotExist(pixels);
@@ -3942,12 +3928,12 @@ public class DeleteServiceTest extends AbstractServerTest {
         assertExists(img1);
         assertExists(img2);
         assertExists(file);
-        Delete2 dc = Requests.delete("Image", img1.getId().getValue());
+        Delete2 dc = Requests.delete().target(img1).build();
         callback(true, client, dc);
         assertDoesNotExist(img1);
         assertExists(img2);
         assertExists(file);
-        dc = Requests.delete("Image", img2.getId().getValue());
+        dc = Requests.delete().target(img2).build();
         callback(true, client, dc);
         assertDoesNotExist(img1);
         assertDoesNotExist(img2);

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -386,8 +386,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                         if (!isSecuritySystemGroup(targetGroup)
                                 && targetGroup != sourceGroup) {
                             img = images.get(k);
-                            long imageId = img.getId().getValue();
-                            final Chgrp2 dc = Requests.chgrp("Image", imageId, targetGroup);
+                            final Chgrp2 dc = Requests.chgrp().target(img).toGroup(targetGroup).build();
                             testParams.add(new TestParam(dc, testUserNames[i],
                                     PASSWORD, sourceGroup));
                         }

--- a/components/tools/OmeroJava/test/integration/TableTest.java
+++ b/components/tools/OmeroJava/test/integration/TableTest.java
@@ -106,7 +106,7 @@ public class TableTest extends AbstractServerTest {
     private void deleteTable() throws Exception {
         if (myTable != null) {
             OriginalFile f = myTable.getOriginalFile();
-            final Delete2 dc = Requests.delete("OriginalFile", f.getId().getValue());
+            final Delete2 dc = Requests.delete().target(f).build();
             callback(true, client, dc);
             myTable = null;
         }

--- a/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
@@ -900,7 +900,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         assertNotNull(l);
         long id = l.getId().getValue();
         // annotation and image are linked. Remove the link.
-        final Delete2 dc = Requests.delete("ImageAnnotationLink", l.getId().getValue());
+        final Delete2 dc = Requests.delete().target(l).build();
         callback(true, client, dc);
         // now check that the image is no longer linked to the annotation
         String sql = "select link from ImageAnnotationLink as link";

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -74,7 +74,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         // Create a new group and make owner of first group an owner.
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -116,7 +116,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -156,7 +156,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -197,7 +197,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         // Now check that the image is no longer in group
@@ -241,7 +241,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -282,7 +282,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser("rwr---", ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -323,7 +323,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser("rw----", ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -364,7 +364,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, false);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -405,7 +405,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         ExperimenterGroup g = newGroupAddUser(perms, ctx.userId, true);
         iAdmin.getEventContext(); // Refresh
 
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -445,7 +445,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         // admin logs into first group
         disconnect();
         logRootIntoGroup(ctx);
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -497,7 +497,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(dataset).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -564,7 +564,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(dataset).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -634,7 +634,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(dataset).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -710,7 +710,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // loginUser(ctx);
         // Now try to move the dataset.
-        final Chgrp2 dc = Requests.chgrp("Dataset", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(dataset).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -775,7 +775,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         // user2 tries to move it.
         ctx2 = init(ctx2);
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -840,7 +840,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         /* move the middle folder from the first group to the second */
 
-        doChange(Requests.chgrp("Folder", middleFolder.getId().getValue(), toGroup.getId().getValue()));
+        doChange(Requests.chgrp().target(middleFolder).toGroup(toGroup).build());
 
         /* check that only the top folder remains */
 
@@ -954,9 +954,9 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         final ChildOption option;
         if (Boolean.TRUE.equals(includeOrphans)) {
-            option = Requests.option(folderOption ? "Folder" : "Roi", null);
+            option = Requests.option().includeType(folderOption ? "Folder" : "Roi").build();
         } else if (Boolean.FALSE.equals(includeOrphans)) {
-            option = Requests.option(null, folderOption ? "Folder" : "Roi");
+            option = Requests.option().excludeType(folderOption ? "Folder" : "Roi").build();
         } else {
             option = null;
         }

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveCombinedDataTest.java
@@ -128,7 +128,7 @@ public class HierarchyMoveCombinedDataTest extends AbstractServerTest {
                 logRootIntoGroup(ctx.groupId);
         }
         // Create commands to move and create the link in target
-        final Chgrp2 dc = Requests.chgrp("Dataset", d.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(d).toGroup(g).build();
         callback(true, client, dc);
 
         // Check if the dataset has been removed.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveDatasetTest.java
@@ -145,7 +145,7 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
 
         // Create commands to move and create the link in target
         List<Request> list = new ArrayList<Request>();
-        final Chgrp2 dc = Requests.chgrp("Dataset", d.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(d).toGroup(g).build();
         list.add(dc);
 
         ProjectDatasetLink link = null;
@@ -259,7 +259,7 @@ public class HierarchyMoveDatasetTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = Requests.chgrp("Dataset", s1.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(s1).toGroup(g).build();
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -129,8 +129,6 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         ExperimenterGroup targetGroup = createGroupWithMember(userId,
                 targetGroupPermissions);
 
-        long targetGroupId = targetGroup.getId().getValue();
-
         // force a refresh of the user's group membership
         iAdmin.getEventContext();
 
@@ -146,7 +144,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         loginUser(sourceGroup);
 
         // Perform the move operation.
-        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, targetGroupId);
+        final Chgrp2 dc = Requests.chgrp().target(savedImage).toGroup(targetGroup).build();
         callback(true, client, dc);
 
         // check if the image have been moved.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiFromOtherUserTest.java
@@ -104,7 +104,7 @@ public class HierarchyMoveImageWithRoiFromOtherUserTest extends
         }
         iAdmin.getEventContext();
         // Perform the move operation as original user
-        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, targetGroup.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(image).toGroup(targetGroup).build();
         callback(true, client, dc);
 
         // check the roi has been moved to target group

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithRoiTest.java
@@ -72,7 +72,6 @@ public class HierarchyMoveImageWithRoiTest extends AbstractServerTest {
 
         ExperimenterGroup targetGroup = newGroupAddUser(targetGroupPermissions,
                         userId);
-        long rwGroupId = targetGroup.getId().getValue();
 
         // force a refresh of the user's group membership
         iAdmin.getEventContext();
@@ -94,7 +93,7 @@ public class HierarchyMoveImageWithRoiTest extends AbstractServerTest {
         loginUser(sourceGroup);
 
         // Perform the move operation.
-        final Chgrp2 dc = Requests.chgrp("Image", originalImageId, rwGroupId);
+        final Chgrp2 dc = Requests.chgrp().target(image).toGroup(targetGroup).build();
         callback(true, client, dc);
 
         // check if the objects have been moved.

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -93,7 +93,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         Image img = (Image) iUpdate
                 .saveAndReturnObject(mmFactory.createImage());
         long id = img.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         // Now check that the image is no longer in group
         ParametersI param = new ParametersI();
@@ -151,7 +151,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         // Move the image
-        final Chgrp2 dc = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, dc);
         ParametersI param = new ParametersI();
         param.addId(id);
@@ -282,7 +282,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
             shapeIds.add(shape.getId().getValue());
         }
         // Move the image.
-        final Chgrp2 dc = Requests.chgrp("Image", image.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(image).toGroup(g).build();
         callback(true, client, dc);
 
         // check if the objects have been delete.
@@ -367,7 +367,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
             }
         }
         // Move the plate.
-        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(p).toGroup(g).build();
         callback(true, client, dc);
 
         // check the well
@@ -489,7 +489,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         // Move the plate.
-        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(p).toGroup(g).build();
         callback(true, client, dc);
 
         // check the well
@@ -579,7 +579,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = Requests.chgrp("Screen", screen.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(screen).toGroup(g).build();
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -651,7 +651,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         p = link.getChild();
         long plateID = p.getId().getValue();
 
-        final Chgrp2 dc = Requests.chgrp("Screen", screenId, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(s).toGroup(g).build();
         callback(true, client, dc);
 
         sql = "select r from Screen as r ";
@@ -732,7 +732,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ScreenPlateLink link = (ScreenPlateLink) iQuery.findByQuery(sql, param);
         p = link.getChild();
         long plateID = p.getId().getValue();
-        final Chgrp2 dc = Requests.chgrp("Plate", plateID, g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(p).toGroup(g).build();
         callback(true, client, dc);
         sql = "select r from Screen as r ";
         sql += "where r.id = :id";
@@ -832,7 +832,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(il);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = Requests.chgrp("Plate", p.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(p).toGroup(g).build();
         callback(true, client, dc);
  
         // Shouldn't have measurements
@@ -889,7 +889,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         ids.add(image1.getId().getValue());
         ids.add(image2.getId().getValue());
 
-        final Chgrp2 dc = Requests.chgrp("Project", p.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(p).toGroup(g).build();
         callback(true, client, dc);
 
         // Check if objects have been deleted
@@ -964,7 +964,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(link);
         iUpdate.saveAndReturnArray(links);
 
-        final Chgrp2 dc = Requests.chgrp("Screen", s1.getId().getValue(), g.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(s1).toGroup(g).build();
         callback(true, client, dc);
 
         List<Long> ids = new ArrayList<Long>();
@@ -1051,7 +1051,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         }
 
         /* move the dataset */
-        final Chgrp2 chgrp = Requests.chgrp("Dataset", dataset.getId().getValue(), destination.getId().getValue());
+        final Chgrp2 chgrp = Requests.chgrp().target(dataset).toGroup(destination).build();
         callback(true, client, chgrp);
 
         /* check what remains in the source group */

--- a/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
@@ -169,15 +169,12 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
         long fs1 = f.images.get(1).getFileset().getId().getValue();
         assertEquals(fs0, fs1);
 
-        final Chgrp2 mv = Requests.chgrp("Image", img0, secondGroup.getId().getValue());
+        final Chgrp2 mv = Requests.chgrp().target(f.images.get(0)).toGroup(secondGroup).build();
 
         Response rsp = doChange(client, factory, mv, false); // Don't pass
         // However, it should still be possible to delete the 2 images
         // and have the fileset cleaned up.
-        List<Long> ids = new ArrayList<Long>();
-        ids.add(img0);
-        ids.add(img1);
-        Delete2 dc = Requests.delete("Image", ids);
+        Delete2 dc = Requests.delete().target("Image").id(img0, img1).build();
         callback(true, client, dc);
         assertDoesNotExist(new FilesetI(fs0, false));
     }
@@ -189,9 +186,8 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     public void testMoveFilesetAsRoot() throws Throwable {
     	int imageCount = 2;
     	List<Image> images = importMIF(imageCount);
-        long fs0 = images.get(0).getFileset().getId().getValue();
 
-        final Chgrp2 mv = Requests.chgrp("Fileset", fs0, secondGroup.getId().getValue());
+        final Chgrp2 mv = Requests.chgrp().target(images.get(0).getFileset()).toGroup(secondGroup).build();
 
         Response rsp = doChange(client, factory, mv, true);
         OK err = (OK) rsp;
@@ -234,7 +230,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     		set.addImage(j.next());
 		}
     	set = (Fileset) iUpdate.saveAndReturnObject(set);
-    	final Chgrp2 mv = Requests.chgrp("Fileset", set.getId().getValue(), secondGroup.getId().getValue());
+    	final Chgrp2 mv = Requests.chgrp().target(set).toGroup(secondGroup).build();
     	Response rsp = doChange(client, factory, mv, true);
     	OK err = (OK) rsp;
     	assertNotNull(err);
@@ -418,7 +414,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
 		}
         long filesetID = images.get(0).getFileset().getId().getValue();
         iUpdate.saveAndReturnArray(links);
-        final Chgrp2 dc = Requests.chgrp("Dataset", dataset.getId().getValue(), secondGroup.getId().getValue());
+        final Chgrp2 dc = Requests.chgrp().target(dataset).toGroup(secondGroup).build();
 
     	doAllChanges(client, factory, true, dc);
 

--- a/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/RenderingSettingsMoveTest.java
@@ -96,10 +96,8 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
             logRootIntoGroup(ctx);
         }
 
-        //move the image(s)
-        long id = img.getId().getValue();
         // Move the image
-        final Chgrp2 mv = Requests.chgrp("Image", id, g.getId().getValue());
+        final Chgrp2 mv = Requests.chgrp().target(img).toGroup(g).build();
         callback(true, client, mv);
 
         //Check if the settings have been deleted.
@@ -114,6 +112,7 @@ public class RenderingSettingsMoveTest extends AbstractServerTest {
         loginUser(g);
 
         //Check that image has been moved.
+        long id = img.getId().getValue();
         assertNotNull(iQuery.find(Image.class.getSimpleName(), id));
 
         //Load the settings.

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -111,7 +111,7 @@ public class PermissionsTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = Requests.delete("Image", testImages);
+        final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }
@@ -224,7 +224,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chmod */
 
         init(chmodder);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(toPerms).build();
         doChange(client, factory, chmod, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -391,7 +391,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chmod */
 
         init(chmodder);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, "rw----");
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms("rw----").build();
         doChange(client, factory, chmod, true);
 
         /* check that exactly the expected object deletions have occurred */
@@ -536,7 +536,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(toPerms).build();
         doChange(client, factory, chmod, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -599,7 +599,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(toPerms).build();
         doChange(client, factory, chmod, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -682,7 +682,7 @@ public class PermissionsTest extends AbstractServerTest {
         final boolean isExpectSuccess = !"rw----".equals(toPerms);
 
         init(chmodder);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, toPerms);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(toPerms).build();
         doChange(client, factory, chmod, isExpectSuccess);
 
         logRootIntoGroup(dataGroupId);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -108,7 +108,7 @@ public class PermissionsTest extends AbstractServerTest {
      */
     @AfterClass
     public void deleteTestImages() throws Exception {
-        final Delete2 delete = Requests.delete("Image", testImages);
+        final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
         doChange(root, root.getSession(), delete, true);
         clearTestImages();
     }
@@ -263,7 +263,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(chowner);
-        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
+        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -353,7 +353,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(chowner);
-        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
+        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -473,7 +473,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
+        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, true);
 
         /* check that the objects' ownership is all as expected */
@@ -554,7 +554,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* perform the chown */
 
         init(containerOwner);
-        final Chown2 chown = Requests.chown(isInDataset ? "Dataset" : "Folder", container.getId().getValue(), recipient.userId);
+        final Chown2 chown = Requests.chown().target(container).toUser(recipient.userId).build();
         doChange(client, factory, chown, true);
 
         /* check that the objects' ownership is all as expected */
@@ -650,13 +650,13 @@ public class PermissionsTest extends AbstractServerTest {
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(groupPermissions).build();
         doChange(client, factory, chmod, true);
 
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
+        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, true);
 
         /* check that the objects' ownership is all as expected */
@@ -712,13 +712,13 @@ public class PermissionsTest extends AbstractServerTest {
         /* chmod the group to the required permissions */
 
         logRootIntoGroup(dataGroupId);
-        final Chmod2 chmod = Requests.chmod("ExperimenterGroup", dataGroupId, groupPermissions);
+        final Chmod2 chmod = Requests.chmod().target(dataGroup).toPerms(groupPermissions).build();
         doChange(client, factory, chmod, true);
 
         /* perform the chown */
 
         init(imageOwner);
-        final Chown2 chown = Requests.chown("Image", imageId, recipient.userId);
+        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, true);
 
         /* check that the objects' ownership is all as expected */
@@ -833,13 +833,13 @@ public class PermissionsTest extends AbstractServerTest {
 
         switch (target) {
         case DATASET:
-            chown = Requests.chown("Dataset", datasetId, recipient.userId);
+            chown = Requests.chown().target(dataset).toUser(recipient.userId).build();
             break;
         case IMAGES:
-            chown = Requests.chown("Image", imageIds, recipient.userId);
+            chown = Requests.chown().target("Image").id(imageIds).toUser(recipient.userId).build();
             break;
         case PLATE:
-            chown = Requests.chown("Plate", plateId, recipient.userId);
+            chown = Requests.chown().target(plate).toUser(recipient.userId).build();
             break;
         default:
             chown = null;

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -81,7 +81,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         Assert.assertFalse(ids.isEmpty());
 
         // Perform delete
-        final SkipHead dc = Requests.skipHead("Image", imageId, "Channel", new Delete2());
+        final SkipHead dc = Requests.skipHead().target("Image").id(imageId).startFrom("Channel")
+                .request(Delete2.class).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -112,7 +113,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         Assert.assertFalse(ids.isEmpty());
 
         // Perform delete
-        final SkipHead dc = Requests.skipHead("Image", imageId, "RenderingDef", new Delete2());
+        final SkipHead dc = Requests.skipHead().target("Image").id(imageId).startFrom("RenderingDef")
+                .request(Delete2.class).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -137,7 +139,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
      */
     public void testImage() throws Exception {
         final long imageId = iUpdate.saveAndReturnObject(mmFactory.createImage()).getId().getValue();
-        final Delete2 dc = Requests.delete("Image", imageId);
+        final Delete2 dc = Requests.delete().target("Image").id(imageId).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -151,7 +153,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
      */
     public void testImageI() throws Exception {
         final long imageId = iUpdate.saveAndReturnObject(mmFactory.createImage()).getId().getValue();
-        final Delete2 dc = Requests.delete("ImageI", imageId);
+        final Delete2 dc = Requests.delete().target("ImageI").id(imageId).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -175,7 +177,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long annId = link.getChild().getId().getValue();
 
         // Perform delete
-        final Delete2 dc = Requests.delete("Image", imageId);
+        final Delete2 dc = Requests.delete().target("Image").id(imageId).build();
         callback(true, client, dc);
 
         // Check that the annotation is gone
@@ -211,7 +213,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         link2 = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link2);
 
         // Perform delete
-        final Delete2 dc = Requests.delete("Image", imageId1);
+        final Delete2 dc = Requests.delete().target("Image").id(imageId1).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -245,7 +247,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long id = p.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Project", id);
+        final Delete2 dc = Requests.delete().target("Project").id(id).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -279,7 +281,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long did = d.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Project", pid);
+        final Delete2 dc = Requests.delete().target("Project").id(pid).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -316,7 +318,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long wsid = ws.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Plate", pid);
+        final Delete2 dc = Requests.delete().target("Plate").id(pid).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -352,7 +354,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long aid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Image", iid);
+        final Delete2 dc = Requests.delete().target("Image").id(iid).build();
         callback(true, client, dc);
 
         // Check that data is gone
@@ -384,7 +386,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("Annotation", cid);
+        final Delete2 dc = Requests.delete().target("Annotation").id(cid).build();
         callback(true, client, dc);
 
         // Make sure the parent annotation still exists, but both the annotation
@@ -417,8 +419,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final ChildOption option = Requests.option(null, "TagAnnotation");
-        final Delete2 dc = Requests.delete("Image", pid, option);
+        final ChildOption option = Requests.option().excludeType("TagAnnotation").build();
+        final Delete2 dc = Requests.delete().target("Image").id(pid).option(option).build();
         callback(true, client, dc);
 
         // Make sure the image is deleted but the annotation remains.
@@ -455,8 +457,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         final long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final ChildOption option = Requests.option(null, "FileAnnotation");
-        final Delete2 dc = Requests.delete("Image", pid, option);
+        final ChildOption option = Requests.option().excludeType("FileAnnotation").build();
+        final Delete2 dc = Requests.delete().target("Image").id(pid).option(option).build();
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -492,8 +494,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         long cid = link.getChild().getId().getValue();
 
         // Do Delete
-        final ChildOption option = Requests.option(null, "FileAnnotation", null, "keepme");
-        final Delete2 dc = Requests.delete("Image", pid, option);
+        final ChildOption option = Requests.option().excludeType("FileAnnotation").excludeNs("keepme").build();
+        final Delete2 dc = Requests.delete().target("Image").id(pid).option(option).build();
         callback(true, client, dc);
 
         // Make sure the image and annotation are deleted.
@@ -526,8 +528,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         List<Long> annotationIds = createNonSharableAnnotation(obj, null);
         List<Long> annotationIdsNS = createNonSharableAnnotation(obj, "TEST");
 
-        final ChildOption option = Requests.option(null, "Annotation", null, "TEST");
-        final Delete2 dc = Requests.delete(type, id, option);
+        final ChildOption option = Requests.option().excludeType("Annotation").excludeNs("TEST").build();
+        final Delete2 dc = Requests.delete().target(type).id(id).option(option).build();
         callback(true, client, dc);
 
         ParametersI param = new ParametersI();
@@ -566,10 +568,9 @@ public class AdditionalDeleteTest extends AbstractServerTest {
     public void testOriginalFileAnnotation() throws Exception {
         final FileAnnotationI ann = mockAnnotation();
         final OriginalFile file = ann.getFile();
-        final long id = file.getId().getValue();
 
         // Do Delete
-        final Delete2 dc = Requests.delete("OriginalFile", id);
+        final Delete2 dc = Requests.delete().target(file).build();
         callback(true, client, dc);
 
         assertGone(file);
@@ -584,11 +585,10 @@ public class AdditionalDeleteTest extends AbstractServerTest {
     public void testOriginalFileAnnotationWithKeep() throws Exception {
         final FileAnnotationI ann = mockAnnotation();
         final OriginalFile file = ann.getFile();
-        final long id = file.getId().getValue();
 
         // Do Delete
-        final ChildOption option = Requests.option(null, "Annotation");
-        final Delete2 dc = Requests.delete("OriginalFile", id, option);
+        final ChildOption option = Requests.option().excludeType("Annotation").build();
+        final Delete2 dc = Requests.delete().target(file).option(option).build();
         callback(true, client, dc);
 
         assertGone(ann);

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -10,6 +10,7 @@ import static omero.rtypes.rstring;
 import integration.AbstractServerTest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +93,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
                 .saveAndReturnObject(new TagAnnotationI());
         IObject link = mmFactory.createAnnotationLink(obj.proxy(), ann);
         link = iUpdate.saveAndReturnObject(link);
-        final Delete2 dc = Requests.delete(command, id.getValue());
+        final Delete2 dc = Requests.delete().target(command).id(id).build();
         callback(true, client, dc);
         assertDoesNotExist(obj);
         assertDoesNotExist(link);
@@ -124,7 +125,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             fa.setFile(mmFactory.createOriginalFile());
             fa = (FileAnnotation) iUpdate.saveAndReturnObject(fa);
             file = fa.getFile();
-            final Delete2 dc = Requests.delete("Annotation", fa.getId().getValue());
+            final Delete2 dc = Requests.delete().target(fa).build();
             callback(true, client, dc);
             assertDoesNotExist(fa);
             assertDoesNotExist(file);
@@ -156,7 +157,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         disconnect();
 
         loginUser(owner);
-        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
+        final Delete2 dc = Requests.delete().target(i1).build();
         callback(true, client, dc);
         assertDoesNotExist(i1);
         assertDoesNotExist(link);
@@ -296,23 +297,21 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         }
 
         /* delete the first tag set */
-        final Delete2 request;
-        final Long tagset0Id = tagsets.get(0).getId().getValue();
+        final Delete2 request = Requests.delete().target(tagsets.get(0)).build();
         switch (option) {
         case NONE:
-            request = Requests.delete("Annotation", tagset0Id);
             break;
         case INCLUDE:
-            request = Requests.delete("Annotation", tagset0Id, Requests.option("Annotation", null));
+            request.childOptions = Collections.singletonList(Requests.option().includeType("Annotation").build());
             break;
         case EXCLUDE:
-            request = Requests.delete("Annotation", tagset0Id, Requests.option(null, "Annotation"));
+            request.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
             break;
         case BOTH:
-            request = Requests.delete("Annotation", tagset0Id, Requests.option("Annotation", "Annotation"));
+            request.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
+                                                                              .excludeType("Annotation").build());
             break;
         default:
-            request = null;
             Assert.fail("unexpected option for delete");
         }
         doChange(request);
@@ -340,12 +339,12 @@ public class AnnotationDeleteTest extends AbstractServerTest {
             assertExists(tags.get(1));
             assertExists(tags.get(2));
             /* delete the tag that is not in the second tag set */
-            doChange(Requests.delete("Annotation", tags.get(0).getId().getValue()));
+            doChange(Requests.delete().target(tags.get(0)).build());
             break;
         }
 
         /* delete the second tag set */
-        doChange(Requests.delete("Annotation", tagsets.get(1).getId().getValue()));
+        doChange(Requests.delete().target(tagsets.get(1)).build());
 
         /* check that the tag set and the remaining tags are deleted */
         assertNoneExist(tagsets);

--- a/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/DeleteProjectedImageTest.java
@@ -134,15 +134,15 @@ public class DeleteProjectedImageTest extends AbstractServerTest {
         Delete2 dc;
         switch (action) {
         case SOURCE_IMAGE:
-            dc = Requests.delete("Image", id);
+            dc = Requests.delete().target("Image").id(id).build();
             callback(passes, client, dc);
             break;
         case PROJECTED_IMAGE:
-            dc = Requests.delete("Image", projectedID);
+            dc = Requests.delete().target("Image").id(projectedID).build();
             callback(passes, client, dc);
             break;
         case BOTH_IMAGES:
-            dc = Requests.delete("Image", Arrays.asList(id, projectedID));
+            dc = Requests.delete().target("Image").id(id, projectedID).build();
             callback(passes, client, dc);
             break;
         }

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -122,7 +122,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         ds2.linkImage(i2);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(ds2).build();
         callback(true, client, dc);
 
         assertDoesNotExist(ds2);
@@ -167,7 +167,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         link.setParent((Image) i.proxy());
         iUpdate.saveAndReturnObject(link);
 
-        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(ds2).build();
         callback(true, client, dc);
         assertDoesNotExist(ds2);
         assertExists(ds1);
@@ -202,7 +202,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         ds2.linkImage(i);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        final Delete2 dc = Requests.delete("Dataset", ds2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(ds2).build();
         callback(true, client, dc);
 
         assertDoesNotExist(ds2);
@@ -239,7 +239,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         p2.linkDataset(d);
         p2 = (Project) iUpdate.saveAndReturnObject(p2);
 
-        final Delete2 dc = Requests.delete("Project", p2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(p2).build();
         callback(true, client, dc);
 
         assertDoesNotExist(p2);
@@ -275,7 +275,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         s2.linkPlate(p);
         s2 = (Screen) iUpdate.saveAndReturnObject(s2);
 
-        final Delete2 dc = Requests.delete("Screen", s2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(s2).build();
         callback(true, client, dc);
 
         assertDoesNotExist(s2);
@@ -462,7 +462,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
 
             /* Delete the run. */
 
-            final Delete2 dc = Requests.delete("PlateAcquisition", runIdToDelete);
+            final Delete2 dc = Requests.delete().target("PlateAcquisition").id(runIdToDelete).build();
             callback(true, client, dc);
             
             /* Verify that exactly the expected entities remain. */
@@ -474,7 +474,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
        }
  
         /* Delete the plate. */
-        final Delete2 dc = Requests.delete("Plate", plateId);
+        final Delete2 dc = Requests.delete().target("Plate").id(plateId).build();
         callback(true, client, dc);
 
         /* Verify that no entities remain. */
@@ -546,7 +546,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnObject(link);
 
         /* delete the dataset */
-        final Delete2 delete = Requests.delete("Dataset", dataset.getId().getValue());
+        final Delete2 delete = Requests.delete().target(dataset).build();
         callback(true, client, delete);
 
         /* check what is left afterward */
@@ -604,13 +604,13 @@ public class HierarchyDeleteTest extends AbstractServerTest {
 
         switch (target) {
         case DATASET:
-            delete = Requests.delete("Dataset", datasetId);
+            delete = Requests.delete().target(dataset).build();
             break;
         case IMAGES:
-            delete = Requests.delete("Image", imageIds);
+            delete = Requests.delete().target("Image").id(imageIds).build();
             break;
         case PLATE:
-            delete = Requests.delete("Plate", plateId);
+            delete = Requests.delete().target(plate).build();
             break;
         default:
             delete = null;
@@ -721,9 +721,9 @@ public class HierarchyDeleteTest extends AbstractServerTest {
 
         final ChildOption option;
         if (Boolean.TRUE.equals(includeOrphans)) {
-            option = Requests.option(folderOption ? "Folder" : "Roi", null);
+            option = Requests.option().includeType(folderOption ? "Folder" : "Roi").build();
         } else if (Boolean.FALSE.equals(includeOrphans)) {
-            option = Requests.option(null, folderOption ? "Folder" : "Roi");
+            option = Requests.option().excludeType(folderOption ? "Folder" : "Roi").build();
         } else {
             option = null;
         }

--- a/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/MultiImageFilesetDeleteTest.java
@@ -6,7 +6,6 @@
 package integration.delete;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import integration.AbstractServerTest;
@@ -71,7 +70,7 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
     	link.setChild((Image) i2.proxy());
     	link.setParent((Dataset) d2.proxy());
     	iUpdate.saveAndReturnObject(link);
-    	Delete2 dc = Requests.delete("Dataset", Arrays.asList(d1.getId().getValue(), d2.getId().getValue()));
+    	Delete2 dc = Requests.delete().target(d1, d2).build();
     	doChange(dc);
     	assertDoesNotExist(d1);
     	assertDoesNotExist(d2);
@@ -116,7 +115,6 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
         fileset.addImage(image1);
         fileset.addImage(image2);
         fileset = (Fileset) iUpdate.saveAndReturnObject(fileset);
-        final long filesetId = fileset.getId().getValue();
 
         final IRenderingSettingsPrx renderingSettingsService = factory.getRenderingSettingsService();
         renderingSettingsService.setOriginalSettingsInImage(image1Id);
@@ -127,16 +125,16 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
         final SkipHead skipHead;
         switch (target) {
         case IMAGES_OF_FILESET:
-            skipHead = Requests.skipHead("Fileset", filesetId, dryRun, "Image", new Delete2());
+            skipHead = Requests.skipHead().target(fileset).startFrom("Image").dryRun(dryRun).request(Delete2.class).build();
             break;
         case RENDERING_SETTINGS_OF_FILESET:
-            skipHead = Requests.skipHead("Fileset", filesetId, dryRun, "RenderingDef", new Delete2());
+            skipHead = Requests.skipHead().target(fileset).startFrom("RenderingDef").dryRun(dryRun).request(Delete2.class).build();
             break;
         case RENDERING_SETTINGS_OF_IMAGE:
-            skipHead = Requests.skipHead("Image", image1Id, dryRun, "RenderingDef", new Delete2());
+            skipHead = Requests.skipHead().target(image1).startFrom("RenderingDef").dryRun(dryRun).request(Delete2.class).build();
             break;
         case NONSENSE_OF_IMAGE:
-            skipHead = Requests.skipHead("Image", image1Id, dryRun, "I like penguins", new Delete2());
+            skipHead = Requests.skipHead().target(image1).startFrom("I like snails").dryRun(dryRun).request(Delete2.class).build();
             break;
         default:
             skipHead = null;
@@ -171,7 +169,7 @@ public class MultiImageFilesetDeleteTest extends AbstractServerTest {
             assertHasRenderingDef(image2Id, isImage2SettingsExist);
 
             /* delete the fileset */
-            final Delete2 delete = Requests.delete("Fileset", filesetId);
+            final Delete2 delete = Requests.delete().target(fileset).build();
             doChange(delete);
         }
 

--- a/components/tools/OmeroJava/test/integration/delete/RelatedToTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/RelatedToTest.java
@@ -40,7 +40,7 @@ public class RelatedToTest extends AbstractServerTest {
         p2 = (Pixels) iUpdate.saveAndReturnObject(p2);
         assertEquals(p1.getId(), p2.getRelatedTo().getId());
 
-        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
+        final Delete2 dc = Requests.delete().target(i1).build();
         callback(true, client, dc);
 
         assertDoesNotExist(i1);
@@ -71,7 +71,7 @@ public class RelatedToTest extends AbstractServerTest {
         assertNotNull(pixels);
         assertEquals(pixels.getId().getValue(), pixels2.getId().getValue());
 
-        final Delete2 dc = Requests.delete("Image", img2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(img2).build();
         callback(true, client, dc);
 
         String sql = "select i from Image i where i.id = :id";
@@ -111,7 +111,7 @@ public class RelatedToTest extends AbstractServerTest {
         assertNotNull(pixels);
         assertEquals(pixels.getId().getValue(), pixels2.getId().getValue());
 
-        final Delete2 dc = Requests.delete("Image", img2.getId().getValue());
+        final Delete2 dc = Requests.delete().target(img2).build();
         callback(true, client, dc);
 
         String sql = "select i from Image i where i.id = :id";

--- a/components/tools/OmeroJava/test/integration/delete/RoiDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/RoiDeleteTest.java
@@ -72,7 +72,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         disconnect();
 
         loginUser(owner);
-        final Delete2 dc = Requests.delete("Image", i1.getId().getValue());
+        final Delete2 dc = Requests.delete().target(i1).build();
         callback(true, client, dc);
 
         assertDoesNotExist(i1);
@@ -145,7 +145,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         // Now delete the rois.
-        final Delete2 dc = Requests.delete("Roi", roiID);
+        final Delete2 dc = Requests.delete().target(roi).build();
         callback(true, client, dc);
         assertDoesNotExist(roi);
         l = svc.getRoiMeasurements(image.getId().getValue(), options);
@@ -218,7 +218,7 @@ public class RoiDeleteTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(links);
 
         // Now delete the plate
-        final Delete2 dc = Requests.delete("Plate", p.getId().getValue());
+        final Delete2 dc = Requests.delete().target(p).build();
         callback(true, client, dc);
         assertDoesNotExist(p);
         assertDoesNotExist(roi);

--- a/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/SpwDeleteTest.java
@@ -71,7 +71,7 @@ public class SpwDeleteTest extends AbstractServerTest {
         // see XMLMockObjects.createScreen()
         scalingFactor *= 1*2*2*2*2;
 
-        final Delete2 dc = Requests.delete("Screen", screen.getId().getValue());
+        final Delete2 dc = Requests.delete().target(screen).build();
         callback(true, client, dc);
 
         assertDoesNotExist(screen);
@@ -97,10 +97,9 @@ public class SpwDeleteTest extends AbstractServerTest {
         WellSample ws = getWellSample(p);
         Plate plate = ws.getWell().getPlate();
         Screen screen = plate.copyScreenLinks().get(0).getParent();
-        long sid = screen.getId().getValue();
 
-        final ChildOption option = Requests.option(null, "Plate");
-        final Delete2 dc = Requests.delete("Screen", sid, option);
+        final ChildOption option = Requests.option().excludeType("Plate").build();
+        final Delete2 dc = Requests.delete().target(screen).option(option).build();
         callback(true, client, dc);
 
         assertDoesNotExist(screen);


### PR DESCRIPTION
With this PR and #4653 there should be no more uses of deprecated Requests methods in OMERO. CI should remain green. The code changes should be reviewed to ensure that tests are still acting as intended.