### PR TITLE
make the CLI cleanse operation admin-only

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -27,6 +27,7 @@ from path import path
 import omero
 import omero.config
 
+from omero.cli import admin_only
 from omero.cli import CLI
 from omero.cli import DirectoryType
 from omero.cli import NonZeroReturnCode
@@ -962,6 +963,7 @@ present, the user will enter a console""")
         client = self.ctx.conn(args)
         client.getSessionId()
         fixpyramids(data_dir=args.data_dir, dry_run=args.dry_run,
+                    admin_service=client.sf.getAdminService(),
                     query_service=client.sf.getQueryService(),
                     config_service=client.sf.getConfigService())
 
@@ -1784,6 +1786,7 @@ OMERO Diagnostics %s
             " regenerated. Use the omero.ports.xxx configuration properties"
             " instead.")
 
+    @admin_only
     def cleanse(self, args):
         self.check_access()
         from omero.util.cleanse import cleanse

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -160,7 +160,8 @@ already be running. This may automatically restart some server components.""")
             "ice", "Drop user into icegridadmin console or execute arguments")
 
         fixpyramids = Action(
-            "fixpyramids", "Remove empty pyramid pixels files").parser
+            "fixpyramids",
+            "Remove empty pyramid pixels files (admins only)").parser
         # See cleanse options below
 
         diagnostics = Action(
@@ -362,7 +363,7 @@ dt_socket,address=8787,suspend=y" \\
             "sessionlist", "List currently running sessions").parser
         sessionlist.add_login_arguments()
 
-        cleanse = Action("cleanse", """Remove binary data files from OMERO
+        cleanse = Action("cleanse", """Remove binary data files from OMERO  (admins only)
 
 Deleting an object from OMERO currently may not remove all the binary data.
 Use this command either manually or in a cron job periodically to remove
@@ -956,6 +957,7 @@ present, the user will enter a console""")
         else:
             self.ctx.call(command)
 
+    @admin_only
     @with_config
     def fixpyramids(self, args, config):
         self.check_access()

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -189,12 +189,9 @@ class Cleanser(object):
             (len(self.cleansed), self.bytes_cleansed)
 
 
-def initial_check(admin_service, config_service):
+def initial_check(config_service, admin_service):
     if admin_service is None:
-        print("No admin service provided! "
-              "Waiting 10 seconds to allow cancellation")
-        from threading import Event
-        Event().wait(10)
+        raise Exception("No admin service provided!")
 
     ctx = admin_service.getEventContext()
     if not ctx.isAdmin:
@@ -224,7 +221,7 @@ def cleanse(data_dir, client, dry_run=False):
     config_service = client.sf.getConfigService()
     shared_resources = client.sf.sharedResources()
 
-    initial_check(admin_service, config_service)
+    initial_check(config_service, admin_service)
 
     try:
         cleanser = ""
@@ -306,7 +303,7 @@ def is_empty_dir(repo, directory, may_delete_dir, to_delete):
 
 def fixpyramids(data_dir, admin_service, query_service,
                 dry_run=False, config_service=None):
-    initial_check(admin_service, config_service)
+    initial_check(config_service, admin_service)
 
     # look for any pyramid files with length 0
     # if there is no matching .*.tmp or .*.pyr_lock file, then

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -189,7 +189,7 @@ class Cleanser(object):
             (len(self.cleansed), self.bytes_cleansed)
 
 
-def initial_check(config_service, admin_service):
+def initial_check(config_service, admin_service=None):
     if admin_service is None:
         raise Exception("No admin service provided!")
 
@@ -301,8 +301,8 @@ def is_empty_dir(repo, directory, may_delete_dir, to_delete):
     return is_empty
 
 
-def fixpyramids(data_dir, admin_service, query_service,
-                dry_run=False, config_service=None):
+def fixpyramids(data_dir,query_service,
+                dry_run=False, config_service=None, admin_service=None):
     initial_check(config_service, admin_service)
 
     # look for any pyramid files with length 0

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -369,20 +369,17 @@ def main():
     try:
         client = omero.client('localhost')
         client.setAgent("OMERO.cleanse")
-        session = None
         if session_key is None:
-            session = client.createSession(username, password)
+            client.createSession(username, password)
         else:
-            session = client.createSession(session_key)
+            client.createSession(session_key)
     except PermissionDeniedException:
         print "%s: Permission denied" % sys.argv[0]
         print "Sorry."
         sys.exit(1)
 
-    query_service = session.getQueryService()
-    config_service = session.getConfigService()
     try:
-        cleanse(data_dir, query_service, dry_run, config_service)
+        cleanse(data_dir, client, dry_run)
     finally:
         if session_key is None:
             client.closeSession()

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -301,7 +301,7 @@ def is_empty_dir(repo, directory, may_delete_dir, to_delete):
     return is_empty
 
 
-def fixpyramids(data_dir,query_service,
+def fixpyramids(data_dir, query_service,
                 dry_run=False, config_service=None, admin_service=None):
     initial_check(config_service, admin_service)
 

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -55,7 +55,7 @@ def usage(error):
     """
     cmd = sys.argv[0]
     print """%s
-Usage: %s [-dry-run] [-u username | -k] <omero.data.dir>
+Usage: %s [--dry-run] [-u username | -k] <omero.data.dir>
 Cleanses files in the OMERO data directory that have no reference in the
 OMERO database. NOTE: As this script is designed to be run via cron or in
 a scheduled manner it produces NO output unless a dry run is performed.


### PR DESCRIPTION
This PR limits cleansing to admins. Test that it otherwise works exactly as before: so, test with both admin and non-admin users. Also test both `bin/omero admin cleanse` and the direct `cleanse.py`.

--rebased-to #4691