### PR TITLE
Deprecate OmeroPopo module

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/OmeroPopo.py
+++ b/components/tools/OmeroPy/src/omero/util/OmeroPopo.py
@@ -38,6 +38,7 @@ from omero.model import MaskI
 from omero.model import NamespaceI
 from omero.rtypes import rdouble, rint, rlong, rstring
 
+import warnings
 # Popo helpers #
 
 
@@ -47,6 +48,8 @@ def toCSV(list):
     @param list The list to convert.
     @return See above.
     """
+    warnings.warn(
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
     lenList = len(list)
     cnt = 0
     str = ""
@@ -64,6 +67,8 @@ def toList(csvString):
     @param csvString The CSV string to convert.
     @return See above.
     """
+    warnings.warn(
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
     list = csvString.split(',')
     for index in range(len(list)):
         list[index] = list[index].strip()
@@ -81,6 +86,8 @@ class DataObject(object):
     #
 
     def __init__(self):
+        warnings.warn(
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
         self.value = None
         self.dirty = False
 

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -1279,7 +1279,8 @@ def registerNamespace(iQuery, iUpdate, namespace, keywords):
     @return see above.
     """
     from omero.util.OmeroPopo import WorkflowData as WorkflowData
-
+    warnings.warn(
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
     # Support rstring and str namespaces
     namespace = unwrap(namespace)
     keywords = unwrap(keywords)
@@ -1311,6 +1312,8 @@ def findROIByImage(roiService, image, namespace):
     @return see above.
     """
     from omero.util.OmeroPopo import ROIData as ROIData
+    warnings.warn(
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
     roiOptions = omero.api.RoiOptions()
     roiOptions.namespace = omero.rtypes.rstring(namespace)
     results = roiService.findByImage(image, roiOptions)


### PR DESCRIPTION
See https://trello.com/c/0dkqUU9f/51-deprecate-omeropopo-py

The `omero.util.OmeroPopo` module is no longer actively used in our repositories. As suggested in the card, this PR deprecates the various classes as well as the two isolated methods `omero.util.script_utils.registerNamespace()` and `omero.util.script_utils.findROIByImage()` which were consuming it.

To test this PR, check all tests remain green and that there is no other place in this code or elsewhere (scripts) where these methods are used.