### PR TITLE
prevent clients from saving deleted objects

### DIFF
--- a/components/server/src/ome/logic/UpdateImpl.java
+++ b/components/server/src/ome/logic/UpdateImpl.java
@@ -1,7 +1,5 @@
 /*
- *   $Ids$
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -269,9 +267,17 @@ public class UpdateImpl extends AbstractLevel1Service implements LocalUpdate {
         if (getBeanHelper().getLogger().isDebugEnabled()) {
             getBeanHelper().getLogger().debug(" Internal merge. ");
         }
-
+        final Long previousId = obj.getId();
         IObject result = (IObject) filter.filter(null, obj);
         result = (IObject) session.merge(result);
+        final Long currentId = result.getId();
+        if (previousId != null && previousId != currentId) {
+            /* HHH-1661: merge may insert deleted entities with new ID */
+            if (getBeanHelper().getLogger().isDebugEnabled()) {
+                getBeanHelper().getLogger().debug("attempt to save deleted object: " + obj);
+            }
+            throw new ValidationException("object no longer exists in database");
+        }
         return result;
     }
 

--- a/components/tools/OmeroPy/test/integration/test_iupdate.py
+++ b/components/tools/OmeroPy/test/integration/test_iupdate.py
@@ -91,6 +91,14 @@ class TestIUpdate(lib.ITest):
         with pytest.raises(Exception):
             self.assert_type(ds, "updated")
 
+    def testCannotSaveDeleted(self):
+        ds = self.mkdataset(True)
+        ds = self.update.saveAndReturnObject(ds)
+        self.delete([ds])
+        ds.name = omero.rtypes.rstring("now is deleted")
+        with pytest.raises(omero.ValidationException):
+            self.update.saveObject(ds)
+
     # Helpers
 
     def reload(self, ds):


### PR DESCRIPTION
# What this PR does

This causes the update service to throw a validation exception if a client attempts to save an object with an ID that does not exist in the database.

# Testing this PR

See https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.test_iupdate/TestIUpdate/

# Related reading

https://trello.com/c/qWNt9vLN/178-save-deleted-object