### PR TITLE
Rgb to hex

### DIFF
--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -10,7 +10,7 @@ Suite Teardown      Close all browsers
 
 *** Variables ***
 
-${importedChColor}                  rgb(128, 128, 128)
+${importedChColor}                  808080
 ${importedMax}                      255
 ${sizeZ}                            3
 ${defaultZ}                         2
@@ -19,7 +19,7 @@ ${currZ}                            3
 *** Keywords ***
 
 Pick Color
-    [Arguments]          ${btnColor}        ${hexColor}       ${rgbColor}
+    [Arguments]          ${btnColor}        ${hexColor}
     Click Element                           xpath=//button[@id="wblitz-ch0-color"]
     Wait Until Element Is Visible           id=cbpicker-box
     # Click yellow color-picker button
@@ -27,11 +27,13 @@ Pick Color
     Textfield Value Should Be               cbpicker-tb         ${hexColor}
     Click Element                           cbpicker-OK-btn
     # Wait for the channel toggle button to turn yellow
-    Wait For Channel Color                  ${rgbColor}
+    Wait For Channel Color                  ${hexColor}
 
 Wait For Channel Color
-    [Arguments]          ${rgbColor}
-    Wait Until Element Is Visible           xpath=//button[@id="rd-wblitz-ch0"][contains(@style, "background-color: ${rgbColor}")]      ${WAIT}
+    [Arguments]          ${hexColor}
+    # Can't use @style to check color since Firefox will auto convert hex to rgb() in the DOM but Chrome won't.
+    # Wait Until Element Is Visible           xpath=//button[@id="rd-wblitz-ch0"][contains(@style, "background-color: ${rgbColor}")]      ${WAIT}
+    Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"][@data-color="${hexColor}"]
 
 Wait For BlockUI
     # Wait Until Element Is Visible           xpath=//div[contains(@class, 'blockOverlay')]
@@ -109,8 +111,8 @@ Test Rdef Copy Paste Save
     Element Text Should Be                  id=wblitz-z-curr        ${defaultZ}
 
     # Color-picker, Yellow then Blue.
-    Pick Color          ff0       FFFF00        rgb(255, 255, 0)
-    Pick Color          00f       0000FF        rgb(0, 0, 255)
+    Pick Color          ff0       FFFF00
+    Pick Color          00f       0000FF
 
     # ONLY Redo should be disabled
     Element Should Be Enabled               id=rdef-undo-btn
@@ -118,7 +120,7 @@ Test Rdef Copy Paste Save
     Element Should Be Enabled               id=rdef-setdef-btn
     # Click Undo - Channel should be Yellow
     Click Element                           id=rdef-undo-btn
-    Wait For Channel Color                  rgb(255, 255, 0)
+    Wait For Channel Color                  FFFF00
 
     # And all buttons Undo, Redo & Save enabled
     Element Should Be Enabled               id=rdef-undo-btn
@@ -132,7 +134,7 @@ Test Rdef Copy Paste Save
     Wait Until Page Contains Element        xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
     # Redo (to Blue channel)
     Click Element                           id=rdef-redo-btn
-    Wait For Channel Color                  rgb(0, 0, 255)
+    Wait For Channel Color                  0000FF
     # Copy (paste button is enabled)
     Click Element                           id=rdef-copy-btn
     Wait For Toolbar Button Enabled         rdef-paste-btn
@@ -142,7 +144,7 @@ Test Rdef Copy Paste Save
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
     Wait For Toolbar Button Enabled         rdef-paste-btn
     # Channel should be Yellow
-    Wait For Channel Color                  rgb(255, 255, 0)
+    Wait For Channel Color                  FFFF00
 
     # Select Next Image
     Click Next Thumbnail
@@ -153,7 +155,7 @@ Test Rdef Copy Paste Save
 
     # Paste (Blue channel)
     Click Element                           xpath=//button[@id='rdef-paste-btn']
