### PR TITLE
Output Image ids from CLI import

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -129,6 +129,7 @@ public class ImportConfig {
     public final StrValue target;
 
     public final BoolValue debug;
+    public final BoolValue legacy;
     public final BoolValue contOnError;
     public final BoolValue sendReport;
     public final BoolValue sendFiles;
@@ -274,6 +275,7 @@ public class ImportConfig {
         savedScreen  = new LongValue("savedScreen", this, 0L);
 
         debug        = new BoolValue("debug", this, false);
+        legacy       = new BoolValue("legacy", this, false);
         contOnError  = new BoolValue("contOnError", this, false);
         sendReport   = new BoolValue("sendReport", this, false);
         sendFiles    = new BoolValue("sendFiles", this, true);

--- a/components/blitz/src/ome/formats/importer/ImportContainer.java
+++ b/components/blitz/src/ome/formats/importer/ImportContainer.java
@@ -64,15 +64,23 @@ public class ImportContainer
     private IObject target;
     private String checksumAlgorithm;
     private ImportConfig config;
+    private Boolean legacyOutput;
 
     public ImportContainer(File file, IObject target, Double[] userPixels,
             String reader, String[] usedFiles, Boolean isSPW) {
-        this(null, file, target, userPixels, reader, usedFiles, isSPW);
+        this(null, file, target, userPixels, reader, usedFiles, isSPW, false);
     }
 
     public ImportContainer(ImportConfig config,
             File file, IObject target, Double[] userPixels,
             String reader, String[] usedFiles, Boolean isSPW) {
+        this(config, file, target, userPixels, reader, usedFiles, isSPW, false);
+    }
+
+    public ImportContainer(ImportConfig config,
+            File file, IObject target, Double[] userPixels,
+            String reader, String[] usedFiles, Boolean isSPW,
+            Boolean legacyOutput) {
         this.config = config;
         this.file = file;
         this.target = target;
@@ -80,6 +88,7 @@ public class ImportContainer
         this.reader = reader;
         this.usedFiles = usedFiles;
         this.isSPW = isSPW;
+        this.legacyOutput = legacyOutput;
     }
 
     // Various Getters and Setters //
@@ -253,6 +262,22 @@ public class ImportContainer
      */
     public void setIsSPW(Boolean isSPW) {
         this.isSPW = isSPW;
+    }
+
+    /**
+     * Return true if the legacy output flag is set. False otherwise.
+     * @return See above.
+     */
+    public Boolean getLegacyOutput() {
+        return legacyOutput;
+    }
+
+    /**
+     * Set true if the legacy output flag is set. False otherwise.
+     * @param legacyOutput True if legacy output flag is set, false otherwise.
+     */
+    public void setLegacyOutput(Boolean legacyOutput) {
+        this.legacyOutput = legacyOutput;
     }
 
     /**

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -281,7 +281,7 @@ public class ImportLibrary implements IObservable
                         throw new RuntimeException("Failed to load target", e);
                     }
                 }
-
+                ic.setLegacyOutput(config.legacy.get());
                 if (config.checksumAlgorithm.get() != null) {
                     ic.setChecksumAlgorithm(config.checksumAlgorithm.get());
                 }

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -356,6 +356,7 @@ public class CommandLineImporter {
             + "  --logs\t\t\t\tUpload log file (if any) with report. Required --report\n"
             + "  --email EMAIL\t\t\t\tEmail for reported errors. Required --report\n"
             + "  --debug LEVEL\t\t\t\tTurn debug logging on (optional level)\n"
+            + "  --legacy\t\t\t\tUse legacy output format\n"
             + "  --annotation-ns ANNOTATION_NS\t\tNamespace to use for subsequent annotation\n"
             + "  --annotation-text ANNOTATION_TEXT\tContent for a text annotation (requires namespace)\n"
             + "  --annotation-link ANNOTATION_LINK\tComment annotation ID to link all images to\n"
@@ -567,6 +568,7 @@ public class CommandLineImporter {
                 new LongOpt("no-stats-info", LongOpt.NO_ARGUMENT, null, 23);
         LongOpt noUpgradeCheck =
                 new LongOpt("no-upgrade-check", LongOpt.NO_ARGUMENT, null, 24);
+        LongOpt legacy = new LongOpt("legacy", LongOpt.NO_ARGUMENT, null, 25);
 
         // DEPRECATED OPTIONS
         LongOpt plateName = new LongOpt(
@@ -592,7 +594,7 @@ public class CommandLineImporter {
                                 checksumAlgorithm, minutesWait,
                                 closeCompleted, waitCompleted, autoClose,
                                 exclude, target, noStatsInfo,
-                                noUpgradeCheck, qaBaseURL,
+                                noUpgradeCheck, qaBaseURL, legacy,
                                 plateName, plateDescription,
                                 noThumbnailsDeprecated,
                                 checksumAlgorithmDeprecated,
@@ -733,6 +735,11 @@ public class CommandLineImporter {
             case 24: {
                 log.info("Disabling upgrade check");
                 config.checkUpgrade.set(false);
+                break;
+            }
+            case 25: {
+                log.info("Enabling legacy output");
+                config.legacy.set(true);
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
+++ b/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
@@ -39,10 +39,11 @@ public class LoggingImportMonitor implements IObserver
             // send the import results to stdout
             // to enable external tools integration
             if (ev.container.getLegacyOutput()) {
-                importSummary.outputGreppableResults(ev);
+                importSummary.outputPixelsIds(ev);
             } else {
                 importSummary.outputImageIds(ev);
             }
+            importSummary.outputOtherObjects(ev);
             importSummary.update(ev);
         } else if (event instanceof IMPORT_SUMMARY) {
             IMPORT_SUMMARY ev = (IMPORT_SUMMARY) event;
@@ -172,27 +173,10 @@ public class LoggingImportMonitor implements IObserver
          *
          * @param ev the end of import event.
          */
-        void outputGreppableResults(IMPORT_DONE ev) {
+        void outputPixelsIds(IMPORT_DONE ev) {
             System.err.println("Imported pixels:");
             for (Pixels p : ev.pixels) {
                 System.out.println(p.getId().getValue());
-            }
-
-            System.err.println("Other imported objects:");
-            System.err.print("Fileset:");
-            System.err.println(ev.fileset.getId().getValue());
-            for (IObject object : ev.objects) {
-                if (object != null && object.getId() != null) {
-                    // Not printing to stdout since the contract at the moment
-                    // is that only pixel IDs hit stdout.
-                    String kls = object.getClass().getSimpleName();
-                    if (kls.endsWith("I")) {
-                        kls = kls.substring(0,kls.length()-1);
-                    }
-                    System.err.print(kls);
-                    System.err.print(":");
-                    System.err.println(object.getId().getValue());
-                }
             }
         }
 
@@ -226,5 +210,31 @@ public class LoggingImportMonitor implements IObserver
             System.out.print(sb.toString());
 
         }
+
+        /**
+         * Displays a list of other imported objects on sdtandard error.
+         *
+         * @param ev the end of import event.
+         */
+        void outputOtherObjects(IMPORT_DONE ev) {
+            System.err.println("Other imported objects:");
+            System.err.print("Fileset:");
+            System.err.println(ev.fileset.getId().getValue());
+            for (IObject object : ev.objects) {
+                if (object != null && object.getId() != null) {
+                    // Not printing to stdout since the contract at the moment
+                    // is that only pixel IDs hit stdout.
+                    String kls = object.getClass().getSimpleName();
+                    if (kls.endsWith("I")) {
+                        kls = kls.substring(0,kls.length()-1);
+                    }
+                    System.err.print(kls);
+                    System.err.print(":");
+                    System.err.println(object.getId().getValue());
+                }
+            }
+        }
+
+
     }
 }

