### PR TITLE
Fix window position of login screen of Insight on dual screen Linux.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -1013,7 +1013,10 @@ public class ScreenLogin
 	{
 		setIconImage(frameIcon);
 		setDefaultCloseOperation(EXIT_ON_CLOSE);
-		setResizable(false);
+		// Setting resizable to false causes the login screen to be positioned in
+		// the center of a dual screen setup, instead of the center of the primary
+		// screen.
+		setResizable(true);
 		setUndecorated(true);
 		toFront();
 	}


### PR DESCRIPTION
# What this PR does

The login screen of Insight and Importer are for our dual screen setups (Ubuntu 14.04) positioned in the middle of the two screens. Meaning that the login-window spans over two screens. This is quite annoying, especially because the window is not movable. 

This PR fixes that by setting setResizable to true. There seem to my (limited) testing no negative side effects from this. Looking back at the history of this code, there seem to be no particular reason why setResizable was set to false. 

# Testing this PR

## required setup

* Linux (Ubuntu 14.04 in our case)
* OMERO.insight

## actions to perform

* Start OMERO.insight
* Watch position on screen of splash window and login window

## expected observations

* With this PR the login window should be positioned in the middle of the primary screen
* Without this PR the login window is positioned in the middle of both screen (spanning both screens)

I'm worried that this change will effect other OS'es. So needs some testing in those.