### PR TITLE
Bugfix: Point figure offset when close to x and or y axis

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasurePointFigure.java
@@ -411,8 +411,8 @@ public class MeasurePointFigure
     {
         if (shape == null) return;
         UnitPoint c = getMeasurementCentre();
-        AnnotationKeys.CENTREX.set(shape, transformX(c.x.getValue()));
-        AnnotationKeys.CENTREY.set(shape, transformY(c.y.getValue()));
+        AnnotationKeys.CENTREX.set(shape, c.x);
+        AnnotationKeys.CENTREY.set(shape, c.y);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -299,8 +299,8 @@ class InputServerStrategy
 	private MeasurePointFigure createPointFigure(PointData data)
 	{
 		double r = PointFigure.FIGURE_SIZE/2;
-		double x = Math.abs(data.getX()-r);
-		double y = Math.abs(data.getY()-r);
+		double x = data.getX()-r;
+		double y = data.getY()-r;
 		
 		MeasurePointFigure fig = new MeasurePointFigure(data.getText(), x, y, 
 				2*r, 2*r, data.isReadOnly(), data.isClientObject(), 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -303,7 +303,7 @@ class InputServerStrategy
 		double y = data.getY()-r;
 		
 		MeasurePointFigure fig = new MeasurePointFigure(data.getText(), x, y, 
-				2*r, 2*r, data.isReadOnly(), data.isClientObject(), 
+		        PointFigure.FIGURE_SIZE, PointFigure.FIGURE_SIZE, data.isReadOnly(), data.isClientObject(), 
 				data.canEdit(), data.canDelete(), data.canAnnotate());
 		addShapeSettings(fig, data.getShapeSettings());
 		AffineTransform transform;


### PR DESCRIPTION
Tiny bugfix for [Ticket 13232](http://trac.openmicroscopy.org/ome/ticket/13232) / [Trello - Insight drawing bug](https://trello.com/c/YFAxjYtL/60-insight-drawing-bug). 

**Test**: Draw a point ROI close (< 10px) to the upper and/or left edge of the image, check the x,y coordinates via Results tab and make sure the point is displayed in the place where it's supposed to be.