### PR TITLE
have metadata browser show annotation counts

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -1,7 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -28,6 +27,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 
 import omero.gateway.model.AnnotationData;
+
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
@@ -188,6 +188,7 @@ public class AnnotationTaskPane extends JXTaskPane {
      */
     void refreshUI() {
         ui.refreshUI();
+        setAnnotationCount(ui.getUnfilteredAnnotationCount());
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
@@ -191,7 +191,7 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
      * Get the toolbar buttons; override this method if a toolbar is needed
      */
     List<JButton> getToolbarButtons() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
@@ -1,7 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -223,4 +222,9 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
      * Informs the UI when the related nodes have been set.
      * */
     abstract void onRelatedNodesSet();
+
+    /**
+     * @return the number of annotations regardless of current filter
+     */
+    abstract int getUnfilteredAnnotationCount();
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -518,4 +518,12 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         
     }
 
+    @Override
+    int getUnfilteredAnnotationCount() {
+        if (model.isMultiSelection()) {
+            return model.getAllAttachments().size();
+        } else {
+            return model.getAttachments().size();
+        }
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -1,7 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -410,6 +409,9 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
         addButton.setEnabled(model.canAddAnnotationLink());
         refreshUI();
     }
-    
-    
+
+    @Override
+    int getUnfilteredAnnotationCount() {
+        return model.getTextualAnnotationCount();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
@@ -67,12 +67,12 @@ public class DummyTaskPaneUI extends AnnotationTaskPaneUI {
 
     @Override
     List<AnnotationData> getAnnotationsToSave() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
     List<Object> getAnnotationsToRemove() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
@@ -1,7 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -80,6 +79,9 @@ public class DummyTaskPaneUI extends AnnotationTaskPaneUI {
     void onRelatedNodesSet() {
         
     }
-    
-    
+
+    @Override
+    int getUnfilteredAnnotationCount() {
+        return 0;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -1,7 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -36,6 +35,7 @@ import java.awt.event.MouseListener;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -771,7 +771,17 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         clearDisplay();
         refreshButtonStates();
     }
-    
-    
 
+    @Override
+    int getUnfilteredAnnotationCount() {
+        int count = 0;
+        for (final MapAnnotationType type : MapAnnotationType.values()) {
+            for (final MapAnnotationData map : model.getMapAnnotations(type)) {
+                if (!((Collection<?>) map.getContent()).isEmpty()) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
@@ -308,6 +308,13 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
     void onRelatedNodesSet() {
         removeButton.setEnabled(model.canAddAnnotationLink());
     }
-    
-    
+
+    @Override
+    int getUnfilteredAnnotationCount() {
+        if (model.isMultiSelection()) {
+            return model.getAllOtherAnnotations().size();
+        } else {
+            return model.getOtherAnnotations().size();
+        }
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
@@ -223,7 +223,7 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
     List<AnnotationData> getAnnotationsToSave() {
         // Edits are saved instantly and there's no way to create
         // "other" annotations, so it's safe to just return an empty list.
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -204,4 +204,12 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         rating.setEnabled(model.canAddAnnotationLink());
     }
 
+    @Override
+    int getUnfilteredAnnotationCount() {
+        if (model.isMultiSelection()) {
+            return model.getRatingCount(EditorModel.ME);
+        } else {
+            return model.getRatingCount(EditorModel.ALL);
+        }
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -324,5 +324,13 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
         addTagsButton.setEnabled(model.canAddAnnotationLink());
         removeTagsButton.setEnabled(model.canDeleteAnnotationLink());
     }
-    
+
+    @Override
+    int getUnfilteredAnnotationCount() {
+        if (model.isMultiSelection()) {
+            return model.getAllTags().size();
+        } else {
+            return model.getTags().size();
+        }
+    }
 }


### PR DESCRIPTION
# What this PR does

In Insight the right-hand metadata browser panel should now show annotation counts even before accordion tabs are expanded.

# Testing this PR

Try adding and removing annotations and see that the annotation counts generally stay correct, especially after selecting a different entity then moving back. Counts under multiselect should also be reasonable. Will generally correspond to *total* that is visible *across* different filtering options in right pane (e.g., show mine or others').

(Sync isn't always immediately perfect but trying to keep implementation sane.)

# Related reading

https://trello.com/c/bc6ZtV0x/144-rfe-indication-of-number-of-annotations-on-an-image-in-brackets-5-on-accordion-tabs-in-right-hand-pane