### PR TITLE
Add parents and children to omero obj

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -450,6 +450,62 @@ class ListGetTxAction(NonFieldTxAction):
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
 
+class ParentsTxAction(NonFieldTxAction):
+
+    def on_go(self, ctx, args):
+        from omero.cmd import FindParents
+        import omero.callbacks
+
+        if len(self.tx_cmd.arg_list) != 3:
+            ctx.die(335, "usage: parents OBJ type")
+
+        req = FindParents()
+        req.targetObjects = {self.kls: [self.obj.id.val]}
+        req.typesOfParents = [self.tx_cmd.arg_list[2]]
+        handle = self.client.sf.submit(req)
+        cb = omero.callbacks.CmdCallbackI(self.client, handle)
+        cb.loop(8, 500)
+
+        rsp = cb.getResponse()
+        if isinstance(rsp, omero.cmd.ERR):
+            proxy = "failed: '%s'\n" % rsp.name
+        else:
+            proxy = ""
+            for kls, ids in rsp.parents.items():
+                proxy += (kls.split(".")[-1] + ":"
+                          + ",".join(str(id) for id in ids) + "\n")
+
+        self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
+
+
+class ChildrenTxAction(NonFieldTxAction):
+
+    def on_go(self, ctx, args):
+        from omero.cmd import FindChildren
+        import omero.callbacks
+
+        if len(self.tx_cmd.arg_list) != 3:
+            ctx.die(335, "usage: children OBJ type")
+
+        req = FindChildren()
+        req.targetObjects = {self.kls: [self.obj.id.val]}
+        req.typesOfChildren = [self.tx_cmd.arg_list[2]]
+        handle = self.client.sf.submit(req)
+        cb = omero.callbacks.CmdCallbackI(self.client, handle)
+        cb.loop(8, 500)
+
+        rsp = cb.getResponse()
+        if isinstance(rsp, omero.cmd.ERR):
+            proxy = "failed: '%s'\n" % rsp.name
+        else:
+            proxy = ""
+            for kls, ids in rsp.children.items():
+                proxy += (kls.split(".")[-1] + ":"
+                          + ",".join(str(id) for id in ids) + "\n")
+
+        self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
+
+
 class TxState(object):
 
     def __init__(self, ctx):
@@ -536,7 +592,8 @@ Bash examples:
             "command", nargs="?",
             choices=("new", "update", "null",
                      "map-get", "map-set",
-                     "get", "list-get"),
+                     "get", "list-get",
+                     "parents", "children"),
             help="operation to be performed")
         parser.add_argument(
             "Class", nargs="?",
@@ -591,6 +648,10 @@ Bash examples:
             return ObjGetTxAction(tx_state, tx_cmd)
         elif tx_cmd.action == "list-get":
             return ListGetTxAction(tx_state, tx_cmd)
+        elif tx_cmd.action == "parents":
+            return ParentsTxAction(tx_state, tx_cmd)
+        elif tx_cmd.action == "children":
+            return ChildrenTxAction(tx_state, tx_cmd)
         else:
             raise self.ctx.die(100, "Unknown command: %s" % tx_cmd)
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -366,7 +366,7 @@ class ObjGetTxAction(NonFieldTxAction):
                                       + str(self.get_field(field)) + "\n")
                         except AttributeError:
                             pass
-
+            proxy = proxy.strip()
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
     def get_field(self, field):
@@ -468,13 +468,13 @@ class ParentsTxAction(NonFieldTxAction):
 
         rsp = cb.getResponse()
         if isinstance(rsp, omero.cmd.ERR):
-            proxy = "failed: '%s'\n" % rsp.name
+            proxy = "failed: '%s'" % rsp.name
         else:
             proxy = ""
             for kls, ids in rsp.parents.items():
                 proxy += (kls.split(".")[-1] + ":"
                           + ",".join(str(id) for id in ids) + "\n")
-
+            proxy = proxy.strip()
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
 
@@ -496,13 +496,13 @@ class ChildrenTxAction(NonFieldTxAction):
 
         rsp = cb.getResponse()
         if isinstance(rsp, omero.cmd.ERR):
-            proxy = "failed: '%s'\n" % rsp.name
+            proxy = "failed: '%s'" % rsp.name
         else:
             proxy = ""
             for kls, ids in rsp.children.items():
                 proxy += (kls.split(".")[-1] + ":"
                           + ",".join(str(id) for id in ids) + "\n")
