### PR TITLE
improve test coverage for attachments sharing files

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -267,7 +267,9 @@
 
         <!-- If an original file is moved then any corresponding file annotation must also be moved. -->
 
-        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E].file = OF:[I]" p:error="may not move {OF} while used by {A}"/>
+        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[I].file = OF:[E]" p:error="may not move {A} without {OF}"/>
+        <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[ED].file = OF:[I]"
+                                       p:error="may not move {OF} while used by {A}"/>
 
         <!-- If both parent and child are moved then move the annotation link regardless of permissions. -->
 


### PR DESCRIPTION
Discussion at the users' meeting made me think to improve handling of when multiple attachments refer to the same underlying file. CI should be green, including https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.delete/AnnotationDeleteTest/ and https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.chgrp/AnnotationMoveTest/.