### PR TITLE
Ignore stroke width < 1

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -46,7 +46,6 @@ import static org.jhotdraw.draw.AttributeKeys.STROKE_WIDTH;
 import org.jhotdraw.draw.AttributeKey;
 import org.jhotdraw.geom.BezierPath.Node;
 
-import ome.model.units.BigResult;
 import omero.model.Length;
 import omero.model.enums.UnitsLength;
 
@@ -513,16 +512,10 @@ class InputServerStrategy
 	    Length l;
         try {
             l = data.getStrokeWidth(UnitsLength.PIXEL);
-            if (l != null) {
+            if (l != null && l.getValue() >= 1) {
                 value = l.getValue();
             }
         } catch (Exception e) {
-            if (e instanceof BigResult) {
-                BigResult ex = (BigResult) e;
-                if (ex.result != null) {
-                    value = ex.result.doubleValue();
-                }
-            }
         }
 		STROKE_WIDTH.set(figure, value);
 		STROKE_COLOR.set(figure, data.getStroke());


### PR DESCRIPTION
# What this PR does

Makes sure that the line width used for drawing ROIs is at least 1 px.

# Testing this PR

Draw an ROI; set the line width in the DB to a value < 1; make sure ROI tool doesn't crash.

# Related reading
[[ome-users] OMERO Client crashes when lauching ROI tool](http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-August/006117.html)
The user imported ROIs with stroke width < 1, which made Insight ROI tool practically unusable.
I'm not sure if it's worth fixing in Insight, as it's a problem with the ROIs, but on the other hand, using a 1px default is better than crashing Insight in these cases.


