### PR TITLE
Codomain per channel rnd

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -497,15 +497,15 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- If rendering settings are moved then move the subgraph below. -->
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- Regardless of permissions move thumbnails, except to a private group delete them if another's. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -163,8 +163,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -523,8 +523,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- Give thumbnails only in a private group. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -193,8 +193,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -191,8 +191,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].projections = [I]" p:changes="RD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].quantization = [I]" p:changes="RD:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].spatialDomainEnhancement = [I]" p:changes="RD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].waveRendering = [I]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="CB:ChannelBinding[E].spatialDomainEnhancement = [I]" p:changes="CB:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -379,8 +379,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
@@ -193,8 +193,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -302,8 +302,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- We cannot yet duplicate thumbnails. -->
 

--- a/components/blitz/resources/omero/ROMIO.ice
+++ b/components/blitz/resources/omero/ROMIO.ice
@@ -85,9 +85,6 @@ module romio
     {
     };
 
-    ["java:type:java.util.ArrayList<omero.romio.CodomainMapContext>:java.util.List<omero.romio.CodomainMapContext>"]
-    sequence<CodomainMapContext> CodomainMapContextList;
-
 };
 
 };

--- a/components/blitz/resources/omero/ROMIO.ice
+++ b/components/blitz/resources/omero/ROMIO.ice
@@ -26,8 +26,8 @@ Primitives for working with binary data.
  **/
 module romio
 {
-    sequence<Ice::ByteSeq> RGBBands;
 
+    sequence<Ice::ByteSeq> RGBBands;
     const int RedBand = 0;
     const int GreenBand = 1;
     const int BlueBand = 2;
@@ -84,6 +84,10 @@ module romio
     class ReverseIntensityMapContext extends CodomainMapContext
     {
     };
+
+    ["java:type:java.util.ArrayList<omero.romio.CodomainMapContext>:java.util.List<omero.romio.CodomainMapContext>"]
+    sequence<CodomainMapContext> CodomainMapContextList;
+
 };
 
 };

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -530,7 +530,13 @@ module omero {
                  */
                 idempotent double getPixelsTypeLowerBound(int w) throws ServerError;
 
-                idempotent IObjectList getCodomainMapContext() throws ServerError;
+                /**
+                 * Returns the list of codomain contexts for the specified
+                 * channel.
+                 *
+                 * @param w The channel index.
+                 */
+                idempotent omero::romio::CodomainMapContextList getCodomainMapContext(int w) throws ServerError;
             };
     };
 };

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -536,7 +536,7 @@ module omero {
                  *
                  * @param w The channel index.
                  */
-                idempotent omero::romio::CodomainMapContextList getCodomainMapContext(int w) throws ServerError;
+                idempotent IObjectList getCodomainMapContext(int w) throws ServerError;
             };
     };
 };

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -421,6 +421,7 @@ module omero {
                  * @see #updateCodomainMap
                  * @see #removeCodomainMap
                  */
+                 ["deprecated:addCodomainMap() is deprecated. use addCodomainMapToChannel instead."]
                 void addCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
 
                 /**
@@ -432,6 +433,7 @@ module omero {
                  * @see #addCodomainMap
                  * @see #removeCodomainMap
                  */
+                 ["deprecated:removeCodomainMap() is deprecated."]
                 void updateCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
 
                 /**
@@ -442,7 +444,31 @@ module omero {
                  * @see #addCodomainMap
                  * @see #updateCodomainMap
                  */
+                 ["deprecated:removeCodomainMap() is deprecated. use removeCodomainMapFromChannel instead."]
                 void removeCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
+
+                /**
+                 * Adds the context to the mapping chain. Only one context of
+                 * the same type can be added to the chain. The codomain
+                 * transformations are functions from the device space to
+                 * device space. Each time a new context is added, the second
+                 * LUT is rebuilt.
+                 *
+                 * @param mapCtx The context to add.
+                 * @param w The channel to add the context to.
+                 * @see #removeCodomainMapFromChannel
+                 */
+                void addCodomainMapToChannel(omero::romio::CodomainMapContext mapCtx, int w) throws ServerError;
+
+                /**
+                 * Removes the specified context from the chain. Each time a
+                 * new context is removed, the second LUT is rebuilt.
+                 *
+                 * @param mapCtx The context to remove.
+                 * @param w The channel to remove the context from.
+                 * @see #addCodomainMapToChannel
+                 */
+                void removeCodomainMapFromChannel(omero::romio::CodomainMapContext mapCtx, int w) throws ServerError;
 
                 /** Saves the current rendering settings in the database. */
                 void saveCurrentSettings() throws ServerError;

--- a/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
@@ -476,8 +476,8 @@ public class RenderingEngineI extends AbstractPyramidServant implements
 
     @Override
     public void getCodomainMapContext_async(
-            AMD_RenderingEngine_getCodomainMapContext __cb, Current __current)
+            AMD_RenderingEngine_getCodomainMapContext __cb, int w, Current __current)
             throws ServerError {
-        callInvokerOnRawArgs(__cb, __current);
+        callInvokerOnRawArgs(__cb, __current, w);
     }
 }

--- a/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
@@ -1,10 +1,7 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
-
 package ome.services.blitz.impl;
 
 import java.util.LinkedHashMap;
@@ -18,6 +15,7 @@ import omero.InternalException;
 import omero.RLong;
 import omero.ServerError;
 import omero.api.AMD_RenderingEngine_addCodomainMap;
+import omero.api.AMD_RenderingEngine_addCodomainMapToChannel;
 import omero.api.AMD_RenderingEngine_getAvailableFamilies;
 import omero.api.AMD_RenderingEngine_getAvailableModels;
 import omero.api.AMD_RenderingEngine_getChannelCurveCoefficient;
@@ -45,6 +43,7 @@ import omero.api.AMD_RenderingEngine_loadRenderingDef;
 import omero.api.AMD_RenderingEngine_lookupPixels;
 import omero.api.AMD_RenderingEngine_lookupRenderingDef;
 import omero.api.AMD_RenderingEngine_removeCodomainMap;
+import omero.api.AMD_RenderingEngine_removeCodomainMapFromChannel;
 import omero.api.AMD_RenderingEngine_render;
 import omero.api.AMD_RenderingEngine_renderAsPackedInt;
 import omero.api.AMD_RenderingEngine_renderCompressed;
@@ -113,6 +112,12 @@ public class RenderingEngineI extends AbstractPyramidServant implements
     public void addCodomainMap_async(AMD_RenderingEngine_addCodomainMap __cb,
             CodomainMapContext mapCtx, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, mapCtx);
+
+    }
+
+    public void addCodomainMapToChannel_async(AMD_RenderingEngine_addCodomainMapToChannel __cb,
+            CodomainMapContext mapCtx, int w, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, mapCtx, w);
 
     }
 
@@ -325,6 +330,13 @@ public class RenderingEngineI extends AbstractPyramidServant implements
             AMD_RenderingEngine_removeCodomainMap __cb,
             CodomainMapContext mapCtx, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, mapCtx);
