### PR TITLE
Swing library dependency

### DIFF
--- a/components/tests/ui/library/java/ivy.xml
+++ b/components/tests/ui/library/java/ivy.xml
@@ -15,6 +15,7 @@
   </publications>
   <dependencies defaultconfmapping="build,client->default">
     <dependency org="org.robotframework" name="swinglibrary" rev="${versions.robotframework.swinglibrary}"/>
+    <dependency org="abbot" name="costello" rev="${versions.abbot.costello}"/>
     <dependency org="org.swinglabs" name="swingx" rev="${versions.swingx}"/>
     <dependency org="com.google.guava" name="guava" rev="${versions.guava}"/>
     <dependency org="org.testng" name="testng" rev="${versions.testng}"/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -73,11 +73,6 @@
           m2compatible="true"
           root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
-      <ibiblio name="laughingpanda-maven" cache="maven"
-          usepoms="true" useMavenMetadata="true"
-          m2compatible="true"
-          root="http://maven.laughingpanda.org/maven2/"/>
-
       <ibiblio name="unidata.releases" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
@@ -113,12 +108,6 @@
         <resolver ref="maven"/>
     </chain>
 
-    <!-- Laughing Panda resolver -->
-    <chain name="laughingpanda-resolver" returnFirst="true">
-        <resolver ref="user-maven"/>
-        <resolver ref="laughingpanda-maven"/>
-    </chain>
-
    <!-- Resolver for all the test jars which should not be shipped -->
     <chain name="test-resolver" returnFirst="true">
       <resolver ref="test"/>
@@ -145,8 +134,6 @@
     <module organisation="omero" name="omejava" resolver="omero-resolver" />
     <module organisation="omero" name="*-test" resolver="test-resolver" matcher="glob"/>
     <module organisation="org.springframework" resolver="maven-resolver"/>
-    <module organisation="abbot" resolver="laughingpanda-resolver"/>
-    <module organisation="jretrofit" resolver="laughingpanda-resolver"/>
     <module organisation="ome" name="appbundler" resolver="ome-resolver"/>
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -973,7 +973,9 @@ versions.spring-ldap=1.3.0.RELEASE
 versions.spring-security=3.0.2.RELEASE
 versions.subethasmtp=3.1.7
 versions.swingx=0.9.4
-versions.robotframework.swinglibrary=1.6.0
+versions.robotframework.swinglibrary=1.9.6
+# Costello's version matches SwingLibrary's dependency
+versions.abbot.costello=1.4.0
 versions.testng=6.8
 versions.velocity-tools=1.1
 versions.velocity=1.4


### PR DESCRIPTION
# What this PR does

OMERO cannot be fully built because the UI testing component depends on presently unavailable Maven artifacts. This PR updates the dependencies to allow more reliable fetching.

# Testing this PR

Move your `.m2/repository/` elsewhere and try building OMERO's `build-dev` target. After a couple of goes (for instance, `backport-util-concurrent` often fails for me and I have to wipe its directory and retry) the build should succeed.

# Related reading

https://github.com/robotframework/SwingLibrary/issues/87
--rebased-from #4790