### PR TITLE
Chown tests

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -20,6 +20,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+import pytest
+
 import omero
 from omero.cli import CLI
 from omero.plugins.sessions import SessionsControl
@@ -70,6 +72,15 @@ class CLITest(AbstractCLITest):
         assert found_object.id.val == new_object.id.val
 
         return new_object.id.val
+
+    @pytest.fixture()
+    def simpleHierarchy(self):
+        proj = self.make_project()
+        dset = self.make_dataset()
+        img = self.update.saveAndReturnObject(self.new_image())
+        self.link(proj, dset)
+        self.link(dset, img)
+        return proj, dset, img
 
 
 class RootCLITest(AbstractCLITest):

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -499,7 +499,7 @@ class TestChown(CLITest):
 
     def testOutputWithElision(self, capfd):
         DATASETS = 8
-        # Import several images
+        # Create several datasets
         ids = []
         for i in range(DATASETS):
             ids.append(self.make_dataset().id.val)
@@ -508,7 +508,7 @@ class TestChown(CLITest):
         assert ids[-1] - ids[0] + 1 == DATASETS
         ids = [str(id) for id in ids]
 
-        # Create user and transfer some of those images
+        # Create user and transfer some of those datasets
         # to the user, mix up the order
         client, user = self.new_client_and_user(group=self.group)
         self.args += ['%s' % user.id.val]

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -312,6 +312,49 @@ class TestChown(CLITest):
             assert obj.id.val == d.id.val
             assert obj.details.owner.id.val == user.id.val
 
+    @pytest.mark.parametrize('number', [1, 2, 3])
+    @pytest.mark.parametrize("ordered", ordered)
+    def testMultipleSkipheadsPlusObjectsInterlaced(self, number, ordered):
+        projs = [self.make_project() for i in range(number)]
+        dsets = [self.make_dataset() for i in range(number)]
+        imgs = [self.update.saveAndReturnObject(self.new_image())
+                for i in range(number)]
+
+        for i in range(number):
+            self.link(projs[i], dsets[i])
+            self.link(dsets[i], imgs[i])
+
+        ds = [self.make_dataset() for i in range(number)]
+
+        # Create user and transfer the objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        for i in range(number):
+            self.args += ['Project/Dataset/Image:%s' % projs[i].id.val]
+            self.args += ['Dataset:%s' % ds[i].id.val]
+        if ordered:
+            self.args += ["--ordered"]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that only the images and separate datasets
+        # have been transferred
+        for p in projs:
+            obj = self.query.get('Project', p.id.val, all_grps)
+            assert obj.id.val == p.id.val
+            assert obj.details.owner.id.val == self.user.id.val
+        for d in dsets:
+            obj = self.query.get('Dataset', d.id.val, all_grps)
+            assert obj.id.val == d.id.val
+            assert obj.details.owner.id.val == self.user.id.val
+        for i in imgs:
+            obj = self.query.get('Image', i.id.val, all_grps)
+            assert obj.id.val == i.id.val
+            assert obj.details.owner.id.val == user.id.val
+        for d in ds:
+            obj = self.query.get('Dataset', d.id.val, all_grps)
+            assert obj.id.val == d.id.val
+            assert obj.details.owner.id.val == user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -260,7 +260,6 @@ class TestChown(CLITest):
         obj = self.query.get('Project', proj.id.val, all_grps)
         assert obj.id.val == proj.id.val
         assert obj.details.owner.id.val == self.user.id.val
-        assert self.query.find('Dataset', dset.id.val)
         obj = self.query.get('Dataset', dset.id.val, all_grps)
         assert obj.id.val == dset.id.val
         assert obj.details.owner.id.val == self.user.id.val

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -111,6 +111,21 @@ class TestChown(CLITest):
             assert obj.id.val == i.id.val
             assert obj.details.owner.id.val == user.id.val
 
+    def testFilesetPartialFailing(self):
+        images = self.importMIF(2)  # 2 images sharing a fileset
+
+        # Create user and try to transfer only one image to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Image:%s' % images[0].id.val]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check the images have not been transferred
+        for i in images:
+            obj = self.query.get('Image', i.id.val, all_grps)
+            assert obj.id.val == i.id.val
+            assert obj.details.owner.id.val == self.user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -444,6 +444,28 @@ class TestChown(CLITest):
         assert obj.id.val == img.id.val
         assert obj.details.owner.id.val == self.user.id.val
 
