### PR TITLE
guest login check

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_login.txt
+++ b/components/tests/ui/testcases/web/webadmin_login.txt
@@ -54,3 +54,14 @@ Invalid Login
     Page Should Be Open     ${WEBADMIN LOGIN URL}           OMERO.web - Login
     Page Should Contain     This field is required.
 
+Guest Login
+
+    Go To                   ${LOGIN URL}
+    # Check that 'g' is not mistaken for 'guest' https://github.com/openmicroscopy/openmicroscopy/pull/4686
+    Log In As               g                               secret                  ${SERVER_ID}
+    Page Should Be Open     ${LOGIN URL}                    OMERO.web - Login
+    Page Should Contain     Error: Connection not available, please check your user name and password.
+    Go To                   ${LOGIN URL}
+    Log In As               guest                           secret                  ${SERVER_ID}
+    Page Should Be Open     ${LOGIN URL}                    OMERO.web - Login
+    Page Should Contain     Guest account is not supported.

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -70,7 +70,7 @@ class LoginForm(NonASCIIForm):
         ' secure." alt="SSL"/>' % settings.STATIC_URL)
 
     def clean_username(self):
-        if (self.cleaned_data['username'] in ('guest')):
+        if (self.cleaned_data['username'] == 'guest'):
             raise forms.ValidationError("Guest account is not supported.")
         return self.cleaned_data['username']
 

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests webclient login
+"""
+
+from weblibrary import IWebTest, _csrf_post_response
+from django.core.urlresolvers import reverse
+
+
+class TestLogin(IWebTest):
+    """
+    Tests login
+    """
+
+    def test_guest_login_not_supported(self):
+        """
+        Test that guest login is not permitted
+        """
+        django_client = self.django_root_client
+        request_url = reverse('weblogin')
+        data = {'username': 'guest', 'password': 'secret', 'server': 1}
+        rsp = _csrf_post_response(django_client, request_url, data,
+                                  status_code=200)
+        assert "Guest account is not supported." in rsp.content
+
+    def test_wrong_guest_login(self):
+        """
+        Test that login as 'g' doesn't give wrong error message
+        https://trello.com/c/U47AiD1R/682-weird-guest-login
+        """
+        django_client = self.django_root_client
+        request_url = reverse('weblogin')
+        data = {'username': 'g', 'password': 'secret', 'server': 1}
+        rsp = _csrf_post_response(django_client, request_url, data,
+                                  status_code=200)
+        assert "Guest account is not supported." not in rsp.content
+        assert "please check your user name and password" in rsp.content

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -33,7 +33,7 @@ class TestLogin(IWebTest):
     """
 
     @pytest.mark.parametrize("login", [['guest', 'guest'],
-                                      ['g', str(random())]])
+                                       ['g', str(random())]])
     def test_guest_login_not_supported(self, login):
         """
         Test that guest login is not permitted and login as 'g' is not


### PR DESCRIPTION
Simple fix for https://trello.com/c/U47AiD1R/682-weird-guest-login

To test, try logging in as 'g' or 's', or 't'. Shouldn't see the "guest not supported" error.
Only when logging is as "guest" should you see this.