### PR TITLE
clean up viewer before reloading

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -279,6 +279,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
     _this.refresh(true);
     
     // Here we set up PanoJs Big image viewer...
+    _this.viewportimg.get(0).destroyTiles();
     if (_this.loadedImg.tiles) {
         // This is called for every tile, each time they move
         var hrefProvider = function() {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -658,8 +658,11 @@ jQuery.fn.viewportImage = function(options) {
     };
     
     this.destroyTiles = function () {
-        jQuery(viewerBeanId).remove();
-        viewerBean = null;
+        if (viewerBean) {
+            viewerBean.clear()
+            viewerBean.viewer.remove()
+            viewerBean = null;
+        }
     };
 
     this.refresh = function () {


### PR DESCRIPTION
attempt to fix viewer cleanup issue reported in https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8058&p=17131

to test:
 - use https://raw.githubusercontent.com/aleksandra-tarkowska/weblabs/7c396e8a5e5c8e3d29f5f6064f010904e4121ba2/image_viewer_demo/index.html
 - make sure header contains:

 ```
  <link href="https://cowfish.openmicroscopy.org/webmerge/static/omeroweb.viewer.min.css" type="text/css" rel="stylesheet"></link>
  <script src="https://cowfish.openmicroscopy.org/webmerge/static/omeroweb.viewer.min.js" type="text/javascript"></script>
```

see http://aleksandra-tarkowska.github.io/weblabs/image_viewer_demo/ 

you have to VPN 

cc: @will-moore 