### PR TITLE
Deprecate apache

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -275,7 +275,7 @@ class WebControl(BaseControl):
         if server == "apache":
             server = "apache22"
         if server in ("apache22", "apache24"):
-            self.ctx.err(("WARNING: Apache and mod_wsgi is deprecated."
+            self.ctx.err(("WARNING: Apache and mod_wsgi are deprecated."
                           " Please use nginx."))
         if args.http:
             port = args.http

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -274,6 +274,9 @@ class WebControl(BaseControl):
         # DEPRECATED: apache
         if server == "apache":
             server = "apache22"
+        if server in ("apache22", "apache24"):
+            self.ctx.err(("WARNING: Apache and mod_wsgi is deprecated."
+                          " Please use nginx."))
         if args.http:
             port = args.http
         elif server in ('nginx-development',):


### PR DESCRIPTION
# What this PR does

Deprecate apache that will be removed in next release

# Testing this PR

- generate config:

 ```
$ bin/omero config set omero.web.application_server wsgi
$ bin/omero web config apache 2>&1 > apache.conf
WARNING: Apache and mod_wsgi is deprecated. Please use nginx.
```

- check if `apache.conf` does not contains WARNING message,
- download 5.2.5 release

 ```
$ bin/omero config set omero.web.application_server wsgi
$ bin/omero web config apache > apache_525.conf
```

- `diff /path/to/apache.conf /path/to/apache_525.conf` should give only diff in paths
