### PR TITLE
Mapr annotations: query database for existing map-annotations

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -195,7 +195,7 @@ class MapAnnotationManager(object):
     def get_map_annotations(self):
         return self.mapanns.values() + self.nokey
 
-    def add_from_namespace_query(self, session, ns, primary_keys):
+    def add_from_namespace_query(self, session, ns, primary_keys, unique_keys):
         """
         Fetches all map-annotations with the given namespace
         This will only work if there are no duplicates, otherwise an
@@ -210,6 +210,7 @@ class MapAnnotationManager(object):
         :param session: An OMERO session
         :param ns: The namespace
         :param primary_keys: Primary keys
+        :param unique_keys: Whether keys have to be unique in a map
         """
         qs = session.getQueryService()
         q = 'FROM MapAnnotation WHERE ns=:ns ORDER BY id DESC'
@@ -218,7 +219,7 @@ class MapAnnotationManager(object):
         results = qs.findAllByQuery(q, p)
         log.debug('Found %d MapAnnotations in ns:%s', len(results), ns)
         for ma in results:
-            cma = CanonicalMapAnnotation(ma, primary_keys)
+            cma = CanonicalMapAnnotation(ma, primary_keys, unique_keys)
             r = self.add(cma)
             if r:
                 raise Exception(

--- a/components/tools/OmeroPy/src/omero/util/metadata_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_utils.py
@@ -40,8 +40,8 @@ NSBULKANNOTATIONSRAW = namespaces.NSBULKANNOTATIONS + "/raw"
 
 class GroupConfig(object):
 
-    def __init__(self, groupname, column_cfg):
-        self.groupname = groupname
+    def __init__(self, namespace, column_cfg):
+        self.namespace = namespace
         self.columns = column_cfg
 
     def __eq__(self, other):
@@ -66,7 +66,7 @@ class BulkAnnotationConfiguration(object):
         "visible",
         "omitempty",
         ])
-    GROUPREQUIRED = set(["groupname", "columns"])
+    GROUPREQUIRED = set(["namespace", "columns"])
 
     def __init__(self, default_cfg, column_cfgs):
         """
@@ -177,7 +177,7 @@ class BulkAnnotationConfiguration(object):
                 "Required key(s) missing from group configuration: %s" %
                 list(missing))
 
-        if not cfg["groupname"]:
+        if not cfg["namespace"]:
             raise Exception("Empty name in group configuration: %s" % cfg)
 
         if not cfg["columns"]:
@@ -198,7 +198,7 @@ class BulkAnnotationConfiguration(object):
             self.validate_group_config(gcfg)
             column_cfgs = [
                 self.get_column_config(gc) for gc in gcfg['columns']]
-            return GroupConfig(gcfg['groupname'], column_cfgs)
+            return GroupConfig(gcfg['namespace'], column_cfgs)
 
         self.validate_column_config(cfg)
         column_cfg = self.default_cfg.copy()
@@ -251,7 +251,7 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
     def get_output_configs(self):
         """
         Get the full set of output column configs including column groups
-        The default set of column configs has an empty groupname
+        The default set of column configs has an empty namespace
         """
 
         # First process groups in case the default is to include all
@@ -259,7 +259,7 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
         output_configs = []
         for gcfg in self.group_cfgs:
             output_cfg = self.get_group_output_configs(gcfg.columns, False)
-            output_configs.append(GroupConfig(gcfg.groupname, output_cfg))
+            output_configs.append(GroupConfig(gcfg.namespace, output_cfg))
 
         output_defcfg = self.get_group_output_configs(self.column_cfgs, True)
         output_configs.append(GroupConfig('', output_defcfg))
@@ -326,7 +326,7 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
         Return a set of KeyValueListTransformer objects, one for each group
         """
         transformers = [KeyValueListTransformer(
-            self.headers, gc.columns, gc.groupname)
+            self.headers, gc.columns, gc.namespace)
             for gc in self.output_configs]
         return transformers
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1101,7 +1101,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
         for pk in pkcfg:
             try:
-                gns = pk['groupname']
+                gns = pk['namespace']
                 keys = pk['keys']
             except KeyError:
                 raise Exception('Invalid primary_group_keys: %s' % pk)
