### PR TITLE
Search result tables 13255

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -685,7 +685,8 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
             select coalesce(sowner.id, plowner.id, aowner.id, wsowner.id),
                    slink.parent.id,
                    plate.id,
-                   acquisition.id
+                   acquisition.id,
+                   well.id
             from WellSample wellsample
             left outer join wellsample.details.owner wsowner
             left outer join wellsample.plateAcquisition acquisition
@@ -746,6 +747,12 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
                 path.append({
                     'type': 'acquisition',
                     'id': e[3].val
+                })
+
+            if e[4] is not None:
+                path.append({
+                    'type': 'well',
+                    'id': e[4].val
                 })
 
             paths.append(path)

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -749,7 +749,8 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
                     'id': e[3].val
                 })
 
-            if e[4] is not None:
+            # Include Well if path is to image
+            if e[4] is not None and orphanedImage:
                 path.append({
                     'type': 'well',
                     'id': e[4].val

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -351,12 +351,48 @@
             {% endif %}
 
 
-                // For wells, we try to load Bulk table annotations attached to parent Screen / Plate
+                // For wells (or images that may be in a Well), we try to
+                //load Bulk table annotations attached to parent Screen / Plate
                 // loading just the row we need for the current well.
-                {% if manager.well %}
-                    var wellsUrl = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
-                        linksUrl = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}",
+                {% if manager.well or manager.image %}
+                    {% if manager.well %}
+                    var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
+                    var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}";
+                    {% elif manager.image %}
+                    var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
+                        plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    {% endif %}
+
+
+                    var wellId;
+                    {% if manager.well %}
                         wellId = {{ manager.well.id }};
+                    {% endif %}
+
+                    // Since we may not have the WellId in hand (if we're an image)
+                    // this returns a Promise() that will return wellId on resolve();
+                    var getWellId = function() {
+                        var d = $.Deferred();
+                        if (wellId) {
+                            // If we have it already, resolve immediately
+                            d.resolve(wellId);
+                        } else {
+                            // Otherwise, get paths to Image which may include SPW path...
+                            $.getJSON(WEBCLIENT.URLS.api_paths_to_object+'?image={{ manager.image.id }}', function(data){
+                                if (data.paths && data.paths.length > 0) {
+                                    wellId = data.paths[0].reduce(function(prev, node){
+                                        if (node.type === "well") {
+                                            return node.id;
+                                        }
+                                        return prev;
+                                    }, undefined);
+                                }
+                                d.resolve(wellId);
+                            });
+                        }
+                        return d.promise();
+
+                    }
 
                     var showBulkAnnTooltip = function(data) {
                         var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
@@ -391,8 +427,11 @@
                         OME.setPaneExpanded('tables', expanded);
 
                         if (expanded && $("#bulk_annotations_table").is(":empty")) {
-                            loadBulkAnnotations(wellsUrl, wellId, showBulkAnnTooltip);
-                            loadBulkAnnotations(linksUrl, wellId, showBulkAnnTooltip);
+                            getWellId().done(function(wId){
+                                if (!wId) return;
+                                loadBulkAnnotations(screenQuery, wId, showBulkAnnTooltip);
+                                loadBulkAnnotations(plateQuery, wId, showBulkAnnTooltip);
+                            });
                         }
                     });
 
@@ -401,8 +440,17 @@
                         $('.can-collapse.closed[data-name="tables"]')
                             .toggleClass('closed')
                             .next().slideToggle();
-                        loadBulkAnnotations(wellsUrl, wellId, showBulkAnnTooltip);
-                        loadBulkAnnotations(linksUrl, wellId, showBulkAnnTooltip);
+                        if ($("#bulk_annotations_table").is(":empty")) {
+                            getWellId().done(function(wId){
+                                if (!wId) {
+                                    // Close tab so we don't keep querying for Well.
+                                    OME.setPaneExpanded('tables', false);
+                                    return;
+                                }
+                                loadBulkAnnotations(screenQuery, wId, showBulkAnnTooltip);
+                                loadBulkAnnotations(plateQuery, wId, showBulkAnnTooltip);
+                            });
+                        }
                     }
 
                 {% endif %}
@@ -715,7 +763,7 @@
 
 
             <!-- TABLES -->
-            {% if manager.well %}
+            {% if manager.well or manager.image %}
             <h1 class="can-collapse closed" data-name="tables">
                 Tables
             </h1>

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1717,7 +1717,9 @@ class TestShow(IWebTest):
                                 ws_a1.image.id.val, None, None, None, None)
         # Image is only in ONE acquisition
         assert len(paths) == 1
-        assert paths[0] == expected[0]
+        pathToImg = expected[0]
+        pathToImg.append({'type': 'well', 'id': well_a.id.val})
+        assert paths[0] == pathToImg
 
     def test_well_restrict_acquisition_multi(self,
                                              screen_plate_run_well_multi):


### PR DESCRIPTION
# What this PR does

Fixes https://trac.openmicroscopy.org/ome/ticket/13255. When an Image from SPW is found in a search and loaded in the right panel, we don't know that this is in a Well.
Therefore, the *Tables* tab was not shown so you couldn't query for tables data (needs Well Id).
Now, we always show the Tables tab, and if a user expands it then we do an AJAX call to check whether the image is in a Well (uses the paths_to_object query). If we get a Well Id then we do a second query to load the Tables data as normal.

# Testing this PR

See ticket above. 
 - Need to have tables data in SPW as described http://help.openmicroscopy.org/scripts.html#metadata
 - Add table data for a bunch of wells in plate (doesn't have to be all)
 - Table data should be displayed as normal when the Well is loaded in right panel.
 - Add unique tag name to Wells (images) to aid searching for them.
 - Search for tag name - click on Images in search results
 - In right panel expand Tables tab - should load Tables data as before.
 - Clicking on another SPW image in search results should auto-load Tables data if tab is left open.
 - For non-SPW images (either in search results or main Data tab) clicking Tables tab will open tab and query for wellId, but well Id won't be found so the Tables tab will not be opened automatically for subsequent images.
