### PR TITLE
allow customize CSRF cookie

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -326,6 +326,15 @@ INTERNAL_SETTINGS_MAPPING = {
          parse_boolean,
          ("Whether to use a TLS (secure) connection when talking to the SMTP"
           " server.")],
+
+    "omero.web.session_file_path":
+        ["SESSION_FILE_PATH",
+         tempfile.gettempdir(),
+         str,
+         ("Set the directory in which Django will store session data and"
+          " save temprorarly created files. By default, Django will use"
+          " the standard temporary directory for the system. Note: it will"
+          " also respect env TEMPDIR/TEMP/TMP.")],
 }
 
 CUSTOM_SETTINGS_MAPPINGS = {
@@ -1184,15 +1193,9 @@ FEEDBACK_APP = 6
 # Default: ('mail.pl', 'mailform.pl', 'mail.cgi', 'mailform.cgi',
 # 'favicon.ico', '.php')
 
-# SESSION_FILE_PATH: If you're using file-based session storage, this sets the
-# directory in which Django will store session data. When the default value
-# (None) is used, Django will use the standard temporary directory for the
-# system.
-SESSION_FILE_PATH = tempfile.gettempdir()
-
 # FILE_UPLOAD_TEMP_DIR: The directory to store data temporarily while
 # uploading files.
-FILE_UPLOAD_TEMP_DIR = tempfile.gettempdir()
+FILE_UPLOAD_TEMP_DIR = SESSION_FILE_PATH  # noqa
 
 # # FILE_UPLOAD_MAX_MEMORY_SIZE: The maximum size (in bytes) that an upload
 # will be before it gets streamed to the file system.

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -433,12 +433,55 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["SESSION_COOKIE_DOMAIN",
          None,
          leave_none_unset,
-         "The domain to use for session cookies"],
+         "The domain to use for session cookies."],
     "omero.web.session_cookie_name":
         ["SESSION_COOKIE_NAME",
          None,
          leave_none_unset,
-         "The name to use for session cookies"],
+         "The name to use for session cookies."],
+    "omero.web.session_cookie_secure":
+        ["SESSION_COOKIE_SECURE",
+         "false",
+         parse_boolean,
+         "Use a secure cookie for the session cookie."],
+    "omero.web.session_cookie_path":
+        ["SESSION_COOKIE_PATH",
+         "/",
+         str,
+         ("The path set on the session cookie. This is useful if you have"
+          " multiple Django instances running under the same hostname."
+          " They can use different cookie paths, and each instance will"
+          " only see its own session cookie.")],
+    "omero.web.csrf_cookie_age":
+        ["CSRF_COOKIE_AGE",
+         31449600,
+         int,
+         "The age of CSRF cookies, in seconds."],
+    "omero.web.csrf_cookie_name":
+        ["CSRF_COOKIE_NAME",
+         None,
+         leave_none_unset,
+         "The name to use for CSRF cookies."],
+    "omero.web.csrf_cookie_domain":
+        ["CSRF_COOKIE_DOMAIN",
+         None,
+         leave_none_unset,
+         ("The domain to use for CSRF cookies. It allows cross-subdomain"
+          " requests to be excluded from the normal cross site request"
+          " forgery protection.")],
+    "omero.web.csrf_cookie_secure":
+        ["CSRF_COOKIE_SECURE",
+         "false",
+         parse_boolean,
+         "Whether to use a secure cookie for the CSRF cookie."],
+    "omero.web.csrf_cookie_path":
+        ["CSRF_COOKIE_PATH",
+         "/",
+         str,
+         ("The path set on the CSRF cookie. This is useful if you have"
+          " multiple Django instances running under the same hostname."
+          " They can use different cookie paths, and each instance will"
+          " only see its own CSRF cookie.")],
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
     "omero.web.secure_proxy_ssl_header":


### PR DESCRIPTION
This PR allows customizing csrf cookie, see https://docs.djangoproject.com/en/1.8/ref/settings/#csrf-cookie-name (age and domain), and using ‘secure’ cookies.

```
bin/omero config set omero.web.csrf_cookie_age 
bin/omero config set omero.web.csrf_cookie_name
bin/omero config set omero.web.csrf_cookie_domain
```

above tested via https://github.com/openmicroscopy/management_tools/pull/168

- to test secure cookies set

 ```
bin/omero config set omero.web.csrf_cookie_secure
bin/omero config set omero.web.session_cookie_secure
 ```

 and test as described in https://docs.djangoproject.com/en/1.8/topics/security/#ssl-https


- test custom tmp path:

 ```
bin/omero config set omero.web.session_file_path "/path/to/mytmp"
 ```
