### PR TITLE
Change Pascal case to PASCAL

### DIFF
--- a/components/blitz/resources/omero/model/Units.ice
+++ b/components/blitz/resources/omero/model/Units.ice
@@ -148,7 +148,7 @@ module omero {
                 KILOPASCAL,
                 HECTOPASCAL,
                 DECAPASCAL,
-                Pascal,
+                PASCAL,
                 DECIPASCAL,
                 CENTIPASCAL,
                 MILLIPASCAL,

--- a/components/blitz/resources/templates/combined.vm
+++ b/components/blitz/resources/templates/combined.vm
@@ -152,6 +152,7 @@ DECLARATION BLOCK:
 [$ice]
 #end
 
+[$cpp] \#include <omero/internal/fixes.h>
 #foreach( $property in $type.propertyClosure )
 #if($property.type.startsWith("ome"))
 #if($property.isLink)

--- a/components/blitz/src/omero/model/PressureI.java
+++ b/components/blitz/src/omero/model/PressureI.java
@@ -83,7 +83,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 13))), Sym("atm")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Mul(Int(101325), Pow(10, 12)), Sym("atm")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(120625), Pow(10, 9)), Int("8208044396629")), Sym("atm")));
-        c.put(UnitsPressure.Pascal, Mul(Int(101325), Sym("atm")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(101325), Sym("atm")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 10))), Sym("atm")));
         c.put(UnitsPressure.TORR, Mul(Int(760), Sym("atm")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Mul(Int(101325), Pow(10, 24)), Sym("atm")));
@@ -120,7 +120,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 33)), Sym("attopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Int(1), Pow(10, 6)), Sym("attopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 7))), Sym("attopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 30)), Sym("attopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("attopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 6), Sym("attopa")));
@@ -157,7 +157,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 10)), Sym("bar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 17), Sym("bar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 14)), Int("172368932329209")), Sym("bar")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 5), Sym("bar")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 5), Sym("bar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 7)), Sym("bar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("bar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 29), Sym("bar")));
@@ -194,7 +194,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 12)), Sym("cbar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 15), Sym("cbar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("cbar")));
-        c.put(UnitsPressure.Pascal, Mul(Int(1000), Sym("cbar")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(1000), Sym("cbar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 9)), Sym("cbar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(30400), Int(4053)), Sym("cbar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 27), Sym("cbar")));
@@ -231,7 +231,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 17)), Sym("centipa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 10), Sym("centipa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 7)), Int("172368932329209")), Sym("centipa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Int(100)), Sym("centipa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Int(100)), Sym("centipa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 14)), Sym("centipa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(38), Int(506625)), Sym("centipa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 22), Sym("centipa")));
@@ -268,7 +268,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 14)), Sym("decapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 13), Sym("decapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 10)), Int("172368932329209")), Sym("decapa")));
-        c.put(UnitsPressure.Pascal, Mul(Int(10), Sym("decapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(10), Sym("decapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 11)), Sym("decapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(304), Int(4053)), Sym("decapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 25), Sym("decapa")));
@@ -305,7 +305,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 11)), Sym("dbar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 16), Sym("dbar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 13)), Int("172368932329209")), Sym("dbar")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 4), Sym("dbar")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 4), Sym("dbar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 8)), Sym("dbar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(304000), Int(4053)), Sym("dbar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 28), Sym("dbar")));
@@ -342,7 +342,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 16)), Sym("decipa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 11), Sym("decipa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 8)), Int("172368932329209")), Sym("decipa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Int(10)), Sym("decipa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Int(10)), Sym("decipa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 13)), Sym("decipa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(76), Int(101325)), Sym("decipa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 23), Sym("decipa")));
@@ -379,7 +379,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Int(1000), Sym("exapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 30), Sym("exapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 27)), Int("172368932329209")), Sym("exapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 18), Sym("exapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 18), Sym("exapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Pow(10, 6), Sym("exapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("exapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 42), Sym("exapa")));
@@ -416,7 +416,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 30)), Sym("femtopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Int(1), Int(1000)), Sym("femtopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 4))), Sym("femtopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 27)), Sym("femtopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("femtopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 9), Sym("femtopa")));
@@ -453,7 +453,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 6)), Sym("gigapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 21), Sym("gigapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 18)), Int("172368932329209")), Sym("gigapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 9), Sym("gigapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 9), Sym("gigapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Int(1000)), Sym("gigapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("gigapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 33), Sym("gigapa")));
@@ -490,7 +490,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 13)), Sym("hectopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 14), Sym("hectopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("hectopa")));
-        c.put(UnitsPressure.Pascal, Mul(Int(100), Sym("hectopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(100), Sym("hectopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 10)), Sym("hectopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(3040), Int(4053)), Sym("hectopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 26), Sym("hectopa")));
@@ -527,7 +527,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 7)), Sym("kbar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 20), Sym("kbar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 17)), Int("172368932329209")), Sym("kbar")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 8), Sym("kbar")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 8), Sym("kbar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 4)), Sym("kbar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("kbar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 32), Sym("kbar")));
@@ -564,7 +564,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 12)), Sym("kilopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 15), Sym("kilopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("kilopa")));
-        c.put(UnitsPressure.Pascal, Mul(Int(1000), Sym("kilopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(1000), Sym("kilopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 9)), Sym("kilopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(30400), Int(4053)), Sym("kilopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 27), Sym("kilopa")));
@@ -601,7 +601,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 4)), Sym("megabar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 23), Sym("megabar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 20)), Int("172368932329209")), Sym("megabar")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 11), Sym("megabar")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 11), Sym("megabar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Int(10)), Sym("megabar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 10)), Int(4053)), Sym("megabar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 35), Sym("megabar")));
@@ -638,7 +638,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 9)), Sym("megapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 18), Sym("megapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 15)), Int("172368932329209")), Sym("megapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 6), Sym("megapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 6), Sym("megapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 6)), Sym("megapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("megapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 30), Sym("megapa")));
@@ -675,7 +675,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 21)), Sym("micropa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 6), Sym("micropa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(25000), Int("172368932329209")), Sym("micropa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 18)), Sym("micropa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Int("2533125000")), Sym("micropa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 18), Sym("micropa")));
@@ -712,7 +712,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 13)), Sym("mbar")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 14), Sym("mbar")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("mbar")));
-        c.put(UnitsPressure.Pascal, Mul(Int(100), Sym("mbar")));
+        c.put(UnitsPressure.PASCAL, Mul(Int(100), Sym("mbar")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 10)), Sym("mbar")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(3040), Int(4053)), Sym("mbar")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 26), Sym("mbar")));
@@ -749,7 +749,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 18)), Sym("millipa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 9), Sym("millipa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 6)), Int("172368932329209")), Sym("millipa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Int(1000)), Sym("millipa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Int(1000)), Sym("millipa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 15)), Sym("millipa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Int(2533125)), Sym("millipa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 21), Sym("millipa")));
@@ -786,7 +786,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("mtorr")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("mtorr")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(3015625), Pow(10, 9)), Int("155952843535951")), Sym("mtorr")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(2533125), Int(19)), Sym("mtorr")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(2533125), Int(19)), Sym("mtorr")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("mtorr")));
         c.put(UnitsPressure.TORR, Mul(Int(1000), Sym("mtorr")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Rat(Mul(Int(2533125), Pow(10, 24)), Int(19)), Sym("mtorr")));
