### PR TITLE
Remove ref to jnlp (Web start)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.init.SplashScreenInit
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -23,11 +23,6 @@
 
 package org.openmicroscopy.shoola.env.init;
 
-//Java imports
-
-//Third-party libraries
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.LoginConfig;
@@ -36,7 +31,6 @@ import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.env.ui.SplashScreen;
 import org.openmicroscopy.shoola.env.ui.UIFactory;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 /** 
  * Does some configuration required for the initialization process to run.
@@ -161,19 +155,8 @@ public final class SplashScreenInit
         int index = max;
         UserCredentials uc;
         UserNotifier un = UIFactory.makeUserNotifier(container);
-        String jnlpHost = System.getProperty("jnlp.omero.host");
-        String jnlpPort = System.getProperty("jnlp.omero.port");
-        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
         while (0 < max--) {
-            if (CommonsLangUtils.isNotBlank(jnlpSession)) {
-                uc = new UserCredentials(jnlpSession,
-                        jnlpSession, jnlpHost, UserCredentials.HIGH);
-                try {
-                    uc.setPort(Integer.parseInt(jnlpPort));
-                } catch (Exception e) {}//use the default port.
-            } else {
-                uc = splashScreen.getUserCredentials((max == index-1));
-            }
+            uc = splashScreen.getUserCredentials((max == index-1));
             //needed b/c need to retrieve user's details later.
             reg.bind(LookupNames.USER_CREDENTIALS, uc);
 
@@ -189,7 +172,6 @@ public final class SplashScreenInit
 					if (max != 0) {
 						loginSvc.notifyLoginFailure();
 						splashScreen.onLoginFailure();
-						jnlpSession = null;
 		        	} else if (max == 0) {
 		        		//Exit if we couldn't manage to log in.
 		        		 un.notifyError("Login Failure", 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.SplashScreenManager
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,6 @@
 
 package org.openmicroscopy.shoola.env.ui;
 
-//Java imports
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.Toolkit;
@@ -36,19 +35,12 @@ import java.beans.PropertyChangeListener;
 import javax.swing.Icon;
 import javax.swing.JFrame;
 
-//Third-party libraries
 
-
-
-
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.login.LoginCredentials;
@@ -181,23 +173,8 @@ class SplashScreenManager
     	String port = ""+ info.getPortSSL();
     	String host = info.getHostName();
     	boolean configurable = info.isHostNameConfigurable();
-    	//check if we have jnlp option
-    	String jnlpHost = System.getProperty("jnlp.omero.host");
-    	if (CommonsLangUtils.isNotBlank(jnlpHost)) {
-    	    host = jnlpHost;
-    	    configurable = false;
-    	}
-        String jnlpPort = System.getProperty("jnlp.omero.port");
-        if (CommonsLangUtils.isNotBlank(jnlpPort)) {
-            port = jnlpPort;
-            p = Integer.parseInt(port);
-            configurable = false;
-        }
-        String jnlpSession = System.getProperty("jnlp.omero.sessionid");
+
         boolean serverAvailable = connectToServer();
-        if (CommonsLangUtils.isNotBlank(jnlpSession)) {
-            serverAvailable = false;
-        }
     	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port,
     			host, serverAvailable);
     	view.setEncryptionConfiguration(info.isEncrypted(),

--- a/components/tools/OmeroWeb/omeroweb/http.py
+++ b/components/tools/OmeroWeb/omeroweb/http.py
@@ -41,12 +41,6 @@ class HttpJsonResponse(HttpResponse):
             self, json.dumps(content), content_type="application/json")
 
 
-class HttpJNLPResponse(HttpResponse):
-    def __init__(self, content):
-        HttpResponse.__init__(
-            self, content, content_type="application/x-java-jnlp-file")
-
-
 class HttpJPEGResponse(HttpResponse):
     def __init__(self, content):
         HttpResponse.__init__(self, content, content_type="image/jpeg")

--- a/etc/mime.types
+++ b/etc/mime.types
@@ -34,7 +34,6 @@ types {
     application/vnd.wap.xhtml+xml         xhtml;
     application/x-cocoa                   cco;
     application/x-java-archive-diff       jardiff;
-    application/x-java-jnlp-file          jnlp;
     application/x-makeself                run;
     application/x-perl                    pl pm;
     application/x-pilot                   prc pdb;


### PR DESCRIPTION
# What this PR does

Remove ref to jnlp since we no longer use webstart.


# Testing this PR
Check that the Desktop client works and web is up.


# Related reading
Original card (5.2.0) https://trello.com/c/sqkNtuBY/58-drop-webstart

