### PR TITLE
Ticket 13202

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/ResultsCellRenderer.java
@@ -284,10 +284,6 @@ public class ResultsCellRenderer
 				}
     		}
     		
-    		if(k.equals(AnnotationKeys.ANGLE.getKey())) {
-    			s += UIUtilities.DEGREE_SYMBOL;
-    		}
-    		
     		label.setText(s);
     		thisComponent = label;
     	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/IntensityView.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.Map.Entry;
+
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultComboBoxModel;
@@ -83,9 +84,13 @@ import org.openmicroscopy.shoola.agents.measurement.util.TabPaneInterface;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnalysisStatsWrapper.StatsType;
 import org.openmicroscopy.shoola.env.config.Registry;
+
 import omero.log.Logger;
+import omero.model.Length;
+
 import org.openmicroscopy.shoola.env.rnd.roi.ROIShapeStatsSimple;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+
 import omero.gateway.model.ChannelData;
 
 /** 
@@ -655,13 +660,18 @@ class IntensityView
 	private void addValuesForAreaFigure(ROIFigure fig, Double data[][], 
 			int channel, int count)
 	{
-		data[count][6] = AnnotationKeys.AREA.get(fig.getROIShape()).getValue();
-		data[count][7] = fig.getBounds().getX();
-		data[count][8] = fig.getBounds().getY();
-		data[count][9] = AnnotationKeys.WIDTH.get(fig.getROIShape()).getValue();
-		data[count][10] = AnnotationKeys.HEIGHT.get(fig.getROIShape()).getValue();
-		data[count][11] = AnnotationKeys.CENTREX.get(fig.getROIShape()).getValue();
-		data[count][12] = AnnotationKeys.CENTREY.get(fig.getROIShape()).getValue();
+        Length l = AnnotationKeys.AREA.get(fig.getROIShape());
+        data[count][6] = l != null ? l.getValue() : 0;
+        data[count][7] = fig.getBounds().getX();
+        data[count][8] = fig.getBounds().getY();
+        l = AnnotationKeys.WIDTH.get(fig.getROIShape());
+        data[count][9] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.HEIGHT.get(fig.getROIShape());
+        data[count][10] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.CENTREX.get(fig.getROIShape());
+        data[count][11] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.CENTREY.get(fig.getROIShape());
+        data[count][12] = l != null ? l.getValue() : 0;
 	}
 	
 	/**
@@ -674,12 +684,18 @@ class IntensityView
 	private void addValuesForLineFigure(ROIFigure fig, Double data[][], 
 			int channel, int count)
 	{
-		data[count][6] = AnnotationKeys.STARTPOINTX.get(shape).getValue();
-		data[count][7] = AnnotationKeys.STARTPOINTY.get(shape).getValue();
-		data[count][8] = AnnotationKeys.ENDPOINTX.get(shape).getValue();
-		data[count][9] = AnnotationKeys.ENDPOINTY.get(shape).getValue();
-		data[count][10] = AnnotationKeys.CENTREX.get(shape).getValue();
-		data[count][11] = AnnotationKeys.CENTREY.get(shape).getValue();
+        Length l = AnnotationKeys.STARTPOINTX.get(shape);
+        data[count][6] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.STARTPOINTY.get(shape);
+        data[count][7] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.ENDPOINTX.get(shape);
+        data[count][8] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.ENDPOINTY.get(shape);
+        data[count][9] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.CENTREX.get(shape);
+        data[count][10] = l != null ? l.getValue() : 0;
+        l = AnnotationKeys.CENTREY.get(shape);
+        data[count][11] = l != null ? l.getValue() : 0;
 	}
 	
 
@@ -693,8 +709,10 @@ class IntensityView
 	private void addValuesForPointFigure(ROIFigure fig, Double data[][], 
 			int channel, int count)
 	{
-		data[count][6] = AnnotationKeys.CENTREX.get(shape).getValue();
-		data[count][7] = AnnotationKeys.CENTREY.get(shape).getValue();
+	    Length l = AnnotationKeys.CENTREX.get(shape);
+		data[count][6] = l != null ? l.getValue() : 0;
+		l = AnnotationKeys.CENTREY.get(shape);
+		data[count][7] = l != null ? l.getValue() : 0;
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementResults.java
@@ -539,7 +539,7 @@ class MeasurementResults
 		String filename = file.getAbsolutePath();
 		MeasurementTableModel tm = (MeasurementTableModel) results.getModel();
 		tm = tm.copy();
-		tm.setShowUnits(true);
+		tm.setShowUnits(false);
 		ExcelWriter writer = new ExcelWriter(filename);
 		writer.openFile();
 		writer.createSheet("Measurement Results");

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
@@ -148,6 +148,11 @@ public class MeasurementTableModel extends AbstractTableModel
                     buffer.append(UIUtilities.formatToDecimal(d));
                     buffer.append(" ");
                 }
+                if (v instanceof Length) {
+                    Length n = (Length) v;
+                    buffer.append(UIUtilities.twoDecimalPlaces(n.getValue()));
+                    buffer.append(" ");
+                }
             }
             if (total > 0) {
                 buffer.append("= "+UIUtilities.formatToDecimal(total));

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
@@ -164,16 +164,15 @@ public class MeasurementTableModel extends AbstractTableModel
                     }
                 }
                 return buffer.toString();
-            } else {
-                if (value instanceof Number) {
+            } 
+            else if (value instanceof Number) {
                     double d = ((Number) value).doubleValue();
                     return UIUtilities.twoDecimalPlaces(d);
-                }
-                if (value instanceof Length) 
+                    }
+            else if (value instanceof Length) 
                     return UIUtilities.twoDecimalPlaces(((Length) value)
                             .getValue());
-                return value;
-            }
+            return value;
         } else {
             if (value instanceof List) {
                 List<Object> l = (List<Object>) value;
@@ -201,16 +200,15 @@ public class MeasurementTableModel extends AbstractTableModel
                         buffer.append(" ");
                 }
                 return buffer.toString();
-            } else {
-                if (value instanceof Number) {
+            } 
+            else if (value instanceof Number) {
                     double d = ((Number) value).doubleValue();
                     return UIUtilities.twoDecimalPlacesAsNumber(d);
                 }
-                if (value instanceof Length) 
+            else if (value instanceof Length)  
                     return UIUtilities.twoDecimalPlacesAsNumber(((Length) value)
-                            .getValue());
-                return value;
-            }
+                            .getValue());      
+            return value;
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementTableModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2014-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -131,39 +131,9 @@ public class MeasurementTableModel extends AbstractTableModel
         if (row < 0 || row > values.size()) return null;
         MeasurementObject rowData = values.get(row);
         Object value = rowData.getElement(col);
-        if (value instanceof List && !showUnits) {
-            List<Object> l = (List<Object>) value;
-            
-            if (l.size() == 1) 
-            	return l.get(0);
-            StringBuilder buffer = new StringBuilder();
-            Iterator<Object> i = l.iterator();
-            Object v;
-            double total = 0;
-            while (i.hasNext()) {
-                v = i.next();
-                if (v instanceof Number) {
-                    double d = ((Number) v).doubleValue();
-                    total += d;
-                    buffer.append(UIUtilities.formatToDecimal(d));
-                    buffer.append(" ");
-                }
-                if (v instanceof Length) {
-                    Length n = (Length) v;
-                    buffer.append(UIUtilities.twoDecimalPlaces(n.getValue()));
-                    buffer.append(" ");
-                }
-            }
-            if (total > 0) {
-                buffer.append("= "+UIUtilities.formatToDecimal(total));
-            }
-            return buffer.toString();
-        }
+                    
         if (showUnits) {
-            if (value instanceof Length) {
-                Length n = (Length) value;
-                return convertLength(n, col);
-            } else if (value instanceof List) {
+            if (value instanceof List) {
                 List l = (List) value;
                 Iterator<Object> i = l.iterator();
                 Object v;
@@ -175,7 +145,8 @@ public class MeasurementTableModel extends AbstractTableModel
                     if (v instanceof Length) {
                         Length n = (Length) v;
                         s = convertLength(n, col);
-                        if (size == 1) return s;
+                        if (size == 1)
+                            return s;
                         if (s != null) {
                             buffer.append(s);
                             buffer.append(" ");
@@ -183,7 +154,7 @@ public class MeasurementTableModel extends AbstractTableModel
                     } else if (v instanceof Number) {
                         double d = ((Number) v).doubleValue();
                         if (size == 1) {
-                            return UIUtilities.twoDecimalPlacesAsNumber(d);
+                            return UIUtilities.twoDecimalPlaces(d);
                         }
                         s = UIUtilities.twoDecimalPlaces(d);
                         if (s != null) {
@@ -193,12 +164,54 @@ public class MeasurementTableModel extends AbstractTableModel
                     }
                 }
                 return buffer.toString();
-            } else if (value instanceof Number) {
-                double d = ((Number) value).doubleValue();
-                return UIUtilities.twoDecimalPlacesAsNumber(d);
+            } else {
+                if (value instanceof Number) {
+                    double d = ((Number) value).doubleValue();
+                    return UIUtilities.twoDecimalPlaces(d);
+                }
+                if (value instanceof Length) 
+                    return UIUtilities.twoDecimalPlaces(((Length) value)
+                            .getValue());
+                return value;
+            }
+        } else {
+            if (value instanceof List) {
+                List<Object> l = (List<Object>) value;
+                StringBuilder buffer = new StringBuilder();
+                Iterator<Object> i = l.iterator();
+                Object v;
+                while (i.hasNext()) {
+                    v = i.next();
+                    if (v instanceof Number) {
+                        double d = ((Number) v).doubleValue();
+                        if (l.size() == 1)
+                            return UIUtilities.twoDecimalPlacesAsNumber(d);
+                        else
+                            buffer.append(UIUtilities
+                                    .twoDecimalPlacesAsNumber(d));
+                    }
+                    if (v instanceof Length) {
+                        Length n = (Length) v;
+                        if (l.size() == 1)
+                            return UIUtilities.twoDecimalPlacesAsNumber(n.getValue());
+                        else
+                            buffer.append(UIUtilities.twoDecimalPlacesAsNumber(n.getValue()));
+                    }
+                    if (i.hasNext())
+                        buffer.append(" ");
+                }
+                return buffer.toString();
+            } else {
+                if (value instanceof Number) {
+                    double d = ((Number) value).doubleValue();
+                    return UIUtilities.twoDecimalPlacesAsNumber(d);
+                }
+                if (value instanceof Length) 
+                    return UIUtilities.twoDecimalPlacesAsNumber(((Length) value)
+                            .getValue());
+                return value;
             }
         }
-        return value;
     }
 
     /**
@@ -214,18 +227,14 @@ public class MeasurementTableModel extends AbstractTableModel
         String k = key.getKey();
         String s = null;
         if (!units.getUnit().equals(UnitsLength.PIXEL)) {
-            if (unitsDisplay.size() > col && unitsDisplay.get(col)) {
-                s = UIUtilities.formatValue(n,
-                        AnnotationKeys.AREA.getKey().equals(k));
-            } else {
-                return UIUtilities.formatValueNoUnitAsNumber(n,
-                        AnnotationKeys.AREA.getKey().equals(k));
-            }
+            s = UIUtilities.formatValue(n,
+                    AnnotationKeys.AREA.getKey().equals(k));
             if (CommonsLangUtils.isNotBlank(s))
                return s;
         }
         Number value = UIUtilities.twoDecimalPlacesAsNumber(n.getValue());
-        if (value.doubleValue() == 0) return null;
+        if (value.doubleValue() == 0)
+            return null;
         return value;
     }
 
@@ -237,12 +246,40 @@ public class MeasurementTableModel extends AbstractTableModel
 
     /**
      * Overridden to return the name of the specified column.
+     * 
      * @see AbstractTableModel#getColumnName(int)
      */
