### PR TITLE
Chown java integration test

### DIFF
--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -363,7 +363,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* chown the image */
 
         init(chowner);
-        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
+        Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -408,31 +408,26 @@ public class PermissionsTest extends AbstractServerTest {
         
         /* chown the first tag set */
         init(chowner);
-        final Chown2 chown2 = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
+        chown = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
         
-        doChange(client, factory, chown, isExpectSuccess);
-
-        if (!isExpectSuccess) {
-            return;
-        }
         
         switch (option) {
         case NONE:
             break;
         case INCLUDE:
-            chown2.childOptions = Collections.singletonList(Requests.option().includeType("Annotation").build());
+            chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation").build());
             break;
         case EXCLUDE:
-            chown2.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
+            chown.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
             break;
         case BOTH:
-            chown2.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
+            chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
                                                                               .excludeType("Annotation").build());
             break;
         default:
             Assert.fail("unexpected option for chown");
         }
-        doChange(client, factory, chown2, isExpectSuccess);
+        doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
             return;
@@ -463,8 +458,8 @@ public class PermissionsTest extends AbstractServerTest {
         	assertOwnedBy(tags.get(2), importer);
             /* transfer the tag that is not in the second tag set */
             init(chowner);
-            final Chown2 chown3 = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
-            doChange(client, factory, chown3, isExpectSuccess);
+            chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
+            doChange(client, factory, chown, isExpectSuccess);
             if (!isExpectSuccess) {
                 return;
             }
@@ -473,8 +468,8 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* transfer the second tag set */
         init(chowner);
-        final Chown2 chown4 = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
-        doChange(client, factory, chown4, isExpectSuccess);
+        chown = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
+        doChange(client, factory, chown, isExpectSuccess);
         if (!isExpectSuccess) {
             return;
         }
@@ -556,7 +551,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* chown the image */
         init(chowner);
-        final Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
+        Chown2 chown = Requests.chown().target(image).toUser(recipient.userId).build();
         doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
@@ -572,31 +567,27 @@ public class PermissionsTest extends AbstractServerTest {
         
         
         /* chown the first tag set */
-        final Chown2 chown2 = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
+        chown = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
         
-        doChange(client, factory, chown, isExpectSuccess);
-
-        if (!isExpectSuccess) {
-            return;
-        }
+        
         
         switch (option) {
         case NONE:
             break;
         case INCLUDE:
-            chown2.childOptions = Collections.singletonList(Requests.option().includeType("Annotation").build());
+            chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation").build());
             break;
         case EXCLUDE:
-            chown2.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
+            chown.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
             break;
         case BOTH:
-            chown2.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
+            chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
                                                                               .excludeType("Annotation").build());
             break;
         default:
             Assert.fail("unexpected option for chown");
         }
-        doChange(client, factory, chown2, isExpectSuccess);
+        doChange(client, factory, chown, isExpectSuccess);
 
         if (!isExpectSuccess) {
             return;
@@ -627,8 +618,8 @@ public class PermissionsTest extends AbstractServerTest {
         	assertOwnedBy(tags.get(2), annotator);
             /* transfer the tag that is not in the second tag set */
             init(chowner);
-            final Chown2 chown3 = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
-            doChange(client, factory, chown3, isExpectSuccess);
+            chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
+            doChange(client, factory, chown, isExpectSuccess);
             if (!isExpectSuccess) {
                 return;
             }
@@ -637,8 +628,8 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* transfer the second tag set */
         init(chowner);
-        final Chown2 chown4 = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
-        doChange(client, factory, chown4, isExpectSuccess);
+        chown = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
+        doChange(client, factory, chown, isExpectSuccess);
         if (!isExpectSuccess) {
             return;
         }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -186,8 +186,12 @@ public class PermissionsTest extends AbstractServerTest {
 
         return annotationObjects;
     }
-    
-    /* create two tag sets */
+
+    /**
+     * Create tag sets
+     * @return the newly created tag sets
+     * @throws Exception unexpected
+     */
     private List<TagAnnotation> createTagsets() throws Exception {
         final List<TagAnnotation> tagsets = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= 2; i++) {
@@ -199,7 +203,11 @@ public class PermissionsTest extends AbstractServerTest {
         return tagsets;
     }
     
-    /* create three tags */
+    /**
+     * Create tags
+     * @return the newly created tags
+     * @throws Exception unexpected
+     */
     private List<TagAnnotation> createTags() throws Exception {
         final List<TagAnnotation> tags = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= 3; i++) {
@@ -210,7 +218,13 @@ public class PermissionsTest extends AbstractServerTest {
          return tags;
     }
     
-    /* define how to link the tag sets to the tags */
+    /**
+     * Define how to link the tag sets to the tags
+     * @param tags the tags to be mapped for linking
+     * @param tagsets the tag sets to be mapped for linking
+     * @return the map of the prospective links
+     * @throws Exception unexpected
+     */
     private SetMultimap<TagAnnotation, TagAnnotation> defineLinkingTags(List<TagAnnotation> tags, List<TagAnnotation> tagsets) throws Exception {
         final SetMultimap<TagAnnotation, TagAnnotation> members = HashMultimap.create();
         members.put(tagsets.get(0), tags.get(0));
@@ -220,7 +234,12 @@ public class PermissionsTest extends AbstractServerTest {
         return members;
     }
     
-    /* perform the linking */
+    /**
+     * Perform the linking
+     * of tags and tag sets
+     * @param members the map of the links
+     * @throws Exception unexpected
+     */
     private void linkTagsTagsets(SetMultimap<TagAnnotation, TagAnnotation> members) throws Exception {
     	for (final Map.Entry<TagAnnotation, TagAnnotation> toLink : members.entries()) {
             final AnnotationAnnotationLink link = new AnnotationAnnotationLinkI();
@@ -267,6 +286,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isGroupOwner if the user submitting the {@link Chown2} request owns the group itself
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
      * @param isExpectSuccess if the chown is expected to succeed
+     * @param option the child option to use in the tagset transfer
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown annotation test cases")

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -316,7 +316,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* note which objects were used to annotate an image */
 
-        final List<IObject> annotations;
+        final List<IObject> annotationsDoublyLinked;
         final List<IObject> annotationsSinglyLinked;
         final List<ImageAnnotationLink> tagLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
         final List<ImageAnnotationLink> fileAnnLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
@@ -328,16 +328,17 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        annotations = annotateImage(image);
+        annotationsDoublyLinked = annotateImage(image);
         annotationsSinglyLinked = annotateImage(image);
 
-        /* Link Tag, FileAnnotation and MapAnnotation from "annotations" to a second image.
-         * Note that ALL of both "annotations" and "annotationsSinglyLinked" are already linked to the first image.
+        /* Link Tag, FileAnnotation and MapAnnotation from "annotationsDoublyLinked" to a second image.
+         * Note that ALL of both "annotationsDoublyLinked" and "annotationsSinglyLinked"
+         * are already linked to the first image.
          * NONE of the "annotationsSinglyLinked" will be linked to the second image.*/
 
         final Image otherImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         testImages.add(otherImage.getId().getValue());
-        for (final IObject annotation : annotations) {
+        for (final IObject annotation : annotationsDoublyLinked) {
             if (annotation instanceof TagAnnotation) {
                 final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
@@ -377,7 +378,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(image, recipient);
-        for (final IObject annotation : annotations) {
+        for (final IObject annotation : annotationsDoublyLinked) {
             if (annotation instanceof TagAnnotation || annotation instanceof FileAnnotation || 
                 annotation instanceof MapAnnotation) {
                 assertOwnedBy(annotation, importer);
@@ -491,7 +492,6 @@ public class PermissionsTest extends AbstractServerTest {
      * @param option the child option to use in the tagset transfer
      * @throws Exception unexpected
      */
-
 
     @Test(dataProvider = "chown annotation test cases")
     public void testChownAnnotationReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isGroupOwner,

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -19,8 +19,6 @@
 
 package integration.chown;
 
-import static omero.rtypes.rstring;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +30,7 @@ import java.util.Set;
 import omero.RLong;
 import omero.RType;
 import omero.ServerError;
+import omero.rtypes;
 import omero.cmd.Chmod2;
 import omero.cmd.Chown2;
 import omero.cmd.Delete2;
@@ -194,8 +193,8 @@ public class PermissionsTest extends AbstractServerTest {
         final List<TagAnnotation> tagsets = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= number; i++) {
             final TagAnnotation tagset = new TagAnnotationI();
-            tagset.setName(rstring("tagset #" + i));
-            tagset.setNs(rstring(omero.constants.metadata.NSINSIGHTTAGSET.value));
+            tagset.setName(rtypes.rstring("tagset #" + i));
+            tagset.setNs(rtypes.rstring(omero.constants.metadata.NSINSIGHTTAGSET.value));
             tagsets.add((TagAnnotation) iUpdate.saveAndReturnObject(tagset).proxy());
         }
         return tagsets;
@@ -211,7 +210,7 @@ public class PermissionsTest extends AbstractServerTest {
         final List<TagAnnotation> tags = new ArrayList<TagAnnotation>();
         for (int i = 1; i <= number; i++) {
             final TagAnnotation tag = new TagAnnotationI();
-            tag.setName(rstring("tag #" + i));
+            tag.setName(rtypes.rstring("tag #" + i));
             tags.add((TagAnnotation) iUpdate.saveAndReturnObject(tag).proxy());
         }
          return tags;

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -342,14 +342,12 @@ public class PermissionsTest extends AbstractServerTest {
             if (annotation instanceof TagAnnotation) {
                 final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
-            }
-            else if (annotation instanceof FileAnnotation) {
-                final ImageAnnotationLink linkf = (ImageAnnotationLink) annotateImage(otherImage, (FileAnnotation) annotation);
-                fileAnnLinksOnOtherImage.add((ImageAnnotationLink) linkf.proxy());
-            }
-            else if (annotation instanceof MapAnnotation) {
-                final ImageAnnotationLink linkf = (ImageAnnotationLink) annotateImage(otherImage, (MapAnnotation) annotation);
-                mapAnnLinksOnOtherImage.add((ImageAnnotationLink) linkf.proxy());
+            } else if (annotation instanceof FileAnnotation) {
+                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (FileAnnotation) annotation);
+                fileAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
+            } else if (annotation instanceof MapAnnotation) {
+                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (MapAnnotation) annotation);
+                mapAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
         }
         

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -407,8 +407,7 @@ public class PermissionsTest extends AbstractServerTest {
         /* chown the first tag set */
         init(chowner);
         chown = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
-        
-        
+
         switch (option) {
         case NONE:
             break;
@@ -466,7 +465,6 @@ public class PermissionsTest extends AbstractServerTest {
         assertOwnedBy(tagsets, recipient);
         /* check that the tag in the second tag set was implicitly transferred */
         assertOwnedBy(tags.get(2), recipient);
-      
     }
 
     /**
@@ -480,7 +478,6 @@ public class PermissionsTest extends AbstractServerTest {
      * @param option the child option to use in the tagset transfer
      * @throws Exception unexpected
      */
-
     @Test(dataProvider = "chown annotation test cases")
     public void testChownAnnotationReadAnnotate(boolean isDataOwner, boolean isAdmin, boolean isGroupOwner,
             boolean isRecipientInGroup, boolean isExpectSuccess, Option option) throws Exception {

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -647,17 +647,11 @@ public class PermissionsTest extends AbstractServerTest {
                         testCase[IS_GROUP_OWNER] = isGroupOwner;
                         testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
                         testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
-                        for (final Option value : values) {
-                            /* only add one tag set child option per one permission
-                             * test, but alternate over all child options doing this */
-                            if (count_value < value.ordinal()) {
-                                continue;
-                            }
-                            testCase[CHILD_OPTION] = value;
-                        }
-                        count_value = (count_value + 1) % values.length;;
-                        // DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
-                        //            isRecipientInGroup == true)
+                        /* only add one tag set child option per one permission
+                         * test, but alternate over all child options doing this */
+                        testCase[CHILD_OPTION] = values[count_value++ % values.length];
+                        //DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == false &&
+                        //           isRecipientInGroup == true && testCase[CHILD_OPTION] == Option.BOTH)
                         testCases.add(testCase);
                     }
                 }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -35,6 +35,8 @@ import omero.cmd.Delete2;
 import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
+import omero.model.FileAnnotationI;
+import omero.model.MapAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
@@ -147,7 +149,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         final List<IObject> annotationObjects = new ArrayList<IObject>();
 
-        for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(), new TagAnnotationI()}) {
+        for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(), new TagAnnotationI(), new FileAnnotationI(), new MapAnnotationI()}) {
             final ImageAnnotationLink link = annotateImage(image, annotation);
             annotationObjects.add(link.proxy());
             annotationObjects.add(link.getChild().proxy());

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -427,11 +427,7 @@ public class PermissionsTest extends AbstractServerTest {
         default:
             Assert.fail("unexpected option for chown");
         }
-        doChange(client, factory, chown, isExpectSuccess);
-
-        if (!isExpectSuccess) {
-            return;
-        }
+        doChange(chown);
 
          /* check that the tag set is transferred and the other remains owned by original owner */
         assertOwnedBy(tagsets.get(0), recipient);
@@ -458,20 +454,14 @@ public class PermissionsTest extends AbstractServerTest {
             /* transfer the tag that is not in the second tag set */
             init(chowner);
             chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
-            doChange(client, factory, chown, isExpectSuccess);
-            if (!isExpectSuccess) {
-                return;
-            }
+            doChange(chown);
             break;
         }
 
         /* transfer the second tag set */
         init(chowner);
         chown = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
-        doChange(client, factory, chown, isExpectSuccess);
-        if (!isExpectSuccess) {
-            return;
-        }
+        doChange(chown);
 
         /* check that the tag sets are transferred */
         logRootIntoGroup(dataGroupId);
@@ -581,11 +571,7 @@ public class PermissionsTest extends AbstractServerTest {
         default:
             Assert.fail("unexpected option for chown");
         }
-        doChange(client, factory, chown, isExpectSuccess);
-
-        if (!isExpectSuccess) {
-            return;
-        }
+        doChange(chown);
 
         /* check that the tag set is transferred and the other remains owned by original owner */
         assertOwnedBy(tagsets.get(0), recipient);
@@ -612,20 +598,14 @@ public class PermissionsTest extends AbstractServerTest {
             /* transfer the tag that is not in the second tag set */
             init(chowner);
             chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
-            doChange(client, factory, chown, isExpectSuccess);
-            if (!isExpectSuccess) {
-                return;
-            }
+            doChange(chown);
             break;
         }
 
         /* transfer the second tag set */
         init(chowner);
         chown = Requests.chown().target(tagsets.get(1)).toUser(recipient.userId).build();
-        doChange(client, factory, chown, isExpectSuccess);
-        if (!isExpectSuccess) {
-            return;
-        }
+        doChange(chown);
 
         /* check that the tag sets are transferred */
         logRootIntoGroup(dataGroupId);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -342,11 +342,11 @@ public class PermissionsTest extends AbstractServerTest {
                 final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
-            if (annotation instanceof FileAnnotation) {
+            else if (annotation instanceof FileAnnotation) {
                 final ImageAnnotationLink linkf = (ImageAnnotationLink) annotateImage(otherImage, (FileAnnotation) annotation);
                 fileAnnLinksOnOtherImage.add((ImageAnnotationLink) linkf.proxy());
             }
-            if (annotation instanceof MapAnnotation) {
+            else if (annotation instanceof MapAnnotation) {
                 final ImageAnnotationLink linkf = (ImageAnnotationLink) annotateImage(otherImage, (MapAnnotation) annotation);
                 mapAnnLinksOnOtherImage.add((ImageAnnotationLink) linkf.proxy());
             }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -637,27 +637,13 @@ public class PermissionsTest extends AbstractServerTest {
     /* child options to try using in transfer */
     private enum Option { NONE, INCLUDE, EXCLUDE, BOTH };
 
-
-    /**
-     * @return the child options to try using in chown of tags/tagsets
-     */
-    @DataProvider(name = "child option")
-    public Object[][] provideChildOption() {
-        final Option[] values = Option.values();
-        final Object[][] testCases = new Object[values.length][1];
-        int index = 0;
-        for (final Option value : values) {
-            testCases[index++][0] = value;
-        }
-        return testCases;
-    }
-
     /**
      * @return a variety of test cases for annotation chown
      */
     @DataProvider(name = "chown annotation test cases")
     public Object[][] provideChownAnnotationCases() {
         int index = 0;
+        int count_value = 0;
         final int IS_DATA_OWNER = index++;
         final int IS_ADMIN = index++;
         final int IS_GROUP_OWNER = index++;
@@ -676,36 +662,47 @@ public class PermissionsTest extends AbstractServerTest {
             for (final boolean isAdmin : booleanCases) {
                 for (final boolean isGroupOwner : booleanCases) {
                     for (final boolean isRecipientInGroup : booleanCases) {
-                        for (final Option value : values) {
-                        	if (isAdmin && isGroupOwner) {
-                        		/* not an interesting case */
-                        		continue;
-                        	}
-                        	final Object[] testCase = new Object[index];
-                        	testCase[IS_DATA_OWNER] = isDataOwner;
-                        	testCase[IS_ADMIN] = isAdmin;
-                        	testCase[IS_GROUP_OWNER] = isGroupOwner;
-                        	testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
-                        	testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
-                        	testCase[CHILD_OPTION] = value;
-                        	// DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
-                        	//            isRecipientInGroup == true)
-                        	testCases.add(testCase);
+                        if (isAdmin && isGroupOwner) {
+                            /* not an interesting case */
+                            continue;
                         }
+                        final Object[] testCase = new Object[index];
+                        testCase[IS_DATA_OWNER] = isDataOwner;
+                        testCase[IS_ADMIN] = isAdmin;
+                        testCase[IS_GROUP_OWNER] = isGroupOwner;
+                        testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
+                        testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
+                        for (final Option value : values) {
+                            /* only add one tag set child options per one permission
+                             * test, but alternate over all child options doing this
+                             */
+                            if (count_value < value.ordinal()) {
+                                continue;
+                            }
+                            testCase[CHILD_OPTION] = value;
+                        }
+                        count_value++;
+                        if (count_value == 4) {
+                            count_value = count_value - 4;
+                        }
+                        // DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
+                        //            isRecipientInGroup == true)
+                        testCases.add(testCase);
                     }
                 }
             }
         }
-        
-        
-
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
     
     
 
-    /**
+
+
+
+
+	/**
      * Test a specific case of using {@link Chown2} on an image that is in a dataset or a folder.
      * @param isImageOwner if the user who owns the container also owns the image
      * @param isLinkOwner if the user who owns the container also linked the image to the container

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -653,17 +653,14 @@ public class PermissionsTest extends AbstractServerTest {
                         testCase[IS_RECIPIENT_IN_GROUP] = isRecipientInGroup;
                         testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
                         for (final Option value : values) {
-                            /* only add one tag set child options per one permission
+                            /* only add one tag set child option per one permission
                              * test, but alternate over all child options doing this */
                             if (count_value < value.ordinal()) {
                                 continue;
                             }
                             testCase[CHILD_OPTION] = value;
                         }
-                        count_value++;
-                        if (count_value == 4) {
-                            count_value = count_value - 4;
-                        }
+                        count_value = (count_value + 1) % values.length;;
                         // DEBUG: if (isDataOwner == true && isAdmin == true && isGroupOwner == true &&
                         //            isRecipientInGroup == true)
                         testCases.add(testCase);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -189,12 +189,13 @@ public class PermissionsTest extends AbstractServerTest {
 
     /**
      * Create tag sets
+     * @param number number of tag sets to create
      * @return the newly created tag sets
      * @throws Exception unexpected
      */
-    private List<TagAnnotation> createTagsets() throws Exception {
+    private List<TagAnnotation> createTagsets(int number) throws Exception {
         final List<TagAnnotation> tagsets = new ArrayList<TagAnnotation>();
-        for (int i = 1; i <= 2; i++) {
+        for (int i = 1; i <= number; i++) {
             final TagAnnotation tagset = new TagAnnotationI();
             tagset.setName(rstring("tagset #" + i));
             tagset.setNs(rstring(omero.constants.metadata.NSINSIGHTTAGSET.value));
@@ -205,12 +206,13 @@ public class PermissionsTest extends AbstractServerTest {
     
     /**
      * Create tags
+     * @param number number of tags to create
      * @return the newly created tags
      * @throws Exception unexpected
      */
-    private List<TagAnnotation> createTags() throws Exception {
+    private List<TagAnnotation> createTags(int number) throws Exception {
         final List<TagAnnotation> tags = new ArrayList<TagAnnotation>();
-        for (int i = 1; i <= 3; i++) {
+        for (int i = 1; i <= number; i++) {
             final TagAnnotation tag = new TagAnnotationI();
             tag.setName(rstring("tag #" + i));
             tags.add((TagAnnotation) iUpdate.saveAndReturnObject(tag).proxy());
@@ -353,8 +355,8 @@ public class PermissionsTest extends AbstractServerTest {
         }
         
         /* create two tag sets and three tags */
-        final List<TagAnnotation> tagsets = createTagsets();
-        final List<TagAnnotation> tags = createTags();
+        final List<TagAnnotation> tagsets = createTagsets(2);
+        final List<TagAnnotation> tags = createTags(3);
 
         /* define how to link the tag sets to the tags and link them */
         final SetMultimap<TagAnnotation, TagAnnotation> members = defineLinkingTags(tags, tagsets);
@@ -542,8 +544,8 @@ public class PermissionsTest extends AbstractServerTest {
         otherAnnotations = annotateImage(image);
 
         /* create two tag sets and three tags */
-        final List<TagAnnotation> tagsets = createTagsets();
-        final List<TagAnnotation> tags = createTags();
+        final List<TagAnnotation> tagsets = createTagsets(2);
+        final List<TagAnnotation> tags = createTags(3);
 
         /* define how to link the tag sets to the tags and link them */
         final SetMultimap<TagAnnotation, TagAnnotation> members = defineLinkingTags(tags, tagsets);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -472,7 +472,6 @@ public class PermissionsTest extends AbstractServerTest {
             return;
         }
 
-        
         /* check that the tag sets are transferred */
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(tagsets, recipient);

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -84,7 +84,6 @@ import com.google.common.collect.SetMultimap;
 
 import integration.AbstractServerTest;
 
-
 /**
  * Tests that only appropriate users may use {@link Chown2} and that others' data is left unchanged.
  * @author m.t.b.carroll@dundee.ac.uk
@@ -167,8 +166,6 @@ public class PermissionsTest extends AbstractServerTest {
             annotationObjects.add(link.getChild().proxy());
         }
 
-
-
         Roi roi = new RoiI();
         roi.addShape(new RectangleI());
         roi.setImage((Image) image.proxy());
@@ -203,7 +200,7 @@ public class PermissionsTest extends AbstractServerTest {
         }
         return tagsets;
     }
-    
+
     /**
      * Create tags
      * @param number number of tags to create
@@ -216,10 +213,10 @@ public class PermissionsTest extends AbstractServerTest {
             final TagAnnotation tag = new TagAnnotationI();
             tag.setName(rstring("tag #" + i));
             tags.add((TagAnnotation) iUpdate.saveAndReturnObject(tag).proxy());
-    	    }
+        }
          return tags;
     }
-    
+
     /**
      * Define how to link the tag sets to the tags
      * @param tags the tags to be mapped for linking
@@ -235,7 +232,7 @@ public class PermissionsTest extends AbstractServerTest {
         members.put(tagsets.get(1), tags.get(2));
         return members;
     }
-    
+
     /**
      * Perform the linking
      * of tags and tag sets
@@ -387,7 +384,6 @@ public class PermissionsTest extends AbstractServerTest {
             } else if (annotation instanceof ImageAnnotationLink) {
                 imageLinkIds.add(annotation.getId().getValue());
             } else {
-
                 assertOwnedBy(annotation, recipient);
             }
         }
@@ -425,7 +421,7 @@ public class PermissionsTest extends AbstractServerTest {
             break;
         case BOTH:
             chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
-                                                                              .excludeType("Annotation").build());
+                                                                            .excludeType("Annotation").build());
             break;
         default:
             Assert.fail("unexpected option for chown");
@@ -435,7 +431,6 @@ public class PermissionsTest extends AbstractServerTest {
         if (!isExpectSuccess) {
             return;
         }
-
 
          /* check that the tag set is transferred and the other remains owned by original owner */
         assertOwnedBy(tagsets.get(0), recipient);
@@ -451,14 +446,14 @@ public class PermissionsTest extends AbstractServerTest {
         case BOTH:
             /* include overrides exclude */
         case INCLUDE:
-        	assertOwnedBy(tags.get(0), recipient);
-        	assertOwnedBy(tags.get(1), recipient);
-        	assertOwnedBy(tags.get(2), importer);
+            assertOwnedBy(tags.get(0), recipient);
+            assertOwnedBy(tags.get(1), recipient);
+            assertOwnedBy(tags.get(2), importer);
             break;
         case EXCLUDE:
-        	assertOwnedBy(tags.get(0), importer);
-        	assertOwnedBy(tags.get(1), importer);
-        	assertOwnedBy(tags.get(2), importer);
+            assertOwnedBy(tags.get(0), importer);
+            assertOwnedBy(tags.get(1), importer);
+            assertOwnedBy(tags.get(2), importer);
             /* transfer the tag that is not in the second tag set */
             init(chowner);
             chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
@@ -478,7 +473,7 @@ public class PermissionsTest extends AbstractServerTest {
         }
 
         
-        /* check that the tag sets are transferred*/
+        /* check that the tag sets are transferred */
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(tagsets, recipient);
         /* check that the tag in the second tag set was implicitly transferred */
@@ -560,20 +555,17 @@ public class PermissionsTest extends AbstractServerTest {
         if (!isExpectSuccess) {
             return;
         }
-        
+
         /* check that the objects' ownership is all as expected */
 
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(image, recipient);
         assertOwnedBy(ownerAnnotations, importer);
         assertOwnedBy(otherAnnotations, annotator);
-        
-        
+
         /* chown the first tag set */
         chown = Requests.chown().target(tagsets.get(0)).toUser(recipient.userId).build();
-        
-        
-        
+
         switch (option) {
         case NONE:
             break;
@@ -585,7 +577,7 @@ public class PermissionsTest extends AbstractServerTest {
             break;
         case BOTH:
             chown.childOptions = Collections.singletonList(Requests.option().includeType("Annotation")
-                                                                              .excludeType("Annotation").build());
+                                                                            .excludeType("Annotation").build());
             break;
         default:
             Assert.fail("unexpected option for chown");
@@ -596,8 +588,7 @@ public class PermissionsTest extends AbstractServerTest {
             return;
         }
 
-
-         /* check that the tag set is transferred and the other remains owned by original owner */
+        /* check that the tag set is transferred and the other remains owned by original owner */
         assertOwnedBy(tagsets.get(0), recipient);
         assertOwnedBy(tagsets.get(1), annotator);
 
@@ -611,14 +602,14 @@ public class PermissionsTest extends AbstractServerTest {
         case BOTH:
             /* include overrides exclude */
         case INCLUDE:
-        	assertOwnedBy(tags.get(0), recipient);
-        	assertOwnedBy(tags.get(1), recipient);
-        	assertOwnedBy(tags.get(2), annotator);
+            assertOwnedBy(tags.get(0), recipient);
+            assertOwnedBy(tags.get(1), recipient);
+            assertOwnedBy(tags.get(2), annotator);
             break;
         case EXCLUDE:
-        	assertOwnedBy(tags.get(0), annotator);
-        	assertOwnedBy(tags.get(1), annotator);
-        	assertOwnedBy(tags.get(2), annotator);
+            assertOwnedBy(tags.get(0), annotator);
+            assertOwnedBy(tags.get(1), annotator);
+            assertOwnedBy(tags.get(2), annotator);
             /* transfer the tag that is not in the second tag set */
             init(chowner);
             chown = Requests.chown().target(tags.get(0)).toUser(recipient.userId).build();
@@ -637,8 +628,7 @@ public class PermissionsTest extends AbstractServerTest {
             return;
         }
 
-        
-        /* check that the tag sets are transferred*/
+        /* check that the tag sets are transferred */
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(tagsets, recipient);
         /* check that the tag in the second tag set was not implicitly transferred */
@@ -646,8 +636,6 @@ public class PermissionsTest extends AbstractServerTest {
         
     }
 
-
-    
     /* child options to try using in transfer */
     private enum Option { NONE, INCLUDE, EXCLUDE, BOTH };
 
@@ -666,12 +654,11 @@ public class PermissionsTest extends AbstractServerTest {
         final int CHILD_OPTION = index++;
 
         final boolean[] booleanCases = new boolean[]{false, true};
-        
+
         final Option[] values = Option.values();
-        
+
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-        
         for (final boolean isDataOwner : booleanCases) {
             for (final boolean isAdmin : booleanCases) {
                 for (final boolean isGroupOwner : booleanCases) {
@@ -688,8 +675,7 @@ public class PermissionsTest extends AbstractServerTest {
                         testCase[IS_EXPECT_SUCCESS] = isAdmin || isGroupOwner && isRecipientInGroup;
                         for (final Option value : values) {
                             /* only add one tag set child options per one permission
-                             * test, but alternate over all child options doing this
-                             */
+                             * test, but alternate over all child options doing this */
                             if (count_value < value.ordinal()) {
                                 continue;
                             }
@@ -706,17 +692,11 @@ public class PermissionsTest extends AbstractServerTest {
                 }
             }
         }
+
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
-    
-    
-
-
-
-
-
-	/**
+    /**
      * Test a specific case of using {@link Chown2} on an image that is in a dataset or a folder.
      * @param isImageOwner if the user who owns the container also owns the image
      * @param isLinkOwner if the user who owns the container also linked the image to the container

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -319,8 +319,8 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* note which objects were used to annotate an image */
 
-        final List<IObject> imageAnnotations;
-        final List<IObject> imageAnnotations2;
+        final List<IObject> annotations;
+        final List<IObject> annotationsSinglyLinked;
         final List<ImageAnnotationLink> tagLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
         final List<ImageAnnotationLink> fileAnnLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
         final List<ImageAnnotationLink> mapAnnLinksOnOtherImage = new ArrayList<ImageAnnotationLink>();
@@ -331,15 +331,16 @@ public class PermissionsTest extends AbstractServerTest {
         final Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         final long imageId = image.getId().getValue();
         testImages.add(imageId);
-        imageAnnotations = annotateImage(image);
-        imageAnnotations2 = annotateImage(image);
+        annotations = annotateImage(image);
+        annotationsSinglyLinked = annotateImage(image);
 
-        /* tag and add FileAnnotation and MapAnnotation from "imageAnnotations", but not from "imageAnnotations2"
-         to another image with the tags and FileAnnotations from the first image */
+        /* Link Tag, FileAnnotation and MapAnnotation from "annotations" to a second image.
+         * Note that ALL of both "annotations" and "annotationsSinglyLinked" are already linked to the first image.
+         * NONE of the "annotationsSinglyLinked" will be linked to the second image.*/
 
         final Image otherImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage()).proxy();
         testImages.add(otherImage.getId().getValue());
-        for (final IObject annotation : imageAnnotations) {
+        for (final IObject annotation : annotations) {
             if (annotation instanceof TagAnnotation) {
                 final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
@@ -379,7 +380,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(image, recipient);
-        for (final IObject annotation : imageAnnotations) {
+        for (final IObject annotation : annotations) {
             if (annotation instanceof TagAnnotation || annotation instanceof FileAnnotation || 
                 annotation instanceof MapAnnotation) {
                 assertOwnedBy(annotation, importer);
@@ -391,7 +392,7 @@ public class PermissionsTest extends AbstractServerTest {
             }
         }
 
-        for (final IObject annotation : imageAnnotations2) {
+        for (final IObject annotation : annotationsSinglyLinked) {
         	assertOwnedBy(annotation, recipient);
         }
 


### PR DESCRIPTION
# What this PR does
This PR expands the java integration tests for changing ownership for complementing the python tests. The additions are concentrating at first on the annotations behaviour. See the gist of the changes in the [trello card comment](https://trello.com/c/RpdAOmKp/102-permissions-system-problems-chown#comment-5761290e6d2d6f948a4e181a)


# Testing this PR

Check the java integration tests are still passing.
Check that the [chown permissions test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java) makes sense in that it is covering the most used objects of annotations and their combination as compared with the [cli-delete-test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py) and complementing the [cli-chown-test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_chown.py).

# Related reading
[Chown trello card](https://trello.com/c/RpdAOmKp/102-permissions-system-problems-chown)

1. background for understanding this PR

As I understand it, the java integration tests are testing the more complicated graph issues. Trying here to complement my changes in the chown.py test concerned rather with the command line options with the more wide-ranging permission testing here in java. This means here the permutating over types of annotation and group permission levels as well as ownership and user permission levels covered in this java test is being expanded to put in what is "missing" in the cli-chown-test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_chown.py). as compared with [cli-delete-test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py) 


cc @mtbc @ximenesuk 

