### PR TITLE
Configuration of web link-to URL protocol/host

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -680,15 +680,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          None,
          identity,
          ("Use this host (including protocol) for absolute urls displayed in "
-          "the client. If omero.web.ui.use_client_host=True this will only be "
-          "used for absolute URLs which cannot be created with client-side "
-          "javascript.")],
-    "omero.web.ui.use_client_host":
-        ["WEB_URL_USE_CLIENT_HOST",
-         False,
-         bool,
-         ("If True build link-to URLs using client-side javascript, otherwise"
-          " use the server side HOST header")],
+          "the client. This does not include client-side generated URLs.")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -675,6 +675,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " 'webtest/webclient_plugins/center_plugin.overlay.js.html',"
           " 'channel_overlay_panel']``. "
           "The javascript loads data into ``$('#div_id')``.")],
+    "omero.web.ui.default_client_baseurl":
+        ["WEB_URL_DEFAULT_CLIENT_BASEURL",
+         None,
+         identity,
+         ("Use this host (including protocol) for absolute urls displayed in "
+          "the client. If omero.web.ui.use_client_host=True this will only be "
+          "used for absolute URLs which cannot be created with client-side "
+          "javascript.")],
     "omero.web.ui.use_client_host":
         ["WEB_URL_USE_CLIENT_HOST",
          False,

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -675,6 +675,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " 'webtest/webclient_plugins/center_plugin.overlay.js.html',"
           " 'channel_overlay_panel']``. "
           "The javascript loads data into ``$('#div_id')``.")],
+    "omero.web.ui.use_client_host":
+        ["WEB_URL_USE_CLIENT_HOST",
+         False,
+         bool,
+         ("If True build link-to URLs using client-side javascript, otherwise"
+          " use the server side HOST header")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -675,12 +675,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " 'webtest/webclient_plugins/center_plugin.overlay.js.html',"
           " 'channel_overlay_panel']``. "
           "The javascript loads data into ``$('#div_id')``.")],
-    "omero.web.ui.default_client_baseurl":
-        ["WEB_URL_DEFAULT_CLIENT_BASEURL",
+    "omero.web.ui.external_link_baseurl":
+        ["WEB_EXTERNAL_LINK_BASEURL",
          None,
          identity,
-         ("Use this host (including protocol) for absolute urls displayed in "
-          "the client. This does not include client-side generated URLs.")],
+         ("Use this host (including protocol) for absolute HTML urls "
+          "in the client, such as social media links. This does not include "
+          "client-side generated URLs.")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -33,10 +33,12 @@
                     $(this).css('visibility', 'hidden');
                 }).hide();
 
+                {% if link_string %}
+                $("#link_info_popup_string").val(location.protocol + "//" + location.host + "{{ webclient_path }}?show={{ link_string }}");
+                {% endif %}
 
                 // We do this here and in batch_annotate panel
                 OME.initToolbarDropdowns();
-
             });
             
     </script>
@@ -54,11 +56,7 @@
         <table>
           <tr><td>
             <!-- In 'batch_annotate' panel we have 'link_string'. In 'metadata_general' we use js to get value -->
