### PR TITLE
close parenthesis in CLI help

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -66,7 +66,7 @@ class SearchControl(HqlControl):
             dest="_to",
             metavar="YYYY-MM-DD",
             type=self.date,
-            help="End date for limiting searches (YYYY-MM-DD")
+            help="End date for limiting searches (YYYY-MM-DD)")
         parser.add_argument(
             "--date-type",
             default="import",


### PR DESCRIPTION
Fixes minor typo in `bin/omero search -h`, see diff.

Cc: @ximenesuk for presentation slide.