### PR TITLE
Fix gateway test

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -204,7 +204,7 @@ class TestFindObject (object):
         fileAnn = omero.gateway.FileAnnotationWrapper(gatewaywrapper.gateway)
         # An original file object needs to be linked to the annotation or it
         # will fail to be loaded on getObject(s).
-        fileObj = omero.model.OriginalFileI(False)
+        fileObj = omero.model.OriginalFileI()
         fileObj = omero.gateway.OriginalFileWrapper(
             gatewaywrapper.gateway, fileObj)
         fileObj.setName(omero.rtypes.rstring('a'))


### PR DESCRIPTION
# What this PR does

This PR fixes a gateway test that failed due to the changes in gh-4829.

It looks like the test had a benign error in it where the created OriginalFile object had its ID set to 0. The changes in the above PR uncovered this. It might be that Carlos intended something else here but with this change the test still checks the same functionality.

# Testing this PR

The integration test should pass.


