### PR TITLE
Add --set to config append, --report to config {set,append,remove}

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -165,6 +165,9 @@ class PrefsControl(WriteableConfigControl):
         for x in [set, append, remove]:
             x.add_argument(
                 "KEY", help="Name of the key in the current profile")
+            # report is intended for use with cfg mgmt tools
+            x.add_argument("--report", action="store_true",
+                           help="Report if changes are made")
         set.add_argument(
             "-f", "--file", type=ExistingFile('r'),
             help="Load value from file")
@@ -320,8 +323,12 @@ class PrefsControl(WriteableConfigControl):
                 f.close()
         elif args.VALUE is None:
             del config[args.KEY]
+            if args.report:
+                self.ctx.out('Changed: Removed %s' % args.KEY)
         else:
             config[args.KEY] = args.VALUE
+            if args.report:
+                self.ctx.out('Changed: Set %s:%s' % (args.KEY, args.VALUE))
 
     def get_list_value(self, args, config):
         import json
@@ -359,9 +366,9 @@ class PrefsControl(WriteableConfigControl):
         if not args.set or jv not in list_value:
             list_value.append(json.loads(args.VALUE))
             config[args.KEY] = json.dumps(list_value)
-            if args.set:
-                # Only output if --set so that user knows if it was changed
-                self.ctx.out('Appended %s:%s' % (args.KEY, args.VALUE))
+            if args.report:
+                self.ctx.out(
+                    'Changed: Appended %s:%s' % (args.KEY, args.VALUE))
 
     @with_rw_config
     def remove(self, args, config):
@@ -379,6 +386,8 @@ class PrefsControl(WriteableConfigControl):
 
         list_value.remove(json.loads(args.VALUE))
         config[args.KEY] = json.dumps(list_value)
+        if args.report:
+            self.ctx.out('Changed: Removed %s:%s' % (args.KEY, args.VALUE))
 
     @with_config
     def keys(self, args, config):

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -257,6 +257,24 @@ class TestPrefs(object):
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[]')
 
+    def testAppendSet(self, capsys):
+        self.invoke("append --set A 1")
+        self.assertStdoutStderr(capsys, out='Appended A:1')
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[1]')
+        self.invoke("append --set A 2")
+        self.assertStdoutStderr(capsys, out='Appended A:2')
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[1, 2]')
+        self.invoke("append --set A 1")
+        self.assertStdoutStderr(capsys, out='')
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[1, 2]')
+        self.invoke("append A 1")
+        self.assertStdoutStderr(capsys, out='')
+        self.invoke("get A")
+        self.assertStdoutStderr(capsys, out='[1, 2, 1]')
+
     def testRemoveIdenticalValues(self, capsys):
         self.invoke("set A [1,1]")
         self.invoke("remove A 1")
@@ -273,9 +291,15 @@ class TestPrefs(object):
             "omero.web.test": ["TEST", "[1,2,3]", json.loads],
             "omero.web.notalist": ["NOTALIST", "abc", str],
         })
+
         self.invoke("append omero.web.test 4")
         self.invoke("get omero.web.test")
         self.assertStdoutStderr(capsys, out='[1, 2, 3, 4]')
+        self.invoke("append --set omero.web.test 2")
+        self.assertStdoutStderr(capsys, out='')
+        self.invoke("get omero.web.test")
+        self.assertStdoutStderr(capsys, out='[1, 2, 3, 4]')
+
         self.invoke("append omero.web.unknown 1")
         self.invoke("get omero.web.unknown")
         self.assertStdoutStderr(capsys, out='[1]')

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -243,35 +243,47 @@ class TestPrefs(object):
         with pytest.raises(NonZeroReturnCode):
             self.invoke("remove A %s" % newval)
 
-    def testAppendRemove(self, capsys):
-        self.invoke("append A 1")
+    @pytest.mark.parametrize('report', ['--report', ''])
+    def testAppendRemove(self, report, capsys):
+        self.invoke("append %s A 1" % report)
+        self.assertReportStdout(report, capsys, 'Appended A:1')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1]')
-        self.invoke("append A \"y\"")
+        self.invoke("append %s A \"y\"" % report)
+        self.assertReportStdout(report, capsys, 'Appended A:"y"')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1, "y"]')
-        self.invoke("remove A \"y\"")
+        self.invoke("remove %s A \"y\"" % report)
+        self.assertReportStdout(report, capsys, 'Removed A:"y"')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1]')
-        self.invoke("remove A 1")
+        self.invoke("remove %s A 1" % report)
+        self.assertReportStdout(report, capsys, 'Removed A:1')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[]')
 
-    def testAppendSet(self, capsys):
-        self.invoke("append --set A 1")
-        self.assertStdoutStderr(capsys, out='Appended A:1')
+    def assertReportStdout(self, report, capsys, out):
+        if report and out:
+            self.assertStdoutStderr(capsys, out='Changed: %s' % out)
+        else:
+            self.assertStdoutStderr(capsys, out='')
+
+    @pytest.mark.parametrize('report', ['--report', ''])
+    def testAppendSet(self, report, capsys):
+        self.invoke("append %s --set A 1" % report)
+        self.assertReportStdout(report, capsys, 'Appended A:1')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1]')
-        self.invoke("append --set A 2")
-        self.assertStdoutStderr(capsys, out='Appended A:2')
+        self.invoke("append %s --set A 2" % report)
+        self.assertReportStdout(report, capsys, 'Appended A:2')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1, 2]')
-        self.invoke("append --set A 1")
-        self.assertStdoutStderr(capsys, out='')
+        self.invoke("append %s --set A 1" % report)
+        self.assertReportStdout(report, capsys, '')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1, 2]')
-        self.invoke("append A 1")
-        self.assertStdoutStderr(capsys, out='')
+        self.invoke("append %s A 1" % report)
+        self.assertReportStdout(report, capsys, 'Appended A:1')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1, 2, 1]')
 


### PR DESCRIPTION
# What this PR does

Adds `--set` option to `omero config append`, to indicate a value should only be added if it's not already in the list, taking into account the defaults, see https://github.com/openmicroscopy/openmicroscopy/issues/4597

Adds `--report` option to `omero config {append,set,remove}`. This will always print out `Changed: ...` if a change was made, and nothing if no change was made.

# Testing this PR

1. Check `omero config append/set/remove` behaves as before.

2. Try something like

        omero config append --set omero.web.ui.top_links '["History", "history", {"title": "History"}]'

   this should have no effect (E.g. `omero config get`, or `omero web restart` and check the top-links) because this value is part of the standard defaults.

3. Try it without `--set`, you should see the old behaviour i.e. the duplicate value is appended

        omero config append omero.web.ui.top_links '["History", "history", {"title": "History"}]'

4. Add a different value, e.g.

        omero config append --set omero.web.ui.top_links '["BBC", "http://www.bbc.co.uk/"]'

5. Try `omero config {append,set,remove} --report`. If a change was made you should see a message such as `Changed: Appended omero.web.ui.top_links:["BBC", "http://www.bbc.co.uk/"]`

The idea behind this is to assist with Ansible deployments where you want to programmatically know whether or not a change was made.

# Related reading

- https://github.com/openmicroscopy/openmicroscopy/issues/4597
- Motivation: Deploy [mapr](https://github.com/aleksandra-tarkowska/mapannotations) on the IDR with Ansible
  - https://github.com/openmicroscopy/infrastructure/pull/104