### PR TITLE
populate_metadata.py: add batches to write_to_omero

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -36,6 +36,8 @@ import Ice
 import Glacier2
 import omero
 import omero.gateway
+
+from collections import defaultdict
 from omero.cmd import DoAll, State, ERR, OK, Chmod2, Chgrp2, Delete2
 from omero.callbacks import CmdCallbackI
 from omero.model import DatasetI, DatasetImageLinkI, ImageI, ProjectI
@@ -1031,26 +1033,19 @@ class ITest(object):
             link.setChild(obj2.proxy())
         return client.sf.getUpdateService().saveAndReturnObject(link)
 
-    def delete(self, obj):
+    def delete(self, objs):
         """
-        Deletes a list of model entities (ProjectI, DatasetI or ImageI)
+        Deletes model entities (ProjectI, DatasetI, ImageI, etc)
         by creating Delete2 commands and calling
         :func:`~test.ITest.doSubmit`.
 
         :param obj: a list of objects to be deleted
         """
-        if isinstance(obj[0], ProjectI):
-            t = "Project"
-        elif isinstance(obj[0], DatasetI):
-            t = "Dataset"
-        elif isinstance(obj[0], ImageI):
-            t = "Image"
-        else:
-            assert False, "Object type not supported."
-
-        ids = [i.id.val for i in obj]
-        command = Delete2(targetObjects={t: ids})
-
+        to_delete = defaultdict(list)
+        for obj in objs:
+            t = obj.__class__.__name__
+            to_delete[t].append(obj.id.val)
+        command = Delete2(targetObjects=to_delete)
         self.doSubmit(command, self.client)
 
     def change_group(self, obj, target, client=None):

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -147,6 +147,11 @@ class MetadataControl(BaseControl):
         populate = parser.add(sub, self.populate)
         populateroi = parser.add(sub, self.populateroi)
 
+        populate.add_argument("--batch",
+                              type=long,
+                              default=1000,
+                              help="Number of objects to save at once")
+
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):
             x.add_argument("obj",
@@ -423,7 +428,7 @@ class MetadataControl(BaseControl):
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach)
         ctx.parse()
         if not args.dry_run:
-            ctx.write_to_omero()
+            ctx.write_to_omero(batch_size=args.batch)
 
     def rois(self, args):
         "Manage ROIs"

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -150,7 +150,7 @@ class MetadataControl(BaseControl):
         populate.add_argument("--batch",
                               type=long,
                               default=1000,
-                              help="Number of objects to save at once")
+                              help="Number of objects to process at once")
 
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -942,7 +942,6 @@ class _QueryContext(object):
         for batch in (i[pos:pos + sz] for pos in xrange(0, len(i), sz)):
             yield batch
 
-
     def projection(self, q, ids, ns=None):
         """
         Run a projection query designed to return scalars only
@@ -1293,7 +1292,7 @@ class DeleteMapAnnotationContext(_QueryContext):
 
     def write_to_omero(self, batch_size=1000):
         combined = self.mapannids + self.fileannids
-        for batch in self._batch(self.mapannids + self.fileannids, sz=batch_size):
+        for batch in self._batch(combined, sz=batch_size):
             self._write_to_omero_batch(batch)
 
     def _write_to_omero_batch(self, batch):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -34,6 +34,7 @@ from itertools import izip
 from collections import defaultdict
 
 import omero.clients
+from omero import CmdError
 from omero.callbacks import CmdCallbackI
 from omero.rtypes import rstring, unwrap
 from omero.model import DatasetAnnotationLinkI, DatasetI, FileAnnotationI
@@ -939,6 +940,7 @@ class _QueryContext(object):
         Generate batches of size sz (by default 1000) from the input
         iterable `i`.
         """
+        i = list(i)  # Copying list to handle sets and modifications
         for batch in (i[pos:pos + sz] for pos in xrange(0, len(i), sz)):
             yield batch
 
@@ -1285,10 +1287,12 @@ class DeleteMapAnnotationContext(_QueryContext):
         # TODO: This should really include:
         #    raise Exception("Unknown target: %s" % target.__class__.__name__)
 
-        log.debug("Parent IDs: %s", parentids)
+        log.debug("Parent IDs: %s",
+                  ["%s:%s" % (k, v is not None and len(v) or "NA")
+                   for k, v in parentids.items()])
 
-        self.mapannids = []
-        self.fileannids = []
+        self.mapannids = set()
+        self.fileannids = set()
         not_annotatable = ('WellSample',)
 
         ns = omero.constants.namespaces.NSBULKANNOTATIONS
@@ -1297,7 +1301,7 @@ class DeleteMapAnnotationContext(_QueryContext):
                 continue
             r = self._get_annotations_for_deletion(
                 objtype, objids, 'MapAnnotation', ns)