-    public String getColumnName(int col) 
-    {
-    	return columnNames.get(col).getDescription();
-     }
+    public String getColumnName(int col) {
+        KeyDescription k = columnNames.get(col);
+
+        String symbol = unitsType.getPixelSizeX().getSymbol();
+        
+        if (k.getKey().equals(AnnotationKeys.ANGLE.getKey()))
+            return k.getDescription() + "(" + UIUtilities.DEGREE_SYMBOL + ")";
+        
+        UnitsLength unit = unitsType.getPixelSizeX().getUnit();
+        if (!unit.equals(UnitsLength.PIXEL)) {
+            if (k.getKey().equals(AnnotationKeys.LENGTH.getKey())
+                    || k.getKey().equals(AnnotationKeys.CENTREX.getKey())
+                    || k.getKey().equals(AnnotationKeys.CENTREY.getKey())
+                    || k.getKey().equals(AnnotationKeys.WIDTH.getKey())
+                    || k.getKey().equals(AnnotationKeys.HEIGHT.getKey())
+                    || k.getKey().equals(AnnotationKeys.ENDPOINTX.getKey())
+                    || k.getKey().equals(AnnotationKeys.ENDPOINTY.getKey())
+                    || k.getKey().equals(AnnotationKeys.PERIMETER.getKey())
+                    || k.getKey().equals(AnnotationKeys.POINTARRAYX.getKey())
+                    || k.getKey().equals(AnnotationKeys.POINTARRAYY.getKey())
+                    || k.getKey().equals(AnnotationKeys.STARTPOINTX.getKey())
+                    || k.getKey().equals(AnnotationKeys.STARTPOINTY.getKey()))
+                return k.getDescription() + "(" + symbol + ")";
+            
+            if (k.getKey().equals(AnnotationKeys.AREA.getKey()))
+                return k.getDescription() + "(" + symbol
+                        + UIUtilities.SQUARED_SYMBOL + ")";
+        }
+
+        return k.getDescription();
+    }
     
     /**
      * Overridden to return the number of columns.
@@ -306,14 +343,7 @@ public class MeasurementTableModel extends AbstractTableModel
                             !l.getUnit().equals(UnitsLength.PIXEL)) {
                         symbols.add(s);
                     }
-                } else if (v instanceof Number) {
-                    if (k.equals(AnnotationKeys.ANGLE.getKey())) {
-                        String s = UIUtilities.DEGREE_SYMBOL;
-                        if (!symbols.contains(s)) {
-                            symbols.add(s);
-                        }
-                    }
-                }
+                } 
             }
             if (symbols.size() == 1) {
                 String value = key.getDescription()+" ("+symbols.get(0);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureBezierFigure.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -561,7 +561,8 @@ public class MeasureBezierFigure
 
 		for (int i = 0 ; i < path.size(); i++)
 		{
-			pointArrayY.add(new LengthI(path.get(i).getControlPoint(0).getY(), getUnit()));
+		    pointArrayX.add(transformX(path.get(i).getControlPoint(0).getX()));
+		    pointArrayY.add(transformY(path.get(i).getControlPoint(0).getY()));
 		}
 		AnnotationKeys.POINTARRAYX.set(shape, pointArrayX);
 		AnnotationKeys.POINTARRAYY.set(shape, pointArrayY);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/annotation/AnnotationKeys.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/annotation/AnnotationKeys.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -51,15 +51,15 @@ public class AnnotationKeys
 	
 	/** The area of the figure. */
 	public static final AnnotationKey<Length> AREA = 