@@ -823,7 +823,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 23))), Sym("mmhg")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Int("133322387415000"), Sym("mmhg")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int("158717127875"), Int("8208044396629")), Sym("mmhg")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 20))), Sym("mmhg")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 6))), Sym("mmhg")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Mul(Int("133322387415"), Pow(10, 15)), Sym("mmhg")));
@@ -860,7 +860,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 24)), Sym("nanopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Int(1000), Sym("nanopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(25), Int("172368932329209")), Sym("nanopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 21)), Sym("nanopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("nanopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 15), Sym("nanopa")));
@@ -897,7 +897,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.NANOPASCAL, Mul(Pow(10, 24), Sym("petapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 27), Sym("petapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 24)), Int("172368932329209")), Sym("petapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 15), Sym("petapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 15), Sym("petapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Int(1000), Sym("petapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("petapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 39), Sym("petapa")));
@@ -934,7 +934,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.NANOPASCAL, Mul(Rat(Int(1), Int(1000)), Sym("picopa")));
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 27)), Sym("picopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(1), Int("6894757293168360")), Sym("picopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 24)), Sym("picopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("picopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 12), Sym("picopa")));
@@ -971,7 +971,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.NANOPASCAL, Mul(Rat(Int("172368932329209"), Int(25)), Sym("psi")));
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 24))), Sym("psi")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Int("6894757293168360"), Sym("psi")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 21))), Sym("psi")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 6))), Sym("psi")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Mul(Int("689475729316836"), Pow(10, 13)), Sym("psi")));
@@ -981,7 +981,7 @@ public class PressureI extends Pressure implements ModelBased {
         return Collections.unmodifiableMap(c);
     }
 
-    private static Map<UnitsPressure, Conversion> createMapPascal() {
+    private static Map<UnitsPressure, Conversion> createMapPASCAL() {
         EnumMap<UnitsPressure, Conversion> c =
             new EnumMap<UnitsPressure, Conversion>(UnitsPressure.class);
         c.put(UnitsPressure.ATMOSPHERE, Mul(Rat(Int(1), Int(101325)), Sym("pa")));
@@ -1046,7 +1046,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Int(1000)), Sym("terapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 24), Sym("terapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 21)), Int("172368932329209")), Sym("terapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 12), Sym("terapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 12), Sym("terapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("terapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 36), Sym("terapa")));
         c.put(UnitsPressure.YOTTAPASCAL, Mul(Rat(Int(1), Pow(10, 12)), Sym("terapa")));
@@ -1083,7 +1083,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("torr")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("torr")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(3015625), Pow(10, 6)), Int("155952843535951")), Sym("torr")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(20265), Int(152)), Sym("torr")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(20265), Int(152)), Sym("torr")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("torr")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("torr")));
         c.put(UnitsPressure.YOTTAPASCAL, Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 23))), Sym("torr")));
