### PR TITLE
Allow customizing tree (rebase onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1026,12 +1026,6 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
-    'omeroweb.feedback',
-    'omeroweb.webadmin',
-    'omeroweb.webclient',
-    'omeroweb.webgateway',
-    'omeroweb.webredirect',
-    'pipeline',
 )
 
 # ADDITONAL_APPS: We import any settings.py from apps. This allows them to
@@ -1057,6 +1051,15 @@ for app in ADDITIONAL_APPS:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
         report_settings(module.settings)
     except ImportError:
         logger.debug("Couldn't import settings from app: %s" % app)
+
+INSTALLED_APPS += (
+    'omeroweb.feedback',
+    'omeroweb.webadmin',
+    'omeroweb.webclient',
+    'omeroweb.webgateway',
+    'omeroweb.webredirect',
+    'pipeline',
+)
 
 logger.debug('INSTALLED_APPS=%s' % [INSTALLED_APPS])
 

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -64,12 +64,23 @@ def redirect_urlpatterns():
 
 # url patterns
 
-urlpatterns = patterns(
+urlpatterns = patterns('',)
+
+for app in settings.ADDITIONAL_APPS:
+    # Depending on how we added the app to INSTALLED_APPS in settings.py,
+    # include the urls the same way
+    if 'omeroweb.%s' % app in settings.INSTALLED_APPS:
+        urlmodule = 'omeroweb.%s.urls' % app
+    else:
+        urlmodule = '%s.urls' % app
+    regex = '^(?i)%s/' % app
+    urlpatterns += patterns('', (regex, include(urlmodule)),)
+
+urlpatterns += patterns(
     '',
     (r'^favicon\.ico$',
      lambda request: redirect('%swebgateway/img/ome.ico'
                               % settings.STATIC_URL)),
-
     (r'^(?i)webgateway/', include('omeroweb.webgateway.urls')),
     (r'^(?i)webadmin/', include('omeroweb.webadmin.urls')),
     (r'^(?i)webclient/', include('omeroweb.webclient.urls')),
@@ -83,15 +94,6 @@ urlpatterns = patterns(
 
 urlpatterns += redirect_urlpatterns()
 
-for app in settings.ADDITIONAL_APPS:
-    # Depending on how we added the app to INSTALLED_APPS in settings.py,
-    # include the urls the same way
-    if 'omeroweb.%s' % app in settings.INSTALLED_APPS:
-        urlmodule = 'omeroweb.%s.urls' % app
-    else:
-        urlmodule = '%s.urls' % app
-    regex = '^(?i)%s/' % app
-    urlpatterns += patterns('', (regex, include(urlmodule)),)
 
 if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/jquery.jstree.pagination_plugin.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/jquery.jstree.pagination_plugin.js
@@ -24,6 +24,8 @@
         this.get_page = function(node) {
             if (node.id in page_map) {
                 return page_map[node.id];
+            } else if (node.data && node.data.obj.childPage != undefined) {
+                return node.data.obj.childPage;
             }
             return 1;
         };

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -136,7 +136,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     $mapAnnContainer.html(html);
 
                     // Finish up...
-                    OME.linkify_element($( "table.keyValueTable tbody tr td" ));
+                    OME.linkify_element($( "table.keyValueTable tbody tr" ));
                     OME.filterAnnotationsAddedBy();
                     $(".tooltip", $mapAnnContainer).tooltip_init();
                 }

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -69,21 +69,27 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
             
             $.getJSON(this.apiAnnotationUrl(opts.url) + "?type=map&" + request, function(data){
 
-                // manipulate data...
-                // make an object of eid: experimenter
-                var experimenters = data.experimenters.reduce(function(prev, exp){
-                    prev[exp.id + ""] = exp;
-                    return prev;
-                }, {});
+                var experimenters = []
+                if (data.experimenters.length > 0) {
+                    // manipulate data...
+                    // make an object of eid: experimenter
+                    experimenters = data.experimenters.reduce(function(prev, exp){
+                        prev[exp.id + ""] = exp;
+                        return prev;
+                    }, {});
+
+                }
 
                 // Populate experimenters within anns
                 var anns = data.annotations.map(function(ann){
-                    ann.owner = experimenters[ann.owner.id];
+                    if (data.experimenters.length > 0) {
+                        ann.owner = experimenters[ann.owner.id];
+                    }
                     if (ann.link && ann.link.owner) {
                         ann.link.owner = experimenters[ann.link.owner.id];
+                        // AddedBy IDs for filtering
+                        ann.addedBy = [ann.link.owner.id]; 
                     }
-                    // AddedBy IDs for filtering
-                    ann.addedBy = [ann.link.owner.id];
                     return ann;
                 });
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -63,71 +63,83 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
             }
 
             // convert objects to json data
-            var request = objects.map(function(o){
-                return o.replace("-", "=");
-            });
-            
-            $.getJSON(this.apiAnnotationUrl(opts.url) + "?type=map&" + request, function(data){
-
-                var experimenters = []
-                if (data.experimenters.length > 0) {
-                    // manipulate data...
-                    // make an object of eid: experimenter
-                    experimenters = data.experimenters.reduce(function(prev, exp){
-                        prev[exp.id + ""] = exp;
-                        return prev;
-                    }, {});
-
+            ajaxdata = {"type": "map"};
+            for (var i=0; i < objects.length; i++) {
+                var o = objects[i].split(/-(.+)/);
+                if (typeof ajaxdata[o[0]] !== 'undefined') {
+                    ajaxdata[o[0]].push(o[1]);
+                } else {
+                    ajaxdata[o[0]] = [o[1]];
                 }
+            }
 
-                // Populate experimenters within anns
-                var anns = data.annotations.map(function(ann){
+            $.ajax({
+                dataType: "json",
+                url: this.apiAnnotationUrl(opts.url),
+                data: ajaxdata,
+                traditional: true,
+                success: function(data){
+
+                    var experimenters = []
                     if (data.experimenters.length > 0) {
-                        ann.owner = experimenters[ann.owner.id];
+                        // manipulate data...
+                        // make an object of eid: experimenter
+                        experimenters = data.experimenters.reduce(function(prev, exp){
+                            prev[exp.id + ""] = exp;
+                            return prev;
+                        }, {});
                     }
-                    if (ann.link && ann.link.owner) {
-                        ann.link.owner = experimenters[ann.link.owner.id];
-                        // AddedBy IDs for filtering
-                        ann.addedBy = [ann.link.owner.id]; 
-                    }
-                    return ann;
-                });
 
-                // Sort map anns into 3 lists...
-                var client_map_annotations = [];
-                var my_client_map_annotations = [];
-                var map_annotations = [];
+                    // Populate experimenters within anns
+                    var anns = data.annotations.map(function(ann){
+                        if (data.experimenters.length > 0) {
+                            ann.owner = experimenters[ann.owner.id];
+                        }
+                        if (ann.link && ann.link.owner) {
+                            ann.link.owner = experimenters[ann.link.owner.id];
+                            // AddedBy IDs for filtering
+                            ann.addedBy = [ann.link.owner.id]; 
+                        }
+                        return ann;
+                    });
 
-                anns.forEach(function(ann){
-                    if (isMyClientMapAnn(ann)) {
-                        my_client_map_annotations.push(ann);
-                    } else if (isClientMapAnn(ann)) {
-                        client_map_annotations.push(ann);
-                    } else {
-                        map_annotations.push(ann);
-                    }
-                });
+                    // Sort map anns into 3 lists...
+                    var client_map_annotations = [];
+                    var my_client_map_annotations = [];
+                    var map_annotations = [];
 
-                // Update html...
-                var html = "";
-                var showHead = true;
-                if (canAnnotate) {
-                    if (my_client_map_annotations.length === 0) {
-                        showHead = false;
-                        my_client_map_annotations = [{}];   // placeholder
+                    anns.forEach(function(ann){
+                        if (isMyClientMapAnn(ann)) {
+                            my_client_map_annotations.push(ann);
+                        } else if (isClientMapAnn(ann)) {
+                            client_map_annotations.push(ann);
+                        } else {
+                            map_annotations.push(ann);
+                        }
+                    });
+
+                    // Update html...
+                    var html = "";
+                    var showHead = true;
+                    if (canAnnotate) {
+                        if (my_client_map_annotations.length === 0) {
+                            showHead = false;
+                            my_client_map_annotations = [{}];   // placeholder
+                        }
+                        html = mapAnnsTempl({'anns': my_client_map_annotations,
+                        'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true});
                     }
-                    html = mapAnnsTempl({'anns': my_client_map_annotations,
-                    'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true});
+                    html = html + mapAnnsTempl({'anns': client_map_annotations,
+                        'showTableHead': false, 'showNs': false, 'clientMapAnn': true});
+                    html = html + mapAnnsTempl({'anns': map_annotations,
+                        'showTableHead': false, 'showNs': true, 'clientMapAnn': false});
+                    $mapAnnContainer.html(html);
+
+                    // Finish up...
+                    OME.linkify_element($( "table.keyValueTable tbody tr td" ));
+                    OME.filterAnnotationsAddedBy();
+                    $(".tooltip", $mapAnnContainer).tooltip_init();
                 }
-                html = html + mapAnnsTempl({'anns': client_map_annotations,
-                    'showTableHead': false, 'showNs': false, 'clientMapAnn': true});
-                html = html + mapAnnsTempl({'anns': map_annotations,
-                    'showTableHead': false, 'showNs': true, 'clientMapAnn': false});
-                $mapAnnContainer.html(html);
-
-                // Finish up...
-                OME.filterAnnotationsAddedBy();
-                $(".tooltip", $mapAnnContainer).tooltip_init();
             });
         }
     };

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -26,7 +26,6 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
     var tmplText = $('#mapanns_template').html();
     var mapAnnsTempl = _.template(tmplText);
 
-
     var initEvents = (function initEvents() {
 
         $header.click(function(){
@@ -50,6 +49,10 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
         return isClientMapAnn(ann) && ann.owner.id == WEBCLIENT.USER.id;
     };
 
+    this.apiAnnotationUrl = function apiAnnotationUrl(url) {
+        if (!url) { return WEBCLIENT.URLS.webindex + "api/annotations/";}
+        return url;
+    }
 
     this.render = function render() {
 
@@ -59,11 +62,12 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                 $mapAnnContainer.html("Loading key value annotations...");
             }
 
+            // convert objects to json data
             var request = objects.map(function(o){
                 return o.replace("-", "=");
             });
-
-            $.getJSON(WEBCLIENT.URLS.webindex + "api/annotations/?type=map&" + request, function(data){
+            
+            $.getJSON(this.apiAnnotationUrl(opts.url) + "?type=map&" + request, function(data){
 
                 // manipulate data...
                 // make an object of eid: experimenter

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -442,9 +442,10 @@ $(function() {
                 // we want the specific page, or use default first page
 
                 // Disable paging for node without counter
+                var nopageTypes = ['project', 'screen', 'plate', 'tagset', 'tag'];
                 if (node.data && node.data.obj.childCount === undefined) {
                     payload['page'] = 0;
-                } else if (node.type === 'project' || node.type === 'screen' || node.type === 'plate') {
+                } else if (nopageTypes.indexOf(node.type) > -1) {
                     // TODO: temporary workaround to not paginate datasets,
                     // plates and acquisitions
                     // see center_plugin.thumbs.js.html
@@ -483,6 +484,8 @@ $(function() {
                 var url;
                 if (node.type === 'experimenter') {
                     // This will be set to containers or tags url, depending on page we're on 
+                    url = WEBCLIENT.URLS.tree_top_level;
+                } else if (node.type === 'map') {
                     url = WEBCLIENT.URLS.tree_top_level;
                 } else if (node.type === 'tagset') {
                     url = WEBCLIENT.URLS.tree_top_level;
@@ -579,6 +582,13 @@ $(function() {
                             if (data.hasOwnProperty('experimenter')) {
                                 node = makeNode(data.experimenter, 'experimenter');
                                 jstree_data.push(node);
+                            }
+
+                            if (data.hasOwnProperty('maps')) {
+                                $.each(data.maps, function(index, value) {
+                                    var node = makeNode(value, 'map');
+                                    jstree_data.push(node);
+                                });
                             }
 
                             // Add tags to the jstree data structure
@@ -736,6 +746,11 @@ $(function() {
             'experimenter': {
                 'icon' : WEBCLIENT.URLS.static_webclient + 'image/icon_user.png',
                 'valid_children': ['project','dataset','screen','plate', 'tag', 'tagset']
+            },
+            'map': {
+                'icon': WEBCLIENT.URLS.static_webclient + 'image/left_sidebar_icon_tag.png',
+                'valid_children': ['project', 'screen'],
+                'draggable': false
             },
             'tagset': {
                 'icon': WEBCLIENT.URLS.static_webclient + 'image/left_sidebar_icon_tags.png',

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -378,20 +378,27 @@ $(function() {
             'force_text': true,
             // Make use of function for 'data' because there are some scenarios in which
             // an ajax call is not used to get the data. Namely, the all-user view
-            'data' : function(node, callback) {
+            'data' : function(node, callback, payload={}) {
                 // Get the data for this query
-                var payload = {};
+                // var payload = {};
                 // We always use the parent id to fitler. E.g. experimenter id, project id etc.
                 // Exception to this for orphans as in the case of api_images, id is a dataset
                 if (node.hasOwnProperty('data') && node.type != 'orphaned') {
-
                     // NB: In case of loading Tags, we don't want to use 'id' for top level
                     // since that will filter by tag.
                     // TODO: fix inconsistency between url apis by using 'owner'
                     var tagroot = (WEBCLIENT.URLS.tree_top_level === WEBCLIENT.URLS.api_tags_and_tagged &&
                             node.type === 'experimenter');
 
+                    if (node.data.hasOwnProperty('obj')) {
+                        // Allows to load custom parameters to QUERY_STRING
+                        if (node.data.obj.hasOwnProperty('extra')) {
+                            $.extend(payload, node.data.obj.extra)
+                        }
+                    }
+
                     if (!tagroot && node.data.hasOwnProperty('obj')) {
+                        // Allows to load custom parameters to QUERY_STRING
                         payload['id'] = node.data.obj.id;
                     }
 
@@ -551,7 +558,8 @@ $(function() {
                                     'type': type,
                                     'li_attr': {
                                         'data-id': value.id
-                                    }
+                                    },
+                                    'extra': value.extra
                                 };
                                 if (type === 'experimenter') {
                                     rv.text = value.firstName + ' ' + value.lastName;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -378,9 +378,11 @@ $(function() {
             'force_text': true,
             // Make use of function for 'data' because there are some scenarios in which
             // an ajax call is not used to get the data. Namely, the all-user view
-            'data' : function(node, callback, payload={}) {
+            'data' : function(node, callback, payload) {
                 // Get the data for this query
-                // var payload = {};
+                if (payload === undefined) {
+                    var payload = {};
+                }
                 // We always use the parent id to fitler. E.g. experimenter id, project id etc.
                 // Exception to this for orphans as in the case of api_images, id is a dataset
                 if (node.hasOwnProperty('data') && node.type != 'orphaned') {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -433,10 +433,6 @@ $(function() {
                 if (path && (node.type === 'experimenter' || node.type === 'orphaned')) {
                     payload['experimenter_id'] = inst.get_node(path[0]).data.obj.id;
                 }
-                // set activate user to load root node
-                if (!path) {
-                    payload['experimenter'] = WEBCLIENT.active_user_id;
-                }
 
                 // If this is a node which can have paged results then either specify that
                 // we want the specific page, or use default first page

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -424,6 +424,10 @@ $(function() {
                 if (path && (node.type === 'experimenter' || node.type === 'orphaned')) {
                     payload['experimenter_id'] = inst.get_node(path[0]).data.obj.id;
                 }
+                // set activate user to load root node
+                if (!path) {
+                    payload['experimenter'] = WEBCLIENT.active_user_id;
+                }
 
                 // If this is a node which can have paged results then either specify that
                 // we want the specific page, or use default first page
@@ -488,26 +492,7 @@ $(function() {
                 } else if (node.id === '#') {
                     // Here we handle root of jsTree
                     // Either show a single experimenters's data...
-                    if (WEBCLIENT.active_user && WEBCLIENT.active_user.id != -1) {
-                        url = WEBCLIENT.URLS.api_experimenter;   // url includes active_user.id
-                    } else {
-                        // ...or multiple experimenters
-                        node = {
-                            'data': {'id': -1, 'obj': {'id': -1}},
-                            'text': WEBCLIENT.LABELS.all_members,
-                            'children': true,
-                            'type': 'experimenter',
-                            'state': {
-                                'opened': true
-                            },
-                            'li_attr': {
-                                'data-id': -1
-                            }
-                        };
-
-                        callback.call(this, [node]);
-                        return;
-                    }
+                    url = WEBCLIENT.URLS.api_experimenters;   // url includes 
                 }
 
                 if (url === undefined) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -425,16 +425,22 @@ $(function() {
 
                 // If this is a node which can have paged results then either specify that
                 // we want the specific page, or use default first page
-                if (node.type === 'dataset' || node.type === 'orphaned') {
+
+                // Disable paging for node without counter
+                if (node.data && node.data.obj.childCount === undefined) {
+                    payload['page'] = 0;
+                } else if (node.type === 'project' || node.type === 'screen' || node.type === 'plate') {
+                    // TODO: temporary workaround to not paginate datasets,
+                    // plates and acquisitions
+                    // see center_plugin.thumbs.js.html
+                    payload['page'] = 0;
+                } else {
                     // Attempt to get the current page desired if there is one
                     var page = inst.get_page(node);
                     if (page) {
                         payload['page'] = page;
                         // Otherwise, no 'page' will give us default, first page
                     }
-                } else {
-                    // Disable paging for other queries
-                    payload['page'] = 0;
                 }
 
                 // Specify that orphans are specifically sought
@@ -741,7 +747,7 @@ $(function() {
             },
             'tag': {
                 'icon': WEBCLIENT.URLS.static_webclient + 'image/left_sidebar_icon_tag.png',
-                'valid_children': ['project, dataset, image, screen, plate, acquisition'],
+                'valid_children': ['project', 'dataset', 'image', 'screen', 'plate', 'acquisition'],
                 'draggable': true
             },
             'project': {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -486,7 +486,7 @@ $(function() {
                         // ...or multiple experimenters
                         node = {
                             'data': {'id': -1, 'obj': {'id': -1}},
-                            'text': 'All members',
+                            'text': WEBCLIENT.LABELS.all_members,
                             'children': true,
                             'type': 'experimenter',
                             'state': {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -561,6 +561,7 @@ $(function() {
                                     'text': value.name,
                                     'children': value.childCount ? true : false,
                                     'type': type,
+                                    'state': value.state ? value.state : {'opened': false},
                                     'li_attr': {
                                         'data-id': value.id
                                     },
@@ -568,7 +569,7 @@ $(function() {
                                 };
                                 if (type === 'experimenter') {
                                     rv.text = value.firstName + ' ' + value.lastName;
-                                    rv.state = {'opened': true};
+                                    rv.state = value.state ? value.state : {'opened': true},
                                     rv.children = true;
                                 } else if (type === 'tag') {
                                     // We don't count children for Tags (too expensive?) Assume they have children

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -390,7 +390,7 @@ $(function() {
             'data' : function(node, callback, payload) {
                 // Get the data for this query
                 if (payload === undefined) {
-                    var payload = {};
+                    payload = {};
                 }
                 // We always use the parent id to fitler. E.g. experimenter id, project id etc.
                 // Exception to this for orphans as in the case of api_images, id is a dataset
@@ -439,9 +439,7 @@ $(function() {
 
                 // Disable paging for node without counter
                 var nopageTypes = ['project', 'screen', 'plate', 'tagset', 'tag'];
-                if (node.data && node.data.obj.childCount === undefined) {
-                    payload['page'] = 0;
-                } else if (nopageTypes.indexOf(node.type) > -1) {
+                if (nopageTypes.indexOf(node.type) > -1) {
                     // TODO: temporary workaround to not paginate datasets,
                     // plates and acquisitions
                     // see center_plugin.thumbs.js.html
@@ -449,10 +447,7 @@ $(function() {
                 } else {
                     // Attempt to get the current page desired if there is one
                     var page = inst.get_page(node);
-                    if (page) {
-                        payload['page'] = page;
-                        // Otherwise, no 'page' will give us default, first page
-                    }
+                    payload['page'] = page;
                 }
 
                 // Specify that orphans are specifically sought
@@ -499,8 +494,8 @@ $(function() {
                     url = WEBCLIENT.URLS.api_images;
                 } else if (node.id === '#') {
                     // Here we handle root of jsTree
-                    // Either show a single experimenters's data...
-                    url = WEBCLIENT.URLS.api_experimenters;   // url includes 
+                    // Experimenhter ID is set for user ID or -1 for entire group
+                    url = WEBCLIENT.URLS.api_experimenter;
                 }
 
                 if (url === undefined) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -486,7 +486,7 @@ $(function() {
                     // This will be set to containers or tags url, depending on page we're on 
                     url = WEBCLIENT.URLS.tree_top_level;
                 } else if (node.type === 'map') {
-                    url = WEBCLIENT.URLS.tree_top_level;
+                    url = WEBCLIENT.URLS.tree_map_level;
                 } else if (node.type === 'tagset') {
                     url = WEBCLIENT.URLS.tree_top_level;
                 } else if (node.type === 'tag') {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapannotations.html
@@ -92,7 +92,7 @@
 
             var annId = $table.attr('data-annId'),
                 url = "{% url 'annotate_map' %}",
-                data = {"{{ manager.obj_type }}": {{ manager.obj_id }} },
+                data = {"{{ manager.obj_type }}": "{{ manager.obj_id }}" },
                 $mapAnnotationSpinner = $(".mapAnnotationSpinner", $table.parent()),
                 tableData = [];
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -1,6 +1,6 @@
 <% _.each(anns, function(ann) { %>
 
-<table <% if (ann.id) { %>
+<table <% if (ann.id && ann.addedBy) { %>
             data-annId="<%= ann.id %>"
             data-added-by="<% print (ann.addedBy.join(',')) %>"
         <% } else { %>
@@ -17,9 +17,13 @@
 
                 <span class="tooltip_html" style='display:none'>
                     <b>ID:</b> <%= ann.id %><br />
-                    <b>Owner:</b> <%= ann.owner.firstName %> <%= ann.owner.lastName %><br />
-                    <b>Linked by:</b> <%= ann.link.owner.firstName %> <%= ann.link.owner.lastName %><br />
-                    <b>On:</b> <% print(OME.formatDate(ann.link.date)) %>
+                    <% if (ann.owner) { %>
+                        <b>Owner:</b> <%= ann.owner.firstName %> <%= ann.owner.lastName %><br />
+                    <% } %>
+                    <% if (ann.link) { %>
+                        <b>Linked by:</b> <%= ann.link.owner.firstName %> <%= ann.link.owner.lastName %><br />
+                        <b>On:</b> <% print(OME.formatDate(ann.link.date)) %>
+                    <% } %>
                 </span>
             <% } %>
           </th>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -746,7 +746,7 @@
             <!-- MAP ANNOTATIONS -->
             <div id="mapAnnsPane">
             <h1 class="can-collapse closed" data-name="keyvaluepairs">
-                Key-Value Pairs
+                Attributes
             </h1>
             <div class="annotations_section" style="display:none">
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -746,7 +746,7 @@
             <!-- MAP ANNOTATIONS -->
             <div id="mapAnnsPane">
             <h1 class="can-collapse closed" data-name="keyvaluepairs">
-                Attributes
+                Key-Value Pairs
             </h1>
             <div class="annotations_section" style="display:none">
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -160,8 +160,6 @@
         WEBCLIENT.USER = {'id': {{ ome.user.id }} };
         WEBCLIENT.active_user_id = {{ ome.user_id }};
 
-        WEBCLIENT.LABELS = {'all_members':'All members'};
-
         WEBCLIENT.URLS = {};
         WEBCLIENT.URLS.webindex = "{% url 'webindex' %}";
         WEBCLIENT.URLS.api_paths_to_object = "{% url 'api_paths_to_object' %}";
@@ -189,10 +187,7 @@
             WEBCLIENT.URLS.tree_top_level = WEBCLIENT.URLS.api_containers;
         {% endifequal %}
 
-        {% if active_user %}
-        WEBCLIENT.active_user = {'id': {{ active_user.id }} };
-        WEBCLIENT.URLS.api_experimenter = "{% url 'api_experimenter' active_user.id %}";
-        {% endif %}
+        WEBCLIENT.URLS.api_experimenters = "{% url 'api_experimenters' %}";
 
         WEBCLIENT.UI = {};
         WEBCLIENT.UI.TREE = {};

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -187,7 +187,7 @@
             WEBCLIENT.URLS.tree_top_level = WEBCLIENT.URLS.api_containers;
         {% endifequal %}
 
-        WEBCLIENT.URLS.api_experimenters = "{% url 'api_experimenter' ome.user_id %}";
+        WEBCLIENT.URLS.api_experimenter = "{% url 'api_experimenter' ome.user_id %}";
 
         WEBCLIENT.UI = {};
         WEBCLIENT.UI.TREE = {};

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -160,6 +160,8 @@
         WEBCLIENT.USER = {'id': {{ ome.user.id }} };
         WEBCLIENT.active_user_id = {{ ome.user_id }};
 
+        WEBCLIENT.LABELS = {'all_members':'All members'};
+
         WEBCLIENT.URLS = {};
         WEBCLIENT.URLS.webindex = "{% url 'webindex' %}";
         WEBCLIENT.URLS.api_paths_to_object = "{% url 'api_paths_to_object' %}";

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -187,7 +187,7 @@
             WEBCLIENT.URLS.tree_top_level = WEBCLIENT.URLS.api_containers;
         {% endifequal %}
 
-        WEBCLIENT.URLS.api_experimenters = "{% url 'api_experimenters' %}";
+        WEBCLIENT.URLS.api_experimenters = "{% url 'api_experimenter' ome.user_id %}";
 
         WEBCLIENT.UI = {};
         WEBCLIENT.UI.TREE = {};
@@ -219,11 +219,7 @@
         // The shown user's ID. This is located here because static javascript files
         // are not preprocessed by django
         function activeUserId() {
-            {% if active_user.id %}
-                return {{ active_user.id }}
-            {% else %}
-                return -1;
-            {% endif %}
+            return {{ ome.user_id }};
         };
 
         // The currently logged in user ID

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -55,7 +55,6 @@
 
     <script type="text/javascript">
 
-
     // Variable to store selection data when using jstree refresh
     var refreshPathsReverse = [];
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -155,10 +155,11 @@ $(document).ready(function() {
             return;
         }
 
-        // parent node could be dataset, orphaned, share or tag
-        var parentTypes = ["dataset", "orphaned", "tag", "share"],
+        // parent node cannot be "screen", "plate", "acquisition", "project", "image"
+        // see ome.tree.js
+        var parentTypes = ["screen", "plate", "acquisition", "project", "image", "tagset", "tag"],
             imgNodes = [];
-        if (parentTypes.indexOf(dtype) > -1) {
+        if (parentTypes.indexOf(dtype) < 0) {
             parentNode = selected[0];
         } else if (dtype === "image") {
             parentNode = inst.get_node(inst.get_parent(selected[0]));
@@ -810,6 +811,7 @@ $(document).ready(function() {
         $("div#page").removeData('page');
         $contentDetails.removeData('field');
     };
+    OME.clearThumbnailsPanel = clearThumbnailsPanel;
 
     var setThumbnailsPanel = function(type, id, path, page, field) {
         var $contentDetails = $("div#content_details");

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -811,6 +811,7 @@ $(document).ready(function() {
         $("div#page").removeData('page');
         $contentDetails.removeData('field');
     };
+    // Allows other web apps to access this method
     OME.clearThumbnailsPanel = clearThumbnailsPanel;
 
     var setThumbnailsPanel = function(type, id, path, page, field) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -1679,9 +1679,10 @@ def _marshal_annotation(conn, annotation, link=None):
         ann['link']['id'] = link.id.val
         ann['link']['owner'] = {'id': link.details.owner.id.val}
         # Parent (Acquisition has no Name)
-        ann['link']['parent'] = {'id': link.parent.id.val,
-                                 'name': unwrap(link.parent.name),
-                                 'class': link.parent.__class__.__name__}
+        if link.parent.isLoaded():
+            ann['link']['parent'] = {'id': link.parent.id.val,
+                                     'name': unwrap(link.parent.name),
+                                     'class': link.parent.__class__.__name__}
         linkCreation = link.details.creationEvent._time
         ann['link']['date'] = _marshal_date(unwrap(linkCreation))
         p = link.details.permissions

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -266,8 +266,6 @@ urlpatterns = patterns(
 
     url(r'^api/experimenters/$', views.api_experimenter_list,
         name='api_experimenters'),
-    url(r'^api/experimenters/(?P<experimenter_id>[0-9]+)/$',
-        views.api_experimenter_detail, name='api_experimenter'),
 
     # Generic container list. This is necessary as an experimenter may have
     # datasets/etc which do not belong to any project

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -266,6 +266,8 @@ urlpatterns = patterns(
 
     url(r'^api/experimenters/$', views.api_experimenter_list,
         name='api_experimenters'),
+    url(r'^api/experimenters/(?P<experimenter_id>-?\d+)/$',
+        views.api_experimenter_detail, name='api_experimenter'),
 
     # Generic container list. This is necessary as an experimenter may have
     # datasets/etc which do not belong to any project

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -330,6 +330,22 @@ def switch_active_group(request, active_group=None):
         request.session['active_group'] = active_group
 
 
+def fake_experimenter(request, default_name='All members'):
+    """
+    Marshal faked experimenter when id is -1
+    Load omero.client.ui.menu.dropdown.everyone.label as username
+    """
+    label = request.session.get('server_settings').get('ui', {}) \
+        .get('menu', {}).get('dropdown', {}).get('everyone', {}) \
+        .get('label', default_name)
+    return {
+        'id': -1,
+        'omeName': label,
+        'firstName': label,
+        'lastName': ''
+    }
+
+
 @login_required(login_redirect='webindex')
 def logout(request, conn=None, **kwargs):
     """
@@ -548,45 +564,32 @@ def api_experimenter_list(request, conn=None, **kwargs):
         page = get_long_or_default(request, 'page', 1)
         limit = get_long_or_default(request, 'limit', settings.PAGE)
         group_id = get_long_or_default(request, 'group', -1)
+        experimenter_id = get_long_or_default(request, 'experimenter', None)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
     try:
-        # Get the experimenters
-        experimenters = tree.marshal_experimenters(conn=conn,
-                                                   group_id=group_id,
-                                                   page=page,
-                                                   limit=limit)
+        if experimenter_id:
+            if experimenter_id < 0:
+                experimenter = fake_experimenter(request)
+            else:
+                # Get the experimenter
+                experimenter = tree.marshal_experimenter(
+                    conn=conn, experimenter_id=experimenter_id)
+            return HttpJsonResponse({'experimenter': experimenter})
+        else:
+            # Get the experimenters
+            experimenters = tree.marshal_experimenters(conn=conn,
+                                                       group_id=group_id,
+                                                       page=page,
+                                                       limit=limit)
+            return HttpJsonResponse({'experimenters': experimenters})
     except ApiUsageException as e:
         return HttpResponseBadRequest(e.serverStackTrace)
     except ServerError as e:
         return HttpResponseServerError(e.serverStackTrace)
     except IceException as e:
         return HttpResponseServerError(e.message)
-
-    return HttpJsonResponse({'experimenters': experimenters})
-
-
-@login_required()
-def api_experimenter_detail(request, experimenter_id, conn=None, **kwargs):
-    # Validate parameter
-    try:
-        experimenter_id = long(experimenter_id)
-    except ValueError:
-        return HttpResponseBadRequest('Invalid experimenter id')
-
-    try:
-        # Get the experimenter
-        experimenter = tree.marshal_experimenter(
-            conn=conn, experimenter_id=experimenter_id)
-    except ApiUsageException as e:
-        return HttpResponseBadRequest(e.serverStackTrace)
-    except ServerError as e:
-        return HttpResponseServerError(e.serverStackTrace)
-    except IceException as e:
-        return HttpResponseServerError(e.message)
-
-    return HttpJsonResponse({'experimenter': experimenter})
 
 
 @login_required()

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -342,7 +342,7 @@ def fake_experimenter(request, default_name='All members'):
         'id': -1,
         'omeName': label,
         'firstName': label,
-        'lastName': ''
+        'lastName': '',
     }
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -564,26 +564,42 @@ def api_experimenter_list(request, conn=None, **kwargs):
         page = get_long_or_default(request, 'page', 1)
         limit = get_long_or_default(request, 'limit', settings.PAGE)
         group_id = get_long_or_default(request, 'group', -1)
-        experimenter_id = get_long_or_default(request, 'experimenter', None)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
     try:
-        if experimenter_id:
-            if experimenter_id < 0:
-                experimenter = fake_experimenter(request)
-            else:
-                # Get the experimenter
-                experimenter = tree.marshal_experimenter(
-                    conn=conn, experimenter_id=experimenter_id)
-            return HttpJsonResponse({'experimenter': experimenter})
+        # Get the experimenters
+        experimenters = tree.marshal_experimenters(conn=conn,
+                                                   group_id=group_id,
+                                                   page=page,
+                                                   limit=limit)
+        return HttpJsonResponse({'experimenters': experimenters})
+    except ApiUsageException as e:
+        return HttpResponseBadRequest(e.serverStackTrace)
+    except ServerError as e:
+        return HttpResponseServerError(e.serverStackTrace)
+    except IceException as e:
+        return HttpResponseServerError(e.message)
+
+
+@login_required()
+def api_experimenter_detail(request, experimenter_id, conn=None, **kwargs):
+    # Validate parameter
+    try:
+        experimenter_id = long(experimenter_id)
+    except ValueError:
+        return HttpResponseBadRequest('Invalid experimenter id')
+
+    try:
+        # Get the experimenter
+        if experimenter_id < 0:
+            experimenter = fake_experimenter(request)
         else:
-            # Get the experimenters
-            experimenters = tree.marshal_experimenters(conn=conn,
-                                                       group_id=group_id,
-                                                       page=page,
-                                                       limit=limit)
-            return HttpJsonResponse({'experimenters': experimenters})
+            # Get the experimenter
+            experimenter = tree.marshal_experimenter(
+                conn=conn, experimenter_id=experimenter_id)
+        return HttpJsonResponse({'experimenter': experimenter})
+
     except ApiUsageException as e:
         return HttpResponseBadRequest(e.serverStackTrace)
     except ServerError as e:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
@@ -18,5 +18,5 @@
 -->
 {% endcomment %}
 
-<link rel="shortcut icon" href="{% static "/favicon.ico" %}" type="image/x-icon" />
+<link rel="shortcut icon" href="{% static 'webgateway/img/ome.ico' %}" type="image/x-icon" />
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base_site.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base_site.html
@@ -17,7 +17,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="{% static 'webgateway/img/ome.ico' %}" type="image/x-icon" />
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <meta http-equiv="imagetoolbar" content="no" />
     <title>{% block title %}{% endblock %}</title>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
@@ -27,12 +27,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     {% block link %}
-		<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-		<link rel="icon" href="/favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="{% static "webgateway/css/reset.css"|add:url_suffix %}" type="text/css" />   
 		<link rel="stylesheet" href="{% static "webgateway/css/ome.body.css"|add:url_suffix %}" type="text/css" />
 		<link rel="stylesheet" href="{% static "webclient/css/dusty.css"|add:url_suffix %}" type="text/css" media="screen"/>
-		
     {% endblock %}
 
 


### PR DESCRIPTION
This is the same as #4704 but rebased onto develop.

----
# What this PR does

This make OMERO.web more customizable.

# Testing this PR
- light test scenario
- concentrate on tree and pagination.
- check functionality of right hand panel, most of the changes were done to map annotation

----

MAPR test was removed as this is no longer on breaking