@@ -1319,7 +1319,7 @@ class DeleteMapAnnotationContext(_QueryContext):
         if self.column_cfgs:
             for c in self.column_cfgs:
                 try:
-                    ns = c['group']['groupname']
+                    ns = c['group']['namespace']
                     nss.add(ns)
                 except KeyError:
                     continue

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1113,7 +1113,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
                 self.pkmap[gns] = keys
                 self.mapannotations.add_from_namespace_query(
-                    self.client.getSession(), gns, keys)
+                    self.client.getSession(), gns, keys, False)
                 log.debug('Loaded ns:%s primary-keys:%s', gns, keys)
 
     def _get_ns_primary_keys(self, ns):
@@ -1266,11 +1266,11 @@ class BulkToMapAnnotationContext(_QueryContext):
         for cma in self.mapannotations.get_map_annotations():
             links.append(self._create_map_annotation_links(cma))
         for batch in self._grouped_batch(links, sz=batch_size):
-            ids = update_service.saveAndReturnIds(
+            arr = update_service.saveAndReturnArray(
                 batch, {'omero.group': group})
-            i += len(ids)
+            i += len(arr)
             log.info('Created/linked %d MapAnnotations (total %s)',
-                     len(ids), i)
+                     len(arr), i)
 
 
 class DeleteMapAnnotationContext(_QueryContext):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1113,7 +1113,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
                 self.pkmap[gns] = keys
                 self.mapannotations.add_from_namespace_query(
-                    self.client.getSession(), gns, keys, False)
+                    self.client.getSession(), gns, keys)
                 log.debug('Loaded ns:%s primary-keys:%s', gns, keys)
 
     def _get_ns_primary_keys(self, ns):
@@ -1152,7 +1152,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
         log.debug('Creating CanonicalMapAnnotation ns:%s pks:%s kvs:%s',
                   ns, pks, rowkvs)
-        cma = CanonicalMapAnnotation(ma, primary_keys=pks, unique_keys=False)
+        cma = CanonicalMapAnnotation(ma, primary_keys=pks)
         for (otype, oid) in targets:
             cma.add_parent(otype, oid)
         return cma

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.yml
@@ -18,7 +18,7 @@ columns:
   include: no
   includeclient: no
 - group:
-    groupname: openmicroscopy.org/mapr/gene
+    namespace: openmicroscopy.org/mapr/gene
     columns:
     # Intentionally duplicate a column in a different group
     - name: Gene

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2.yml
@@ -18,7 +18,7 @@ columns:
   include: no
   includeclient: no
 - group:
-    groupname: openmicroscopy.org/mapr/gene
+    namespace: openmicroscopy.org/mapr/gene
     columns:
     # Intentionally duplicate a column in a different group
     - name: Gene
@@ -29,6 +29,6 @@ columns:
 advanced:
 #    well_to_images: yes
     primary_group_keys:
-    - groupname: openmicroscopy.org/mapr/gene
+    - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -63,7 +63,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
 
         assert len(mgr.mapanns) == 2
         pk1 = (ns1, frozenset([('a', '1')]))
