### PR TITLE
 Copy ome.api.* documentation to omero.api.* (5)

### DIFF
--- a/components/blitz/resources/omero/api/Exporter.ice
+++ b/components/blitz/resources/omero/api/Exporter.ice
@@ -23,7 +23,7 @@ module omero {
          *
          *   ExporterPrx e = sf.createExporter();
          *
-         *   // Exporter is currently in the "configuration" state
+         *   // Exporter is currently in the <i>configuration</i> state
          *   // Objects can be added by id which should be present
          *   // in the output.
          *
@@ -82,8 +82,8 @@ module omero {
             long generateTiff() throws ServerError;
 
             /**
-             * Returns ""length"" bytes from the output file. The file can
-             * be safely read until reset() is called.
+             * Returns <code>length</code> bytes from the output file. The
+             * file can be safely read until reset() is called.
              **/
             idempotent Ice::ByteSeq read(long position, int length) throws ServerError;
 

--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -194,7 +194,7 @@ module omero {
                  * {@link omero.model.Experimenter} object via an
                  * {@link omero.model.FileAnnotation} with
                  * the namespace:
-                 *  "openmicroscopy.org/omero/experimenter/photo"
+                 *  <i>openmicroscopy.org/omero/experimenter/photo</i>
                  * (NSEXPERIMENTERPHOTO).
                  * If such an {@link omero.model.OriginalFile} instance
                  * already exists, it will be overwritten. If more than one
@@ -202,8 +202,8 @@ module omero {
                  * the highest updateEvent id).
                  *
                  * Note: as outlined in <a href="https://trac.openmicroscopy.org/ome/ticket/1794">ticket 1794</a>
-                 * this photo will be placed in the "user" group and therefore
-                 * will be visible to everyone on the system.
+                 * this photo will be placed in the <i>user</i> group and
+                 * therefore will be visible to everyone on the system.
                  *
                  * @param filename Not null. String name which will be used.
                  * @param format Not null. Format.value string. 'image/jpeg'
@@ -275,8 +275,8 @@ module omero {
 
                 /**
                  * Creates and returns a new system user. This user will be
-                 * created with the "System" (administration) group as default
-                 * and will also be in the "user" group.
+                 * created with the <i>System</i> (administration) group as
+                 * default and will also be in the <i>user</i> group.
                  *
                  * @param experimenter a new {@link omero.model.Experimenter}
                  *        instance
@@ -383,7 +383,7 @@ module omero {
                  * Adds the user to the owner list for this group.
                  *
                  * Since <a href="https://trac.openmicroscopy.org/ome/ticket/1434">Beta 4.2</a>
-                 * multiple users can be the "owner" of a group.
+                 * multiple users can be the <i>owner</i> of a group.
                  *
                  * @param group A currently managed
                  *        {@link omero.model.ExperimenterGroup}. Not null.
@@ -396,7 +396,7 @@ module omero {
                  * Removes the user from the owner list for this group.
                  *
                  * Since <a href="https://trac.openmicroscopy.org/ome/ticket/1434">Beta 4.2</a>
-                 * multiple users can be the "owner" of a group.
+                 * multiple users can be the <i>owner</i> of a group.
                  *
                  * @param group A currently managed
                  *        {@link omero.model.ExperimenterGroup}. Not null.
@@ -454,8 +454,8 @@ module omero {
                 idempotent void changePermissions(omero::model::IObject obj, omero::model::Permissions perms) throws ServerError;
 
                 /**
-                 * Moves the given objects into the "user" group to make them
-                 * visible and linkable from all security contexts.
+                 * Moves the given objects into the <i>user</i> group to make
+                 * them visible and linkable from all security contexts.
                  *
                  * See also <a href="https://trac.openmicroscopy.org/ome/ticket/1794">ticket 1794</a>
                  *

--- a/components/blitz/resources/omero/api/IConfig.ice
+++ b/components/blitz/resources/omero/api/IConfig.ice
@@ -88,7 +88,7 @@ module omero {
 
                 /**
                  * Retrieves configuration values like {@link #getConfigValues}
-                 * but only those with the prefix "omero.client".
+                 * but only those with the prefix <i>omero.client</i>.
                  *
                  * @return a map from the found keys to the linked values.
                  */
@@ -97,7 +97,7 @@ module omero {
                 /**
                  * Reads the etc/omero.properties file and returns all the
                  * key/value pairs that are found there which match the prefix
-                 * "omero.client".
+                 * <i>omero.client</i>.
                  *
                  * @return a map from the found keys to the linked values.
                  */
@@ -143,7 +143,7 @@ module omero {
                  * invalid as soon as one modification is made.
                  *
                  * This value is stored in the configuration table under the
-                 * key "omero.db.uuid"
+                 * key <i>omero.db.uuid</i>.
                  *
                  * @return String not null.
                  */

--- a/components/blitz/resources/omero/api/IContainer.ice
+++ b/components/blitz/resources/omero/api/IContainer.ice
@@ -19,8 +19,8 @@ module omero {
     module api {
 
         /**
-         * Provides methods for dealing with the core "Pojos" of OME. Included
-         * are:
+         * Provides methods for dealing with the core <i>Pojos</i> of OME.
+         * Included are:
          * Projects, Datasets, Images.
          *
          * <h3>Read API</h3>
@@ -323,10 +323,10 @@ module omero {
 
                 /**
                  * Retrieves a collection with all members initialized
-                 * ("loaded"). This is useful when a collection has been
+                 * (<i>loaded</i>). This is useful when a collection has been
                  * nulled in a previous query.
                  *
-                 * @param obj Can be "unloaded".
+                 * @param obj Can be <i>unloaded</i>.
                  * @param collectionName
                  *            <code>public final static String</code> from the
                  *            IObject.class

--- a/components/blitz/resources/omero/api/IProjection.ice
+++ b/components/blitz/resources/omero/api/IProjection.ice
@@ -112,7 +112,7 @@ module omero {
                  *             <code>null</code> the name of the Image linked
                  *             to the Pixels qualified by
                  *             <code>pixelsId</code> will be used with a
-                 *             "Projection" suffix. For example,
+                 *             <i>Projection</i> suffix. For example,
                  *             <i>GFP-H2B Image of HeLa Cells</i> will have an
                  *             Image name of
                  *             <i>GFP-H2B Image of HeLa Cells Projection</i>

--- a/components/blitz/resources/omero/api/IQuery.ice
+++ b/components/blitz/resources/omero/api/IQuery.ice
@@ -166,7 +166,7 @@ module omero {
                  * select this from SomeModelClass this ...
                  * </pre>
                  *
-                 * though the alias "this" is unimportant. Do not try to
+                 * though the alias <i>this</i> is unimportant. Do not try to
                  * return multiple classes in one call like:
                  *
                  * <pre>

--- a/components/blitz/resources/omero/api/IRoi.ice
+++ b/components/blitz/resources/omero/api/IRoi.ice
@@ -184,9 +184,9 @@ module omero {
                 /**
                  * Returns a list of {@link omero.model.FileAnnotation}
                  * instances with the namespace
-                 * "openmicroscopy.org/measurements" which are attached to the
-                 * {@link omero.model.Plate} containing the given image AND
-                 * which are attached to at least one
+                 * <i>openmicroscopy.org/measurements</i> which are attached
+                 * to the {@link omero.model.Plate} containing the given image
+                 * AND which are attached to at least one
                  * {@link omero.model.Roi}
                  *
                  * @param opts, userId and groupId are respected based on the

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -88,7 +88,7 @@ module omero {
                 /**
                  * Returns non-official scripts which have been uploaded by individual users.
                  * These scripts will <em>not</me> be run by the server, though a user can
-                 * start a personal ""usermode processor"" which will allow the scripts to be
+                 * start a personal <i>usermode processor</i> which will allow the scripts to be
                  * executed. This is particularly useful for testing new scripts.
                  */
                 idempotent OriginalFileList getUserScripts(IObjectList acceptsList) throws ServerError;
@@ -185,8 +185,9 @@ module omero {
                 /**
                  * If {@link ResourceError} is thrown, then no
                  * {@link Processor} is available. Use {@link #scheduleJob}
-                 * to create a {@link omero.model.ScriptJob} in the "Waiting"
-                 * state. A {@link Processor} may become available.
+                 * to create a {@link omero.model.ScriptJob} in the
+                 * <i>Waiting</i> state. A {@link Processor} may become
+                 * available.
                  *
                  * <pre>
                  * try:
@@ -197,7 +198,7 @@ module omero {
                  *
                  * The {@link ScriptProcess} proxy MUST be closed before
                  * exiting. If you would like the script execution to continue
-                 * in the background, pass "True" as the argument.
+                 * in the background, pass <code>True</code> as the argument.
                  *
                  * <pre>
                  * try:

--- a/components/blitz/resources/omero/api/IScript.ice
+++ b/components/blitz/resources/omero/api/IScript.ice
@@ -74,7 +74,8 @@ module omero {
                  * scripts = scriptService.getScripts()
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
-                 *     path = script.path.val\[1:\] # First symbol is a "/"
+                 *     # First character is a "/" symbol
+                 *     path = script.path.val\[1:\]
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
                  * </pre>

--- a/components/blitz/resources/omero/api/IShare.ice
+++ b/components/blitz/resources/omero/api/IShare.ice
@@ -74,8 +74,8 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All ""draft"" shares (see
-                 *            {@link #createShare} and closed shares (see
+                 *            login will be returned. All <i>draft</i> shares
+                 *            (see {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
@@ -87,8 +87,8 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All ""draft"" shares (see
-                 *            {@link #createShare}) and closed shares (see
+                 *            login will be returned. All <i>draft</i> shares
+                 *            (see {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
@@ -100,8 +100,8 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All ""draft"" shares (see
-                 *            {@link #createShare}) and closed shares (see
+                 *            login will be returned. All <i>draft</i> shares
+                 *            (see {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
@@ -113,8 +113,8 @@ module omero {
                  *
                  * @param onlyActive
                  *            if true, then only shares which can be used for
-                 *            login will be returned. All ""draft"" shares (see
-                 *            {@link #createShare}) and closed shares (see
+                 *            login will be returned. All <i>draft</i> shares
+                 *            (see {@link #createShare}) and closed shares (see
                  *            {@link #closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */

--- a/components/blitz/resources/omero/api/ITimeline.ice
+++ b/components/blitz/resources/omero/api/ITimeline.ice
@@ -20,19 +20,19 @@ module omero {
     module api {
 
         /**
-         * Service for the querying of OMERO metadata based on creation and modification
-         * time. Currently supported types for querying include:
+         * Service for the querying of OMERO metadata based on creation and
+         * modification time. Currently supported types for querying include:
          *
-         *    - "Annotation"
-         *    - "Dataset"
-         *    - "Image"
-         *    - "Project"
-         *    - "RenderingDef"
+         *    - {@link omero.model.Annotation}
+         *    - {@link omero.model.Dataset}
+         *    - {@link omero.model.Image}
+         *    - {@link omero.model.Project}
+         *    - {@link omero.model.RenderingDef}
          *
          * Return maps:
          * -----------
          * The map return values will be indexed by the short type name above:
-         * ""Project", ""Image"", ... All keys which are passed in the StringSet
+         * <i>Project</i>, <i>Image</i>, ... All keys which are passed in the StringSet
          * argument will be included in the returned map, even if they have no
          * values. A default value of 0 or the empty list \[] will be used.
          * The only exception to this rule is that the null or empty StringSet
@@ -51,7 +51,7 @@ module omero {
          * Merging:
          * -------
          * The methods which take a StringSet and a Parameters object, also have
-         * a ""bool merge"" argument. This argument defines whether or not the LIMIT
+         * a <i>bool merge</i> argument. This argument defines whether or not the LIMIT
          * applies to each object independently (\["a","b"] @ 100 == 200) or merges
          * the lists together chronologically (\["a","b"] @ 100 merged == 100).
          *
@@ -142,10 +142,10 @@ module omero {
 
             /**
              * Returns the EventLog table objects which are queried to produce the counts above.
-             * Note the concept of ""period inclusion"" mentioned above.
+             * Note the concept of <i>period inclusion</i> mentioned above.
              *
              * WORKAROUND WARNING: this method returns non-managed EventLogs (i.e.
-             * eventLog.getId() == null) for "Image acquisitions".
+             * eventLog.getId() == null) for <i>Image acquisitions</i>.
              **/
             idempotent
             EventLogList

--- a/components/blitz/resources/omero/api/IUpdate.ice
+++ b/components/blitz/resources/omero/api/IUpdate.ice
@@ -26,7 +26,7 @@ module omero {
          * <p>
          * All the save* methods act recursively on the entire object graph,
          * replacing placeholders and details where necessary, and then
-         * ""merging"" the final graph.
+         * <i>merging</i> the final graph.
          * This means that the objects that are passed into IUpdate.save*
          * methods are copied over to new instances which are then returned.
          * The original objects <b>should be discarded</b>.

--- a/components/blitz/resources/omero/api/JobHandle.ice
+++ b/components/blitz/resources/omero/api/JobHandle.ice
@@ -77,7 +77,7 @@ module omero {
 
                 /**
                  * Returns <code>true</code> if the {@link omero.model.Job} is
-                 * running, I.e. has an attached process.
+                 * running, i.e. has an attached process.
                  */
                 idempotent bool jobRunning()  throws ServerError;
 

--- a/components/blitz/resources/omero/api/RawFileStore.ice
+++ b/components/blitz/resources/omero/api/RawFileStore.ice
@@ -20,7 +20,7 @@ module omero {
         /**
          * Raw file gateway which provides access to the OMERO file repository.
          *
-         * Note: methods on this service are protected by a ""DOWNLOAD""
+         * Note: methods on this service are protected by a <i>DOWNLOAD</i>
          * restriction.
          **/
         ["ami", "amd"] interface RawFileStore extends StatefulServiceInterface

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -205,7 +205,7 @@ module omero {
                  */
                 ["deprecated: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
 
-                /** Creates a instance of the rendering engine. */
+                /** Creates an instance of the rendering engine. */
                 idempotent void load() throws ServerError;
 
                 /**

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -20,57 +20,488 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/omeis/providers/re/RenderingEngine.html">RenderingEngine.html</a>
+         * Defines a service to render a given pixels set.
+         *
+         * A pixels set is a <i>5D</i> array that stores the pixels data of an
+         * image, that is the pixels intensity values. Every instance of this
+         * service is paired up to a pixels set. Use this service to transform
+         * planes within the pixels set onto an <i>RGB</i> image.
+         *
+         * The RenderingEngine allows to fine-tune the settings that
+         * define the transformation context &#151; that is, a specification
+         * of how raw pixels data is to be transformed into an image that can
+         * be displayed on screen. Those settings are referred to as rendering
+         * settings or display options. After tuning those settings it is
+         * possible to save them to the metadata repository so that they can
+         * be used the next time the pixels set is accessed for rendering; for
+         * example by another RenderingEngine instance. Note that the display
+         * options are specific to the given pixels set and are experimenter
+         * scoped &#151; that is, two different users can specify different
+         * display options for the <i>same</i> pixels set. (A RenderingEngine
+         * instance takes this into account automatically as it is always
+         * bound to a given experimenter.)
+         *
+         * This service is <b>thread-safe</b>.
          **/
         ["ami", "amd"] interface RenderingEngine extends PyramidService
             {
+                /**
+                 * Renders the data selected by <code>def</code> according to
+                 * the current rendering settings.
+                 * The passed argument selects a plane orthogonal to one
+                 * of the <i>X</i>, <i>Y</i>, or <i>Z</i> axes. How many
+                 * wavelengths are rendered and what color model is used
+                 * depends on the current rendering settings.
+                 *
+                 * @param def Selects a plane orthogonal to one of the
+                 *            <i>X</i>, <i>Y</i>, or <i>Z</i> axes.
+                 * @return An <i>RGB</i> image ready to be displayed on screen.
+                 * @throws ValidationException
+                 *             If <code>def</code> is <code>null</code>.
+                 */
                 idempotent omero::romio::RGBBuffer render(omero::romio::PlaneDef def) throws ServerError;
+
+                /**
+                 * Renders the data selected by <code>def</code> according to
+                 * the current rendering settings.
+                 * The passed argument selects a plane orthogonal to one
+                 * of the <i>X</i>, <i>Y</i>, or <i>Z</i> axes. How many
+                 * wavelengths are rendered and what color model is used
+                 * depends on the current rendering settings.
+                 *
+                 * @param def Selects a plane orthogonal to one of the
+                 *            <i>X</i>, <i>Y</i>, or <i>Z</i> axes.
+                 * @return An <i>RGB</i> image ready to be displayed on screen.
+                 * @throws ValidationException
+                 *             If <code>def</code> is <code>null</code>.
+                 * @see {@link #render}
+                 */
                 idempotent Ice::IntSeq renderAsPackedInt(omero::romio::PlaneDef def) throws ServerError;
+
+                /**
+                 * Performs a projection through selected optical sections of
+                 * a particular timepoint with the currently active channels
+                 * and renders the data for display.
+                 *
+                 * @param algorithm {@link ome.api.IProjection#MAXIMUM_INTENSITY},
+                 * {@link ome.api.IProjection#MEAN_INTENSITY} or
+                 * {@link ome.api.IProjection#SUM_INTENSITY}.
+                 * @param stepping Stepping value to use while calculating the
+                 *                 projection.
+                 *                 For example, <code>stepping=1</code> will
+                 *                 use every optical section from
+                 *                 <code>start</code> to <code>end</code>
+                 *                 where <code>stepping=2</code> will use every
+                 *                 other section from <code>start</code> to
+                 *                 <code>end</code> to perform the projection.
+                 * @param start Optical section to start projecting from.
+                 * @param end Optical section to finish projecting.
+                 * @return A packed-integer <i>RGBA</i> rendered image of the
+                 *         projected pixels.
+                 * @throws ValidationException Where:
+                 * <ul>
+                 *   <li><code>algorithm</code> is unknown</li>
+                 *   <li><code>timepoint</code> is out of range</li>
+                 *   <li><code>start</code> is out of range</li>
+                 *   <li><code>end</code> is out of range</li>
+                 *   <li><code>start > end</code></li>
+                 * </ul>
+                 * @see omero.api.IProjection#projectPixels
+                 */
                 idempotent Ice::IntSeq renderProjectedAsPackedInt(omero::constants::projection::ProjectionType algorithm, int timepoint, int stepping, int start, int end) throws ServerError;
+
+                /**
+                 * Renders the data selected by <code>def</code> according to
+                 * the current rendering settings and compresses the resulting
+                 * RGBA composite image.
+                 *
+                 * @param def Selects a plane orthogonal to one of the
+                 *            <i>X</i>, <i>Y</i> or <i>Z</i> axes.
+                 * @return A compressed RGBA JPEG for display.
+                 * @throws ValidationException
+                 *             If <code>def</code> is <code>null</code>.
+                 * @see #render
+                 * @see #renderAsPackedInt
+                 */
                 idempotent Ice::ByteSeq renderCompressed(omero::romio::PlaneDef def) throws ServerError;
+
+                /**
+                 * Performs a projection through selected optical sections of
+                 * a particular timepoint with the currently active channels,
+                 * renders the data for display and compresses the resulting
+                 * RGBA composite image.
+                 *
+                 * @param algorithm {@link ome.api.IProjection#MAXIMUM_INTENSITY},
+                 * {@link ome.api.IProjection#MEAN_INTENSITY} or
+                 * {@link ome.api.IProjection#SUM_INTENSITY}.
+                 * @param stepping Stepping value to use while calculating the
+                 *                 projection.
+                 *                 For example, <code>stepping=1</code> will
+                 *                 use every optical section from
+                 *                 <code>start</code> to <code>end</code>
+                 *                 where <code>stepping=2</code> will use every
+                 *                 other section from <code>start</code> to
+                 *                 <code>end</code> to perform the projection.
+                 * @param start Optical section to start projecting from.
+                 * @param end Optical section to finish projecting.
+                 * @return A compressed <i>RGBA</i> rendered JPEG image of the
+                 *         projected pixels.
+                 * @throws ValidationException Where:
+                 * <ul>
+                 *   <li><code>algorithm</code> is unknown</li>
+                 *   <li><code>timepoint</code> is out of range</li>
+                 *   <li><code>start</code> is out of range</li>
+                 *   <li><code>end</code> is out of range</li>
+                 *   <li><code>start > end</code></li>
+                 * </ul>
+                 * @see omero.api.IProjection#projectPixels
+                 */
                 idempotent Ice::ByteSeq renderProjectedCompressed(omero::constants::projection::ProjectionType algorithm, int timepoint, int stepping, int start, int end) throws ServerError;
+
+                /**
+                 * Returns the id of the {@link omero.model.RenderingDef}
+                 * loaded by either {@link #lookupRenderingDef} or
+                 * {@link #loadRenderingDef}.
+                 */
                 idempotent long getRenderingDefId() throws ServerError;
+
+                /**
+                 * Loads the Pixels set this Rendering Engine is for.
+                 *
+                 * @param pixelsId The pixels set ID.
+                 */
                 idempotent void lookupPixels(long pixelsId) throws ServerError;
+
+                /**
+                 * Loads the rendering settings associated to the specified
+                 * pixels set.
+                 *
+                 * @param pixelsId The pixels set ID.
+                 * @return <code>true</code> if a RenderingDef exists for the
+                 *         Pixels set, otherwise <code>false</code>.
+                 */
                 idempotent bool lookupRenderingDef(long pixelsId) throws ServerError;
+
+                /**
+                 * Loads a specific set of rendering settings that does not
+                 * necessarily have to be linked to the given Pixels set.
+                 * However, the rendering settings <b>must</b> be linked to a
+                 * compatible Pixels set as defined by
+                 * {@link omero.api.IRenderingSettings#sanityCheckPixels}.
+                 *
+                 * @param renderingDefId The rendering definition ID.
+                 * @throws ValidationException If a RenderingDef does not
+                 *         exist with the ID <code>renderingDefId</code> or if
+                 *         the RenderingDef is incompatible due to differing
+                 *         pixels sets.
+                 */
                 idempotent void loadRenderingDef(long renderingDefId) throws ServerError;
+
+                /**
+                 * Informs the rendering engine that it should render a set of
+                 * overlays on each rendered frame. These are expected to be
+                 * binary masks.
+                 * @param overlays Binary mask to color map.
+                 */
                 ["deprecated: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
+
+                /** Creates a instance of the rendering engine. */
                 idempotent void load() throws ServerError;
+
+                /**
+                 * Specifies the model that dictates how transformed raw data
+                 * has to be mapped onto a color space.
+                 *
+                 * @param model Identifies the color space model.
+                 */
                 idempotent void setModel(omero::model::RenderingModel model) throws ServerError;
+
+                /**
+                 * Returns the model that dictates how transformed raw data
+                 * has to be mapped onto a color space.
+                 */
                 idempotent omero::model::RenderingModel getModel() throws ServerError;
+
+                /**
+                 * Returns the index of the default focal section.
+                 */
                 idempotent int getDefaultZ() throws ServerError;
+
+                /**
+                 * Returns the default timepoint index.
+                 */
                 idempotent int getDefaultT() throws ServerError;
+
+                /**
+                 * Sets the index of the default focal section. This index is
+                 * used to define a default plane.
+                 *
+                 * @param z The value to set.
+                 */
                 idempotent void setDefaultZ(int z) throws ServerError;
+
+                /**
+                 * Sets the default timepoint index. This index is used to
+                 * define a default plane.
+                 *
+                 * @param t The value to set.
+                 */
                 idempotent void setDefaultT(int t) throws ServerError;
+
+                /**
+                 * Returns the {@link omero.model.Pixels} set the Rendering
+                 * engine is for.
+                 */
                 idempotent omero::model::Pixels getPixels() throws ServerError;
+
+                /**
+                 * Returns the list of color models supported by the Rendering
+                 * engine.
+                 */
                 idempotent IObjectList getAvailableModels() throws ServerError;
+
+                /**
+                 * Returns the list of mapping families supported by the
+                 * Rendering engine.
+                 */
                 idempotent IObjectList getAvailableFamilies() throws ServerError;
+
+                /**
+                 * Sets the quantization strategy. The strategy is common to
+                 * all channels.
+                 *
+                 * @param bitResolution The bit resolution defining associated
+                 *                      to the strategy.
+                 */
                 idempotent void setQuantumStrategy(int bitResolution) throws ServerError;
+
+                /**
+                 * Sets the sub-interval of the device space i.e. a discrete
+                 * sub-interval of \[0, 255].
+                 *
+                 * @param start The lower bound of the interval.
+                 * @param end The upper bound of the interval.
+                 */
                 idempotent void setCodomainInterval(int start, int end) throws ServerError;
+
+                /**
+                 * Returns the quantization object.
+                 */
                 idempotent omero::model::QuantumDef getQuantumDef() throws ServerError;
+
+                /**
+                 * Sets the quantization map, one per channel.
+                 *
+                 * @param w  The channel index.
+                 * @param family The mapping family.
+                 * @param coefficient The coefficient identifying a curve in
+                 *                    the family.
+                 * @param noiseReduction Pass <code>true</code> to turn the
+                 *                       noise reduction algorithm on,
+                 *                       <code>false</code> otherwise.
+                 * @see #getAvailableFamilies
+                 * @see #getChannelCurveCoefficient
+                 * @see #getChannelFamily
+                 * @see #getChannelNoiseReduction
+                 */
                 idempotent void setQuantizationMap(int w, omero::model::Family fam, double coefficient, bool noiseReduction) throws ServerError;
+
+                /**
+                 * Returns the family associated to the specified channel.
+                 *
+                 * @param w The channel index.
+                 * @return See above.
+                 * @see #getAvailableFamilies
+                 */
                 idempotent omero::model::Family getChannelFamily(int w) throws ServerError;
+
+                /**
+                 * Returns <code>true</code> if the noise reduction algorithm
+                 * used to map the pixels intensity values is turned on,
+                 * <code>false</code> if the algorithm is turned off. Each
+                 * channel has an algorithm associated to it.
+                 *
+                 * @param w The channel index.
+                 * @return See above.
+                 */
                 idempotent bool getChannelNoiseReduction(int w) throws ServerError;
                 idempotent Ice::DoubleSeq getChannelStats(int w) throws ServerError;
+
+                /**
+                 * Returns the coefficient identifying a map in the family.
+                 * Each channel has a map associated to it.
+                 *
+                 * @param w The channel index.
+                 * @return See above.
+                 * @see #getChannelFamily
+                 */
                 idempotent double getChannelCurveCoefficient(int w) throws ServerError;
+
+                /**
+                 * Returns the pixels intensity interval. Each channel has a
+                 * pixels intensity interval associated to it.
+                 *
+                 * @param w The channel index.
+                 * @param start The lower bound of the interval.
+                 * @param end The upper bound of the interval.
+                 */
                 idempotent void setChannelWindow(int w, double start, double end) throws ServerError;
+
+                /**
+                 * Returns the lower bound of the pixels intensity interval.
+                 * Each channel has a pixels intensity interval associated to
+                 * it.
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent double getChannelWindowStart(int w) throws ServerError;
+
+                /**
+                 * Returns the upper bound of the pixels intensity interval.
+                 * Each channel has a pixels intensity interval associated to
+                 * it.
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent double getChannelWindowEnd(int w) throws ServerError;
+
+                /**
+                 * Sets the four components composing the color associated to
+                 * the specified channel.
+                 *
+                 * @param w The channel index.
+                 * @param red The red component. A value between 0 and 255.
+                 * @param green The green component. A value between 0 and 255.
+                 * @param blue The blue component. A value between 0 and 255.
+                 * @param alpha The alpha component. A value between 0 and 255.
+                 */
                 idempotent void setRGBA(int w, int red, int green, int blue, int alpha) throws ServerError;
+
+                /**
+                 * Returns a 4D-array representing the color associated to the
+                 * specified channel. The first element corresponds to the red
+                 * component (value between 0 and 255). The second corresponds
+                 * to the green component (value between 0 and 255). The third
+                 * corresponds to the blue component (value between 0 and
+                 * 255). The fourth corresponds to the alpha component (value
+                 * between 0 and 255).
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent Ice::IntSeq getRGBA(int w) throws ServerError;
+
+                /**
+                 * Maps the specified channel if <code>true</code>, unmaps the
+                 * channel otherwise.
+                 *
+                 * @param w The channel index.
+                 * @param active Pass <code>true</code> to map the channel,
+                 *               <code>false</code> otherwise.
+                 */
                 idempotent void setActive(int w, bool active) throws ServerError;
+
+                /**
+                 * Returns <code>true</code> if the channel is mapped,
+                 * <code>false</code> otherwise.
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent bool isActive(int w) throws ServerError;
                 idempotent void setChannelLookupTable(int w, string lookup) throws ServerError;
                 idempotent string getChannelLookupTable(int w) throws ServerError;
+
+                /**
+                 * Adds the context to the mapping chain. Only one context of
+                 * the same type can be added to the chain. The codomain
+                 * transformations are functions from the device space to
+                 * device space. Each time a new context is added, the second
+                 * LUT is rebuilt.
+                 *
+                 * @param mapCtx The context to add.
+                 * @see #updateCodomainMap
+                 * @see #removeCodomainMap
+                 */
                 void addCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
+
+                /**
+                 * Updates the specified context. The codomain chain already
+                 * contains the specified context. Each time a new context is
+                 * updated, the second LUT is rebuilt.
+                 *
+                 * @param mapCtx The context to update.
+                 * @see #addCodomainMap
+                 * @see #removeCodomainMap
+                 */
                 void updateCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
+
+                /**
+                 * Removes the specified context from the chain. Each time a
+                 * new context is removed, the second LUT is rebuilt.
+                 *
+                 * @param mapCtx The context to remove.
+                 * @see #addCodomainMap
+                 * @see #updateCodomainMap
+                 */
                 void removeCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
+
+                /** Saves the current rendering settings in the database. */
                 void saveCurrentSettings() throws ServerError;
+
+                /**
+                 * Saves the current rendering settings in the database
+                 * as a new {@link omero.model.RenderingDef} and loads the
+                 * object into the current {@link omero.api.RenderingEngine}.
+                 */
                 long saveAsNewSettings() throws ServerError;
+
+                /**
+                 * Resets the default settings i.e. the default values
+                 * internal to the Rendering engine. The settings will be
+                 * saved.
+                 *
+                 * @param save Pass <code>true</code> to save the settings,
+                 *             <code>false</code> otherwise.
+                 */
                 long resetDefaultSettings(bool save) throws ServerError;
+
+		/**
+		 * Sets the current compression level for the service. (The
+                 * default is 85%)
+		 *
+		 * @param percentage A percentage compression level from 1.00
+                 *                  (100%) to 0.01 (1%).
+		 * @throws ValidationException if the <code>percentage</code
+                 *         is out of range.
+		 */
                 idempotent void setCompressionLevel(float percentage) throws ServerError;
+
+		/**
+		 * Returns the current compression level for the service.
+		 */
                 idempotent float getCompressionLevel() throws ServerError;
+
+		/**
+                 * Returns <code>true</code> if the pixels type is signed,
+                 * <code>false</code> otherwise.
+                 */
                 idempotent bool isPixelsTypeSigned() throws ServerError;
+
+		/**
+                 * Returns the minimum value for that channels depending on
+                 * the pixels type and the original range (globalmax,
+                 * globalmin)
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent double getPixelsTypeUpperBound(int w) throws ServerError;
+
+		/**
+                 * Returns the maximum value for that channels depending on
+                 * the pixels type and the original range (globalmax,
+                 * globalmin)
+                 *
+                 * @param w The channel index.
+                 */
                 idempotent double getPixelsTypeLowerBound(int w) throws ServerError;
 
             };

--- a/components/blitz/resources/omero/api/Search.ice
+++ b/components/blitz/resources/omero/api/Search.ice
@@ -411,8 +411,9 @@ module omero {
                  * Returns transient (without ID)
                  * {@link omero.model.TextAnnotation} instances which represent
                  * terms which are similar to the given terms. For example, if
-                 * the argument is "cell", one return value might have as its
-                 * textValue: "cellular" while another has "cellularize".
+                 * the argument is <i>cell</i>, one return value might have as
+                 * its textValue: <i>cellular</i> while another has
+                 * <i>cellularize</i>.
                  *
                  * No filtering or fetching is performed.
                  *

--- a/components/blitz/resources/omero/api/Search.ice
+++ b/components/blitz/resources/omero/api/Search.ice
@@ -21,8 +21,8 @@ module omero {
          * Central search interface, allowing Web2.0 style queries. Each
          * {@link omero.api.Search} instance keeps up with several queries and
          * lazily-loads the results as {@link #hasNext}, {@link #next} and
-         * {@link #results} are called. These queries are created by the "by*"
-         * methods.
+         * {@link #results} are called. These queries are created by the
+         * <i>by*</i> methods.
          *
          * Each instance also has a number of settings which can all be
          * changed from their defaults via accessors, e.g.
@@ -33,7 +33,7 @@ module omero {
          * <ul>
          * <li>{@link #onlyType}, {@link #onlyTypes} OR
          * {@link #allTypes}</li>
-         * <li>Any by* method to create a query</li>
+         * <li>Any <i>by*</i> method to create a query</li>
          * </ul>
          * Use of the {@link #allTypes} method is discouraged, since it is
          * possibly very resource intensive, which is why any attempt to

--- a/components/blitz/resources/omero/api/Search.ice
+++ b/components/blitz/resources/omero/api/Search.ice
@@ -18,86 +18,588 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/Search.html">Search.html</a>
-         **/
+         * Central search interface, allowing Web2.0 style queries. Each
+         * {@link omero.api.Search} instance keeps up with several queries and
+         * lazily-loads the results as {@link #hasNext}, {@link #next} and
+         * {@link #results} are called. These queries are created by the "by*"
+         * methods.
+         *
+         * Each instance also has a number of settings which can all be
+         * changed from their defaults via accessors, e.g.
+         * {@link #setBatchSize} or {@link #setCaseSentivice}.
+         *
+         * The only methods which are required for the proper functioning of a
+         * {@link Search} instance are:
+         * <ul>
+         * <li>{@link #onlyType}, {@link #onlyTypes} OR
+         * {@link #allTypes}</li>
+         * <li>Any by* method to create a query</li>
+         * </ul>
+         * Use of the {@link #allTypes} method is discouraged, since it is
+         * possibly very resource intensive, which is why any attempt to
+         * receive results without specifically setting types or allowing all
+         * is prohibited.
+         *
+         * @see omero.api.IQuery
+         */
         ["ami", "amd"] interface Search extends StatefulServiceInterface
             {
 
                 // Non-query state ~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * Returns the number of active queries. This means that
+                 * {@link #activeQueries} gives the minimum number of
+                 * remaining calls to {@link #results} when batches are not
+                 * merged.
+                 *
+                 * @return number of active queries
+                 */
                 idempotent int activeQueries() throws ServerError;
+
+                /**
+                 * Sets the maximum number of results that will be returned by
+                 * one call to {@link #results}. If batches are not merged,
+                 * then results may often be less than the batch size. If
+                 * batches are merged, then only the last call to
+                 * {@link #results} can be less than batch size.
+                 *
+                 * Note: some query types may not support batching at the
+                 * query level, and all instances must then be loaded into
+                 * memory simultaneously.
+                 *
+                 * @param size maximum number of results per call to
+                 *             {@link #results}
+                 */
                 idempotent void setBatchSize(int size) throws ServerError;
+
+                /**
+                 * Returns the current batch size. If {@link #setBatchSize}
+                 * has not been called, the default value will be in effect.
+                 *
+                 * @return maximum number of results per call to
+                 *         {@link #results}
+                 */
                 idempotent int getBatchSize() throws ServerError;
+
+                /**
+                 * Set whether or not results from two separate queries can be
+                 * returned in the same call to {@link #results}.
+                 */
                 idempotent void setMergedBatches(bool merge) throws ServerError;
+
+                /**
+                 * Returns the current merged-batches setting. If
+                 * {@link #setMergedBatches} has not been called, the
+                 * default value will be in effect.
+                 */
                 idempotent bool isMergedBatches() throws ServerError;
+
+                /**
+                 * Sets the case sensitivity on all queries where
+                 * case-sensitivity is supported.
+                 */
                 idempotent void setCaseSentivice(bool caseSensitive) throws ServerError;
+
+                /**
+                 * Returns the current case sensitivity setting. If
+                 * {@link #setCaseSentivice} has not been called, the
+                 * default value will be in effect.
+                 */
                 idempotent bool isCaseSensitive() throws ServerError;
+
+                /**
+                 * Determines if Lucene queries should not hit the database.
+                 * Instead all values which are stored in the index will be
+                 * loaded into the object, which includes the id. However, the
+                 * entity will not be marked unloaded and therefore it is
+                 * especially important to not allow a projection-instance to
+                 * be saved back to the server. This can result in DATA LOSS.
+                 */
                 idempotent void setUseProjections(bool useProjections) throws ServerError;
+
+                /**
+                 * Returns the current use-projection setting. If true, the
+                 * client must be careful with all results that are returned.
+                 * See {@link #setUseProjections} for more. If
+                 * {@link #setUseProjections} has not been called, the
+                 * default value will be in effect.
+                 */
                 idempotent bool isUseProjections() throws ServerError;
+
+                /**
+                 * Determines if all results should be returned as unloaded
+                 * objects. This is particularly useful for creating lists for
+                 * further querying via {@link omero.api.IQuery}. This value
+                 * overrides the {@link #setUseProjections} setting.
+                 */
                 idempotent void setReturnUnloaded(bool returnUnloaded) throws ServerError;
+
+                /**
+                 * Returns the current return-unloaded setting. If true, all
+                 * returned entities will be unloaded. If
+                 * {@link #setReturnUnloaded} has not been called, the
+                 * default value will be in effect.
+                 */
                 idempotent bool isReturnUnloaded() throws ServerError;
+
+                /**
+                 * Permits full-text queries with a leading query if true.
+                 *
+                 * @see #isAllowLeadingWildcard
+                 * @see #byFullText
+                 * @see #bySomeMustNone
+                 */
                 idempotent void setAllowLeadingWildcard(bool allowLeadingWildcard) throws ServerError;
+
+                /**
+                 * Returns the current leading-wildcard setting. If false,
+                 * {@link #byFullText} and {@link #bySomeMustNone} will throw
+                 * an {@link omero.ApiUsageException}, since leading-wildcard
+                 * searches are quite slow. Use
+                 * {@link #setAllowLeadingWildcard} in order to permit this
+                 * usage.
+                 */
                 idempotent bool isAllowLeadingWildcard() throws ServerError;
 
 
                 // Filters ~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * Restricts the search to a single type. All return values
+                 * will match this type.
+                 */
                 void onlyType(string klass) throws ServerError;
+
+                /**
+                 * Restricts searches to a set of types. The entities returned
+                 * are guaranteed to be one of these types.
+                 */
                 void onlyTypes(StringSet classes) throws ServerError;
+
+                /**
+                 * Permits all types to be returned. For some types of
+                 * queries, this carries a performance penalty as every
+                 * database table must be hit.
+                 */
                 void allTypes() throws ServerError;
+
+                /**
+                 * Restricts the set of ids which will be checked.
+                 * This is useful for testing one of the given restrictions on
+                 * a reduced set of objects.
+                 *
+                 * @param ids Can be null, in which case the previous
+                 *            restriction is removed.
+                 */
                 void onlyIds(omero::sys::LongList ids) throws ServerError;
+
+                /**
+                 * Uses the {@link omero.model.Details#getOwner} and
+                 * {@link omero.model.Details#getGroup} information to
+                 * restrict the entities which will be returned. If both are
+                 * non-null, the two restrictions are joined by an AND.
+                 *
+                 * @param d Can be null, in which case the previous
+                 *          restriction is removed.
+                 */
                 void onlyOwnedBy(omero::model::Details d) throws ServerError;
+
+                /**
+                 * Uses the {@link omero.model.Details#getOwner} and
+                 * {@link omero.model.Details#getGroup} information to
+                 * restrict the entities which will be returned. If both are
+                 * non-null, the two restrictions are joined by an AND.
+                 *
+                 * @param d Can be null, in which case the previous
+                 *          restriction is removed.
+                 */
                 void notOwnedBy(omero::model::Details d) throws ServerError;
+
+                /**
+                 * Restricts the time between which an entity may have been
+                 * created.
+                 *
+                 * @param start Can be null, i.e. interval open to negative
+                 *              infinity.
+                 * @param stop Can be null, i.e. interval opens to positive
+                 *             infinity.
+                 */
                 void onlyCreatedBetween(omero::RTime start, omero::RTime  stop) throws ServerError;
+
+                /**
+                 * Restricts the time between which an entity may have last
+                 * been modified.
+                 *
+                 * @param start Can be null, i.e. interval open to negative
+                 *              infinity.
+                 * @param stop Can be null, i.e. interval open to positive
+                 *             infinity.
+                 */
                 void onlyModifiedBetween(omero::RTime start, omero::RTime stop) throws ServerError;
+
+                /**
+                 * Restricts entities by the time in which any annotation
+                 * (which matches the other filters) was added them. This
+                 * matches the {@link omero.model.Details#getCreationEvent}
+                 * creation event of the {@link omero..model.Annotation}.
+                 *
+                 * @param start Can be null, i.e. interval open to negative
+                 *              infinity.
+                 * @param stop Can be null, i.e. interval open to positive
+                 *             infinity.
+                 */
                 void onlyAnnotatedBetween(omero::RTime start, omero::RTime stop) throws ServerError;
+
+                /**
+                 * Restricts entities by who has annotated them with an
+                 * {@link omero.model.Annotation} matching the other filters.
+                 * As {@link #onlyOwnedBy}, the
+                 * {@link omero.model.Details#getOwner} and
+                 * {@link omero.model.Details#getGroup} information is
+                 * combined with an AND condition.
+                 *
+                 * @param d Can be null, in which case any previous
+                 *          restriction is removed.
+                 */
                 void onlyAnnotatedBy(omero::model::Details d) throws ServerError;
+
+                /**
+                 * Restricts entities by who has not annotated them with an
+                 * {@link omero.model.Annotation} matching the other filters.
+                 * As {@link #notOwnedBy}, the
+                 * {@link omero.model.Details#getOwner} and
+                 * {@link omero.model.Details#getGroup} information is
+                 * combined with an AND condition.
+                 *
+                 * @param d Can be null, in which case any previous
+                 *          restriction is removed.
+                 */
                 void notAnnotatedBy(omero::model::Details d) throws ServerError;
+
+                /**
+                 * Restricts entities to having an
+                 * {@link omero.model.Annotation} of all the given types. This
+                 * is useful in combination with the other onlyAnnotated*
+                 * methods to say, e.g., only annotated with a file by user X.
+                 * By default, this value is <code>null</code> and imposes no
+                 * restriction. Passing an empty array implies an object that
+                 * is not annotated at all.
+                 *
+                 *
+                 * Note: If the semantics were OR, then a client would have to
+                 * query each class individually, and compare all the various
+                 * values, checking which ids are where. However, since this
+                 * method defaults to AND, multiple calls (optionally with
+                 * {@link #isMergedBatches} and {@link #isReturnUnloaded})
+                 * and combine the results. Duplicate ids are still possible
+                 * so a set of some form should be used to collect the results.
+                 *
+                 * @param classes Can be empty, in which case restriction is
+                 *                removed.
+                 */
                 void onlyAnnotatedWith(StringSet classes) throws ServerError;
 
 
                 // Fetches, order, counts, etc ~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * A path from the target entity which will be added to the
+                 * current stack of order statements applied to the query.
+                 *
+                 * @param path Non-null.
+                 * @see #unordered
+                 */
                 void addOrderByAsc(string path) throws ServerError;
+
+                /**
+                 * A path from the target entity which will be added to the
+                 * current stack of order statements applied to the query.
+                 *
+                 * @param path Non-null.
+                 * @see #unordered
+                 */
                 void addOrderByDesc(string path) throws ServerError;
+
+                /**
+                 * Removes the current stack of order statements.
+                 *
+                 * @see #addOrderByAsc
+                 * @see #addOrderByDesc
+                 */
                 void unordered() throws ServerError;
+
+                /**
+                 * Queries the database for all {@link omero.model.Annotation}
+                 * annotations of the given types for all returned instances.
+                 *
+                 * @param classes Can be empty, which removes previous fetch
+                 *                setting.
+                 */
                 void fetchAnnotations(StringSet classes) throws ServerError;
+
+                /**
+                 * Adds a fetch clause for loading non-annotation fields of
+                 * returned entities. Each fetch is a hibernate clause in dot
+                 * notation.
+                 *
+                 * @param fetches Can be empty, which removes previous fetch
+                 *                setting.
+                 */
                 void fetchAlso(StringSet fetches) throws ServerError;
 
 
                 // Reset ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * Resets all settings (non-query state) to the original
+                 * default values, as if the instance had just be created.
+                 */
                 void resetDefaults() throws ServerError;
 
 
                 // Query state  ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * Returns transient (without ID)
+                 * {@link omero.model.TagAnnotation} instances which
+                 * represent all the
+                 * {@link omero.model.TagAnnotation} tags in the given group.
+                 * The entities are transient and without ownership since
+                 * multiple users can own the same tag. This method will
+                 * override settings for types.
+                 *
+                 * @param group Can be null or empty to return all tags.
+                 */
                 void byGroupForTags(string group) throws ServerError;
+
+                /**
+                 * Creates a query which will return transient (without ID)
+                 * {@link omero.model.TagAnnotation} instances which represent
+                 * all the {@link omero.model.TagAnnotation} tag groups which
+                 * the given tag belongs to. The entities are transient and
+                 * without ownership since multiple users can own the same tag
+                 * group. This method will override settings for types.
+                 *
+                 * @param tag Can be null or empty to return all groups.
+                 */
                 void byTagForGroups(string tag) throws ServerError;
+
+                /**
+                 * Passes the query as is to the Lucene backend.
+                 *
+                 * @param query May not be null or of zero length.
+                 */
                 void byFullText(string query) throws ServerError;
+
+                /**
+                 * Builds a Lucene query and passes it to the Lucene backend.
+                 *
+                 * @param fields   The fields (comma separated) to search in
+                 *                 (name, description, ...)
+                 * @param from     The date range from, in the form YYYYMMDD
+                 *                 (may be null)
+                 * @param to       The date range to (inclusive), in the form
+                 *                 YYYYMMDD (may be null)
+                 * @param dateType {@link #DATE_TYPE_ACQUISITION} or
+                 *                 {@link #DATE_TYPE_IMPORT}
+                 * @param query May not be null or of zero length.
+                 */
                 void byLuceneQueryBuilder(string fields, string from, string to, string dateType, string query) throws ServerError;
+
+                /**
+                 * Returns transient (without ID)
+                 * {@link omero.model.TextAnnotation} instances which represent
+                 * terms which are similar to the given terms. For example, if
+                 * the argument is "cell", one return value might have as its
+                 * textValue: "cellular" while another has "cellularize".
+                 *
+                 * No filtering or fetching is performed.
+                 *
+                 * @param terms Cannot be empty.
+                 */
                 void bySimilarTerms(StringSet terms) throws ServerError;
+
+                /**
+                 * Delegates to {@link omero.api.IQuery#findAllByQuery} method
+                 * to take advantage of the {@link #and}, {@link #or}, and
+                 * {@link #not} methods, or queue-semantics.
+                 *
+                 * @param query Not null.
+                 * @param p May be null. Defaults are then in effect.
+                 * @see omero.api.IQuery#findAllByQuery
+                 */
                 void byHqlQuery(string query, omero::sys::Parameters params) throws ServerError;
+
+                /**
+                 * Builds a Lucene query and passes it to {@link #byFullText}.
+                 *
+                 * @param some Some (at least one) of these terms must be
+                 *             present in the document. May be null.
+                 * @param must All of these terms must be present in the
+                 *             document. May be null.
+                 * @param none None of these terms may be present in the
+                 *             document. May be null.
+                 */
                 void bySomeMustNone(StringSet some, StringSet must, StringSet none) throws ServerError;
+
+                /**
+                 * Finds entities annotated with an
+                 * {@link omero.model.Annotation} similar to the example. This
+                 * does not use Hibernate's
+                 * {@link omero.api.IQuery#findByExample} Query-By-Example}
+                 * mechanism, since that cannot handle joins. The fields which
+                 * are used are:
+                 * <ul>
+                 * <li>the main content of the annotation : String,
+                 * {@link omero.model.OriginalFile#getId}, etc.</li>
+                 * </ul>
+                 *
+                 * If the main content is <code>null</code> it is assumed to
+                 * be a wildcard searched, and only the type of the annotation
+                 * is searched. Currently, ListAnnotations are not supported.
+                 *
+                 *
+                 * @param examples Not empty.
+                 */
                 void byAnnotatedWith(AnnotationList examples) throws ServerError;
+
+                /**
+                 * Removes all active queries (leaving {@link #resetDefaults}
+                 * settings alone), such that {@link #activeQueries} will
+                 * return 0.
+                 */
                 void clearQueries() throws ServerError;
 
+                /**
+                 * Applies the next by* method to the previous by* method, so
+                 * that a call {@link #hasNext}, {@link #next}, or
+                 * {@link #results} sees only the intersection of the two
+                 * calls.
+                 *
+                 * For example,
+                 *
+                 * <pre>
+                 * service.onlyType(Image.class);
+                 * service.byFullText(&quot;foo&quot;);
+                 * service.intersection();
+                 * service.byAnnotatedWith(TagAnnotation.class);
+                 * </pre>
+                 *
+                 * will return only the Images with TagAnnotations.
+                 *
+                 * <p>
+                 * Calling this method overrides a previous setting of
+                 * {@link #or} or {@link #not}. If there is no active queries
+                 * (i.e. {@link #activeQueries} > 0), then an
+                 * {@link ApiUsageException} will be thrown.</p>
+                 */
                 void and() throws ServerError;
+
+                /**
+                 * Applies the next by* method to the previous by* method, so
+                 * that a call {@link #hasNext}, {@link #next} or
+                 * {@link #results} sees only the union of the two calls.
+                 *
+                 * For example,
+                 *
+                 * <pre>
+                 * service.onlyType(Image.class);
+                 * service.byFullText(&quot;foo&quot;);
+                 * service.or();
+                 * service.onlyType(Dataset.class);
+                 * service.byFullText(&quot;foo&quot;);
+                 * </pre>
+                 *
+                 * will return both Images and Datasets together.
+                 *
+                 * Calling this method overrides a previous setting of
+                 * {@link #and} or {@link #not}. If there is no active queries
+                 * (i.e. {@link #activeQueries} > 0), then an
+                 * {@link omero.ApiUsageException} will be thrown.
+                 */
                 void or() throws ServerError;
+
+                /**
+                 * Applies the next by* method to the previous by* method, so
+                 * that a call {@link #hasNext}, {@link #next}, or
+                 * {@link #results} sees only the intersection of the two
+                 * calls.
+                 * 
+                 * For example,
+                 * 
+                 * <pre>
+                 * service.onlyType(Image.class);
+                 * service.byFullText(&quot;foo&quot;);
+                 * service.complement();
+                 * service.byAnnotatedWith(TagAnnotation.class);
+                 * </pre>
+                 * 
+                 * will return all the Images <em>not</em> annotated with
+                 * TagAnnotation. <p>
+                 * Calling this method overrides a previous setting of
+                 * {@link #or} or {@link #and}. If there is no active queries
+                 * (i.e. {@link #activeQueries} > 0), then an
+                 * {@link ApiUsageException} will be thrown.
+                 * </p>
+                 */
                 void not() throws ServerError;
 
 
                 // Retrieval  ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+                /**
+                 * Returns <code>true</code> if another call to
+                 * {@link #next} is valid. A call to {@link #next} may throw
+                 * an exception for another reason, however.
+                 */
                 idempotent bool hasNext() throws ServerError;
+
+                /**
+                 * Returns the next entity from the current query. If the
+                 * previous call returned the last entity from a given query,
+                 * the first entity from the next query will be returned and
+                 * {@link #activeQueries} decremented.
+                 * Since this method only returns the entity itself, a single
+                 * call to {@link #currentMetadata} may follow this call to
+                 * gather the extra metadata which is returned in the map via
+                 * {@link #results}.
+                 * 
+                 * @throws ApiUsageException if {@link #hasNext} returns false.
+                 */
                 omero::model::IObject next() throws ServerError;
+
+                /**
+                 * Returns up to {@link #getBatchSize} batch size number of
+                 * results along with the related query metadata. If
+                 * {@link #isMergedBatches} batches are merged then the
+                 * results from multiple queries may be returned together.
+                 * 
+                 * @throws ApiUsageException if {@link #hasNext} returns false.
+                 */
                 IObjectList results() throws ServerError;
 
                 // Currently unused
+                /**
+                 * Provides access to the extra query information (for example
+                 * Lucene score and boost values) for a single call to
+                 * {@link #next}. This method may only be called once for any
+                 * given call to {@link #next}.
+                 */
                 idempotent SearchMetadata currentMetadata() throws ServerError;
+
+                /**
+                 * Provides access to the extra query information (for example
+                 * Lucene score and boost values) for a single call to
+                 * {@link #results}. This method may only be called once for
+                 * any given call to {@link #results}.
+                 */
                 idempotent SearchMetadataList currentMetadataList() throws ServerError;
 
                 // Unused; Part of Java Iterator interface
+                /**
+                 * Unsupported operation.
+                 */
                 void remove() throws ServerError;
             };
 

--- a/components/blitz/resources/omero/api/ThumbnailStore.ice
+++ b/components/blitz/resources/omero/api/ThumbnailStore.ice
@@ -18,26 +18,360 @@ module omero {
     module api {
 
         /**
-         * See <a href="http://downloads.openmicroscopy.org/latest/omero5.2/api/ome/api/ThumbnailStore.html">ThumbnailStore.html</a>
+         * Provides methods for dealing with thumbnails. Provision is provided
+         * to retrieve thumbnails using the on-disk cache (provided by
+         * <i>ROMIO</i>) or on the fly.
+         * <p>
+         * NOTE: The calling order for the service is as follows:
+         * <ol>
+         * <li>{@link #setPixelsId}</li>
+         * <li>any of the thumbnail accessor methods or
+         * {@link #resetDefaults}</li>
+         * </ol>
+         * </p>
          **/
         ["ami", "amd"] interface ThumbnailStore extends StatefulServiceInterface
             {
+                /**
+                 * This method manages the state of the service; it must be
+                 * invoked before using any other methods. As the
+                 * {@link omero.api.ThumbnailStore} relies on the
+                 * {@link omero.api.RenderingEngine}, a valid rendering
+                 * definition must be available for it to work.
+                 *
+                 * @param pixelsId an {@link omero.model.Pixels} id.
+                 * @throws ApiUsageException if no pixels object exists with
+                 *         the ID <code>pixelsId</code>.
+                 * @return <code>true</code> if a
+                 *         {@link omero.model.RenderingDef} exists for the
+                 *         {@link omero.model.Pixels} set, otherwise
+                 *         <code>false</code>
+                 */
                 bool setPixelsId(long pixelsId) throws ServerError;
+
+                /**
+                 * This returns the last available <i>in progress</i> state
+                 * for a thumbnail. Its return value is <b>only</b> expected
+                 * to be valid after the call to any of the individual
+                 * thumbnail retrieval methods.
+                 * @return <code>true</code> if the image is in the process of
+                 *         being imported or a pyramid is being generated for
+                 *         it.
+                 *
+                 */
                 idempotent bool isInProgress() throws ServerError;
+
+                /**
+                 * This method manages the state of the service; it should be
+                 * invoked directly after {@link #setPixelsId}. If it is not
+                 * invoked with a valid rendering definition ID before using
+                 * the thumbnail accessor methods execution continues as if
+                 * <code>renderingDefId</code> were set to <code>null</code>.
+                 *
+                 * @param renderingDefId
+                 *            an {@link omero.model.RenderingDef} id.
+                 *            <code>null</code> specifies the user's currently
+                 *            active rendering settings to be used.
+                 * @throws ValidationException
+                 *             if no rendering definition exists with the ID
+                 *             <code>renderingDefId</code>.
+                 */
                 idempotent void setRenderingDefId(long renderingDefId) throws ServerError;
+
+                /**
+                 * Return the id of the {@link omero.model.RenderingDef}
+                 * loaded in this instance.
+                 */
                 idempotent long getRenderingDefId() throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef). If the thumbnail exists
+                 * in the on-disk cache it will be returned directly,
+                 * otherwise it will be created as in
+                 * {@link #getThumbnailDirect}, placed in the on-disk
+                 * cache and returned.
+                 *
+                 * @param sizeX the X-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param sizeY the Y-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is negative</li>
+                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is negative</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnailDirect
+                 */
                 idempotent Ice::ByteSeq getThumbnail(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Retrieves a number of thumbnails for pixels sets using
+                 * given sets of rendering settings (RenderingDef). If the
+                 * thumbnails exist in the on-disk cache they will be returned
+                 * directly, otherwise they will be created as in
+                 * {@link #getThumbnailDirect}, placed in the on-disk cache
+                 * and returned. Unlike the other thumbnail retrieval methods,
+                 * this method <b>may</b> be called without first calling
+                 * {@link #setPixelsId}.
+                 *
+                 * @param sizeX the X-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param sizeY the Y-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param pixelsIds the Pixels sets to retrieve thumbnails for.
+                 * @return a map whose keys are pixels ids and values are JPEG
+                 *         thumbnail byte buffers or <code>null</code> if an
+                 *         exception was thrown while attempting to retrieve
+                 *         the thumbnail for that particular Pixels set.
+                 * @see #getThumbnail
+                 */
                 idempotent omero::sys::IdByteMap getThumbnailSet(omero::RInt sizeX, omero::RInt sizeY, omero::sys::LongList pixelsIds) throws ServerError;
+
+                /**
+                 * Retrieves a number of thumbnails for pixels sets using
+                 * given sets of rendering settings (RenderingDef). If the
+                 * Thumbnails exist in the on-disk cache they will be returned
+                 * directly, otherwise they will be created as in
+                 * {@link #getThumbnailByLongestSideDirect}. The longest
+                 * side of the image will be used to calculate the size for
+                 * the smaller side in order to keep the aspect ratio of the
+                 * original image. Unlike the other thumbnail retrieval
+                 * methods, this method <b>may</b> be called without first
+                 * calling {@link #setPixelsId}.
+                 *
+                 * @param size the size of the longest side of the thumbnail
+                 *             requested. <code>null</code> specifies the
+                 *             default size of 48.
+                 * @param pixelsIds the Pixels sets to retrieve thumbnails for.
+                 * @return a map whose keys are pixels ids and values are JPEG
+                 *         thumbnail byte buffers or <code>null</code> if an
+                 *         exception was thrown while attempting to retrieve
+                 *         the thumbnail for that particular Pixels set.
+                 * @see #getThumbnailSet
+                 */
                 idempotent omero::sys::IdByteMap getThumbnailByLongestSideSet(omero::RInt size, omero::sys::LongList pixelsIds) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef). If the thumbnail exists
+                 * in the on-disk cache it will bereturned directly, otherwise
+                 * it will be created as in {@link #getThumbnailDirect},
+                 * placed in the on-disk cache and returned. The longest side
+                 * of the image will be used to calculate the size for the
+                 * smaller side in order to keep the aspect ratio of the
+                 * original image.
+                 *
+                 * @param size the size of the longest side of the thumbnail
+                 *             requested. <code>null</code> specifies the
+                 *             default size of 48.
+                 * @throws ApiUsageException if:
+                 *         <ul>
+                 *         <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
+                 *         <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnail
+                 */
                 idempotent Ice::ByteSeq getThumbnailByLongestSide(omero::RInt size) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef). The Thumbnail will
+                 * always be created directly, ignoring the on-disk cache. The
+                 * longest side of the image will be used to calculate the
+                 * size for the smaller side in order to keep the aspect ratio
+                 * of the original image.
+                 *
+                 * @param size the size of the longest side of the thumbnail
+                 *             requested. <code>null</code> specifies the
+                 *             default size of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnailDirect
+                 */
                 idempotent Ice::ByteSeq getThumbnailByLongestSideDirect(omero::RInt size) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef). The Thumbnail will
+                 * always be created directly, ignoring the on-disk cache.
+                 *
+                 * @param sizeX the X-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param sizeY the Y-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is negative</li>
+                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is negative</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnail
+                 */
                 idempotent Ice::ByteSeq getThumbnailDirect(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef) for a particular section.
+                 * The Thumbnail will always be created directly, ignoring the
+                 * on-disk cache.
+                 *
+                 * @param theZ the optical section (offset across the Z-axis)
+                 *             to use.
+                 * @param theT the timepoint (offset across the T-axis) to use.
+                 * @param sizeX the X-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param sizeY the Y-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is negative</li>
+                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is negative</li>
+                 *             <li><code>theZ</code> is out of range</li>
+                 *             <li><code>theT</code> is out of range</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnail
+                 */
                 idempotent Ice::ByteSeq getThumbnailForSectionDirect(int theZ, int theT, omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef) for a particular section.
+                 * The Thumbnail will always be created directly, ignoring the
+                 * on-disk cache. The longest side of the image will be used
+                 * to calculate the size for the smaller side in order to keep
+                 * the aspect ratio of the original image.
+                 *
+                 * @param theZ the optical section (offset across the Z-axis)
+                 *             to use.
+                 * @param theT the timepoint (offset across the T-axis) to use.
+                 * @param size the size of the longest side of the thumbnail
+                 *             requested. <code>null</code> specifies the
+                 *             default size of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer.
+                 * @see #getThumbnailDirect
+                 */
                 idempotent Ice::ByteSeq getThumbnailForSectionByLongestSideDirect(int theZ, int theT, omero::RInt size) throws ServerError;
+
+                /**
+                 * Creates thumbnails for a pixels set using a given set of
+                 * rendering settings (RenderingDef) in the on-disk cache for
+                 * <b>every</b> sizeX/sizeY combination already cached.
+                 *
+                 * @see #getThumbnail
+                 * @see #getThumbnailDirect
+                 */
                 void createThumbnails() throws ServerError;
+
+                 /**
+                  * Creates a thumbnail for a pixels set using a given set of
+                  * rendering settings (RenderingDef) in the on-disk cache.
+                  *
+                  * @param sizeX the X-axis width of the thumbnail.
+                  *              <code>null</code> specifies the default size
+                  *              of 48.
+                  * @param sizeY the Y-axis width of the thumbnail.
+                  *              <code>null</code> specifies the default size
+                  *              of 48.
+                  * @throws ApiUsageException
+                  *             if:
+                  *             <ul>
+                  *             <li><code>sizeX</code> > pixels.sizeX</li>
+                  *             <li><code>sizeX</code> is negative</li>
+                  *             <li><code>sizeY</code> > pixels.sizeY</li>
+                  *             <li><code>sizeY</code> is negative</li>
+                  *             <li>{@link #setPixelsId} has not yet been called</li>
+                  *             </ul>
+                  * @see #getThumbnail
+                  * @see #getThumbnailDirect
+                  */
                 void createThumbnail(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Creates thumbnails for a number of pixels sets using a
+                 * given set of rendering settings (RenderingDef) in the
+                 * on-disk cache. Unlike the other thumbnail creation methods,
+                 * this method <b>may</b> be called without first calling
+                 * {@link #setPixelsId}. This method <b>will not</b> reset or
+                 * modify rendering settings in any way. If rendering settings
+                 * for a pixels set are not present, thumbnail creation for
+                 * that pixels set <b>will not</b> be performed.
+                 *
+                 * @param size the size of the longest side of the thumbnail
+                 *             requested. <code>null</code> specifies the
+                 *             default size of 48.
+                 * @param pixelsIds the Pixels sets to retrieve thumbnails for.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
+                 *             <li><code>size</code> is negative</li>
+                 *             </ul>
+                 * @see #createThumbnail
+                 * @see #createThumbnails
+                 */
                 void createThumbnailsByLongestSideSet(omero::RInt size, omero::sys::LongList pixelsIds) throws ServerError;
+
+                /**
+                 * Checks if a thumbnail of a particular size exists for a
+                 * pixels set.
+                 *
+                  * @param sizeX the X-axis width of the thumbnail.
+                  *              <code>null</code> specifies the default size
+                  *              of 48.
+                  * @param sizeY the Y-axis width of the thumbnail.
+                  *              <code>null</code> specifies the default size
+                  *              of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>sizeX</code> is negative</li>
+                 *             <li><code>sizeY</code> is negative</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @see #getThumbnail
+                 * @see #getThumbnailDirect
+                 */
                 idempotent bool thumbnailExists(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Resets the rendering definition for the active pixels set
+                 * to its default settings.
+                 */
                 idempotent void resetDefaults() throws ServerError;
             };
     };


### PR DESCRIPTION
See https://trello.com/c/JQ9AcNa2/77-copy-ome-api-documentation-to-omero-api

Follow-up of #4547, #4569, #4578 and #4605, this PR copies the remaining `ome.api.*` Javadoc documentation into the slice `omero.api.*` classes. It also includes a minor fix reported in https://github.com/openmicroscopy/openmicroscopy/pull/4605#discussion_r66062485. This should be the final set of migration PRs associated with this documentation epic. Thanks to @ximenesuk for his infinite patience.

To review this PR, either build the slice documentation via release-slice2html or use the published CI documentation or OMERO.docs* artifacts. Check the links are all working and the method parameters match.