### PR TITLE
Script test

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -552,15 +552,25 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
         safeRunnableCall(__current, cb, true, new Callable<Object>() {
             public Object call() throws Exception {
 
-                OriginalFile file = getOriginalFileOrNull(id, __current);
+                final OriginalFile file = getOriginalFileOrNull(id, __current);
                 if (file == null) {
                     throw new ApiUsageException(null, null,
                             "No script with id " + id + " on server.");
                 }
 
                 deleteOriginalFile(file, __current);
-                return null; // void
+                factory.executor.execute(
+                        __current.ctx, factory.principal, new Executor.SimpleWork(this, "deleteScript") {
 
+                            @Transactional(readOnly = false)
+                            public Object doWork(Session session, ServiceFactory sf) {
+                                session.delete(file);
+                                return null;
+                            }
+
+                        });
+                
+                return null; // void
             }
         });
     }
@@ -679,14 +689,11 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
         if (file == null) {
             return;
         }
-
-        if (scripts.delete(file.getId())) {
+       if (scripts.delete(file.getId())) {
             return;
         }
-
         scripts.simpleDelete(current.ctx, factory.executor, factory.principal,
             file.getId());
-
     }
 
     /**

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -689,7 +689,7 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
         if (file == null) {
             return;
         }
-       if (scripts.delete(file.getId())) {
+        if (scripts.delete(file.getId())) {
             return;
         }
         scripts.simpleDelete(current.ctx, factory.executor, factory.principal,

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -209,6 +209,7 @@ public class ScriptServiceTest extends AbstractServerTest {
         String folder = f.getName().getValue();
         long id = svc.uploadOfficialScript(folder, str);
         Assert.assertTrue(id > 0);
+        Assert.assertEquals(svc.getScripts().size(), scripts.size()+1);
         deleteScript(id);
     }
 

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -259,17 +259,13 @@ public class ScriptServiceTest extends AbstractServerTest {
     @Test
     public void testUploadOfficialLUTAsRoot() throws Exception {
         logRootIntoGroup();
-        StringBuffer buf = new StringBuffer("");
-        String[] values = { "a", "b", "c" };
-        for (int i = 0; i < values.length; i++) {
-            buf.append(values[i].charAt(0));
-        }
-        String uuid = UUID.randomUUID().toString();
-        String folder = "officialTestFolder"+uuid+".lut";
         IScriptPrx svc = factory.getScriptService();
         List<OriginalFile> scripts = svc.getScriptsByMimetype(LUT_MIMETYPE);
         int n = scripts.size();
-        long id = svc.uploadOfficialScript(folder, buf.toString());
+        OriginalFile f = scripts.get(0);
+        String str = readScript(f);
+        String folder = f.getName().getValue();
+        long id = svc.uploadOfficialScript(folder, str);
         Assert.assertTrue(id > 0);
         Assert.assertEquals(svc.getScriptsByMimetype(LUT_MIMETYPE).size(),
                 n+1);

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -30,6 +30,7 @@ import omero.api.RawFileStorePrx;
 import omero.grid.JobParams;
 import omero.model.IObject;
 import omero.model.OriginalFile;
+import omero.model.OriginalFileI;
 import omero.sys.ParametersI;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -227,12 +228,7 @@ public class ScriptServiceTest extends AbstractServerTest {
         deleteScript(id);
         Assert.assertEquals(svc.getScripts().size(), scripts.size());
         //Check that the entry has been removed from DB
-        ParametersI param = new ParametersI();
-        param.map.put("id", omero.rtypes.rlong(id));
-        f = (OriginalFile) factory.getQueryService().findByQuery(
-                "select p from OriginalFile as p " +
-                "where p.id = :id", param);
-        Assert.assertNull(f);
+        assertDoesNotExist(new OriginalFileI(id, false));
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -166,6 +166,7 @@ public class ScriptServiceTest extends AbstractServerTest {
      */
     @Test
     public void testUploadOfficialScript() throws Exception {
+        newUserAndGroup("rwr---");
         StringBuffer buf = new StringBuffer("");
         String[] values = { "a", "b", "c" };
         for (int i = 0; i < values.length; i++) {

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -280,7 +280,6 @@ public class ScriptServiceTest extends AbstractServerTest {
      */
     private void deleteScript(long id) throws Exception {
         IScriptPrx svc = factory.getScriptService();
-        //currently the deleteScript does not delete the entry in the DB.
         svc.deleteScript(id);
     }
 

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -202,6 +202,7 @@ public class ScriptServiceTest extends AbstractServerTest {
         try {
             long id = svc.uploadOfficialScript(folder, buf.toString());
             Assert.assertTrue(id > 0);
+            deleteScript(id);
         } catch (Exception e) {
         }
     }
@@ -248,9 +249,22 @@ public class ScriptServiceTest extends AbstractServerTest {
         try {
             long id = svc.uploadOfficialScript(folder, buf.toString());
             Assert.assertTrue(id > 0);
+            Assert.assertEquals(n+1, svc.getScriptsByMimetype(LUT_MIMETYPE).size());
+            deleteScript(id);
         } catch (Exception e) {
         }
-        Assert.assertEquals(n+1, svc.getScriptsByMimetype(LUT_MIMETYPE).size());
+    }
+
+    /**
+     * Delete the uploaded script.
+     *
+     * @param id The identifier of the script.
+     * @throws Exception Thrown if an error occurred.
+     */
+    private void deleteScript(long id) throws Exception {
+        IScriptPrx svc = factory.getScriptService();
+        //currently the deleteScript does not delete the entry in the DB.
+        svc.deleteScript(id);
     }
 
 }

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -66,7 +66,7 @@ public class ScriptServiceTest extends AbstractServerTest {
         String sql = "select f from OriginalFile as f "
                 + "where f.mimetype = :m";
         List<IObject> values = iQuery.findAllByQuery(sql, param);
-        Assert.assertEquals(n, values.size());
+        Assert.assertEquals(values.size(), n);
     }
 
     /**
@@ -123,7 +123,7 @@ public class ScriptServiceTest extends AbstractServerTest {
             f = i.next();
             Assert.assertNotNull(f);
             String mimetype = f.getMimetype().getValue();
-            Assert.assertEquals(LUT_MIMETYPE, mimetype);
+            Assert.assertEquals(mimetype, LUT_MIMETYPE);
         }
         scripts = svc.getScriptsByMimetype(LUT_MIMETYPE);
         i = scripts.iterator();
@@ -131,7 +131,7 @@ public class ScriptServiceTest extends AbstractServerTest {
             f = i.next();
             Assert.assertNotNull(f);
             String mimetype = f.getMimetype().getValue();
-            Assert.assertEquals(LUT_MIMETYPE, mimetype);
+            Assert.assertEquals(mimetype, LUT_MIMETYPE);
         }
     }
     
@@ -179,7 +179,7 @@ public class ScriptServiceTest extends AbstractServerTest {
             Assert.fail("Only administrators can upload official script.");
         } catch (Exception e) {
         }
-        Assert.assertEquals(n, svc.getScripts().size());
+        Assert.assertEquals(svc.getScripts().size(), n);
     }
 
     /**
@@ -224,6 +224,7 @@ public class ScriptServiceTest extends AbstractServerTest {
         IScriptPrx svc = factory.getScriptService();
         long id = svc.uploadScript(folder, buf.toString());
         Assert.assertTrue(id > 0);
+        deleteScript(id);
     }
 
     /**
@@ -249,7 +250,8 @@ public class ScriptServiceTest extends AbstractServerTest {
         try {
             long id = svc.uploadOfficialScript(folder, buf.toString());
             Assert.assertTrue(id > 0);
-            Assert.assertEquals(n+1, svc.getScriptsByMimetype(LUT_MIMETYPE).size());
+            Assert.assertEquals(svc.getScriptsByMimetype(LUT_MIMETYPE).size(),
+                    n+1);
             deleteScript(id);
         } catch (Exception e) {
         }

--- a/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ScriptServiceTest.java
@@ -94,6 +94,7 @@ public class ScriptServiceTest extends AbstractServerTest {
                 Assert.fail("Lut should not be returned.");
             }
         }
+        //do it twice since we had initially a bug in loading
         scripts = svc.getScripts();
         Assert.assertNotNull(scripts);
         Assert.assertTrue(CollectionUtils.isNotEmpty(scripts));
@@ -170,16 +171,15 @@ public class ScriptServiceTest extends AbstractServerTest {
     @Test
     public void testUploadOfficialScript() throws Exception {
         newUserAndGroup("rwr---");
-        StringBuffer buf = new StringBuffer("");
-        String[] values = { "a", "b", "c" };
-        for (int i = 0; i < values.length; i++) {
-            buf.append(values[i].charAt(0));
-        }
-        String folder = "officialTestFolder";
         IScriptPrx svc = factory.getScriptService();
+        List<OriginalFile> scripts = svc.getScripts();
+        OriginalFile f = scripts.get(0);
         int n = svc.getScripts().size();
+        //read the script. This is tested elsewhere
+        String str = readScript(f);
+        String folder = f.getName().getValue();
         try {
-            svc.uploadOfficialScript(folder, buf.toString());
+            svc.uploadOfficialScript(folder, str);
             Assert.fail("Only administrators can upload official script.");
         } catch (Exception e) {
         }
@@ -239,16 +239,14 @@ public class ScriptServiceTest extends AbstractServerTest {
      */
     @Test
     public void testUploadScript() throws Exception {
-        StringBuffer buf = new StringBuffer("");
-        String[] values = { "a", "b", "c" };
-        for (int i = 0; i < values.length; i++) {
-            buf.append(values[i].charAt(0));
-        }
-        String folder = "scriptTestFolder";
         IScriptPrx svc = factory.getScriptService();
-        long id = svc.uploadScript(folder, buf.toString());
+        List<OriginalFile> scripts = svc.getScripts();
+        OriginalFile f = scripts.get(0);
+        //read the script. This is tested elsewhere
+        String str = readScript(f);
+        String folder = f.getName().getValue();
+        long id = svc.uploadScript(folder, str);
         Assert.assertTrue(id > 0);
-        deleteScript(id);
     }
 
     /**


### PR DESCRIPTION
# What this PR does

 * Delete the script, the file was removed from disk but the entry was not removed from DB

# Testing this PR
Integration tests added.
Also fixed the upload script
Making the tests are green

# Related reading
Problem found out when working on LUT

cc @mtbc 

The ``simpleDelete`` in ``scriptRepoHelper`` could be marked as deprecated.