### PR TITLE
populate_metadata many rows

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -235,6 +235,9 @@ class ValueResolver(object):
     """
 
     AS_ALPHA = [chr(v) for v in range(97, 122 + 1)]  # a-z
+    # Support more than 26 rows
+    for v in range(97, 122 + 1):
+        AS_ALPHA.append('a' + chr(v))
     WELL_REGEX = re.compile(r'^([a-zA-Z]+)(\d+)$')
 
     def __init__(self, client, target_object):


### PR DESCRIPTION
# What this PR does

Fix bug with populate_metadata.py reported at http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2016-July/003701.html where the script fails if the plate has more than 26 rows.

# Testing this PR

 - Use the Dataset_To_Plate.py script to create a Plate with more than 26 rows.
 - Create a csv file that names Wells using A->Z then AA->AZ etc. 
E.g.
```
Well,	Well Type,	TestValue
A01,	Treatment,	1
A02,	Control,	2
AA01,	Treatment,	3
AB02,	Treatment,	4
```
 - Attach CSV to Plate and run Populate_Metadata as described http://help.openmicroscopy.org/scripts.html#metadata
 - The Script should complete without error. Selecting Wells specified in the csv file should show the corresponding values in the Tables section, with the Well Name of that well.

![screen shot 2016-07-04 at 13 00 27](https://cloud.githubusercontent.com/assets/900055/16559811/66addad2-41e7-11e6-91ee-184f672a0217.png)

cc @chris-allan 
