### PR TITLE
add enumeration values for acquisition mode

### DIFF
--- a/components/model/resources/mappings/acquisition.ome.xml
+++ b/components/model/resources/mappings/acquisition.ome.xml
@@ -717,9 +717,11 @@
 <!-- Channel Entity -->
 	<enum id="ome.model.enums.AcquisitionMode">
 		<entry name="WideField"/>
+		<entry name="BrightField"/>
 		<entry name="LaserScanningConfocalMicroscopy"/>
 		<entry name="SpinningDiskConfocal"/>
 		<entry name="SlitScanConfocal"/>
+		<entry name="SweptFieldConfocal"/>
 		<entry name="MultiPhotonMicroscopy"/>
 		<entry name="StructuredIllumination"/>
 		<entry name="SingleMoleculeImaging"/>
@@ -735,6 +737,7 @@
 		<entry name="TIRF"/>
 		<entry name="FSM"/>
 		<entry name="LCM"/>
+		<entry name="SPIM"/>
 		<entry name="Other"/>
 		<entry name="Unknown"/>
 	</enum>

--- a/components/model/resources/mappings/acquisition.ome.xml
+++ b/components/model/resources/mappings/acquisition.ome.xml
@@ -717,11 +717,9 @@
 <!-- Channel Entity -->
 	<enum id="ome.model.enums.AcquisitionMode">
 		<entry name="WideField"/>
-		<entry name="BrightField"/>
 		<entry name="LaserScanningConfocalMicroscopy"/>
 		<entry name="SpinningDiskConfocal"/>
 		<entry name="SlitScanConfocal"/>
-		<entry name="SweptFieldConfocal"/>
 		<entry name="MultiPhotonMicroscopy"/>
 		<entry name="StructuredIllumination"/>
 		<entry name="SingleMoleculeImaging"/>
@@ -737,9 +735,11 @@
 		<entry name="TIRF"/>
 		<entry name="FSM"/>
 		<entry name="LCM"/>
-		<entry name="SPIM"/>
 		<entry name="Other"/>
 		<entry name="Unknown"/>
+		<entry name="BrightField"/>
+		<entry name="SweptFieldConfocal"/>
+		<entry name="SPIM"/>
 	</enum>
 <!-- Detector Settings Entity -->
 	<enum id="ome.model.enums.Binning">

--- a/sql/psql/OMERO5.3DEV__10/enums_update.sql
+++ b/sql/psql/OMERO5.3DEV__10/enums_update.sql
@@ -10,10 +10,6 @@ insert into acquisitionmode (id,permissions,value)
         select 1 from acquisitionmode where value = 'WideField') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-35,'BrightField' from acquisitionmode where not exists(
-        select 1 from acquisitionmode where value = 'BrightField') limit 1;
-
-insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'LaserScanningConfocalMicroscopy' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'LaserScanningConfocalMicroscopy') limit 1;
 
@@ -24,10 +20,6 @@ insert into acquisitionmode (id,permissions,value)
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'SlitScanConfocal' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'SlitScanConfocal') limit 1;
-
-insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-35,'SweptFieldConfocal' from acquisitionmode where not exists(
-        select 1 from acquisitionmode where value = 'SweptFieldConfocal') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'MultiPhotonMicroscopy' from acquisitionmode where not exists(
@@ -90,16 +82,24 @@ insert into acquisitionmode (id,permissions,value)
         select 1 from acquisitionmode where value = 'LCM') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-35,'SPIM' from acquisitionmode where not exists(
-        select 1 from acquisitionmode where value = 'SPIM') limit 1;
-
-insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'Other' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'Other') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'Unknown' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'Unknown') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'BrightField' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'BrightField') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'SweptFieldConfocal' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'SweptFieldConfocal') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'SPIM' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'SPIM') limit 1;
 
 insert into arctype (id,permissions,value)
     select ome_nextval('seq_arctype'),-35,'Hg' from arctype where not exists(

--- a/sql/psql/OMERO5.3DEV__10/enums_update.sql
+++ b/sql/psql/OMERO5.3DEV__10/enums_update.sql
@@ -10,6 +10,10 @@ insert into acquisitionmode (id,permissions,value)
         select 1 from acquisitionmode where value = 'WideField') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'BrightField' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'BrightField') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'LaserScanningConfocalMicroscopy' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'LaserScanningConfocalMicroscopy') limit 1;
 
