### PR TITLE
CLI: get import log for Fileset

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -31,7 +31,9 @@ from collections import namedtuple
 
 from omero import client as Client
 from omero import CmdError
+from omero import ResourceError
 from omero import ServerError
+from omero import ValidationException
 from omero.cli import admin_only
 from omero.cli import CmdControl
 from omero.cli import CLI
@@ -135,6 +137,16 @@ def prep_directory(client, mrepo):
     return fs.templatePrefix.val
 
 
+def get_logfile(query, fid):
+    from omero.sys import ParametersI
+    q = ("select o from FilesetJobLink l "
+         "join l.parent as fs join l.child as j "
+         "join j.originalFileLinks l2 join l2.child as o "
+         "where fs.id = :id and "
+         "o.mimetype = 'application/omero-log-file'")
+    return query.findByQuery(q, ParametersI().addId(fid))
+
+
 def rename_fileset(client, mrepo, fileset, new_dir, ctx=None):
     """
     Loads each OriginalFile found under orig_dir and
@@ -195,15 +207,7 @@ def rename_fileset(client, mrepo, fileset, new_dir, ctx=None):
     tosave.insert(1, link)
 
     # And now move the log file as well:
-    from omero.sys import ParametersI
-    q = ("select o from FilesetJobLink l "
-         "join l.parent as fs join l.child as j "
-         "join j.originalFileLinks l2 join l2.child as o "
-         "where fs.id = :id and "
-         "o.mimetype = 'application/omero-log-file'")
-    log = query.findByQuery(
-        q, ParametersI().addId(fileset.id.val))
-
+    log = get_logfile(query, fileset.id.val)
     if log is not None:
         target = new_parpath + new_logname
         source = orig_parpath + orig_logname
@@ -271,6 +275,12 @@ class FsControl(CmdControl):
         ls.add_argument(
             "fileset",
             type=ProxyStringType("Fileset"))
+
+        logfile = parser.add(sub, self.logfile)
+        logfile.add_argument("fileset", type=ProxyStringType("Fileset"))
+        logfile.add_argument(
+            "filename",  nargs="?", default="-",
+            help="Local filename to be saved to. '-' for stdout")
 
         usage = parser.add(sub, self.usage)
         usage.set_args_unsorted()
@@ -701,6 +711,31 @@ Examples:
         defaultdict(list)
         for ofile in fileset.listFiles():
             print ofile.path + ofile.name
+
+    def logfile(self, args):
+        """Return the logfile associated with a fileset"""
+        client = self.ctx.conn(args)
+        query = client.sf.getQueryService()
+        log = get_logfile(query, args.fileset.id.val)
+        if log is not None:
+            target_file = str(args.filename)
+            try:
+                if target_file == "-":
+                    client.download(log, filehandle=sys.stdout)
+                    sys.stdout.flush()
+                else:
+                    client.download(log, target_file)
+            except ValidationException, ve:
+                # This should effectively be handled by None being returned
+                # from the logfile query above.
+                self.ctx.die(115, "ValidationException: %s" % ve.message)
+            except ResourceError, re:
+                # ID exists in DB, but not on FS
+                self.ctx.die(116, "ResourceError: %s" % re.message)
+        else:
+            self.ctx.die(
+                117,
+                "Log file not accessible for Fileset:%s" % args.fileset.id.val)
 
     @admin_only
     def set_repo(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -281,6 +281,9 @@ class FsControl(CmdControl):
         logfile.add_argument(
             "filename",  nargs="?", default="-",
             help="Local filename to be saved to. '-' for stdout")
+        logfile.add_argument(
+            "--name", action="store_true",
+            help="return only the name of the logfile")
 
         usage = parser.add(sub, self.usage)
         usage.set_args_unsorted()
@@ -718,20 +721,23 @@ Examples:
         query = client.sf.getQueryService()
         log = get_logfile(query, args.fileset.id.val)
         if log is not None:
-            target_file = str(args.filename)
-            try:
-                if target_file == "-":
-                    client.download(log, filehandle=sys.stdout)
-                    sys.stdout.flush()
-                else:
-                    client.download(log, target_file)
-            except ValidationException, ve:
-                # This should effectively be handled by None being returned
-                # from the logfile query above.
-                self.ctx.die(115, "ValidationException: %s" % ve.message)
-            except ResourceError, re:
-                # ID exists in DB, but not on FS
-                self.ctx.die(116, "ResourceError: %s" % re.message)
+            if args.name:
+                self.ctx.out(log.path.val + log.name.val)
+            else:
+                target_file = str(args.filename)
+                try:
+                    if target_file == "-":
+                        client.download(log, filehandle=sys.stdout)
+                        sys.stdout.flush()
+                    else:
+                        client.download(log, target_file)
+                except ValidationException, ve:
+                    # This should effectively be handled by None being
+                    # returned from the logfile query above.
+                    self.ctx.die(115, "ValidationException: %s" % ve.message)
+                except ResourceError, re:
+                    # ID exists in DB, but not on FS
+                    self.ctx.die(116, "ResourceError: %s" % re.message)
         else:
             self.ctx.die(
                 117,

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -281,9 +281,13 @@ class FsControl(CmdControl):
         logfile.add_argument(
             "filename",  nargs="?", default="-",
             help="Local filename to be saved to. '-' for stdout")
-        logfile.add_argument(
+        logopts = logfile.add_mutually_exclusive_group()
+        logopts.add_argument(
             "--name", action="store_true",
-            help="return only the name of the logfile")
+            help="return the path of the logfile within the ManagedRepository")
+        logopts.add_argument(
+            "--size", action="store_true",
+            help="return the size of the logfile in bytes")
 
         usage = parser.add(sub, self.usage)
         usage.set_args_unsorted()
@@ -723,6 +727,8 @@ Examples:
         if log is not None:
             if args.name:
                 self.ctx.out(log.path.val + log.name.val)
+            elif args.size:
+                self.ctx.out(log.size.val)
             else:
                 target_file = str(args.filename)
                 try:


### PR DESCRIPTION
# What this PR does

This PR adds an `fs logfile` subcommand to get the import logfile associated with a Fileset. The logfile can be saved to a local file or output to standard out. Additional options provide the file name (full path within the ManagedRepository) and the file size. 

# Testing this PR

Import some images as different users and note the Fileset IDs. 

```
$ omero fs logfile 1 --size
Log file not accessible for Fileset:1
$ omero fs logfile 2 --name
user-0_2/2016-09/01/09-53-57.029.log
$ omero fs logfile 2 --size
32720
$ omero fs logfile Fileset:2 local.log
$ cat local.log
2016-09-01 09:53:58,095 INFO  [    ome.formats.OMEROMetadataStoreClient] (2-thread-3) Call context: {omero.logfilename:user-0_2/2016-09/01/09-53-57.029.log}
...
2016-09-01 09:53:59,839 INFO  [    o.s.blitz.repo.ManagedImportRequestI] (2-thread-3) Finalizing log file.
$ omero fs logfile Fileset:2 -
2016-09-01 09:53:58,095 INFO  [    ome.formats.OMEROMetadataStoreClient] (2-thread-3) Call context: {omero.logfilename:user-0_2/2016-09/01/09-53-57.029.log}
...
2016-09-01 09:53:59,839 INFO  [    o.s.blitz.repo.ManagedImportRequestI] (2-thread-3) Finalizing log file.
$ omero fs logfile Fileset:2
2016-09-01 09:53:58,095 INFO  [    ome.formats.OMEROMetadataStoreClient] (2-thread-3) Call context: {omero.logfilename:user-0_2/2016-09/01/09-53-57.029.log}
...
2016-09-01 09:53:59,839 INFO  [    o.s.blitz.repo.ManagedImportRequestI] (2-thread-3) Finalizing log file.
```
In the first case the Fileset belongs to another user and so the log is inaccessible. In the other cases the log is accessible. Either `-` or the absence of a filename will have output go to standard out. The two options are mutually exclusive and both override the output of the log itself, i.e.

```
$ omero fs logfile 2 local.log --size
32720
```
will result in no local file being created.

# Related reading

https://trello.com/c/fAzIWvBk/703-cli-fetch-import-log
