### PR TITLE
Insight Bugfixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserFactory.java
@@ -142,7 +142,7 @@ public class DataBrowserFactory
 	 */
 	public static final DataBrowser getWellsDataBrowser(
 			SecurityContext ctx, Map<Class, Object> ancestors, Object parent,
-			Set<WellData> wells, boolean withThumbnails)
+			Collection<WellData> wells, boolean withThumbnails)
 	{
 		return singleton.createWellsDataBrowser(ctx, ancestors, parent, wells,
 				withThumbnails);
@@ -503,7 +503,7 @@ public class DataBrowserFactory
 	 */
 	private DataBrowser createWellsDataBrowser(SecurityContext ctx,
 			Map<Class, Object> ancestors,
-			Object parent, Set<WellData> wells, boolean withThumbnails)
+			Object parent, Collection<WellData> wells, boolean withThumbnails)
 	{
 		Object p = parent;
 		Object go = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
@@ -232,7 +232,7 @@ class WellsModel
 	 * @param withThumbnails Pass <code>true</code> to load the thumbnails,
      * 						 <code>false</code> otherwise.
 	 */
-	WellsModel(SecurityContext ctx, Object parent, Set<WellData> wells, 
+	WellsModel(SecurityContext ctx, Object parent, Collection<WellData> wells, 
 			boolean withThumbnails)
 	{
 		super(ctx);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -336,7 +336,6 @@ class EditorComponent
 			return;
 		}
 		showSelectionWizard(TagAnnotationData.class, available, selected, true);
-		setStatus(false);
 	}
 
 	/** 
@@ -444,7 +443,6 @@ class EditorComponent
 		}
 		showSelectionWizard(FileAnnotationData.class, available, selected,
 							true);
-		setStatus(false);
 	}
 	
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -608,7 +608,10 @@ class EditorControl
 				view.handleObjectsSelection(type, 
 						(Collection) entry.getValue());
 			}
-		} else if (MetadataViewer.SETTINGS_APPLIED_PROPERTY.equals(name)) {
+		} else if (SelectionWizard.CANCEL_SELECTION_PROPERTY.equals(name)) {
+		    view.setStatus(false);
+		}
+		else if (MetadataViewer.SETTINGS_APPLIED_PROPERTY.equals(name)) {
 			model.loadRenderingControl(RenderingControlLoader.RELOAD);
 			view.onSettingsApplied(true);
 		} else if (MetadataViewer.ACTIVITY_OPTIONS_PROPERTY.equals(name)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorUI.java
@@ -393,6 +393,7 @@ class EditorUI
 			metadata = acquisitionPane.prepareDataToSave();
 
 		model.fireAnnotationSaving(object, metadata, async);
+		toolBar.setStatus(true);
 	}
 
 	/** Shows the image's info. */
@@ -612,7 +613,9 @@ class EditorUI
 	 */
 	void handleObjectsSelection(Class<?> type, Collection objects)
 	{
-		if (objects == null) return;
+		if (objects == null)
+		    return;
+		
 		List<Object> selection = new ArrayList<Object>();
 		if (CollectionUtils.isNotEmpty(objects)) {
 		    selection.addAll(objects);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -434,23 +434,29 @@ class GeneralPaneUI extends JPanel
             
             String ownerName = model.getOwnerName();
             ownerLabel.setText("");
-            if(multi) {
-                // on multiselection 'misuse' the owner label to indicate
-                // that the user can still annotate the objects
-                StringBuffer buffer = new StringBuffer();
-                buffer.append("Annotate the selected ");
-                buffer.append(model.getObjectTypeAsString(refObject));
-                buffer.append("s");
-                ownerLabel.setText(buffer.toString());
+            filterButton.setVisible(true);
+            if (multi) {
+                if (!(refObject instanceof TagAnnotationData)) {
+                    // on multiselection 'misuse' the owner label to indicate
+                    // that the user can still annotate the objects
+                    StringBuffer buffer = new StringBuffer();
+                    buffer.append("Annotate the selected ");
+                    buffer.append(model.getObjectTypeAsString(refObject));
+                    buffer.append("s");
+                    ownerLabel.setText(buffer.toString());
+                }
+                else {
+                    filterButton.setVisible(false);
+                }
+                
             }
             else if (ownerName != null && ownerName.length() > 0) {
                 ownerLabel.setText(OWNER_TEXT+ownerName);
             }
             
             propertiesUI.buildUI();
-            Object ho = model.getRefObject();
-            boolean visible = !(ho instanceof TagAnnotationData) ||
-                    (ho instanceof FileAnnotationData);
+            boolean visible = !(refObject instanceof TagAnnotationData) ||
+                    (refObject instanceof FileAnnotationData);
 
             tagsTaskPane.setVisible(visible);
             roiTaskPane.setVisible(visible);
@@ -591,8 +597,6 @@ class GeneralPaneUI extends JPanel
 	 */
 	void setRootObject(Object oldObject)
 	{
-	    System.out.println(System.currentTimeMillis()+" setRootObject "+oldObject);
-	    
 		if (!init) {
 			buildGUI();
 			init = true;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -448,31 +448,29 @@ class GeneralPaneUI extends JPanel
             }
             
             propertiesUI.buildUI();
-            boolean visible = true;
             Object ho = model.getRefObject();
-            if ((ho instanceof TagAnnotationData) ||
-                    (ho instanceof FileAnnotationData)) {
-                visible = false;
-                tagsTaskPane.setVisible(false);
-                roiTaskPane.setVisible(false);
-                mapTaskPane.setVisible(false);
-                attachmentTaskPane.setVisible(false);
-                ratingTaskPane.setVisible(false);
-                commentTaskPane.setVisible(false);
-                otherTaskPane.setVisible(false);
-            } else {
+            boolean visible = !(ho instanceof TagAnnotationData) ||
+                    (ho instanceof FileAnnotationData);
+
+            tagsTaskPane.setVisible(visible);
+            roiTaskPane.setVisible(visible);
+            mapTaskPane.setVisible(visible && !multi);
+            attachmentTaskPane.setVisible(visible);
+            ratingTaskPane.setVisible(visible);
+            commentTaskPane.setVisible(visible);
+            otherTaskPane.setVisible(visible
+                    && !model.getAllOtherAnnotations().isEmpty());
+    
+            if (visible) {
                 tagsTaskPane.refreshUI();
                 roiTaskPane.refreshUI();
                 mapTaskPane.refreshUI();
                 attachmentTaskPane.refreshUI();
                 ratingTaskPane.refreshUI();
                 commentTaskPane.refreshUI();
-
-                otherTaskPane.setVisible(
-                        !model.getAllOtherAnnotations().isEmpty());
                 otherTaskPane.refreshUI();
             }
-
+            
             propertiesTaskPane.setTitle(propertiesUI.getText() + DETAILS);
            
             boolean showBrowser = false;
@@ -506,9 +504,7 @@ class GeneralPaneUI extends JPanel
             namePane.setVisible(!multi);
             idLabel.setVisible(!multi);
             propertiesTaskPane.setVisible(!multi);
-            if (visible) {
-                mapTaskPane.setVisible(!multi);
-            }
+ 
             revalidate();
         }
 	
@@ -595,6 +591,8 @@ class GeneralPaneUI extends JPanel
 	 */
 	void setRootObject(Object oldObject)
 	{
+	    System.out.println(System.currentTimeMillis()+" setRootObject "+oldObject);
+	    
 		if (!init) {
 			buildGUI();
 			init = true;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GeneralPaneUI.java
@@ -436,7 +436,8 @@ class GeneralPaneUI extends JPanel
             ownerLabel.setText("");
             filterButton.setVisible(true);
             if (multi) {
-                if (!(refObject instanceof TagAnnotationData)) {
+                if (!(refObject instanceof TagAnnotationData) && 
+                        !(refObject instanceof FileAnnotationData)) {
                     // on multiselection 'misuse' the owner label to indicate
                     // that the user can still annotate the objects
                     StringBuffer buffer = new StringBuffer();
@@ -455,8 +456,8 @@ class GeneralPaneUI extends JPanel
             }
             
             propertiesUI.buildUI();
-            boolean visible = !(refObject instanceof TagAnnotationData) ||
-                    (refObject instanceof FileAnnotationData);
+            boolean visible = !(refObject instanceof TagAnnotationData) &&
+                    !(refObject instanceof FileAnnotationData);
 
             tagsTaskPane.setVisible(visible);
             roiTaskPane.setVisible(visible);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerModel.java
@@ -300,7 +300,7 @@ class MetadataViewerModel
 	 */
 	void discard()
 	{
-		state = MetadataViewer.DISCARDED;
+		setState(MetadataViewer.DISCARDED);
 		loaders.entrySet().iterator();
 		Iterator<Entry<Integer, MetadataLoader>>
 		i = loaders.entrySet().iterator();
@@ -459,7 +459,7 @@ class MetadataViewerModel
 					ctx, Arrays.asList((DataObject) node), loaderID);
 			loaders.put(loaderID, loader);
 			loader.load();
-			state = MetadataViewer.LOADING_METADATA;
+			setState(MetadataViewer.LOADING_METADATA);
 		}
 	}
 	
@@ -595,6 +595,9 @@ class MetadataViewerModel
      */
     void fireSaving(DataToSave object, List<Object> metadata,
             Collection<DataObject> data, boolean asynch) {
+        if(state != MetadataViewer.READY) {
+            return;
+        }
         List<AnnotationData> toAdd = null;
         List<Object> toRemove = null;
         if (object != null) {
@@ -607,7 +610,7 @@ class MetadataViewerModel
             loaderID++;
             loaders.put(loaderID, loader);
             loader.load();
-            state = MetadataViewer.SAVING;
+            setState(MetadataViewer.SAVING);
         } else {
             OmeroMetadataService os = MetadataViewerAgent.getRegistry()
                     .getMetadataService();
@@ -660,7 +663,7 @@ class MetadataViewerModel
 	            data, loaderID);
 	    loaders.put(loaderID, loader);
 	    loader.load();
-	    state = MetadataViewer.SAVING;
+	    setState(MetadataViewer.SAVING);
 	}
 	
 	/**
@@ -702,7 +705,7 @@ class MetadataViewerModel
                         data.getPermissions(), loaderID, GroupEditor.UPDATE);
                 loaders.put(loaderID, loader);
                 loader.load();
-                state = MetadataViewer.SAVING;
+                setState(MetadataViewer.SAVING);
                 break;
             case AdminObject.UPDATE_EXPERIMENTER:
                 loaderID++;
@@ -710,7 +713,7 @@ class MetadataViewerModel
                         data.getExperimenters(), loaderID);
                 loaders.put(loaderID, loader);
                 loader.load();
-                state = MetadataViewer.SAVING;
+                setState(MetadataViewer.SAVING);
         }
 	}
 	
@@ -725,7 +728,7 @@ class MetadataViewerModel
 	{
 		loaders.remove(loaderID);
 		this.data = data;
-		state = MetadataViewer.READY;
+		setState(MetadataViewer.READY);
 	}
 	
 	/**
@@ -739,7 +742,7 @@ class MetadataViewerModel
 	{
 		loaders.remove(loaderID);
 		this.parentData = parentData;
-		state = MetadataViewer.READY;
+		setState(MetadataViewer.READY);
 	}
 	
 	/**
@@ -806,7 +809,7 @@ class MetadataViewerModel
 				toSave, toAdd, toRemove, loaderID);
 		loader.load();
 		loaderID++;
-		state = MetadataViewer.BATCH_SAVING;
+		setState(MetadataViewer.BATCH_SAVING);
 	}
 	
 	/** 
@@ -852,7 +855,7 @@ class MetadataViewerModel
 	            ctx, l, loaderID);
 	    loaders.put(loaderID, loader);
 	    loader.load();
-	    state = MetadataViewer.LOADING_METADATA;
+	    setState(MetadataViewer.LOADING_METADATA);
 	}
 
 	/**
@@ -862,12 +865,17 @@ class MetadataViewerModel
 	 */
 	List<DataObject> getRelatedNodes() { return relatedNodes; }
 
-	/**
-	 * Sets the state.
-	 * 
-	 * @param state The value to set.
-	 */
-	void setState(int state) { this.state = state; }
+    /**
+     * Sets the state.
+     * 
+     * @param state
+     *            The value to set.
+     */
+    void setState(int state) {
+        this.state = state;
+        if(state==MetadataViewer.READY || state==MetadataViewer.DISCARDED)
+            editor.setStatus(false);
+    }
 
 	/**
 	 * Starts an asynchronous retrieval of the containers hosting the 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/PlateWellsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/PlateWellsLoader.java
@@ -20,6 +20,7 @@
  */
 package org.openmicroscopy.shoola.agents.treeviewer;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -30,8 +31,11 @@ import java.util.Map.Entry;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageSet;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.PlateData;
@@ -135,13 +139,13 @@ public class PlateWellsLoader
     {
         if (viewer.getState() == TreeViewer.DISCARDED) return;  //Async cancel.
         Map m = (Map) result;
-        Map<TreeImageSet, Set> plates = new HashMap<TreeImageSet, Set>();
+        Map<TreeImageSet, Collection> plates = new HashMap<TreeImageSet, Collection>();
         
         Iterator i = m.entrySet().iterator();
         Entry entry;
         while (i.hasNext()) {
 			entry = (Entry) i.next();
-			plates.put(nodes.get(entry.getKey()), (Set) entry.getValue());
+			plates.put(nodes.get(entry.getKey()), (Collection) entry.getValue());
 		}
         viewer.setPlates(plates, withThumbnails);
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ProjectsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/ProjectsLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,13 +22,16 @@ package org.openmicroscopy.shoola.agents.treeviewer;
 
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
+
 import omero.gateway.model.ProjectData;
 
 /** 
@@ -102,7 +105,7 @@ public class ProjectsLoader
     public void handleResult(Object result)
     {
         if (viewer.getState() == TreeViewer.DISCARDED) return;  //Async cancel.
-        viewer.browseHierarchyRoots(node, (Set) result);
+        viewer.browseHierarchyRoots(node, (Collection) result);
     }
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TimeIntervalsLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TimeIntervalsLoader.java
@@ -23,15 +23,18 @@
 package org.openmicroscopy.shoola.agents.treeviewer;
 
 //Java imports
-import java.util.Set;
+import java.util.Collection;
 
 //Third-party libraries
+
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageTimeSet;
 import org.openmicroscopy.shoola.env.data.model.TimeRefObject;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 /** 
@@ -102,7 +105,7 @@ public class TimeIntervalsLoader
     public void handleResult(Object result)
     {
         if (viewer.getState() == TreeViewer.DISCARDED) return;  //Async cancel.
-        viewer.browseTimeInterval(node, (Set) result);
+        viewer.browseTimeInterval(node, (Collection) result);
     }
     
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewer.java
@@ -802,7 +802,7 @@ public interface TreeViewer
 	 * @param node The node holding the time information.
 	 * @param set  The elements to add.
 	 */
-	public void browseTimeInterval(TreeImageTimeSet node, Set set);
+	public void browseTimeInterval(TreeImageTimeSet node, Collection set);
 
 	/**
 	 * Sets the wells linked to the specified plates.
@@ -811,7 +811,7 @@ public interface TreeViewer
 	 * @param withThumbnails Pass <code>true</code> to load the thumbnails,
      * 						 <code>false</code> otherwise.
 	 */
-	public void setPlates(Map<TreeImageSet, Set> plates, boolean withThumbnails);
+	public void setPlates(Map<TreeImageSet, Collection> plates, boolean withThumbnails);
 
 	/**
 	 * Browses the passed node.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3233,9 +3233,9 @@ class TreeViewerComponent
 
 	/**
 	 * Implemented as specified by the {@link TreeViewer} interface.
-	 * @see TreeViewer#browseTimeInterval(TreeImageTimeSet, Set)
+	 * @see TreeViewer#browseTimeInterval(TreeImageTimeSet, Collection)
 	 */
-	public void browseTimeInterval(TreeImageTimeSet parent, Set leaves)
+	public void browseTimeInterval(TreeImageTimeSet parent, Collection leaves)
 	{
 		if (leaves == null) return;
 		
@@ -3268,7 +3268,7 @@ class TreeViewerComponent
 	 * Implemented as specified by the {@link TreeViewer} interface.
 	 * @see TreeViewer#setPlates(Map, boolean)
 	 */
-	public void setPlates(Map<TreeImageSet, Set> plates, boolean withThumbnails)
+	public void setPlates(Map<TreeImageSet, Collection> plates, boolean withThumbnails)
 	{
 		if (plates == null || plates.size() == 0) {
 			return;
@@ -3305,7 +3305,7 @@ class TreeViewerComponent
 				
 				db = DataBrowserFactory.getWellsDataBrowser(
 						model.getSecurityContext(parent), m, parentObject, 
-						(Set) entry.getValue(), withThumbnails);
+						(Collection) entry.getValue(), withThumbnails);
 			}
 		}
 		if (db != null) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeViewerTranslator.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeViewerTranslator.java
@@ -676,7 +676,7 @@ public class TreeViewerTranslator
         Entry entry;
         Iterator i = set.iterator();
         TreeImageDisplay node;
-        Set results;
+        Collection results;
         Iterator j;
         DataObject ho;
         Set<TreeImageDisplay> converted;
@@ -684,7 +684,7 @@ public class TreeViewerTranslator
             entry = (Entry) i.next();
             node = (TreeImageDisplay) entry.getKey();
             if (node instanceof TreeImageTimeSet) {
-                results = (Set) entry.getValue();
+                results = (Collection) entry.getValue();
                 converted = new HashSet<TreeImageDisplay>(results.size());
                 j = results.iterator();
                 while (j.hasNext()) {
@@ -694,7 +694,7 @@ public class TreeViewerTranslator
                 }
                 r.put(((TreeImageTimeSet) node).getIndex(), converted);
             } else if (node instanceof TreeFileSet) {
-                results = (Set) entry.getValue();
+                results = (Collection) entry.getValue();
                 converted = new HashSet<TreeImageDisplay>(results.size());
                 j = results.iterator();
                 while (j.hasNext()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/DMRefreshLoader.java
@@ -100,7 +100,7 @@ public class DMRefreshLoader
         Class klass;
         Map topNodes;
         DataObject child, parent;
-        Set s;
+        Collection s;
         Entry<SecurityContext, List> entry;
         SecurityContext ctx;
         TimeRefObject ref;
@@ -115,8 +115,8 @@ public class DMRefreshLoader
         		result = os.loadContainerHierarchy(ctx, rootNodeType, null, 
                 		false, ctx.getExperimenter());
         		if (mapResult.containsKey(ctx)) {
-        			s = (Set) mapResult.get(userID);
-        			s.addAll((Set) result);
+        			s = (Collection) mapResult.get(userID);
+        			s.addAll((Collection) result);
         		} else {
         			mapResult.put(ctx, result);
         		}


### PR DESCRIPTION
# What this PR does

Some bug fixes for Insight, see [Trello - Insight Bugs](https://trello.com/c/1gwgUlz9/165-insight-bugs)

- Fixed a ClassCastException (1)
- Fixed multiple save actions when selection changes (2)
- Fixed disappearing Annotation task panes when the view was changed to Tags and/or Attachment view (3)

# Testing this PR

- Bugfix 1: Search for an image which is part of a project. Expand the "Located in" tab in preview panel, click on the project. The project should open, no exception thrown.
- Bugfix 2: Attach some (newly created) tags to multiple images (> 200, so that the tagging action takes a while). Immediately switch to the "Tags" view (left hand side panel). Refresh the view until all images have been tagged, ie tagging action finished. Make sure the tags only were created once (no duplicates with same name).
- Do the same again, but now don't switch the view, just watch the right hand side metadata panel. The loading/saving spinner should keep spinning until the action has been completed. Before there was no feedback about the ongoing tagging action.
- Bugfix 3: Go to "Tags" view. Expand a Tag. Select a tag: The right hand side metadata panel will be reduced, no annotation task panes should be shown. Select an image. The metadata panel should now show the annotation task panes again. 


