### PR TITLE
give LoginCredentials a Session ID constructor

### DIFF
--- a/components/blitz/src/omero/gateway/LoginCredentials.java
+++ b/components/blitz/src/omero/gateway/LoginCredentials.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package omero.gateway;
 
 import java.util.List;
@@ -115,6 +116,36 @@ public class LoginCredentials {
         user.setPassword(password);
         server.setHostname(host);
         server.setPort(port);
+    }
+
+    /**
+     * Creates a new instance with the given credentials and default port.
+     * Note that the given session ID is passed via the user name property
+     * and is subsequently available from {@link UserCredentials#getUsername()}.
+     *
+     * @param sessionId
+     *            The session UUID
+     * @param host
+     *            The server hostname
+     */
+    public LoginCredentials(String sessionId, String host) {
+        this(sessionId, null, host, omero.constants.GLACIER2PORT.value);
+    }
+
+    /**
+     * Creates a new instance with the given credentials.
+     * Note that the given session ID is passed via the user name property
+     * and is subsequently available from {@link UserCredentials#getUsername()}.
+     *
+     * @param sessionId
+     *            The session UUID
+     * @param host
+     *            The server hostname
+     * @param port
+     *            The server port
+     */
+    public LoginCredentials(String sessionId, String host, int port) {
+        this(sessionId, null, host, port);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.gateway;
 
 import integration.AbstractServerTest;
@@ -30,7 +31,6 @@ import omero.log.SimpleLogger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
 /**
  * Tests the login options supported by gateway
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
@@ -40,8 +40,12 @@ import org.testng.annotations.Test;
 public class GatewayUsageTest extends AbstractServerTest
 {
 
+    /**
+     * Check logging in using username and password.
+     * @throws DSOutOfServiceException unexpected
+     */
     @Test
-    public void testLoginWithCredentials()
+    public void testLoginWithCredentialsUserPass()
             throws DSOutOfServiceException {
         omero.client client =  new omero.client();
         String port = client.getProperty("omero.port");
@@ -52,6 +56,24 @@ public class GatewayUsageTest extends AbstractServerTest
         c.getUser().setPassword(client.getProperty("omero.rootpass"));
         Gateway gw = new Gateway(new SimpleLogger());
         ExperimenterData root = gw.connect(c);
+        Assert.assertNotNull(root);
+        gw.disconnect();
+    }
+
+    /**
+     * Check logging in using a session ID.
+     * @throws DSOutOfServiceException unexpected
+     */
+    @Test
+    public void testLoginWithCredentialsSessionId()
+            throws DSOutOfServiceException {
+        final omero.client client =  new omero.client();
+        final LoginCredentials c = new LoginCredentials(
+                root.getSessionId(),  // use an active session
+                client.getProperty("omero.host"),
+                Integer.parseInt(client.getProperty("omero.port")));
+        final Gateway gw = new Gateway(new SimpleLogger());
+        final ExperimenterData root = gw.connect(c);
         Assert.assertNotNull(root);
         gw.disconnect();
     }


### PR DESCRIPTION
# What this PR does

It is not obvious from our code how to use `LoginCredentials` to connect to the server using a session ID instead of a username and password. This PR adds a constructor to fit the session ID pattern and an integration test that uses it.

# Testing this PR

Check that the code looks clear and that https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.gateway/GatewayUsageTest/ passes.

# Related reading

https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8071