### PR TITLE
Load annotations on demand 2

### DIFF
--- a/components/blitz/src/omero/gateway/model/DataObject.java
+++ b/components/blitz/src/omero/gateway/model/DataObject.java
@@ -244,6 +244,16 @@ public abstract class DataObject {
     }
 
     /**
+     * Get an unique ID for the object, built from concrete class and id of the
+     * object.
+     * 
+     * @return See above
+     */
+    public String getUniqueId() {
+        return getClass().getSimpleName() + "_" + getId();
+    }
+    
+    /**
      * Sets the database id.
      *
      * @param id

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ReportLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/ReportLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -23,6 +23,7 @@ package org.openmicroscopy.shoola.agents.dataBrowser;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.Map.Entry;
 import org.openmicroscopy.shoola.agents.dataBrowser.browser.ImageNode;
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
 import omero.gateway.SecurityContext;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 import omero.gateway.model.DataObject;
@@ -112,7 +114,7 @@ public class ReportLoader
 	 */
 	public void load()
 	{
-		handle = mhView.loadStructuredData(ctx, nodes, -1, false, this);
+		handle = mhView.loadStructuredData(ctx, nodes, EnumSet.of(AnnotationType.TAG), -1, false, this);
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/TagsLoader.java
@@ -23,8 +23,12 @@ package org.openmicroscopy.shoola.agents.dataBrowser;
 import java.util.Collection;
 
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
+
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
 import omero.gateway.model.TagAnnotationData;
 
 /** 
@@ -85,7 +89,7 @@ public class TagsLoader
 	{
 		long userID = getCurrentUser();
 		if (loadAll) userID = -1;
-		handle = mhView.loadExistingAnnotations(ctx, TagAnnotationData.class,
+		handle = mhView.loadExistingAnnotations(ctx, AnnotationType.TAG,
 												userID, this);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/TagsLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -23,13 +23,10 @@ package org.openmicroscopy.shoola.agents.dataBrowser;
 import java.util.Collection;
 
 import org.openmicroscopy.shoola.agents.dataBrowser.view.DataBrowser;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
-import omero.gateway.model.TagAnnotationData;
 
 /** 
  * Loads the available tags owned by the currently logged in user.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/AnnotationDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/AnnotationDataLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2013-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -31,9 +31,7 @@ import java.util.Map;
 
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.agents.treeviewer.DataBrowserLoader;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/AnnotationDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/AnnotationDataLoader.java
@@ -25,12 +25,16 @@ package org.openmicroscopy.shoola.agents.fsimporter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.agents.treeviewer.DataBrowserLoader;
+
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 import omero.gateway.model.FileAnnotationData;
@@ -82,7 +86,7 @@ public class AnnotationDataLoader
 		List<String> nsInclude = new ArrayList<String>();
 		nsInclude.add(FileAnnotationData.LOG_FILE_NS);
 		handle = mhView.loadAnnotations(ctx, FilesetData.class,
-				Arrays.asList(fileSetID), FileAnnotationData.class, nsInclude,
+				Arrays.asList(fileSetID), EnumSet.of(AnnotationType.ATTACHMENT), nsInclude,
 				null, this);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
@@ -21,13 +21,17 @@
 package org.openmicroscopy.shoola.agents.fsimporter;
 
 import java.util.Collection;
+import java.util.EnumSet;
 
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
-import omero.gateway.SecurityContext;
-import org.openmicroscopy.shoola.env.data.views.CallHandle;
-import omero.log.LogMessage;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 
+import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
+import omero.log.LogMessage;
 import omero.gateway.model.TagAnnotationData;
 
 /** 
@@ -79,7 +83,7 @@ public class TagsLoader
 	{
 		long userID = getCurrentUserID();
 		if (loadAll) userID = -1;
-		handle = mhView.loadExistingAnnotations(ctx, TagAnnotationData.class,
+		handle = mhView.loadExistingAnnotations(ctx, AnnotationType.TAG,
 				userID, this);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -21,7 +21,6 @@
 package org.openmicroscopy.shoola.agents.fsimporter;
 
 import java.util.Collection;
-import java.util.EnumSet;
 
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
@@ -32,7 +31,6 @@ import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 import omero.log.LogMessage;
-import omero.gateway.model.TagAnnotationData;
 
 /** 
  * Loads the available Tags

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
@@ -25,11 +25,8 @@ import java.util.Collection;
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
-
 import omero.log.LogMessage;
 
 /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/ROIAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/ROIAnnotationLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  */
 package org.openmicroscopy.shoola.agents.measurement;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import omero.gateway.SecurityContext;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.agents.measurement.view.MeasurementViewer;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
@@ -74,7 +76,7 @@ public class ROIAnnotationLoader
      */
     public void load()
     {
-        handle = mhView.loadStructuredData(ctx, shapes, -1, false, this);
+        handle = mhView.loadStructuredData(ctx, shapes, EnumSet.of(AnnotationType.TAG), -1, false, this);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/AttachmentsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/AttachmentsLoader.java
@@ -23,8 +23,12 @@ package org.openmicroscopy.shoola.agents.metadata;
 import java.util.Collection;
 
 import org.openmicroscopy.shoola.agents.metadata.editor.Editor;
+
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
 import omero.gateway.model.FileAnnotationData;
 
 /** 
@@ -78,7 +82,7 @@ public class AttachmentsLoader
 	{
 		long userID = viewer.getUserID();
 		if (canAnnotate) userID = -1;
-		handle = mhView.loadExistingAnnotations(ctx, FileAnnotationData.class,
+		handle = mhView.loadExistingAnnotations(ctx, AnnotationType.ATTACHMENT,
 												userID, this);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/AttachmentsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/AttachmentsLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -23,13 +23,9 @@ package org.openmicroscopy.shoola.agents.metadata;
 import java.util.Collection;
 
 import org.openmicroscopy.shoola.agents.metadata.editor.Editor;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
-
-import omero.gateway.model.FileAnnotationData;
 
 /** 
  * Retrieves the files already uploaded to the server by the currently

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/StructuredDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/StructuredDataLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,15 +20,16 @@
  */
 package org.openmicroscopy.shoola.agents.metadata;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.env.data.events.DSCallAdapter;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
@@ -56,23 +57,28 @@ public class StructuredDataLoader
 	/** Handle to the asynchronous call so that we can cancel it. */
     private CallHandle  handle;
 
+    /** The types of Annotations to load */
+    private EnumSet<AnnotationType> types;
+    
 	/**
 	 * Creates a new instance.
 	 * 
 	 * @param viewer The viewer this data loader is for.
      *               Mustn't be <code>null</code>.
      * @param ctx The security context.
+     * @param types The types of Annotations to load
 	 * @param dataObjects The objects the data are related to.
 	 *                   Mustn't be <code>null</code>.
 	 * @param loaderID The identifier of the loader.
 	 */
 	public StructuredDataLoader(MetadataViewer viewer, SecurityContext ctx,
-			List<DataObject> dataObjects, int loaderID)
+			List<DataObject> dataObjects, EnumSet<AnnotationType> types, int loaderID)
 	{
 		super(viewer, ctx, null, loaderID);
 		if (CollectionUtils.isEmpty(dataObjects))
 			throw new IllegalArgumentException("No object specified.");
 		this.dataObjects = dataObjects;
+		this.types = types;
 	}
 
 	/** 
@@ -81,7 +87,7 @@ public class StructuredDataLoader
 	 */
 	public void load()
 	{
-	    handle = mhView.loadStructuredData(ctx, dataObjects, -1, false, this);
+	    handle = mhView.loadStructuredData(ctx, dataObjects, types, -1, false, this);
 	}
 
 	/** 
@@ -97,7 +103,7 @@ public class StructuredDataLoader
     public void handleResult(Object result) 
     {
     	if (viewer.getState() == MetadataViewer.DISCARDED) return;  //Async cancel.
-    	viewer.setMetadata((Map<DataObject, StructuredDataResults>) result,
+    	viewer.setMetadata((Map<DataObject, StructuredDataResults>) result, types,
     			loaderID);
     }
 
@@ -117,6 +123,6 @@ public class StructuredDataLoader
             data = i.next();
             m.put(data, new StructuredDataResults(data, false));
         }
-        viewer.setMetadata(m, loaderID);
+        viewer.setMetadata(m, types, loaderID);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -78,7 +78,7 @@ public class AnnotationTaskPane extends JXTaskPane {
      */
     AnnotationTaskPane(AnnotationType type, EditorUI view,
             EditorModel model, EditorControl controller) {
-        setTitle(type.getName());
+        setTitle(type.getDescriptiveName());
         this.type = type;
         this.view = view;
         this.model = model;
@@ -110,7 +110,7 @@ public class AnnotationTaskPane extends JXTaskPane {
      *            The number of annotations available
      */
     void setAnnotationCount(int n) {
-        setTitle(type.getName() + " (" + n + ")");
+        setTitle(type.getDescriptiveName() + " (" + n + ")");
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -31,6 +31,7 @@ import omero.gateway.model.AnnotationData;
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
@@ -53,48 +54,6 @@ public class AnnotationTaskPane extends JXTaskPane {
     /** The component hosting the UI elements */
     private AnnotationTaskPaneUI ui;
 
-    /**
-     * The different kind of annotations
-     * 
-     * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
-     *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
-     */
-    public enum AnnotationType {
-        /** Tags */
-        TAGS("Tags"),
-
-        /** ROIs */
-        ROIS("ROIs"),
-
-        /** Map annotations */
-        MAP("Key-Value Pairs"),
-
-        /** File attachments */
-        ATTACHMENTS("Attachments"),
-
-        /** Other annotations */
-        OTHER("Others"),
-
-        /** Rating */
-        RATING("Ratings"),
-
-        /** User comments */
-        COMMENTS("Comments");
-
-        /** Human readable name for this annotation type */
-        String name = "";
-
-        /**
-         * Creates a new enumeration instance
-         * 
-         * @param name
-         *            Human readable name for this annotation type
-         */
-        AnnotationType(String name) {
-            this.name = name;
-        }
-    }
-
     /** The {@link AnnotationType} this taskpane should display */
     private AnnotationType type;
 
@@ -112,7 +71,7 @@ public class AnnotationTaskPane extends JXTaskPane {
      */
     AnnotationTaskPane(AnnotationType type, EditorUI view,
             EditorModel model, EditorControl controller) {
-        setTitle(type.name);
+        setTitle(type.getName());
         this.type = type;
         this.view = view;
         this.model = model;
@@ -144,7 +103,7 @@ public class AnnotationTaskPane extends JXTaskPane {
      *            The number of annotations available
      */
     void setAnnotationCount(int n) {
-        setTitle(type.name + " (" + n + ")");
+        setTitle(type.getName() + " (" + n + ")");
     }
 
     /**
@@ -218,16 +177,16 @@ public class AnnotationTaskPane extends JXTaskPane {
      */
     private void buildUI() {
         switch (type) {
-        case TAGS:
+        case TAG:
             ui = new TagsTaskPaneUI(model, view, controller);
             break;
         case MAP:
             ui = new MapTaskPaneUI(model, view, controller);
             break;
-        case ATTACHMENTS:
+        case ATTACHMENT:
             ui = new AttachmentsTaskPaneUI(model, view, controller);
             break;
-        case COMMENTS:
+        case COMMENT:
             ui = new CommentsTaskPaneUI(model, view, controller);
             break;
         case OTHER:
@@ -236,7 +195,7 @@ public class AnnotationTaskPane extends JXTaskPane {
         case RATING:
             ui = new RatingTaskPaneUI(model, view, controller);
             break;
-        case ROIS:
+        case ROI:
         default:
             ui = new DummyTaskPaneUI(model, view, controller);
             MetadataViewerAgent

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -29,7 +29,6 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 
 import omero.gateway.model.AnnotationData;
-
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
@@ -224,4 +223,10 @@ public class AnnotationTaskPane extends JXTaskPane {
         add(ui);
     }
 
+    /**
+     * Called when the data for this annotation task pane has been loaded
+     */
+    public void onLoaded() {
+        ui.onLoaded();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -21,6 +21,8 @@ package org.openmicroscopy.shoola.agents.metadata.editor;
 
 import java.awt.Container;
 import java.awt.Font;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -42,6 +44,9 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
  */
 public class AnnotationTaskPane extends JXTaskPane {
 
+    /** The {@link JXTaskPane} property fired on collapse/expansion of the pane */
+    private static final String COLLAPSED_PROPERTY = "collapsed";
+    
     /** Reference to the {@link EditorUI} */
     private EditorUI view;
 
@@ -206,6 +211,16 @@ public class AnnotationTaskPane extends JXTaskPane {
                                     + " annotations not implemented yet!");
         }
 
+        addPropertyChangeListener(new PropertyChangeListener() {
+
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                if (COLLAPSED_PROPERTY.equals(evt.getPropertyName())) {
+                    ui.onCollapsed((Boolean) evt.getNewValue());
+                }
+            }
+        });
+        
         add(ui);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -23,15 +23,18 @@ import java.awt.Container;
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.EnumSet;
 import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 
 import omero.gateway.model.AnnotationData;
+
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
+import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.State;
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -229,4 +232,10 @@ public class AnnotationTaskPane extends JXTaskPane {
     public void onLoaded() {
         ui.onLoaded();
     }
+
+    public void setLoadingState() {
+        ui.state = State.LOADING;
+    }
+
 }
+

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPane.java
@@ -23,14 +23,12 @@ import java.awt.Container;
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.EnumSet;
 import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 
 import omero.gateway.model.AnnotationData;
-
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
@@ -233,6 +231,9 @@ public class AnnotationTaskPane extends JXTaskPane {
         ui.onLoaded();
     }
 
+    /**
+     * Overwrite the current state to LOADING state
+     */
     public void setLoadingState() {
         ui.state = State.LOADING;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
@@ -32,6 +32,7 @@ import javax.swing.JPanel;
 import omero.gateway.model.AnnotationData;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
@@ -227,4 +228,13 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
      * @return the number of annotations regardless of current filter
      */
     abstract int getUnfilteredAnnotationCount();
+    
+    /**
+     * Called when the parent {@link JXTaskPane} is collapsed/expanded
+     * 
+     * @param collapsed
+     *            <code>true</code> if the new state is collapsed,
+     *            <code>false</code> if it is expanded
+     */
+    abstract void onCollapsed(boolean collapsed);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import omero.gateway.model.AnnotationData;
@@ -73,10 +74,15 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
         }
     }
     
+    /**
+     * The state of this component, either Loading if the data has not been
+     * loaded yet or Ready when the data is available
+     */
     enum State {
         LOADING, READY
     }
 
+    /** The current state */
     State state = State.LOADING;
     
     /** Reference to the {@link EditorModel} */
@@ -91,6 +97,9 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
     /** The default {@link Filter}, set to 'show all' */
     Filter filter = Filter.SHOW_ALL;
 
+    /** Label indicating that the data has not been loaded yet */
+    final JLabel loadingLabel = new JLabel("Loading...");
+    
     /** The panel holding the actual content */
     private JPanel contentPane;
 
@@ -244,7 +253,12 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
      */
     abstract void onCollapsed(boolean collapsed);
     
+    /**
+     * Called once the data for this component is ready; removes the loading
+     * label and refreshes the UI
+     */
     void onLoaded() {
+        contentPane.remove(loadingLabel);
         state = State.READY;
         refreshUI();
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AnnotationTaskPaneUI.java
@@ -72,7 +72,13 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
             this.name = name;
         }
     }
+    
+    enum State {
+        LOADING, READY
+    }
 
+    State state = State.LOADING;
+    
     /** Reference to the {@link EditorModel} */
     EditorModel model;
 
@@ -237,4 +243,9 @@ public abstract class AnnotationTaskPaneUI extends JPanel {
      *            <code>false</code> if it is expanded
      */
     abstract void onCollapsed(boolean collapsed);
+    
+    void onLoaded() {
+        state = State.READY;
+        refreshUI();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -26,6 +26,7 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -43,6 +44,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
 
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.WrapLayout;
 
@@ -233,6 +235,11 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
     @Override
     void refreshUI() {
         clearDisplay();
+        
+        if(state == State.LOADING) {
+            add(loadingLabel);
+            return;
+        }
         
         Collection list;
         if (model.isMultiSelection()) 
@@ -520,7 +527,9 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
     
     @Override
     void onCollapsed(boolean collapsed) {
-        
+        if(!collapsed) {
+            model.loadStructuredData(EnumSet.of(AnnotationType.ATTACHMENT));
+        }
     }
 
     @Override

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/AttachmentsTaskPaneUI.java
@@ -517,6 +517,11 @@ public class AttachmentsTaskPaneUI extends AnnotationTaskPaneUI {
         
         
     }
+    
+    @Override
+    void onCollapsed(boolean collapsed) {
+        
+    }
 
     @Override
     int getUnfilteredAnnotationCount() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -153,6 +153,7 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
         commentArea.addPropertyChangeListener(controller);
         commentArea.setForeground(UIUtilities.DEFAULT_FONT_COLOR);
         commentArea.setComponentBorder(EDIT_BORDER);
+        commentArea.addDocumentListener(this);
         commentArea.addFocusListener(new FocusListener() {
 
             public void focusLost(FocusEvent arg0) {
@@ -248,6 +249,7 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
         if (enabled && model.isMultiSelection()) {
             enabled = !model.isAcrossGroups();
         }
+        
         commentArea.setEnabled(enabled);
 
         buildGUI();
@@ -357,6 +359,7 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
      * @see AnnotationUI#hasDataToSave()
      */
     protected boolean hasDataToSave() {
+        System.out.println("hasDataToSave "+CommonsLangUtils.isNotBlank(commentArea.getText()));
         String text = commentArea.getText();
         return CommonsLangUtils.isNotBlank(text);
     }
@@ -371,9 +374,8 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
             annotationToRemove.clear();
         annotationToDisplay = null;
         setAreaText("");
-        
-        if (addButton != null)
-            addButton.setEnabled(model.canAddAnnotationLink());
+        if (commentArea != null && !model.canAddAnnotationLink())
+            commentArea.setEnabled(false);
     }
 
 
@@ -420,7 +422,6 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
 
     @Override
     void onRelatedNodesSet() {
-        addButton.setEnabled(model.canAddAnnotationLink());
         refreshUI();
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -249,7 +249,6 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
         if (enabled && model.isMultiSelection()) {
             enabled = !model.isAcrossGroups();
         }
-        
         commentArea.setEnabled(enabled);
 
         buildGUI();
@@ -359,7 +358,6 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
      * @see AnnotationUI#hasDataToSave()
      */
     protected boolean hasDataToSave() {
-        System.out.println("hasDataToSave "+CommonsLangUtils.isNotBlank(commentArea.getText()));
         String text = commentArea.getText();
         return CommonsLangUtils.isNotBlank(text);
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/CommentsTaskPaneUI.java
@@ -414,4 +414,9 @@ public class CommentsTaskPaneUI extends AnnotationTaskPaneUI implements
     int getUnfilteredAnnotationCount() {
         return model.getTextualAnnotationCount();
     }
+    
+    @Override
+    void onCollapsed(boolean collapsed) {
+        
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/DummyTaskPaneUI.java
@@ -84,4 +84,10 @@ public class DummyTaskPaneUI extends AnnotationTaskPaneUI {
     int getUnfilteredAnnotationCount() {
         return 0;
     }
+    
+    @Override
+    void onCollapsed(boolean collapsed) {
+        
+    }
+    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -25,6 +25,7 @@ package org.openmicroscopy.shoola.agents.metadata.editor;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +37,7 @@ import org.openmicroscopy.shoola.agents.metadata.util.AnalysisResultsItem;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DiskQuota;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.env.data.util.Target;
@@ -134,8 +136,11 @@ public interface Editor
 	/** Identified the <code>mode</code> enumeration. */
 	public static final String MODE = OmeroMetadataService.ACQUISITION_MODE;
 
-	/** Feeds the metadata back to the editor. */
-	public void setStructuredDataResults();
+	/** 
+	 * Feeds the metadata back to the editor. 
+	 * @param types The {@link AnnotationType}s which have been loaded
+	 */
+	public void setStructuredDataResults(EnumSet<AnnotationType> types);
 	
 	/**
 	 * Returns the View.
@@ -144,6 +149,11 @@ public interface Editor
 	 */
 	public JComponent getUI();
 	
+	/**
+	 * Layout/Refresh the UI
+	 */
+    public void layoutUI();
+    
 	/**
 	 * Sets the root of the tree.
 	 * 
@@ -568,5 +578,7 @@ public interface Editor
      * Reload the ROI count
      */
     public void reloadROICount();
+
+    public void fireStructuredDataLoading(EnumSet<AnnotationType> types);
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -578,7 +578,5 @@ public interface Editor
      * Reload the ROI count
      */
     public void reloadROICount();
-
-    public void fireStructuredDataLoading(EnumSet<AnnotationType> types);
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -28,6 +28,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,6 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.metadata.FileAnnotationCheckResult;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
@@ -54,6 +54,7 @@ import org.openmicroscopy.shoola.agents.util.SelectionWizard;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptingDialog;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DiskQuota;
 import org.openmicroscopy.shoola.env.data.model.ExportActivityParam;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
@@ -255,18 +256,29 @@ class EditorComponent
 	 */
 	public JComponent getUI() { return view; }
 
+	public void layoutUI() {
+	    view.layoutUI();
+	}
+	
 	/** 
 	 * Implemented as specified by the {@link Editor} interface.
-	 * @see Editor#setStructuredDataResults()
+	 * @see Editor#setStructuredDataResults(EnumSet)
 	 */
-	public void setStructuredDataResults()
+	public void setStructuredDataResults(EnumSet<AnnotationType> types)
 	{
 		view.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+		
+		for (AnnotationType type : types) {
+            AnnotationTaskPane p = view.getAnnotationTaskPane(type);
+            if (p != null)
+                p.onLoaded();
+        }
+		
 		view.layoutUI();
 		view.setStatus(false);
 	}
-
-	/** 
+	
+    /** 
 	 * Implemented as specified by the {@link Editor} interface.
 	 * @see Editor#setRootObject(Object)
 	 */
@@ -1251,5 +1263,9 @@ class EditorComponent
     @Override
     public void reloadROICount() {
         view.reloadROICount();
+    }
+    
+    public void fireStructuredDataLoading(EnumSet<AnnotationType> types) {
+        
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -256,6 +256,7 @@ class EditorComponent
 	 */
 	public JComponent getUI() { return view; }
 
+	@Override
 	public void layoutUI() {
 	    view.layoutUI();
 	}
@@ -1263,9 +1264,5 @@ class EditorComponent
     @Override
     public void reloadROICount() {
         view.reloadROICount();
-    }
-    
-    public void fireStructuredDataLoading(EnumSet<AnnotationType> types) {
-        
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -1916,6 +1916,9 @@ class EditorModel
 		Collection<XMLAnnotationData> xml = data.getXMLAnnotations();
 		if (xml != null && !xml.isEmpty())
 			l.addAll(xml);
+		Collection<TermAnnotationData> term = data.getTerms();
+        if (term != null && !term.isEmpty())
+            l.addAll(term);
 		Collection<AnnotationData> others = data.getOtherAnnotations();
 		if (others != null && !others.isEmpty())
 			l.addAll(others);
@@ -1981,12 +1984,16 @@ class EditorModel
 		i = r.entrySet().iterator();
 
 		Collection<XMLAnnotationData> files;
+		Collection<TermAnnotationData> terms;
 		Collection<AnnotationData> others;
 		List<AnnotationData> results = new ArrayList<AnnotationData>();
 		List<Long> ids = new ArrayList<Long>();
+		List<Long> ids2 = new ArrayList<Long>();
 		Iterator<XMLAnnotationData> j;
+		Iterator<TermAnnotationData> j2;
 		Iterator<AnnotationData> k;
 		XMLAnnotationData file;
+		TermAnnotationData term;
 		AnnotationData other;
 		while (i.hasNext()) {
 			e = i.next();
@@ -2001,6 +2008,17 @@ class EditorModel
 					}
 				}
 			}
+			terms = e.getValue().getTerms();
+            if (terms != null) {
+                j2 = terms.iterator();
+                while (j2.hasNext()) {
+                    term = j2.next();
+                    if (!ids2.contains(term)) {
+                        results.add(term);
+                        ids2.add(term.getId());
+                    }
+                }
+            }
 			others = e.getValue().getOtherAnnotations();
 			if (others != null) {
 				k = others.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -86,6 +87,7 @@ import org.openmicroscopy.shoola.env.data.OmeroImageService;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
 import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 import org.openmicroscopy.shoola.env.data.model.DeleteActivityParam;
 import org.openmicroscopy.shoola.env.data.model.DownloadActivityParam;
@@ -4612,5 +4614,13 @@ class EditorModel
             }
         }
         return imgSize <= maxSize;
+    }
+
+    /**
+     * Triggers the loading of the annotations
+     * @param types The types of annotations to load.
+     */
+    public void loadStructuredData(EnumSet<AnnotationType> types) {
+        parent.loadStructuredData(types);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -44,12 +44,12 @@ import javax.swing.SwingUtilities;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXTaskPane;
-
 import org.openmicroscopy.shoola.agents.metadata.util.AnalysisResultsItem;
 import org.openmicroscopy.shoola.agents.metadata.util.DataToSave;
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewer;
 import org.openmicroscopy.shoola.agents.util.ui.PermissionMenu;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DiskQuota;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
@@ -1052,4 +1052,17 @@ class EditorUI
 	        generalPane.getPropertiesUI().loadROICount((ImageData) model.getRefObject());
 	    }
 	}
+	
+    /**
+     * Get a reference to the {@link AnnotationTaskPane} which is responsible
+     * for displaying annotations of the specified type
+     * 
+     * @param type
+     *            The type of annotation
+     * @return See above
+     */
+    public AnnotationTaskPane getAnnotationTaskPane(AnnotationType type) {
+        return generalPane != null ? generalPane.getAnnotationTaskPane(type)
+                : null;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -32,6 +32,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -361,6 +362,11 @@ class EditorUI
 			}
 			generalPane.setRootObject(oldObject);
 			acquisitionPane.setRootObject(load);
+			
+            EnumSet<AnnotationType> annosOnDisplay = generalPane
+                    .getAnnotationTypesOnDisplay();
+            if (!annosOnDisplay.isEmpty())
+                model.loadStructuredData(annosOnDisplay);
 		}
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -377,7 +377,6 @@ class GeneralPaneUI extends JPanel
         add(browserTaskPane, c);
         c.gridy++;
         
-        otherTaskPane.setVisible(false);
         add(otherTaskPane, c);
         c.gridy++;
         
@@ -468,9 +467,6 @@ class GeneralPaneUI extends JPanel
                 attachmentTaskPane.refreshUI();
                 ratingTaskPane.refreshUI();
                 commentTaskPane.refreshUI();
-
-                otherTaskPane.setVisible(
-                        !model.getAllOtherAnnotations().isEmpty());
                 otherTaskPane.refreshUI();
             }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -53,11 +53,11 @@ import javax.swing.JTextField;
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.agents.metadata.browser.Browser;
-import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPane.AnnotationType;
 import org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter;
 import org.openmicroscopy.shoola.agents.metadata.util.DataToSave;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.agents.util.editorpreview.PreviewPanel;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 import omero.gateway.model.AnnotationData;
@@ -249,19 +249,19 @@ class GeneralPaneUI extends JPanel
 		propertiesTaskPane.add(propertiesUI);
 		propertiesTaskPane.setCollapsed(false);
 		
-		tagsTaskPane = new AnnotationTaskPane(AnnotationType.TAGS, view, model, controller);
+		tagsTaskPane = new AnnotationTaskPane(AnnotationType.TAG, view, model, controller);
 	    
-	    roiTaskPane = new AnnotationTaskPane(AnnotationType.ROIS, view, model, controller);
+	    roiTaskPane = new AnnotationTaskPane(AnnotationType.ROI, view, model, controller);
 	    
 	    mapTaskPane = new AnnotationTaskPane(AnnotationType.MAP, view, model, controller);
 	    
-	    attachmentTaskPane = new AnnotationTaskPane(AnnotationType.ATTACHMENTS, view, model, controller);
+	    attachmentTaskPane = new AnnotationTaskPane(AnnotationType.ATTACHMENT, view, model, controller);
 	    
 	    otherTaskPane = new AnnotationTaskPane(AnnotationType.OTHER, view, model, controller);
 	    
 	    ratingTaskPane = new AnnotationTaskPane(AnnotationType.RATING, view, model, controller);
 	    
-	    commentTaskPane = new AnnotationTaskPane(AnnotationType.COMMENTS, view, model, controller); 
+	    commentTaskPane = new AnnotationTaskPane(AnnotationType.COMMENT, view, model, controller); 
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -888,4 +888,33 @@ class GeneralPaneUI extends JPanel
 	    AttachmentsTaskPaneUI p = (AttachmentsTaskPaneUI) attachmentTaskPane.getTaskPaneUI();
 	    return p.getSelectedFileAnnotations();
 	}
+	
+    /**
+     * Get a reference to the {@link AnnotationTaskPane} which is responsible
+     * for displaying annotations of the specified type
+     * 
+     * @param type
+     *            The type of annotation
+     * @return See above
+     */
+    public AnnotationTaskPane getAnnotationTaskPane(AnnotationType type) {
+        switch (type) {
+        case ATTACHMENT:
+            return attachmentTaskPane;
+        case COMMENT:
+            return commentTaskPane;
+        case MAP:
+            return mapTaskPane;
+        case OTHER:
+            return otherTaskPane;
+        case RATING:
+            return ratingTaskPane;
+        case ROI:
+            return roiTaskPane;
+        case TAG:
+            return tagsTaskPane;
+        default:
+            return null;
+        }
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -38,6 +38,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -610,6 +611,14 @@ class GeneralPaneUI extends JPanel
         ratingTaskPane.clearDisplay();
         commentTaskPane.clearDisplay();
         
+        tagsTaskPane.setLoadingState();
+        roiTaskPane.setLoadingState();
+        mapTaskPane.setLoadingState();
+        attachmentTaskPane.setLoadingState();
+        otherTaskPane.setLoadingState();
+        ratingTaskPane.setLoadingState();
+        commentTaskPane.setLoadingState();
+        
     	browserTaskPane.removeAll();
     	browserTaskPane.setCollapsed(true);
     	
@@ -916,5 +925,36 @@ class GeneralPaneUI extends JPanel
         default:
             return null;
         }
+    }
+    
+    /**
+     * Get the annotation types which are currently shown
+     * 
+     * @return See above
+     */
+    public EnumSet<AnnotationType> getAnnotationTypesOnDisplay() {
+        EnumSet<AnnotationType> result = EnumSet.noneOf(AnnotationType.class);
+        if (!attachmentTaskPane.isCollapsed()) {
+            result.add(AnnotationType.ATTACHMENT);
+        }
+        if (!commentTaskPane.isCollapsed()) {
+            result.add(AnnotationType.COMMENT);
+        }
+        if (!mapTaskPane.isCollapsed()) {
+            result.add(AnnotationType.MAP);
+        }
+        if (!otherTaskPane.isCollapsed()) {
+            result.add(AnnotationType.OTHER);
+        }
+        if (!ratingTaskPane.isCollapsed()) {
+            result.add(AnnotationType.RATING);
+        }
+        if (!roiTaskPane.isCollapsed()) {
+            result.add(AnnotationType.ROI);
+        }
+        if (!tagsTaskPane.isCollapsed()) {
+            result.add(AnnotationType.TAG);
+        }
+        return result;
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -65,6 +66,7 @@ import org.openmicroscopy.shoola.agents.metadata.editor.maptable.MapTableSelecti
 import org.openmicroscopy.shoola.agents.metadata.view.MetadataViewerFactory;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.agents.util.ToolTipGenerator;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -123,7 +125,7 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
      */
     MapTaskPaneUI(EditorModel model, EditorUI view, EditorControl controller) {
         super(model, view, controller);
-        buildUI();
+        refreshUI();
     }
 
     
@@ -319,11 +321,13 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
 
     @Override
     void clearDisplay() {
-        mapTables.clear();
-        tablePanel.removeAll();
-        c.gridy = 0;
-        tablePanel.add(headerPanel, c);
-        c.gridy++;
+        if (tablePanel != null) {
+            mapTables.clear();
+            tablePanel.removeAll();
+            c.gridy = 0;
+            tablePanel.add(headerPanel, c);
+            c.gridy++;
+        }
     }
 
     /**
@@ -707,6 +711,15 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
 
     @Override
     void refreshUI() {
+        clearDisplay();
+        
+        if(state == State.LOADING) {
+            add(loadingLabel);
+            return;
+        }
+        
+        buildUI();
+        
         List<MapAnnotationData> list = new ArrayList<MapAnnotationData>();
 
         if (filter == Filter.SHOW_ALL || filter == Filter.ADDED_BY_ME) {
@@ -787,6 +800,8 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
     
     @Override
     void onCollapsed(boolean collapsed) {
-        
+        if(!collapsed) {
+            model.loadStructuredData(EnumSet.of(AnnotationType.MAP));
+        }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -113,6 +113,9 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
     /** Scrollpane hosting the tables component */
     private JScrollPane sp;
 
+    /** Flag to indicate that the UI has to be initialized */
+    private boolean init = true;
+    
     /**
      * Creates a new instance
      * 
@@ -146,11 +149,15 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
        return result;
     }
 
-
     /**
      * Builds the component
      */
     private void buildUI() {
+        if (!init) {
+            return;
+        }
+        
+        init = false;
         setLayout(new BorderLayout());
         setBackground(UIUtilities.BACKGROUND_COLOR);
 
@@ -212,7 +219,6 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         d.width += 5;
         d.height += 5;
         sp.setPreferredSize(d);
-        view.revalidate();
     }
 
     /**
@@ -776,6 +782,11 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         refreshButtonStates();
         setVisible(!mapTables.isEmpty());
         adjustScrollPane();
+        
+        // remove and add the scrollpane again to
+        // trigger a complete refresh of the UI
+        remove(sp);
+        add(sp, BorderLayout.CENTER);
     }
 
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -784,4 +784,9 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
         }
         return count;
     }
+    
+    @Override
+    void onCollapsed(boolean collapsed) {
+        
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
@@ -26,6 +26,8 @@ import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -46,6 +48,7 @@ import omero.gateway.model.XMLAnnotationData;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
@@ -90,6 +93,11 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
     @Override
     void refreshUI() {
         clearDisplay();
+        
+        if(state == State.LOADING) {
+            add(loadingLabel);
+            return;
+        }
         
         Collection l;
         if (!model.isMultiSelection())
@@ -320,7 +328,9 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
     
     @Override
     void onCollapsed(boolean collapsed) {
-        
+        if(!collapsed) {
+            model.loadStructuredData(EnumSet.of(AnnotationType.OTHER));
+        }
     }
   
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/OtherTaskPaneUI.java
@@ -317,4 +317,10 @@ public class OtherTaskPaneUI extends AnnotationTaskPaneUI {
             return model.getOtherAnnotations().size();
         }
     }
+    
+    @Override
+    void onCollapsed(boolean collapsed) {
+        
+    }
+  
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -27,6 +27,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 import javax.swing.Box;
@@ -37,6 +38,7 @@ import omero.gateway.model.AnnotationData;
 import omero.gateway.model.RatingAnnotationData;
 
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.RatingComponent;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -84,15 +86,11 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
         rating.setOpaque(false);
         rating.setBackground(UIUtilities.BACKGROUND_COLOR);
         rating.addPropertyChangeListener(this);
-        add(rating);
-        
-        add(Box.createHorizontalStrut(2));
-        
+
         otherRating = new JLabel();
         otherRating.setBackground(UIUtilities.BACKGROUND_COLOR);
         Font font = otherRating.getFont();
         otherRating.setFont(font.deriveFont(Font.ITALIC, font.getSize()-2));
-        add(otherRating);
     }
 
     @Override
@@ -109,6 +107,16 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
     @Override
     void refreshUI() {
         clearDisplay();
+        
+        if(state == State.LOADING) {
+            add(loadingLabel);
+            return;
+        }
+        
+        add(rating);
+        add(Box.createHorizontalStrut(2));
+        add(otherRating);
+        
         StringBuilder buffer = new StringBuilder();
         if (!model.isMultiSelection()) {
             originalValue = model.getUserRating();
@@ -214,6 +222,8 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
     }
     
     void onCollapsed(boolean collapsed) {
-        
+        if(!collapsed) {
+            model.loadStructuredData(EnumSet.of(AnnotationType.RATING));
+        }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -212,4 +212,8 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
             return model.getRatingCount(EditorModel.ALL);
         }
     }
+    
+    void onCollapsed(boolean collapsed) {
+        
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -22,6 +22,7 @@ package org.openmicroscopy.shoola.agents.metadata.editor;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -34,6 +35,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.TagAnnotationData;
 
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.WrapLayout;
 
@@ -163,6 +165,11 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
     @Override
     void refreshUI() {
         clearDisplay();
+        
+        if(state == State.LOADING) {
+            add(loadingLabel);
+            return;
+        }
         
         toAdd.clear();
         toRemove.clear();
@@ -335,7 +342,9 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
     }
     
     void onCollapsed(boolean collapsed) {
-        
+        if(!collapsed) {
+            model.loadStructuredData(EnumSet.of(AnnotationType.TAG));
+        }
     }
    
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/TagsTaskPaneUI.java
@@ -333,4 +333,9 @@ public class TagsTaskPaneUI extends AnnotationTaskPaneUI {
             return model.getTags().size();
         }
     }
+    
+    void onCollapsed(boolean collapsed) {
+        
+    }
+   
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewer.java
@@ -27,6 +27,7 @@ import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import javax.swing.JComponent;
@@ -36,6 +37,7 @@ import org.openmicroscopy.shoola.agents.metadata.browser.TreeBrowserDisplay;
 import org.openmicroscopy.shoola.agents.metadata.editor.Editor;
 import org.openmicroscopy.shoola.agents.metadata.rnd.Renderer;
 import org.openmicroscopy.shoola.agents.metadata.util.DataToSave;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.ScriptObject;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
@@ -239,14 +241,19 @@ public interface MetadataViewer
 	 */
 	public void cancel(int loaderID);
 	
-	/**
-	 * Feeds the metadata back to the viewer.
-	 * 
-	 * @param results The result to feed back.
-	 * @param loader The identifier of the loader.
-	 */
-	public void setMetadata(Map<DataObject, StructuredDataResults> results,
-			int loader);
+    /**
+     * Feeds the metadata back to the viewer.
+     * 
+     * @param results
+     *            The result to feed back.
+     * @param types
+     *            The type of annotations which have been requested to be
+     *            loaded.
+     * @param loader
+     *            The identifier of the loader.
+     */
+    public void setMetadata(Map<DataObject, StructuredDataResults> results,
+            EnumSet<AnnotationType> types, int loader);
 	
 	/**
 	 * Returns the UI used to select the metadata.
@@ -712,4 +719,12 @@ public interface MetadataViewer
 	 * Reload the ROI count
 	 */
     void reloadROICount();
+
+    /**
+     * Triggers the loading of the annotations of the specified types
+     * 
+     * @param types
+     *            The types of annotations to load
+     */
+    public void loadStructuredData(EnumSet<AnnotationType> types);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -419,8 +419,6 @@ class MetadataViewerComponent
 		boolean same = model.isSameObject(root);
 		model.setRootObject(root, ctx);
 		if (model.isSingleMode()) {
-			// Commented out, don't load all annotations by default
-		    //model.fireStructuredDataLoading(root);
 			fireStateChange();
 		}
 		view.setRootObject();
@@ -437,10 +435,7 @@ class MetadataViewerComponent
 	 */
 	public void refresh()
 	{
-		if (model.isSingleMode()) {
-		    // Commented out, don't load all annotations by default
-			//model.fireStructuredDataLoading(model.getRefObject());
-		} else {
+		if (!model.isSingleMode()) {
 			model.setRelatedNodes(model.getRelatedNodes());
 		}
 		fireStateChange();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -30,6 +30,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,6 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsSaved;
 import org.openmicroscopy.shoola.agents.metadata.IconManager;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
@@ -58,6 +58,8 @@ import org.openmicroscopy.shoola.agents.util.ui.MovieExportDialog;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptingDialog;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
+import org.openmicroscopy.shoola.env.data.model.AnalysisParam;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 import org.openmicroscopy.shoola.env.data.model.DeleteActivityParam;
 import org.openmicroscopy.shoola.env.data.model.MovieActivityParam;
@@ -285,51 +287,53 @@ class MetadataViewerComponent
 		model.cancel(loaderID);
 	}
 
-	/** 
-	 * Implemented as specified by the {@link MetadataViewer} interface.
-	 * @see MetadataViewer#setMetadata(Map<DataObject, StructuredDataResults>)
-	 */
-	public void setMetadata(Map<DataObject, StructuredDataResults> results,
-			int loaderID)
-	{
-		if (results == null || results.size() == 0) return;
-		//Need to check the size of the results map.
-		Browser browser = model.getBrowser();
-		DataObject node;
-		StructuredDataResults data;
-		Entry<DataObject, StructuredDataResults> e;
-		Iterator<Entry<DataObject, StructuredDataResults>>
-		i = results.entrySet().iterator();
-		if (results.size() == 1) { //handle the single selection
-			while (i.hasNext()) {
-				e = i.next();
-				node = e.getKey();
-				if (!model.isSameObject(node)) {
-					model.setStructuredDataResults(null, loaderID);
-					fireStateChange();
-					return;
-				}
-				data = e.getValue();
-				Object object = data.getRelatedObject();
-				if (object == model.getParentRefObject() ||
-					(object instanceof PlateData && node 
-							instanceof WellSampleData)) {
-					model.setParentDataResults(data, node, loaderID);
-					model.fireStructuredDataLoading(node);
-				} else {
-					model.setStructuredDataResults(results, loaderID);
-					browser.setParents(null, data.getParents());
-					model.getEditor().setStructuredDataResults();
-				}
-				fireStateChange();
-			}
-		} else {
-			if (model.isSameSelection(results.keySet())) {
-				model.setStructuredDataResults(results, loaderID);
-				model.getEditor().setStructuredDataResults();
-			}
-		}
-	}
+    /**
+     * Implemented as specified by the {@link MetadataViewer} interface.
+     * 
+     * @see MetadataViewer#setMetadata(Map, EnumSet, int)
+     */
+    public void setMetadata(Map<DataObject, StructuredDataResults> results, EnumSet<AnnotationType> types,
+            int loaderID) {
+        if (results == null || results.size() == 0)
+            return;
+        
+        // Need to check the size of the results map.
+        Browser browser = model.getBrowser();
+        DataObject node;
+        StructuredDataResults data;
+        Entry<DataObject, StructuredDataResults> e;
+        Iterator<Entry<DataObject, StructuredDataResults>> i = results
+                .entrySet().iterator();
+        if (results.size() == 1) { // handle the single selection
+            while (i.hasNext()) {
+                e = i.next();
+                node = e.getKey();
+                if (!model.isSameObject(node)) {
+                    model.setStructuredDataResults(null, loaderID);
+                    fireStateChange();
+                    return;
+                }
+                data = e.getValue();
+                Object object = data.getRelatedObject();
+                if (object == model.getParentRefObject()
+                        || (object instanceof PlateData && node instanceof WellSampleData)) {
+                    model.setParentDataResults(data, node, loaderID);
+                    // TODO: Find a workaround, guess this loads the plate metadata for wells
+                   // model.fireStructuredDataLoading(node);
+                } else {
+                    model.setStructuredDataResults(results, loaderID);
+                    browser.setParents(null, data.getParents());
+                    model.getEditor().setStructuredDataResults(types);
+                }
+                fireStateChange();
+            }
+        } else {
+            if (model.isSameSelection(results.keySet())) {
+                model.setStructuredDataResults(results, loaderID);
+                model.getEditor().setStructuredDataResults(types);
+            }
+        }
+    }
 
 	/** 
 	 * Implemented as specified by the {@link MetadataViewer} interface.
@@ -417,7 +421,8 @@ class MetadataViewerComponent
 		boolean same = model.isSameObject(root);
 		model.setRootObject(root, ctx);
 		if (model.isSingleMode()) {
-			model.fireStructuredDataLoading(root);
+			// Commented out, don't load all annotations by default
+		    //model.fireStructuredDataLoading(root);
 			fireStateChange();
 		}
 		view.setRootObject();
@@ -435,7 +440,8 @@ class MetadataViewerComponent
 	public void refresh()
 	{
 		if (model.isSingleMode()) {
-			model.fireStructuredDataLoading(model.getRefObject());
+		    // Commented out, don't load all annotations by default
+			//model.fireStructuredDataLoading(model.getRefObject());
 		} else {
 			model.setRelatedNodes(model.getRelatedNodes());
 		}
@@ -1321,5 +1327,10 @@ class MetadataViewerComponent
     @Override
     public void reloadROICount() {
         model.getEditor().reloadROICount();
+    }
+    
+    @Override
+    public void loadStructuredData(EnumSet<AnnotationType> types) {
+        model.fireStructuredDataLoading(getRefObject(), types);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -318,8 +318,6 @@ class MetadataViewerComponent
                 if (object == model.getParentRefObject()
                         || (object instanceof PlateData && node instanceof WellSampleData)) {
                     model.setParentDataResults(data, node, loaderID);
-                    // TODO: Find a workaround, guess this loads the plate metadata for wells
-                   // model.fireStructuredDataLoading(node);
                 } else {
                     model.setStructuredDataResults(results, loaderID);
                     browser.setParents(null, data.getParents());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerComponent.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 
@@ -58,7 +57,6 @@ import org.openmicroscopy.shoola.agents.util.ui.MovieExportDialog;
 import org.openmicroscopy.shoola.agents.util.ui.ScriptingDialog;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
-import org.openmicroscopy.shoola.env.data.model.AnalysisParam;
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 import org.openmicroscopy.shoola.env.data.model.DeleteActivityParam;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -23,6 +23,7 @@ package org.openmicroscopy.shoola.agents.metadata.view;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -54,6 +55,7 @@ import org.openmicroscopy.shoola.agents.metadata.util.DataToSave;
 import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import org.openmicroscopy.shoola.env.data.model.AdminObject;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.MovieExportParam;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
@@ -330,7 +332,8 @@ class MetadataViewerModel
 		}
 		browser.setRootObject(refObject);
 		editor.setRootObject(refObject);
-		data = null;
+		data = new HashMap<DataObject, StructuredDataResults>();
+		data.put((DataObject)refObject, new StructuredDataResults((DataObject)refObject));
 		if (!(refObject instanceof WellSampleData) && parentData != null) {
 			parentData = null;
 		}
@@ -442,8 +445,9 @@ class MetadataViewerModel
 	 * to the passed node.
 	 * 
 	 * @param node The node to handle.
+	 * @param types The types of annotations to load
 	 */
-	void fireStructuredDataLoading(Object node)
+	void fireStructuredDataLoading(Object node, EnumSet<AnnotationType> types)
 	{
 		if (!(node instanceof DataObject)) return;
 		if (node instanceof ExperimenterData) return;
@@ -456,7 +460,7 @@ class MetadataViewerModel
 			}
 			ctx = retrieveContext((DataObject) node);
 			StructuredDataLoader loader = new StructuredDataLoader(component,
-					ctx, Arrays.asList((DataObject) node), loaderID);
+					ctx, Arrays.asList((DataObject) node), types, loaderID);
 			loaders.put(loaderID, loader);
 			loader.load();
 			state = MetadataViewer.LOADING_METADATA;
@@ -723,9 +727,15 @@ class MetadataViewerModel
 	void setStructuredDataResults(Map<DataObject, StructuredDataResults> data, 
 			int loaderID)
 	{
-		loaders.remove(loaderID);
-		this.data = data;
-		state = MetadataViewer.READY;
+        loaders.remove(loaderID);
+        for (Entry<DataObject, StructuredDataResults> e : data.entrySet()) {
+            StructuredDataResults r = this.data.get(e.getKey());
+            if (r == null)
+                this.data.put(e.getKey(), e.getValue());
+            else
+                this.data.get(e.getKey()).merge(e.getValue());
+        }
+        state = MetadataViewer.READY;
 	}
 	
 	/**
@@ -836,6 +846,7 @@ class MetadataViewerModel
 	 */
 	void setRelatedNodes(List<DataObject> relatedNodes)
 	{ 
+	    System.out.println("setRelatedNodes "+relatedNodes);
 	    this.relatedNodes = relatedNodes;
 	    if (CollectionUtils.isEmpty(relatedNodes)) return;
 	    DataObject ho = relatedNodes.get(0);
@@ -846,13 +857,15 @@ class MetadataViewerModel
 	            l.add(((WellSampleData) i.next()).getImage());
 	        }
 	    } else l.addAll(relatedNodes);
-	    loaderID++;
-	    ctx = retrieveContext(ho);
-	    StructuredDataLoader loader = new StructuredDataLoader(component,
-	            ctx, l, loaderID);
-	    loaders.put(loaderID, loader);
-	    loader.load();
-	    state = MetadataViewer.LOADING_METADATA;
+	    
+	    // commented out, don't load all annotations by default
+//	    loaderID++;
+//	    ctx = retrieveContext(ho);
+//	    StructuredDataLoader loader = new StructuredDataLoader(component,
+//	            ctx, l, loaderID);
+//	    loaders.put(loaderID, loader);
+//	    loader.load();
+//	    state = MetadataViewer.LOADING_METADATA;
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -332,11 +332,14 @@ class MetadataViewerModel
 		}
 		browser.setRootObject(refObject);
 		editor.setRootObject(refObject);
-		data = new HashMap<DataObject, StructuredDataResults>();
-		data.put((DataObject)refObject, new StructuredDataResults((DataObject)refObject));
-		if (!(refObject instanceof WellSampleData) && parentData != null) {
-			parentData = null;
-		}
+        if (refObject instanceof DataObject) {
+            data = new HashMap<DataObject, StructuredDataResults>();
+            data.put((DataObject) refObject, new StructuredDataResults(
+                    (DataObject) refObject));
+            if (!(refObject instanceof WellSampleData) && parentData != null) {
+                parentData = null;
+            }
+        }
 		parentRefObject = null;
 		viewedBy = null;
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -849,7 +849,6 @@ class MetadataViewerModel
 	 */
 	void setRelatedNodes(List<DataObject> relatedNodes)
 	{ 
-	    System.out.println("setRelatedNodes "+relatedNodes);
 	    this.relatedNodes = relatedNodes;
 	    if (CollectionUtils.isEmpty(relatedNodes)) return;
 	    DataObject ho = relatedNodes.get(0);
@@ -860,15 +859,6 @@ class MetadataViewerModel
 	            l.add(((WellSampleData) i.next()).getImage());
 	        }
 	    } else l.addAll(relatedNodes);
-	    
-	    // commented out, don't load all annotations by default
-//	    loaderID++;
-//	    ctx = retrieveContext(ho);
-//	    StructuredDataLoader loader = new StructuredDataLoader(component,
-//	            ctx, l, loaderID);
-//	    loaders.put(loaderID, loader);
-//	    loader.load();
-//	    state = MetadataViewer.LOADING_METADATA;
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -181,6 +181,8 @@ class MetadataViewerUI
 		uiDelegate.revalidate();
 		uiDelegate.repaint();
 		viewedByItems.clear();
+		
+		model.getEditor().layoutUI();
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
@@ -29,8 +29,12 @@ import java.util.Set;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageSet;
 import org.openmicroscopy.shoola.env.data.FSFileSystemView;
+
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
@@ -189,7 +193,7 @@ public class ExperimenterDataLoader
     				ctx.getGroupID(), this);
     	} else if (FileAnnotationData.class.equals(rootNodeType)) {
     		handle = mhView.loadExistingAnnotations(ctx,
-    				rootNodeType, expID, this); //TO BE MODIFIED
+    				AnnotationType.ATTACHMENT, expID, this); //TO BE MODIFIED
     	} else {
     		if (viewer.getBrowserType() == Browser.FILE_SYSTEM_EXPLORER) {
     			//handle = dmView.loadRepositories(ctx, exp.getId(), this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ExperimenterDataLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -29,12 +29,9 @@ import java.util.Set;
 import org.openmicroscopy.shoola.agents.treeviewer.browser.Browser;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageSet;
 import org.openmicroscopy.shoola.env.data.FSFileSystemView;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
-
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/TagsLoader.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.List;
 
 import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 import omero.gateway.model.ExperimenterData;
@@ -65,7 +67,7 @@ public class TagsLoader
      */
     public void load()
     {
-		handle = mhView.loadExistingAnnotations(ctx, TagAnnotationData.class,
+		handle = mhView.loadExistingAnnotations(ctx, AnnotationType.TAG,
 				-1, this);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/TagsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/finder/TagsLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -24,13 +24,9 @@ import java.util.Collection;
 import java.util.List;
 
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
-import omero.gateway.model.ExperimenterData;
-import omero.gateway.model.GroupData;
-import omero.gateway.model.TagAnnotationData;
 
 /** 
  * Loads the existing tags.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1277,9 +1277,9 @@ class OMEROGateway
 		else if (FileAnnotationData.class.equals(pojo))
 			return "ome.model.annotations.FileAnnotation";
 		else if (TermAnnotationData.class.equals(pojo))
-			return "ome.model.annotations.UriAnnotation";
+			return "ome.model.annotations.TermAnnotation";
 		else if (TimeAnnotationData.class.equals(pojo))
-			return "ome.model.annotations.TimeAnnotation";
+			return "ome.model.annotations.TimestampAnnotation";
 		else if (BooleanAnnotationData.class.equals(pojo))
 			return "ome.model.annotations.BooleanAnnotation";
 		else if (DoubleAnnotationData.class.equals(pojo))
@@ -1289,7 +1289,7 @@ class OMEROGateway
 		else if (MapAnnotationData.class.equals(pojo))
             return "ome.model.annotations.MapAnnotation";
 		else if (XMLAnnotationData.class.equals(pojo))
-            return "ome.model.annotations.XMLAnnotation";
+            return "ome.model.annotations.XmlAnnotation";
 		return null;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -210,6 +210,7 @@ import omero.gateway.model.BooleanAnnotationData;
 import omero.gateway.model.ChannelAcquisitionData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
+import omero.gateway.model.DoubleAnnotationData;
 import omero.gateway.model.EllipseData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FileAnnotationData;
@@ -240,6 +241,7 @@ import omero.gateway.model.TextualAnnotationData;
 import omero.gateway.model.TimeAnnotationData;
 import omero.gateway.model.WellData;
 import omero.gateway.model.WellSampleData;
+import omero.gateway.model.XMLAnnotationData;
 
 
 /**
@@ -1280,6 +1282,14 @@ class OMEROGateway
 			return "ome.model.annotations.TimeAnnotation";
 		else if (BooleanAnnotationData.class.equals(pojo))
 			return "ome.model.annotations.BooleanAnnotation";
+		else if (DoubleAnnotationData.class.equals(pojo))
+            return "ome.model.annotations.DoubleAnnotation";
+		else if (LongAnnotationData.class.equals(pojo))
+            return "ome.model.annotations.LongAnnotation";
+		else if (MapAnnotationData.class.equals(pojo))
+            return "ome.model.annotations.MapAnnotation";
+		else if (XMLAnnotationData.class.equals(pojo))
+            return "ome.model.annotations.XMLAnnotation";
 		return null;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1716,6 +1716,8 @@ class OMEROGateway
 		}
 		try {
 		    IMetadataPrx service = gw.getMetadataService(ctx);
+            if (types == null || types.isEmpty())
+                System.out.println("Avoid this !!!");
 			return PojoMapper.asDataObjects(
 					service.loadAnnotations(PojoMapper.getModelType(nodeType).getName(),
 							nodeIDs, types, annotatorIDs, options));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1727,7 +1727,11 @@ class OMEROGateway
 		try {
 		    IMetadataPrx service = gw.getMetadataService(ctx);
             if (types == null || types.isEmpty())
-                System.out.println("Avoid this !!!");
+                dsFactory.getLogger().warn(
+                        this,
+                        "Loading *all* annotations for " + nodeType + " "
+                                + String.join(",", nodeIDs)
+                                + ", avoid this where possible.");
 			return PojoMapper.asDataObjects(
 					service.loadAnnotations(PojoMapper.getModelType(nodeType).getName(),
 							nodeIDs, types, annotatorIDs, options));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -22,6 +22,7 @@ package org.openmicroscopy.shoola.env.data;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -44,8 +45,11 @@ import omero.model.MicroscopeType;
 import omero.model.PhotometricInterpretation;
 import omero.model.Pulse;
 
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
+
 import omero.gateway.model.TableResult;
+
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
 
@@ -218,6 +222,25 @@ public interface OmeroMetadataService
 			SecurityContext ctx, List<DataObject> data, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 	
+	
+	/**
+     * Loads data related to the specified objects
+     * 
+     * @param ctx The security context.
+     * @param data The objects to handle.
+     * @param types The types of annotations to load
+     * @param userID The id of the user who added attachments to the object 
+     *               or <code>-1</code> if the user is not specified.
+     * @return See above.
+     * @throws DSOutOfServiceException  If the connection is broken, or logged
+     *                                  in.
+     * @throws DSAccessException        If an error occurred while trying to 
+     *                                  retrieve data from OMEDS service.
+     */
+    public Map<DataObject, StructuredDataResults> loadStructuredData(
+            SecurityContext ctx, List<DataObject> data, EnumSet<AnnotationType> types, long userID)
+        throws DSOutOfServiceException, DSAccessException;
+    
 	/**
 	 * Annotates the specified data object and returns the annotated object.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -47,9 +47,7 @@ import omero.model.Pulse;
 
 import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
-
 import omero.gateway.model.TableResult;
-
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -189,8 +189,6 @@ public interface OmeroMetadataService
 	 * @param object The object to handle.
      * @param userID The id of the user who added attachments to the object 
      *               or <code>-1</code> if the user is not specified.
-     * @param viewed Pass <code>true</code> to load the rendering settings 
-	 *               related to the objects, <code>false<code> otherwise.
      * @return See above.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
 	 *                                  in.
@@ -198,7 +196,7 @@ public interface OmeroMetadataService
 	 *                                  retrieve data from OMEDS service.
 	 */
 	public StructuredDataResults loadStructuredData(SecurityContext ctx,
-			Object object, long userID, boolean viewed)
+			Object object, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 
 	/**
@@ -217,8 +215,7 @@ public interface OmeroMetadataService
 	 *                                  retrieve data from OMEDS service.
 	 */
 	public Map<DataObject, StructuredDataResults> loadStructuredData(
-			SecurityContext ctx, List<DataObject> data, long userID,
-			boolean viewed)
+			SecurityContext ctx, List<DataObject> data, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -985,7 +985,7 @@ class OmeroMetadataServiceImpl
 	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, DataObject, long, boolean)
 	 */
 	public StructuredDataResults loadStructuredData(SecurityContext ctx,
-			Object object, long userID, boolean viewed) 
+			Object object, long userID) 
 	    throws DSOutOfServiceException, DSAccessException 
 	{
 		if (object == null)
@@ -1024,11 +1024,11 @@ class OmeroMetadataServiceImpl
 	
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, List, long, boolean)
+	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, List, long)
 	 */
 	public Map<DataObject, StructuredDataResults>
 		loadStructuredData(SecurityContext ctx, List<DataObject> data,
-			long userID, boolean viewed) 
+			long userID) 
 	    throws DSOutOfServiceException, DSAccessException
 	{
 		if (data == null)
@@ -2310,7 +2310,6 @@ class OmeroMetadataServiceImpl
 	public DataObject loadAnnotation(SecurityContext ctx, long annotationID)
 			throws DSOutOfServiceException, DSAccessException
 	{
-		//Tmp code
 	    Collection<DataObject> set = gateway.loadAnnotation(ctx, 
 				Arrays.asList(annotationID));
 		if (set.size() != 1) return null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -1205,9 +1205,18 @@ class OmeroMetadataServiceImpl
         }
         
         List<Class> annotationTypes = new ArrayList<Class>();
-        for(AnnotationType t : types)
+        for(AnnotationType t : types) {
             if(t.getPojoClass()!=null)
                 annotationTypes.add(t.getPojoClass());
+            else if(t==AnnotationType.OTHER) {
+                annotationTypes.add(AnnotationType.BOOLEAN.getPojoClass());
+                annotationTypes.add(AnnotationType.DOUBLE.getPojoClass());
+                annotationTypes.add(AnnotationType.LONG.getPojoClass());
+                annotationTypes.add(AnnotationType.XML.getPojoClass());
+                annotationTypes.add(AnnotationType.TERM.getPojoClass());
+                annotationTypes.add(AnnotationType.TIME.getPojoClass());
+            }
+        }
         
         Map map = gateway.loadAnnotations(ctx, klass, ids, annotationTypes, usersIDs,
                 new Parameters());

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -82,6 +83,7 @@ import org.apache.commons.collections.ListUtils;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
@@ -982,7 +984,7 @@ class OmeroMetadataServiceImpl
     
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, DataObject, long, boolean)
+	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, Object, long)
 	 */
 	public StructuredDataResults loadStructuredData(SecurityContext ctx,
 			Object object, long userID) 
@@ -1022,6 +1024,62 @@ class OmeroMetadataServiceImpl
 		return results;
 	}
 	
+	/**
+     * Implemented as specified by {@link OmeroDataService}.
+     * @see OmeroMetadataService#loadStructuredData(SecurityContext, List, EnumSet, long)
+     */
+    public Map<DataObject, StructuredDataResults>
+        loadStructuredData(SecurityContext ctx, List<DataObject> data, EnumSet<AnnotationType> types,
+            long userID) 
+        throws DSOutOfServiceException, DSAccessException
+    {
+        if (data == null)
+            throw new IllegalArgumentException("Object not valid.");
+        
+        Map<DataObject, StructuredDataResults> 
+            results = new HashMap<DataObject, StructuredDataResults>();
+        Iterator<DataObject> i = data.iterator();
+        DataObject n;
+        List<Long> ids = new ArrayList<Long>();
+        Class<?> klass = null;
+        List<Long> fids = new ArrayList<Long>();
+        ImageData img;
+        Multimap<Class<?>, Long> mm = ArrayListMultimap.create();
+        while (i.hasNext()) {
+            n = i.next();
+            if (n != null) {
+                ids.add(n.getId());
+                mm.put(n.getClass(), n.getId());
+                if (n instanceof ImageData) {
+                    img = (ImageData) n;
+                    long fID = img.getFilesetId();
+                    if (fID >=0 && !fids.contains(fID)) {
+                        fids.add(fID);
+                    }
+                }
+            }
+        }
+        Map<Long, Collection<AnnotationData>> filesetMap =
+                new HashMap<Long, Collection<AnnotationData>>();
+        if (!fids.isEmpty()) {
+            filesetMap = loadAnnotations(ctx, FilesetData.class, fids,
+                    TextualAnnotationData.class,
+                    Arrays.asList(AnnotationData.FILE_TRANSFER_NS), null);
+        }
+        //load all the annotations
+        List<Long> usersIDs = null;
+        if (userID != -1) {
+            usersIDs = new ArrayList<Long>(1);
+            usersIDs.add(userID);
+        }
+        //Load annotations
+        for (Class<?> k : mm.keySet()) {
+            loadAnnotations(ctx, k, (List) mm.get(k), userID, data, types,
+                    filesetMap, results);
+        }
+        return results;
+    }
+    
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
 	 * @see OmeroMetadataService#loadStructuredData(SecurityContext, List, long)
@@ -1133,6 +1191,69 @@ class OmeroMetadataServiceImpl
             }
         }
 	}
+	
+	private void loadAnnotations(SecurityContext ctx, Class<?> klass,
+            List<Long> ids, long userID, List<DataObject> data, EnumSet<AnnotationType> types,
+            Map<Long, Collection<AnnotationData>> filesetMap,
+            Map<DataObject, StructuredDataResults> results)
+    throws DSOutOfServiceException, DSAccessException
+    {
+        List<Long> usersIDs = null;
+        if (userID != -1) {
+            usersIDs = new ArrayList<Long>(1);
+            usersIDs.add(userID);
+        }
+        
+        List<Class> annotationTypes = new ArrayList<Class>();
+        for(AnnotationType t : types)
+            if(t.getPojoClass()!=null)
+                annotationTypes.add(t.getPojoClass());
+        
+        Map map = gateway.loadAnnotations(ctx, klass, ids, annotationTypes, usersIDs,
+                new Parameters());
+        Multimap<Long, IObject> linkMap = ArrayListMultimap.create();
+        if (!(klass.equals(TagAnnotationData.class) ||
+                klass.equals(FileAnnotationData.class))) {
+            Collection values = map.values();
+            Iterator k = values.iterator();
+            List<Long> annotationIds = new ArrayList<Long>();
+            while (k.hasNext()) {
+                Collection l = (Collection) k.next();
+                Iterator j = l.iterator();
+                while (j.hasNext()) {
+                    AnnotationData object = (AnnotationData) j.next();
+                    if (!annotationIds.contains(object.getId()))
+                        annotationIds.add(object.getId());
+                    
+                }
+               
+            }
+            if (CollectionUtils.isNotEmpty(annotationIds)) {
+                linkMap = gateway.findAnnotationLinks(ctx, klass, ids,
+                        annotationIds, userID);
+            }
+        }
+        //format the results
+        Iterator<DataObject> i = data.iterator();
+        StructuredDataResults r;
+        List<IObject> links;
+        DataObject n;
+        while (i.hasNext()) {
+            n = i.next();
+            if (n != null && ids.contains(n.getId())) {
+                r = new StructuredDataResults(n);
+                loadStructuredData(ctx, userID,
+                        (Collection) map.get(n.getId()), r, false);
+                results.put(n, r);
+                if (n instanceof ImageData) {
+                    ImageData img = (ImageData) n;
+                    r.setTransferlinks(filesetMap.get(img.getFilesetId()));
+                }
+                formatAnnotationLinks(linkMap.get(n.getId()), r);
+            }
+        }
+    }
+	
 	/**
 	 * Formats the annotation links.
 	 *

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
@@ -4,6 +4,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.LongAnnotationData;
 import omero.gateway.model.MapAnnotationData;
+import omero.gateway.model.RatingAnnotationData;
 import omero.gateway.model.TagAnnotationData;
 import omero.gateway.model.TextualAnnotationData;
 
@@ -25,7 +26,7 @@ public enum AnnotationType {
     ATTACHMENT("Attachments", FileAnnotationData.class), 
     
     /** Rating Annotation */
-    RATING("Ratings", LongAnnotationData.class), 
+    RATING("Ratings", RatingAnnotationData.class), 
     
     /** Other Annotations */
     OTHER("Others", null), 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
@@ -1,12 +1,19 @@
 package org.openmicroscopy.shoola.env.data.model;
 
+import ome.model.annotations.BooleanAnnotation;
+import ome.model.annotations.DoubleAnnotation;
+import omero.gateway.model.BooleanAnnotationData;
 import omero.gateway.model.DataObject;
+import omero.gateway.model.DoubleAnnotationData;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.LongAnnotationData;
 import omero.gateway.model.MapAnnotationData;
 import omero.gateway.model.RatingAnnotationData;
 import omero.gateway.model.TagAnnotationData;
+import omero.gateway.model.TermAnnotationData;
 import omero.gateway.model.TextualAnnotationData;
+import omero.gateway.model.TimeAnnotationData;
+import omero.gateway.model.XMLAnnotationData;
 
 /**
  * The different types of Annotations
@@ -35,7 +42,25 @@ public enum AnnotationType {
     COMMENT("Comments", TextualAnnotationData.class), 
     
     /** ROIs */
-    ROI("ROIs", null);
+    ROI("ROIs", null),
+    
+    /** Boolean */
+    BOOLEAN("Boolean", BooleanAnnotationData.class),
+    
+    /** Double */
+    DOUBLE("Numeric (double)", DoubleAnnotationData.class),
+    
+    /** Long */
+    LONG("Numeric (long)", LongAnnotationData.class),
+    
+    /** Term */
+    TERM("Term", TermAnnotationData.class),
+    
+    /** Time */
+    TIME("Time", TimeAnnotationData.class),
+    
+    /** XML */
+    XML("XML", XMLAnnotationData.class);
 
     /** The {@link DataObject} type this annotation is represented by (if any) */
     private Class<? extends DataObject> pojoClass;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
@@ -1,0 +1,78 @@
+package org.openmicroscopy.shoola.env.data.model;
+
+import omero.gateway.model.DataObject;
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.LongAnnotationData;
+import omero.gateway.model.MapAnnotationData;
+import omero.gateway.model.TagAnnotationData;
+import omero.gateway.model.TextualAnnotationData;
+
+/**
+ * The different types of Annotations
+ *
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public enum AnnotationType {
+    
+    /** Tag Annotation */
+    TAG("Tags", TagAnnotationData.class), 
+    
+    /** Map Annotation */
+    MAP("Key-Value Pairs", MapAnnotationData.class),
+    
+    /** File Attachment Annotation */
+    ATTACHMENT("Attachments", FileAnnotationData.class), 
+    
+    /** Rating Annotation */
+    RATING("Ratings", LongAnnotationData.class), 
+    
+    /** Other Annotations */
+    OTHER("Others", null), 
+    
+    /** Comment Annotation */
+    COMMENT("Comments", TextualAnnotationData.class), 
+    
+    /** ROIs */
+    ROI("ROIs", null);
+
+    /** The {@link DataObject} type this annotation is represented by (if any) */
+    private Class<? extends DataObject> pojoClass;
+
+    /** Human readable name for this annotation type */
+    private String name;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param name
+     *            Human readable name for this annotation type
+     * @param pojoClass
+     *            The {@link DataObject} type this annotation is represented by
+     *            (if any)
+     */
+    AnnotationType(String name, Class<? extends DataObject> pojoClass) {
+        this.name = name;
+        this.pojoClass = pojoClass;
+    }
+
+    /**
+     * Get the {@link DataObject} type this annotation is represented by (if
+     * any)
+     * 
+     * @return See above
+     */
+    public Class<? extends DataObject> getPojoClass() {
+        return pojoClass;
+    }
+
+    /**
+     * Get the human readable name for this annotation type
+     * 
+     * @return See above
+     */
+    public String getName() {
+        return name;
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
@@ -1,7 +1,5 @@
 package org.openmicroscopy.shoola.env.data.model;
 
-import ome.model.annotations.BooleanAnnotation;
-import ome.model.annotations.DoubleAnnotation;
 import omero.gateway.model.BooleanAnnotationData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DoubleAnnotationData;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/AnnotationType.java
@@ -1,3 +1,24 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
 package org.openmicroscopy.shoola.env.data.model;
 
 import omero.gateway.model.BooleanAnnotationData;
@@ -64,7 +85,7 @@ public enum AnnotationType {
     private Class<? extends DataObject> pojoClass;
 
     /** Human readable name for this annotation type */
-    private String name;
+    private String descriptiveName;
 
     /**
      * Creates a new instance
@@ -75,8 +96,8 @@ public enum AnnotationType {
      *            The {@link DataObject} type this annotation is represented by
      *            (if any)
      */
-    AnnotationType(String name, Class<? extends DataObject> pojoClass) {
-        this.name = name;
+    AnnotationType(String descriptiveName, Class<? extends DataObject> pojoClass) {
+        this.descriptiveName = descriptiveName;
         this.pojoClass = pojoClass;
     }
 
@@ -95,8 +116,8 @@ public enum AnnotationType {
      * 
      * @return See above
      */
-    public String getName() {
-        return name;
+    public String getDescriptiveName() {
+        return descriptiveName;
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
@@ -20,7 +20,6 @@
  */
 package org.openmicroscopy.shoola.env.data.util;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,8 +28,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
 
 import omero.gateway.model.AnnotationData;
 import omero.gateway.model.DataObject;
@@ -43,95 +40,96 @@ import omero.gateway.model.TermAnnotationData;
 import omero.gateway.model.TextualAnnotationData;
 import omero.gateway.model.XMLAnnotationData;
 
-/** 
+import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
+import org.openmicroscopy.shoola.util.PojosUtil;
+
+/**
  * Helper class storing the various data related to a given object.
  *
- * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
  * @since OME3.0
  */
-public class StructuredDataResults
-{
-	
-	/** The tags related to the object. */
-	private Collection<TagAnnotationData>	tags = new ArrayList<TagAnnotationData>();
-	
-	/** The attachments related to the object. */
-	private Collection<FileAnnotationData>	attachments = new ArrayList<FileAnnotationData>();
-	
-	/** The terms related to the object. */
-	private Collection<TermAnnotationData>	terms = new ArrayList<TermAnnotationData>();
-	
-	/** The textual annotations. */
-	private Collection<TextualAnnotationData> texts = new ArrayList<TextualAnnotationData>();
+public class StructuredDataResults {
 
-	/** The ratings of the objects. */
-	private Collection<RatingAnnotationData>  ratings = new ArrayList<RatingAnnotationData>();
-	
-	/** The XML type of the objects. */
-	private Collection<XMLAnnotationData>  xmlAnnotations = new ArrayList<XMLAnnotationData>();
-	
-	/** Collection of annotations not already stored. */
-	private Collection<AnnotationData>     otherAnnotation = new ArrayList<AnnotationData>();
-	
-	/** The MapAnnotations. */
-	private Collection<MapAnnotationData>     mapAnnotations = new ArrayList<MapAnnotationData>();
-	
-	/** The object the results are for. */
-	private DataObject					relatedObject;
-	
-	/** The collection of links  for in-place imports.*/
-	private Collection<AnnotationData> transferlinks = new ArrayList<AnnotationData>();
+    /** The tags related to the object. */
+    private Collection<TagAnnotationData> tags = new ArrayList<TagAnnotationData>();
 
-	/** 
-	 * Collection of parents. 
-	 * Filled when the related object is an <code>image</code> or
-	 * <code>dataset</code>.
-	 */
-	private Collection					parents;
+    /** The attachments related to the object. */
+    private Collection<FileAnnotationData> attachments = new ArrayList<FileAnnotationData>();
 
-	/** The tags and documents links. */
-	private Map<DataObject, ExperimenterData> links = new HashMap<DataObject, ExperimenterData>();
-	
-	/** The concrete links.*/
-	private Collection<AnnotationLinkData> annotationLinks = new ArrayList<AnnotationLinkData>();
-	
-	/** Flag indicating if the annotations have been loaded or not.*/
-	private boolean loaded;
-	
-	/**
-	 * Creates a new instance.
-	 * 
-	 * @param relatedObject The object the results are for. 
-	 * 						Mustn't be <code>null</code>.
-	 */
-	public StructuredDataResults(DataObject relatedObject)
-	{
-		this(relatedObject, true);
-	}
-	
-	/**
-	 * Creates a new instance.
-	 * 
-	 * @param relatedObject The object the results are for.
-	 * 						Mustn't be <code>null</code>.
-	 * @param loaded Flag indicating if the annotations have been loaded or not.
-	 * The default value is <code>true</code>
-	 */
-	public StructuredDataResults(DataObject relatedObject, boolean loaded)
-	{
-		if (relatedObject == null)
-			throw new IllegalArgumentException("No object related.");
-		this.relatedObject = relatedObject;
-		this.loaded = loaded;
-	}
+    /** The terms related to the object. */
+    private Collection<TermAnnotationData> terms = new ArrayList<TermAnnotationData>();
+
+    /** The textual annotations. */
+    private Collection<TextualAnnotationData> texts = new ArrayList<TextualAnnotationData>();
+
+    /** The ratings of the objects. */
+    private Collection<RatingAnnotationData> ratings = new ArrayList<RatingAnnotationData>();
+
+    /** The XML type of the objects. */
+    private Collection<XMLAnnotationData> xmlAnnotations = new ArrayList<XMLAnnotationData>();
+
+    /** Collection of annotations not already stored. */
+    private Collection<AnnotationData> otherAnnotation = new ArrayList<AnnotationData>();
+
+    /** The MapAnnotations. */
+    private Collection<MapAnnotationData> mapAnnotations = new ArrayList<MapAnnotationData>();
+
+    /** The object the results are for. */
+    private DataObject relatedObject;
+
+    /** The collection of links for in-place imports. */
+    private Collection<AnnotationData> transferlinks = new ArrayList<AnnotationData>();
+
+    /**
+     * Collection of parents. Filled when the related object is an
+     * <code>image</code> or <code>dataset</code>.
+     */
+    private Collection parents;
+
+    /** The tags and documents links. */
+    private Map<DataObject, ExperimenterData> links = new HashMap<DataObject, ExperimenterData>();
+
+    /** The concrete links. */
+    private Collection<AnnotationLinkData> annotationLinks = new ArrayList<AnnotationLinkData>();
+
+    /** Flag indicating if the annotations have been loaded or not. */
+    private boolean loaded;
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param relatedObject
+     *            The object the results are for. Mustn't be <code>null</code>.
+     */
+    public StructuredDataResults(DataObject relatedObject) {
+        this(relatedObject, true);
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param relatedObject
+     *            The object the results are for. Mustn't be <code>null</code>.
+     * @param loaded
+     *            Flag indicating if the annotations have been loaded or not.
+     *            The default value is <code>true</code>
+     */
+    public StructuredDataResults(DataObject relatedObject, boolean loaded) {
+        if (relatedObject == null)
+            throw new IllegalArgumentException("No object related.");
+        this.relatedObject = relatedObject;
+        this.loaded = loaded;
+    }
 
     /**
      * Merges the specified {@link StructuredDataResults} into this one. Throws
-     * an {@link IllegalArgumentException} if they are not compatible (ie. refer
+     * an {@link IllegalArgumentException} if they are not compatible (i.e refer
      * to different objects)
      * 
      * @param other
@@ -140,303 +138,310 @@ public class StructuredDataResults
     public void merge(StructuredDataResults other) {
         DataObject o1 = (DataObject) getRelatedObject();
         DataObject o2 = (DataObject) other.getRelatedObject();
-        if (!o1.getClass().equals(o2.getClass()) || o1.getId() != o2.getId())
+        if (!o1.getUniqueId().equals(o2.getUniqueId()))
             throw new IllegalArgumentException(
-                    "Can't merge results for two differente objects!");
+                    "Can't merge results for two different objects!");
 
         // merge annotations
-        Set<String> ownData = new HashSet<String>();
-        for (Object o : getAllAnnotations()) {
-            AnnotationData a = (AnnotationData) o;
-            ownData.add(a.getClass().getSimpleName() + "_" + a.getId());
-        }
+        Collection<AnnotationData> ownAnnotations = getAllAnnotations();
 
-        Collection toAdd = other.getAllAnnotations();
-        Iterator it = toAdd.iterator();
+        Collection<AnnotationData> toAdd = other.getAllAnnotations();
+        Iterator<AnnotationData> it = toAdd.iterator();
         while (it.hasNext()) {
-            AnnotationData a = (AnnotationData) it.next();
-            if (ownData
-                    .contains(a.getClass().getSimpleName() + "_" + a.getId()))
+            AnnotationData a = it.next();
+            if (PojosUtil.contains(ownAnnotations, a))
                 it.remove();
         }
 
         addAnnotations(toAdd);
 
         // merge links
-        ownData.clear();
+        for (AnnotationData d : other.transferlinks) {
+            if (!PojosUtil.contains(transferlinks, d))
+                transferlinks.add(d);
+        }
+        
+        Set<String> ids = new HashSet<String>();
         for (AnnotationLinkData d : annotationLinks) {
             String s = "" + d.getLink().getId().getValue();
-            ownData.add(s);
+            ids.add(s);
         }
         for (AnnotationLinkData d : other.annotationLinks) {
             String s = "" + d.getLink().getId().getValue();
-            if (!ownData.contains(s))
+            if (!ids.contains(s))
                 annotationLinks.add(d);
         }
-
-        ownData.clear();
-        for (AnnotationData d : transferlinks) {
-            String s = "" + d.getId();
-            ownData.add(s);
-        }
-        for (AnnotationData d : other.transferlinks) {
-            String s = "" + d.getId();
-            if (!ownData.contains(s))
-                transferlinks.add(d);
-        }
-
-        ownData.clear();
+        
+        ids.clear();
         for (Entry<DataObject, ExperimenterData> e : links.entrySet()) {
-            String s = e.getKey().getClass().getSimpleName() + "_"
-                    + e.getValue().getId();
-            ownData.add(s);
+            String s = e.getKey().getUniqueId() + "_"
+                    + e.getValue().getUniqueId();
+            ids.add(s);
         }
         for (Entry<DataObject, ExperimenterData> e : other.links.entrySet()) {
-            String s = e.getKey().getClass().getSimpleName() + "_"
-                    + e.getValue().getId();
-            if (!ownData.contains(s))
+            String s = e.getKey().getUniqueId() + "_"
+                    + e.getValue().getUniqueId();
+            if (!ids.contains(s))
                 links.put(e.getKey(), e.getValue());
         }
     }
-	
-	/**
-	 * Returns <code>true</code> if the annotations are loaded,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean isLoaded() { return loaded; }
-	
-	/**
-	 * Returns the object the results are for.
-	 * 
-	 * @return See above.
-	 */
-	public Object getRelatedObject() { return relatedObject; }
 
-	/**
-	 * Returns the identifier of the data object.
-	 *
-	 * @return See above.
-	 */
-	public long getObjectId() { return relatedObject.getId(); }
+    /**
+     * Returns <code>true</code> if the annotations are loaded,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean isLoaded() {
+        return loaded;
+    }
 
-	/**
-	 * Returns the collection of parents.
-	 * 
-	 * @return See above.
-	 */
-	public Collection getParents() { return parents; }
-	
-	/** 
-	 * Sets the collection of parents.
-	 * 
-	 * @param parents The value to set.
-	 */
-	public void setParents(Collection parents) { this.parents = parents; }
-	
-	/**
-	 * Returns the annotations.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<TextualAnnotationData> getTextualAnnotations()
-	{ 
-		return texts; 
-	}
+    /**
+     * Returns the object the results are for.
+     * 
+     * @return See above.
+     */
+    public Object getRelatedObject() {
+        return relatedObject;
+    }
 
-	/**
-	 * Sets the collection of annotations.
-	 * 
-	 * @param texts The value to set.
-	 */
-	public void setTextualAnnotations(Collection<TextualAnnotationData> texts)
-	{
-		this.texts = texts;
-	}
+    /**
+     * Returns the identifier of the data object.
+     *
+     * @return See above.
+     */
+    public long getObjectId() {
+        return relatedObject.getId();
+    }
 
-	/**
-	 * Returns the collection of attachments.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<FileAnnotationData> getAttachments()
-	{ 
-		return attachments; 
-	}
+    /**
+     * Returns the collection of parents.
+     * 
+     * @return See above.
+     */
+    public Collection getParents() {
+        return parents;
+    }
 
-	/**
-	 * Sets the collections of attachments.
-	 * 
-	 * @param attachments The value to set.
-	 */
-	public void setAttachments(Collection<FileAnnotationData> attachments)
-	{
-		this.attachments = attachments;
-	}
+    /**
+     * Sets the collection of parents.
+     * 
+     * @param parents
+     *            The value to set.
+     */
+    public void setParents(Collection parents) {
+        this.parents = parents;
+    }
 
-	/**
-	 * Returns the collection of <code>XML</code> annotations.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<XMLAnnotationData> getXMLAnnotations()
-	{ 
-		return xmlAnnotations; 
-	}
-	
-	/**
-	 * Sets the collections of <code>XML</code> annotations.
-	 * 
-	 * @param xmlAnnotations The value to set.
-	 */
-	public void setXMLAnnotations(Collection<XMLAnnotationData> xmlAnnotations)
-	{
-		this.xmlAnnotations = xmlAnnotations;
-	}
-	
-	/**
-	 * Returns the ratings.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<RatingAnnotationData> getRatings() { return ratings; }
+    /**
+     * Returns the annotations.
+     * 
+     * @return See above.
+     */
+    public Collection<TextualAnnotationData> getTextualAnnotations() {
+        return texts;
+    }
 
-	/**
-	 * Sets the ratings.
-	 * 
-	 * @param ratings The value to set.
-	 */
-	public void setRatings(Collection<RatingAnnotationData> ratings)
-	{ 
-		this.ratings = ratings; 
-	}
+    /**
+     * Sets the collection of annotations.
+     * 
+     * @param texts
+     *            The value to set.
+     */
+    public void setTextualAnnotations(Collection<TextualAnnotationData> texts) {
+        this.texts = texts;
+    }
 
-	/**
-	 * Returns the collection of tags.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<TagAnnotationData> getTags() { return tags; }
+    /**
+     * Returns the collection of attachments.
+     * 
+     * @return See above.
+     */
+    public Collection<FileAnnotationData> getAttachments() {
+        return attachments;
+    }
 
-	/**
-	 * Sets the collections of tags.
-	 * 
-	 * @param tags The value to set.
-	 */
-	public void setTags(Collection<TagAnnotationData> tags)
-	{ 
-		this.tags = tags;
-	}
+    /**
+     * Sets the collections of attachments.
+     * 
+     * @param attachments
+     *            The value to set.
+     */
+    public void setAttachments(Collection<FileAnnotationData> attachments) {
+        this.attachments = attachments;
+    }
 
-	/**
-	 * Returns the collection of terms.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<TermAnnotationData> getTerms() { return terms; }
+    /**
+     * Returns the collection of <code>XML</code> annotations.
+     * 
+     * @return See above.
+     */
+    public Collection<XMLAnnotationData> getXMLAnnotations() {
+        return xmlAnnotations;
+    }
 
-	/**
-	 * Sets the collections of terms.
-	 * 
-	 * @param terms The value to set.
-	 */
-	public void setTerms(Collection<TermAnnotationData> terms)
-	{ 
-		this.terms = terms; 
-	}
-	
-	/**
-	 * Returns the collection of annotations.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<AnnotationData> getOtherAnnotations()
-	{ 
-		return otherAnnotation; 
-	}
+    /**
+     * Sets the collections of <code>XML</code> annotations.
+     * 
+     * @param xmlAnnotations
+     *            The value to set.
+     */
+    public void setXMLAnnotations(Collection<XMLAnnotationData> xmlAnnotations) {
+        this.xmlAnnotations = xmlAnnotations;
+    }
 
-	/**
-	 * Sets the collections of annotations.
-	 * 
-	 * @param otherAnnotation The value to set.
-	 */
-	public void setOtherAnnotation(Collection<AnnotationData> otherAnnotation)
-	{ 
-		this.otherAnnotation = otherAnnotation; 
-	}
-	
-	/**
-	 * Returns the collection of links.
-	 * 
-	 * @return See above.
-	 */
-	public Map<DataObject, ExperimenterData> getLinks() { return links; }
-	
-	/**
-	 * Sets the collection.
-	 * 
-	 * @param links The collection to set.
-	 */
-	public void setLinks(Map<DataObject, ExperimenterData> links) { this.links = links; }
-	
-	/**
-	 * Returns the collection of links.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<AnnotationLinkData> getAnnotationLinks()
-	{
-		return annotationLinks;
-	}
-	
-	/**
-	 * Sets the collection.
-	 * 
-	 * @param annotationLinks The collection to set.
-	 */
-	public void setAnnotationLinks(Collection<AnnotationLinkData> annotationLinks)
-	{
-		this.annotationLinks = annotationLinks;
-	}
-	
-	/**
-	 * Sets the collection of transferlink annotations (in-place imports)
-	 * @param transferlinks Transferlink annotations to set
-	 */
-	public void setTransferlinks(Collection<AnnotationData> transferlinks)
-	{
-		this.transferlinks = transferlinks;
-	}
-	
-	/**
-	 * Returns the collection of links (in-place imports).
-	 * 
-	 * @return See above.
-	 */
-	public Collection<AnnotationData> getTransferLinks()
-	{
-		return transferlinks;
-	}
+    /**
+     * Returns the ratings.
+     * 
+     * @return See above.
+     */
+    public Collection<RatingAnnotationData> getRatings() {
+        return ratings;
+    }
 
-	/**
-	 * Returns the collection of {@link MapAnnotationData}.
-	 * 
-	 * @return See above.
-	 */
-	public Collection<MapAnnotationData> getMapAnnotations() {
-		return mapAnnotations;
-	}
+    /**
+     * Sets the ratings.
+     * 
+     * @param ratings
+     *            The value to set.
+     */
+    public void setRatings(Collection<RatingAnnotationData> ratings) {
+        this.ratings = ratings;
+    }
 
-	/**
-	 * Sets the collection of {@link MapAnnotationData}.
-	 * 
-	 * @param mapAnnotations The value to set.
-	 */
-	public void setMapAnnotations(Collection<MapAnnotationData> mapAnnotations)
-	{
-		this.mapAnnotations = mapAnnotations;
-	}
+    /**
+     * Returns the collection of tags.
+     * 
+     * @return See above.
+     */
+    public Collection<TagAnnotationData> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets the collections of tags.
+     * 
+     * @param tags
+     *            The value to set.
+     */
+    public void setTags(Collection<TagAnnotationData> tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * Returns the collection of terms.
+     * 
+     * @return See above.
+     */
+    public Collection<TermAnnotationData> getTerms() {
+        return terms;
+    }
+
+    /**
+     * Sets the collections of terms.
+     * 
+     * @param terms
+     *            The value to set.
+     */
+    public void setTerms(Collection<TermAnnotationData> terms) {
+        this.terms = terms;
+    }
+
+    /**
+     * Returns the collection of annotations.
+     * 
+     * @return See above.
+     */
+    public Collection<AnnotationData> getOtherAnnotations() {
+        return otherAnnotation;
+    }
+
+    /**
+     * Sets the collections of annotations.
+     * 
+     * @param otherAnnotation
+     *            The value to set.
+     */
+    public void setOtherAnnotation(Collection<AnnotationData> otherAnnotation) {
+        this.otherAnnotation = otherAnnotation;
+    }
+
+    /**
+     * Returns the collection of links.
+     * 
+     * @return See above.
+     */
+    public Map<DataObject, ExperimenterData> getLinks() {
+        return links;
+    }
+
+    /**
+     * Sets the collection.
+     * 
+     * @param links
+     *            The collection to set.
+     */
+    public void setLinks(Map<DataObject, ExperimenterData> links) {
+        this.links = links;
+    }
+
+    /**
+     * Returns the collection of links.
+     * 
+     * @return See above.
+     */
+    public Collection<AnnotationLinkData> getAnnotationLinks() {
+        return annotationLinks;
+    }
+
+    /**
+     * Sets the collection.
+     * 
+     * @param annotationLinks
+     *            The collection to set.
+     */
+    public void setAnnotationLinks(
+            Collection<AnnotationLinkData> annotationLinks) {
+        this.annotationLinks = annotationLinks;
+    }
+
+    /**
+     * Sets the collection of transferlink annotations (in-place imports)
+     * 
+     * @param transferlinks
+     *            Transferlink annotations to set
+     */
+    public void setTransferlinks(Collection<AnnotationData> transferlinks) {
+        this.transferlinks = transferlinks;
+    }
+
+    /**
+     * Returns the collection of links (in-place imports).
+     * 
+     * @return See above.
+     */
+    public Collection<AnnotationData> getTransferLinks() {
+        return transferlinks;
+    }
+
+    /**
+     * Returns the collection of {@link MapAnnotationData}.
+     * 
+     * @return See above.
+     */
+    public Collection<MapAnnotationData> getMapAnnotations() {
+        return mapAnnotations;
+    }
+
+    /**
+     * Sets the collection of {@link MapAnnotationData}.
+     * 
+     * @param mapAnnotations
+     *            The value to set.
+     */
+    public void setMapAnnotations(Collection<MapAnnotationData> mapAnnotations) {
+        this.mapAnnotations = mapAnnotations;
+    }
 
     /**
      * Add Annotations
@@ -471,7 +476,7 @@ public class StructuredDataResults
      * 
      * @return All Annotations
      */
-    public Collection getAllAnnotations() {
+    public Collection<AnnotationData> getAllAnnotations() {
         Collection<AnnotationData> result = new ArrayList<AnnotationData>();
         result.addAll(attachments);
         result.addAll(mapAnnotations);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
@@ -23,7 +23,10 @@ package org.openmicroscopy.shoola.env.data.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.openmicroscopy.shoola.env.data.model.AnnotationLinkData;
 
@@ -123,6 +126,39 @@ public class StructuredDataResults
 		this.loaded = loaded;
 	}
 
+    /**
+     * Merges the specified {@link StructuredDataResults} into this one. Throws
+     * an {@link IllegalArgumentException} if they are not compatible (ie. refer
+     * to different objects)
+     * 
+     * @param other
+     *            The {@link StructuredDataResults} to merge
+     */
+    public void merge(StructuredDataResults other) {
+        DataObject o1 = (DataObject) getRelatedObject();
+        DataObject o2 = (DataObject) other.getRelatedObject();
+        if (!o1.getClass().equals(o2.getClass()) || o1.getId() != o2.getId())
+            throw new IllegalArgumentException(
+                    "Can't merge results for two differente objects!");
+
+        Set<String> ownData = new HashSet<String>();
+        for (Object o : getAllAnnotations()) {
+            AnnotationData a = (AnnotationData) o;
+            ownData.add(a.getClass().getSimpleName() + "_" + a.getId());
+        }
+
+        Collection toAdd = other.getAllAnnotations();
+        Iterator it = toAdd.iterator();
+        while (it.hasNext()) {
+            AnnotationData a = (AnnotationData) it.next();
+            if (ownData
+                    .contains(a.getClass().getSimpleName() + "_" + a.getId()))
+                it.remove();
+        }
+
+        addAnnotations(toAdd);
+    }
+	
 	/**
 	 * Returns <code>true</code> if the annotations are loaded,
 	 * <code>false</code> otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StructuredDataResults.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -21,6 +21,7 @@
 package org.openmicroscopy.shoola.env.data.util;
 
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -50,28 +51,28 @@ public class StructuredDataResults
 {
 	
 	/** The tags related to the object. */
-	private Collection<TagAnnotationData>	tags;
+	private Collection<TagAnnotationData>	tags = new ArrayList<TagAnnotationData>();
 	
 	/** The attachments related to the object. */
-	private Collection<FileAnnotationData>	attachments;
+	private Collection<FileAnnotationData>	attachments = new ArrayList<FileAnnotationData>();
 	
 	/** The terms related to the object. */
-	private Collection<TermAnnotationData>	terms;
+	private Collection<TermAnnotationData>	terms = new ArrayList<TermAnnotationData>();
 	
 	/** The textual annotations. */
-	private Collection<TextualAnnotationData> texts;
+	private Collection<TextualAnnotationData> texts = new ArrayList<TextualAnnotationData>();
 
 	/** The ratings of the objects. */
-	private Collection<RatingAnnotationData>  ratings;
+	private Collection<RatingAnnotationData>  ratings = new ArrayList<RatingAnnotationData>();
 	
 	/** The XML type of the objects. */
-	private Collection<XMLAnnotationData>  xmlAnnotations;
+	private Collection<XMLAnnotationData>  xmlAnnotations = new ArrayList<XMLAnnotationData>();
 	
 	/** Collection of annotations not already stored. */
-	private Collection<AnnotationData>     otherAnnotation;
+	private Collection<AnnotationData>     otherAnnotation = new ArrayList<AnnotationData>();
 	
 	/** The MapAnnotations. */
-	private Collection<MapAnnotationData>     mapAnnotations;
+	private Collection<MapAnnotationData>     mapAnnotations = new ArrayList<MapAnnotationData>();
 	
 	/** The object the results are for. */
 	private DataObject					relatedObject;
@@ -360,5 +361,51 @@ public class StructuredDataResults
 	{
 		this.mapAnnotations = mapAnnotations;
 	}
+
+    /**
+     * Add Annotations
+     * 
+     * @param annos
+     *            The Annotations to add
+     */
+    public void addAnnotations(Collection<AnnotationData> annos) {
+        for (AnnotationData data : annos) {
+            if (data instanceof TermAnnotationData) {
+                terms.add((TermAnnotationData) data);
+            } else if (data instanceof TextualAnnotationData)
+                texts.add((TextualAnnotationData) data);
+            else if (data instanceof TagAnnotationData) {
+                tags.add((TagAnnotationData) data);
+            } else if (data instanceof RatingAnnotationData)
+                ratings.add((RatingAnnotationData) data);
+            else if (data instanceof FileAnnotationData) {
+                attachments.add((FileAnnotationData) data);
+            } else if (data instanceof XMLAnnotationData) {
+                xmlAnnotations.add((XMLAnnotationData) data);
+            } else if (data instanceof MapAnnotationData) {
+                mapAnnotations.add((MapAnnotationData) data);
+            } else {
+                otherAnnotation.add(data);
+            }
+        }
+    }
+
+    /**
+     * Get all Annotations
+     * 
+     * @return All Annotations
+     */
+    public Collection getAllAnnotations() {
+        Collection<AnnotationData> result = new ArrayList<AnnotationData>();
+        result.addAll(attachments);
+        result.addAll(mapAnnotations);
+        result.addAll(otherAnnotation);
+        result.addAll(ratings);
+        result.addAll(tags);
+        result.addAll(terms);
+        result.addAll(texts);
+        result.addAll(xmlAnnotations);
+        return result;
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -22,15 +22,19 @@ package org.openmicroscopy.shoola.env.data.views;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.calls.FilesLoader;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.util.ui.MessengerDetails;
@@ -118,19 +122,6 @@ public interface MetadataHandlerView
 	public CallHandle loadThumbnails(SecurityContext ctx, ImageData image,
 		Set<Long> userIDs, int thumbWidth, int thumbHeight,
 		AgentEventListener observer);
-
-	/**
-	 * Loads all annotations related the specified object.
-	 * Retrieves the files if the userID is not <code>-1</code>.
-	 * 
-	 * @param ctx The security context.
-	 * @param dataObject The object to handle. Mustn't be <code>null</code>.
-	 * @param userID Pass <code>-1</code> if no user specified.
-	 * @param observer Call-back handler.
-	 * @return A handle that can be used to cancel the call.
-	 */
-	public CallHandle loadStructuredData(SecurityContext ctx, Object dataObject,
-			long userID, AgentEventListener observer);
 	
 	/**
 	 * Loads all annotations related the specified objects.
@@ -148,6 +139,10 @@ public interface MetadataHandlerView
 		List<DataObject> data, long userID, boolean viewed,
 		AgentEventListener observer);
 	
+	public CallHandle loadStructuredData(SecurityContext ctx,
+	        List<DataObject> data, long userID, boolean viewed, EnumSet<AnnotationType> types,
+	        AgentEventListener observer);
+	        
 	/**
 	 * Loads all {@link DataObject}s the given annotations ({@link FileAnnotationData}) are linked to
 	 * @param ctx The security context.
@@ -173,7 +168,7 @@ public interface MetadataHandlerView
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadExistingAnnotations(SecurityContext ctx,
-			Class annotation, long userID, AgentEventListener observer);
+	        AnnotationType annotation, long userID, AgentEventListener observer);
 
 	/**
 	 * Loads the existing annotations defined by the annotation type
@@ -188,7 +183,7 @@ public interface MetadataHandlerView
          * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadExistingAnnotations(List<SecurityContext> ctx,
-			Class annotation, long userID, AgentEventListener observer);
+	        AnnotationType annotation, long userID, AgentEventListener observer);
 	
 	/**
 	 * Saves the object, adds (resp. removes) annotations to (resp. from)
@@ -267,17 +262,6 @@ public interface MetadataHandlerView
 	 */
 	public CallHandle loadFile(SecurityContext ctx, File file, long fileID,
 			int index, AgentEventListener observer);
-	
-	/**
-	 * Loads the annotation corresponding to the passed id.
-	 * 
-	 * @param ctx The security context.
-	 * @param annotationID The id of the annotation file.
-	 * @param observer Call-back handler.
-	 * @return A handle that can be used to cancel the call.
-	 */
-	public CallHandle loadAnnotation(SecurityContext ctx, long annotationID,
-							AgentEventListener observer);
 	
 	/**
 	 * Loads the original files related to a given pixels set.
@@ -499,13 +483,14 @@ public interface MetadataHandlerView
 	 * Image.
 	 * @param rootIDs The collection of object's ids the annotations are linked
 	 * to.
-	 * @param annotationType The type of annotation to load.
+	 * @param annotationTypes The type of annotation to load.
 	 * @param nsInclude The annotation's name space to include if any.
 	 * @param nsExlcude The annotation's name space to exclude if any.
 	 * @return A handle that can be used to cancel the call.
 	 */
+
 	public CallHandle loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
-		List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
+		List<Long> rootIDs, EnumSet<AnnotationType> annotationTypes, List<String> nsInclude,
 		List<String> nsExlcude, AgentEventListener observer);
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -32,9 +32,7 @@ import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.views.calls.FilesLoader;
 import org.openmicroscopy.shoola.env.event.AgentEventListener;
 import org.openmicroscopy.shoola.util.ui.MessengerDetails;
@@ -129,6 +127,7 @@ public interface MetadataHandlerView
 	 * 
 	 * @param ctx The security context.
 	 * @param data The objects to handle. Mustn't be <code>null</code>.
+	 * @param types The types of annotations to load (<code>null</code> means all annotation).
 	 * @param userID Pass <code>-1</code> if no user specified.
 	 * @param viewed Pass <code>true</code> to load the rendering settings 
 	 * related to the objects, <code>false<code> otherwise.
@@ -136,11 +135,7 @@ public interface MetadataHandlerView
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadStructuredData(SecurityContext ctx,
-		List<DataObject> data, long userID, boolean viewed,
-		AgentEventListener observer);
-	
-	public CallHandle loadStructuredData(SecurityContext ctx,
-	        List<DataObject> data, long userID, boolean viewed, EnumSet<AnnotationType> types,
+	        List<DataObject> data, EnumSet<AnnotationType> types, long userID, boolean viewed,
 	        AgentEventListener observer);
 	        
 	/**
@@ -437,6 +432,7 @@ public interface MetadataHandlerView
 	 * @param userID The id of the experimenter or <code>-1</code>.
 	 * @param all Pass <code>true</code> to retrieve all the scripts uploaded
 	 * ones and the default ones, <code>false</code>.
+	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadScripts(SecurityContext ctx, long userID, boolean all,
@@ -447,6 +443,7 @@ public interface MetadataHandlerView
 	 * 
 	 * @param ctx The security context.
 	 * @param scriptID The id of the script.
+	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadScript(SecurityContext ctx, long scriptID,
@@ -458,6 +455,7 @@ public interface MetadataHandlerView
 	 * @param ctx The security context.
 	 * @param parameters The parameters indicating the data to load.
 	 * @param userID The id of the experimenter or <code>-1</code>.
+	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadTabularData(SecurityContext ctx,
@@ -468,6 +466,7 @@ public interface MetadataHandlerView
 	 * 
 	 * @param ctx The security context.
 	 * @param imageId The id of the image.
+	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 	public CallHandle loadFileset(SecurityContext ctx,
@@ -486,6 +485,7 @@ public interface MetadataHandlerView
 	 * @param annotationTypes The type of annotation to load.
 	 * @param nsInclude The annotation's name space to include if any.
 	 * @param nsExlcude The annotation's name space to exclude if any.
+	 * @param observer Call-back handler.
 	 * @return A handle that can be used to cancel the call.
 	 */
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -31,9 +31,7 @@ import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
-
 import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedFilesLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedFilesSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedImageLoader;
@@ -98,28 +96,15 @@ class MetadataHandlerViewImpl
 				thumbHeight, userIDs);
 		return cmd.exec(observer);
 	}
-
-	/**
-	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadStructuredData(SecurityContext, List,
-	 * long, boolean, AgentEventListener)
-	 */
-	public CallHandle loadStructuredData(SecurityContext ctx,
-		List<DataObject> data, long userID, boolean viewed,
-		AgentEventListener observer)
-	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, null, data, userID);
-		return cmd.exec(observer);
-	}
 	
 	/**
      * Implemented as specified by the view interface.
-     * @see MetadataHandlerView#loadStructuredData(SecurityContext, List,
-     * long, boolean, EnumSet, AgentEventListener)
+     * @see MetadataHandlerView#loadStructuredData(SecurityContext, List, EnumSet,
+     * long, boolean, AgentEventListener)
      */
 	@Override
     public CallHandle loadStructuredData(SecurityContext ctx,
-        List<DataObject> data, long userID, boolean viewed, EnumSet<AnnotationType> types,
+        List<DataObject> data, EnumSet<AnnotationType> types, long userID, boolean viewed,
         AgentEventListener observer)
     {
         BatchCallTree cmd = new StructuredAnnotationLoader(ctx, types, data, userID);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -22,14 +22,18 @@ package org.openmicroscopy.shoola.env.data.views;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
 import org.openmicroscopy.shoola.env.data.model.TableParameters;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
 import org.openmicroscopy.shoola.env.data.util.FilterContext;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedFilesLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedFilesSaver;
 import org.openmicroscopy.shoola.env.data.views.calls.ArchivedImageLoader;
@@ -39,6 +43,8 @@ import org.openmicroscopy.shoola.env.data.views.calls.FileAnnotationCheckLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.FileUploader;
 import org.openmicroscopy.shoola.env.data.views.calls.FilesLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.FilesetLoader;
+import org.openmicroscopy.shoola.env.data.views.calls.MeasurementLoader;
+import org.openmicroscopy.shoola.env.data.views.calls.RatingLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.RelatedContainersLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.ScriptsLoader;
 import org.openmicroscopy.shoola.env.data.views.calls.StructuredAnnotationLoader;
@@ -95,19 +101,6 @@ class MetadataHandlerViewImpl
 
 	/**
 	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadStructuredData(SecurityContext, DataObject,
-	 * long, AgentEventListener)
-	 */
-	public CallHandle loadStructuredData(SecurityContext ctx, Object dataObject,
-								long userID, AgentEventListener observer)
-	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx,
-						StructuredAnnotationLoader.ALL, dataObject, userID);
-		return cmd.exec(observer);
-	}
-
-	/**
-	 * Implemented as specified by the view interface.
 	 * @see MetadataHandlerView#loadStructuredData(SecurityContext, List,
 	 * long, boolean, AgentEventListener)
 	 */
@@ -115,21 +108,33 @@ class MetadataHandlerViewImpl
 		List<DataObject> data, long userID, boolean viewed,
 		AgentEventListener observer)
 	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx,
-						StructuredAnnotationLoader.ALL, data, userID, viewed);
+		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, null, data, userID);
 		return cmd.exec(observer);
 	}
+	
+	/**
+     * Implemented as specified by the view interface.
+     * @see MetadataHandlerView#loadStructuredData(SecurityContext, List,
+     * long, boolean, EnumSet, AgentEventListener)
+     */
+	@Override
+    public CallHandle loadStructuredData(SecurityContext ctx,
+        List<DataObject> data, long userID, boolean viewed, EnumSet<AnnotationType> types,
+        AgentEventListener observer)
+    {
+        BatchCallTree cmd = new StructuredAnnotationLoader(ctx, types, data, userID);
+        return cmd.exec(observer);
+    }
 
 	/**
 	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadExistingAnnotations(SecurityContext, Class,
-	 * long, long, AgentEventListener)
+	 * @see MetadataHandlerView#loadExistingAnnotations(SecurityContext, AnnotationType,
+	 * long, AgentEventListener)
 	 */
 	public CallHandle loadExistingAnnotations(SecurityContext ctx,
-		Class annotation, long userID, AgentEventListener observer)
+		AnnotationType annotation, long userID, AgentEventListener observer)
 	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, annotation,
-														userID);
+		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, annotation, userID);
 		return cmd.exec(observer);
 	}
 
