### PR TITLE
properly count warnings and errors in OMERO server logs

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1140,7 +1140,7 @@ OMERO Diagnostics %s
                 if not p.exists():
                     self.ctx.out("n/a")
                 else:
-                    warn_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+warn(ing:)?\s'
+                    warn_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+warn(i(ng:)?)?\s'
                     err_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+error:?\s'
                     warn = 0
                     err = 0

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1140,18 +1140,17 @@ OMERO Diagnostics %s
                 if not p.exists():
                     self.ctx.out("n/a")
                 else:
+                    warn_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+warn(ing:)?\s'
+                    err_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+error:?\s'
                     warn = 0
                     err = 0
                     for l in p.lines():
                         # ensure errors/warnings search is case-insensitive
                         lcl = l.lower()
-                        found_err = lcl.find("error") >= 0
-                        found_warn = lcl.find("warn") >= 0
-
-                        if found_err:
-                            err += 1
-                        elif found_warn:
+                        if re.match(warn_regex, lcl):
                             warn += 1
+                        elif re.match(err_regex, lcl):
+                            err += 1
                     msg = ""
                     if warn or err:
                         msg = " errors=%-4s warnings=%-4s" % (err, warn)

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1141,7 +1141,7 @@ OMERO Diagnostics %s
                     self.ctx.out("n/a")
                 else:
                     warn_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+warn(i(ng:)?)?\s'
-                    err_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+error:?\s'
+                    err_regex = '(!! )?[\d\-/]+\s+[\d:,.]+\s+error:?\s'
                     warn = 0
                     err = 0
                     for l in p.lines():

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1140,8 +1140,10 @@ OMERO Diagnostics %s
                 if not p.exists():
                     self.ctx.out("n/a")
                 else:
-                    warn_regex = '(-! )?[\d\-/]+\s+[\d:,.]+\s+warn(i(ng:)?)?\s'
-                    err_regex = '(!! )?[\d\-/]+\s+[\d:,.]+\s+error:?\s'
+                    warn_regex = ('(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                                  'warn(i(ng:)?)?\s')
+                    err_regex = ('(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                                 'error:?\s')
                     warn = 0
                     err = 0
                     for l in p.lines():


### PR DESCRIPTION
# What this PR does

This PR attempts to increase accuracy in counting errors and warnings in OMERO.server logs.

# Testing this PR

Arrange some warnings and/or errors among the regular logs (like `Blitz-0.log`) and also `master.err` and suchlike. Run `bin/omero admin diagnostics` and check that they are correctly counted.

If it's too tricky to stimulate such log entries locally, just copy logs from some other system or append them to the end of yours: [from CI](https://www.openmicroscopy.org/private/ome-internal/instructions/server-logs.html), some bug report in a ticket, etc.

# Related reading

https://trello.com/c/ecsPd9WE/87-diag-false-positives-on-error