### PR TITLE
 Ticket 13269

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
@@ -100,7 +100,7 @@ public class PojosUtil {
             WellSampleData w = (WellSampleData) obj;
             return w.getImage().isArchived()
                     && !w.asWellSample()
-                            .getPlateAcquisition()
+                            .getWell()
                             .getPlate()
                             .getDetails()
                             .getPermissions()


### PR DESCRIPTION
# What this PR does

Fixes [Ticket 13269](https://trac.openmicroscopy.org/ome/ticket/13269) (NPE when a Well without PlateAcquisition is selected).

Instead of checking the PlateAcquisition now the Well of the WellsampleData is checked if it is restricted with respect to downloading. But I don't really understand the implications here. Can a WellsampleData have a PlateAcquisition and a Well or both, and what to check in that case?

# Testing this PR

Import the file mentioned in the ticket. Click on the Well.