+    def testExcludeOverridesInclude(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        # Create user and transfer objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Dataset']
+        self.args += ['--include', 'Image']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that only the Project has been transferred
+        obj = self.query.get('Project', proj.id.val, all_grps)
+        assert obj.id.val == proj.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Dataset', dset.id.val, all_grps)
+        assert obj.id.val == dset.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -27,7 +27,6 @@ from test.integration.clitest.cli import CLITest, RootCLITest
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
-object_forms = ["Dataset", "/Dataset", "DatasetI", "/DatasetI"]
 user_prefixes = ["", "User:", "Experimenter:"]
 all_grps = {'omero.group': '-1'}
 ordered = [True, False]
@@ -58,18 +57,20 @@ class TestChown(CLITest):
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 
-    @pytest.mark.parametrize("object_form", object_forms)
-    def testChownBasicUsageWithName(self, object_form):
-        oid = self.create_object("Dataset")
+    @pytest.mark.parametrize("object_prefix", ["", "/"])
+    @pytest.mark.parametrize("object_suffix", ["", "I"])
+    def testChownBasicUsageWithName(self, object_prefix, object_suffix):
+        object_name = "Dataset"
+        oid = self.create_object(object_name)
+        argument = object_prefix + object_name + object_suffix
 
         # create a user in the same group and transfer the object to the user
         client, user = self.new_client_and_user(group=self.group)
-        self.args += ['%s' % (user.omeName.val),
-                      '%s:%s' % (object_form, oid)]
+        self.args += ['%s' % (user.omeName.val), '%s:%s' % (argument, oid)]
         self.cli.invoke(self.args, strict=True)
 
         # check the object has been transferred
-        obj = client.sf.getQueryService().get("Dataset", oid, all_grps)
+        obj = client.sf.getQueryService().get(object_name, oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -466,6 +466,37 @@ class TestChown(CLITest):
         assert obj.id.val == img.id.val
         assert obj.details.owner.id.val == self.user.id.val
 
+    def testSeparateAnnotationTransfer(self):
+        img = self.update.saveAndReturnObject(self.new_image())
+        fa = self.make_file_annotation()
+        fa2 = self.make_file_annotation()
+        tag = self.make_tag()
+
+        self.link(img, fa)
+        self.link(img, tag)
+
+        # Create user and transfer objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Image:%s' % img.id.val]
+        self.args += ['Annotation:%s' % fa2.id.val]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that the image and and all annotations
+        # have been transferred, both linked and not linked
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('FileAnnotation', fa.id.val, all_grps)
+        assert obj.id.val == fa.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('TagAnnotation', tag.id.val, all_grps)
+        assert obj.id.val == tag.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('FileAnnotation', fa2.id.val, all_grps)
+        assert obj.id.val == fa2.id.val
+        assert obj.details.owner.id.val == user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -92,11 +92,9 @@ class TestChown(CLITest):
         fileset = self.query.get('Fileset', filesetId)
         assert fileset is not None
 
-        # create user and try to transfer the object to the user
+        # create user and transfer the object to the user
         client, user = self.new_client_and_user(group=self.group)
         self.args += ['%s' % user.id.val]
-
-        # Delete the fileset
         if arguments == 'fileset':
             self.args += ['%s:%s' % ('Fileset', filesetId)]
         else:

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -27,6 +27,7 @@ from test.integration.clitest.cli import CLITest, RootCLITest
 import pytest
 
 object_types = ["Image", "Dataset", "Project", "Plate", "Screen"]
+object_forms = ["Dataset", "/Dataset", "DatasetI", "/DatasetI"]
 user_prefixes = ["", "User:", "Experimenter:"]
 all_grps = {'omero.group': '-1'}
 ordered = [True, False]
@@ -57,17 +58,18 @@ class TestChown(CLITest):
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 
-    def testChownBasicUsageWithName(self):
-        oid = self.create_object("Image")
+    @pytest.mark.parametrize("object_form", object_forms)
+    def testChownBasicUsageWithName(self, object_form):
+        oid = self.create_object("Dataset")
 
         # create a user in the same group and transfer the object to the user
         client, user = self.new_client_and_user(group=self.group)
         self.args += ['%s' % (user.omeName.val),
-                      '%s:%s' % ("Image", oid)]
+                      '%s:%s' % (object_form, oid)]
         self.cli.invoke(self.args, strict=True)
 
         # check the object has been transferred
-        obj = client.sf.getQueryService().get("Image", oid, all_grps)
+        obj = client.sf.getQueryService().get("Dataset", oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -208,6 +208,32 @@ class TestChown(CLITest):
             assert obj.id.val == d.id.val
             assert obj.details.owner.id.val == user.id.val
 
+    @pytest.mark.parametrize('number', [1, 2, 3])
+    @pytest.mark.parametrize("ordered", ordered)
+    def testMultipleSimpleObjectsTwoClassesInterlaced(self, number, ordered):
+        projs = [self.make_project() for i in range(number)]
+        dsets = [self.make_dataset() for i in range(number)]
+
+        # Create user and transfer the objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        for i in range(number):
+            self.args += ['Project:%s' % projs[i].id.val]
+            self.args += ['Dataset:%s' % dsets[i].id.val]
+        if ordered:
+            self.args += ["--ordered"]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check the objects have been transferred
+        for p in projs:
+            obj = self.query.get('Project', p.id.val, all_grps)
+            assert obj.id.val == p.id.val
+            assert obj.details.owner.id.val == user.id.val
+        for d in dsets:
+            obj = self.query.get('Dataset', d.id.val, all_grps)
+            assert obj.id.val == d.id.val
+            assert obj.details.owner.id.val == user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -423,6 +423,27 @@ class TestChown(CLITest):
         assert obj.id.val == img.id.val
         assert obj.details.owner.id.val == self.user.id.val
 
+    def testExcludeImage(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        # Create user and transfer objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Image']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that only Project & Dataset have been transferred
+        obj = self.query.get('Project', proj.id.val, all_grps)
+        assert obj.id.val == proj.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Dataset', dset.id.val, all_grps)
+        assert obj.id.val == dset.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -58,8 +58,7 @@ class TestChown(CLITest):
         oid = self.create_object("Image")
 
         # create a user in the same group and transfer the object to the user
-        client, user = self.new_client_and_user()
-        self.add_experimenters(self.group, [user])
+        client, user = self.new_client_and_user(group=self.group)
         self.args += ['%s' % (user.omeName.val),
                       '%s:%s' % ("Image", oid)]
         self.cli.invoke(self.args, strict=True)
@@ -78,7 +77,7 @@ class TestChown(CLITest):
                       '%s:%s' % ("Image", oid)]
         self.cli.invoke(self.args, strict=True)
 
-        # check the object has been transferred
+        # check the object still belongs to the original user
         obj = self.query.get("Image", oid, all_grps)
         assert obj.id.val == oid
         assert obj.details.owner.id.val == self.user.id.val

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -181,6 +181,33 @@ class TestChown(CLITest):
             assert obj.id.val == d.id.val
             assert obj.details.owner.id.val == user.id.val
 
+    @pytest.mark.parametrize('number', [1, 2, 3])
+    @pytest.mark.parametrize("ordered", ordered)
+    def testMultipleSimpleObjectsTwoClassesSeparated(self, number, ordered):
+        projs = [self.make_project() for i in range(number)]
+        dsets = [self.make_dataset() for i in range(number)]
+
+        # Create user and transfer the objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        for p in projs:
+            self.args += ['Project:%s' % p.id.val]
+        for d in dsets:
+            self.args += ['Dataset:%s' % d.id.val]
+        if ordered:
+            self.args += ["--ordered"]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check the objects have been transferred
+        for p in projs:
+            obj = self.query.get('Project', p.id.val, all_grps)
+            assert obj.id.val == p.id.val
+            assert obj.details.owner.id.val == user.id.val
+        for d in dsets:
+            obj = self.query.get('Dataset', d.id.val, all_grps)
+            assert obj.id.val == d.id.val
+            assert obj.details.owner.id.val == user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -498,14 +498,14 @@ class TestChown(CLITest):
         assert obj.details.owner.id.val == user.id.val
 
     def testOutputWithElision(self, capfd):
-        IMAGES = 8
+        DATASETS = 8
         # Import several images
         ids = []
-        for i in range(IMAGES):
-            ids.append(self.importSingleImage().id.val)
+        for i in range(DATASETS):
+            ids.append(self.make_dataset().id.val)
         ids = sorted(ids)
-        assert len(ids) == IMAGES
-        assert ids[-1] - ids[0] + 1 == IMAGES
+        assert len(ids) == DATASETS
+        assert ids[-1] - ids[0] + 1 == DATASETS
         ids = [str(id) for id in ids]
 
         # Create user and transfer some of those images
@@ -513,7 +513,7 @@ class TestChown(CLITest):
         client, user = self.new_client_and_user(group=self.group)
         self.args += ['%s' % user.id.val]
         iids = [ids[5], ids[4], ids[0], ids[7], ids[2], ids[1]]
-        self.args += ['Image:%s' % ",".join(iids)]
+        self.args += ['Dataset:%s' % ",".join(iids)]
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
         o = o.strip().split(" ")
@@ -523,7 +523,7 @@ class TestChown(CLITest):
         assert o[2] == "ok"
         type, oids = o[1].split(":")
         # ... the object type,...
-        assert type == "Image"
+        assert type == "Dataset"
         oids = oids.split(",")
         # ... the first three sequential ids elided,...
         assert oids[0] == ids[0]+"-"+ids[2]

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -355,6 +355,23 @@ class TestChown(CLITest):
             assert obj.id.val == d.id.val
             assert obj.details.owner.id.val == user.id.val
 
+    # Test dry-run option
+    def testDryRun(self):
+        img = self.update.saveAndReturnObject(self.new_image())
+
+        # Create user and try to transfer image to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Image:%s' % img.id.val]
+        self.args += ['--dry-run']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check the image has not been transferred
+        assert self.query.find('Image', img.id.val)
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -402,6 +402,27 @@ class TestChown(CLITest):
         assert obj.id.val == img.id.val
         assert obj.details.owner.id.val == user.id.val
 
+    def testExcludeDataset(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        # Create user and transfer objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Project:%s' % proj.id.val]
+        self.args += ['--exclude', 'Dataset']
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that only the Project has been transferred
+        obj = self.query.get('Project', proj.id.val, all_grps)
+        assert obj.id.val == proj.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Dataset', dset.id.val, all_grps)
+        assert obj.id.val == dset.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == self.user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -372,6 +372,36 @@ class TestChown(CLITest):
         assert obj.id.val == img.id.val
         assert obj.details.owner.id.val == self.user.id.val
 
+    # Test combinations of include and exclude other than annotations
+    @pytest.fixture()
+    def simpleHierarchy(self):
+        proj = self.make_project()
+        dset = self.make_dataset()
+        img = self.update.saveAndReturnObject(self.new_image())
+        self.link(proj, dset)
+        self.link(dset, img)
+        return proj, dset, img
+
+    def testExcludeNone(self, simpleHierarchy):
+        proj, dset, img = simpleHierarchy
+
+        # Create user and transfer objects to the user
+        client, user = self.new_client_and_user(group=self.group)
+        self.args += ['%s' % user.id.val]
+        self.args += ['Project:%s' % proj.id.val]
+        self.cli.invoke(self.args, strict=True)
+
+        # Check that all objects have been transferred
+        obj = self.query.get('Project', proj.id.val, all_grps)
+        assert obj.id.val == proj.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Dataset', dset.id.val, all_grps)
+        assert obj.id.val == dset.id.val
+        assert obj.details.owner.id.val == user.id.val
+        obj = self.query.get('Image', img.id.val, all_grps)
+        assert obj.id.val == img.id.val
+        assert obj.details.owner.id.val == user.id.val
+
 
 class TestChownRoot(RootCLITest):
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -377,15 +377,6 @@ class TestChown(CLITest):
         assert obj.details.owner.id.val == self.user.id.val
 
     # Test combinations of include and exclude other than annotations
-    @pytest.fixture()
-    def simpleHierarchy(self):
-        proj = self.make_project()
-        dset = self.make_dataset()
-        img = self.update.saveAndReturnObject(self.new_image())
-        self.link(proj, dset)
-        self.link(dset, img)
-        return proj, dset, img
-
     def testExcludeNone(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -288,15 +288,6 @@ class TestDelete(CLITest):
         assert self.query.find('Image', img.id.val)
 
     # Test combinations of include and exclude other than annotations
-    @pytest.fixture()
-    def simpleHierarchy(self):
-        proj = self.make_project()
-        dset = self.make_dataset()
-        img = self.update.saveAndReturnObject(self.new_image())
-        self.link(proj, dset)
-        self.link(dset, img)
-        return proj, dset, img
-
     def testExcludeNone(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
 


### PR DESCRIPTION
See [chown trello card](https://trello.com/c/RpdAOmKp/37-permissions-system-problems-chown#comment-5734d47e92374a1dec3292d5).
This PR should be a suggestion to cpmplement the tests and changes of existing tests in [chown trello card](https://trello.com/c/RpdAOmKp/37-permissions-system-problems-chown#comment-5734d47e92374a1dec3292d5). It deals with Python tests only. 

The tests added here should deal with the comments [comment1 on trello](https://trello.com/c/RpdAOmKp/37-permissions-system-problems-chown#comment-5734d6a14a903d90c3e3b14a) and [comment2 on trello](https://trello.com/c/RpdAOmKp/37-permissions-system-problems-chown#comment-5734d47e92374a1dec3292d50) as well as other tests which bring the [chown test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_chown.py) in line with the [delete test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py). 

The two parts which are not completely in line between delete and chown tests are "default exclusion" which is missing in chown logic (on CLI) and the Tag/Tagset workflow (which again, is intrinsically different for delete and chown). I have added just two tests representing these two paragraphs in [delete test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py), namely https://github.com/openmicroscopy/openmicroscopy/pull/4669/commits/7c59c652cdf502af71b0afbe1983f99de8c64900 and https://github.com/openmicroscopy/openmicroscopy/pull/4669/commits/68385640dfafdaeea6b17fe3f3d79c65c1d9c9f3 which check the default behaviour in the private group of attachments and tags/tagsets. I think the permissions here should be checked via  the java integration test. 

To test:
Check that the integration test [chown test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_chown.py) is passing and makes sense.
