### PR TITLE
adjust how Java clients have Blitz close sessions

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -66,6 +66,7 @@ import omero.util.Resources;
 import omero.util.Resources.Entry;
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+import Glacier2.SessionNotExistException;
 import Ice.Current;
 
 /**
@@ -931,6 +932,7 @@ public class client {
         try {
             if (oldSf != null && !fast) {
                 oldSf = ServiceFactoryPrxHelper.uncheckedCast(oldSf.ice_oneway());
+                getRouter(oldIc).destroySession();
             }
         } catch (Ice.ConnectionLostException cle) {
             // ok. Exception will always be thrown
@@ -942,6 +944,8 @@ public class client {
             // ok. client is having network issues
         } catch (Ice.SocketException se) {
             // ok. client is having network issues
+        } catch (SessionNotExistException e) {
+            // ok. we don't want the session to exist
         } finally {
             try {
                 if (oldIc != null && !fast) {

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -932,7 +932,9 @@ public class client {
         try {
             if (oldSf != null && !fast) {
                 oldSf = ServiceFactoryPrxHelper.uncheckedCast(oldSf.ice_oneway());
-                getRouter(oldIc).destroySession();
+                if (oldIc != null) {
+                    getRouter(oldIc).destroySession();
+                }
             }
         } catch (Ice.ConnectionLostException cle) {
             // ok. Exception will always be thrown

--- a/components/tools/OmeroJava/test/integration/ClientUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/ClientUsageTest.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -23,6 +21,8 @@ import omero.sys.EventContext;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import Ice.UserException;
 
 /**
  * Various uses of the {@link omero.client} object. All configuration comes from
@@ -155,8 +155,11 @@ public class ClientUsageTest extends AbstractServerTest {
         sf.setSecurityContext(new omero.model.ExperimenterGroupI(1L, false));
     }
 
+    /**
+     * Test that {@link client#joinSession(String)} fails after the client is disconnected.
+     * @throws Exception unexpected
+     */
     public void testJoinSession() throws Exception {
-        
         //create a new user.
         EventContext ec = newUserAndGroup("rw----", true);
         String session = ec.sessionUuid;
@@ -165,14 +168,9 @@ public class ClientUsageTest extends AbstractServerTest {
         client c = new client();
         try {
             c.joinSession(session);
-            if (Ice.Util.intVersion() >= 30600) {
-                Assert.fail("The session should have been deleted");
-            }
-        } catch (Exception e) {
-            if (Ice.Util.intVersion() < 30600) {
-                Assert.fail("Ice 3.5 do not close the session."
-                        + "An error should not have been thrown");
-            }
+            Assert.fail("The session should have been deleted");
+        } catch (UserException e) {
+            /* expected because the client is disconnected */
         }
     }
 }


### PR DESCRIPTION
This PR has the client's `closeSession()` also destroy the session via the router as already occurs in Python. It is probably one to keep in a bit to see if any problems are noticed. See https://trello.com/c/NWT3qUma/172-client-del-session-still-alive for more specific discussion.