### PR TITLE
Improve formatting of omero.api.ITimeline slice2html page

### DIFF
--- a/components/blitz/resources/omero/api/ITimeline.ice
+++ b/components/blitz/resources/omero/api/ITimeline.ice
@@ -22,55 +22,59 @@ module omero {
         /**
          * Service for the querying of OMERO metadata based on creation and
          * modification time. Currently supported types for querying include:
+         * <ul>
+         *   <li>{@link omero.model.Annotation}</li>
+         *   <li>{@link omero.model.Dataset}</li>
+         *   <li>{@link omero.model.Image}</li>
+         *   <li>{@link omero.model.Project}</li>
+         *   <li>{@link omero.model.RenderingDef}</li>
+         * </ul>
          *
-         *    - {@link omero.model.Annotation}
-         *    - {@link omero.model.Dataset}
-         *    - {@link omero.model.Image}
-         *    - {@link omero.model.Project}
-         *    - {@link omero.model.RenderingDef}
+         * <h4>Return maps</h4>
          *
-         * Return maps:
-         * -----------
          * The map return values will be indexed by the short type name above:
-         * <i>Project</i>, <i>Image</i>, ... All keys which are passed in the StringSet
-         * argument will be included in the returned map, even if they have no
-         * values. A default value of 0 or the empty list \[] will be used.
+         * <i>Project</i>, <i>Image</i>, ... All keys which are passed in the
+         * StringSet argument will be included in the returned map, even if
+         * they have no values. A default value of 0 or the empty list \[]
+         * will be used.
          * The only exception to this rule is that the null or empty StringSet
          * implies all valid keys.
          *
-         * Parameters:
-         * ----------
+         * <h4>Parameters</h4>
+         *
          * All methods take a omero::sys::Parameters object and will apply the filter
          * object for paging through the data in order to prevent loading too
          * many objects. If the parameters argument is null or no paging is activated,
          * then the default will be: OFFSET=0, LIMIT=50. Filter.ownerId and
          * Filter.groupId will also be AND'ed to the query if either value is present.
          * If both are null, then the current user id will be used. To retrieve for
-         * all users, use ownerId == rlong(-1) and groupId == null.
+         * all users, use <code>ownerId == rlong(-1)</code> and
+         * <code>groupId == null</code>.
          *
-         * Merging:
-         * -------
-         * The methods which take a StringSet and a Parameters object, also have
-         * a <i>bool merge</i> argument. This argument defines whether or not the LIMIT
-         * applies to each object independently (\["a","b"] @ 100 == 200) or merges
-         * the lists together chronologically (\["a","b"] @ 100 merged == 100).
+         * <h4>Merging</h4>
          *
-         * Time used:
-         * =========
-         * Except for Image, IObject.details.updateEvent is used in all cases for
-         * determining most recent events. Images are compared via
-         * Image.acquisitionDate which is unlike the other properties is modifiable
-         * by the user.
+         * The methods which take a StringSet and a Parameters object, also
+         * have a <i>bool merge</i> argument. This argument defines whether or
+         * not the LIMIT applies to each object independently
+         * (<code>["a","b"] @ 100 == 200</code>) or merges the lists together
+         * chronologically (<code>["a","b"] @ 100 merged == 100</code>).
+         *
+         * <h4>Time used</h4>
+         *
+         * Except for Image, IObject.details.updateEvent is used in all cases
+         * for determining most recent events. Images are compared via
+         * Image.acquisitionDate which is unlike the other properties is
+         * modifiable by the user.
          *
          *
          *
          * A typical invocation might look like (in Python):
-         *
+         * <pre>
          *     timeline = sf.getTimelineService()
          *     params = ParametersI().page(0,100)
          *     types = \["Project","Dataset"])
          *     map = timeline.getByPeriod(types, params, False)
-         *
+         * </pre>
          * At this point, map will not contain more than 200 objects.
          *
          * This service is defined only in Blitz and so no javadoc is available


### PR DESCRIPTION
This PR addresses https://github.com/openmicroscopy/openmicroscopy/pull/4702#issuecomment-225578494 by cleaning the introduction of the `omero.api.ITimeline` documentation page.

To test this PR, check the Slice generated documentation page under https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-build/ICE=3.6,jdk=8_LATEST,label=octopus/javadoc/slice2html/omero/api/ITimeline.html