### PR TITLE
File filter from B-F

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1355,17 +1355,24 @@ class OmeroImageServiceImpl
 	 */
 	public FileFilter[] getSupportedFileFormats()
 	{
-		if (filters != null) return filters;
-		//improve that code.
-		ImageReader reader = new ImageReader();
-		FileFilter[] array = loci.formats.gui.GUITools.buildFileFilters(reader);
-		if (array != null) {
-			filters = new FileFilter[array.length];
-			System.arraycopy(array, 0, filters, 0, array.length);
-		} else filters = new FileFilter[0];
+	    if (filters != null) return filters;
+	    try {
+	        ImageReader reader = new ImageReader();
+	        FileFilter[] array = loci.formats.gui.GUITools.buildFileFilters(reader);
+	        if (array != null) {
+	            filters = new FileFilter[array.length];
+	            System.arraycopy(array, 0, filters, 0, array.length);
+	        } else filters = new FileFilter[0];
+	    } catch (Exception e) {
+	        LogMessage msg = new LogMessage();
+            msg.print("Cannot retrieve the list of supported formats.");
+            msg.print(e);
+            context.getLogger().error(this, msg);
+	        filters = new FileFilter[0];
+	    }
 		return filters;
 	}
-	
+
 	/** 
 	 * Implemented as specified by {@link OmeroImageService}. 
 	 * @see OmeroImageService#createMovie(SecurityContext, long, long, List,


### PR DESCRIPTION
# What this PR does

Add try/catch block to handle error when loading supported files




# Testing this PR

Open the importer, 
Make sure the application does not need to crash if the list of
supported file formats cannot be retrieved.
This can be triggered by not having a "readers.txt" file, the file is read by B-F

The "readers.txt" file is in the``formats-api.jar``. This is part of the jars shipped with insight
Open the ``formats-api.jar``, and remove the file.

# Related reading

See https://www.openmicroscopy.org/qa2/qa/feedback/17307/