--- a/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
+++ b/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
@@ -38,7 +38,11 @@ public class LoggingImportMonitor implements IObserver
 
             // send the import results to stdout
             // to enable external tools integration
-            importSummary.outputGreppableResults(ev);
+            if (ev.container.getLegacyOutput()) {
+                importSummary.outputGreppableResults(ev);
+            } else {
+                importSummary.outputImageIds(ev);
+            }
             importSummary.update(ev);
         } else if (event instanceof IMPORT_SUMMARY) {
             IMPORT_SUMMARY ev = (IMPORT_SUMMARY) event;
@@ -190,6 +194,37 @@ public class LoggingImportMonitor implements IObserver
                     System.err.println(object.getId().getValue());
                 }
             }
+        }
+
+        /**
+         * Displays a list of successfully imported Image IDs on standard
+         * output using the Object:id format.
+         *
+         * Note that this behavior is intended for other command line tools to
+         * pipe/grep the import results, and should be kept as is.
+         *
+         * @param ev the end of import event.
+         */
+        void outputImageIds(IMPORT_DONE ev) {
+            StringBuilder sb = new StringBuilder();
+            String separator = "";
+            sb.append("Image:");
+            for (IObject object : ev.objects) {
+                sb.append(separator);
+                separator = ",";
+                if (object != null && object.getId() != null) {
+                    String kls = object.getClass().getSimpleName();
+                    if (kls.endsWith("I")) {
+                        kls = kls.substring(0,kls.length()-1);
+                    }
+                    if (kls.equals("Image")) {
+                        sb.append(object.getId().getValue());
+                    }
+                }
+            }
+            sb.append("\n");
+            System.out.print(sb.toString());
+
         }
     }
 }

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -91,6 +91,9 @@ class ImportControl(BaseControl):
             "--clientdir", type=str,
             help="Path to the directory containing the client JARs. "
             " Default: lib/client")