@@ -145,10 +150,10 @@ class MetadataHandlerViewImpl
 	/**
 	 * Implemented as specified by the view interface.
 	 * @see MetadataHandlerView#loadExistingAnnotations(SecurityContext,
-	 * Class, long, AgentEventListener)
+	 * AnnotationType, long, AgentEventListener)
 	 */
 	public CallHandle loadExistingAnnotations(List<SecurityContext> ctx,
-		Class annotation, long userID, AgentEventListener observer)
+	        AnnotationType annotation, long userID, AgentEventListener observer)
 	{
 		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, annotation,
 														userID);
@@ -257,8 +262,7 @@ class MetadataHandlerViewImpl
 	public CallHandle loadRatings(SecurityContext ctx, Class nodeType,
 		List<Long> nodeIDs, long userID, AgentEventListener observer)
 	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx,
- 				StructuredAnnotationLoader.RATING, nodeType, nodeIDs, userID);
+		BatchCallTree cmd = new RatingLoader(ctx, nodeType, nodeIDs, userID);
 		return cmd.exec(observer);
 	}
 
@@ -330,16 +334,6 @@ class MetadataHandlerViewImpl
 		return cmd.exec(observer);
 	}
 
-	/**
-	 * Implemented as specified by the view interface.
-	 * @see MetadataHandlerView#loadAnnotation(SecurityContext, long, AgentEventListener)
-	 */
-	public CallHandle loadAnnotation(SecurityContext ctx, long annotationID,
-			AgentEventListener observer)
-	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, annotationID);
-		return cmd.exec(observer);
-	}
 
 	/**
 	 * Implemented as specified by the view interface.
@@ -373,8 +367,7 @@ class MetadataHandlerViewImpl
 	public CallHandle loadROIMeasurement(SecurityContext ctx,
 		Object dataObject, long userID, AgentEventListener observer)
 	{
-		BatchCallTree cmd = new StructuredAnnotationLoader(ctx,
- 				StructuredAnnotationLoader.ROI_MEASUREMENT, dataObject,
+		BatchCallTree cmd = new MeasurementLoader(ctx, dataObject,
  					userID);
 		return cmd.exec(observer);
 	}
@@ -455,14 +448,15 @@ class MetadataHandlerViewImpl
 	/**
 	 * Implemented as specified by the view interface.
 	 * @see MetadataHandlerView#loadAnnotations(SecurityContext, Class, List,
-	 * Class, List, List, AgentEventListener)
+	 * EnumSet, List, List, AgentEventListener)
 	 */
