### PR TITLE
modify the WeblitzPlateview.load() to tell gs_json to use GET

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -164,7 +164,7 @@ jQuery._WeblitzPlateview = function (container, options) {
     if (field === undefined) {
       field = 0;
     }
-    gs_json(opts.baseurl+'/plate/'+pid+'/'+field+'/', {size:opts.size}, _reset);
+    gs_json(opts.baseurl+'/plate/'+pid+'/'+field+'/?size='+opts.size, null, _reset);
   };
 
   this.setFocus = function (elm, evt) {


### PR DESCRIPTION
# What this PR does

As pointed in https://github.com/openmicroscopy/openmicroscopy/pull/4687#issuecomment-226798195 plate should load data using GET rather then POST 


# Testing this PR

load a plate and check if query string contains size like ``http://.../webgateway/plate/PLATE_ID/INDEX/?size=96&callback=...``


cc @chris-allan @will-moore 