@@ -88,7 +88,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
 
         ma4 = MapAnnotationI()
         ma4 = MapAnnotationI()

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Integration test of metadata_mapannotation
+"""
+
+
+import library as lib
+from omero.model import MapAnnotationI, NamedValue
+from omero.rtypes import wrap
+from omero.util.metadata_mapannotations import MapAnnotationManager
+
+
+def assert_equal_name_value(a, b):
+    assert isinstance(a, NamedValue)
+    assert isinstance(b, NamedValue)
+    assert a.name == b.name
+    assert a.value == b.value
+
+
+class TestMapAnnotationManager(lib.ITest):
+
+    def create_mas(self):
+        ns1 = self.uuid()
+        ns3 = self.uuid()
+        ma1 = MapAnnotationI()
+        ma1.setNs(wrap(ns1))
+        ma1.setMapValue([NamedValue('a', '1')])
+        ma2 = MapAnnotationI()
+        ma2.setNs(wrap(ns1))
+        ma2.setMapValue([NamedValue('a', '2')])
+        ma3 = MapAnnotationI()
+        ma3.setNs(wrap(ns3))
+        ma3.setMapValue([NamedValue('a', '1')])
+
+        mids = self.update.saveAndReturnIds([ma1, ma2, ma3])
+        print ns1, ns3, mids
+        return ns1, ns3, mids
+
+    def test_add_from_namespace_query(self):
+        ns1, ns3, mids = self.create_mas()
+        pks = ['a']
+        mgr = MapAnnotationManager()
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
+
+        assert len(mgr.mapanns) == 2
+        pk1 = (ns1, frozenset([('a', '1')]))
+        pk2 = (ns1, frozenset([('a', '2')]))
+        assert len(mgr.mapanns) == 2
+        assert pk1 in mgr.mapanns
+        assert pk2 in mgr.mapanns
+
+        cma1 = mgr.mapanns[pk1]
+        assert cma1.kvpairs == [('a', '1')]
+        assert cma1.parents == set()
+        mv1 = cma1.get_mapann().getMapValue()
+        assert len(mv1) == 1
+        assert_equal_name_value(mv1[0], NamedValue('a', '1'))
+
+        cma2 = mgr.mapanns[pk2]
+        assert cma2.kvpairs == [('a', '2')]
+        assert cma2.parents == set()
+        mv2 = cma2.get_mapann().getMapValue()
+        assert len(mv2) == 1
+        assert_equal_name_value(mv2[0], NamedValue('a', '2'))

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -63,7 +63,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks)
+        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
 
         assert len(mgr.mapanns) == 2
         pk1 = (ns1, frozenset([('a', '1')]))
@@ -88,7 +88,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks)
+        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
 
         ma4 = MapAnnotationI()
         ma4 = MapAnnotationI()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -757,6 +757,9 @@ class TestPopulateMetadata(lib.ITest):
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
         self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
+        # TODO: This will currently fail because the MapAnnotations are
+        # deleted even if they're multiply linked
+        # self._test_delete_map_annotation_context_dedup(fixture1, fixture2)
 
     def _test_parsing_context(self, fixture, batch_size):
         """
@@ -877,6 +880,25 @@ class TestPopulateMetadata(lib.ITest):
             ctx.write_to_omero(batch_size=batch_size)
         assert len(fixture.get_child_annotations()) == 0
         assert len(fixture.get_all_map_annotations()) == 0