@@ -20,6 +24,10 @@ insert into acquisitionmode (id,permissions,value)
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'SlitScanConfocal' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'SlitScanConfocal') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'SweptFieldConfocal' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'SweptFieldConfocal') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'MultiPhotonMicroscopy' from acquisitionmode where not exists(
@@ -80,6 +88,10 @@ insert into acquisitionmode (id,permissions,value)
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'LCM' from acquisitionmode where not exists(
         select 1 from acquisitionmode where value = 'LCM') limit 1;
+
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-35,'SPIM' from acquisitionmode where not exists(
+        select 1 from acquisitionmode where value = 'SPIM') limit 1;
 
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-35,'Other' from acquisitionmode where not exists(

--- a/sql/psql/OMERO5.3DEV__10/psql-footer.sql
+++ b/sql/psql/OMERO5.3DEV__10/psql-footer.sql
@@ -2110,11 +2110,15 @@ alter table pixelstype alter column bitsize drop not null;
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'WideField';
 insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'BrightField';
+insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'LaserScanningConfocalMicroscopy';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'SpinningDiskConfocal';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'SlitScanConfocal';
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'SweptFieldConfocal';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'MultiPhotonMicroscopy';
 insert into acquisitionmode (id,permissions,value)
@@ -2145,6 +2149,8 @@ insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'FSM';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'LCM';
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'SPIM';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'Other';
 insert into acquisitionmode (id,permissions,value)

--- a/sql/psql/OMERO5.3DEV__10/psql-footer.sql
+++ b/sql/psql/OMERO5.3DEV__10/psql-footer.sql
@@ -2110,15 +2110,11 @@ alter table pixelstype alter column bitsize drop not null;
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'WideField';
 insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-52,'BrightField';
-insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'LaserScanningConfocalMicroscopy';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'SpinningDiskConfocal';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'SlitScanConfocal';
-insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-52,'SweptFieldConfocal';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'MultiPhotonMicroscopy';
 insert into acquisitionmode (id,permissions,value)
@@ -2150,11 +2146,15 @@ insert into acquisitionmode (id,permissions,value)
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'LCM';
 insert into acquisitionmode (id,permissions,value)
-    select ome_nextval('seq_acquisitionmode'),-52,'SPIM';
-insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'Other';
 insert into acquisitionmode (id,permissions,value)
     select ome_nextval('seq_acquisitionmode'),-52,'Unknown';
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'BrightField';
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'SweptFieldConfocal';
+insert into acquisitionmode (id,permissions,value)
+    select ome_nextval('seq_acquisitionmode'),-52,'SPIM';
 insert into arctype (id,permissions,value)
     select ome_nextval('seq_arctype'),-52,'Hg';
 insert into arctype (id,permissions,value)


### PR DESCRIPTION
# What this PR does

To the OMERO model object mapping adds acquisition modes,
* BrightField
* SweptFieldConfocal
* SPIM

# Testing this PR

The BIOFORMATS-DEV-merge-full-repository job's logs record various "Unknown AcquisitionMode value" warnings. Pick one of the corresponding images and import it into OMERO. Without these changes (including the entailed Bio-Formats changes) the Blitz log will warn that the enumeration does not exist and will set the image's acquisition mode to "Other". With this PR, having run the `enums_update.sql` script or used a build with #4837 included, the correct acquisition mode should be noted among the image's metadata for subsequent imports. (With these changes in OMERO but without running that database script import is as if OMERO hadn't been changed at all.)

# Related reading

https://github.com/openmicroscopy/bioformats/pull/2553
https://trello.com/c/0zNp8HvU/167-enumerations-addition