### PR TITLE
Elision on CLI tests

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -516,7 +516,7 @@ class TestDelete(CLITest):
         self.cli.invoke(self.args, strict=True)
 
         # Check that the Datasets were not deleted
-        # because I dont have permission to delete the dat2
+        # because the user does not have permission to delete the dat2
         assert self.query.find('Dataset', ids[0])
         assert client.sf.getQueryService().find("Dataset", ids[1])
         assert self.query.find('Dataset', ids[2])

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -457,6 +457,39 @@ class TestDelete(CLITest):
         assert not self.query.find('FileAnnotation', fa.id.val)
         assert not self.query.find('FileAnnotation', fa2.id.val)
 
+    @pytest.mark.parametrize('number', [1, 2, 3])
+    def testInputWithElisionDefault(self, number, capfd):
+        # Create several datasets
+        ids = []
+        for i in range(number):
+            ids.append(self.make_dataset().id.val)
+        ids = sorted(ids)
+        assert len(ids) == number
+        assert ids[-1] - ids[0] + 1 == number
+        # Try to delete the datasets, defaults to --dry-run for elision
+        self.args += ['Dataset:%s' % str(ids[0]) + "-" + str(ids[number-1])]
+        self.cli.invoke(self.args, strict=True)
+        # Check that the Datasets were not deleted
+        for did in ids:
+            assert self.query.find('Dataset', did)
+
+    def testInputWithElisionForce(self, capfd):
+        DATASETS = 3
+        # Create several datasets
+        ids = []
+        for i in range(DATASETS):
+            ids.append(self.make_dataset().id.val)
+        ids = sorted(ids)
+        assert len(ids) == DATASETS
+        assert ids[-1] - ids[0] + 1 == DATASETS
+        # Delete the datasets using --force flag
+        self.args += ['Dataset:%s' % str(ids[0]) + "-" + str(ids[2])]
+        self.args += ['--force']
+        self.cli.invoke(self.args, strict=True)
+        # Check that the Datasets were deleted
+        for did in ids:
+            assert not self.query.find('Dataset', did)
+
     def testOutputWithElision(self, capfd):
         IMAGES = 8
         # Import several images


### PR DESCRIPTION
# What this PR does
Adds new python integration tests for new functionelity of CLI. See details below.



# Testing this PR

1. required setup
Check that the python integration tests are passing on CI.
2. actions to perform
No special actions to perform except checking that the three added tests make sense and are complying with the standards.
3. expected observations
Tests on CI pass.

# Related reading

See https://github.com/openmicroscopy/openmicroscopy/pull/4707

1. background for understanding this PR

Elision means shorthand input, where a continuous row of IDs is approximated with first-hphen-last pattern (see https://github.com/openmicroscopy/openmicroscopy/pull/4707).
This PR here adds 3 new tests (one of them parametrized) for CLI for Elision input and does it specifically in the [delete test](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py) because this is the easiest test for creating asserts. The other commands on CLI such as chown or chgrp will also use the Elision input, but as the logic of the CLI is the same there, this amount of test coverage is sufficient.

cc @ximenesuk , @mtbc  @sbesson 

(Probably for another PR, as this is not something introduced here, my tests work only with Datasets: 
  - should I get rid of the Images logic in the existing [Elision Output](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_delete.py#L460) test as well in this PR, and replace the images with Datasets ? )

READY FOR REVIEW  the first commit of @ximenesuk will not be a problem as discussed with @ximenesuk .