+
+    def _test_delete_map_annotation_context_dedup(self, fixture1, fixture2):
+        assert len(fixture1.get_child_annotations()) == fixture1.annCount
+        assert len(fixture2.get_child_annotations()) == fixture2.annCount
+
+        ctx = DeleteMapAnnotationContext(
+            self.client, fixture1.get_target(), cfg=fixture1.get_cfg())
+        ctx.parse()
+        ctx.write_to_omero()
+        assert len(fixture1.get_child_annotations()) == 0
+        assert len(fixture2.get_child_annotations()) == fixture2.annCount
+
+        ctx = DeleteMapAnnotationContext(
+            self.client, fixture2.get_target(), cfg=fixture2.get_cfg())
+        ctx.parse()
+        ctx.write_to_omero()
+        assert len(fixture2.get_child_annotations()) == 0
+        assert len(fixture1.get_all_map_annotations()) == 0
+        assert len(fixture2.get_all_map_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -723,6 +723,9 @@ class TestPopulateMetadata(lib.ITest):
         self._test_bulk_to_map_annotation_context(fixture, 2)
         self._test_delete_map_annotation_context(fixture, 2)
 
+    # TODO: testPopulateMetadataNsAnns with multiple separate Plates
+    # to check duplicate map-annotations aren't created
+
     def _test_parsing_context(self, fixture, batch_size):
         """
             Create a small csv file, use populate_metadata.py to parse and

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -40,7 +40,7 @@ from omero.model import OriginalFileI
 from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
 from omero.model import RoiI, PointI, ProjectI, ScreenI
-from omero.rtypes import rdouble, rstring, unwrap
+from omero.rtypes import rdouble, rlist, rstring, unwrap
 from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
@@ -149,6 +149,9 @@ class Fixture(object):
         return os.path.join(
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
 
+    def get_namespaces(self):
+        return NSBULKANNOTATIONS
+
     def assert_rows(self, rows):
         assert rows == self.rowCount * self.colCount
 
@@ -165,6 +168,14 @@ class Fixture(object):
             else:
                 assert mv['Well Type'] == 'Treatment'
                 assert mv['Concentration'] == '10'
+
+    def get_all_map_annotations(self):
+        qs = self.test.client.sf.getQueryService()
+        q = "FROM MapAnnotation WHERE ns in (:nss)"
+        p = ParametersI()
+        p.map['nss'] = rlist(rstring(ns) for ns in self.get_namespaces())
+        r = qs.findAllByQuery(q, p)
+        return r
 
 
 class Screen2Plates(Fixture):
@@ -263,6 +274,9 @@ class Plate2WellsNs(Plate2Wells):
     def get_cfg(self):
         return os.path.join(os.path.dirname(__file__),
                             'bulk_to_map_annotation_context_ns.yml')
+
+    def get_namespaces(self):
+        return [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
 
     def assert_row_values(self, rowvalues):
         # First column is the WellID
@@ -734,15 +748,15 @@ class TestPopulateMetadata(lib.ITest):
         except Exception:
             skip("PyYAML not installed.")
 
-        fixture = Plate2WellsNs2()
-        fixture.init(self)
-        self._test_parsing_context(fixture, 2)
-        self._test_bulk_to_map_annotation_context(fixture, 2)
+        fixture1 = Plate2WellsNs2()
+        fixture1.init(self)
+        self._test_parsing_context(fixture1, 2)
+        self._test_bulk_to_map_annotation_context(fixture1, 2)
 
         fixture2 = Plate2WellsNs2()
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
-        self._test_bulk_to_map_annotation_dedup(fixture, fixture2, 2)
+        self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
 
     def _test_parsing_context(self, fixture, batch_size):
         """
@@ -794,6 +808,7 @@ class TestPopulateMetadata(lib.ITest):
 
     def _test_bulk_to_map_annotation_context(self, fixture, batch_size):
         # self._testPopulateMetadataPlate()
+        assert len(fixture.get_all_map_annotations()) == 0
         assert len(fixture.get_child_annotations()) == 0
 
         cfg = fixture.get_cfg()
@@ -814,8 +829,7 @@ class TestPopulateMetadata(lib.ITest):
         assert len(oas) == fixture.annCount
         fixture.assert_child_annotations(oas)
 
-    def _test_bulk_to_map_annotation_dedup(
-            self, fixture1, fixture2, batch_size):
+    def _test_bulk_to_map_annotation_dedup(self, fixture1, fixture2):
         ann_count = fixture1.annCount
         assert fixture2.annCount == ann_count
         assert len(fixture1.get_child_annotations()) == ann_count
@@ -832,10 +846,7 @@ class TestPopulateMetadata(lib.ITest):
         assert len(fixture1.get_child_annotations()) == ann_count
         assert len(fixture2.get_child_annotations()) == 0
 
-        if batch_size is None:
-            ctx.write_to_omero()
-        else:
-            ctx.write_to_omero(batch_size=batch_size)
+        ctx.write_to_omero()
 
         oas1 = fixture1.get_child_annotations()
         oas2 = fixture2.get_child_annotations()
@@ -865,6 +876,7 @@ class TestPopulateMetadata(lib.ITest):
         else:
             ctx.write_to_omero(batch_size=batch_size)
         assert len(fixture.get_child_annotations()) == 0
+        assert len(fixture.get_all_map_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):

--- a/components/tools/OmeroPy/test/unit/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/unit/test_metadata_mapannotations.py
@@ -81,20 +81,6 @@ class TestCanonicalMapAnnotation(object):
             CanonicalMapAnnotation(ma)
         assert str(excinfo.value).startswith('Duplicate ')
 
-    @pytest.mark.parametrize('unique_keys', [False, True])
-    def test_init_unique_keys(self, unique_keys):
-        ma = MapAnnotationI(1)
-        ma.setMapValue([NamedValue('b', '2'), NamedValue('b', '1')])
-
-        if unique_keys:
-            with pytest.raises(ValueError) as excinfo:
-                CanonicalMapAnnotation(ma, unique_keys=unique_keys)
-                assert str(excinfo.value).startswith('Duplicate ')
-        else:
-            cma = CanonicalMapAnnotation(ma, unique_keys=unique_keys)
-            assert cma.kvpairs == [('b', '2'), ('b', '1')]
-            assert cma.primary is None
-
     @pytest.mark.parametrize('ns', [None, '', 'NS'])
     @pytest.mark.parametrize('primary_keys', [[], ['a'], ['a', 'b']])
     def test_init_primary_keys(self, ns, primary_keys):

--- a/components/tools/OmeroPy/test/unit/test_metadata_utils.py
+++ b/components/tools/OmeroPy/test/unit/test_metadata_utils.py
@@ -88,7 +88,7 @@ class TestBulkAnnotationConfiguration(object):
     def test_init_group(self):
         c = BulkAnnotationConfiguration({"omitempty": True}, [
             {"name": "a1"},
-            {"group": {"groupname": "group2", "columns": [{"name": "b2"}]}}
+            {"group": {"namespace": "group2", "columns": [{"name": "b2"}]}}
         ])
         assert c.default_cfg == expected(omitempty=True)
         assert len(c.column_cfgs) == 1
@@ -131,7 +131,7 @@ class TestBulkAnnotationConfiguration(object):
     def test_validate_group_config(self):
         with pytest.raises(Exception):
             BulkAnnotationConfiguration.validate_group_config({
-                "groupname": "ga"})
+                "namespace": "ga"})
 
         with pytest.raises(Exception):
             BulkAnnotationConfiguration.validate_group_config({
@@ -139,16 +139,16 @@ class TestBulkAnnotationConfiguration(object):
 
         with pytest.raises(Exception):
             BulkAnnotationConfiguration.validate_group_config({
-                "groupname": "", "columns": [{"name": "a"}]})
+                "namespace": "", "columns": [{"name": "a"}]})
 
         with pytest.raises(Exception):
             BulkAnnotationConfiguration.validate_group_config({
-                "groupname": "ga", "columns": [{"name": "a"}],
+                "namespace": "ga", "columns": [{"name": "a"}],
                 "nonexistent": "na"})
 
         # Shouldn't throw
         BulkAnnotationConfiguration.validate_group_config({
-            "groupname": "ga", "columns": [{"name": "a"}]})
+            "namespace": "ga", "columns": [{"name": "a"}]})
 
 
 class TestKeyValueListPassThrough(object):
