### PR TITLE
slack notification

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/custom_middleware.py
+++ b/components/tools/OmeroWeb/omeroweb/custom_middleware.py
@@ -1,0 +1,48 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from django_slack import slack_message
+except:
+    logger.error("Cannot resolve 'django_slack.log.SlackExceptionHandler':"
+                 " No module named django_slack")
+
+from django.conf import settings
+from django.middleware.common import BrokenLinkEmailsMiddleware
+
+from django.utils.encoding import force_text
+
+
+class BrokenLinkSlackMiddleware(BrokenLinkEmailsMiddleware):
+
+    def process_response(self, request, response):
+        """
+        Send broken link emails for relevant 404 NOT FOUND responses.
+        """
+        if response.status_code == 404 and not settings.DEBUG:
+            domain = request.get_host()
+            path = request.get_full_path()
+            referer = force_text(request.META.get('HTTP_REFERER', ''),
+                                 errors='replace')
+
+            if not self.is_ignorable_request(request, path, domain, referer):
+                ua = request.META.get('HTTP_USER_AGENT', '<none>')
+                ip = request.META.get('REMOTE_ADDR', '<none>')
+
+                subject = "Broken %slink on %s" % (
+                    ('INTERNAL ' if self.is_internal_request(
+                        domain, referer) else ''),
+                    domain
+                )
+                message = ("Referrer: %s\nRequested URL: %s\nUser agent: %s\n"
+                           "IP address: %s\n" % (referer, path, ua, ip))
+                attachments = {
+                    'subject': subject,
+                    'text': message,
+                    'color': 'warning',
+                }
+                template = 'django_slack/exception.slack'
+
+                slack_message(template, {'text': subject}, [attachments])
+        return response

--- a/components/tools/OmeroWeb/omeroweb/log.py
+++ b/components/tools/OmeroWeb/omeroweb/log.py
@@ -1,0 +1,63 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from django_slack.log import SlackExceptionHandler
+except:
+    logger.error("Cannot resolve 'django_slack.log.SlackExceptionHandler':"
+                 " No module named django_slack")
+
+from django.conf import settings
+from django.utils.encoding import force_text
+from django.views.debug import get_exception_reporter_filter
+
+
+class OmeroSlackExceptionHandler(SlackExceptionHandler):
+
+    def __init__(self, **kwargs):
+        SlackExceptionHandler.__init__(self)
+
+    def emit(self, record):
+        try:
+            request = record.request
+            subject = '%s (%s IP): %s' % (
+                record.levelname,
+                ('internal' if request.META.get(
+                    'REMOTE_ADDR') in settings.INTERNAL_IPS
+                 else 'EXTERNAL'),
+                record.getMessage()
+            )
+            filter = get_exception_reporter_filter(request)
+            request_repr = '\n{}'.format(force_text(
+                filter.get_request_repr(request)))
+        except Exception:
+            subject = '%s: %s' % (
+                record.levelname,
+                record.getMessage()
+            )
+            request = None
+            request_repr = "unavailable"
+        subject = self.format_subject(subject)
+
+        message = "%s\n\nRequest repr(): %s" % (
+            self.format(record), request_repr
+        )
+        colors = {
+            'ERROR': 'danger',
+            'WARNING': 'warning',
+            'INFO': 'good',
+        }
+
+        attachments = {
+            'title': subject,
+            'text': message,
+            'color': colors.get(record.levelname, '#AAAAAA'),
+        }
+
+        attachments.update(self.kwargs)
+        self.send_message(
+            self.template,
+            {'text': subject},
+            self.generate_attachments(**attachments),
+        )

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -326,28 +326,28 @@ INTERNAL_SETTINGS_MAPPING = {
          parse_boolean,
          ("Whether to use a TLS (secure) connection when talking to the SMTP"
           " server.")],
-    "omero.slack.enabled":
+    "omero.notify.slack.enabled":
         ["SLACK_ENABLED",
          "false",
          parse_boolean,
          "Enable and disable the OMERO.web slack error notification."],