-            self.mapannids.extend(r)
+            self.mapannids.update(r)
 
         log.info("Total: %d MapAnnotation(s) in %s",
                  len(set(self.mapannids)), ns)
@@ -1309,31 +1313,38 @@ class DeleteMapAnnotationContext(_QueryContext):
                     continue
                 r = self._get_annotations_for_deletion(
                     objtype, objids, 'FileAnnotation', ns)
-                self.fileannids.extend(r)
+                self.fileannids.update(r)
 
             log.info("Total: %d FileAnnotation(s) in %s",
                      len(set(self.fileannids)), ns)
 
     def write_to_omero(self, batch_size=1000):
-        combined = self.mapannids + self.fileannids
-        for batch in self._batch(combined, sz=batch_size):
-            self._write_to_omero_batch(batch)
+        for batch in self._batch(self.mapannids, sz=batch_size):
+            self._write_to_omero_batch({"MapAnnotation": batch})
+        for batch in self._batch(self.fileannids, sz=batch_size):
+            self._write_to_omero_batch({"FileAnnotation": batch})
 
-    def _write_to_omero_batch(self, batch):
-        to_delete = {"Annotation": batch}
+    def _write_to_omero_batch(self, to_delete):
         delCmd = omero.cmd.Delete2(targetObjects=to_delete)
-        callback = self.client.submit(
-            delCmd, loops=100, failontimeout=True)
+        try:
+            callback = self.client.submit(
+                delCmd, loops=100, failontimeout=True)
+        except CmdError, ce:
+            log.error("Failed to delete: %s" % to_delete)
+            raise Exception(ce.err)
+
         # At this point, we're sure that there's a response OR
         # an exception has been thrown (likely LockTimeout)
         rsp = callback.getResponse()
         if isinstance(rsp, omero.cmd.OK):
             ndma = len(rsp.deletedObjects.get(
                 "ome.model.annotations.MapAnnotation", []))
-            log.info("Deleted %d MapAnnotation(s)", ndma)
             ndfa = len(rsp.deletedObjects.get(
                 "ome.model.annotations.FileAnnotation", []))
-            log.info("Deleted %d FileAnnotation(s)", ndfa)
+            if ndma:
+                log.info("Deleted %d MapAnnotation(s)", ndma)
+            if ndfa:
+                log.info("Deleted %d FileAnnotation(s)", ndfa)
         else:
             log.error("Delete failed: %s", rsp)
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -893,10 +893,9 @@ class ParsingContext(object):
         original_file = table.getOriginalFile()
         log.info('Created new table OriginalFile:%d' % original_file.id.val)
 
-        columns = self.columns
         values = []
         length = -1
-        for x in columns:
+        for x in self.columns:
             if length < 0:
                 length = len(x.values)
             else:
@@ -911,9 +910,10 @@ class ParsingContext(object):
         for pos in xrange(0, length, batch_size):
             i += 1
             for idx, x in enumerate(values):
-                columns[idx].values = x[pos:pos+batch_size]
+                self.columns[idx].values = x[pos:pos+batch_size]
             table.addData(self.columns)
-            log.info('Added %s rows of column data (batch %s)', batch_size, i)
+            count = min(batch_size, length - pos)
+            log.info('Added %s rows of column data (batch %s)', count, i)
 
         table.close()
         file_annotation = FileAnnotationI()

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -24,6 +24,7 @@ Populate bulk metadata tables from delimited text files.
 
 
 import logging
+import gzip
 import sys
 import csv
 import re
@@ -762,7 +763,11 @@ class ParsingContext(object):
             (o.name, len(o.values)) for o in self.columns])
 
     def parse(self):
