### PR TITLE
Initial implementation of "group shares" (rebased onto develop)

### DIFF
--- a/components/server/src/ome/services/sharing/BlobShareStore.java
+++ b/components/server/src/ome/services/sharing/BlobShareStore.java
@@ -44,6 +44,7 @@ import ome.model.display.QuantumDef;
 import ome.model.display.RenderingDef;
 import ome.model.display.Thumbnail;
 import ome.model.meta.Experimenter;
+import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.Share;
 import ome.model.meta.ShareMember;
 import ome.model.stats.StatsInfo;
@@ -299,8 +300,18 @@ public class BlobShareStore extends ShareStore implements
          * "left outer join fetch r.quantization "
          */
 
-        List<Long> images = data.objectMap.get(Image.class.getName());
         Session s = session();
+
+        List<Long> groups = data.objectMap.get(ExperimenterGroup.class.getName());
+        if (groups.size() > 0) {
+            ExperimenterGroup g = (ExperimenterGroup) s.createQuery(
+                    String.format("select x.details.group from %s x where x.id = %d", kls.getSimpleName(), objId)).uniqueResult();
+            if (g != null && groups.contains(g.getId())) {
+                return true;
+            }
+        }
+
+        List<Long> images = data.objectMap.get(Image.class.getName());
         if (Pixels.class.isAssignableFrom(kls)) {
             return imagesContainsPixels(s, images, objId, pixToImageCache);
         } else if (RenderingDef.class.isAssignableFrom(kls)) {


### PR DESCRIPTION

This is the same as gh-4709 but rebased onto develop.

----

Rather than placing multiple elements from a single-group in
a share, this allows adding an entire group to a share creating
a proper read-only environment. Primary concern here is under
what conditions should this be **disallowed** since, for example,
it allows illegally opening up a private group.

                