+
+    }
+
+    public void removeCodomainMapFromChannel_async(
+            AMD_RenderingEngine_removeCodomainMapFromChannel __cb,
+            CodomainMapContext mapCtx, int w, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, mapCtx, w);
 
     }
 

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1227,6 +1228,22 @@ public class IceMapper extends ome.util.ModelMapper implements
             return map(new ArrayList((Set) o)); // Necessary since Ice
             // doesn't support Sets.
         } else if (Collection.class.isAssignableFrom(type)) {
+            Collection l = (Collection) o;
+            //not part of the model so map "manually"
+            if (l.size() > 0) {
+                Object ho = l.iterator().next();
+                if (ho instanceof CodomainMapContext) {
+                    List result = new ArrayList();
+                    Iterator i = l.iterator();
+                    while (i.hasNext()) {
+                        Object t = reverse((CodomainMapContext) i.next());
+                        if (t != null) {
+                            result.add(t);
+                        }
+                    }
+                    return result;
+                }
+            }
             return map((Collection) o);
         } else if (IObject.class.isAssignableFrom(type)) {
             return map((Filterable) o);
@@ -1238,6 +1255,14 @@ public class IceMapper extends ome.util.ModelMapper implements
             throw new ApiUsageException(null, null, "Can't handle output "
                     + type);
         }
+    }
+
+    private omero.model.CodomainMapContext reverse(CodomainMapContext ctx)
+    {
+        if (ctx instanceof ReverseIntensityContext) {
+            return new omero.model.ReverseIntensityContextI();
+        }
+        return null;
     }
 
     /**

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -470,7 +470,7 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * @param w The channel to add the context to.
      * @see #removeCodomainMapFromChannel(CodomainMapContext, int)
      */
-    public void addCodomainMapForChannel(CodomainMapContext mapCtx, int w);
+    public void addCodomainMapToChannel(CodomainMapContext mapCtx, int w);
 
     /**
      * Updates the specified context. The codomain chain already contains the

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -1,10 +1,7 @@
 /*
- * omeis.providers.re.RenderingEngine
- *
- *   Copyright 2006-2014 University of Dundee. All rights reserved.
+ *   Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
-
 package omeis.providers.re;
 
 import java.util.List;
@@ -459,7 +456,21 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * @see #updateCodomainMap(CodomainMapContext)
      * @see #removeCodomainMap(CodomainMapContext)
      */
+    @Deprecated
     public void addCodomainMap(CodomainMapContext mapCtx);
+
+    /**
+     * Adds the context to the mapping chain. Only one context of the same type
+     * can be added to the chain. The codomain transformations are functions
+     * from the device space to device space. Each time a new context is added,
+     * the second LUT is rebuilt.
+     * 
+     * @param mapCtx
+     *            The context to add.
+     * @param w The channel to add the context to.
+     * @see #removeCodomainMapFromChannel(CodomainMapContext, int)
+     */
+    public void addCodomainMapForChannel(CodomainMapContext mapCtx, int w);
 
     /**
      * Updates the specified context. The codomain chain already contains the
@@ -471,6 +482,7 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * @see #addCodomainMap(CodomainMapContext)
      * @see #removeCodomainMap(CodomainMapContext)
      */
+    @Deprecated
     public void updateCodomainMap(CodomainMapContext mapCtx);
 
     /**
@@ -482,7 +494,18 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * @see #addCodomainMap(CodomainMapContext)
      * @see #updateCodomainMap(CodomainMapContext)
      */
+    @Deprecated
     public void removeCodomainMap(CodomainMapContext mapCtx);
+
+    /**
+     * Removes the specified context from the chain. Each time a new context is
+     * removed, the second LUT is rebuilt.
+     * 
+     * @param mapCtx
+     *            The context to remove.
+     * @see #addCodomainMapToChannel(CodomainMapContext, int)
+     */
+    public void removeCodomainMapFromChannel(CodomainMapContext mapCtx, int w);
 
     /** Saves the current rendering settings in the database. */
     public void saveCurrentSettings();

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -585,5 +585,13 @@ public interface RenderingEngine extends StatefulServiceInterface {
 
     public String getChannelLookupTable(int w);
 
+    /**
+     * Returns the list of codomain contexts associated to the specified
+     * channel.
+     *
+     * @param w The channel the contexts are associated to.
+     * @return see above.
+     */
+    public List<CodomainMapContext> getCodomainMapContext(int w);
 }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -507,18 +507,6 @@ class RendererModel
 	*/
 
 	/**
-	 * Returns a read-only list of {@link CodomainMapContext}s using during
-	 * the mapping process in the device space.
-	 *
-	 * @return See above.
-	 */
-	List getCodomainMaps()
-	{ 
-		if (rndControl == null) return new ArrayList();
-		return rndControl.getCodomainMaps();
-	}
-
-	/**
 	 * Removes the codomain map identified by the class from the chain of 
 	 * codomain transformations.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -18,7 +18,6 @@
  *
  *------------------------------------------------------------------------------
  */
-
 package org.openmicroscopy.shoola.env.rnd;
 
 import java.awt.Color;
@@ -446,10 +445,11 @@ public interface RenderingControl
     /**
      * Returns a read-only list of <code>CodomainMapContext</code>s using during
      * the mapping process in the device space.
-     * 
+     *
+     * @param w The channel
      * @return See above.
      */
-    public List getCodomainMaps()
+    public List<CodomainMapContext> getCodomainMaps(int w)
         throws RenderingServiceException, DSOutOfServiceException;
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -412,10 +412,11 @@ public interface RenderingControl
      * managing the codomain transformations is rebuilt. 
      *
      * @param mapCtx The context to add.
+     * @param w The channel to add the context to.
      * @throws RenderingServiceException If an error occurred while setting the value.
      * @throws DSOutOfServiceException If the connection is broken.
      */
-    public void addCodomainMap(CodomainMapContext mapCtx)
+    public void addCodomainMap(CodomainMapContext mapCtx, int w)
             throws RenderingServiceException, DSOutOfServiceException;
     
     /**
@@ -435,10 +436,11 @@ public interface RenderingControl
      * transformations.
      * 
      * @param mapCtx The context to remove.
+     * @param w The channel to remove the context from.
      * @throws RenderingServiceException If an error occurred while setting the value.
      * @throws DSOutOfServiceException If the connection is broken.
      */
-    public void removeCodomainMap(CodomainMapContext mapCtx)
+    public void removeCodomainMap(CodomainMapContext mapCtx, int w)
             throws RenderingServiceException, DSOutOfServiceException;
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -42,7 +42,6 @@ import omero.api.RenderingEnginePrx;
 import omero.api.ResolutionDescription;
 import omero.model.CodomainMapContext;
 import omero.model.Family;
-import omero.model.IObject;
 import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.Pixels;
@@ -1308,19 +1307,29 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getCodomainMaps()
      */
-    public List getCodomainMaps()
+    public List<CodomainMapContext> getCodomainMaps(int w)
             throws RenderingServiceException, DSOutOfServiceException
     {
         isSessionAlive();
+        isSessionAlive();
+        List<CodomainMapContext> l = new ArrayList<CodomainMapContext>();
         try {
-            return servant.getCodomainMapContext();
+            List<omero.romio.CodomainMapContext> m = servant.getCodomainMapContext(w);
+            Iterator<omero.romio.CodomainMapContext> i = m.iterator();
+            omero.romio.CodomainMapContext c;
+            while (i.hasNext()) {
+                c = i.next();
+                if (c instanceof omero.romio.ReverseIntensityMapContext) {
+                    l.add(new ReverseIntensityContextI());
+                }
+            }
+            invalidateCache();
         } catch (Exception e) {
-            e.printStackTrace();
-            handleException(e, "Cannot load the map context.");
+            handleException(e, ERROR+"cannot set the map context.");
         }
-        return new ArrayList(0);
+        return l;
     }
