### PR TITLE
contextmenu_create_share

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -905,7 +905,6 @@ $(function() {
                 config["share"] = {
                     "label" : "Create share",
                     "_disabled": function(){
-                        console.log("disabled", arguments);
                         var selected = $.jstree.reference('#dataTree').get_selected(true);
                         var enabled = true;
                         $.each(selected, function(index, node) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -904,7 +904,19 @@ $(function() {
                 
                 config["share"] = {
                     "label" : "Create share",
-                    "_disabled": true,
+                    "_disabled": function(){
+                        console.log("disabled", arguments);
+                        var selected = $.jstree.reference('#dataTree').get_selected(true);
+                        var enabled = true;
+                        $.each(selected, function(index, node) {
+                            if (node.type != 'image' || !OME.nodeHasPermission(node, 'canLink')) {
+                                enabled = false;
+                                // Break out of $.each
+                                return false;
+                            }
+                        });
+                        return !enabled;
+                    },
                     "icon"  : WEBCLIENT.URLS.static_webclient + 'image/icon_toolbar_share2.png',
                     "action": function(){
                         // We get_selected() within createShare()


### PR DESCRIPTION
Fixes disabled 'Create Share' option in tree right-click menu.
http://trac.openmicroscopy.org/ome/ticket/13250

To test:
 - Create Share in right-click menu should be enabled when you select one or more images that you 'canLink' (same as toolbar Share button).
 - Should be disabled for other data types P/D/S/P/W and for images you don't own / can't link