### PR TITLE
allow customizing lefthand tabs 

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -646,6 +646,20 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Add plugins to the right-hand panel. "
           "Plugins are ``['Label', 'include.js', 'div_id']``. "
           "The javascript loads data into ``$('#div_id')``.")],
+    "omero.web.ui.left_plugins":
+        ["LEFT_PLUGINS",
+         ('[["Explore",'
+          ' "userdata",'
+          ' {"viewname": "load_template", "args":["userdata"]}],'
+          ' ["Tags",'
+          ' "usertags",'
+          ' {"viewname": "load_template", "args":["usertags"]}],'
+          ' ["Shares",'
+          ' "public",'
+          ' {"viewname": "load_template", "args":["public"]}]]'),
+         json.loads,
+         ("Add plugins to the left-hand panel. "
+          "Plugins are ``['label', 'id', 'url']``. ")],
     "omero.web.ui.center_plugins":
         ["CENTER_PLUGINS",
          ('['

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -646,20 +646,6 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Add plugins to the right-hand panel. "
           "Plugins are ``['Label', 'include.js', 'div_id']``. "
           "The javascript loads data into ``$('#div_id')``.")],
-    "omero.web.ui.left_plugins":
-        ["LEFT_PLUGINS",
-         ('[["Explore",'
-          ' "userdata",'
-          ' {"viewname": "load_template", "args":["userdata"]}],'
-          ' ["Tags",'
-          ' "usertags",'
-          ' {"viewname": "load_template", "args":["usertags"]}],'
-          ' ["Shares",'
-          ' "public",'
-          ' {"viewname": "load_template", "args":["public"]}]]'),
-         json.loads,
-         ("Add plugins to the left-hand panel. "
-          "Plugins are ``['label', 'id', 'url']``. ")],
     "omero.web.ui.center_plugins":
         ["CENTER_PLUGINS",
          ('['
@@ -784,6 +770,13 @@ DEVELOPMENT_SETTINGS_MAPPINGS = {
          ("(SYNC WORKERS only) The number of worker threads for handling "
           "requests. Check Gunicorn Documentation "
           "http://docs.gunicorn.org/en/stable/settings.html#threads")],
+    "omero.web.ui.left_plugins":
+        ["LEFT_PLUGINS",
+         ('[{"label": "Explore", "menu": "userdata"},'
+          ' {"label": "Tags", "menu": "usertags"},'
+          ' {"label": "Shares", "menu": "public"}]'),
+         json.loads,
+         ("Manage plugins in the left-hand panel.")],
 }
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -31,7 +31,9 @@ from omero import constants
 from django.http import HttpResponse
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http import Http404
 
+from omeroweb.decorators import parse_url
 from omeroweb.webclient.forms import GlobalSearchForm
 
 logger = logging.getLogger('omeroweb.webclient.decorators')
@@ -186,8 +188,24 @@ class render_response(omeroweb.decorators.render_response):
                 "label": label, "include": include, "plugin_id": plugin_id})
         context['ome']['right_plugins'] = r_plugins
 
+        left_plugins = settings.LEFT_PLUGINS
+        l_plugins = []
+        label = plugin_id = url = ""
+        for lt in left_plugins:
+            label = lt[0]
+            plugin_id = lt[1]
+            url = None
+            try:
+                url = parse_url(lt[2])
+            except Http404:
+                logger.error('Cannot parse url %s' % url)
+            l_plugins.append({
+                "label": label, "plugin_id": plugin_id, "url": url})
+        context['ome']['left_plugins'] = l_plugins
+
         center_plugins = settings.CENTER_PLUGINS
         c_plugins = []
+        label = include = plugin_id = ""
         for cp in center_plugins:
             label = cp[0]
             include = cp[1]

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -750,16 +750,11 @@
         <ul id="left_panel_tab_list" class="ui-tabs-nav">
 			
 			<!-- Remember to update this in public/public.html as well. We should change this, but for the meantime, you need to manually update the menu there too -->