-        data = open(self.file, 'U')
+        if self.file.endswith(".gz"):
+            data = gzip.open(self.file, "rb")
+        else:
+            data = open(self.file, 'U')
+
         try:
             return self.parse_from_handle(data)
         finally:

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -424,6 +424,9 @@ class TestPopulateMetadata(lib.ITest):
         """
 
         target = fixture.get_target()
+        # Deleting anns so that we can re-use the same user
+        self.delete(fixture.get_annotations())
+
         csv = fixture.get_csv()
         ctx = ParsingContext(self.client, target, file=csv)
         ctx.parse()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -112,9 +112,11 @@ class Fixture(object):
 
     def createDataset(self, names=("A1", "A2")):
         ds = self.test.make_dataset()
-        for name in names:
-            img = self.test.importSingleImage(name=name)
+        imgs = self.test.importMIF(
+            seriesCount=len(names))
+        for i, name in enumerate(names):
             # Name must match exactly. No ".fake"
+            img = imgs[i]
             img = self.setName(img, name)
             self.test.link(ds, img)
         return ds.proxy()
@@ -249,6 +251,7 @@ class Dataset2Images(Fixture):
         )
         self.dataset = None
         self.images = None
+        self.names = ("A1", "A2")
 
     def assert_rows(self, rows):
         # Hard-coded in createCsv's arguments
@@ -256,7 +259,7 @@ class Dataset2Images(Fixture):
 
     def get_target(self):
         if not self.dataset:
-            self.dataset = self.createDataset()
+            self.dataset = self.createDataset(self.names)
             self.images = self.get_dataset_images()
         return self.dataset
 
@@ -301,14 +304,39 @@ class Dataset2Images(Fixture):
             img = mv['Image Name']
             con = mv['Concentration']
             typ = mv['Type']
-            if img == "A1":
+            assert img[0] in ("A", "a")
+            which = long(img[1:])
+            if which % 2 == 1:
                 assert con == '0'
                 assert typ == 'Control'
-            elif img == "A2":
+            elif which % 2 == 0:
                 assert con == '10'
                 assert typ == 'Treatment'
-            else:
-                raise Exception("Unknown img: %s" % img)
+
+
+class Dataset101Images(Dataset2Images):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 102
+        self.names = []
+        rowData = []
+        for x in range(0, 101, 2):
+            name = "A%s" % (x+1)
+            self.names.append(name)
+            rowData.append("%s,Control,0" % name)
+            name = "A%s" % (x+2)
+            self.names.append(name)
+            rowData.append("A%s,Treatment,10" % (x+2))
+        self.csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+            rowData=rowData,
+        )
+        self.dataset = None
+        self.images = None
+
+    def assert_rows(self, rows):
+        assert rows == 102
 
 
 class Project2Datasets(Fixture):
@@ -395,6 +423,7 @@ class TestPopulateMetadata(lib.ITest):
         Screen2Plates(),
         Plate2Wells(),
         Dataset2Images(),
+        Dataset101Images(),
         Project2Datasets(),
     )
     METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
@@ -427,6 +456,9 @@ class TestPopulateMetadata(lib.ITest):
         target = fixture.get_target()
         # Deleting anns so that we can re-use the same user
         self.delete(fixture.get_annotations())
+        child_anns = fixture.get_child_annotations()
+        child_anns = [x[0] for x in child_anns]
+        self.delete(child_anns)
 
         csv = fixture.get_csv()
         ctx = ParsingContext(self.client, target, file=csv)
@@ -459,9 +491,6 @@ class TestPopulateMetadata(lib.ITest):
                 assert "Control" in rowValues
             elif "A2" in rowValues or "a2" in rowValues:
                 assert "Treatment" in rowValues
-            else:
-                assert False, \
-                    "Row does not contain 'a1' or 'a2': %s" % rowValues
 
     def _test_bulk_to_map_annotation_context(self, fixture, batch_size):
         # self._testPopulateMetadataPlate()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -27,8 +27,10 @@
 import library as lib
 import string
 import csv
+import gzip
 import os.path
 import re
+import shutil
 
 from omero.api import RoiOptions
 from omero.grid import ImageColumn
@@ -339,6 +341,18 @@ class Dataset101Images(Dataset2Images):
         assert rows == 102
 
 
+class GZIP(Dataset2Images):
+
+    def createCsv(self, *args, **kwargs):
+        csvFileName = super(GZIP, self).createCsv(*args, **kwargs)
+        gzipFileName = "%s.gz" % csvFileName
+        with open(csvFileName, 'rb') as f_in, \
+            gzip.open(gzipFileName, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        return gzipFileName
+
+
 class Project2Datasets(Fixture):
 
     def __init__(self):
@@ -425,6 +439,7 @@ class TestPopulateMetadata(lib.ITest):
         Dataset2Images(),
         Dataset101Images(),
         Project2Datasets(),
+        GZIP(),
     )
     METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 


### PR DESCRIPTION
# What this PR does

The new `QueryContext` implementations in `populate_metadata.py` were not batching in their `write_to_omero` methods. For very large screens (e.g. idr0016):

 * `BulkToMapAnnotationContext` tends to hit MESSAGESIZEMAX limits and
 * `DeleteMapAnnotationContext` hits `Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 109734`

Now both are done in batches of 1000.

*Note:* projections are also causing issues so batching is being added to invocations of `projection` as well.

# Testing this PR

1. A bulk annotation YML configuration is required. This is minimal possible via `test/integration/metadata/test_populate.py`.
2. There should be no change in functionality and no overt slowdown in creation or deletion.

# Related reading

 * https://trello.com/c/urQCwi0v/470-error-creating-map-annotations-in-demo2-for-idr0016
 * https://trello.com/c/88jfqEem/469-error-deleting-map-annotations-for-idr0001-screena

cc: @eleanorwilliams 