@@ -171,7 +171,7 @@ class TestKeyValueGroupList(object):
         assert kvgl.headerindexmap == {'a1': 0}
 
         assert len(kvgl.output_configs) == 1
-        assert kvgl.output_configs[0].groupname == ""
+        assert kvgl.output_configs[0].namespace == ""
         configs = kvgl.output_configs[0].columns
         assert configs[0] == (expected(name="a1", visible=False), 0)
 
@@ -200,7 +200,7 @@ class TestKeyValueGroupList(object):
         assert kvgl.default_cfg == expected()
 
         assert len(kvgl.output_configs) == 1
-        assert kvgl.output_configs[0].groupname == ""
+        assert kvgl.output_configs[0].namespace == ""
         configs = kvgl.output_configs[0].columns
         assert len(configs) == 2
         assert configs[0] == (expected(name="a1", position=1), 1)
@@ -214,7 +214,7 @@ class TestKeyValueGroupList(object):
         assert kvgl.default_cfg == expected(include=False, includeclient=False)
 
         assert len(kvgl.output_configs) == 1
-        assert kvgl.output_configs[0].groupname == ""
+        assert kvgl.output_configs[0].namespace == ""
         configs = kvgl.output_configs[0].columns
         assert len(configs) == 1
         assert configs[0] == (expected(
@@ -226,7 +226,7 @@ class TestKeyValueGroupList(object):
         assert kvgl.default_cfg == expected()
 
         assert len(kvgl.output_configs) == 1
-        assert kvgl.output_configs[0].groupname == ""
+        assert kvgl.output_configs[0].namespace == ""
         configs = kvgl.output_configs[0].columns
         assert len(configs) == 6
         assert configs[0] == (expected(name="a1", position=1, split="|"), 3)
@@ -241,7 +241,7 @@ class TestKeyValueGroupList(object):
         headers = ["a1", "a2"]
         desc = [
             {"name": "a1"},
-            {"group": {"groupname": "g2", "columns": [{"name": "a2"}]}},
+            {"group": {"namespace": "g2", "columns": [{"name": "a2"}]}},
         ]
         kvgl = KeyValueGroupList(headers, None, desc)
         assert kvgl.default_cfg == expected()
@@ -249,21 +249,21 @@ class TestKeyValueGroupList(object):
 
         assert len(kvgl.output_configs) == 2
 
-        assert kvgl.output_configs[0].groupname == "g2"
+        assert kvgl.output_configs[0].namespace == "g2"
         assert kvgl.output_configs[0].columns == [(expected(name="a2"), 1)]
 
         # Default group always comes last
-        assert kvgl.output_configs[1].groupname == ""
+        assert kvgl.output_configs[1].namespace == ""
         assert kvgl.output_configs[1].columns == [(expected(name="a1"), 0)]
 
     def test_init_col_group_multi(self):
         headers = ["a1", "a2", "a3", "a4", "a5"]
         desc = [
             {"name": "a1"},
-            {"group": {"groupname": "g2", "columns": [{"name": "a2"}]}},
+            {"group": {"namespace": "g2", "columns": [{"name": "a2"}]}},
             {"name": "a3"},
             {"group": {
-                "groupname": "g4", "columns": [{"name": "a4"}, {"name": "a5"}]
+                "namespace": "g4", "columns": [{"name": "a4"}, {"name": "a5"}]
             }},
         ]
         kvgl = KeyValueGroupList(headers, None, desc)
@@ -273,15 +273,15 @@ class TestKeyValueGroupList(object):
 
         assert len(kvgl.output_configs) == 3
 
-        assert kvgl.output_configs[0].groupname == "g2"
+        assert kvgl.output_configs[0].namespace == "g2"
         assert kvgl.output_configs[0].columns == [(expected(name="a2"), 1)]
 
-        assert kvgl.output_configs[1].groupname == "g4"
+        assert kvgl.output_configs[1].namespace == "g4"
         assert kvgl.output_configs[1].columns == [
             (expected(name="a4"), 3), (expected(name="a5"), 4)]
 
         # Default group always comes last
-        assert kvgl.output_configs[2].groupname == ""
+        assert kvgl.output_configs[2].namespace == ""
         assert kvgl.output_configs[2].columns == [
             (expected(name="a1"), 0), (expected(name="a3"), 2)]
 


### PR DESCRIPTION
# What this PR does

This is a follow-up to https://github.com/openmicroscopy/openmicroscopy/pull/4775 to use/update existing map-annotations in the database instead of creating duplicates.

There are several limitations which is why I've kept this as a separate PR:
- De-duplication only occurs between different screens/projects. This mean you can't re-run `metadata populate` on the same screen with the same `bulkmap-config.yml` file unless you first delete the map-annotations on the target.
- The database query loads all map-annotations in the given namespace, this is potentially resource intensive on both server and client
- Haven't figured out proper deletion semantics yet
  - Can you delete only annotation links, unless it's the last one in which case also delete the annotation?


# Testing this PR

1. Setup is similar to https://github.com/openmicroscopy/openmicroscopy/pull/4775, but this time create two screens with at least one overlapping primary key
2. `populate metadata` both screens.
3. Only one map-annotation for each primary key should exist, regardless of how many screens it is found in


# For discussion: upsert

There's two use cases here:

1. CreateIfNotExist: Create XxxAnnotationLink(parent,chlid) only if that link doesn't already exist. This would help fix the current lack of implementation for modifying annotations on existing screens. Example:
  - A screen contains `Images 1-10`. All of the images are linked to `MapAnnotation A`.
  - `Images 11-100` are subsequently added to the screen, and also need to be linked to `MapAnnotation A`.
  - The easiest way is to create 100 ImageAnnotationLinks with the same child, and use `UpdateServer.saveAndReturnArray`. This will fail because some of the `ImageAnnotationLink` already exist
  - In practice the Images to be annotated are filtered according to some other criteria, so the existence of the link would have to be checked for each image
2. Creating/merging mMapAnnotations. In #4775 I added support for deduplicating MapAnnotations before they were saved. This PR now takes existing MapAnnotations into account. Most of the merging logic is handled by `components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py`

# TODO:
- [x] Rename `groupname` to `namespace`
- [ ] Maybe delete?