@@ -1120,7 +1120,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 13))), Sym("yoctopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("yoctopa")));
         c.put(UnitsPressure.YOTTAPASCAL, Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctopa")));
@@ -1157,7 +1157,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Pow(10, 9), Sym("yottapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 36), Sym("yottapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 33)), Int("172368932329209")), Sym("yottapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 24), Sym("yottapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 24), Sym("yottapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Pow(10, 12), Sym("yottapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 23)), Int(4053)), Sym("yottapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 48), Sym("yottapa")));
@@ -1194,7 +1194,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptopa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptopa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 10))), Sym("zeptopa")));
-        c.put(UnitsPressure.Pascal, Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa")));
+        c.put(UnitsPressure.PASCAL, Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptopa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("zeptopa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Int(1000), Sym("zeptopa")));
@@ -1231,7 +1231,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, Mul(Pow(10, 6), Sym("zettapa")));
         c.put(UnitsPressure.PICOPASCAL, Mul(Pow(10, 33), Sym("zettapa")));
         c.put(UnitsPressure.PSI, Mul(Rat(Mul(Int(25), Pow(10, 30)), Int("172368932329209")), Sym("zettapa")));
-        c.put(UnitsPressure.Pascal, Mul(Pow(10, 21), Sym("zettapa")));
+        c.put(UnitsPressure.PASCAL, Mul(Pow(10, 21), Sym("zettapa")));
         c.put(UnitsPressure.TERAPASCAL, Mul(Pow(10, 9), Sym("zettapa")));
         c.put(UnitsPressure.TORR, Mul(Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("zettapa")));
         c.put(UnitsPressure.YOCTOPASCAL, Mul(Pow(10, 45), Sym("zettapa")));
@@ -1271,7 +1271,7 @@ public class PressureI extends Pressure implements ModelBased {
         c.put(UnitsPressure.PETAPASCAL, createMapPETAPASCAL());
         c.put(UnitsPressure.PICOPASCAL, createMapPICOPASCAL());
         c.put(UnitsPressure.PSI, createMapPSI());
-        c.put(UnitsPressure.Pascal, createMapPascal());
+        c.put(UnitsPressure.PASCAL, createMapPASCAL());
         c.put(UnitsPressure.TERAPASCAL, createMapTERAPASCAL());
         c.put(UnitsPressure.TORR, createMapTORR());
         c.put(UnitsPressure.YOCTOPASCAL, createMapYOCTOPASCAL());
@@ -1309,7 +1309,7 @@ public class PressureI extends Pressure implements ModelBased {
         s.put(UnitsPressure.PETAPASCAL, "PPa");
         s.put(UnitsPressure.PICOPASCAL, "pPa");
         s.put(UnitsPressure.PSI, "psi");
-        s.put(UnitsPressure.Pascal, "Pa");
+        s.put(UnitsPressure.PASCAL, "Pa");
         s.put(UnitsPressure.TERAPASCAL, "TPa");
         s.put(UnitsPressure.TORR, "Torr");
         s.put(UnitsPressure.YOCTOPASCAL, "yPa");

--- a/components/model/src/ome/model/enums/UnitsPressure.java
+++ b/components/model/src/ome/model/enums/UnitsPressure.java
@@ -37,7 +37,7 @@ public enum UnitsPressure implements UnitEnum {
     KILOPASCAL("kPa"),
     HECTOPASCAL("hPa"),
     DECAPASCAL("daPa"),
-    Pascal("Pa"),
+    PASCAL("Pa"),
     DECIPASCAL("dPa"),
     CENTIPASCAL("cPa"),
     MILLIPASCAL("mPa"),

--- a/components/tools/OmeroCpp/CMakeLists.txt
+++ b/components/tools/OmeroCpp/CMakeLists.txt
@@ -185,7 +185,7 @@ function(icegen in outsrc outhdr)
         OUTPUT ${GEN_DIR}/${ICECPP} ${GEN_DIR}/${ICEHPP}
         WORKING_DIRECTORY gen
         COMMAND ${CMAKE_COMMAND} -E make_directory "${ICE_PATH}"
-        COMMAND "${Ice_SLICE2CPP_EXECUTABLE}" ${SLICEOPTS} ${incdir} "--output-dir=${ICE_PATH}" "${PROJECT_SOURCE_DIR}/${icesrc}"
+        COMMAND "${Ice_SLICE2CPP_EXECUTABLE}" ${SLICEOPTS} ${incdir} --add-header "omero/internal/fixes.h" "--output-dir=${ICE_PATH}" "${PROJECT_SOURCE_DIR}/${icesrc}"
         DEPENDS "${PROJECT_SOURCE_DIR}/${icesrc}")
       install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${GEN_DIR}/${ICEHPP}
               DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${ICE_PATH}")
@@ -243,7 +243,12 @@ abspath_sources(OMERO_API_GENERATED_SOURCES OMERO_API_GENERATED_SOURCES_ABS)
 abspath_sources(OMERO_MODEL_GENERATED_SOURCES OMERO_MODEL_GENERATED_SOURCES_ABS)
 abspath_sources(OMERO_COMMON_GENERATED_SOURCES OMERO_COMMON_GENERATED_SOURCES_ABS)
 
+# Private headers which aren't installed.  Used only at compile time.
+set(OMERO_INTERNAL_HEADERS
+    src/omero/internal/fixes.h)
+
 set(OMERO_ICE_HEADERS
+    ${OMERO_INTERNAL_HEADERS}
     ${OMERO_COMMON_STATIC_ICE_HEADERS}
     ${OMERO_COMMON_GENERATED_ICE_HEADERS}
     ${OMERO_MODEL_STATIC_ICE_HEADERS}
@@ -292,6 +297,7 @@ set(OMERO_COMMON_STATIC_SOURCES
     src/omero/sys/ParametersI.cpp)
 
 set(OMERO_COMMON_HEADERS
+    ${OMERO_INTERNAL_HEADERS}
     ${OMERO_COMMON_STATIC_HEADERS}
     ${OMERO_COMMON_STATIC_SYS_HEADERS}
     ${OMERO_COMMON_GENERATED_HEADERS_ABS})

--- a/components/tools/OmeroCpp/CMakeLists.txt
+++ b/components/tools/OmeroCpp/CMakeLists.txt
@@ -283,6 +283,8 @@ set(OMERO_COMMON_STATIC_HEADERS
     src/omero/ClientErrors.h
     src/omero/IceNoWarnPop.h
     src/omero/IceNoWarnPush.h
+    src/omero/IcePortPop.h
+    src/omero/IcePortPush.h
     src/omero/ObjectFactoryRegistrar.h
     src/omero/RTypesI.h
     src/omero/templates.h)

--- a/components/tools/OmeroCpp/src/omero/IcePortPop.h
+++ b/components/tools/OmeroCpp/src/omero/IcePortPop.h
@@ -1,0 +1,3 @@
+#ifdef _MSC_VER
+#pragma pop_macro("PASCAL")
+#endif

--- a/components/tools/OmeroCpp/src/omero/IcePortPush.h
+++ b/components/tools/OmeroCpp/src/omero/IcePortPush.h
@@ -1,0 +1,6 @@
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#pragma push_macro("PASCAL")
+#undef PASCAL
+#endif

--- a/components/tools/OmeroCpp/src/omero/internal/fixes.h
+++ b/components/tools/OmeroCpp/src/omero/internal/fixes.h
@@ -6,6 +6,8 @@
 #define OMERO_INTERNAL_FIXES_H
 
 #ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #undef PASCAL
 #endif
 

--- a/components/tools/OmeroCpp/src/omero/internal/fixes.h
+++ b/components/tools/OmeroCpp/src/omero/internal/fixes.h
@@ -1,0 +1,12 @@
+/*
+ * Windows portability fixes.
+ */
+
+#ifndef OMERO_INTERNAL_FIXES_H
+#define OMERO_INTERNAL_FIXES_H
+
+#ifdef _MSC_VER
+#undef PASCAL
+#endif
+
+#endif // OMERO_INTERNAL_FIXES_H

--- a/components/tools/OmeroCpp/src/omero/model/ElectricPotentialI.h
+++ b/components/tools/OmeroCpp/src/omero/model/ElectricPotentialI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_ELECTRICPOTENTIALI_H
 #define OMERO_MODEL_ELECTRICPOTENTIALI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/ElectricPotential.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_ELECTRICPOTENTIALI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/FrequencyI.h
+++ b/components/tools/OmeroCpp/src/omero/model/FrequencyI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_FREQUENCYI_H
 #define OMERO_MODEL_FREQUENCYI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Frequency.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_FREQUENCYI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/LengthI.h
+++ b/components/tools/OmeroCpp/src/omero/model/LengthI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_LENGTHI_H
 #define OMERO_MODEL_LENGTHI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Length.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_LENGTHI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/PowerI.h
+++ b/components/tools/OmeroCpp/src/omero/model/PowerI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_POWERI_H
 #define OMERO_MODEL_POWERI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Power.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_POWERI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/PressureI.cpp
+++ b/components/tools/OmeroCpp/src/omero/model/PressureI.cpp
@@ -56,7 +56,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 13))), Sym("atm"));
             c[enums::PICOPASCAL] = Mul(Mul(Int(101325), Pow(10, 12)), Sym("atm"));
             c[enums::PSI] = Mul(Rat(Mul(Int(120625), Pow(10, 9)), Int("8208044396629")), Sym("atm"));
-            c[enums::Pascal] = Mul(Int(101325), Sym("atm"));
+            c[enums::PASCAL] = Mul(Int(101325), Sym("atm"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 10))), Sym("atm"));
             c[enums::TORR] = Mul(Int(760), Sym("atm"));
             c[enums::YOCTOPASCAL] = Mul(Mul(Int(101325), Pow(10, 24)), Sym("atm"));