-            <input type="text" size="30"
-              {% if link_string %}
-              value="{{ webclient_path }}?show={{ link_string }}"
-              {% endif %}
-              />
+            <input type="text" size="30" id="link_info_popup_string" />
           </td><td>
             <img title="Close" src="{% static 'webgateway/img/close.gif' %}" />
           </td></tr>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -103,12 +103,7 @@
                 // show a link to the current object
                 $("#show_link_btn").click(function(){
                     $("#link_info_popup").show();
-                {% if webclient_path %}
                     var lnk = location.protocol + "//" + location.host + "{{ webclient_path }}";
-                {% else %}
-                    var lnk = location.href.substring(0,location.href.length - location.search.length);
-                    if (lnk.charAt( lnk.length-1 ) == "#") { lnk = lnk.substring(0, lnk.length-1)}
-                {% endif %}
                     var obj_type = "{{manager.obj_type}}";
                     if (obj_type === "acquisition") {
                         obj_type = "run";

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -105,6 +105,8 @@
                     $("#link_info_popup").show();
                 {% if webclient_path %}
                     var lnk = "{{ webclient_path }}";
+                {% elif webclient_pathname %}
+                    var lnk = location.protocol + "//" + location.host + "{{ webclient_pathname }}";
                 {% else %}
                     var lnk = location.href.substring(0,location.href.length - location.search.length);
                     if (lnk.charAt( lnk.length-1 ) == "#") { lnk = lnk.substring(0, lnk.length-1)}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -104,9 +104,7 @@
                 $("#show_link_btn").click(function(){
                     $("#link_info_popup").show();
                 {% if webclient_path %}
-                    var lnk = "{{ webclient_path }}";
-                {% elif webclient_pathname %}
-                    var lnk = location.protocol + "//" + location.host + "{{ webclient_pathname }}";
+                    var lnk = location.protocol + "//" + location.host + "{{ webclient_path }}";
                 {% else %}
                     var lnk = location.href.substring(0,location.href.length - location.search.length);
                     if (lnk.charAt( lnk.length-1 ) == "#") { lnk = lnk.substring(0, lnk.length-1)}

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1566,8 +1566,11 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
 
     context['figScripts'] = figScripts
     context['template'] = template
-    context['webclient_path'] = request.build_absolute_uri(
-        reverse('webindex'))
+    if settings.WEB_URL_USE_CLIENT_HOST:
+        context['webclient_pathname'] = reverse('webindex')
+    else:
+        context['webclient_path'] = request.build_absolute_uri(
+            reverse('webindex'))
     return context
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2094,7 +2094,7 @@ def batch_annotate(request, conn=None, **kwargs):
         context['differentGroups'] = True       # E.g. don't run scripts etc
     context['canDownload'] = manager.canDownload(objs)
     context['template'] = "webclient/annotations/batch_annotate.html"
-    context['webclient_path'] = request.build_absolute_uri(reverse('webindex'))
+    context['webclient_path'] = reverse('webindex')
     return context
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1566,14 +1566,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
 
     context['figScripts'] = figScripts
     context['template'] = template
-    if settings.WEB_URL_USE_CLIENT_HOST:
-        context['webclient_pathname'] = reverse('webindex')
-    elif settings.WEB_URL_DEFAULT_CLIENT_BASEURL:
-        context['webclient_path'] = "%s%s" % (
-            settings.WEB_URL_DEFAULT_CLIENT_BASEURL, reverse('webindex'))
-    else:
-        context['webclient_path'] = request.build_absolute_uri(
-            reverse('webindex'))
+    context['webclient_path'] = reverse('webindex')
     return context
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1568,6 +1568,9 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
     context['template'] = template
     if settings.WEB_URL_USE_CLIENT_HOST:
         context['webclient_pathname'] = reverse('webindex')
+    elif settings.WEB_URL_DEFAULT_CLIENT_BASEURL:
+        context['webclient_path'] = "%s%s" % (
+            settings.WEB_URL_DEFAULT_CLIENT_BASEURL, reverse('webindex'))
     else:
         context['webclient_path'] = request.build_absolute_uri(
             reverse('webindex'))

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1974,12 +1974,16 @@ def full_viewer(request, iid, conn=None, **kwargs):
             prefix = kwargs.get(
                 'thumbprefix', 'webgateway.views.render_thumbnail')
 
-            def urlprefix(iid):
-                return reverse(prefix, args=(iid,))
+            def reverse_urlprefix(p, iid):
+                r = reverse(p, args=(iid,))
+                if settings.WEB_URL_DEFAULT_CLIENT_BASEURL:
+                    return "%s%s" % (
+                        settings.WEB_URL_DEFAULT_CLIENT_BASEURL, r)
+                else:
+                    return request.build_absolute_uri(r)
 
-            image_preview = request.build_absolute_uri(urlprefix(iid))
-            page_url = request.build_absolute_uri(reverse(
-                'webgateway.views.full_viewer', args=(iid,)))
+            image_preview = reverse_urlprefix(prefix, iid)
+            page_url = reverse_urlprefix('webgateway.views.full_viewer', iid)
 
         d = {'blitzcon': conn,
              'image': image,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1976,9 +1976,9 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
             def reverse_urlprefix(p, iid):
                 r = reverse(p, args=(iid,))
-                if settings.WEB_URL_DEFAULT_CLIENT_BASEURL:
+                if settings.WEB_EXTERNAL_LINK_BASEURL:
                     return "%s%s" % (
-                        settings.WEB_URL_DEFAULT_CLIENT_BASEURL, r)
+                        settings.WEB_EXTERNAL_LINK_BASEURL, r)
                 else:
                     return request.build_absolute_uri(r)
 


### PR DESCRIPTION
# What this PR does

The web metadata panel `Link to this <object>` contains a server side URL created from the HTTP `Host` header. This causes problems with server-side caching.

- Wherever possible client-side URLs should be constructed in javascript using the `location` object, so that the `/path` will be cached but the `protocol://host` will be handled by the client browser
- Where this isn't possible (e.g. embedded non-javascript metadata such as URLs parsed by social media) this can be overridden using `omero.web.ui.omero.web.ui.external_link_baseurl` (this must include the protocol).

# Testing this PR

1. Setup OMERO.web, optionally with a public user (makes testing easier)
2. Check `Link to this <object>` in the web RH metadata panel. The URL should use whatever the browser has in the location bar, and in additional examination of the returned html such as `http://host/webclient/metadata_details/image/ID/` should show `var lnk = location.protocol + "//" + location.host + "/webclient/";` instead of a URL.
3. Set `omero.web.ui.omero.web.ui.external_link_baseurl`: If twitter or opengraph is enabled the html for the full image viewer should contain URLs with this value instead of the Host header.

# Related reading

Link to cards, tickets, other PRs:
- See https://trello.com/c/KETiUCeR/373-metadata-cache-refresh-incorrect-link-to for a particular use-case

# Note

The only other place I'm aware of that let's you copy a link is in the full image viewer where it is already generated by client-side javascript: https://github.com/manics/openmicroscopy/blob/metadata52-linkto/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html#L665

This is unchanged, but maybe it should be unified?

Note: Description updated 2016-07-07