### PR TITLE
change terminator method name to "close"

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1748,7 +1748,7 @@ class _BlitzGateway (object):
     def seppuku(self, softclose=False):  # pragma: no cover
         """
         Terminates connection with killSession(). If softclose is False, the
-        session is really terminate disregarding its connection refcount.
+        session is really terminated disregarding its connection refcount.
 
         :param softclose:   Boolean
 
@@ -1762,7 +1762,7 @@ class _BlitzGateway (object):
     def terminateAllClients(self, softclose=False):  # pragma: no cover
         """
         Terminates connection with killSession(). If softclose is False, the
-        session is really terminate disregarding its connection refcount.
+        session is really terminated disregarding its connection refcount.
 
         :param softclose:   Boolean
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1757,15 +1757,6 @@ class _BlitzGateway (object):
         """
         warnings.warn("Deprecated. Use terminateAllClients",
                       DeprecationWarning)
-        self.terminateAllClients(softclose)
-
-    def terminateAllClients(self, softclose=False):  # pragma: no cover
-        """
-        Terminates connection with killSession(). If softclose is False, the
-        session is really terminated disregarding its connection refcount.
-
-        :param softclose:   Boolean
-        """
         self._connected = False
         oldC = self.c
         if oldC is not None:
@@ -1781,6 +1772,24 @@ class _BlitzGateway (object):
                         oldC.closeSession()
                 else:
                     self._closeSession()
+            finally:
+                oldC.__del__()
+                oldC = None
+                self.c = None
+
+        self._proxies = NoProxies()
+        logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
+
+    def terminateAllClients(self):  # pragma: no cover
+        """
+        Terminates connection with killSession(). The session is terminated
+        regardless of its connection refcount.
+        """
+        self._connected = False
+        oldC = self.c
+        if oldC is not None:
+            try:
+                self._closeSession()
             finally:
                 oldC.__del__()
                 oldC = None

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1043,7 +1043,7 @@ class BlitzObjectWrapper (object):
                 clone = self.__class__(newConn, self._obj)
                 ann = clone._linkAnnotation(ann)
                 if newConn != self._conn:
-                    newConn.terminateAllClients()
+                    newConn.close()
             elif d.getGroup():
                 # Try to match group
                 # TODO: Should switch session of this object to use group from
@@ -1753,10 +1753,10 @@ class _BlitzGateway (object):
 
         :param softclose:   Boolean
 
-        ** Deprecated ** Use :meth:`terminateAllClients`.
+        ** Deprecated ** Use :meth:`close`.
         Our apologies for any offense caused by this previous method name.
         """