@@ -92,7 +92,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 33)), Sym("attopa"));
             c[enums::PICOPASCAL] = Mul(Rat(Int(1), Pow(10, 6)), Sym("attopa"));
             c[enums::PSI] = Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 7))), Sym("attopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 30)), Sym("attopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("attopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 6), Sym("attopa"));
@@ -128,7 +128,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 10)), Sym("bar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 17), Sym("bar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 14)), Int("172368932329209")), Sym("bar"));
-            c[enums::Pascal] = Mul(Pow(10, 5), Sym("bar"));
+            c[enums::PASCAL] = Mul(Pow(10, 5), Sym("bar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 7)), Sym("bar"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("bar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 29), Sym("bar"));
@@ -164,7 +164,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 12)), Sym("cbar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 15), Sym("cbar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("cbar"));
-            c[enums::Pascal] = Mul(Int(1000), Sym("cbar"));
+            c[enums::PASCAL] = Mul(Int(1000), Sym("cbar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 9)), Sym("cbar"));
             c[enums::TORR] = Mul(Rat(Int(30400), Int(4053)), Sym("cbar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 27), Sym("cbar"));
@@ -200,7 +200,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 17)), Sym("centipa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 10), Sym("centipa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 7)), Int("172368932329209")), Sym("centipa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Int(100)), Sym("centipa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Int(100)), Sym("centipa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 14)), Sym("centipa"));
             c[enums::TORR] = Mul(Rat(Int(38), Int(506625)), Sym("centipa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 22), Sym("centipa"));
@@ -236,7 +236,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 14)), Sym("decapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 13), Sym("decapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 10)), Int("172368932329209")), Sym("decapa"));
-            c[enums::Pascal] = Mul(Int(10), Sym("decapa"));
+            c[enums::PASCAL] = Mul(Int(10), Sym("decapa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 11)), Sym("decapa"));
             c[enums::TORR] = Mul(Rat(Int(304), Int(4053)), Sym("decapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 25), Sym("decapa"));
@@ -272,7 +272,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 11)), Sym("dbar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 16), Sym("dbar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 13)), Int("172368932329209")), Sym("dbar"));
-            c[enums::Pascal] = Mul(Pow(10, 4), Sym("dbar"));
+            c[enums::PASCAL] = Mul(Pow(10, 4), Sym("dbar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 8)), Sym("dbar"));
             c[enums::TORR] = Mul(Rat(Int(304000), Int(4053)), Sym("dbar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 28), Sym("dbar"));
@@ -308,7 +308,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 16)), Sym("decipa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 11), Sym("decipa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 8)), Int("172368932329209")), Sym("decipa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Int(10)), Sym("decipa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Int(10)), Sym("decipa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 13)), Sym("decipa"));
             c[enums::TORR] = Mul(Rat(Int(76), Int(101325)), Sym("decipa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 23), Sym("decipa"));
@@ -344,7 +344,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Int(1000), Sym("exapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 30), Sym("exapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 27)), Int("172368932329209")), Sym("exapa"));
-            c[enums::Pascal] = Mul(Pow(10, 18), Sym("exapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 18), Sym("exapa"));
             c[enums::TERAPASCAL] = Mul(Pow(10, 6), Sym("exapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("exapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 42), Sym("exapa"));
@@ -380,7 +380,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 30)), Sym("femtopa"));
             c[enums::PICOPASCAL] = Mul(Rat(Int(1), Int(1000)), Sym("femtopa"));
             c[enums::PSI] = Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 4))), Sym("femtopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 27)), Sym("femtopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("femtopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 9), Sym("femtopa"));
@@ -416,7 +416,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 6)), Sym("gigapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 21), Sym("gigapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 18)), Int("172368932329209")), Sym("gigapa"));
-            c[enums::Pascal] = Mul(Pow(10, 9), Sym("gigapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 9), Sym("gigapa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Int(1000)), Sym("gigapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("gigapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 33), Sym("gigapa"));
@@ -452,7 +452,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 13)), Sym("hectopa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 14), Sym("hectopa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("hectopa"));
-            c[enums::Pascal] = Mul(Int(100), Sym("hectopa"));
+            c[enums::PASCAL] = Mul(Int(100), Sym("hectopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 10)), Sym("hectopa"));
             c[enums::TORR] = Mul(Rat(Int(3040), Int(4053)), Sym("hectopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 26), Sym("hectopa"));
@@ -488,7 +488,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 7)), Sym("kbar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 20), Sym("kbar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 17)), Int("172368932329209")), Sym("kbar"));
-            c[enums::Pascal] = Mul(Pow(10, 8), Sym("kbar"));
+            c[enums::PASCAL] = Mul(Pow(10, 8), Sym("kbar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 4)), Sym("kbar"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("kbar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 32), Sym("kbar"));
@@ -524,7 +524,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 12)), Sym("kilopa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 15), Sym("kilopa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("kilopa"));
-            c[enums::Pascal] = Mul(Int(1000), Sym("kilopa"));
+            c[enums::PASCAL] = Mul(Int(1000), Sym("kilopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 9)), Sym("kilopa"));
             c[enums::TORR] = Mul(Rat(Int(30400), Int(4053)), Sym("kilopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 27), Sym("kilopa"));
@@ -560,7 +560,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 4)), Sym("megabar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 23), Sym("megabar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 20)), Int("172368932329209")), Sym("megabar"));
-            c[enums::Pascal] = Mul(Pow(10, 11), Sym("megabar"));
+            c[enums::PASCAL] = Mul(Pow(10, 11), Sym("megabar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Int(10)), Sym("megabar"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 10)), Int(4053)), Sym("megabar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 35), Sym("megabar"));
@@ -596,7 +596,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 9)), Sym("megapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 18), Sym("megapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 15)), Int("172368932329209")), Sym("megapa"));
-            c[enums::Pascal] = Mul(Pow(10, 6), Sym("megapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 6), Sym("megapa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 6)), Sym("megapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("megapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 30), Sym("megapa"));
@@ -632,7 +632,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 21)), Sym("micropa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 6), Sym("micropa"));
             c[enums::PSI] = Mul(Rat(Int(25000), Int("172368932329209")), Sym("micropa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 18)), Sym("micropa"));
             c[enums::TORR] = Mul(Rat(Int(19), Int("2533125000")), Sym("micropa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 18), Sym("micropa"));
@@ -668,7 +668,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 13)), Sym("mbar"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 14), Sym("mbar"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("mbar"));
-            c[enums::Pascal] = Mul(Int(100), Sym("mbar"));
+            c[enums::PASCAL] = Mul(Int(100), Sym("mbar"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 10)), Sym("mbar"));
             c[enums::TORR] = Mul(Rat(Int(3040), Int(4053)), Sym("mbar"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 26), Sym("mbar"));
@@ -704,7 +704,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 18)), Sym("millipa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 9), Sym("millipa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 6)), Int("172368932329209")), Sym("millipa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Int(1000)), Sym("millipa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Int(1000)), Sym("millipa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 15)), Sym("millipa"));
             c[enums::TORR] = Mul(Rat(Int(19), Int(2533125)), Sym("millipa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 21), Sym("millipa"));
@@ -740,7 +740,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("mtorr"));
             c[enums::PICOPASCAL] = Mul(Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("mtorr"));
             c[enums::PSI] = Mul(Rat(Mul(Int(3015625), Pow(10, 9)), Int("155952843535951")), Sym("mtorr"));
-            c[enums::Pascal] = Mul(Rat(Int(2533125), Int(19)), Sym("mtorr"));
+            c[enums::PASCAL] = Mul(Rat(Int(2533125), Int(19)), Sym("mtorr"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("mtorr"));
             c[enums::TORR] = Mul(Int(1000), Sym("mtorr"));
             c[enums::YOCTOPASCAL] = Mul(Rat(Mul(Int(2533125), Pow(10, 24)), Int(19)), Sym("mtorr"));
@@ -776,7 +776,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 23))), Sym("mmhg"));
             c[enums::PICOPASCAL] = Mul(Int("133322387415000"), Sym("mmhg"));
             c[enums::PSI] = Mul(Rat(Int("158717127875"), Int("8208044396629")), Sym("mmhg"));
