### PR TITLE
OMERO.web only supports Python 2.7

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/python_warning.py
+++ b/components/tools/OmeroPy/src/omero/install/python_warning.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+   python helper plugin
+
+   Copyright 2016 University of Dundee. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+"""
+
+import sys
+import platform
+
+
+PYTHON_WARNING = ("Python version %s is not "
+                  "supported!" % platform.python_version())
+
+
+def py27_only():
+    if sys.version_info < (2, 7) or sys.version_info >= (2, 8):
+        return False
+    return True

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -26,6 +26,9 @@ HELP = "OMERO.web configuration/deployment tools"
 if platform.system() == 'Windows':
     HELP += ("\n\n%s" % WINDOWS_WARNING)
 
+if not py27_only():
+    HELP += ("\n\nERROR: %s" % PYTHON_WARNING)
+
 LONGHELP = """OMERO.web configuration/deployment tools
 
 Configuration:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -19,6 +19,7 @@ from functools import wraps
 from omero_ext.argparse import SUPPRESS
 
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
+from omero.install.python_warning import py27_only, PYTHON_WARNING
 
 HELP = "OMERO.web configuration/deployment tools"
 
@@ -65,20 +66,13 @@ APACHE_MOD_WSGI_ERR = ("[ERROR] You are deploying OMERO.web using Apache and"
                        " a request.")
 
 
-def py27_only():
-    if sys.version_info < (2, 7) or sys.version_info >= (2, 8):
-        return False
-    return True
-
-
 def config_required(func):
     """Decorator validating Django dependencies and omeroweb/settings.py"""
     def import_django_settings(func):
         @windows_warning
         def wrapper(self, *args, **kwargs):
             if not py27_only():
-                self.ctx.die(681, "ERROR: Python version %s is not "
-                                  "supported!" % platform.python_version())
+                self.ctx.die(681, "ERROR: %s" % PYTHON_WARNING)
             try:
                 import django  # NOQA
             except:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -65,11 +65,20 @@ APACHE_MOD_WSGI_ERR = ("[ERROR] You are deploying OMERO.web using Apache and"
                        " a request.")
 
 
+def py27_only():
+    if sys.version_info < (2, 7) or sys.version_info >= (2, 8):
+        return False
+    return True
+
+
 def config_required(func):
     """Decorator validating Django dependencies and omeroweb/settings.py"""
     def import_django_settings(func):
         @windows_warning
         def wrapper(self, *args, **kwargs):
+            if not py27_only():
+                self.ctx.die(681, "ERROR: Python version %s is not "
+                                  "supported!" % platform.python_version())
             try:
                 import django  # NOQA
             except:

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -28,6 +28,7 @@
 
 
 import os.path
+import warnings
 import sys
 import platform
 import logging
@@ -41,8 +42,12 @@ import random
 import string
 
 from omero_ext import portalocker
+from omero.install.python_warning import py27_only, PYTHON_WARNING
 
 logger = logging.getLogger(__name__)
+
+if not py27_only():
+    warnings.warn("WARNING: %s" % PYTHON_WARNING, RuntimeWarning)
 
 # LOGS
 # NEVER DEPLOY a site into production with DEBUG turned on.

--- a/components/tools/OmeroWeb/requirements-py26-apache.txt
+++ b/components/tools/OmeroWeb/requirements-py26-apache.txt
@@ -1,6 +1,0 @@
-# Python installation requirements for OMERO.web
-# ==============================================
-#
-#     pip install -r requirements-py26-apache.txt
-#
-Django==1.6.11

--- a/components/tools/OmeroWeb/requirements-py26-nginx.txt
+++ b/components/tools/OmeroWeb/requirements-py26-nginx.txt
@@ -1,7 +1,0 @@
-# Python installation requirements for OMERO.web
-# ==============================================
-#
-#     pip install -r requirements-py26-nginx.txt
-#
-Django==1.6.11
-gunicorn>=19.3


### PR DESCRIPTION
This PR remove Python 2.7 support from OMERO.web cli plugin.

See new jobs in https://github.com/openmicroscopy/management_tools/pull/173

to test:
 -  run `bin/omero web *` on python 2.6 and 2.7 environment and see if it behaves as expected
 - report any concerns and suggestion about Warnings/Errors in this PR
