### PR TITLE
Year out of range

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6928,7 +6928,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         t = unwrap(self._obj.acquisitionDate)
         if t is not None and t > 0:
-            return datetime.fromtimestamp(t/1000)
+            try:
+                return datetime.fromtimestamp(t/1000)
+            except ValueError:
+                return None
 
     def getInstrument(self):
         """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -256,6 +256,21 @@ class TestImage (object):
         assert self.image.shortname(length=20, hist=5) == ''
         self.image.name = name
 
+    def testImageDate(self):
+        """ Test getAcquisitionDate() with invalid date """
+        # This imported image has no acquisition date:
+        acq_date = self.image.getAcquisitionDate()
+        assert acq_date is None
+        # Setting date to an invalid number... (not saved)
+        t = 100000 * 265 * 24 * 60 * 60 * 1000
+        self.image._obj.setAcquisitionDate(omero.rtypes.rtime(t))
+        # Check this doesn't throw an exception
+        try:
+            acq_date = self.image.getAcquisitionDate()
+        finally:
+            # Undo change
+            self.image._obj.setAcquisitionDate(None)
+
     def testSimpleMarshal(self, gatewaywrapper):
         """ Test the call to simpleMarhal """
         m = self.image.simpleMarshal()

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -454,8 +454,11 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
 
 
 def _marshal_date(time):
-    d = datetime.fromtimestamp(time/1000)
-    return d.isoformat() + 'Z'
+    try:
+        d = datetime.fromtimestamp(time/1000)
+        return d.isoformat() + 'Z'
+    except ValueError:
+        return ''
 
 
 def _marshal_image(conn, row, row_pixels=None, share_id=None,


### PR DESCRIPTION
# What this PR does

Handles invalid acquisition dates in DB
See https://www.openmicroscopy.org/qa2/qa/feedback/17313/
which gives ```ValueError: year is out of range```

<details>
    <summary>Full stack trace</summary>
    Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/omero/OMERO.server/lib/python/omeroweb/decorators.py", line 497, in wrapped
retval = f(request, *args, **kwargs)
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/views.py", line 745, in api_image_list
limit=limit)
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/tree.py", line 693, in marshal_images
images.append(_marshal_image(**kwargs))
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/tree.py", line 503, in _marshal_image
image['acqDate'] = _marshal_date(unwrap(acqDate))
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/tree.py", line 457, in _marshal_date
d = datetime.fromtimestamp(time/1000)
ValueError: year is out of range
</details>

# Testing this PR

Import a file with invalid date. E.g. this date is sufficient to reproduce the above error.
```
$ touch "date&acquisitionDate=10000-01-01_12-00-00.fake"
$ omero import date\&acquisitionDate\=10000-01-01_12-00-00.fake 
```
Browse to this image in web. Show in right panel.
Shouldn't see any exceptions. Acquisition date won't be shown in right panel.
