### PR TITLE
Removed (not working) tooltips from GraphPane to save memory

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,6 @@ package org.openmicroscopy.shoola.agents.measurement.view;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Point;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -53,7 +52,6 @@ import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
-import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import omero.log.Logger;
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
@@ -63,7 +61,6 @@ import org.openmicroscopy.shoola.util.roi.figures.MeasureTextFigure;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.ROIShape;
 import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
-import org.openmicroscopy.shoola.util.roi.model.util.MeasurementUnits;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.graphutils.HistogramPlot;
 import org.openmicroscopy.shoola.util.ui.graphutils.LinePlot;
@@ -141,9 +138,6 @@ public class GraphPane
 	
 	/** The histogram chart. */
 	private HistogramPlot histogramChart;
-	
-	/** The state of the Graph pane. */
-	private int state = READY;
 	
 	/** Reference to the view.*/
 	private MeasurementViewerUI view;
@@ -342,8 +336,7 @@ public class GraphPane
 	 * @return See above.
 	 */
 	private LinePlot drawLineplot(String title,  List<String> channelNames, 
-			List<double[][]> data, List<Color> channelColours,
-			Map<Integer, List<String>> locations)
+			List<double[][]> data, List<Color> channelColours)
 	{
 		if (channelNames.size() == 0 || data.size() == 0 || 
 			channelColours.size() == 0)
@@ -353,7 +346,6 @@ public class GraphPane
 			return null;
 		LinePlot plot = new LinePlot(title, channelNames, data, 
 			channelColours, channelMinValue(), channelMaxValue());
-		plot.addLocations(locations);
 		plot.setYAxisName("Intensity");
 		plot.setXAxisName("Points");
 		return plot;
@@ -409,8 +401,6 @@ public class GraphPane
 		List<ChannelData> metadata = model.getMetadata();
 		Iterator<ChannelData> j = metadata.iterator();
 		double[] values;
-		Map<Integer, List<String>> locations = new HashMap<Integer, List<String>>();
-		List<String> points = formatPoints(shape.getFigure().getPoints());
 		while (j.hasNext()) {
 			cData = j.next();
 			channel = cData.getIndex();
@@ -428,7 +418,6 @@ public class GraphPane
 					channelData.add(values);
 					
 					if (lineProfileFigure(shape)) {
-					    locations.put(channel, points);
 						dataXY = new double[2][values.length];
 						for (int i = 0 ; i < values.length ; i++)
 						{
@@ -449,7 +438,7 @@ public class GraphPane
 		histogramChart = null;
 		if (lineProfileFigure(shape))
 			lineProfileChart = drawLineplot("Line Profile", 
-					channelName, channelXYData, channelColour, locations);
+					channelName, channelXYData, channelColour);
 		histogramChart = drawHistogram("Histogram", channelName, 
 				channelData, channelColour, 1001);
 			
@@ -467,33 +456,6 @@ public class GraphPane
 		}
 		mainPanel.validate();
 		mainPanel.repaint();
-	}
-
-	/**
-	 * Formats the text associated to the specified points.
-	 *
-	 * @param points
-	 * @return See above.
-	 */
-	private List<String> formatPoints(List<Point> points)
-	{
-	    List<String> values = new ArrayList<String>();
-	    Iterator<Point> i = points.iterator();
-	    Point p;
-	    StringBuilder b;
-	    MeasurementUnits units = model.getMeasurementUnits();
-	    double sx = units.getPixelSizeX().getValue();
-	    double sy = units.getPixelSizeX().getValue();
-	    while (i.hasNext()) {
-            p = i.next();
-            b = new StringBuilder();
-            b.append("("+p.x+", "+p.y+")"+UIUtilities.PIXELS_SYMBOL);
-            b.append("\n");
-            b.append("("+UIUtilities.twoDecimalPlaces(p.x*sx)+", "+
-            UIUtilities.twoDecimalPlaces(p.y*sy)+ ")"+EditorUtil.MICRONS_NO_BRACKET);
-            values.add(b.toString());
-        }
-	    return values;
 	}
 
 	/** Indicates the selected plane.*/


### PR DESCRIPTION
While investigating [QA 17196](https://www.openmicroscopy.org/qa2/qa/feedback/17196) I noticed that  a map of tooltips is generated for the measurement "Graph Pane", which actually doesn't work anyway (there are no tooltips displayed on the graph), but can block for a large ROI for example up to 1 GB of memory. This PR removes that.

**Test**:  Draw/Select an ROI, check that the Graph Pane still works (for large ROIs (eg rectangle nearly completely covering a 4kx4k image) you should also notice a slight performance increase). Also check with latest build (not including this PR) that there are really no tooltips shown on the Graph (maybe I just missed them).