### PR TITLE
fix 13275: in current sessions request don't try to map session context

### DIFF
--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -168,6 +168,9 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
         for (Map.Entry<String, Object> entry2 : data.entrySet()) {
             String key2 = entry2.getKey();
             Object obj2 = entry2.getValue();
+            if ("class".equals(key2) || "sessionContext".equals(key2)) {
+                continue;
+            }
             RType wrapped = null;
             try {
                 if (key2.endsWith("Time")) {
@@ -181,8 +184,6 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
             }
             parsed.put(key2, wrapped);
         }
-        parsed.remove("sessionContext");
-        parsed.remove("class");
         return parsed;
     }
 


### PR DESCRIPTION
# What this PR does

This reorders operations in the current sessions request API implementation to avoid attempting to wrap a `SessionContextImpl` in an rtype.

# Testing this PR

Experiment with `bin/omero sessions who` and anything else that queries current sessions to check that:

1. they still work as before
1. no warnings with stack traces are written to `Blitz-0.log` as they work.

# Related reading

http://trac.openmicroscopy.org/ome/ticket/13275