-    "omero.slack.token":
+    "omero.notify.slack.token":
         ["SLACK_TOKEN",
          None,
          leave_none_unset,
          ("Your Slack authentication token. You can generate a tokens on:"
           "https://api.slack.com/web#authentication")],
-    "omero.slack.channel":
+    "omero.notify.slack.channel":
         ["SLACK_CHANNEL",
          "#logs",
          str,
          ("Set a default channel of the room the message should appear in.")],
-    "omero.slack.username":
+    "omero.notify.slack.username":
         ["SLACK_USERNAME",
          "webbot",
          str,
          ("Set a default name the message will appear be sent from.")],
-    "omero.slack.fail_silently":
+    "omero.notify.slack.fail_silently":
         ["SLACK_FAIL_SILENTLY",
          True,
          bool,
@@ -355,7 +355,7 @@ INTERNAL_SETTINGS_MAPPING = {
           "messages are often for administrators of a site and not the "
           "users, masking temporary errors with the Slack API may be "
           "desired.")],
-    "omero.slack.backend":
+    "omero.notify.slack.backend":
         ["SLACK_BACKEND",
          "django_slack.backends.UrllibBackend",
          str,

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1111,13 +1111,16 @@ if MAIL_ENABLED:  # noqa
 
 # error2slack notification
 if SLACK_ENABLED:  # noqa
+    MIDDLEWARE_CLASSES += \
+        ('custom_middleware.BrokenLinkSlackMiddleware',)
+
     INSTALLED_APPS += ('django_slack',)
 
     LOGGING['handlers']['slack_admins'] = \
         {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
-            'class': 'django_slack.log.SlackExceptionHandler'
+            'class': 'log.OmeroSlackExceptionHandler'
         }
     if 'slack_admins' not in LOGGING['loggers']['django.request']['handlers']:
         LOGGING['loggers']['django.request']['handlers'].append('slack_admins')

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -134,15 +134,10 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'standard'
         },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
     },
     'loggers': {
         'django.request': {  # Stop SQL debug from logging to main logger
-            'handlers': ['default', 'request_handler', 'mail_admins'],
+            'handlers': ['default', 'request_handler'],
             'level': 'DEBUG',
             'propagate': False
         },
@@ -288,6 +283,11 @@ INTERNAL_SETTINGS_MAPPING = {
 
     # Internal email notification for omero.web.admins,
     # loaded from config.xml directly
+    "omero.mail.config":
+        ["MAIL_ENABLED",
+         "false",
+         parse_boolean,
+         "Enable and disable the OMERO.web email error notification."],
     "omero.mail.from":
         ["SERVER_EMAIL",
          None,
@@ -326,6 +326,42 @@ INTERNAL_SETTINGS_MAPPING = {
          parse_boolean,
          ("Whether to use a TLS (secure) connection when talking to the SMTP"
           " server.")],
+    "omero.slack.enabled":
+        ["SLACK_ENABLED",
+         "false",
+         parse_boolean,
+         "Enable and disable the OMERO.web slack error notification."],
+    "omero.slack.token":
+        ["SLACK_TOKEN",
+         None,
+         leave_none_unset,
+         ("Your Slack authentication token. You can generate a tokens on:"
+          "https://api.slack.com/web#authentication")],
+    "omero.slack.channel":
+        ["SLACK_CHANNEL",
+         "#general",
+         str,
+         ("Set a default channel of the room the message should appear in.")],
+    "omero.slack.username":
+        ["SLACK_USERNAME",
+         "webbot",
+         str,
+         ("Set a default name the message will appear be sent from.")],
+    "omero.slack.fail_silently":
+        ["SLACK_FAIL_SILENTLY",
+         True,
+         bool,
+         ("Whether errors should be silenced or raised to the user. As Slack "
+          "messages are often for administrators of a site and not the "
+          "users, masking temporary errors with the Slack API may be "
+          "desired.")],
+    "omero.slack.backend":
+        ["SLACK_BACKEND",
+         "django_slack.backends.UrllibBackend",
+         str,
+         ("A string pointing to the eventual backend class that will "
+          "actually send the message to the Slack API. The default backend "
+          "will send the message using the Python urllib library.")],
 }
 
 CUSTOM_SETTINGS_MAPPINGS = {
@@ -931,13 +967,11 @@ USE_I18N = True
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 # See https://docs.djangoproject.com/en/1.6/topics/http/middleware/.
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
-
 
 # ROOT_URLCONF: A string representing the full Python import path to your root
 # URLconf.
@@ -1032,6 +1066,7 @@ INSTALLED_APPS = (
     'pipeline',
 )
 
+
 # ADDITONAL_APPS: We import any settings.py from apps. This allows them to
 # modify settings.
 # We're also processing any CUSTOM_SETTINGS_MAPPINGS defined there.
@@ -1057,6 +1092,35 @@ for app in ADDITIONAL_APPS:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
         logger.debug("Couldn't import settings from app: %s" % app)
 
 logger.debug('INSTALLED_APPS=%s' % [INSTALLED_APPS])
+
+
+# admins error2email notification
+if MAIL_ENABLED:  # noqa
+    MIDDLEWARE_CLASSES += \
+        ('django.middleware.common.BrokenLinkEmailsMiddleware',)
+
+    LOGGING['handlers']['mail_admins'] = \
+        {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        }
+    if 'mail_admins' not in LOGGING['loggers']['django.request']['handlers']:
+        LOGGING['loggers']['django.request']['handlers'].append('mail_admins')
+
+
+# error2slack notification
+if SLACK_ENABLED:  # noqa
+    INSTALLED_APPS += ('django_slack',)
+
+    LOGGING['handlers']['slack_admins'] = \
+        {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django_slack.log.SlackExceptionHandler'
+        }
+    if 'slack_admins' not in LOGGING['loggers']['django.request']['handlers']:
+        LOGGING['loggers']['django.request']['handlers'].append('slack_admins')
 
 
 PIPELINE_CSS = {

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -339,7 +339,7 @@ INTERNAL_SETTINGS_MAPPING = {
           "https://api.slack.com/web#authentication")],
     "omero.slack.channel":
         ["SLACK_CHANNEL",
-         "#general",
+         "#logs",
          str,
          ("Set a default channel of the room the message should appear in.")],
     "omero.slack.username":


### PR DESCRIPTION
This PR allows to set up custom notification using slack using http://django-slack.readthedocs.io/

To test:

- `pip install django_slack`
- generate your token https://api.slack.com/web#authentication
- set up config:

 ```
 bin/omero config set omero.web.debug false
 bin/omero config set omero.notify.slack.enabled true
 bin/omero config set omero.notify.slack.token "xoxp-123token..."
 bin/omero config set omero.notify.slack.channel "#logs"
 bin/omero config set omero.notify.slack.username "abc"
 ```
- add weberror app for testing
- start web and enjoy slack :)


Additional testing: I also cleaned up email notification
-  set the following:

 ```
bin/omero config set omero.web.debug False
bin/omero config set omero.mail.config true
```
 *mail config is not named `enabled` but `config` because property name is matching server side property*

- add weberror app for testing
- set mail config https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/mail.html or use local SMTP mock (you will not get real email, just console output):
    - set ```bin/omero config set omero.mail.from "your@email``` and ```bin/omero config set omero.mail.host "localhost"```
    - run in new console SMTP mock ```sudo python -m smtpd -n -c DebuggingServer localhost:25```. *Email message will be shown as a plane text on your console.*
- set your email in ```bin/omero config set omero.web.admins '[["Username", "your@email"]]'```
- try to get HTTP500 and 404 (must come from broken link in template, do not access random url) and see if you received both errors by email

**NOTE:** property name change `omero.slack.*` to `omero.notify.slack.*`