-
+            proxy = proxy.strip()
         self.tx_state.set_value(proxy, dest=self.tx_cmd.dest)
 
 

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -456,12 +456,12 @@ class ParentsTxAction(NonFieldTxAction):
         from omero.cmd import FindParents
         import omero.callbacks
 
-        if len(self.tx_cmd.arg_list) != 3:
-            ctx.die(335, "usage: parents OBJ type")
+        if len(self.tx_cmd.arg_list) < 3:
+            ctx.die(335, "usage: parents OBJ type [type ...]")
 
         req = FindParents()
         req.targetObjects = {self.kls: [self.obj.id.val]}
-        req.typesOfParents = [self.tx_cmd.arg_list[2]]
+        req.typesOfParents = self.tx_cmd.arg_list[2:]
         handle = self.client.sf.submit(req)
         cb = omero.callbacks.CmdCallbackI(self.client, handle)
         cb.loop(8, 500)
@@ -484,12 +484,12 @@ class ChildrenTxAction(NonFieldTxAction):
         from omero.cmd import FindChildren
         import omero.callbacks
 
-        if len(self.tx_cmd.arg_list) != 3:
-            ctx.die(335, "usage: children OBJ type")
+        if len(self.tx_cmd.arg_list) < 3:
+            ctx.die(335, "usage: children OBJ type [type ...]")
 
         req = FindChildren()
         req.targetObjects = {self.kls: [self.obj.id.val]}
-        req.typesOfChildren = [self.tx_cmd.arg_list[2]]
+        req.typesOfChildren = self.tx_cmd.arg_list[2:]
         handle = self.client.sf.submit(req)
         cb = omero.callbacks.CmdCallbackI(self.client, handle)
         cb.loop(8, 500)

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -559,6 +559,11 @@ Examples:
     Dataset:123
     $ bin/omero obj get Dataset:123 description
 
+    $ bin/omero obj children Dataset:123 Image
+    Image:51,52
+    $ bin/omero obj parents Image:51 Dataset Fileset
+    Dataset:123
+    Fileset:51
     $ bin/omero obj new MapAnnotation ns=example.com
     MapAnnotation:456
     $ bin/omero obj map-set MapAnnotation:456 mapValue foo bar

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -77,7 +77,7 @@ class TestObj(CLITest):
         assert 1 == len(state)
         assert state.get_row(0).startswith("Dataset")
 
-    def test_linkage(self):
+    def test_linkage_children_and_parents(self):
         path = create_path()
         path.write_text(
             """
@@ -91,6 +91,17 @@ class TestObj(CLITest):
         assert state.get_row(0).startswith("Project")
         assert state.get_row(1).startswith("Dataset")
         assert state.get_row(2).startswith("ProjectDatasetLink")
+        # Now check for children and parents
+        proj = state.get_row(0)
+        dset = state.get_row(1)
+        self.args = self.login_args() + ["obj", "children", proj, "Dataset"]
+        state = self.go()
+        assert 1 == len(state)
+        assert state.get_row(0) == dset
+        self.args = self.login_args() + ["obj", "parents", dset, "Project"]
+        state = self.go()
+        assert 1 == len(state)
+        assert state.get_row(0) == proj
         path.remove()
 
     def test_linkage_via_variables(self):

--- a/components/tools/OmeroPy/test/unit/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_obj.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2013 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2013-2016 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
-Test of the omero/plugins/tx.py module
+Test of the omero/plugins/obj.py module
 """
 
 import pytest


### PR DESCRIPTION
This PR is a side-effect of creating a CLI command to test gh-4531 but rather than throw it away I have tidied it up and added some tests. It may or may not be useful!

The PR adds subcommands to `omero obj` to find `parents` and `children` of specific objects. The type(s) of the relatives must be specified.

Testing
-------
Create come Datasets, import an Image, add it to the Datasets. Tag and Annotate the Image.
```
$ omero obj children Image:101 TagAnnotation
TagAnnotation:101,102
$ omero obj children Image:101 Annotation
TagAnnotation:101,102
FileAnnotation:103
$ omero obj parents Image:101 Dataset
Dataset:1,2
$ omero obj parents Image:101 Dataset Fileset
Fileset:101
Dataset:1,2
$ omero obj parents Image:101 Annotation

$
```
