### PR TITLE
TF8 import

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -95,12 +95,10 @@ import omero.gateway.util.PojoMapper;
 
 import org.openmicroscopy.shoola.env.data.util.Resolver;
 
-import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.RenderingServiceException;
-import omero.gateway.facility.ROIFacility;
 
 import org.openmicroscopy.shoola.env.data.util.StatusLabel;
 import org.openmicroscopy.shoola.env.data.util.Target;
@@ -120,7 +118,6 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FileAnnotationData;
-import omero.gateway.model.FolderData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.model.ROIData;
@@ -1050,7 +1047,7 @@ class OmeroImageServiceImpl
                 status.setText(ImportException.FILE_NOT_VALID_TEXT);
                 return e;
 			}
-			hcsFile = isHCS(ic.getContainers());
+			hcsFile = isHCS(ic.getContainers()) && !ImportableObject.isOMEFile(file);
 			//Create the container if required.
 			if (hcsFile) {
 				if (ic != null) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -122,8 +122,10 @@ public class ImportableObject
 		
 
 		IFormatReader reader = new OMEXMLReader();
-		OME_SUFFIXES = (List<String>) Arrays.asList(reader.getSuffixes());
-
+		OME_SUFFIXES = new ArrayList<String>();
+		OME_SUFFIXES.addAll((List<String>) Arrays.asList(reader.getSuffixes()));
+		OME_SUFFIXES.add("tf8");
+		
 		ARBITRARY_FILES_EXTENSION = new ArrayList<String>();
 		ARBITRARY_FILES_EXTENSION.add("text");
 		ARBITRARY_FILES_EXTENSION.add("txt");


### PR DESCRIPTION
# What this PR does

Treat `*.tf8` images like `ome.tiff` and import them as image (not as plate).

I'm not sure if this is good solution, as I still have lots of question marks about this process, e. g. why do these files have a plate definition in the metadata in first place, when they are not plates; and why do they get imported as images and not as plates, although they have plate definitions.

# Testing this PR

Import a `*.tf8` image into a (Project/)Dataset. Without the PR the image would have been recognised as plate (but not imported as such, for some reason...), and ended in `Orphaned Images` folder.
Test image: 206157 (on demo server)

# Related reading

[Ticket 13243](http://trac.openmicroscopy.org/ome/ticket/13243)

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-July/006095.html



