### PR TITLE
Fix cleanse for null repositories

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 
-   Copyright 2009 - 2014 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009 - 2016 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -716,16 +716,20 @@ class BaseClient(object):
         finally:
             self.__lock.release()
 
-    def getManagedRepository(self):
-        repoMap = self.getSession().sharedResources().repositories()
+    def getManagedRepository(self, description=False):
+        repos = self.getSession().sharedResources().repositories()
+        repoMap = zip(repos.proxies, repos.descriptions)
         prx = None
-        for prx in repoMap.proxies:
+        for (prx, desc) in repoMap:
             if not prx:
                 continue
             prx = omero.grid.ManagedRepositoryPrx.checkedCast(prx)
             if prx:
                 break
-        return prx
+        if description:
+            return(prx, desc)
+        else:
+            return prx
 
     def getRouter(self, comm):
         """

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -5,7 +5,7 @@ Reconcile and cleanse where necessary an OMERO data directory of orphaned data.
 """
 
 #
-#  Copyright (c) 2009-2015 University of Dundee. All rights reserved.
+#  Copyright (c) 2009-2016 University of Dundee. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -219,7 +219,6 @@ def cleanse(data_dir, client, dry_run=False):
     admin_service = client.sf.getAdminService()
     query_service = client.sf.getQueryService()
     config_service = client.sf.getConfigService()
-    shared_resources = client.sf.sharedResources()
 
     initial_check(config_service, admin_service)
 
@@ -242,12 +241,11 @@ def cleanse(data_dir, client, dry_run=False):
             print cleanser
 
     # delete empty directories from the managed repositories
-    repos = shared_resources.repositories()
-    for (description, proxy) in zip(repos.descriptions, repos.proxies):
-        if description.name.val == 'ManagedRepository':
-            # found a managed repository, so delete empty directories
-            root = description.path.val + description.name.val
-            delete_empty_dirs(proxy, root, client, dry_run)
+    proxy, description = client.getManagedRepository(description=True)
+    if proxy:
+        root = description.path.val + description.name.val
+        print "Removing empty directories from...\n %s" % root
+        delete_empty_dirs(proxy, root, client, dry_run)
 
 
 def delete_empty_dirs(repo, root, client, dry_run):
@@ -259,7 +257,7 @@ def delete_empty_dirs(repo, root, client, dry_run):
 
     if dry_run:
         for directory in to_delete:
-            print "Would remove %s%s" % (root, directory)
+            print "   \_ %s%s (remove)" % (root, directory)
     elif to_delete:
         # probably less than a screenful
         batch_size = 20


### PR DESCRIPTION
# What this PR does

This attempts to fix the problem in ticket 13251 where an erroneous null repository would break cleanse. This PR uses a modified client call to get a non-null managed repository.

# Testing this PR

I'm not sure how easy it is to test the fail case here since I'm not sure how to create the set-up of a null repository. Any advice @joshmoore ? For now cleanse should work - with slightly improved output for any empty directories. And the integration tests should pass.

Following Josh's comment below here is a way to reproduce the underlying problem. This needs to be locally unless you really want to annoy everyone on the merge build server!! Without this PR:

 - start a  clean local server
 - import a simple image (ADDED in response to @dominikl as the output is different with no data imported)
 - try `omero admin cleanse /OMERO --dry-run` it should not produce an error and the output should end like this:
```
...
Cleansing context: 0 files (0 bytes)
```

 - stop the server
 - use `chmod 000 /OMERO/ManagedRepository/.omero` (this has created an inaccessible ManagedRepository)
 - start the server
 - try `omero admin cleanse /OMERO --dry-run` again, this should cause an exception:
```
...
Cleansing context: 0 files (0 bytes)
...
File ".../dist/lib/python/omero/util/cleanse.py", line 285, in is_empty_dir
    for entry in repo.listFiles(directory):
AttributeError: 'NoneType' object has no attribute 'listFiles'
```
 - stop the server

Now, with this PR included (rebuild `./build.py build-py` should be enough)

 - start the server (the ManagedRepository is stil linaccessible)
 - try `omero admin cleanse /OMERO --dry-run` it should not produce an error but should end cleanly like this:
```
...
Cleansing context: 0 files (0 bytes)
```
 - stop the server
 - use `chmod 755 /OMERO/ManagedRepository/.omero` (recovering the ManagedRepository)
 - start the server
 - try `omero admin cleanse /OMERO --dry-run` again, this should still be okay though the output should now end differently:
```
...
Cleansing context: 0 files (0 bytes)
Removing empty directories from...
 /OMERO/ManagedRepository
```

# Related reading

http://trac.openmicroscopy.org/ome/ticket/13251