-            c[enums::Pascal] = Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg"));
+            c[enums::PASCAL] = Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg"));
             c[enums::TERAPASCAL] = Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 20))), Sym("mmhg"));
             c[enums::TORR] = Mul(Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 6))), Sym("mmhg"));
             c[enums::YOCTOPASCAL] = Mul(Mul(Int("133322387415"), Pow(10, 15)), Sym("mmhg"));
@@ -812,7 +812,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 24)), Sym("nanopa"));
             c[enums::PICOPASCAL] = Mul(Int(1000), Sym("nanopa"));
             c[enums::PSI] = Mul(Rat(Int(25), Int("172368932329209")), Sym("nanopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 21)), Sym("nanopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("nanopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 15), Sym("nanopa"));
@@ -848,7 +848,7 @@ namespace omero {
             c[enums::NANOPASCAL] = Mul(Pow(10, 24), Sym("petapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 27), Sym("petapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 24)), Int("172368932329209")), Sym("petapa"));
-            c[enums::Pascal] = Mul(Pow(10, 15), Sym("petapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 15), Sym("petapa"));
             c[enums::TERAPASCAL] = Mul(Int(1000), Sym("petapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("petapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 39), Sym("petapa"));
@@ -884,7 +884,7 @@ namespace omero {
             c[enums::NANOPASCAL] = Mul(Rat(Int(1), Int(1000)), Sym("picopa"));
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 27)), Sym("picopa"));
             c[enums::PSI] = Mul(Rat(Int(1), Int("6894757293168360")), Sym("picopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 24)), Sym("picopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("picopa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 12), Sym("picopa"));
@@ -920,7 +920,7 @@ namespace omero {
             c[enums::NANOPASCAL] = Mul(Rat(Int("172368932329209"), Int(25)), Sym("psi"));
             c[enums::PETAPASCAL] = Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 24))), Sym("psi"));
             c[enums::PICOPASCAL] = Mul(Int("6894757293168360"), Sym("psi"));
-            c[enums::Pascal] = Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi"));
+            c[enums::PASCAL] = Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi"));
             c[enums::TERAPASCAL] = Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 21))), Sym("psi"));
             c[enums::TORR] = Mul(Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 6))), Sym("psi"));
             c[enums::YOCTOPASCAL] = Mul(Mul(Int("689475729316836"), Pow(10, 13)), Sym("psi"));
@@ -930,7 +930,7 @@ namespace omero {
             return c;
         }
 