-			
-	        <li id="explore_tab" class="ui-state-default{% ifequal menu 'userdata' %} ui-tabs-active{% endifequal %}">
-                <a href="{% url 'load_template' 'userdata' %}" class="ui-tabs-anchor" title="Explore">{% trans "Explore" %}</a>
-            </li>
-	        <li id="tags_tab" class="ui-state-default{% ifequal menu 'usertags' %} ui-tabs-active{% endifequal %}">
-                <a href="{% url 'load_template' 'usertags' %}" class="ui-tabs-anchor">{% trans "Tags" %}</a>
-            </li>
-	        <li id="public_tab" class="ui-state-default">
-                <a href="{% url 'load_template' 'public' %}" class="ui-tabs-anchor">{% trans "Shares" %}</a>
-            </li>
+            {% for lt in ome.left_plugins %}
+                <li id="{{ lt.plugin_id }}_tab" class="ui-state-default{% ifequal menu lt.plugin_id %} ui-tabs-active{% endifequal %}">
+                    <a href="{{ lt.url }}" class="ui-tabs-anchor" title="{{ lt.label }}">{{ lt.label }}</a>
+                </li>
+            {% endfor %}
        
 	    </ul>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -751,7 +751,7 @@
 			
 			<!-- Remember to update this in public/public.html as well. We should change this, but for the meantime, you need to manually update the menu there too -->
             {% for lt in ome.left_plugins %}
-                <li id="{{ lt.plugin_id }}_tab" class="ui-state-default{% ifequal menu lt.plugin_id %} ui-tabs-active{% endifequal %}">
+                <li class="ui-state-default{% ifequal menu lt.menu %} ui-tabs-active{% endifequal %}">
                     <a href="{{ lt.url }}" class="ui-tabs-anchor" title="{{ lt.label }}">{{ lt.label }}</a>
                 </li>
             {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -459,9 +459,11 @@
 
 <div id="left_panel_tabs" class="absolute_fill ui-tabs">
     <ul id="left_panel_tab_list" class="ui-tabs-nav">
-        <li id="explore_tab" class="ui-state-default"><a href="{% url 'load_template' 'userdata' %}" class="ui-tabs-anchor" title="Explore">{% trans "Explore" %}</a></li>
-        <li id="tags_tab" class="ui-state-default"><a href="{% url 'load_template' 'usertags' %}" class="ui-tabs-anchor">{% trans "Tags" %}</a></li>
-        <li id="public_tab" class="ui-state-default ui-tabs-active"><a class="ui-tabs-anchor">{% trans "Shares" %}</a></li>
+        {% for lt in ome.left_plugins %}
+	        <li id="{{ lt.plugin_id }}_tab" class="ui-state-default{% ifequal menu lt.plugin_id %} ui-tabs-active{% endifequal %}">
+                <a href="{{ lt.url }}" class="ui-tabs-anchor" title="{{ lt.label }}">{{ lt.label }}</a>
+            </li>
+        {% endfor %}
     </ul>
 
     <div id="Public">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -460,7 +460,7 @@
 <div id="left_panel_tabs" class="absolute_fill ui-tabs">
     <ul id="left_panel_tab_list" class="ui-tabs-nav">
         {% for lt in ome.left_plugins %}
-	        <li id="{{ lt.plugin_id }}_tab" class="ui-state-default{% ifequal menu lt.plugin_id %} ui-tabs-active{% endifequal %}">
+            <li class="ui-state-default{% ifequal menu lt.menu %} ui-tabs-active{% endifequal %}">
                 <a href="{{ lt.url }}" class="ui-tabs-anchor" title="{{ lt.label }}">{{ lt.label }}</a>
             </li>
         {% endfor %}


### PR DESCRIPTION
This PR allows customizing names and appearance of left hand tabs.

Tab can be:
- removed
  
  ```
  bin/omero config remove omero.web.ui.left_plugins '{"label": "Shares", "menu": "public"}'
  ```
- added
  
  ```
  bin/omero config append omero.web.ui.left_plugins '{"label": "Shares", "menu": "public"}'
  ```
- updated
  
  ```
  bin/omero config set omero.web.ui.left_plugins '[{"label": "IDR", "menu": "userdata"}, {"label":"Tags", "menu": "usertags"}]'
  ```

Note: removing tab, doesn't invalidate any urls. It is just purely ui manipulation. it is a early step to allow custom apps like https://trello.com/c/s0HD7Vi6/173-tagexport-py

--exclude
