### PR TITLE
have OmeroReader populate channel colors

### DIFF
--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -55,6 +55,7 @@ import omero.RString;
 import omero.RTime;
 import omero.ServerError;
 import omero.api.IAdminPrx;
+import omero.api.IPixelsPrx;
 import omero.api.RawPixelsStorePrx;
 import omero.api.RoiOptions;
 import omero.api.RoiResult;
@@ -320,7 +321,8 @@ public class OmeroReader extends FormatReader {
 
             long pixelsId = img.getPixels(0).getId().getValue();
 
-            pix = serviceFactory.getPixelsService().retrievePixDescription(pixelsId);
+            final IPixelsPrx iPixels = serviceFactory.getPixelsService();
+            pix = iPixels.retrievePixDescription(pixelsId);
             store.setPixelsId(pixelsId, false);
 
             final int sizeX = pix.getSizeX().getValue();

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -61,6 +61,7 @@ import omero.api.RoiOptions;
 import omero.api.RoiResult;
 import omero.api.ServiceFactoryPrx;
 import omero.model.Channel;
+import omero.model.ChannelBinding;
 import omero.model.EllipseI;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
@@ -76,6 +77,7 @@ import omero.model.PolygonI;
 import omero.model.PolylineI;
 import omero.model.RectangleI;
 import omero.model.MaskI;
+import omero.model.RenderingDef;
 import omero.model.Roi;
 import omero.model.Shape;
 import omero.model.Time;
@@ -407,13 +409,36 @@ public class OmeroReader extends FormatReader {
                 store.setPixelsTimeIncrement(t2, 0);
             }
 
+            final RenderingDef renderingSettings;
+            if (isUseRenderingSettings) {
+                renderingSettings = iPixels.retrieveRndSettings(pixelsId);
+            } else {
+                renderingSettings = null;
+            }
+            final List<ChannelBinding> channelBindings;
+            if (renderingSettings != null) {
+                channelBindings = renderingSettings.copyWaveRendering();
+            } else {
+                channelBindings = null;
+            }
+
             List<Channel> channels = pix.copyChannels();
             for (int c=0; c<channels.size(); c++) {
                 final Channel channel = channels.get(c);
-                final RInt red = channel.getRed();
-                final RInt green = channel.getGreen();
-                final RInt blue = channel.getBlue();
-                final RInt alpha = channel.getAlpha();
+
+                final RInt red, green, blue, alpha;
+                if (channelBindings == null) {
+                    red = channel.getRed();
+                    green = channel.getGreen();
+                    blue = channel.getBlue();
+                    alpha = channel.getAlpha();
+                } else {
+                    final ChannelBinding waveRendering = channelBindings.get(c);
+                    red = waveRendering.getRed();
+                    green = waveRendering.getGreen();
+                    blue = waveRendering.getBlue();
+                    alpha = waveRendering.getAlpha();
+                }
                 if (red != null && green != null && blue != null) {
                     final Color color;
                     if (alpha == null) {

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -103,6 +103,7 @@ public class OmeroReader extends FormatReader {
     private String sessionID;
     private String group;
     private Long groupID = null;
+    private boolean isUseRenderingSettings = false;
     private boolean encrypted = true;
 
     private omero.client client;
@@ -148,6 +149,15 @@ public class OmeroReader extends FormatReader {
 
     public void setGroupID(Long groupID) {
         this.groupID = groupID;
+    }
+
+    /**
+     * If rendering settings should be used to complement other metadata, e.g., for channel color.
+     * Defaults to {@code false}.
+     * @param isUseRenderingSettings if to use rendering settings
+     */
+    public void setUseRenderingSettings(boolean isUseRenderingSettings) {
+        this.isUseRenderingSettings = isUseRenderingSettings;
     }
 
     // -- IFormatReader methods --

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME database I/O package for communicating with OME and OMERO servers.
  * %%
- * Copyright (C) 2005 - 2013 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
@@ -47,6 +47,7 @@ import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import ome.units.UNITS;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.Timestamp;
 import omero.RInt;
@@ -395,6 +396,22 @@ public class OmeroReader extends FormatReader {
             }
 
             List<Channel> channels = pix.copyChannels();
+            for (int c=0; c<channels.size(); c++) {
+                final Channel channel = channels.get(c);
+                final RInt red = channel.getRed();
+                final RInt green = channel.getGreen();
+                final RInt blue = channel.getBlue();
+                final RInt alpha = channel.getAlpha();
+                if (red != null && green != null && blue != null) {
+                    final Color color;
+                    if (alpha == null) {
+                        color = new Color(red.getValue(), green.getValue(), blue.getValue(), 255);
+                    } else {
+                        color = new Color(red.getValue(), green.getValue(), blue.getValue(), alpha.getValue());
+                    }
+                    store.setChannelColor(color, 0, c);
+                }
+            }
             for (int c=0; c<channels.size(); c++) {
                 LogicalChannel channel = channels.get(c).getLogicalChannel();
 

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -411,9 +411,8 @@ public class OmeroReader extends FormatReader {
                     }
                     store.setChannelColor(color, 0, c);
                 }
-            }
-            for (int c=0; c<channels.size(); c++) {
-                final LogicalChannel logicalChannel = channels.get(c).getLogicalChannel();
+
+                final LogicalChannel logicalChannel = channel.getLogicalChannel();
 
                 final Length emWave = logicalChannel.getEmissionWave();
                 final Length exWave = logicalChannel.getExcitationWave();

--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -413,12 +413,12 @@ public class OmeroReader extends FormatReader {
                 }
             }
             for (int c=0; c<channels.size(); c++) {
-                LogicalChannel channel = channels.get(c).getLogicalChannel();
+                final LogicalChannel logicalChannel = channels.get(c).getLogicalChannel();
 
-                Length emWave = channel.getEmissionWave();
-                Length exWave = channel.getExcitationWave();
-                Length pinholeSize = channel.getPinHoleSize();
-                RString cname = channel.getName();
+                final Length emWave = logicalChannel.getEmissionWave();
+                final Length exWave = logicalChannel.getExcitationWave();
+                final Length pinholeSize = logicalChannel.getPinHoleSize();
+                final RString cname = logicalChannel.getName();
 
                 ome.units.quantity.Length emission = convertLength(emWave);
                 ome.units.quantity.Length excitation = convertLength(exWave);


### PR DESCRIPTION
# What this PR does

The OMERO reader is a Bio-Formats reader interface to images on the OMERO server. This PR has it read the channel colors from the server and write them to the underlying metadata store so as to be available for reading.

# Testing this PR

I would expect that looking at the code would probably do, I don't think we have any code that uses it and it's a simple change.

I use it in https://github.com/mtbc/omero-downloader and I can show you how to use that and note here the round-trip workflow that this PR improves but you'd have to be extra keen to want to try. Or, just set a channel color for some OMERO image and try to read it from an OmeroReader instance. I could have tried to figure out how to add a corresponding integration test but we don't seem to have any others for it.