+	@Override
 	public CallHandle loadAnnotations(SecurityContext ctx, Class<? extends DataObject> rootType,
-			List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
+			List<Long> rootIDs, EnumSet<AnnotationType> annotationTypes, List<String> nsInclude,
 			List<String> nsExlcude, AgentEventListener observer)
 	{
 		BatchCallTree cmd = new StructuredAnnotationLoader(ctx, rootType,
-			rootIDs, annotationType, nsInclude, nsExlcude);
+			rootIDs, annotationTypes, nsInclude, nsExlcude);
 		return cmd.exec(observer);
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/MeasurementLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/MeasurementLoader.java
@@ -1,0 +1,105 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.data.views.calls;
+
+import omero.gateway.SecurityContext;
+import omero.gateway.model.DataObject;
+
+import org.openmicroscopy.shoola.env.data.OmeroImageService;
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
+/**
+ * Retrieves the ROI measurements
+ */
+public class MeasurementLoader extends BatchCallTree {
+    /** The result of the call. */
+    private Object result;
+
+    /** Loads the specified experimenter groups. */
+    private BatchCall loadCall;
+
+    /** The security context. */
+    private SecurityContext ctx;
+
+    /**
+     * Creates a {@link BatchCall} to load the measurement related to the object
+     * identified by the class and the id.
+     * 
+     * @param type
+     *            The type of the object.
+     * @param id
+     *            The id of the object.
+     * @param userID
+     *            The id of the user who tagged the object or <code>-1</code> if
+     *            the user is not specified.
+     * @return The {@link BatchCall}.
+     */
+    private BatchCall loadROIMeasurements(final Class type, final long id,
+            final long userID) {
+        return new BatchCall("Loading Measurements") {
+            public void doCall() throws Exception {
+                OmeroImageService os = context.getImageService();
+                result = os.loadROIMeasurements(ctx, type, id, userID);
+            }
+        };
+    }
+
+    /**
+     * Adds the {@link #loadCall} to the computation tree.
+     * 
+     * @see BatchCallTree#buildTree()
+     */
+    protected void buildTree() {
+        add(loadCall);
+    }
+
+    /**
+     * Returns, in a <code>Set</code>, the root nodes of the found trees.
+     * 
+     * @see BatchCallTree#getResult()
+     */
+    protected Object getResult() {
+        return result;
+    }
+
+    /**
+     * Creates a new instance. Builds the call corresponding to the passed
+     * index, throws an {@link IllegalArgumentException} if the index is not
+     * supported.
+     * 
+     * @param ctx
+     *            The security context.
+     * @param object
+     *            The object to handle.
+     * @param userID
+     *            The id of the user or <code>-1</code> if the id is not
+     *            specified.
+     */
+    public MeasurementLoader(SecurityContext ctx, Object object, long userID) {
+        if (object == null)
+            throw new IllegalArgumentException("Object not defined.");
+
+        DataObject ho = (DataObject) object;
+        loadCall = loadROIMeasurements(object.getClass(), ho.getId(), userID);
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/RatingLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/RatingLoader.java
@@ -1,0 +1,106 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.data.views.calls;
+
+import java.util.List;
+
+import omero.gateway.SecurityContext;
+
+import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
+/**
+ * Retrieves the ratings
+ */
+public class RatingLoader extends BatchCallTree {
+    /** The result of the call. */
+    private Object result;
+
+    /** Loads the specified experimenter groups. */
+    private BatchCall loadCall;
+
+    /** The security context. */
+    private SecurityContext ctx;
+
+    /**
+     * Creates a {@link BatchCall} to load the ratings related to the object
+     * identified by the class and the id.
+     * 
+     * @param type
+     *            The type of the object.
+     * @param ids
+     *            The collection of id of the object.
+     * @param userID
+     *            The id of the user who tagged the object or <code>-1</code> if
+     *            the user is not specified.
+     * @return The {@link BatchCall}.
+     */
+    private BatchCall loadRatings(final Class type, final List<Long> ids,
+            final long userID) {
+        return new BatchCall("Loading Ratings") {
+            public void doCall() throws Exception {
+                OmeroMetadataService os = context.getMetadataService();
+                result = os.loadRatings(ctx, type, ids, userID);
+            }
+        };
+    }
+
+    /**
+     * Adds the {@link #loadCall} to the computation tree.
+     * 
+     * @see BatchCallTree#buildTree()
+     */
+    protected void buildTree() {
+        add(loadCall);
+    }
+
+    /**
+     * Returns, in a <code>Set</code>, the root nodes of the found trees.
+     * 
+     * @see BatchCallTree#getResult()
+     */
+    protected Object getResult() {
+        return result;
+    }
+
+    /**
+     * Creates a new instance. Builds the call corresponding to the passed
+     * index, throws an {@link IllegalArgumentException} if the index is not
+     * supported.
+     * 
+     * @param ctx
+     *            The security context.
+     * @param type
+     *            The type of node the annotations are related to.
+     * @param ids
+     *            Collection of the id of the object.
+     * @param userID
+     *            The id of the user or <code>-1</code> if the id is not
+     *            specified.
+     */
+    public RatingLoader(SecurityContext ctx, Class type, List<Long> ids,
+            long userID) {
+        this.ctx = ctx;
+        loadCall = loadRatings(type, ids, userID);
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
@@ -23,7 +23,6 @@ package org.openmicroscopy.shoola.env.data.views.calls;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -52,8 +51,6 @@ import edu.emory.mathcs.backport.java.util.Collections;
  * @since OME3.0
  */
 public class StructuredAnnotationLoader extends BatchCallTree {
-    /** The types of annotations to load */
-    private EnumSet<AnnotationType> types;
 
     /** The result of the call. */
     private Object result;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
@@ -20,43 +20,39 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
-
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
-import org.openmicroscopy.shoola.env.data.OmeroImageService;
-import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import omero.gateway.SecurityContext;
-import org.openmicroscopy.shoola.env.data.views.BatchCall;
-import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+import omero.gateway.model.AnnotationData;
 import omero.gateway.model.DataObject;
 
-/** 
+import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
+import org.openmicroscopy.shoola.env.data.model.AnnotationType;
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+/**
  * Retrieves the structures annotations related to a given object.
  *
- * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
  * @since OME3.0
  */
-public class StructuredAnnotationLoader
-    extends BatchCallTree
-{
-
-    /** Indicates to load the annotation related to a given object. */
-    public static final int RATING = 10;
-
-    /** Indicates to load the annotation related to a given object. */
-    public static final int ROI_MEASUREMENT = 11;
-
-    /** Indicates to load structured data */
-    public static final int ALL = 1;
-
-    /** Indicates to load the annotation identified by an Id. */
-    public static final int SINGLE = 2;
+public class StructuredAnnotationLoader extends BatchCallTree {
+    /** The types of annotations to load */
+    private EnumSet<AnnotationType> types;
 
     /** The result of the call. */
     private Object result;
@@ -64,80 +60,87 @@ public class StructuredAnnotationLoader
     /** Loads the specified experimenter groups. */
     private BatchCall loadCall;
 
-    /** The security context.*/
+    /** The security context. */
     private SecurityContext ctx;
 
     /**
      * Creates a {@link BatchCall} to load the specified annotation.
      * 
-     * @param rootType The type of object the annotations are linked to e.g.
-     * Image.
-     * @param rootIDs The collection of object's ids the annotations are linked
-     * to.
-     * @param annotationType The type of annotation to load.
-     * @param nsInclude The annotation's name space to include if any.
-     * @param nsExlcude The annotation's name space to exclude if any.
+     * @param rootType
+     *            The type of object the annotations are linked to e.g. Image.
+     * @param rootIDs
+     *            The collection of object's ids the annotations are linked to.
+     * @param annotationType
+     *            The type of annotation to load.
+     * @param nsInclude
+     *            The annotation's name space to include if any.
+     * @param nsExlcude
+     *            The annotation's name space to exclude if any.
      * @return The {@link BatchCall}.
      */
-    private BatchCall loadSpeficiedAnnotationLinkedTo(final Class<? extends DataObject> rootType,
-            final List<Long> rootIDs, final Class<?> annotationType,
-            final List<String> nsInclude, final List<String> nsExlcude)
-    {
-        return new BatchCall("Loading Specified Annotation") {
-            public void doCall() throws Exception
-            {
-                OmeroMetadataService os = context.getMetadataService();
-                result = os.loadAnnotations(ctx, rootType, rootIDs,
-                        annotationType, nsInclude, nsExlcude);
+    private BatchCall loadSpecifiedAnnotationLinkedTo(final Class<? extends DataObject> rootType,
+            final List<Long> rootIDs,
+            final EnumSet<AnnotationType> annotationTypes,
+            final List<String> nsInclude, final List<String> nsExlcude) {
+        return new BatchCall("Loading Specified Annotations") {
+            public void doCall() throws Exception {
+                
+                for (AnnotationType annotationType : annotationTypes) {
+                    if (annotationType.getPojoClass() != null) {
+                        OmeroMetadataService os = context.getMetadataService();
+                        Map<Long, Collection<AnnotationData>> tmpResult = os
+                                .loadAnnotations(ctx, rootType, rootIDs,
+                                        annotationType.getPojoClass(),
+                                        nsInclude, nsExlcude);
+
+                        if (result == null)
+                            result = tmpResult;
+                        else {
+                            Map<Long, Collection<AnnotationData>> resultCasted = (Map<Long, Collection<AnnotationData>>) result;
+                            for (Entry<Long, Collection<AnnotationData>> e : tmpResult
+                                    .entrySet()) {
+                                Collection<AnnotationData> annos = resultCasted
+                                        .get(e.getKey());
+                                if (annos == null) {
+                                    annos = new ArrayList<AnnotationData>();
+                                    resultCasted.put(e.getKey(), annos);
+                                }
+                                annos.addAll(e.getValue());
+                            }
+                        }
+                    }
+                }
             }
         };
     }
 
     /**
-     * Creates a {@link BatchCall} to load the existing annotations of the 
+     * Creates a {@link BatchCall} to load the existing annotations of the
      * specified type related to the passed type of object.
      * 
-     * @param annotationType The type of annotation to load.
-     * @param userID The id of the user or <code>-1</code> if the id 
-     * is not specified.
-     * @return The {@link BatchCall}.
-     */
-    private BatchCall loadAnnotations(final Class annotationType,
-            final long userID)
-    {
-        return new BatchCall("Loading Existing Annotations") {
-            public void doCall() throws Exception
-            {
-                OmeroMetadataService os = context.getMetadataService();
-                result = os.loadAnnotations(ctx, annotationType, null, userID);
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link BatchCall} to load the existing annotations of the 
-     * specified type related to the passed type of object.
-     * 
-     * @param ctx The security context.
-     * @param annotationType The type of annotation to load.
-     * @param userID The id of the user or <code>-1</code> if the id 
-     * is not specified.
+     * @param ctx
+     *            The security context.
+     * @param annotationType
+     *            The type of annotation to load.
+     * @param userID
+     *            The id of the user or <code>-1</code> if the id is not
+     *            specified.
      * @return The {@link BatchCall}.
      */
     private BatchCall loadAnnotations(final List<SecurityContext> ctx,
-            final Class annotationType, final long userID)
-    {
+            final AnnotationType annotationType, final long userID) {
         return new BatchCall("Loading Existing Annotations") {
-            public void doCall() throws Exception
-            {
-                OmeroMetadataService os = context.getMetadataService();
-                Iterator<SecurityContext> i = ctx.iterator();
-                List l = new ArrayList();
-                while (i.hasNext()) {
-                    l.addAll(os.loadAnnotations(i.next(), annotationType, null,
-                            userID));
+            public void doCall() throws Exception {
+                if (annotationType.getPojoClass() != null) {
+                    OmeroMetadataService os = context.getMetadataService();
+                    Iterator<SecurityContext> i = ctx.iterator();
+                    List l = new ArrayList();
+                    while (i.hasNext()) {
+                        l.addAll(os.loadAnnotations(i.next(),
+                                annotationType.getPojoClass(), null, userID));
+                    }
+                    result = l;
                 }
-                result = l;
             }
         };
     }
@@ -146,62 +149,18 @@ public class StructuredAnnotationLoader
      * Creates a {@link BatchCall} to load the ratings related to the object
      * identified by the class and the id.
      * 
-     * @param type The type of the object.
-     * @param id The id of the object.
-     * @param userID The id of the user who tagged the object or
-     * <code>-1</code> if the user is not specified.
+     * @param object
+     *            The type of the object.
+     * @param userID
+     *            The id of the user who tagged the object or <code>-1</code> if
+     *            the user is not specified.
      * @return The {@link BatchCall}.
      */
-    private BatchCall loadRatings(final Class type, final long id,
-            final long userID)
-    {
-        return new BatchCall("Loading Ratings") {
-            public void doCall() throws Exception
-            {
-                OmeroMetadataService os = context.getMetadataService();
-                result = os.loadRatings(ctx, type, id, userID);
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link BatchCall} to load the measurement related to the object
-     * identified by the class and the id.
-     * 
-     * @param type The type of the object.
-     * @param id The id of the object.
-     * @param userID The id of the user who tagged the object or
-     * <code>-1</code> if the user is not specified.
-     * @return The {@link BatchCall}.
-     */
-    private BatchCall loadROIMeasurements(final Class type, final long id,
-            final long userID)
-    {
-        return new BatchCall("Loading Measurements") {
-            public void doCall() throws Exception
-            {
-                OmeroImageService os = context.getImageService();
-                result = os.loadROIMeasurements(ctx, type, id, userID);
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link BatchCall} to load the ratings related to the object
-     * identified by the class and the id.
-     * 
-     * @param object The type of the object.
-     * @param userID The id of the user who tagged the object or 
-     * <code>-1</code> if the user is not specified.
-     * @return The {@link BatchCall}.
-     */
-    private BatchCall loadStructuredData(final Object object, final long userID)
-    {
+    private BatchCall loadStructuredData(final Object object, final long userID) {
         return new BatchCall("Loading Structured Data") {
-            public void doCall() throws Exception
-            {
+            public void doCall() throws Exception {
                 OmeroMetadataService os = context.getMetadataService();
-                result = os.loadStructuredData(ctx, object, userID, true);
+                result = os.loadStructuredData(ctx, object, userID);
             }
         };
     }
@@ -210,21 +169,22 @@ public class StructuredAnnotationLoader
      * Creates a {@link BatchCall} to load the ratings related to the object
      * identified by the class and the id.
      * 
-     * @param data The objects.
-     * @param userID The id of the user who tagged the object or
-     *               <code>-1</code> if the user is not specified.
-     * @param viewed Pass <code>true</code> to load the rendering settings
-     *               related to the objects, <code>false<code> otherwise.
+     * @param data
+     *            The objects.
+     * @param userID
+     *            The id of the user who tagged the object or <code>-1</code> if
+     *            the user is not specified.
+     * @param viewed
+     *            Pass <code>true</code> to load the rendering settings related
+     *            to the objects, <code>false<code> otherwise.
      * @return The {@link BatchCall}.
      */
     private BatchCall loadStructuredData(final List<DataObject> data,
-            final long userID, final boolean viewed)
-    {
+            final long userID) {
         return new BatchCall("Loading Structured Data") {
-            public void doCall() throws Exception
-            {
+            public void doCall() throws Exception {
                 OmeroMetadataService os = context.getMetadataService();
-                result = os.loadStructuredData(ctx, data, userID, viewed);
+                result = os.loadStructuredData(ctx, data, userID);
             }
         };
     }
@@ -232,14 +192,13 @@ public class StructuredAnnotationLoader
     /**
      * Creates a {@link BatchCall} to load the specified annotation.
      * 
-     * @param annotationID The id of the annotation to load.
+     * @param annotationID
+     *            The id of the annotation to load.
      * @return The {@link BatchCall}.
      */
-    private BatchCall loadAnnotation(final long annotationID)
-    {
+    private BatchCall loadAnnotation(final long annotationID) {
         return new BatchCall("Loading Annotation") {
-            public void doCall() throws Exception
-            {
+            public void doCall() throws Exception {
                 OmeroMetadataService os = context.getMetadataService();
                 result = os.loadAnnotation(ctx, annotationID);
             }
@@ -247,85 +206,51 @@ public class StructuredAnnotationLoader
     }
 
     /**
-     * Creates a {@link BatchCall} to load the ratings related to the object
-     * identified by the class and the id.
-     * 
-     * @param type The type of the object.
-     * @param ids The collection of id of the object.
-     * @param userID The id of the user who tagged the object or
-     *            <code>-1</code> if the user is not specified.
-     * @return The {@link BatchCall}.
-     */
-    private BatchCall loadRatings(final Class type, final List<Long> ids,
-            final long userID)
-    {
-        return new BatchCall("Loading Ratings") {
-            public void doCall() throws Exception
-            {
-                OmeroMetadataService os = context.getMetadataService();
-                result = os.loadRatings(ctx, type, ids, userID);
-            }
-        };
-    }
-
-    /**
      * Adds the {@link #loadCall} to the computation tree.
+     * 
      * @see BatchCallTree#buildTree()
      */
-    protected void buildTree() { add(loadCall); }
+    protected void buildTree() {
+        add(loadCall);
+    }
 
     /**
      * Returns, in a <code>Set</code>, the root nodes of the found trees.
+     * 
      * @see BatchCallTree#getResult()
      */
-    protected Object getResult() { return result; }
+    protected Object getResult() {
+        return result;
+    }
 
-    /**
-     * Creates a new instance. Builds the call corresponding to the passed
-     * index, throws an {@link IllegalArgumentException} if the index is not
-     * supported.
-     * 
-     * @param ctx The security context.
-     * @param index The index identifying the call. One of the constants
-     *              defined by this class.
-     * @param type The type of node the annotations are related to.
-     * @param ids Collection of the id of the object.
-     * @param userID The id of the user or <code>-1</code> if the id 
-     *               is not specified.
-     */
-    public StructuredAnnotationLoader(SecurityContext ctx, int index,
-            Class type, List<Long> ids, long userID)
-    {
+    public StructuredAnnotationLoader(SecurityContext ctx,
+            EnumSet<AnnotationType> types, List<DataObject> data, long userID) {
         this.ctx = ctx;
-        switch (index) {
-            case RATING:
-                loadCall = loadRatings(type, ids, userID);
-                break;
-            default:
-                throw new IllegalArgumentException("Index not supported.");
+        if (types == null) {
+            loadCall = loadStructuredData(data, userID);
+        }
+        else {
+            Class objType = null;
+            List<Long> ids = new ArrayList<Long>(data.size());
+            for (DataObject obj : data) {
+                if (objType == null)
+                    objType = obj.getClass();
+                else if (!objType.equals(obj.getClass()))
+                    throw new IllegalArgumentException(
+                            "The passed objects must be of the same type!");
+                ids.add(obj.getId());
+            }
+
+            loadCall = loadSpecifiedAnnotationLinkedTo(objType, ids, types,
+                    null, null);
         }
     }
 
-    /**
-     * Creates a new instance.
-     * 
-     * @param ctx The security context.
-     * @param index The index identifying the call. One of the constants
-     * defined by this class.
-     * @param userID The id of the user or <code>-1</code> if the id
-     * is not specified.
-     * @param data The collection of data objects to handle.
-     * @param viewed Pass <code>true</code> to load the rendering settings
-     *               related to the objects, <code>false<code> otherwise.
-     */
-    public StructuredAnnotationLoader(SecurityContext ctx, int index,
-            List<DataObject> data, long userID, boolean viewed)
-    {
+    public StructuredAnnotationLoader(SecurityContext ctx,
+            AnnotationType annotationType, long userID) {
         this.ctx = ctx;
-        switch (index) {
-            case ALL:
-                loadCall = loadStructuredData(data, userID, viewed);
-        }
+        loadCall = loadAnnotations(Collections.singletonList(ctx),
+                annotationType, userID);
     }
 
     /**
@@ -333,67 +258,12 @@ public class StructuredAnnotationLoader
      * index, throws an {@link IllegalArgumentException} if the index is not
      * supported.
      * 
-     * @param ctx The security context.
-     * @param index The index identifying the call. One of the constants
-     *              defined by this class.
-     * @param object The object to handle.
-     * @param userID The id of the user or <code>-1</code> if the id is not
-     *               specified.
+     * @param ctx
+     *            The security context.
+     * @param annotationID
+     *            The Id of the annotation to load.
      */
-    public StructuredAnnotationLoader(SecurityContext ctx, int index,
-            Object object, long userID)
-    {
-        if (object == null)
-            throw new IllegalArgumentException("Object not defined.");
-        this.ctx = ctx;
-        switch (index) {
-            case ALL:
-                loadCall = loadStructuredData(object, userID);
-                break;
-            case RATING:
-                if (object instanceof DataObject) {
-                    DataObject ho = (DataObject) object;
-                    loadCall = loadRatings(object.getClass(), ho.getId(),
-                            userID);
-                }
-                break;
-            case ROI_MEASUREMENT:
-                DataObject ho = (DataObject) object;
-                loadCall = loadROIMeasurements(object.getClass(), ho.getId(),
-                        userID);
-                break;
-            default:
-                throw new IllegalArgumentException("Index not supported.");
-        }
-    }
-
-    /**
-     * Creates a new instance. Builds the call corresponding to the passed
-     * index, throws an {@link IllegalArgumentException} if the index is not
-     * supported.
-     * 
-     * @param ctx The security context.
-     * @param annotationType The type of annotations to fetch.
-     * @param userID The id of the user or <code>-1</code> if the id 
-     *               is not specified.
-     */
-    public StructuredAnnotationLoader(SecurityContext ctx, Class annotationType,
-            long userID)
-    {
-        this.ctx = ctx;
-        loadCall = loadAnnotations(annotationType, userID);
-    }
-
-    /**
-     * Creates a new instance. Builds the call corresponding to the passed
-     * index, throws an {@link IllegalArgumentException} if the index is not
-     * supported.
-     * 
-     * @param ctx The security context.
-     * @param annotationID The Id of the annotation to load.
-     */
-    public StructuredAnnotationLoader(SecurityContext ctx, long annotationID)
-    {
+    public StructuredAnnotationLoader(SecurityContext ctx, long annotationID) {
         this.ctx = ctx;
         loadCall = loadAnnotation(annotationID);
     }
@@ -403,35 +273,40 @@ public class StructuredAnnotationLoader
      * index, throws an {@link IllegalArgumentException} if the index is not
      * supported.
      * 
-     * @param ctx The security context.
-     * @param annotationType The type of annotations to fetch.
-     * @param userID The id of the user or <code>-1</code> if the id 
-     *               is not specified.
+     * @param ctx
+     *            The security context.
+     * @param annotationType
+     *            The type of annotations to fetch.
+     * @param userID
+     *            The id of the user or <code>-1</code> if the id is not
+     *            specified.
      */
     public StructuredAnnotationLoader(List<SecurityContext> ctx,
-            Class annotationType, long userID)
-    {
+            AnnotationType annotationType, long userID) {
         loadCall = loadAnnotations(ctx, annotationType, userID);
     }
 
     /**
      * Creates a new instance.
      * 
-     * @param ctx The security context.
-     * @param rootType The type of object the annotations are linked to e.g.
-     *                 Image.
-     * @param rootIDs The collection of object's ids the annotations are linked
-     *                to.
-     * @param annotationType The type of annotation to load.
-     * @param nsInclude The annotation's name space to include if any.
-     * @param nsExlcude The annotation's name space to exclude if any.
+     * @param ctx
+     *            The security context.
+     * @param rootType
+     *            The type of object the annotations are linked to e.g. Image.
+     * @param rootIDs
+     *            The collection of object's ids the annotations are linked to.
+     * @param annotationTypes
+     *            The type of annotations to load.
+     * @param nsInclude
+     *            The annotation's name space to include if any.
+     * @param nsExlcude
+     *            The annotation's name space to exclude if any.
      */
     public StructuredAnnotationLoader(SecurityContext ctx, Class<? extends DataObject> rootType,
-            List<Long> rootIDs, Class<?> annotationType, List<String> nsInclude,
-            List<String> nsExlcude)
-    {
+            List<Long> rootIDs, EnumSet<AnnotationType> annotationTypes,
+            List<String> nsInclude, List<String> nsExlcude) {
         this.ctx = ctx;
-        loadCall = loadSpeficiedAnnotationLinkedTo(rootType, rootIDs,
-                annotationType, nsInclude, nsExlcude);
+        loadCall = loadSpecifiedAnnotationLinkedTo(rootType, rootIDs,
+                annotationTypes, nsInclude, nsExlcude);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -23,6 +23,7 @@ package org.openmicroscopy.shoola.env.data.views.calls;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class StructuredAnnotationLoader extends BatchCallTree {
             final List<String> nsInclude, final List<String> nsExlcude) {
         return new BatchCall("Loading Specified Annotations") {
             public void doCall() throws Exception {
-                
+
                 for (AnnotationType annotationType : annotationTypes) {
                     if (annotationType.getPojoClass() != null) {
                         OmeroMetadataService os = context.getMetadataService();
@@ -113,7 +114,7 @@ public class StructuredAnnotationLoader extends BatchCallTree {
             }
         };
     }
-
+    
     /**
      * Creates a {@link BatchCall} to load the existing annotations of the
      * specified type related to the passed type of object.
@@ -149,26 +150,6 @@ public class StructuredAnnotationLoader extends BatchCallTree {
      * Creates a {@link BatchCall} to load the ratings related to the object
      * identified by the class and the id.
      * 
-     * @param object
-     *            The type of the object.
-     * @param userID
-     *            The id of the user who tagged the object or <code>-1</code> if
-     *            the user is not specified.
-     * @return The {@link BatchCall}.
-     */
-    private BatchCall loadStructuredData(final Object object, final long userID) {
-        return new BatchCall("Loading Structured Data") {
-            public void doCall() throws Exception {
-                OmeroMetadataService os = context.getMetadataService();
-                result = os.loadStructuredData(ctx, object, userID);
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link BatchCall} to load the ratings related to the object
-     * identified by the class and the id.
-     * 
      * @param data
      *            The objects.
      * @param userID
@@ -185,6 +166,31 @@ public class StructuredAnnotationLoader extends BatchCallTree {
             public void doCall() throws Exception {
                 OmeroMetadataService os = context.getMetadataService();
                 result = os.loadStructuredData(ctx, data, userID);
+            }
+        };
+    }
+    
+    /**
+     * Creates a {@link BatchCall} to load the ratings related to the object
+     * identified by the class and the id.
+     * 
+     * @param data
+     *            The objects.
+     * @param types The types of annotations to load
+     * @param userID
+     *            The id of the user who tagged the object or <code>-1</code> if
+     *            the user is not specified.
+     * @param viewed
+     *            Pass <code>true</code> to load the rendering settings related
+     *            to the objects, <code>false<code> otherwise.
+     * @return The {@link BatchCall}.
+     */
+    private BatchCall loadStructuredData(final List<DataObject> data, EnumSet<AnnotationType> types,
+            final long userID) {
+        return new BatchCall("Loading Structured Data") {
+            public void doCall() throws Exception {
+                OmeroMetadataService os = context.getMetadataService();
+                result = os.loadStructuredData(ctx, data, types, userID);
             }
         };
     }
@@ -223,6 +229,13 @@ public class StructuredAnnotationLoader extends BatchCallTree {
         return result;
     }
 
+    /**
+     * Creates a new instance
+     * @param ctx The {@link SecurityContext}
+     * @param types The types of annotations to load
+     * @param data The object to load the annotations for
+     * @param userID The user id
+     */
     public StructuredAnnotationLoader(SecurityContext ctx,
             EnumSet<AnnotationType> types, List<DataObject> data, long userID) {
         this.ctx = ctx;
@@ -241,11 +254,17 @@ public class StructuredAnnotationLoader extends BatchCallTree {
                 ids.add(obj.getId());
             }
 
-            loadCall = loadSpecifiedAnnotationLinkedTo(objType, ids, types,
-                    null, null);
+            loadCall = loadStructuredData(data, types, userID);
         }
     }
 
+    /**
+     * Creates a new instance
+     * @param ctx The {@link SecurityContext}
+     * @param annotationType The type of annotations to load
+     * @param userID The user id
+     * 
+     */
     public StructuredAnnotationLoader(SecurityContext ctx,
             AnnotationType annotationType, long userID) {
         this.ctx = ctx;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/StructuredAnnotationLoader.java
@@ -185,7 +185,7 @@ public class StructuredAnnotationLoader extends BatchCallTree {
      *            to the objects, <code>false<code> otherwise.
      * @return The {@link BatchCall}.
      */
-    private BatchCall loadStructuredData(final List<DataObject> data, EnumSet<AnnotationType> types,
+    private BatchCall loadStructuredData(final List<DataObject> data, final EnumSet<AnnotationType> types,
             final long userID) {
         return new BatchCall("Loading Structured Data") {
             public void doCall() throws Exception {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/PojosUtil.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,10 @@
  */
 
 package org.openmicroscopy.shoola.util;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
@@ -120,4 +124,40 @@ public class PojosUtil {
 
         return false;
     }
+    
+    /**
+     * Generates a Set of unique identifiers of the passed Collection of
+     * {@link DataObject}s, taking the concrete type of the {@link DataObject}s
+     * into account
+     * 
+     * See also {@link DataObject#getUniqueId()}
+     * @param pojos
+     *            The Collection of {@link DataObject}s
+     * @return See above
+     */
+    public static Set<String> getUniqueIdentifiers(
+            Collection<? extends DataObject> pojos) {
+        Set<String> ids = new HashSet<String>();
+        for (DataObject o : pojos) {
+            ids.add(o.getUniqueId());
+        }
+        return ids;
+    }
+
+    /**
+     * Checks if the given {@link DataObject} a is part of the given Collection
+     * b, taking the concrete type and id of the DataObject into account
+     * 
+     * @param a
+     *            The Collection to check
+     * @param b
+     *            The {@link DataObject} to check
+     * @return <code>true</code> if the object is part of the collection,
+     *         <code>false</code> if it is not.
+     */
+    public static boolean contains(Collection<? extends DataObject> a,
+            DataObject b) {
+        return getUniqueIdentifiers(a).contains(b.getUniqueId());
+    }
+    
 }


### PR DESCRIPTION
(Can't get Travis to pass, open this cherry-picked PR instead,  #4654)

Up to now whenever an object is selected all annotations for this object are loaded. As we now have the different taskpanes on the right hand side metadata panel, which are closed by default, this is not necessary any more. With this PR only the specific annotations are loaded on demand, i.e when a taskpane is expanded. While the annotations are loaded from the server, the expanded taskpane displays a simple "Loading..." label.

I started this more as a kind of proof of concept, but it turned into a quite extensive PR. Which means there's a risk that it'll break something and needs a lot of testing (basically everything annotation related). Is it worth it? Taking into account, that this PR won't add a noticeable performance increase in most cases, only for data objects with a very large amount of annotations attached to them.

--exclude Not intended for 5.3.0-m3 build