### PR TITLE
Refactor PojoMapper

### DIFF
--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -120,7 +120,7 @@ public class BrowseFacility extends Facility {
             throws DSOutOfServiceException, DSAccessException {
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
-            return PojoMapper.asDataObjects(service.loadContainerHierarchy(
+            return PojoMapper.convertToDataObjects(service.loadContainerHierarchy(
                     PojoMapper.getModelType(rootType).getName(), rootIDs,
                     options));
         } catch (Throwable t) {
@@ -1157,7 +1157,7 @@ public class BrowseFacility extends Facility {
                 sb.append(" and img.details.owner.id = :userID");
                 param.addLong("userID", userID);
             }
-            return PojoMapper.asDataObjects(svc.findAllByQuery(sb.toString(),
+            return PojoMapper.<ImageData>convertToDataObjects(svc.findAllByQuery(sb.toString(),
                     param));
         } catch (Throwable t) {
             logError(this, "Could not load orphaned images", t);

--- a/components/blitz/src/omero/gateway/util/PojoMapper.java
+++ b/components/blitz/src/omero/gateway/util/PojoMapper.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -229,6 +230,8 @@ public class PojoMapper
      * @return A set of {@link DataObject}s.
      * @throws IllegalArgumentException If the set is <code>null</code>, doesn't
      * contain {@link IObject} or if the type {@link IObject} is unknown.
+     * 
+     * @deprecated Use {@link #convertToDataObjects(Collection)} instead
      */
     public static Set asDataObjects(Collection objects)
     {
@@ -251,6 +254,30 @@ public class PojoMapper
      * @return A set of {@link DataObject}s.
      * @throws IllegalArgumentException If the set is <code>null</code>, doesn't
      * contain {@link IObject} or if the type {@link IObject} is unknown.
+     */
+    public static <T extends DataObject> Collection<T> convertToDataObjects(Collection objects)
+    {
+        if (objects == null) return Collections.EMPTY_LIST;
+        Collection<T> result = new ArrayList<T>(objects.size());
+        Iterator i = objects.iterator();
+        DataObject data;
+        while (i.hasNext()) {
+            data = asDataObject((IObject) i.next());
+            if (data != null) result.add(((T)data));
+        }
+        return result;
+    }
+    
+    /**
+     * Converts each {@link IObject element} of the collection into its 
+     * corresponding {@link DataObject}.
+     *
+     * @param objects The set of objects to convert.
+     * @return A set of {@link DataObject}s.
+     * @throws IllegalArgumentException If the set is <code>null</code>, doesn't
+     * contain {@link IObject} or if the type {@link IObject} is unknown.
+     * 
+     * @deprecated Use {@link #convertToDataObjects(Collection)} instead 
      */
     public static List asDataObjectsAsList(Collection objects)
     {
@@ -277,7 +304,7 @@ public class PojoMapper
     public static <T extends DataObject> Collection<T> asCastedDataObjects(List objects)
     {
         if (objects == null) return new HashSet<T>();
-        Set<T> set = new HashSet<T>(objects.size());
+        Collection<T> set = new ArrayList<T>(objects.size());
         Iterator i = objects.iterator();
         DataObject data;
         while (i.hasNext()) {
@@ -296,6 +323,8 @@ public class PojoMapper
      * @return A set of {@link DataObject}s.
      * @throws IllegalArgumentException If the set is <code>null</code>, doesn't
      * contain {@link IObject} or if the type {@link IObject} is unknown.
+     * 
+     * @deprecated Use {@link #convertToDataObjects(Collection)} instead 
      */
     public static Set asDataObjects(List objects)
     {
@@ -318,6 +347,8 @@ public class PojoMapper
      * @return A set of {@link DataObject}s.
      * @throws IllegalArgumentException If the set is <code>null</code>, doesn't
      * contain {@link IObject} or if the type {@link IObject} is unknown.
+     * 
+     * @deprecated Use {@link #convertToDataObjects(Collection)} instead
      */
     public static Set asDataObjects(IObject[] objects)
     {
@@ -433,6 +464,13 @@ public class PojoMapper
         throw new IllegalArgumentException("type not supported");
     }
 
+    /**
+     * Get the pojo type for a an {@link IObject}
+     * 
+     * @param modelType
+     *            The {@link IObject}
+     * @return See above
+     */
     public static Class<? extends DataObject> getPojoType(Class<? extends IObject> modelType) {
         if (OriginalFile.class.equals(modelType))
             return FileData.class;
@@ -658,7 +696,7 @@ public class PojoMapper
      * Returns the name of the data type which has to used for Graph actions,
      * see {@link Requests}
      *
-     * @param dataType
+     * @param dataType The pojo type
      * @return See above
      */
     public static String getGraphType(Class<? extends DataObject> dataType) {

--- a/components/blitz/src/omero/gateway/util/PojoMapper.java
+++ b/components/blitz/src/omero/gateway/util/PojoMapper.java
@@ -443,6 +443,8 @@ public class PojoMapper
      *
      * @param nodeType The type to convert.
      * @return See above.
+     * 
+     * @deprecated Not used.
      */
     public static String convertTypeForSearchByQuery(Class nodeType) {
         if (nodeType.equals(Image.class) || nodeType.equals(ImageData.class))
@@ -465,7 +467,8 @@ public class PojoMapper
     }
 
     /**
-     * Get the pojo type for a an {@link IObject}
+     * Get the pojo type for a an {@link IObject} class
+     * (Reverse of {@link #getModelType(Class)})
      * 
      * @param modelType
      *            The {@link IObject}
@@ -519,7 +522,8 @@ public class PojoMapper
     }
 
     /**
-     * Converts the specified POJO into the corresponding model class
+     * Converts the specified POJO into the corresponding model class,
+     * see {@link #getModelType(Class)}
      *
      * @param pojoType
      *            The POJO class (Either the simple or the full
@@ -614,12 +618,12 @@ public class PojoMapper
     
     /**
      * Converts the specified POJO into the corresponding model class.
-     *
+     * (Reverse of {@link #getPojoType(Class)})
      * @param pojoType
      *            The POJO class.
      * @return The corresponding {@link IObject} class.
      */
-    public static Class<? extends IObject> getModelType(Class pojoType) {
+    public static Class<? extends IObject> getModelType(Class<? extends DataObject> pojoType) {
         if (!DataObject.class.isAssignableFrom(pojoType))
             throw new IllegalArgumentException(pojoType.getSimpleName()+" is not a DataObject");
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -969,56 +969,63 @@ public class FileImportComponent
 			imageLabel.setData((PlateData) image);
 			fileNameLabel.addMouseListener(adapter);
 			formatResultTooltip();
-		} else if (image instanceof Set) {
-			//Result from the import itself
-			this.image = null;
-			Set set = (Set) image;
-			Iterator i = set.iterator();
-			FileObject f;
-			while (i.hasNext()) {
-                Object object = i.next();
-                if (object instanceof PixelsData) {
-                    PixelsData pix = (PixelsData) object;
-                    if (hasAssociatedFiles()) {
-                        int series = pix.getImage().getSeries();
-                        f = getAssociatedFile(series);
-                        if (f != null) {
-                            f.setImageID(pix.getImage().getId());
-                        }
-                    } else {
-                        f = getOriginalFile();
-                        f.setImageID(pix.getImage().getId());
-                    }
-                }
-            }
-			formatResult();
-		} else if (image instanceof List) {
-			List<ThumbnailData> list = new ArrayList<ThumbnailData>((List) image);
-			int m = list.size();
-			ThumbnailData data = list.get(0);
-			imageLabel.setData(data);
-			list.remove(0);
-			if (list.size() > 0) {
-				ThumbnailLabel label = imageLabels.get(0);
-				label.setVisible(true);
-				label.setData(list.get(0));
-				list.remove(0);
-				if (list.size() > 0) {
-					label = imageLabels.get(1);
-					label.setVisible(true);
-					label.setData(list.get(0));
-					list.remove(0);
-					int n = statusLabel.getNumberOfImportedFiles()-m;
-					if (n > 0) {
-						label = imageLabels.get(2);
-						label.setVisible(true);
-						StringBuffer buf = new StringBuffer("... ");
-						buf.append(n);
-						buf.append(" more");
-						label.setText(buf.toString());
-					}
-				}
-			}
+		}
+		else if (image instanceof Collection){
+		    Collection<?> c = (Collection)image;
+		    if(!c.isEmpty()) {
+		        Object obj = c.iterator().next();
+		        if(obj instanceof ThumbnailData) {
+		            List<ThumbnailData> list = new ArrayList<ThumbnailData>((Collection) image);
+		            int m = list.size();
+		            ThumbnailData data = list.get(0);
+		            imageLabel.setData(data);
+		            list.remove(0);
+		            if (list.size() > 0) {
+		                ThumbnailLabel label = imageLabels.get(0);
+		                label.setVisible(true);
+		                label.setData(list.get(0));
+		                list.remove(0);
+		                if (list.size() > 0) {
+		                    label = imageLabels.get(1);
+		                    label.setVisible(true);
+		                    label.setData(list.get(0));
+		                    list.remove(0);
+		                    int n = statusLabel.getNumberOfImportedFiles()-m;
+		                    if (n > 0) {
+		                        label = imageLabels.get(2);
+		                        label.setVisible(true);
+		                        StringBuffer buf = new StringBuffer("... ");
+		                        buf.append(n);
+		                        buf.append(" more");
+		                        label.setText(buf.toString());
+		                    }
+		                }
+		            }
+		        }
+		        else if (obj instanceof PixelsData) {
+		           //Result from the import itself
+		            this.image = null;
+		            Iterator i = c.iterator();
+		            FileObject f;
+		            while (i.hasNext()) {
+		                Object object = i.next();
+		                if (object instanceof PixelsData) {
+		                    PixelsData pix = (PixelsData) object;
+		                    if (hasAssociatedFiles()) {
+		                        int series = pix.getImage().getSeries();
+		                        f = getAssociatedFile(series);
+		                        if (f != null) {
+		                            f.setImageID(pix.getImage().getId());
+		                        }
+		                    } else {
+		                        f = getOriginalFile();
+		                        f.setImageID(pix.getImage().getId());
+		                    }
+		                }
+		            }
+		            formatResult();
+		        }
+		    }
 		} else if (image instanceof ImportException) {
 			if (getFile().isDirectory()) {
 				this.image = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
@@ -240,7 +240,7 @@ public class ExperimenterDataLoader
     		Class klass = parent.getUserObject().getClass();
     		long id = parent.getUserObjectId();
     		if (TagAnnotationData.class.equals(klass)) {
-    			viewer.setLeaves((Set) result, parent, expNode);
+    			viewer.setLeaves((Collection) result, parent, expNode);
     		} else {
     			while (i.hasNext()) {
         			object = (DataObject) i.next();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2281,7 +2281,7 @@ public class EditorUtil
             if (t != null)  {
                 notSet.remove(DELTA_T);
                 try {
-                    details.put(DELTA_T, UnitsFactory.convertTime(t, UNITS.S).getValue());
+                    details.put(DELTA_T, UnitsFactory.convertTime(t, UNITS.SECOND).getValue());
                 } catch (BigResult e) {
                     details.put(DELTA_T, e);
                 }
@@ -2290,7 +2290,7 @@ public class EditorUtil
             if (t != null) {
                 notSet.remove(EXPOSURE_TIME);
                 try {
-                    details.put(EXPOSURE_TIME, UnitsFactory.convertTime(t, UNITS.S).getValue());
+                    details.put(EXPOSURE_TIME, UnitsFactory.convertTime(t, UNITS.SECOND).getValue());
                 } catch (BigResult e) {
                     details.put(EXPOSURE_TIME, e);
                 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -7409,7 +7409,7 @@ class OMEROGateway
 	 * retrieve data from OMERO service.
 	 */
 	Map<Long, Collection<AnnotationData>>
-	loadSpecifiedAnnotationsLinkedTo(SecurityContext ctx, Class<?> rootType,
+	loadSpecifiedAnnotationsLinkedTo(SecurityContext ctx, Class<? extends DataObject> rootType,
 			List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
 			List<String> nsExclude, Parameters options)
 	throws DSOutOfServiceException, DSAccessException
@@ -7470,7 +7470,7 @@ class OMEROGateway
 	 * retrieve data from OMERO service.
 	 */
 	Map<Long, Map<Boolean, List<Long>>> getImagesBySplitFilesets(
-			SecurityContext ctx, Class<?> rootType, List<Long> rootIDs,
+			SecurityContext ctx, Class<? extends DataObject> rootType, List<Long> rootIDs,
 			Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -7520,7 +7520,7 @@ class OMEROGateway
      * retrieve data from OMERO service.
      */
     Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
-            Class<?> rootType, List<Long> rootIDs)
+            Class<? extends DataObject> rootType, List<Long> rootIDs)
             throws DSOutOfServiceException, DSAccessException
     {
        

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1610,9 +1610,6 @@ class OMEROGateway
 	 * i.e. the requested node as root and all of its descendants.
 	 * The annotation for the current user is also linked to the object.
 	 * Annotations are currently possible only for Image and Dataset.
-	 * Wraps the call to the
-	 * {@link IPojos#loadContainerHierarchy(Class, List, Map)}
-	 * and maps the result calling {@link PojoMapper#asDataObjects(Set)}.
 	 *
 	 * @param ctx The security context, necessary to determine the service.
 	 * @param rootType  The top-most type which will be searched for
@@ -1628,15 +1625,14 @@ class OMEROGateway
 	 * retrieve data from OMERO service.
 	 * @see IPojos#loadContainerHierarchy(Class, List, Map)
 	 */
-	Set loadContainerHierarchy(SecurityContext ctx, Class rootType,
+	Collection<DataObject> loadContainerHierarchy(SecurityContext ctx, Class rootType,
 			List rootIDs, Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	    try {
             BrowseFacility f = gw.getFacility(BrowseFacility.class);
-            // TODO: tmp solution, should be changed to Collection<DataObject> throughout
-           return new HashSet(f.loadHierarchy(ctx, rootType,
-                    rootIDs, options));
+           return f.getHierarchy(ctx, rootType,
+                    rootIDs, options);
         } catch (Throwable e) {
             handleException(e, "Cannot load hierarchy for "+rootType+".");
         }
@@ -1651,7 +1647,7 @@ class OMEROGateway
 	 * Annotations are currently possible only for Image and Dataset.
 	 * Wraps the call to the
 	 * {@link IPojos#findContainerHierarchies(Class, List, Map)}
-	 * and maps the result calling {@link PojoMapper#asDataObjects(Set)}.
+	 * and maps the result calling {@link PojoMapper#convertToDataObjects(Set)}.
 	 *
 	 * @param ctx The security context, necessary to determine the service.
 	 * @param rootNodeType  top-most type which will be searched for
@@ -1666,14 +1662,14 @@ class OMEROGateway
 	 * retrieve data from OMERO service.
 	 * @see IPojos#findContainerHierarchies(Class, List, Map)
 	 */
-	Set findContainerHierarchy(SecurityContext ctx, Class rootNodeType,
+	Collection<DataObject> findContainerHierarchy(SecurityContext ctx, Class rootNodeType,
 			List leavesIDs, Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		try {
 		    IContainerPrx service = gw.getPojosService(ctx);
-			return PojoMapper.asDataObjects(service.findContainerHierarchies(
-					PojoMapper.getModelType(rootNodeType).getName(), leavesIDs, options));
+			return PojoMapper.convertToDataObjects((service.findContainerHierarchies(
+					PojoMapper.getModelType(rootNodeType).getName(), leavesIDs, options)));
 		} catch (Throwable t) {
 			handleException(t, "Cannot find hierarchy for "+rootNodeType+".");
 		}
@@ -1688,9 +1684,6 @@ class OMEROGateway
 	 * that were found for that node. If no annotations were found for that
 	 * node, then the entry will be <code>null</code>. Otherwise it will be a
 	 * <code>Set</code> containing <code>Annotation</code> objects.
-	 * Wraps the call to the
-	 * {@link IMetadataPrx#loadAnnotations(String, List, List, List)}
-	 * and maps the result calling {@link PojoMapper#asDataObjects(Parameters)}.
 	 *
 	 * @param ctx The security context.
 	 * @param nodeType      The type of the rootNodes.
@@ -1748,7 +1741,7 @@ class OMEROGateway
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.s
 	 */
-	Set<DataObject> loadAnnotation(SecurityContext ctx,
+	Collection<DataObject> loadAnnotation(SecurityContext ctx,
 			List<Long> annotationIds)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -1757,7 +1750,7 @@ class OMEROGateway
 
 		try {
 		    IMetadataPrx service = gw.getMetadataService(ctx);
-			return PojoMapper.asDataObjects(
+			return PojoMapper.convertToDataObjects(
 					service.loadAnnotation(annotationIds));
 		} catch (Throwable t) {
 			handleException(t, "Cannot find the annotations.");
@@ -1801,7 +1794,7 @@ class OMEROGateway
 	 * Retrieves the images contained in containers specified by the
 	 * node type.
 	 * Wraps the call to the {@link IPojos#getImages(Class, List, Parameters)}
-	 * and maps the result calling {@link PojoMapper#asDataObjects(Set)}.
+	 * and maps the result calling {@link PojoMapper#convertToDataObjects(Set)}.
 	 *
 	 * @param ctx The security context.
 	 * @param nodeType  The type of container. Can be either Project, Dataset.
@@ -1813,13 +1806,13 @@ class OMEROGateway
 	 * retrieve data from OMERO service.
 	 * @see IPojos#getImages(Class, List, Map)
 	 */
-	Set getContainerImages(SecurityContext ctx, Class nodeType, List nodeIDs,
+	Collection<ImageData> getContainerImages(SecurityContext ctx, Class nodeType, List nodeIDs,
 			Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		try {
 		    IContainerPrx service = gw.getPojosService(ctx);
-			return PojoMapper.asDataObjects(service.getImages(
+			return PojoMapper.<ImageData>convertToDataObjects(service.getImages(
 					PojoMapper.getModelType(nodeType).getName(), nodeIDs, options));
 		} catch (Throwable t) {
 			handleException(t, "Cannot find images for "+nodeType+".");
@@ -1828,10 +1821,7 @@ class OMEROGateway
 	}
 
     /**
-     * Retrieves the images imported by the current user. Wraps the call to the
-     * {@link IPojos#getUserImages(Parameters)} and maps the result calling
-     * {@link PojoMapper#asDataObjects(Set)}.
-     *
+     * Retrieves the images imported by the current user.
      * @param ctx
      *            The security context.
      * @param userID
@@ -3935,7 +3925,7 @@ class OMEROGateway
 		try {
 		    IContainerPrx service = gw.getPojosService(ctx);
 			List result = service.getImagesByOptions(map);
-			if (asDataObject) return PojoMapper.asDataObjects(result);
+			if (asDataObject) return PojoMapper.convertToDataObjects(result);
 			return result;
 		} catch (Exception e) {
 			handleException(e, "Cannot retrieve the images imported during " +
@@ -4241,14 +4231,14 @@ class OMEROGateway
 	 * @throws DSAccessException        If an error occurred while trying to
 	 *                                  retrieve data from OMEDS service.
 	 */
-	Set loadSpecificAnnotation(SecurityContext ctx, Class type,
+	Collection<DataObject> loadSpecificAnnotation(SecurityContext ctx, Class type,
 			List<String> toInclude, List<String> toExclude, Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	   
 		try {
 		    IMetadataPrx service = gw.getMetadataService(ctx);
-			return PojoMapper.asDataObjects(
+			return PojoMapper.convertToDataObjects(
 					service.loadSpecifiedAnnotations(
 							PojoMapper.getModelType(type).getName(), toInclude,
 							toExclude, options));
@@ -4370,7 +4360,7 @@ class OMEROGateway
 	 * @throws DSAccessException        If an error occurred while trying to
 	 *                                  retrieve data from OMEDS service.
 	 */
-	Set searchByTime(SecurityContext ctx, SearchDataContext context)
+	Collection<DataObject> searchByTime(SecurityContext ctx, SearchDataContext context)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	   
@@ -4438,7 +4428,7 @@ class OMEROGateway
 			} else
 				buf.append("where owner.id in (:ids)");
 
-			return PojoMapper.asDataObjects(
+			return PojoMapper.convertToDataObjects(
 					service.findAllByQuery(buf.toString(), param));
 		} catch (Throwable e) {
 			handleException(e, "Cannot retrieve the images.");
@@ -4717,7 +4707,7 @@ class OMEROGateway
 	 * @throws DSAccessException        If an error occurred while trying to
 	 *                                  retrieve data from OMEDS service.
 	 */
-	Set fetchContainers(SecurityContext ctx, Class type, long userID)
+	Collection<DataObject> fetchContainers(SecurityContext ctx, Class type, long userID)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	   
@@ -4727,7 +4717,7 @@ class OMEROGateway
 			p.map = new HashMap<String, RType>();
 			p.map.put("id", omero.rtypes.rlong(userID));
 			String table = getTableForClass(type);
-			return PojoMapper.asDataObjects(service.findAllByQuery(
+			return PojoMapper.convertToDataObjects(service.findAllByQuery(
 	                "from "+table+" as p where p.details.owner.id = :id", p));
 		} catch (Throwable t) {
 			handleException(t, "Cannot retrieve the containers.");
@@ -4747,7 +4737,7 @@ class OMEROGateway
 	 * @throws DSAccessException        If an error occurred while trying to
 	 *                                  retrieve data from OMEDS service.
 	 */
-	Set getAnnotatedObjects(SecurityContext ctx, Class type,
+	Collection<DataObject> getAnnotatedObjects(SecurityContext ctx, Class type,
 			Set<Long> annotationIds, Set<Long> ownerIds)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -4770,7 +4760,7 @@ class OMEROGateway
 	            	sb.append(" and img.details.owner.id in (:ownerIds)");
 	            	param.addLongs("ownerIds", ownerIds);
 	            }
-	            return PojoMapper.asDataObjects(
+	            return PojoMapper.convertToDataObjects(
 	         			service.findAllByQuery(sb.toString(), param));
 			}
 		} catch (Exception e) {
@@ -4935,12 +4925,12 @@ class OMEROGateway
 		throws DSOutOfServiceException, DSAccessException
 	{
 		try {
-			Set result = getContainerImages(ctx, ImageData.class,
+			Collection<ImageData> result = getContainerImages(ctx, ImageData.class,
 					Arrays.asList(imageID), options);
 			if (result != null && result.size() == 1) {
-				Iterator i = result.iterator();
+				Iterator<ImageData> i = result.iterator();
 				while (i.hasNext())
-					return (ImageData) i.next();
+					return i.next();
 			}
 			return null;
 		} catch (Exception e) {
@@ -5268,7 +5258,7 @@ class OMEROGateway
 	 * @throws DSAccessException        If an error occurred while trying to
 	 *                                  retrieve data from OMEDS service.
 	 */
-	Collection loadTags(SecurityContext ctx, Long id, Parameters options)
+	Collection<DataObject> loadTags(SecurityContext ctx, Long id, Parameters options)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	   
@@ -5279,7 +5269,7 @@ class OMEROGateway
 			Map m = service.loadTagContent(ids, options);
 			if (m == null || m.size() == 0)
 				return new ArrayList();
-			return PojoMapper.asDataObjects((Collection) m.get(id));
+			return PojoMapper.convertToDataObjects((Collection) m.get(id));
 		} catch (Exception e) {
 			handleException(e, "Cannot find the Tags.");
 		}
@@ -5303,7 +5293,7 @@ class OMEROGateway
 	   
 		try {
 		    IMetadataPrx service = gw.getMetadataService(ctx);
-			return PojoMapper.asDataObjects(service.loadTagSets(options));
+			return PojoMapper.convertToDataObjects(service.loadTagSets(options));
 		} catch (Exception e) {
 			handleException(e, "Cannot find the Tags.");
 		}
@@ -6171,7 +6161,7 @@ class OMEROGateway
 		    IRoiPrx svc = gw.getROIService(ctx);
 			RoiOptions options = new RoiOptions();
 			options.userId = omero.rtypes.rlong(userID);
-			Collection files = PojoMapper.asDataObjects(
+			Collection files = PojoMapper.convertToDataObjects(
 					svc.getRoiMeasurements(imageID, options));
 			List results = new ArrayList();
 			if (files != null) {
@@ -6669,7 +6659,7 @@ class OMEROGateway
 		                + "left outer join fetch m2.parent" +
 		                		" where g.id = :id", p);
 			}
-			pojos.addAll(PojoMapper.asDataObjects(groups));
+			pojos.addAll(PojoMapper.<GroupData>convertToDataObjects(groups));
 			return pojos;
 		} catch (Throwable t) {
 			handleException(t, "Cannot retrieve the available groups ");
@@ -6703,7 +6693,7 @@ class OMEROGateway
 	                + "left outer join fetch g.groupExperimenterMap m "
 	                + "left outer join fetch m.child u "
 	                + " where u.id = :id", p);
-			pojos.addAll(PojoMapper.asDataObjects(groups));
+			pojos.addAll(PojoMapper.<GroupData>convertToDataObjects(groups));
 			return pojos;
 		} catch (Throwable t) {
 			handleException(t, "Cannot retrieve the available groups ");
@@ -6731,7 +6721,7 @@ class OMEROGateway
 		try {
 		    IAdminPrx service = gw.getAdminService(ctx);
 			List<Experimenter> l = service.lookupExperimenters();
-			pojos.addAll(PojoMapper.asDataObjects(l));
+			pojos.addAll(PojoMapper.<ExperimenterData>convertToDataObjects(l));
 		} catch (Throwable t) {
 			handleException(t, "Cannot retrieve the existing groups.");
 		}
@@ -7367,7 +7357,7 @@ class OMEROGateway
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
-	Set<DataObject> getFileSet(SecurityContext ctx, Collection<Long> imageIds)
+	Collection<DataObject> getFileSet(SecurityContext ctx, Collection<Long> imageIds)
 		throws DSOutOfServiceException, DSAccessException
 	{
 	   
@@ -7379,7 +7369,7 @@ class OMEROGateway
 				l.add(omero.rtypes.rlong(j.next()));
 			ParametersI param = new ParametersI();
 			param.add("imageIds", omero.rtypes.rlist(l));
-			return PojoMapper.asDataObjects(service.findAllByQuery(
+			return PojoMapper.convertToDataObjects(service.findAllByQuery(
 					createFileSetQuery(), param));
 		} catch (Exception e) {
 			handleException(e, "Cannot retrieve the file set");

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -77,7 +77,7 @@ public interface OmeroDataService
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
-	public Set loadContainerHierarchy(SecurityContext ctx,
+	public Collection<DataObject> loadContainerHierarchy(SecurityContext ctx,
 			Class rootNodeType, List rootNodeIDs, boolean withLeaves,
 			long userID)
 		throws DSOutOfServiceException, DSAccessException;
@@ -96,7 +96,7 @@ public interface OmeroDataService
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
-	public Set loadTopContainerHierarchy(SecurityContext ctx,
+	public Collection<DataObject> loadTopContainerHierarchy(SecurityContext ctx,
 			Class rootNodeType, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 
@@ -160,7 +160,7 @@ public interface OmeroDataService
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
-	public Set findContainerHierarchy(SecurityContext ctx,
+	public Collection<DataObject> findContainerHierarchy(SecurityContext ctx,
 			Class rootNodeType, List leavesIDs, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 
@@ -178,7 +178,7 @@ public interface OmeroDataService
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	 */
-	public Set getImages(SecurityContext ctx, Class nodeType, List nodeIDs,
+	public Collection<ImageData> getImages(SecurityContext ctx, Class nodeType, List nodeIDs,
 			long userID)
 		throws DSOutOfServiceException, DSAccessException;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -487,7 +487,7 @@ public interface OmeroDataService
 	 * retrieve data from OMERO service.
 	 */
 	public Map<Long, Map<Boolean, List<ImageData>>> getImagesBySplitFilesets(
-			SecurityContext ctx, Class<?> rootType, List<Long> rootIDs)
+			SecurityContext ctx, Class<? extends DataObject> rootType, List<Long> rootIDs)
 		throws DSOutOfServiceException, DSAccessException;
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -208,7 +208,7 @@ class OmeroDataServiceImpl
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroDataService#loadContainerHierarchy(SecurityContext, Class, List, boolean, long)
 	 */
-	public Set loadContainerHierarchy(SecurityContext ctx,
+	public Collection<DataObject> loadContainerHierarchy(SecurityContext ctx,
 			Class rootNodeType, List rootNodeIDs, boolean withLeaves,
 			long userID)
 		throws DSOutOfServiceException, DSAccessException
@@ -232,7 +232,7 @@ class OmeroDataServiceImpl
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroDataService#loadTopContainerHierarchy(SecurityContext, Class, long)
 	 */
-	public Set loadTopContainerHierarchy(SecurityContext ctx,
+	public Collection<DataObject> loadTopContainerHierarchy(SecurityContext ctx,
 			Class rootNodeType, long userID)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -245,7 +245,7 @@ class OmeroDataServiceImpl
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroDataService#findContainerHierarchy(SecurityContext, Class, List, long)
 	 */
-	public Set findContainerHierarchy(SecurityContext ctx, Class rootNodeType,
+	public Collection<DataObject> findContainerHierarchy(SecurityContext ctx, Class rootNodeType,
 			List leavesIDs, long userID)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -259,7 +259,7 @@ class OmeroDataServiceImpl
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroDataService#getImages(SecurityContext, Class, List, long)
 	 */
-	public Set getImages(SecurityContext ctx, Class nodeType, List nodeIDs,
+	public Collection<ImageData> getImages(SecurityContext ctx, Class nodeType, List nodeIDs,
 			long userID)
 		throws DSOutOfServiceException, DSAccessException
 	{
@@ -686,11 +686,10 @@ class OmeroDataServiceImpl
                 SecurityContext ctx = new SecurityContext(groupId);
     
                 try {
-                    Set tmp = gateway.getContainerImages(ctx, ImageData.class, ids,
+                    Collection<ImageData> tmp = gateway.getContainerImages(ctx, ImageData.class, ids,
                             new Parameters());
                     
-                    for(Object obj : tmp) {
-                        ImageData img = (ImageData) obj;
+                    for(ImageData img : tmp) {
                         for(SearchResult r : byGroup.get(groupId)) {
                             if(r.getObjectId()==img.getId()) {
                                 r.setObject(img);
@@ -1087,7 +1086,7 @@ class OmeroDataServiceImpl
 				ids.addAll(j.next());
 			}
 		}
-		Set<ImageData> imgs = getImages(ctx, ImageData.class, ids, -1);
+		Collection<ImageData> imgs = getImages(ctx, ImageData.class, ids, -1);
 		Map<Long, ImageData> idMap = new HashMap<Long, ImageData>(imgs.size());
 		Iterator<ImageData> k = imgs.iterator();
 		ImageData img;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -1065,7 +1065,7 @@ class OmeroDataServiceImpl
 	 * List)
 	 */
 	public Map<Long, Map<Boolean, List<ImageData>>> getImagesBySplitFilesets(
-			SecurityContext ctx, Class<?> rootType, List<Long> rootIDs)
+			SecurityContext ctx, Class<? extends DataObject> rootType, List<Long> rootIDs)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		if (CollectionUtils.isEmpty(rootIDs) || rootType == null)

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -801,7 +801,7 @@ public interface OmeroImageService
 	 *                                  retrieve data from OMEDS service.
 	 * @throws ProcessException If an error occurred while running the script.
 	 */
-	public Set<DataObject> getFileSet(SecurityContext ctx, long imageId)
+	public Collection<DataObject> getFileSet(SecurityContext ctx, long imageId)
 		throws DSAccessException, DSOutOfServiceException;
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1866,7 +1866,7 @@ class OmeroImageServiceImpl
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroImageService#getFileSet(SecurityContext, long)
 	 */
-	public Set<DataObject> getFileSet(SecurityContext ctx, long imageId)
+	public Collection<DataObject> getFileSet(SecurityContext ctx, long imageId)
 		throws DSAccessException, DSOutOfServiceException
 	{
 		return gateway.getFileSet(ctx, Arrays.asList(imageId));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -730,7 +730,7 @@ public interface OmeroMetadataService
 	 * retrieve data from OMERO service.
 	 */
 	public Map<Long, Collection<AnnotationData>>
-	loadAnnotations(SecurityContext ctx, Class<?> rootType,
+	loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
 		List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
 		List<String> nsExlcude)
 	throws DSOutOfServiceException, DSAccessException;
@@ -747,7 +747,7 @@ public interface OmeroMetadataService
 	 * retrieve data from OMERO service.
 	 */
 	public Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
-	        Class<?> rootType, List<Long> rootIDs)
+	        Class<? extends DataObject> rootType, List<Long> rootIDs)
 	                throws DSOutOfServiceException, DSAccessException;
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -579,7 +579,7 @@ class OmeroMetadataServiceImpl
                             PojoMapper.asDataObject(link.getChild()));
                 }
             }
-			annotations.addAll(PojoMapper.asDataObjects(r));
+			annotations.addAll(PojoMapper.<AnnotationData>convertToDataObjects(r));
 		}
 		return annotations;
     }
@@ -1493,7 +1493,7 @@ class OmeroMetadataServiceImpl
 		Iterator<DataObject> j = data.iterator();
 		DataObject object, child;
 		List<Long> ids;
-		Set images = null;
+		Collection images = null;
 		Parameters po = new Parameters();
 		Iterator k;
 		List result = null;
@@ -2315,7 +2315,7 @@ class OmeroMetadataServiceImpl
 			throws DSOutOfServiceException, DSAccessException
 	{
 		//Tmp code
-		Set<DataObject> set = gateway.loadAnnotation(ctx, 
+	    Collection<DataObject> set = gateway.loadAnnotation(ctx, 
 				Arrays.asList(annotationID));
 		if (set.size() != 1) return null;
 		Iterator<DataObject> i = set.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -2468,7 +2468,7 @@ class OmeroMetadataServiceImpl
 	 * Class, List, List)
 	 */
 	public Map<Long, Collection<AnnotationData>>
-		loadAnnotations(SecurityContext ctx, Class<?> rootType,
+		loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
 			List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
 			List<String> nsExclude)
 		throws DSOutOfServiceException, DSAccessException
@@ -2486,7 +2486,7 @@ class OmeroMetadataServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#downloadMetadataFile(SecurityContext, File, long)
+	 * @see OmeroMetadataService#downloadMetadataFile(SecurityContext, File, long)
 	 */
 	public RequestCallback downloadMetadataFile(SecurityContext ctx,
 			File file, long id)
@@ -2501,10 +2501,10 @@ class OmeroMetadataServiceImpl
 
     /**
      * Implemented as specified by {@link OmeroDataService}.
-     * @see OmeroDataService#loadLogFiles(SecurityContext, Class, List)
+     * @see OmeroMetadataService#loadLogFiles(SecurityContext, Class, List)
      */
     public Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
-            Class<?> rootType, List<Long> rootIDs)
+            Class<? extends DataObject> rootType, List<Long> rootIDs)
                     throws DSOutOfServiceException, DSAccessException
    {
         if (rootType == null || CollectionUtils.isEmpty(rootIDs))
@@ -2514,7 +2514,7 @@ class OmeroMetadataServiceImpl
 
     /**
      * Implemented as specified by {@link OmeroDataService}.
-     * @see OmeroMetadataService#saveData(SecurityContext, Map, Map, long)
+     * @see OmeroMetadataService#saveAnnotationData(SecurityContext, Map, Map, long)
      */
     public void saveAnnotationData(SecurityContext ctx,
             Map<DataObject, List<AnnotationData>> toAdd,

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -26,11 +26,11 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.swing.Box;
 import javax.swing.JLabel;
@@ -218,7 +218,7 @@ public class StatusLabel
     private ImportException exception;
 
     /** The list of pixels' identifiers returned when the import is complete.*/
-    private Set<PixelsData> pixels;
+    private Collection<PixelsData> pixels;
 
     /** The file associated to that import.*/
     private FilesetData fileset;
@@ -648,7 +648,7 @@ public class StatusLabel
             step = 6;
             processingBar.setValue(step);
             processingBar.setString(STEPS.get(step));
-            pixels = (Set<PixelsData>) PojoMapper.asDataObjects(
+            pixels = PojoMapper.<PixelsData>convertToDataObjects(
                     ((ImportEvent.IMPORT_DONE) event).pixels);
             firePropertyChange(IMPORT_DONE_PROPERTY, null, this);
         } else if (event instanceof ImportCandidates.SCANNING) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -504,7 +504,7 @@ public interface MetadataHandlerView
 	 * @param nsExlcude The annotation's name space to exclude if any.
 	 * @return A handle that can be used to cancel the call.
 	 */
-	public CallHandle loadAnnotations(SecurityContext ctx, Class<?> rootType,
+	public CallHandle loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
 		List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
 		List<String> nsExlcude, AgentEventListener observer);
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -457,7 +457,7 @@ class MetadataHandlerViewImpl
 	 * @see MetadataHandlerView#loadAnnotations(SecurityContext, Class, List,
 	 * Class, List, List, AgentEventListener)
 	 */
-	public CallHandle loadAnnotations(SecurityContext ctx, Class<?> rootType,
+	public CallHandle loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
 			List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
 			List<String> nsExlcude, AgentEventListener observer)
 	{

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMLoader.java
@@ -20,13 +20,17 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import org.openmicroscopy.shoola.env.data.OmeroDataService;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ProjectData;
 import omero.gateway.model.ScreenData;
@@ -47,7 +51,7 @@ public class DMLoader
 {
 
     /** The results of the call. */
-    private Set results;
+    private Collection results;
     
     /** Loads the specified tree. */
     private BatchCall loadCall;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
@@ -93,7 +93,7 @@ public class DMRefreshLoader
         List containers;
         
         Object result;
-        Set set, children, newChildren, r;
+        Collection set, children, newChildren, r;
         List<Long> ids;
         Iterator i, j, c, k;
         Long id;
@@ -435,7 +435,7 @@ public class DMRefreshLoader
                 TagAnnotationData tag, child;
                 Map<Long, Collection<?>> values;
                 SecurityContext ctx;
-                Map<DataObject, Set<?>> mapForDataObject;
+                Map<DataObject, Collection<?>> mapForDataObject;
                 while (j.hasNext()) {
                     entry = j.next();
                     ctx = entry.getKey();
@@ -444,7 +444,7 @@ public class DMRefreshLoader
 
                     tags = os.loadTags(ctx, -1L, true, userID, ctx.getGroupID());
                     List<Object> tagResults = new ArrayList<Object>();
-                    mapForDataObject = new HashMap<DataObject, Set<?>>();
+                    mapForDataObject = new HashMap<DataObject, Collection<?>>();
                     if (CollectionUtils.isEmpty(l)) {
                         r.put(ctx, tags);
                     } else {
@@ -499,7 +499,7 @@ public class DMRefreshLoader
      */
     private void handleTags(Collection<TagAnnotationData> tags,
             List<Object> tagResults, Map<Long, Collection<?>> values,
-            Map<DataObject, Set<?>> mapForDataObject)
+            Map<DataObject, Collection<?>> mapForDataObject)
     {
         Iterator<TagAnnotationData> k = tags.iterator();
         TagAnnotationData tag, child;
@@ -536,7 +536,7 @@ public class DMRefreshLoader
      */
     private void populateTag(TagAnnotationData tag,
             Map<Long, Collection<?>> values,
-            Map<DataObject, Set<?>> mapForDataObject)
+            Map<DataObject, Collection<?>> mapForDataObject)
     {
         if (mapForDataObject.isEmpty()) {
             tag.setDataObjects((Set<DataObject>) values.get(tag.getId()));
@@ -557,13 +557,13 @@ public class DMRefreshLoader
      * @param map The list of reloaded object.
      * @param ho The data object of reference.
      */
-    private DataObject getLoadedObject(Map<DataObject, Set<?>> map,
+    private DataObject getLoadedObject(Map<DataObject, Collection<?>> map,
             DataObject ho)
     {
         Set<DataObject> sets = map.keySet();
         Iterator<DataObject> i = sets.iterator();
         DataObject object;
-        Set<?> s;
+        Collection<?> s;
         while (i.hasNext()) {
             object = i.next();
             if (object.getClass().equals(ho.getClass()) &&

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/HierarchyLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/HierarchyLoader.java
@@ -20,13 +20,17 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import org.openmicroscopy.shoola.env.data.OmeroDataService;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ProjectData;
 
@@ -59,7 +63,7 @@ public class HierarchyLoader
     private long        userID;
     
     /** The root nodes of the found trees. */
-    private Set         rootNodes;
+    private Collection         rootNodes;
     
     /** Loads the specified tree. */
     private BatchCall   loadCall;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ImageSplitChecker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ImageSplitChecker.java
@@ -143,7 +143,7 @@ public class ImageSplitChecker
 					e = i.next();
 					j = e.getValue().iterator();
 					ids = new ArrayList<Long>();
-					Class<?> klass = null;
+					Class<? extends DataObject> klass = null;
 					while (j.hasNext()) {
 						uo = j.next();
 						klass = uo.getClass();
@@ -154,7 +154,7 @@ public class ImageSplitChecker
 						}
 					}
 					r = svc.getImagesBySplitFilesets(e.getKey(),
-							klass, ids);
+							 klass, ids);
 					if (r != null && r.size() > 0) {
 						mif = new MIFResultObject(e.getKey(), r);
 						//load the thumbnails for a limited number of images.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ImagesLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ImagesLoader.java
@@ -22,14 +22,18 @@ package org.openmicroscopy.shoola.env.data.views.calls;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import org.openmicroscopy.shoola.env.data.OmeroDataService;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ImageData;
 
@@ -88,7 +92,7 @@ public class ImagesLoader
             public void doCall() throws Exception
             {
                 OmeroDataService os = context.getDataService();
-                Set set = os.getImages(ctx, ImageData.class,
+                Collection set = os.getImages(ctx, ImageData.class,
                 		Arrays.asList(imageID), -1);
                 if (set != null && set.size() == 1) {
                 	Iterator i = set.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
@@ -79,7 +79,7 @@ public class StructuredAnnotationLoader
      * @param nsExlcude The annotation's name space to exclude if any.
      * @return The {@link BatchCall}.
      */
-    private BatchCall loadSpeficiedAnnotationLinkedTo(final Class<?> rootType,
+    private BatchCall loadSpeficiedAnnotationLinkedTo(final Class<? extends DataObject> rootType,
             final List<Long> rootIDs, final Class<?> annotationType,
             final List<String> nsInclude, final List<String> nsExlcude)
     {
@@ -426,7 +426,7 @@ public class StructuredAnnotationLoader
      * @param nsInclude The annotation's name space to include if any.
      * @param nsExlcude The annotation's name space to exclude if any.
      */
-    public StructuredAnnotationLoader(SecurityContext ctx, Class<?> rootType,
+    public StructuredAnnotationLoader(SecurityContext ctx, Class<? extends DataObject> rootType,
             List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
             List<String> nsExlcude)
     {

--- a/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
@@ -449,7 +449,7 @@ public class NullOmeroPojoService
      * @see OmeroDataService#getImagesBySplitFilesets(SecurityContext, Class, List)
      */
 	public Map<Long, Map<Boolean, List<ImageData>>> getImagesBySplitFilesets(
-			SecurityContext ctx, Class<?> rootType, List<Long> rootIDs)
+			SecurityContext ctx, Class<? extends DataObject> rootType, List<Long> rootIDs)
 			throws DSOutOfServiceException, DSAccessException {
 		return null;
 	}

--- a/components/insight/TEST/org/openmicroscopy/shoola/examples/data/LoginHeadless.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/examples/data/LoginHeadless.java
@@ -112,7 +112,7 @@ implements AgentEventListener
 			try {
 				
 				//1 Load images knowing image's id.
-				Set images = dataSvc.getImages(ctx, ImageData.class, imageIds,
+			    Collection images = dataSvc.getImages(ctx, ImageData.class, imageIds,
 						-1);
 				System.err.println("images:"+images.size());
 				


### PR DESCRIPTION
# What this PR does

Refactoring the PojoMapper class: Replaces various similar methods with one method `convertToDataObjects` (previous methods are marked as deprecated). Makes more use of generics. Use general `Collection` interface instead of returning `Set` and `List`. Marks unused methods as deprecated.

# Testing this PR

Nothing particular to test. PojoMapper class is used throughout Insight. Just leave the PR in the build for a while and see if something breaks? I know that's generally not a good strategy for testing... Your thoughts @jburel , @pwalczysko ?

There was one piece of code (the Importer component) where the program logic depended on wether the Collection was a Set or List, which was quite a bad design (fixed that, see last commit bd966ac ). I'm a bit worried that there might be other similar cases. They will compile fine, but either crash Insight or change the behaviour.