-        static std::map<UnitsPressure, ConversionPtr> createMapPascal() {
+        static std::map<UnitsPressure, ConversionPtr> createMapPASCAL() {
             std::map<UnitsPressure, ConversionPtr> c;
             c[enums::ATMOSPHERE] = Mul(Rat(Int(1), Int(101325)), Sym("pa"));
             c[enums::ATTOPASCAL] = Mul(Pow(10, 18), Sym("pa"));
@@ -993,7 +993,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Int(1000)), Sym("terapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 24), Sym("terapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 21)), Int("172368932329209")), Sym("terapa"));
-            c[enums::Pascal] = Mul(Pow(10, 12), Sym("terapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 12), Sym("terapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("terapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 36), Sym("terapa"));
             c[enums::YOTTAPASCAL] = Mul(Rat(Int(1), Pow(10, 12)), Sym("terapa"));
@@ -1029,7 +1029,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("torr"));
             c[enums::PICOPASCAL] = Mul(Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("torr"));
             c[enums::PSI] = Mul(Rat(Mul(Int(3015625), Pow(10, 6)), Int("155952843535951")), Sym("torr"));
-            c[enums::Pascal] = Mul(Rat(Int(20265), Int(152)), Sym("torr"));
+            c[enums::PASCAL] = Mul(Rat(Int(20265), Int(152)), Sym("torr"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("torr"));
             c[enums::YOCTOPASCAL] = Mul(Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("torr"));
             c[enums::YOTTAPASCAL] = Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 23))), Sym("torr"));
@@ -1065,7 +1065,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctopa"));
             c[enums::PICOPASCAL] = Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctopa"));
             c[enums::PSI] = Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 13))), Sym("yoctopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("yoctopa"));
             c[enums::YOTTAPASCAL] = Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctopa"));
@@ -1101,7 +1101,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Pow(10, 9), Sym("yottapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 36), Sym("yottapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 33)), Int("172368932329209")), Sym("yottapa"));
-            c[enums::Pascal] = Mul(Pow(10, 24), Sym("yottapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 24), Sym("yottapa"));
             c[enums::TERAPASCAL] = Mul(Pow(10, 12), Sym("yottapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 23)), Int(4053)), Sym("yottapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 48), Sym("yottapa"));
@@ -1137,7 +1137,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptopa"));
             c[enums::PICOPASCAL] = Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptopa"));
             c[enums::PSI] = Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 10))), Sym("zeptopa"));
-            c[enums::Pascal] = Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa"));
+            c[enums::PASCAL] = Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa"));
             c[enums::TERAPASCAL] = Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptopa"));
             c[enums::TORR] = Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("zeptopa"));
             c[enums::YOCTOPASCAL] = Mul(Int(1000), Sym("zeptopa"));
@@ -1173,7 +1173,7 @@ namespace omero {
             c[enums::PETAPASCAL] = Mul(Pow(10, 6), Sym("zettapa"));
             c[enums::PICOPASCAL] = Mul(Pow(10, 33), Sym("zettapa"));
             c[enums::PSI] = Mul(Rat(Mul(Int(25), Pow(10, 30)), Int("172368932329209")), Sym("zettapa"));
-            c[enums::Pascal] = Mul(Pow(10, 21), Sym("zettapa"));
+            c[enums::PASCAL] = Mul(Pow(10, 21), Sym("zettapa"));
             c[enums::TERAPASCAL] = Mul(Pow(10, 9), Sym("zettapa"));
             c[enums::TORR] = Mul(Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("zettapa"));
             c[enums::YOCTOPASCAL] = Mul(Pow(10, 45), Sym("zettapa"));
@@ -1210,7 +1210,7 @@ namespace omero {
             c[enums::PETAPASCAL] = createMapPETAPASCAL();
             c[enums::PICOPASCAL] = createMapPICOPASCAL();
             c[enums::PSI] = createMapPSI();
-            c[enums::Pascal] = createMapPascal();
+            c[enums::PASCAL] = createMapPASCAL();
             c[enums::TERAPASCAL] = createMapTERAPASCAL();
             c[enums::TORR] = createMapTORR();
             c[enums::YOCTOPASCAL] = createMapYOCTOPASCAL();
@@ -1247,7 +1247,7 @@ namespace omero {
             s[enums::PETAPASCAL] = "PPa";
             s[enums::PICOPASCAL] = "pPa";
             s[enums::PSI] = "psi";
-            s[enums::Pascal] = "Pa";
+            s[enums::PASCAL] = "Pa";
             s[enums::TERAPASCAL] = "TPa";
             s[enums::TORR] = "Torr";
             s[enums::YOCTOPASCAL] = "yPa";

--- a/components/tools/OmeroCpp/src/omero/model/PressureI.cpp
+++ b/components/tools/OmeroCpp/src/omero/model/PressureI.cpp
@@ -20,6 +20,8 @@
 #include <omero/model/PressureI.h>
 #include <omero/ClientErrors.h>
 
+#include <omero/IcePortPush.h>
+
 ::Ice::Object* IceInternal::upCast(::omero::model::PressureI* t) { return t; }
 
 using namespace omero::conversions;
@@ -1322,3 +1324,4 @@ namespace omero {
     }
 }
 
+#include <omero/IcePortPop.h>

--- a/components/tools/OmeroCpp/src/omero/model/PressureI.h
+++ b/components/tools/OmeroCpp/src/omero/model/PressureI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_PRESSUREI_H
 #define OMERO_MODEL_PRESSUREI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Pressure.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_PRESSUREI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/TemperatureI.h
+++ b/components/tools/OmeroCpp/src/omero/model/TemperatureI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_TEMPERATUREI_H
 #define OMERO_MODEL_TEMPERATUREI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Temperature.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_TEMPERATUREI_H
 

--- a/components/tools/OmeroCpp/src/omero/model/TimeI.h
+++ b/components/tools/OmeroCpp/src/omero/model/TimeI.h
@@ -20,6 +20,7 @@
 #ifndef OMERO_MODEL_TIMEI_H
 #define OMERO_MODEL_TIMEI_H
 
+#include <omero/IcePortPush.h>
 #include <omero/IceNoWarnPush.h>
 #include <omero/model/Time.h>
 #include <omero/model/Units.h>
@@ -95,5 +96,8 @@ namespace omero {
     };
   }
 }
+
+#include <omero/IcePortPop.h>
+
 #endif // OMERO_MODEL_TIMEI_H
 

--- a/components/tools/OmeroPy/src/omero_model_PressureI.py
+++ b/components/tools/OmeroPy/src/omero_model_PressureI.py
@@ -97,7 +97,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Mul(Int(101325), Pow(10, 12)), Sym("atm"))  # nopep8
     CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(120625), Pow(10, 9)), Int("8208044396629")), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PASCAL] = \
         Mul(Int(101325), Sym("atm"))  # nopep8
     CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 10))), Sym("atm"))  # nopep8