-    
+
     /** 
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#saveCurrentSettings()

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -42,6 +42,7 @@ import omero.api.RenderingEnginePrx;
 import omero.api.ResolutionDescription;
 import omero.model.CodomainMapContext;
 import omero.model.Family;
+import omero.model.IObject;
 import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.Pixels;
@@ -1311,17 +1312,12 @@ class RenderingControlProxy
             throws RenderingServiceException, DSOutOfServiceException
     {
         isSessionAlive();
-        isSessionAlive();
         List<CodomainMapContext> l = new ArrayList<CodomainMapContext>();
         try {
-            List<omero.romio.CodomainMapContext> m = servant.getCodomainMapContext(w);
-            Iterator<omero.romio.CodomainMapContext> i = m.iterator();
-            omero.romio.CodomainMapContext c;
+            List<IObject> ll = servant.getCodomainMapContext(w);
+            Iterator<IObject> i = ll.iterator();
             while (i.hasNext()) {
-                c = i.next();
-                if (c instanceof omero.romio.ReverseIntensityMapContext) {
-                    l.add(new ReverseIntensityContextI());
-                }
+                l.add((CodomainMapContext) i.next());
             }
             invalidateCache();
         } catch (Exception e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -1253,19 +1253,18 @@ class RenderingControlProxy
 
     /** 
      * Implemented as specified by {@link RenderingControl}.
-     * @see RenderingControl#addCodomainMap(CodomainMapContext)
+     * @see RenderingControl#addCodomainMap(CodomainMapContext, int)
      */