+        parser.add_argument(
+            "--legacy", action="store_true", dest="java_legacy",
+            help="Use legacy output format (**)")
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
@@ -254,6 +257,7 @@ class ImportControl(BaseControl):
             "java_text": "--annotation-text",
             "java_link": "--annotation-link",
             "java_advanced_help": "--advanced-help",
+            "java_legacy": ("--legacy"),
             }
 
         for attr_name, arg_name in java_args.items():


### PR DESCRIPTION
# What this PR does

This PR makes the default output, ie what is sent to standard output, an Image id list in the form of `Image:1,2,3,4`. The existing output is available via a `--legacy` flag. 

# Testing this PR

Import some images with and without the legacy option, for example:
```
$ bin/omero import -- --legacy ~/Work/images/dv/IAGFP-Noc01_R3D.dv
...
2016-06-16 12:47:43,572 4497       [l.Client-0] INFO   ormats.importer.cli.LoggingImportMonitor - IMPORT_DONE Imported file: /Users/colin/Work/images/dv/IAGFP-Noc01_R3D.dv
Imported pixels:
352
Other imported objects:
Fileset:152
Image:352
2016-06-16 12:47:43,573 4498       [l.Client-0] INFO      ome.formats.importer.cli.ErrorHandler - Number of errors: 0

==> Summary
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:02.637

$ bin/omero import ~/Work/images/dv/IAGFP-Noc01_R3D.dv
2016-06-16 12:47:04,789 15738      [l.Client-1] INFO   ormats.importer.cli.LoggingImportMonitor - IMPORT_DONE Imported file: /Users/colin/Work/images/dv/IAGFP-Noc01_R3D.dv
Image:351
Other imported objects:
Fileset:151
Image:351
2016-06-16 12:47:04,804 15753      [l.Client-1] INFO      ome.formats.importer.cli.ErrorHandler - Number of errors: 0

==> Summary
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:09.531
```
It's also worth confirming that what is sent to stdout is what is expected:
```
$ bin/omero import -s localhost -u user-0 -w ome -- --legacy ~/Work/images/dv/IAGFP-Noc01_R3D.dv 1> stdout.txt
...
==> Summary
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:02.637
$ cat stdout.txt
352

$ bin/omero import -s localhost -u user-0 -w ome ~/Work/images/dv/IAGFP-Noc01_R3D.dv 1> stdout.txt
...
==> Summary
2 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:00:09.531
$ cat stdout.txt
Image:351
```
MIFs should also be tried. With the legacy option a list of Pixels IDs will be output each on its own line. Without the legacy option the image IDs should be output on a single line in the form `Image:1,2,3,4,5`

Existing CLI import tests should pass

# Related reading

See: https://trello.com/c/pY5KvRPI/691-cli-return-image-id

--breaking