### PR TITLE
sanitize user and group name for import paths

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -664,7 +664,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
          */
         @SuppressWarnings("unused")  /* used by create() via Method.invoke */
         public String expandUser(String prefix, String suffix) {
-            return prefix + ctx.userName + suffix;
+            return prefix + serverPaths.getPathSanitizer().apply(ctx.userName) + suffix;
         }
 
         /**
@@ -688,7 +688,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
          */
         @SuppressWarnings("unused")  /* used by create() via Method.invoke */
         public String expandGroup(String prefix, String suffix) {
-            return prefix + ctx.groupName + suffix;
+            return prefix + serverPaths.getPathSanitizer().apply(ctx.groupName) + suffix;
         }
 
         /**


### PR DESCRIPTION
Fixes the problem described at https://trello.com/c/Plm8Mrfu/12-usernames-can-contain-filepath-separators:

> Users such as `foo/bar` and `../ManagedRepository` can be created legitimately but they are not able to import any data!

Also adds a new integration test https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ImporterTest/testImportSimpleImageOddlyNamedUser/.