### PR TITLE
Tagging bugfixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,6 +22,7 @@ package org.openmicroscopy.shoola.agents.treeviewer.actions;
 
 import java.awt.event.ActionEvent;
 import javax.swing.Action;
+import javax.swing.tree.TreeNode;
 
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
 import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
@@ -220,7 +221,20 @@ public class CreateTopContainerAction
             setEnabled(TreeViewerAgent.isAdministrator());
             return;
         }
-        if (nodeType != EXPERIMENTER) {
+        if (model.getDisplayMode() == TreeViewer.EXPERIMENTER_DISPLAY
+                && (nodeType == TAG || nodeType == TAG_SET)
+                && selectedDisplay != null) {
+            TreeNode[] nodes = selectedDisplay.getPath();
+            if (nodes.length > 2) {
+                TreeNode expNode = nodes[2];
+                if (((TreeImageDisplay) expNode).getUserObject() instanceof ExperimenterData) {
+                    ExperimenterData exp = (ExperimenterData) ((TreeImageDisplay) expNode)
+                            .getUserObject();
+                    setEnabled(exp.getId() == TreeViewerAgent.getUserDetails()
+                            .getId());
+                }
+            }
+        } else if (nodeType != EXPERIMENTER) {
             if (selectedDisplay != null) {
                 Object ho = selectedDisplay.getUserObject();
                 if (ho instanceof ExperimenterData) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
@@ -539,9 +539,11 @@ public class DMRefreshLoader
             Map<DataObject, Collection<?>> mapForDataObject)
     {
         if (mapForDataObject.isEmpty()) {
-            tag.setDataObjects((Set<DataObject>) values.get(tag.getId()));
+            Set<DataObject> objs = new HashSet<DataObject>();
+            objs.addAll((Collection<DataObject>) values.get(tag.getId()));
+            tag.setDataObjects(objs);
         } else {
-            Set<DataObject> objects = (Set<DataObject>) values.get(tag.getId());
+            Collection<DataObject> objects = (Collection<DataObject>) values.get(tag.getId());
             Set<DataObject> newList = new HashSet<DataObject>(objects.size());
             Iterator<DataObject> kk = objects.iterator();
             while (kk.hasNext()) {


### PR DESCRIPTION
# What this PR does

If you create a new Tag or TagSet while browsing another user's Tags, the newly created Tag/TagSet might not be shown, because it gets listed within the logged in user's branch (which might not be expanded), see example screenshot (logged in as user-6, browsing user-3 tags). The create new Tag/TagSet menus should therefore be disabled in that case.

![screen shot 2016-08-23 at 15 18 06](https://cloud.githubusercontent.com/assets/6575139/17895633/a3c00d0c-6945-11e6-99b0-80f433c11d24.png)

(Also fixes two `ClassCastExceptions` when creating Tags/TagSets which probably have been introduced by  #4734)

# Testing this PR

Make sure that you *cannot* create a new Tag/TagSet while browsing through another user's Tags (another user's tag, tagset, object is selected), check the right click context menu and toolbar menu. 
Make sure you *can* create a new Tag/TagSet while you're browsing your own tags. 


# Related reading

https://trello.com/c/WN0W4D3l/69-minor-tag-bugs-insight

