### PR TITLE
Bump Bio-Formats version to 5.2.0-m4

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -904,7 +904,7 @@ versions.asm=1.5.3
 versions.axis=1.4
 versions.backport=3.1
 versions.batik=1.8pre-jdk6
-versions.bioformats=5.1.9
+versions.bioformats=5.2.0-m4
 versions.btm=2.1.3
 versions.cglib=2.2
 versions.checkstyle=4.3
@@ -976,6 +976,3 @@ versions.bufr=1.1.00
 ###
 ### Appended Values
 ###
-
-# Override BIo-Formats version for the model work
-versions.bioformats=5.2.0-SNAPSHOT


### PR DESCRIPTION
With the finalization of the 2016-06 model and the release of Bio-Formats 5.2.0-m4, there is no more need for the development branch in OMERO to overwrite the Bio-Formats version and consume a SNAPSHOT version.

To test this PR, check that Travis is green, all integration tests pass and that OMERO bundles Bio-Formats 5.2.0-m4 (`bin/omero import -f test.fake` should report the version).

Once merged, as in previous versions, a staging PR can be opened bumping the `versions.bioformats` version to 5.2.0-SNAPSHOT to allow BIo-Formats PRs to be tested in the daily merge build of OMERO>
