### PR TITLE
Rename ROI 'Visibility' to 'Show'

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -446,7 +446,7 @@
       roi_html += "<th>T</th>"; // no T for ROI
       roi_html += "<th>" + toggle_shape_text + " Text</th>";
       roi_html += "<th title='Pick color of ROI outlines'><div style='white-space:nowrap;'>" + toggle_roi_thumbs + "Preview</div>"+ color_picker + "</th>";
-      roi_html += "<th>" + toggle_roi_visibility + " Visibility</th>";
+      roi_html += "<th>" + toggle_roi_visibility + " Show</th>";
       roi_html += "</tr></thead>";
       $roi_table.append($(roi_html));
 


### PR DESCRIPTION
# What this PR does

As requested https://github.com/openmicroscopy/openmicroscopy/pull/4725#issuecomment-229962048 this renames the "Visibility" column in the web ROI table to "Show" in line with Insight.

# Testing this PR

View ROIs on an image in webclient. Table column should be renamed "Show".

![screen shot 2016-07-04 at 13 29 47](https://cloud.githubusercontent.com/assets/900055/16560444/6b57ac80-41eb-11e6-82e3-876dfdf3c12c.png)


