### PR TITLE
fix 500 (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -174,7 +174,7 @@ def handler500(request):
     context = {'form': form}
     t = template_loader.get_template('500.html')
     c = RequestContext(request, context)
-    return HttpResponse(t.render(c))
+    return HttpResponseServerError(t.render(c))
 
 
 def handler404(request):


### PR DESCRIPTION

This is the same as gh-4680 but rebased onto develop.

----

This PR fixes incorrect status code returned when omeroweb catch an exception

https://trello.com/c/qHCkMDIN/88-web-500-error-with-http-200-status


```
$ curl -I http://omero.local/omero/webclient/render_image/2102/
HTTP/1.1 500 INTERNAL SERVER ERROR
Server: nginx/1.8.1
Date: Wed, 25 May 2016 10:20:40 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
Vary: Cookie
Set-Cookie: csrftoken=Yhp07TdEGY7BMYRzbE0NoKWiGCk5ax0U; expires=Wed, 24-May-2017 10:20:40 GMT; Max-Age=31449600; Path=/
```

                