-        warnings.warn("Deprecated. Use terminateAllClients",
+        warnings.warn("Deprecated. Use close()",
                       DeprecationWarning)
         self._connected = False
         oldC = self.c
@@ -1781,7 +1781,7 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def terminateAllClients(self):  # pragma: no cover
+    def close(self):  # pragma: no cover
         """
         Terminates connection with killSession(). The session is terminated
         regardless of its connection refcount.

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1749,6 +1749,7 @@ class _BlitzGateway (object):
         """
         Terminates connection with killSession(). If softclose is False, the
         session is really terminated disregarding its connection refcount.
+        If softclose is True then the connection refcount is decremented by 1.
 
         :param softclose:   Boolean
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1043,7 +1043,7 @@ class BlitzObjectWrapper (object):
                 clone = self.__class__(newConn, self._obj)
                 ann = clone._linkAnnotation(ann)
                 if newConn != self._conn:
-                    newConn.seppuku()
+                    newConn.terminateAllClients()
             elif d.getGroup():
                 # Try to match group
                 # TODO: Should switch session of this object to use group from
@@ -1746,6 +1746,20 @@ class _BlitzGateway (object):
             return False
 
     def seppuku(self, softclose=False):  # pragma: no cover
+        """
+        Terminates connection with killSession(). If softclose is False, the
+        session is really terminate disregarding its connection refcount.
+
+        :param softclose:   Boolean
+
+        ** Deprecated ** Use :meth:`terminateAllClients`.
+        Our apologies for any offense caused by this previous method name.
+        """
+        warnings.warn("Deprecated. Use terminateAllClients",
+                      DeprecationWarning)
+        self.terminateAllClients(softclose)
+
+    def terminateAllClients(self, softclose=False):  # pragma: no cover
         """
         Terminates connection with killSession(). If softclose is False, the
         session is really terminate disregarding its connection refcount.

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -37,7 +37,7 @@ def refreshConfig():
         ru = bg.c.ic.getProperties().getProperty('omero.rootuser')
         rp = bg.c.ic.getProperties().getProperty('omero.rootpass')
     finally:
-        bg.seppuku()
+        bg.terminateAllClients()
 
     if ru:
         ROOT.name = ru
@@ -230,7 +230,7 @@ class UserEntry (object):
         finally:
             # Always clean up the results of login
             if admin_gateway:
-                admin_gateway.seppuku()
+                admin_gateway.terminateAllClients()
 
     @staticmethod
     def setGroupForSession(client, groupname, groupperms=None):
@@ -297,7 +297,7 @@ class ProjectEntry (ObjectEntry):
             try:
                 UserEntry.addGroupToUser(s, groupname, self.group_perms)
             finally:
-                s.seppuku()
+                s.terminateAllClients()
 
             UserEntry.setGroupForSession(client, groupname, self.group_perms)
         p = omero.gateway.ProjectWrapper(
@@ -477,7 +477,8 @@ class ImageEntry (ObjectEntry):
                 self.callback(img)
             return img
         finally:
-            newconn.seppuku()  # Always cleanup the return from clone/connect
+            # Always cleanup the return from clone/connect
+            newconn.terminateAllClients()
 
     def _createWithoutPixels(self, client, dataset):
         img = omero.model.ImageI()
@@ -512,7 +513,7 @@ def getImage(client, alias, forceds=None, autocreate=False):
     rv = IMAGES[alias].get(client, forceds)
     if rv is None and autocreate:
         i = IMAGES[alias].create()
-        i._conn.seppuku()
+        i._conn.terminateAllClients()
         rv = IMAGES[alias].get(client, forceds)
     return rv
 
@@ -529,17 +530,17 @@ def bootstrap(onlyUsers=False, skipImages=True):
             return
         for k, p in PROJECTS.items():
             p = p.create()
-            p._conn.seppuku()
+            p._conn.terminateAllClients()
             # print p.get(client).getDetails().getPermissions().isUserWrite()
         for k, d in DATASETS.items():
             d = d.create()
-            d._conn.seppuku()
+            d._conn.terminateAllClients()
         if not skipImages:
             for k, i in IMAGES.items():
                 i = i.create()
-                i._conn.seppuku()
+                i._conn.terminateAllClients()
     finally:
-        client.seppuku()
+        client.terminateAllClients()
 
 
 def cleanup():
@@ -554,11 +555,11 @@ def cleanup():
                 client._waitOnCmd(handle)
             finally:
                 handle.close()
-    client.seppuku()
+    client.terminateAllClients()
     client = loginAsRoot()
     for k, u in USERS.items():
         u.changePassword(client, None, ROOT.passwd)
-    client.seppuku()
+    client.terminateAllClients()
 
 ROOT = UserEntry('root', 'ome', admin=True)
 

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -37,7 +37,7 @@ def refreshConfig():
         ru = bg.c.ic.getProperties().getProperty('omero.rootuser')
         rp = bg.c.ic.getProperties().getProperty('omero.rootpass')
     finally:
-        bg.terminateAllClients()
+        bg.close()
 
     if ru:
         ROOT.name = ru
@@ -230,7 +230,7 @@ class UserEntry (object):
         finally:
             # Always clean up the results of login
             if admin_gateway:
-                admin_gateway.terminateAllClients()
+                admin_gateway.close()
 
     @staticmethod
     def setGroupForSession(client, groupname, groupperms=None):
@@ -297,7 +297,7 @@ class ProjectEntry (ObjectEntry):
             try:
                 UserEntry.addGroupToUser(s, groupname, self.group_perms)
             finally:
-                s.terminateAllClients()
+                s.close()
 
             UserEntry.setGroupForSession(client, groupname, self.group_perms)
         p = omero.gateway.ProjectWrapper(
@@ -478,7 +478,7 @@ class ImageEntry (ObjectEntry):
             return img
         finally:
             # Always cleanup the return from clone/connect
-            newconn.terminateAllClients()
+            newconn.close()
 
     def _createWithoutPixels(self, client, dataset):
         img = omero.model.ImageI()
@@ -513,7 +513,7 @@ def getImage(client, alias, forceds=None, autocreate=False):
     rv = IMAGES[alias].get(client, forceds)
     if rv is None and autocreate:
         i = IMAGES[alias].create()
-        i._conn.terminateAllClients()
+        i._conn.close()
         rv = IMAGES[alias].get(client, forceds)
     return rv
 
@@ -530,17 +530,17 @@ def bootstrap(onlyUsers=False, skipImages=True):
             return
         for k, p in PROJECTS.items():
             p = p.create()
-            p._conn.terminateAllClients()
+            p._conn.close()
             # print p.get(client).getDetails().getPermissions().isUserWrite()
         for k, d in DATASETS.items():
             d = d.create()
-            d._conn.terminateAllClients()
+            d._conn.close()
         if not skipImages:
             for k, i in IMAGES.items():
                 i = i.create()
-                i._conn.terminateAllClients()
+                i._conn.close()
     finally:
-        client.terminateAllClients()
+        client.close()
 
 
 def cleanup():
@@ -555,11 +555,11 @@ def cleanup():
                 client._waitOnCmd(handle)
             finally:
                 handle.close()
-    client.terminateAllClients()
+    client.close()
     client = loginAsRoot()
     for k, u in USERS.items():
         u.changePassword(client, None, ROOT.passwd)
-    client.terminateAllClients()
+    client.close()
 
 ROOT = UserEntry('root', 'ome', admin=True)
 

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
@@ -66,7 +66,7 @@ class TestDBHelper(object):
             if rp:
                 dbhelpers.ROOT.passwd = rp
         finally:
-            gateway.terminateAllClients()
+            gateway.close()
 
         self.prepTestDB(onlyUsers=skipTestDB, skipImages=skipTestImages)
         self.doDisconnect()
@@ -84,7 +84,7 @@ class TestDBHelper(object):
     def doDisconnect(self):
         if self._has_connected and self.gateway:
             self.doConnect()
-            self.gateway.terminateAllClients()
+            self.gateway.close()
             assert not self.gateway.isConnected(), 'Can not disconnect'
         self.gateway = None
         self._has_connected = False
@@ -118,7 +118,7 @@ class TestDBHelper(object):
 
         try:
             if self.gateway is not None:
-                self.gateway.terminateAllClients()
+                self.gateway.close()
         finally:
             failure = False
             for tmpfile in self.tmpfiles:

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
@@ -66,7 +66,7 @@ class TestDBHelper(object):
             if rp:
                 dbhelpers.ROOT.passwd = rp
         finally:
-            gateway.seppuku()
+            gateway.terminateAllClients()
 
         self.prepTestDB(onlyUsers=skipTestDB, skipImages=skipTestImages)
         self.doDisconnect()
@@ -84,7 +84,7 @@ class TestDBHelper(object):
     def doDisconnect(self):
         if self._has_connected and self.gateway:
             self.doConnect()
-            self.gateway.seppuku()
+            self.gateway.terminateAllClients()
             assert not self.gateway.isConnected(), 'Can not disconnect'
         self.gateway = None
         self._has_connected = False
@@ -118,7 +118,7 @@ class TestDBHelper(object):
 
         try:
             if self.gateway is not None:
-                self.gateway.seppuku()
+                self.gateway.terminateAllClients()
         finally:
             failure = False
             for tmpfile in self.tmpfiles:

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -41,6 +41,7 @@ class TestConnectionMethods(object):
             c3, a.containedGroups(c3.getUserId())[1])
         c3.setGroupForSession(g)
 
+    # seppuku is deprecated: testTerminateAllClients below supersedes this test
     def testSeppuku(self, gatewaywrapper, author_testimg):
         # author_testimg in args to make sure the image has been imported
         gatewaywrapper.loginAsAuthor()
@@ -72,6 +73,42 @@ class TestConnectionMethods(object):
         assert gatewaywrapper.getTestImage() is not None
         assert g2_getTestImage() is not None
         g2.seppuku(softclose=False)
+        pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
+        pytest.raises(Ice.ObjectNotExistException, gatewaywrapper.getTestImage)
+        gatewaywrapper._has_connected = False
+        gatewaywrapper.doDisconnect()
+
+    def testTerminateAllClients(self, gatewaywrapper, author_testimg):
+        # author_testimg in args to make sure the image has been imported
+        gatewaywrapper.loginAsAuthor()
+        assert gatewaywrapper.getTestImage() is not None
+        gatewaywrapper.gateway.terminateAllClients()
+        pytest.raises(Ice.ConnectionLostException, gatewaywrapper.getTestImage)
+        gatewaywrapper._has_connected = False
+        gatewaywrapper.doDisconnect()
+        gatewaywrapper.loginAsAuthor()
+        assert gatewaywrapper.getTestImage() is not None
+        gatewaywrapper.gateway.terminateAllClients(softclose=False)
+        pytest.raises(Ice.ConnectionLostException, gatewaywrapper.getTestImage)
+        gatewaywrapper._has_connected = False
+        gatewaywrapper.doDisconnect()
+        # Also make sure softclose does the right thing
+        gatewaywrapper.loginAsAuthor()
+        g2 = gatewaywrapper.gateway.clone()
+
+        def g2_getTestImage():
+            return dbhelpers.getImage(g2, 'testimg1')
+        assert g2.connect(gatewaywrapper.gateway._sessionUuid)
+        assert gatewaywrapper.getTestImage() is not None
+        assert g2_getTestImage() is not None
+        g2.terminateAllClients(softclose=True)
+        pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
+        assert gatewaywrapper.getTestImage() is not None
+        g2 = gatewaywrapper.gateway.clone()
+        assert g2.connect(gatewaywrapper.gateway._sessionUuid)
+        assert gatewaywrapper.getTestImage() is not None
+        assert g2_getTestImage() is not None
+        g2.terminateAllClients(softclose=False)
         pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
         pytest.raises(Ice.ObjectNotExistException, gatewaywrapper.getTestImage)
         gatewaywrapper._has_connected = False

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -41,7 +41,7 @@ class TestConnectionMethods(object):
             c3, a.containedGroups(c3.getUserId())[1])
         c3.setGroupForSession(g)
 
-    # seppuku is deprecated: testTerminateAllClients below supersedes this test
+    # seppuku is deprecated: testClose below supersedes this test
     def testSeppuku(self, gatewaywrapper, author_testimg):
         # author_testimg in args to make sure the image has been imported
         gatewaywrapper.loginAsAuthor()
@@ -78,11 +78,11 @@ class TestConnectionMethods(object):
         gatewaywrapper._has_connected = False
         gatewaywrapper.doDisconnect()
 
-    def testTerminateAllClients(self, gatewaywrapper, author_testimg):
+    def testClose(self, gatewaywrapper, author_testimg):
         # author_testimg in args to make sure the image has been imported
         gatewaywrapper.loginAsAuthor()
         assert gatewaywrapper.getTestImage() is not None
-        gatewaywrapper.gateway.terminateAllClients()
+        gatewaywrapper.gateway.close()
         pytest.raises(Ice.ConnectionLostException, gatewaywrapper.getTestImage)
         gatewaywrapper._has_connected = False
         gatewaywrapper.doDisconnect()
@@ -94,7 +94,7 @@ class TestConnectionMethods(object):
         assert g2.connect(gatewaywrapper.gateway._sessionUuid)
         assert gatewaywrapper.getTestImage() is not None
         assert g2_getTestImage() is not None
-        g2.terminateAllClients()
+        g2.close()
         pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
         pytest.raises(Ice.ObjectNotExistException, gatewaywrapper.getTestImage)
         gatewaywrapper._has_connected = False

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -87,13 +87,6 @@ class TestConnectionMethods(object):
         gatewaywrapper._has_connected = False
         gatewaywrapper.doDisconnect()
         gatewaywrapper.loginAsAuthor()
-        assert gatewaywrapper.getTestImage() is not None
-        gatewaywrapper.gateway.terminateAllClients(softclose=False)
-        pytest.raises(Ice.ConnectionLostException, gatewaywrapper.getTestImage)
-        gatewaywrapper._has_connected = False
-        gatewaywrapper.doDisconnect()
-        # Also make sure softclose does the right thing
-        gatewaywrapper.loginAsAuthor()
         g2 = gatewaywrapper.gateway.clone()
 
         def g2_getTestImage():
@@ -101,14 +94,7 @@ class TestConnectionMethods(object):
         assert g2.connect(gatewaywrapper.gateway._sessionUuid)
         assert gatewaywrapper.getTestImage() is not None
         assert g2_getTestImage() is not None
-        g2.terminateAllClients(softclose=True)
-        pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
-        assert gatewaywrapper.getTestImage() is not None
-        g2 = gatewaywrapper.gateway.clone()
-        assert g2.connect(gatewaywrapper.gateway._sessionUuid)
-        assert gatewaywrapper.getTestImage() is not None
-        assert g2_getTestImage() is not None
-        g2.terminateAllClients(softclose=False)
+        g2.terminateAllClients()
         pytest.raises(Ice.ConnectionLostException, g2_getTestImage)
         pytest.raises(Ice.ObjectNotExistException, gatewaywrapper.getTestImage)
         gatewaywrapper._has_connected = False

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -340,7 +340,7 @@ def logout(request, conn=None, **kwargs):
     if request.method == "POST":
         try:
             try:
-                conn.terminateAllClients()
+                conn.close()
             except:
                 logger.error('Exception during logout.', exc_info=True)
         finally:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -340,7 +340,7 @@ def logout(request, conn=None, **kwargs):
     if request.method == "POST":
         try:
             try:
-                conn.seppuku()
+                conn.terminateAllClients()
             except:
                 logger.error('Exception during logout.', exc_info=True)
         finally:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2284,7 +2284,7 @@ def su(request, user, conn=None, **kwargs):
         connector.omero_session_key = conn.suConn(user, ttl=ttl)._sessionUuid
         request.session['connector'] = connector
         conn.revertGroupForSession()
-        conn.seppuku()
+        conn.terminateAllClients()
         return True
     else:
         context = {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2284,7 +2284,7 @@ def su(request, user, conn=None, **kwargs):
         connector.omero_session_key = conn.suConn(user, ttl=ttl)._sessionUuid
         request.session['connector'] = connector
         conn.revertGroupForSession()
-        conn.terminateAllClients()
+        conn.close()
         return True
     else:
         context = {

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -84,7 +84,7 @@ class TestConfig(lib.ITest):
         self.conn = BlitzGateway(client_obj=self.new_client())
 
     def teardown_method(self, method):
-        self.conn.terminateAllClients()
+        self.conn.close()
         self.r.session.flush()
 
     def testDefaultConfig(self):

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -84,7 +84,7 @@ class TestConfig(lib.ITest):
         self.conn = BlitzGateway(client_obj=self.new_client())
 
     def teardown_method(self, method):
-        self.conn.seppuku()
+        self.conn.terminateAllClients()
         self.r.session.flush()
 
     def testDefaultConfig(self):


### PR DESCRIPTION
# What this PR does

This PR deprecates the offensively named `seppuku` method in the Python gateway replacing it with `close` and not providing its `softclose` option.

# Testing this PR

Integration testing suffices, see https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.gatewaytest.test_connection/TestConnectionMethods/.

# Related reading

https://trello.com/c/bS7vTB10/114-rfe-replace-conn-seppuku-with-less-offensive-term-in-code-base