### PR TITLE
adjust SQL readme

### DIFF
--- a/sql/README.txt
+++ b/sql/README.txt
@@ -7,7 +7,7 @@ as for upgrading existing databases.
 
 All scripts are of the form:
 
-  CURRENTVERSION__CURRENTPATCH/TARGETVERSION__TARGETPATCH.sql
+  TARGETVERSION__TARGETPATCH/CURRENTVERSION__CURRENTPATCH.sql
 
 with the exception of scripts concatenated by "omero db script":
 

--- a/sql/README.txt
+++ b/sql/README.txt
@@ -1,9 +1,9 @@
-
 DATABASE SCRIPTS:
 =================
 
-The directories which are named after the supported database profiles (currently "psql")
-contain scripts for creating fresh databases as well as for upgrading existing databases.
+The directories which are named after the supported database profiles
+(currently "psql") contain scripts for creating fresh databases as well
+as for upgrading existing databases.
 
 All scripts are of the form:
 
@@ -15,6 +15,7 @@ with the exception of scripts concatenated by "omero db script":
   CURRENTVERSION__0/schema.sql           Creates a fresh database
   CURRENTVERSION__0/psql-footer.sql      Suffixes schema.sql, adjusts the "dbpatch" table
 
-To create the update scripts, first cleaned versions of each schema are compared 
-(where cleaned means simple formatting differences, random foreign key names, etc. 
-are removed). Then it is necessary to compare the values in all enumerations.
+To create the update scripts, first cleaned versions of each schema are
+compared (where cleaned means simple formatting differences, random
+foreign key names, etc. are removed). Then it is necessary to compare
+the values in all enumerations.


### PR DESCRIPTION
# What this PR does

Fixes the SQL script path description in the README.

# Testing this PR

Take a look at `sql/README.txt` and compare with the directory's contents and with https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/server-upgrade.html#run-the-upgrade-script.

# Related reading

https://trello.com/c/ftdGIEl4/163-sql-readme-v-s-web-docs