-    Wait For Channel Color                  rgb(0, 0, 255)
+    Wait For Channel Color                  0000FF
 
     # Save to all (Blue channel)
     Click Element                           id=rdef-save-all
@@ -161,7 +163,7 @@ Test Rdef Copy Paste Save
     # Return to Previous Image (now Blue)
     Select Image By Id                      ${imageId}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
-    Wait For Channel Color                  rgb(0, 0, 255)
+    Wait For Channel Color                  0000FF
 
 
 Test Owners Rdef
@@ -182,7 +184,7 @@ Test Owners Rdef
     # Need user to save an Rdef that is different from 'Imported'
     # Save Channel 'Green' and Window End: 100
     Unselect Checkbox                       rd-wblitz-rmodel
-    Pick Color                              0f0         00FF00          rgb(0, 255, 0)
+    Pick Color                              0f0         00FF00
     Input Text                              id=wblitz-ch0-cw-end        100
     Click Element                           id=rdef-setdef-btn
     Wait For BlockUI
@@ -210,30 +212,30 @@ Test Owners Rdef
 
     # Set to Owner's (click on thumbnail)
     Click Element                           xpath=//button[contains(@class, 'rdef')][descendant::span[contains(@class, 'owner')]]
-    Wait For Channel Color                  rgb(0, 255, 0)
+    Wait For Channel Color                  00FF00
     Textfield Value Should Be               wblitz-ch0-cw-end           100
     Checkbox Should Not Be Selected         rd-wblitz-rmodel
 
     # Set to Full Range
     Click Element                           id=rdef-fullrange-btn
-    Wait For Channel Color                  rgb(0, 255, 0)
+    Wait For Channel Color                  00FF00
     Textfield Value Should Be               wblitz-ch0-cw-end           255
     Checkbox Should Not Be Selected         rd-wblitz-rmodel
 
     # 'Save All' with some different settings (Red channel)
     Unselect Checkbox                       rd-wblitz-rmodel
-    Pick Color                              f00         FF0000          rgb(255, 0, 0)
+    Pick Color                              f00         FF0000
     Click Element                           id=rdef-save-all
     Wait For BlockUI
 
     # Min/Max
     Click Element                           id=rdef-minmax-btn
-    Wait For Channel Color                  rgb(255, 0, 0)
+    Wait For Channel Color                  FF0000
     Textfield Value Should Be               wblitz-ch0-cw-end           255
 
     # New settings (White channel, max 200) and 'Copy'
     Input Text                              id=wblitz-ch0-cw-end        200
-    Pick Color                              fff         FFFFFF          rgb(255, 255, 255)
+    Pick Color                              fff         FFFFFF
     Click Element                           xpath=//button[@id='rdef-copy-btn']
     Wait For Toolbar Button Enabled         rdef-paste-btn
     
@@ -245,7 +247,7 @@ Test Owners Rdef
     # Check applied by refresh right panel
     Select Image By Id                      ${imageId_2}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
-    Wait For Channel Color                  rgb(255, 255, 255)
+    Wait For Channel Color                  FFFFFF
     Textfield Value Should Be               wblitz-ch0-cw-end           200
 
     # Test Set Owner's in same way on first Image
@@ -255,7 +257,7 @@ Test Owners Rdef
     # Check applied by refresh right panel
     Click Element                           id=image_icon-${imageId}
     ${status}    ${oldId}                   Wait For Preview Load   ${status}   ${oldId}
