### PR TITLE
blitz: Use LinkedListMultimap for map annotations

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -39,6 +39,8 @@ import static ome.formats.model.UnitsFactory.convertPressure;
 import static ome.formats.model.UnitsFactory.convertTemperature;
 import static ome.formats.model.UnitsFactory.convertTime;
 
+import com.google.common.collect.LinkedListMultimap;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -85,7 +87,6 @@ import ome.units.quantity.Time;
 import ome.util.LSID;
 import ome.xml.meta.MetadataRoot;
 import ome.xml.model.AffineTransform;
-import ome.xml.model.MapPair;
 import ome.xml.model.enums.Compression;
 import ome.xml.model.enums.FillRule;
 import ome.xml.model.enums.FontFamily;
@@ -4190,7 +4191,7 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex) {
+    public void setGenericExcitationSourceMap(LinkedListMultimap<String, String> map, int instrumentIndex, int lightSourceIndex) {
         final GenericExcitationSource o = getGenericExcitationSource(instrumentIndex, lightSourceIndex);
         o.setMap(IceMapper.convertMapPairs(map));
     }
@@ -4496,7 +4497,7 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex) {
+    public void setImagingEnvironmentMap(LinkedListMultimap<String, String> map, int imageIndex) {
         final ImagingEnvironment o = getImagingEnvironment(imageIndex);
         o.setMap(IceMapper.convertMapPairs(map));
     }
@@ -7974,7 +7975,7 @@ public class OMEROMetadataStoreClient
     }
 
     @Override
-    public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex) {
+    public void setMapAnnotationValue(LinkedListMultimap<String, String> value, int mapAnnotationIndex) {
         final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
         o.setMapValue(IceMapper.convertMapPairs(value));
     }

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -20,6 +20,8 @@ import static omero.rtypes.robject;
 import static omero.rtypes.rstring;
 import static omero.rtypes.rtime;
 
+import com.google.common.collect.LinkedListMultimap;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
@@ -760,16 +762,16 @@ public class IceMapper extends ome.util.ModelMapper implements
         return nvl;
     }
 
-    public static List<NamedValue> convertMapPairs(List<ome.xml.model.MapPair> map) {
+    public static List<NamedValue> convertMapPairs(LinkedListMultimap<String, String> map) {
         if (map == null) {
             return null;
         }
         final List<NamedValue> nvl = new ArrayList<NamedValue>(map.size());
-        for (final ome.xml.model.MapPair nv : map) {
+        for (final Map.Entry<String, String> nv : map.entries()) {
             if (nv == null) {
                 nvl.add(null);
             } else {
-                final String name = nv.getName();
+                final String name = nv.getKey();
                 final String value = nv.getValue();
                 nvl.add(new NamedValue(name, value));
             }


### PR DESCRIPTION
--breaking

Companion to https://github.com/openmicroscopy/bioformats/pull/2427

Update OMEROMetadataStoreClient and IceMapper to replace `List<MapPair>` with `LinkedListMultimap<String, String>`.  See original PR for full description and testing instructions.