-    public void addCodomainMap(CodomainMapContext mapCtx)
+    public void addCodomainMap(CodomainMapContext mapCtx, int w)
             throws RenderingServiceException, DSOutOfServiceException
     {
         if (!(mapCtx instanceof ReverseIntensityContext)){
             return ;
         }
-        //ReverseIntensityContext ric = (ReverseIntensityContext) mapCtx;
         isSessionAlive();
         try {
             omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
-            servant.addCodomainMap(c);
+            servant.addCodomainMapToChannel(c, w);
             invalidateCache();
         } catch (Exception e) {
             handleException(e, ERROR+"cannot set the map context.");
@@ -1287,9 +1286,9 @@ class RenderingControlProxy
 
     /** 
      * Implemented as specified by {@link RenderingControl}.
-     * @see RenderingControl#removeCodomainMap(CodomainMapContext)
+     * @see RenderingControl#removeCodomainMap(CodomainMapContext, int)
      */
-    public void removeCodomainMap(CodomainMapContext mapCtx)
+    public void removeCodomainMap(CodomainMapContext mapCtx, int w)
         throws RenderingServiceException, DSOutOfServiceException
     {
         if (!(mapCtx instanceof ReverseIntensityContext)){
@@ -1298,7 +1297,7 @@ class RenderingControlProxy
         isSessionAlive();
         try {
             omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
-            servant.removeCodomainMap(c);
+            servant.removeCodomainMapFromChannel(c, w);
             invalidateCache();
         } catch (Exception e) {
             handleException(e, ERROR+"cannot set the map context.");

--- a/components/rendering/src/omeis/providers/re/HSBStrategy.java
+++ b/components/rendering/src/omeis/providers/re/HSBStrategy.java
@@ -185,6 +185,25 @@ class HSBStrategy extends RenderingStrategy {
     }
 
     /**
+     * Returns the collection of chains.
+     *
+     * @return See above.
+     */
+    private List<CodomainChain> getChains()
+    {
+        List<CodomainChain> chains = renderer.getCodomainChains();
+        ChannelBinding[] channelBindings = renderer.getChannelBindings();
+        List<CodomainChain> list = new ArrayList<CodomainChain>();
+        for (int w = 0; w < channelBindings.length; w++) {
+            ChannelBinding cb = channelBindings[w];
+            if (cb.getActive()) {
+                list.add(chains.get(w));
+            }
+        }
+        return list;
+    }
+
+    /**
      * Retrieves the color for each active channels.
      * 
      * @return the active channel color data.
@@ -277,8 +296,7 @@ class HSBStrategy extends RenderingStrategy {
             x2Start = i*delta;
             x2End = (i+1)*delta;
             tasks.add(new RenderHSBRegionTask(buf, wData, strategies,
-                    renderer.getCodomainChains(),
-                    colors, renderer.getOptimizations(),
+                    getChains(), colors, renderer.getOptimizations(),
                     x1Start, x1End, x2Start, x2End, readers));
         }
 

--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -1,8 +1,7 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
-
 package omeis.providers.re;
 
 import java.awt.Dimension;
@@ -698,8 +697,8 @@ public class Renderer {
      * 
      * @return See above.
      */
-    public List<CodomainChain> getCodomainChains() {
-        return codomainChains;
+    List<CodomainChain> getCodomainChains() {
+        return Collections.unmodifiableList(codomainChains);
     }
 
     /**
@@ -760,10 +759,10 @@ public class Renderer {
      *            The upper bound of the interval.
      */
     public void setCodomainInterval(int start, int end) {
-        List<CodomainChain> chains = getCodomainChains();
-        Iterator<CodomainChain> i = chains.iterator();
-        while (i.hasNext()) {
-             i.next().setInterval(start, end);
+        CodomainChain c;
+        for (int i = 0; i < getPixels().getSizeC(); i++) {
+            c = getCodomainChain(i);
+            c.setInterval(start, end);
         }
         /*
          * RenderingDef rd = getRenderingDef(); QuantumDef qd =
@@ -776,15 +775,6 @@ public class Renderer {
         QuantumDef qd = rd.getQuantization();
         qd.setCdStart(Integer.valueOf(start));
         qd.setCdEnd(Integer.valueOf(end));
-        ome.model.display.CodomainMapContext mapCtx;
-        /*
-        Iterator<ome.model.display.CodomainMapContext> i = rd.iterateSpatialDomainEnhancement();
-        while (i.hasNext()) {
-            mapCtx = i.next();
-            throw new UnsupportedOperationException("BROKEN");
-            // XXX What is supposed to happen here? mapCtx.setCodomain(start, end);
-        }
-        */
         //need to rebuild the look up table
         updateQuantumManager();
     }

--- a/components/rendering/src/omeis/providers/re/RenderingStats.java
+++ b/components/rendering/src/omeis/providers/re/RenderingStats.java
@@ -193,15 +193,14 @@ public class RenderingStats
     	a += String.format(
     			"CONTEXT ---- OMEIS Pixels ID: %d Plane: %s Type: %s " +
     			"PlaneData: %s Channels: %d Renderered Image: %s " +
-    			"Color Model: %s Maps: %s\n",
+    			"Color Model: %s\n",
     				context.getMetadata().getId(),
     				plane,
     				context.getPlaneDimsAsString(plane),
     				context.getPixelsType(),
     				ioTime.keySet().size(),
     				context.getImageSize(plane),
-    				context.getRenderingDef().getModel().getValue(),
-    				context.getCodomainChains());
+    				context.getRenderingDef().getModel().getValue());
     	a += String.format(
     			"TIMES (ms) ---- Memory Allocation: %d I/O: %s " +
     			"Rendering: %d Total: %d\n",

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -5,7 +5,6 @@
 package omeis.providers.re.codomain;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -318,9 +317,10 @@ public class CodomainChain {
     }
 
     /**
-     * Returns <code>true</code> if some transformations need to be applied
+     * Returns <code>true</code> if some transformations need to be applied,
+     * <code>false</code> otherwise.
      * 
-     * @return
+     * @return See above.
      */
     public boolean hasMapContext()
     {

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -1,10 +1,11 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package omeis.providers.re.codomain;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -326,6 +327,20 @@ public class CodomainChain {
         return !chain.isEmpty();
     }
 
+    /**
+     * Returns a copy of the codomain context if any.
+     *
+     * @return See above.
+     */
+    public List<CodomainMapContext> getContexts()
+    {
+        Iterator<CodomainMapContext> i = chain.iterator();
+        List<CodomainMapContext> contexts = new ArrayList<CodomainMapContext>();
+        while (i.hasNext()) {
+            contexts.add(i.next().copy());
+        }
+        return contexts;
+    }
     /**
      * Overrides the toString method.
      * 

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -160,12 +160,16 @@ public class CodomainChain {
             CodomainMapContext ctx;
             while (i.hasNext()) {
                 ctx = (CodomainMapContext) i.next();
-                if (chain.contains(ctx)) {
-                    throw new IllegalArgumentException(
-                            "Context already defined.");
+                if (!chain.contains(ctx)) {
+                    ctx = ctx.copy();
+                    chain.add(ctx);
+                } else {
+                    int j = chain.indexOf(ctx);
+                    if (j != -1) {
+                        ctx = ctx.copy();
+                        chain.set(j, ctx);
+                    }
                 }
-                ctx = ctx.copy();
-                chain.add(ctx);
             }
         }
         setInterval(start, end);

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -242,20 +242,23 @@ public class CodomainChain {
      * 
      * @param mapCtx
      *            The context to add. Mustn't be <code>null</code>.
+     * @return Return <code>true</code> if the context was added,
+     *                <code>false</code> otherwise.
      */
-    public void add(CodomainMapContext mapCtx) {
+    public boolean add(CodomainMapContext mapCtx) {
         if (mapCtx == null) {
             throw new NullPointerException("No context.");
         }
         if (chain.contains(mapCtx)) {
             update(mapCtx);
-            return;
+            return false;
         }
         mapCtx = mapCtx.copy(); // Get memento and discard original object.
         mapCtx.setCodomain(intervalStart, intervalEnd);
         mapCtx.buildContext();
         chain.add(mapCtx);
         buildLUT();
+        return true;
     }
 
     /**
@@ -296,13 +299,17 @@ public class CodomainChain {
      * 
      * @param mapCtx
      *            The context to remove.
+     * @return Returns <code>true</code> if the chain was removed,
+     *         <code>false</code> otherwise.
      */
-    public void remove(CodomainMapContext mapCtx) {
+    public boolean remove(CodomainMapContext mapCtx) {
         if (mapCtx != null && chain.contains(mapCtx)) { // Recall equals() is
                                                         // overridden.
             chain.remove(mapCtx);
             buildLUT();
+            return true;
         }
+        return false;
     }
 
     /**

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -244,6 +244,7 @@ public class CodomainChain {
             throw new NullPointerException("No context.");
         }
         if (chain.contains(mapCtx)) {
+            update(mapCtx);
             return;
         }
         mapCtx = mapCtx.copy(); // Get memento and discard original object.

--- a/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
+++ b/components/rendering/src/omeis/providers/re/codomain/CodomainChain.java
@@ -238,15 +238,13 @@ public class CodomainChain {
      * 
      * @param mapCtx
      *            The context to add. Mustn't be <code>null</code>.
-     * @throws IllegalArgumentException
-     *             If the context is already defined.
      */
     public void add(CodomainMapContext mapCtx) {
         if (mapCtx == null) {
             throw new NullPointerException("No context.");
         }
         if (chain.contains(mapCtx)) {
-            throw new IllegalArgumentException("Context already defined.");
+            return;
         }
         mapCtx = mapCtx.copy(); // Get memento and discard original object.
         mapCtx.setCodomain(intervalStart, intervalEnd);

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1047,6 +1047,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             bindingTo.setRed(binding.getRed());
             // lut used
             bindingTo.setLookupTable(binding.getLookupTable());
+            bindingTo.clearSpatialDomainEnhancement();
             Iterator<CodomainMapContext> j = binding.iterateSpatialDomainEnhancement();
             while (j.hasNext()) {
                 ctx = copyContext(j.next());

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -42,8 +42,10 @@ import ome.model.core.Image;
 import ome.model.core.LogicalChannel;
 import ome.model.core.Pixels;
 import ome.model.display.ChannelBinding;
+import ome.model.display.CodomainMapContext;
 import ome.model.display.QuantumDef;
 import ome.model.display.RenderingDef;
+import ome.model.display.ReverseIntensityContext;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import ome.model.screen.PlateAcquisition;
@@ -942,7 +944,23 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         }
         return cbs;
     }
-    
+
+    /**
+     * Copies the context.
+     *
+     * @param ctx The context to copy.
+     * @return See above.
+     */
+    private CodomainMapContext copyContext(CodomainMapContext ctx)
+    {
+        if (ctx instanceof ReverseIntensityContext) {
+            ReverseIntensityContext nc =  new ReverseIntensityContext();
+            nc.setReverse(((ReverseIntensityContext) ctx).getReverse());
+            return nc;
+        }
+        return null;
+    }
+
     /**
      * Applies rendering settings from a source set of pixels and settings to
      * a destination set of pixels and settings.
@@ -1003,6 +1021,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         Iterator<ChannelBinding> i = settingsFrom.iterateWaveRendering();
         Iterator<ChannelBinding> iTo = settingsTo.iterateWaveRendering();
         ChannelBinding binding, bindingTo;
+        CodomainMapContext ctx;
         while (i.hasNext())
         {
             binding = i.next();
@@ -1027,8 +1046,15 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             bindingTo.setRed(binding.getRed());
             // lut used
             bindingTo.setLookupTable(binding.getLookupTable());
+            Iterator<CodomainMapContext> j = binding.iterateSpatialDomainEnhancement();
+            while (j.hasNext()) {
+                ctx = copyContext(j.next());
+                if (ctx != null) {
+                    bindingTo.addCodomainMapContext(ctx);
+                }
+            }
         }
-        
+
         // Increment the version of the rendering settings so that we 
         // can have some notification that either the RenderingDef 
         // object itself or one of its children in the object graph has 

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -806,6 +806,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             channelBinding.setNoiseReduction(false);
             //Set the lookuptable if set during import
             channelBinding.setLookupTable(channel.getLookupTable());
+            channelBinding.clearSpatialDomainEnhancement();
             i++;
         }
         if (count > 0 && count != m.size()) {

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1,9 +1,7 @@
 /*
- *   $Id$
- *  Copyright 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
-
 package ome.logic;
 
 import java.io.IOException;

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1255,8 +1255,14 @@ public class RenderingBean implements RenderingEngine, Serializable {
         rwl.writeLock().lock();
         try {
             errorIfInvalidState();
+            ChannelBinding[] cb = renderer.getChannelBindings();
             for (int i = 0; i < pixelsObj.getSizeC(); i++) {
                 renderer.getCodomainChain(i).remove(mapCtx.copy());
+                List<CodomainMapContext> l = getCodomainMapContext(i);
+                Iterator<CodomainMapContext> j = l.iterator();
+                while (j.hasNext()) {
+                    cb[i].addCodomainMapContext(convert(j.next()));
+                }
             }
         } finally {
             rwl.writeLock().unlock();
@@ -1270,6 +1276,13 @@ public class RenderingBean implements RenderingEngine, Serializable {
         try {
             errorIfInvalidState();
             renderer.getCodomainChain(w).remove(mapCtx.copy());
+            ChannelBinding[] cb = renderer.getChannelBindings();
+            cb[w].clearSpatialDomainEnhancement();
+            List<CodomainMapContext> l = getCodomainMapContext(w);
+            Iterator<CodomainMapContext> i = l.iterator();
+            while (i.hasNext()) {
+                cb[w].addCodomainMapContext(convert(i.next()));
+            }
         } finally {
             rwl.writeLock().unlock();
         }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1202,12 +1202,13 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
     /** Implemented as specified by the {@link RenderingEngine} interface. */
     @RolesAllowed("user")
+    @Deprecated
     public void addCodomainMap(CodomainMapContext mapCtx) {
         rwl.writeLock().lock();
 
         try {
             errorIfInvalidState();
-            renderer.getCodomainChain().add(mapCtx.copy());
+            //renderer.getCodomainChain().add(mapCtx.copy());
         } finally {
             rwl.writeLock().unlock();
         }
@@ -1215,11 +1216,37 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
     /** Implemented as specified by the {@link RenderingEngine} interface. */
     @RolesAllowed("user")
+    public void addCodomainMapToChannel(CodomainMapContext mapCtx, int w) {
+        rwl.writeLock().lock();
+
+        try {
+            errorIfInvalidState();
+            renderer.getCodomainChain(w).add(mapCtx.copy());
+        } finally {
+            rwl.writeLock().unlock();
+        }
+    }
+
+    /** Implemented as specified by the {@link RenderingEngine} interface. */
+    @RolesAllowed("user")
+    @Deprecated
     public void removeCodomainMap(CodomainMapContext mapCtx) {
         rwl.writeLock().lock();
         try {
             errorIfInvalidState();
-            renderer.getCodomainChain().remove(mapCtx.copy());
+            //renderer.getCodomainChain().remove(mapCtx.copy());
+        } finally {
+            rwl.writeLock().unlock();
+        }
+    }
+
+    /** Implemented as specified by the {@link RenderingEngine} interface. */
+    @RolesAllowed("user")
+    public void removeCodomainMapFromChannel(CodomainMapContext mapCtx, int w) {
+        rwl.writeLock().lock();
+        try {
+            errorIfInvalidState();
+            renderer.getCodomainChain(w).remove(mapCtx.copy());
         } finally {
             rwl.writeLock().unlock();
         }
@@ -1547,7 +1574,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         try {
             errorIfInvalidState();
-            return renderer.getCodomainMapContexts();
+            return null;//renderer.getCodomainMapContexts();
         } finally {
             rwl.writeLock().unlock();
         }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -773,6 +773,22 @@ public class RenderingBean implements RenderingEngine, Serializable {
         internalSave(!requestedRenderingDef && !settingsBelongToCurrentUser());
     }
 
+    /**
+     * Copies the context.
+     *
+     * @param ctx The context to copy.
+     * @return See above.
+     */
+    private ome.model.display.CodomainMapContext copyContext(ome.model.display.CodomainMapContext ctx)
+    {
+        if (ctx instanceof ome.model.display.ReverseIntensityContext) {
+            ome.model.display.ReverseIntensityContext nc =  new ome.model.display.ReverseIntensityContext();
+            nc.setReverse(((ome.model.display.ReverseIntensityContext) ctx).getReverse());
+            return nc;
+        }
+        return null;
+    }
+
     private long internalSave(boolean saveAs) {
 
         rwl.writeLock().lock();
@@ -840,8 +856,12 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 Collection<ome.model.display.CodomainMapContext> ctx =
                         binding.unmodifiableSpatialDomainEnhancement();
                 Iterator<ome.model.display.CodomainMapContext> i = ctx.iterator();
+                ome.model.display.CodomainMapContext nc;
                 while (i.hasNext()) {
-                    cb.addCodomainMapContext(i.next());
+                    nc = copyContext(i.next());
+                    if (nc != null) {
+                        cb.addCodomainMapContext(nc);
+                    }
                 }
                 index++;
             }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -55,6 +55,7 @@ import ome.util.ShallowCopy;
 import omeis.providers.re.RGBBuffer;
 import omeis.providers.re.Renderer;
 import omeis.providers.re.RenderingEngine;
+import omeis.providers.re.codomain.CodomainChain;
 import omeis.providers.re.codomain.CodomainMapContext;
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.RegionDef;
@@ -1576,12 +1577,13 @@ public class RenderingBean implements RenderingEngine, Serializable {
      * @see RenderingEngine#getCodomainMapContexts()
      */
     @RolesAllowed("user")
-    public List getCodomainMapContext() {
+    public List<CodomainMapContext> getCodomainMapContext(int w) {
         rwl.readLock().lock();
 
         try {
             errorIfInvalidState();
-            return null;//renderer.getCodomainMapContexts();
+            CodomainChain cc = renderer.getCodomainChain(w);
+            return cc.getContexts();
         } finally {
             rwl.writeLock().unlock();
         }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -781,10 +781,10 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     private ome.model.display.CodomainMapContext copyContext(ome.model.display.CodomainMapContext ctx)
     {
+        if (ctx.getId() != null && ctx.getId().longValue() >= 0) {
+            return ctx;
+        }
         if (ctx instanceof ome.model.display.ReverseIntensityContext) {
-            if (ctx.getId() != null) {
-                return ctx;
-            }
             ome.model.display.ReverseIntensityContext nc =  new ome.model.display.ReverseIntensityContext();
             nc.setReverse(((ome.model.display.ReverseIntensityContext) ctx).getReverse());
             return nc;

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1258,12 +1258,15 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
     /** Implemented as specified by the {@link RenderingEngine} interface. */
     @RolesAllowed("user")
+    @Deprecated
     public void updateCodomainMap(CodomainMapContext mapCtx) {
         rwl.writeLock().lock();
 
         try {
             errorIfInvalidState();
-            renderer.getCodomainChain().update(mapCtx.copy());
+            for (int i = 0; i < pixelsObj.getSizeC(); i++) {
+                renderer.getCodomainChain(i).update(mapCtx.copy());
+            }
         } finally {
             rwl.writeLock().unlock();
         }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -782,6 +782,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
     private ome.model.display.CodomainMapContext copyContext(ome.model.display.CodomainMapContext ctx)
     {
         if (ctx instanceof ome.model.display.ReverseIntensityContext) {
+            if (ctx.getId() != null) {
+                return ctx;
+            }
             ome.model.display.ReverseIntensityContext nc =  new ome.model.display.ReverseIntensityContext();
             nc.setReverse(((ome.model.display.ReverseIntensityContext) ctx).getReverse());
             return nc;
@@ -855,12 +858,14 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 cb.clearSpatialDomainEnhancement();
                 Collection<ome.model.display.CodomainMapContext> ctx =
                         binding.unmodifiableSpatialDomainEnhancement();
-                Iterator<ome.model.display.CodomainMapContext> i = ctx.iterator();
-                ome.model.display.CodomainMapContext nc;
-                while (i.hasNext()) {
-                    nc = copyContext(i.next());
-                    if (nc != null) {
-                        cb.addCodomainMapContext(nc);
+                if (!ctx.isEmpty()) {
+                    Iterator<ome.model.display.CodomainMapContext> i = ctx.iterator();
+                    ome.model.display.CodomainMapContext nc;
+                    while (i.hasNext()) {
+                        nc = copyContext(i.next());
+                        if (nc != null) {
+                            cb.addCodomainMapContext(nc);
+                        }
                     }
                 }
                 index++;

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1579,13 +1578,12 @@ public class RenderingBean implements RenderingEngine, Serializable {
     @RolesAllowed("user")
     public List<CodomainMapContext> getCodomainMapContext(int w) {
         rwl.readLock().lock();
-
         try {
             errorIfInvalidState();
             CodomainChain cc = renderer.getCodomainChain(w);
             return cc.getContexts();
         } finally {
-            rwl.writeLock().unlock();
+            rwl.readLock().unlock();
         }
     }
     

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1573,7 +1573,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
     /**
      * Implemented as specified by the {@link RenderingEngine} interface.
      * 
-     * @see RenderingEngine#getCodomainMapContexts()
+     * @see RenderingEngine#getCodomainMapContext(int)
      */
     @RolesAllowed("user")
     public List<CodomainMapContext> getCodomainMapContext(int w) {

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1208,7 +1208,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         try {
             errorIfInvalidState();
-            //renderer.getCodomainChain().add(mapCtx.copy());
+            for (int i = 0; i < pixelsObj.getSizeC(); i++) {
+              renderer.getCodomainChain(i).add(mapCtx.copy());
+            }
         } finally {
             rwl.writeLock().unlock();
         }
@@ -1234,7 +1236,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
         rwl.writeLock().lock();
         try {
             errorIfInvalidState();
-            //renderer.getCodomainChain().remove(mapCtx.copy());
+            for (int i = 0; i < pixelsObj.getSizeC(); i++) {
+                renderer.getCodomainChain(i).remove(mapCtx.copy());
+            }
         } finally {
             rwl.writeLock().unlock();
         }

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -334,7 +334,10 @@ public class ThumbnailBean extends AbstractLevel2Service
             while (i.hasNext()) {
                 OriginalFile f = i.next();
                 String path = (new File(f.getPath(), f.getName())).getPath();
-                luts.add(new File(dir, path));
+                File ff = new File(dir, path);
+                if (ff.exists()) {
+                    luts.add(ff);
+                }
             }
             iQuery.clear();
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -1224,6 +1224,29 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Create a single image with binary.
+     *
+     * After recent changes on the server to check for existing binary data for
+     * pixels, many resetDefaults methods tested below began returning null
+     * since {@link omero.LockTimeout} exceptions were being thrown server-side.
+     * By using omero.client.forEachTile, we can set the necessary data easily.
+     *
+     * @param sizeX The number of pixels along the X-axis.
+     * @param sizeY The number of pixels along the Y-axis.
+     * @param sizeZ The number of z-sections.
+     * @param sizeT The number of timepoints.
+     * @param sizeC The number of channels.
+     * @see ticket:5755
+     */
+    protected Image createBinaryImage(int sizeX, int sizeY, int sizeZ,
+            int sizeT, int sizeC) throws Exception {
+        Image image = mmFactory.createImage(sizeX, sizeY, sizeZ, sizeT,
+                sizeC);
+        image = (Image) iUpdate.saveAndReturnObject(image);
+        return createBinaryImage(image);
+    }
+
+    /**
      * Create the binary data for the given image.
      */
     protected Image createBinaryImage(Image image) throws Exception {

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3358,12 +3358,6 @@ public class RenderingEngineTest extends AbstractServerTest {
         pDef.slice = omero.romio.XY.value;
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
         List<ChannelBinding> channels = def.copyWaveRendering();
-        IScriptPrx svc = factory.getScriptService();
-        List<OriginalFile> scripts = svc.getScriptsByMimetype(
-                ScriptServiceTest.LUT_MIMETYPE);
-        Assert.assertNotNull(scripts);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(scripts));
-        
         RenderingModel model = re.getModel();
         List<IObject> models = factory.getPixelsService().getAllEnumerations(
                 RenderingModel.class

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -134,6 +134,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         switch (role) {
             case ADMIN:
                 logRootIntoGroup(ctx2);
+                userId = iAdmin.getEventContext().userId;
                 break;
             case GROUP_OWNER:
                 makeGroupOwner();

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -52,6 +52,7 @@ import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
@@ -2606,5 +2607,75 @@ public class RenderingEngineTest extends AbstractServerTest {
             Assert.assertNotNull(cb1.getLookupTable());
             Assert.assertNull(cb2.getLookupTable());
         }
+    }
+
+    /**
+     * Tests to check the rendering settings have correctly been reset.
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testResetDefaultNoSave() throws Exception {
+        IScriptPrx svc = factory.getScriptService();
+        List<OriginalFile> luts = svc.getScriptsByMimetype(
+                ScriptServiceTest.LUT_MIMETYPE);
+        Assert.assertNotNull(luts);
+        IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
+        Image image = createBinaryImage();
+        Pixels pixels = image.getPrimaryPixels();
+        long id = pixels.getId().getValue();
+        ParametersI param = new ParametersI();
+        param.addId(id);
+        String sql = "select pix from Pixels as pix " +
+            "join fetch pix.image " +
+            "join fetch pix.pixelsType " +
+            "join fetch pix.channels as c " +
+            "join fetch c.logicalChannel " +
+            "where pix.id = :id";
+        List<IObject> ll = iQuery.findAllByQuery(sql, param);
+        pixels = (Pixels) ll.get(0);
+
+        // Image
+        prx.setOriginalSettingsInSet(Image.class.getName(),
+                Arrays.asList(image.getId().getValue()));
+        RenderingDef def1 = factory.getPixelsService().retrieveRndSettings(id);
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        List<ChannelBinding> channels = def1.copyWaveRendering();
+
+        for (int k = 0; k < channels.size(); k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(ctx, k);
+            re.setChannelLookupTable(k, luts.get(0).getName().getValue());
+        }
+        re.saveCurrentSettings();
+        // method already tested
+        //re.close();
+        def1 = factory.getPixelsService().retrieveRndSettings(id);
+        //reset and save
+        re.resetDefaultSettings(false);
+        //Check that lut has been removed since we won't have one at import
+        //Check that the list of codomain context is empty
+        channels = def1.copyWaveRendering();
+        ChannelBinding cb1;
+        List<Channel> l = pixels.copyChannels();
+        Channel c;
+        for (int k = 0; k < channels.size(); k++) {
+            cb1 = channels.get(k);
+            c = l.get(k);
+            Assert.assertNotNull(c);
+            Assert.assertNull(c.getLookupTable());
+            Assert.assertEquals(cb1.copySpatialDomainEnhancement().size(), 1);
+            Assert.assertTrue(re.getCodomainMapContext(k).isEmpty());
+            Assert.assertNotNull(cb1.getLookupTable());
+            Assert.assertTrue(StringUtils.isBlank(re.getChannelLookupTable(k)));
+        }
+        re.close();
     }
 }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.imageio.ImageIO;
 
@@ -662,6 +663,9 @@ public class RenderingEngineTest extends AbstractServerTest {
             }
             color.add(rgba);
             re.setRGBA(i, rgba[0], rgba[1], rgba[2], rgba[3]);
+            //reverse intensity
+            omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(c, i);
         }
         //save settings
         re.saveCurrentSettings();
@@ -680,6 +684,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertNotNull(new_model);
         Assert.assertEquals(re.getModel().getValue().getValue(),
                 new_model.getValue().getValue());
+        List<omero.romio.CodomainMapContext> contextList;
         for (int i = 0; i < sizeC; i++) {
             Assert.assertEquals(re.isActive(i), active.get(i).booleanValue());
             Assert.assertEquals(re.getChannelLookupTable(i), lut.get(i));
@@ -692,6 +697,11 @@ public class RenderingEngineTest extends AbstractServerTest {
             Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
                     new_families.get(i).getId().getValue());
             Assert.assertTrue(Arrays.equals(color.get(i), re.getRGBA(i)));
+            contextList = re.getCodomainMapContext(i);
+            Assert.assertNotNull(contextList);
+            Assert.assertEquals(contextList.size(), 1);
+            Assert.assertEquals(contextList.get(0).getClass(),
+                    omero.romio.ReverseIntensityMapContext.class);
         }
         re.close();
     }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -2841,4 +2841,119 @@ public class RenderingEngineTest extends AbstractServerTest {
 
     }
 
+    /**
+     * Tests to rendering settings with multiple codomain can be saved
+     * using the rendering engine. This test adds context, saves them,
+     * removes them, saves them.
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testMultipleCodomainTestAddRemoveSaveForEachChannel() throws Exception {
+        int sizeC = 3;
+        Image image = createBinaryImage(1, 1, 1, 1, sizeC);
+        Pixels pixels = image.getPrimaryPixels();
+        long id = pixels.getId().getValue();
+        IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
+        // Pixels first
+        prx.setOriginalSettingsInSet(Pixels.class.getName(),
+                Arrays.asList(pixels.getId().getValue()));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        Assert.assertEquals(channels.size(), sizeC);
+        for (int k = 0; k < sizeC; k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(ctx, k);
+            //save after adding each context.
+            re.saveCurrentSettings();
+        }
+
+        def = factory.getPixelsService().retrieveRndSettings(id);
+        channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            ChannelBinding c = channels.get(k);
+            List<CodomainMapContext> l  = c.copySpatialDomainEnhancement();
+            Assert.assertEquals(l.size(), 1);
+        }
+        for (int k = 0; k < sizeC; k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.removeCodomainMapFromChannel(ctx, k);
+            //save after adding each context.
+            re.saveCurrentSettings();
+        }
+        def = factory.getPixelsService().retrieveRndSettings(id);
+        channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            ChannelBinding c = channels.get(k);
+            List<CodomainMapContext> l  = c.copySpatialDomainEnhancement();
+            Assert.assertEquals(l.size(), 0);
+        }
+        re.close();
+    }
+
+    /**
+     * Tests to rendering settings with multiple codomain can be saved
+     * using the rendering engine. This test adds context, saves them,
+     * removes them, add them back and saves them.
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testMultipleCodomainTestAddRemoveAddSaveForEachChannel() throws Exception {
+        int sizeC = 3;
+        Image image = createBinaryImage(1, 1, 1, 1, sizeC);
+        Pixels pixels = image.getPrimaryPixels();
+        long id = pixels.getId().getValue();
+        IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
+        // Pixels first
+        prx.setOriginalSettingsInSet(Pixels.class.getName(),
+                Arrays.asList(pixels.getId().getValue()));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        Assert.assertEquals(channels.size(), sizeC);
+        for (int k = 0; k < sizeC; k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(ctx, k);
+            //save after adding each context.
+            re.saveCurrentSettings();
+        }
+
+        def = factory.getPixelsService().retrieveRndSettings(id);
+        channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            ChannelBinding c = channels.get(k);
+            List<CodomainMapContext> l  = c.copySpatialDomainEnhancement();
+            Assert.assertEquals(l.size(), 1);
+        }
+        for (int k = 0; k < sizeC; k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.removeCodomainMapFromChannel(ctx, k);
+            ctx = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(ctx, k);
+            //save after adding each context.
+            re.saveCurrentSettings();
+        }
+        def = factory.getPixelsService().retrieveRndSettings(id);
+        channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            ChannelBinding c = channels.get(k);
+            List<CodomainMapContext> l  = c.copySpatialDomainEnhancement();
+            Assert.assertEquals(l.size(), 1);
+        }
+        re.close();
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import javax.imageio.ImageIO;
 
@@ -42,6 +41,7 @@ import omero.model.ProjectionTypeI;
 import omero.model.QuantumDef;
 import omero.model.RenderingDef;
 import omero.model.RenderingModel;
+import omero.model.ReverseIntensityContext;
 import omero.romio.PlaneDef;
 import omero.romio.RGBBuffer;
 import omero.romio.RegionDef;
@@ -684,7 +684,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertNotNull(new_model);
         Assert.assertEquals(re.getModel().getValue().getValue(),
                 new_model.getValue().getValue());
-        List<omero.romio.CodomainMapContext> contextList;
+        List<IObject> contextList;
         for (int i = 0; i < sizeC; i++) {
             Assert.assertEquals(re.isActive(i), active.get(i).booleanValue());
             Assert.assertEquals(re.getChannelLookupTable(i), lut.get(i));
@@ -700,8 +700,8 @@ public class RenderingEngineTest extends AbstractServerTest {
             contextList = re.getCodomainMapContext(i);
             Assert.assertNotNull(contextList);
             Assert.assertEquals(contextList.size(), 1);
-            Assert.assertEquals(contextList.get(0).getClass(),
-                    omero.romio.ReverseIntensityMapContext.class);
+            IObject ho = contextList.get(0);
+            Assert.assertTrue(ho instanceof ReverseIntensityContext);
         }
         re.close();
     }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -2343,7 +2343,6 @@ public class RenderingEngineTest extends AbstractServerTest {
                 int ap = after[i] & 0x0ff;
                 //check that the reverse intensity was applied
                 Assert.assertEquals(ap, (end-bp));
-                System.err.println(bp);
             }
         }
     }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -2586,6 +2586,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         def1 = factory.getPixelsService().retrieveRndSettings(id);
         //reset and save
         re.resetDefaultSettings(true);
+        re.close();
         RenderingDef def2 = factory.getPixelsService().retrieveRndSettings(id);
         //Check that lut has been removed since we won't have one at import
         //Check that the list of codomain context is empty

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -2287,4 +2287,50 @@ public class RenderingEngineTest extends AbstractServerTest {
         }
     }
 
+    /**
+     * Tests add and remove codomain map context
+     * @throws Exception
+     */
+    @Test
+    public void testAddAndRemoveCodomain() throws Exception {
+        //First import an image
+        File f = File.createTempFile("testReverseIntensity", "."
+                + OME_FORMAT);
+        XMLMockObjects xml = new XMLMockObjects();
+        XMLWriter writer = new XMLWriter();
+        writer.writeFile(f, xml.createImage(), true);
+        List<Pixels> pixels = null;
+        try {
+            pixels = importFile(f, OME_FORMAT);
+        } catch (Throwable e) {
+            throw new Exception("cannot import image", e);
+        }
+        Pixels p = pixels.get(0);
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+
+        for (int k = 0; k < channels.size(); k++) {
+            omero.romio.ReverseIntensityMapContext ctx = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(ctx, k);
+            List<IObject> map = re.getCodomainMapContext(k);
+            Assert.assertEquals(map.size(), 1);
+            re.removeCodomainMapFromChannel(ctx, k);
+            map = re.getCodomainMapContext(k);
+            Assert.assertEquals(map.size(), 0);
+        }
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3305,13 +3305,6 @@ public class RenderingEngineTest extends AbstractServerTest {
         pDef.slice = omero.romio.XY.value;
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
         List<ChannelBinding> channels = def.copyWaveRendering();
-        int end = re.getQuantumDef().getCdEnd().getValue();
-        IScriptPrx svc = factory.getScriptService();
-        List<OriginalFile> scripts = svc.getScriptsByMimetype(
-                ScriptServiceTest.LUT_MIMETYPE);
-        Assert.assertNotNull(scripts);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(scripts));
-        OriginalFile of = scripts.get(0);
         RenderingModel model = re.getModel();
         List<IObject> models = factory.getPixelsService().getAllEnumerations(
                 RenderingModel.class
@@ -3325,7 +3318,7 @@ public class RenderingEngineTest extends AbstractServerTest {
                 re.setModel(m);
         }
         for (int k = 0; k < channels.size(); k++) {
-            re.setChannelLookupTable(k, of.getName().getValue());
+            re.setChannelLookupTable(k, "3-3-2_rgb.lut");
             byte[] before = re.renderCompressed(pDef);
             re.addCodomainMapToChannel(new omero.romio.ReverseIntensityMapContext(), k);
             byte[] after = re.renderCompressed(pDef);

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -1,7 +1,5 @@
 /*
- * $Id$
- *
- *  Copyright 2006-2011 University of Dundee & Open Microscopy Environment.
+ *  Copyright 2006-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -12,11 +10,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import omero.api.IRenderingSettingsPrx;
+import omero.api.IScriptPrx;
+import omero.api.RenderingEnginePrx;
 import omero.cmd.Chmod2;
 import omero.gateway.util.Requests;
 import omero.model.ChannelBinding;
 import omero.model.IObject;
 import omero.model.Image;
+import omero.model.OriginalFile;
 import omero.model.Pixels;
 import omero.model.RenderingDef;
 import omero.sys.EventContext;
@@ -375,7 +376,28 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         prx.setOriginalSettingsInSet(Image.class.getName(), ids);
 
         // method already tested
+        IScriptPrx svc = factory.getScriptService();
+        List<OriginalFile> luts = svc.getScriptsByMimetype(
+                ScriptServiceTest.LUT_MIMETYPE);
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        
+        for (int k = 0; k < channels.size(); k++) {
+            omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
+            re.addCodomainMapToChannel(c, k);
+            re.setChannelLookupTable(k, luts.get(0).getName().getValue());
+        }
+        re.saveCurrentSettings();
+        // method already tested
+        re.close();
+        def = factory.getPixelsService().retrieveRndSettings(id);
         long pix2 = image2.getPrimaryPixels().getId().getValue();
         long pix3 = image3.getPrimaryPixels().getId().getValue();
         ChannelBinding cb = def.getChannelBinding(0);

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -395,7 +395,6 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
             re.setChannelLookupTable(k, luts.get(0).getName().getValue());
         }
         re.saveCurrentSettings();
-        // method already tested
         re.close();
         def = factory.getPixelsService().retrieveRndSettings(id);
         long pix2 = image2.getPrimaryPixels().getId().getValue();
@@ -415,13 +414,30 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         RenderingDef def3 = factory.getPixelsService()
                 .retrieveRndSettings(pix3);
         cb = def2.getChannelBinding(0);
-        Assert.assertEquals(!b, cb.getActive().getValue());
+        Assert.assertEquals(cb.getActive().getValue(), !b);
         cb = def3.getChannelBinding(0);
-        Assert.assertEquals(!b, cb.getActive().getValue());
-
+        Assert.assertEquals(cb.getActive().getValue(), !b);
+        List<ChannelBinding> channels2 = def2.copyWaveRendering();
+        for (int k = 0; k < channels2.size(); k++) {
+            Assert.assertEquals(channels2.get(k).copySpatialDomainEnhancement().size(), 1);
+        }
+        List<ChannelBinding> channels3 = def3.copyWaveRendering();
+        for (int k = 0; k < channels3.size(); k++) {
+            Assert.assertEquals(channels3.get(k).copySpatialDomainEnhancement().size(), 1);
+        }
         // Now pass the original image too.
-        ids.add(image.getId().getValue());
+        //ids.add(image.getId().getValue());
         prx.applySettingsToSet(id, Image.class.getName(), ids);
+        def2 = factory.getPixelsService().retrieveRndSettings(pix2);
+        channels2 = def2.copyWaveRendering();
+        for (int k = 0; k < channels2.size(); k++) {
+            Assert.assertEquals(channels2.get(k).copySpatialDomainEnhancement().size(), 1);
+        }
+        def3 = factory.getPixelsService().retrieveRndSettings(pix2);
+        channels3 = def3.copyWaveRendering();
+        for (int k = 0; k < channels3.size(); k++) {
+            Assert.assertEquals(channels3.get(k).copySpatialDomainEnhancement().size(), 1);
+        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -388,7 +388,7 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         }
         re.load();
         List<ChannelBinding> channels = def.copyWaveRendering();
-        
+
         for (int k = 0; k < channels.size(); k++) {
             omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
             re.addCodomainMapToChannel(c, k);


### PR DESCRIPTION
# What this PR does

Re-activate the codomain map context. This was initially per rendering. Part I of the work
This is now per channel (part II). see https://github.com/openmicroscopy/openmicroscopy/pull/4793

Existing methods ``add/remove/update`` have been deprecated. Note that they have never been used.

New methods have been added to ``add/remove/retrieve`` the codomain contexts associated to a channel
No update method.
Only the ``ReverseIntensityMapContext`` has been added.

# Testing this PR
Integration test has been updated

# Related reading
https://trello.com/c/9iAe3Sg9/95-lut-support

cc @will-moore @dominikl 