-    Wait For Channel Color                  rgb(0, 255, 0)
+    Wait For Channel Color                  00FF00
     Textfield Value Should Be               wblitz-ch0-cw-end           100
 
     # Test "Set Imported" on first Image

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -898,7 +898,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
     }
     for (var i=0; i<e1.channels.length; i++) {
       if (!(e1.channels[i].active == e2.channels[i].active &&
-            OME.rgbToHex(e1.channels[i].color) == OME.rgbToHex(e2.channels[i].color) &&
+            e1.channels[i].color == e2.channels[i].color &&
             e1.channels[i].windowStart == e2.channels[i].windowStart &&
             e1.channels[i].windowEnd == e2.channels[i].windowEnd &&
             e1.channels[i].metalabel == e2.channels[i].metalabel)) {
@@ -914,7 +914,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
     var channels = _this.loadedImg.channels;
     for (i=0; i<channels.length; i++) {
       var channel = {active: channels[i].active,
-                     color: toRGB(channels[i].color),
+                     color: channels[i].color,
                      windowStart: channels[i].window.start,
                      windowEnd: channels[i].window.end,
                      metalabel: channels[i].metalabel};

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -146,10 +146,7 @@
             $('#wblitz-ch'+idx).removeClass('pressed');
             $('#rd-wblitz-ch'+idx).removeClass('pressed');
         }
-        //var t = $('#rd-wblitz-ch'+idx).get(0);
-        //if (t != undefined) t.checked=ch.active;
-        var rgb = OME.hexToRgb(ch.color)
-        $('#wblitz-ch'+idx).css('background-color', 'rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')').attr('title', ch.label);
+        $('#wblitz-ch'+idx).css('background-color', '#' + ch.color).attr('title', ch.label);
     };
 
 
@@ -186,7 +183,7 @@
             $('#wblitz-ch'+i+'-cwslider')
                 .slider( "option", "min", Math.min(w.min, w.start) )   // extend range if needed
                 .slider( "option", "max", Math.max(w.max, w.end) );
-                $('#wblitz-ch'+i+'-color').attr('data-color', toRGB(channels[i].color));//$('#wblitz-ch'+i).css('background-color'));
+                $('#wblitz-ch'+i+'-color').attr('data-color', channels[i].color);
                 $('#wblitz-ch'+i+'-cw-start').val(channels[i].window.start).change();
                 $('#wblitz-ch'+i+'-cw-end').val(channels[i].window.end).change();
         }
@@ -326,11 +323,10 @@
             };
         };
         for (i=0; i<channels.length; i++) {
-            var rgb = OME.hexToRgb(channels[i].color)
             $('<button id="wblitz-ch'+i+
-                '"class="squared' + (channels[i].active?' pressed':'') +
-                '"style="background-color: rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')' +
-                '"title="' + channels[i].label +
+                '" class="squared' + (channels[i].active?' pressed':'') +
+                '" style="background-color: #'+ channels[i].color +
+                '" title="' + channels[i].label +
                 '">'+channels[i].label+'</button>')
             .appendTo(box)
             .bind('click', doToggle(i));
@@ -465,10 +461,9 @@
             if (lbl.length > 7) {
                 lbl = lbl.slice(0, 5) + "...";
             }
-            var rgb = OME.hexToRgb(channels[i].color)
             tmp.after(template
                 .replace(/\$class/g, btnClass)
-                .replace(/\$col/g, 'rgb('+rgb.r+', '+rgb.g+', '+rgb.b+')')
+                .replace(/\$col/g, '#' + channels[i].color)
                 .replace(/\$label/g, channels[i].label)
                 .replace(/\$l/g, lbl)
                 .replace(/\$idx0/g, i) // Channel Index, 0 based


### PR DESCRIPTION
# What this PR does

This separates some changes that were in the histogram work: https://github.com/openmicroscopy/openmicroscopy/pull/4703 into a separate branch to avoid conflicts between #4703 and LUT work.
Here, we always use hex notation for colors in the color-picker and color-picker buttons instead of switching between hex and rgb notation.
Previously, we'd use hex notation for channel colors when the viewer / Preview panel first loads, then when a color is picked we'd use rgb notation.

# Testing this PR
This PR should not show any functional changes to the UI. 
Check that color-picker still works OK and that updated robot tests are passing (Both of these are already tested as part of #4703)
