### PR TITLE
Increase test timeout

### DIFF
--- a/etc/build.properties
+++ b/etc/build.properties
@@ -67,7 +67,7 @@ testng.useDefaultListeners=false
 # to finish. Value is approximately the number of
 # milliseconds to wait, but depends on the specific
 # number of retries used by each test.
-omero.test.timeout=500
+omero.test.timeout=1000
 
 ############################################
 # hard-wired (compile-time) values


### PR DESCRIPTION
# What this PR does

Increases the timeout for integration tests from 5s to 10s

# Testing this PR

Check integration tests.

# Related reading

There've been a lot of cases recently where integration tests didn't finish within the current timeout of 5 sec: https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-java/

The callback has to finish within the given value times 10 (in ms) before a TimoutException is thrown, see https://github.com/openmicroscopy/openmicroscopy/blob/92e1b1751926b1472393fc92a16abf128caab279/components/tools/OmeroJava/test/integration/AbstractServerTest.java#L2011 (the timeout value is the `scalingFactor` in that case)

/cc @sbesson 



