### PR TITLE
7th polygon problem

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerUI.java
@@ -1422,7 +1422,8 @@ class MeasurementViewerUI
 			Figure f;
 			while (i.hasNext()) {
 				f = i.next();
-				MeasurementAttributes.SHOWMEASUREMENT.set(f, show);
+                if (MeasurementAttributes.SHOWMEASUREMENT.get(f) != show)
+                    MeasurementAttributes.SHOWMEASUREMENT.set(f, show);
 			}
 		}
 		


### PR DESCRIPTION
Fix for [Ticket 12883](http://trac.openmicroscopy.org/ome/ticket/12883)

I noticed that the `MeasureBezierFigure.calculateMeasurements()` is called a couple of times on each point for a polygon you draw. There's a weird add-up effect the more polygons you draw, which ends up calling the method hundreds of thousand times when you've drawn >= 7 polygons, which makes Insight practically unresponsive. I haven't found out the reason for this yet, however preventing to set the `SHOWMEASUREMENT` attribute (which triggers the call), when it's not necessary, stops this odd behavior.

**Test**: Draw a couple of polygons (at least more than 7), check that the measurement tool doesn't slow down with the number of polygons you add.