-		new AnnotationKey<Length>("measurementArea", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementArea", null);
 	
 	/** The perimeter of the figure. */
 	public static final AnnotationKey<Length> PERIMETER = 
-		new AnnotationKey<Length>("measurementPerimeter", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementPerimeter", null);
 	
 	/** The volume of the figure. */
 	public static final AnnotationKey<Length> VOLUME = 
-		new AnnotationKey<Length>("measurementVolume", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementVolume", null);
 	
 	/** A list of angles in the figure, used for bezier, line and 
 	 * line connection figures which can have a number of elbows. 
@@ -89,39 +89,39 @@ public class AnnotationKeys
 	
 	/** The X coord of the centre of the object. */
 	public static final AnnotationKey<Length> CENTREX= 
-		new AnnotationKey<Length>("measurementCentreX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementCentreX", null);
 
 	/** The Y coord of the centre of the object. */
 	public static final AnnotationKey<Length> CENTREY= 
-		new AnnotationKey<Length>("measurementCentreY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementCentreY", null);
 
 	/** The X coord of the start of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> STARTPOINTX= 
-		new AnnotationKey<Length>("measurementStartPointX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementStartPointX", null);
 
 	/** The X coord of the start of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> STARTPOINTY= 
-		new AnnotationKey<Length>("measurementStartPointY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementStartPointY", null);
 	
 	/** The X coord of the end of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> ENDPOINTX= 
-		new AnnotationKey<Length>("measurementEndPointX", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementEndPointX", null);
 	
 	/** The Y coord of the end of the object, this is used for line,
 	 * lineconnection and bezier figures. */
 	public static final AnnotationKey<Length> ENDPOINTY= 
-		new AnnotationKey<Length>("measurementEndPointY", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementEndPointY", null);
 	
 	/** The width of the figure. */
 	public static final AnnotationKey<Length> WIDTH = 
-		new AnnotationKey<Length>("measurementWidth", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementWidth", null);
 	
 	/** The height of the figure.*/
 	public static final AnnotationKey<Length> HEIGHT = 
-		new AnnotationKey<Length>("measurementHeight", new LengthI(0, UnitsLength.PIXEL));
+		new AnnotationKey<Length>("measurementHeight", null);
 	
     /** Should the figure show the measurement text. */
     public static final AnnotationKey<Object> TAG =


### PR DESCRIPTION
While investigating [Ticket 13202](https://trac.openmicroscopy.org/ome/ticket/13202) I fixed some problems with the ResultsTable of the MeasurementTool. This should also fix the error the user reported, although I couldn't reproduce it (but my suspicion is, it was some kind of unit conversion problem).

On that occassion I also made sure, that no unit up or down conversion ("round to reasonable unit") happens and that the ResultTable does not contain any unit symbols (numbers only),therefore the unit is shown in the headers of the table only (if it is a real unit and not in pixels). That means the numbers in the table should all be of the same dimension so that they are easily comparable and regonized by Excel as numbers when the results are exported as excel file.

**Test**
-  Make sure Coord_List(X) and Coord_List(Y) values are populated for Polygons, in the ResultsTable as well as the exported Excel file.
- Toggle between "calibrated" and "pixel value" display, check that the numbers are reasonable.