@@ -159,7 +159,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Pow(10, 6)), Sym("attopa"))  # nopep8
     CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 7))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa"))  # nopep8
     CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 30)), Sym("attopa"))  # nopep8
@@ -221,7 +221,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 17), Sym("bar"))  # nopep8
     CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 14)), Int("172368932329209")), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 5), Sym("bar"))  # nopep8
     CONVERSIONS[UnitsPressure.BAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 7)), Sym("bar"))  # nopep8
@@ -283,7 +283,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 15), Sym("cbar"))  # nopep8
     CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PASCAL] = \
         Mul(Int(1000), Sym("cbar"))  # nopep8
     CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 9)), Sym("cbar"))  # nopep8
@@ -345,7 +345,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 10), Sym("centipa"))  # nopep8
     CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 7)), Int("172368932329209")), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Int(100)), Sym("centipa"))  # nopep8
     CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 14)), Sym("centipa"))  # nopep8
@@ -407,7 +407,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 13), Sym("decapa"))  # nopep8
     CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 10)), Int("172368932329209")), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Int(10), Sym("decapa"))  # nopep8
     CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 11)), Sym("decapa"))  # nopep8
@@ -469,7 +469,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 16), Sym("dbar"))  # nopep8
     CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 13)), Int("172368932329209")), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 4), Sym("dbar"))  # nopep8
     CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 8)), Sym("dbar"))  # nopep8
@@ -531,7 +531,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 11), Sym("decipa"))  # nopep8
     CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 8)), Int("172368932329209")), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Int(10)), Sym("decipa"))  # nopep8
     CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 13)), Sym("decipa"))  # nopep8
@@ -593,7 +593,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 30), Sym("exapa"))  # nopep8
     CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 27)), Int("172368932329209")), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 18), Sym("exapa"))  # nopep8
     CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Pow(10, 6), Sym("exapa"))  # nopep8
@@ -655,7 +655,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Int(1000)), Sym("femtopa"))  # nopep8
     CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 4))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa"))  # nopep8
     CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 27)), Sym("femtopa"))  # nopep8
@@ -717,7 +717,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 21), Sym("gigapa"))  # nopep8
     CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 18)), Int("172368932329209")), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 9), Sym("gigapa"))  # nopep8
     CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Int(1000)), Sym("gigapa"))  # nopep8
@@ -779,7 +779,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 14), Sym("hectopa"))  # nopep8
     CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Int(100), Sym("hectopa"))  # nopep8
     CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 10)), Sym("hectopa"))  # nopep8
@@ -841,7 +841,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 20), Sym("kbar"))  # nopep8
     CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 17)), Int("172368932329209")), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 8), Sym("kbar"))  # nopep8
     CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 4)), Sym("kbar"))  # nopep8
@@ -903,7 +903,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 15), Sym("kilopa"))  # nopep8
     CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Int(1000), Sym("kilopa"))  # nopep8
     CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 9)), Sym("kilopa"))  # nopep8
@@ -965,7 +965,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 23), Sym("megabar"))  # nopep8
     CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 20)), Int("172368932329209")), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 11), Sym("megabar"))  # nopep8
     CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Int(10)), Sym("megabar"))  # nopep8
@@ -1027,7 +1027,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 18), Sym("megapa"))  # nopep8
     CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 15)), Int("172368932329209")), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 6), Sym("megapa"))  # nopep8
     CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 6)), Sym("megapa"))  # nopep8
@@ -1089,7 +1089,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 6), Sym("micropa"))  # nopep8
     CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(25000), Int("172368932329209")), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa"))  # nopep8
     CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 18)), Sym("micropa"))  # nopep8
@@ -1151,7 +1151,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 14), Sym("mbar"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PASCAL] = \
         Mul(Int(100), Sym("mbar"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 10)), Sym("mbar"))  # nopep8
@@ -1213,7 +1213,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 9), Sym("millipa"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 6)), Int("172368932329209")), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Int(1000)), Sym("millipa"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 15)), Sym("millipa"))  # nopep8
@@ -1275,7 +1275,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("mtorr"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(3015625), Pow(10, 9)), Int("155952843535951")), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(2533125), Int(19)), Sym("mtorr"))  # nopep8
     CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("mtorr"))  # nopep8
@@ -1337,7 +1337,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Int("133322387415000"), Sym("mmhg"))  # nopep8
     CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PSI] = \
         Mul(Rat(Int("158717127875"), Int("8208044396629")), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PASCAL] = \
         Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg"))  # nopep8
     CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 20))), Sym("mmhg"))  # nopep8
@@ -1399,7 +1399,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Int(1000), Sym("nanopa"))  # nopep8
     CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(25), Int("172368932329209")), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa"))  # nopep8
     CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 21)), Sym("nanopa"))  # nopep8
@@ -1461,7 +1461,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 27), Sym("petapa"))  # nopep8
     CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 24)), Int("172368932329209")), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 15), Sym("petapa"))  # nopep8
     CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Int(1000), Sym("petapa"))  # nopep8
@@ -1523,7 +1523,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Pow(10, 27)), Sym("picopa"))  # nopep8
     CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(1), Int("6894757293168360")), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa"))  # nopep8
     CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 24)), Sym("picopa"))  # nopep8
@@ -1585,7 +1585,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 24))), Sym("psi"))  # nopep8
     CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PICOPASCAL] = \
         Mul(Int("6894757293168360"), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PASCAL] = \
         Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi"))  # nopep8
     CONVERSIONS[UnitsPressure.PSI][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 21))), Sym("psi"))  # nopep8
