### PR TITLE
add url_suffix for custom javascript files

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -87,12 +87,12 @@
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.editinplace-0.1.2.js" %}"></script>
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.form-3.51.js" %}"></script>
     <script type="text/javascript" src="{% static "webclient/javascript/ome.tagging_form.js"|add:url_suffix %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_tags_pane.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_fileanns_pane.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_comments_pane.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_customanns_pane.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_ratings_pane.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_mapanns_pane.js" %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_tags_pane.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_fileanns_pane.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_comments_pane.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_customanns_pane.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_ratings_pane.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_mapanns_pane.js"|add:url_suffix %}"></script>
 
     <!-- preview viewer... -->
     <script type="text/javascript" src="{% static "3rdparty/jquery.blockUI-2.66.0.js" %}"></script>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -38,14 +38,14 @@
     {{ block.super }}
 
     <script type="text/javascript" src="{% static "3rdparty/jquery.jstree-3.0.8/jstree.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.locate_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.conditionalselect_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.pagination_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.fields_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.omecut_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.ometools_plugin.js" %}"></script>
-   <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.childcount_plugin.js" %}"></script>
-   <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.truncatetext_plugin.js" %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.locate_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.conditionalselect_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.pagination_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.fields_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.omecut_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.ometools_plugin.js"|add:url_suffix %}"></script>
+   <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.childcount_plugin.js"|add:url_suffix %}"></script>
+   <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.truncatetext_plugin.js"|add:url_suffix %}"></script>
 
     <script type="text/javascript" src="{% static 'webclient/javascript/ome.chgrp.js'|add:url_suffix %}"></script>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -30,10 +30,10 @@
 {% block script %}
     {{ block.super }}
     <script type="text/javascript" src="{% static "3rdparty/jquery.jstree-3.0.8/jstree.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.locate_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.conditionalselect_plugin.js" %}"></script>
-    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.ometools_plugin.js" %}"></script>
-   <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.truncatetext_plugin.js" %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.locate_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.conditionalselect_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.ometools_plugin.js"|add:url_suffix %}"></script>
+    <script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.truncatetext_plugin.js"|add:url_suffix %}"></script>
 
     <script type="text/javascript">
 


### PR DESCRIPTION
# What this PR does

This PR adds url_suffix to all ome custom JavaScript files

# Testing this PR

To test this PR go to:
 - page webclient/userdata/ check:
    - `<script type="text/javascript" src="{% static "webclient/javascript/ome.right_panel_tags_*` 
    - `<script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.*`
 - page webclient/public/ check:
   - `<script type="text/javascript" src="{% static "webclient/javascript/jquery.jstree.*`
has build number

Basically, make sure if all JS files contains either build number or 3rd party libraries container version number in the path

cc @will-moore 