@@ -1599,67 +1599,67 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Mul(Int("689475729316836"), Pow(10, 10)), Sym("psi"))  # nopep8
     CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ZETTAPASCAL] = \
         Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 30))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.ATMOSPHERE] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATMOSPHERE] = \
         Mul(Rat(Int(1), Int(101325)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.ATTOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATTOPASCAL] = \
         Mul(Pow(10, 18), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.BAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.BAR] = \
         Mul(Rat(Int(1), Pow(10, 5)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.CENTIBAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIBAR] = \
         Mul(Rat(Int(1), Int(1000)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.CENTIPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIPASCAL] = \
         Mul(Int(100), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.DECAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECAPASCAL] = \
         Mul(Rat(Int(1), Int(10)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.DECIBAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIBAR] = \
         Mul(Rat(Int(1), Pow(10, 4)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.DECIPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIPASCAL] = \
         Mul(Int(10), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.EXAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.EXAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 18)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.FEMTOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.FEMTOPASCAL] = \
         Mul(Pow(10, 15), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.GIGAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.GIGAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 9)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.HECTOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.HECTOPASCAL] = \
         Mul(Rat(Int(1), Int(100)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.KILOBAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOBAR] = \
         Mul(Rat(Int(1), Pow(10, 8)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.KILOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOPASCAL] = \
         Mul(Rat(Int(1), Int(1000)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MEGABAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGABAR] = \
         Mul(Rat(Int(1), Pow(10, 11)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MEGAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 6)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MICROPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MICROPASCAL] = \
         Mul(Pow(10, 6), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MILLIBAR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIBAR] = \
         Mul(Rat(Int(1), Int(100)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MILLIPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIPASCAL] = \
         Mul(Int(1000), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MILLITORR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLITORR] = \
         Mul(Rat(Int(19), Int(2533125)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.MMHG] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MMHG] = \
         Mul(Rat(Mul(Int(2), Pow(10, 8)), Int("26664477483")), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.NANOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.NANOPASCAL] = \
         Mul(Pow(10, 9), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.PETAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PETAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 15)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.PICOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PICOPASCAL] = \
         Mul(Pow(10, 12), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.PSI] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 9)), Int("172368932329209")), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.TERAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 12)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.TORR] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TORR] = \
         Mul(Rat(Int(152), Int(20265)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.YOCTOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOCTOPASCAL] = \
         Mul(Pow(10, 24), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.YOTTAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOTTAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 24)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.ZEPTOPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZEPTOPASCAL] = \
         Mul(Pow(10, 21), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.Pascal][UnitsPressure.ZETTAPASCAL] = \
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZETTAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 21)), Sym("pa"))  # nopep8
     CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ATMOSPHERE] = \
         Mul(Rat(Mul(Int(4), Pow(10, 10)), Int(4053)), Sym("terapa"))  # nopep8
@@ -1711,7 +1711,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 24), Sym("terapa"))  # nopep8
     CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 21)), Int("172368932329209")), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 12), Sym("terapa"))  # nopep8
     CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.TORR] = \
         Mul(Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("terapa"))  # nopep8
@@ -1773,7 +1773,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("torr"))  # nopep8
     CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(3015625), Pow(10, 6)), Int("155952843535951")), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(20265), Int(152)), Sym("torr"))  # nopep8
     CONVERSIONS[UnitsPressure.TORR][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("torr"))  # nopep8
@@ -1835,7 +1835,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctopa"))  # nopep8
     CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 13))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa"))  # nopep8
     CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctopa"))  # nopep8
@@ -1897,7 +1897,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 36), Sym("yottapa"))  # nopep8
     CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 33)), Int("172368932329209")), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 24), Sym("yottapa"))  # nopep8
     CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Pow(10, 12), Sym("yottapa"))  # nopep8
@@ -1959,7 +1959,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptopa"))  # nopep8
     CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 10))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PASCAL] = \
         Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa"))  # nopep8
     CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptopa"))  # nopep8
@@ -2021,7 +2021,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         Mul(Pow(10, 33), Sym("zettapa"))  # nopep8
     CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PSI] = \
         Mul(Rat(Mul(Int(25), Pow(10, 30)), Int("172368932329209")), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.Pascal] = \
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PASCAL] = \
         Mul(Pow(10, 21), Sym("zettapa"))  # nopep8
     CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.TERAPASCAL] = \
         Mul(Pow(10, 9), Sym("zettapa"))  # nopep8
@@ -2061,7 +2061,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
     SYMBOLS["PETAPASCAL"] = "PPa"
     SYMBOLS["PICOPASCAL"] = "pPa"
     SYMBOLS["PSI"] = "psi"
-    SYMBOLS["Pascal"] = "Pa"
+    SYMBOLS["PASCAL"] = "Pa"
     SYMBOLS["TERAPASCAL"] = "TPa"
     SYMBOLS["TORR"] = "Torr"
     SYMBOLS["YOCTOPASCAL"] = "yPa"

--- a/components/tools/OmeroPy/test/unit/test_model.py
+++ b/components/tools/OmeroPy/test/unit/test_model.py
@@ -375,7 +375,7 @@ class TestModel(object):
         (PowerI, 1, 'WATT', 10, 'DECIWATT'),
         (PowerI, 1, 'WATT', .1, 'DECAWATT'),
         (PressureI, 1, 'BAR', 100, 'KILOPASCAL'),
-        (PressureI, 1, 'TORR', 133.32236842, 'Pascal'),  # Win hack
+        (PressureI, 1, 'TORR', 133.32236842, 'PASCAL'),
         (TemperatureI, 0, 'CELSIUS', 32, 'FAHRENHEIT'),
         (TemperatureI, -40, 'CELSIUS', -40, 'FAHRENHEIT'),
         (TemperatureI, 100, 'CELSIUS', 212, 'FAHRENHEIT'),


### PR DESCRIPTION
# What this PR does

- Search and replace of `Pascal` to `PASCAL`
- Add PASCAL workaround for windows by adding a private header sourced by the generated Ice sources during compilation.
- May need additional workarounds at a higher level where the units headers get included, as done for the other C++ components.  But there are no such users at this time.

Due to the nature of the Ice code generation, it's not possible to put the workaround in the public header itself as for the other C++ code; we don't have control over this.  But `slice2cpp` does make provision for a single header to be added to the generated source, which we use here.

# Testing this PR

Check builds remain green.  The OMERO C++ jobs should be unchanged if this is all working.

# Related reading

https://trello.com/c/4NOpYKza/39-header-problems-on-windows
https://github.com/openmicroscopy/bioformats/pull/2474/files

Windows defines `PASCAL` in the system headers, which interferes with `PASCAL` as a unit enum.  This PR works around that.  Previously we renamed it to `Pascal` as a workaround, but if this fix works then the nasty hack is no longer necessary.

