### PR TITLE
Fix rendering engine leak on missing or malformed request arguments (develop)

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -157,10 +157,21 @@ class TestRenderImageRegion(IWebTest):
     """
 
     def assert_no_leaked_rendering_engines(self):
+        """
+        Assert no rendering engine stateful services are left open for the
+        current session.
+        """
         for v in self.client.getSession().activeServices():
             assert 'RenderingEngine' not in v, 'Leaked rendering engine!'
 
     def test_render_image_region_incomplete_request(self):
+        """
+        Either `tile` or `region` is a required request argument to
+        `render_image_region()`.  If `c` is also passed, the rendering
+        engine will also be initialised.  This test ensure that the correct
+        HTTP status code is used and that consequently, any and all
+        rendering engines that were created servicing the request are closed.
+        """
         image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
 
         request_url = reverse(
@@ -177,6 +188,13 @@ class TestRenderImageRegion(IWebTest):
             self.assert_no_leaked_rendering_engines()
 
     def test_render_image_region_malformed_tile_argument(self):
+        """
+        Either `tile` or `region` is a required request argument to
+        `render_image_region()`.  This test ensure that if a malformed `tile`
+        is requested the correct HTTP status code is used and that
+        consequently, any and all rendering engines that were created
+        servicing the request are closed.
+        """
         image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
 
         request_url = reverse(
@@ -193,6 +211,13 @@ class TestRenderImageRegion(IWebTest):
             self.assert_no_leaked_rendering_engines()
 
     def test_render_image_region_malformed_region_argument(self):
+        """
+        Either `tile` or `region` is a required request argument to
+        `render_image_region()`.  This test ensure that if a malformed
+        `region` is requested the correct HTTP status code is used and that
+        consequently, any and all rendering engines that were created
+        servicing the request are closed.
+        """
         image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
 
         request_url = reverse(

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -35,10 +35,6 @@ class TestRendering(IWebTest):
     Tests copying and pasting of rendering settings from one image to another
     """
 
-    def assert_no_leaked_rendering_engines(self):
-        for v in self.client.getSession().activeServices():
-            assert 'RenderingEngine' not in v, 'Leaked rendering engine!'
-
     def test_copy_past_rendering_settings_from_image(self):
         # Create 2 images with 2 channels each
         iid1 = self.createTestImage(sizeC=2, session=self.sf).id.val
@@ -153,6 +149,16 @@ class TestRendering(IWebTest):
         assert old_c1 == new_c2
         # check if image2 rendering model changed from greyscale to color
         assert image2.isGreyscaleRenderingModel() is False
+
+
+class TestRenderImageRegion(IWebTest):
+    """
+    Tests rendering of image regions
+    """
+
+    def assert_no_leaked_rendering_engines(self):
+        for v in self.client.getSession().activeServices():
+            assert 'RenderingEngine' not in v, 'Leaked rendering engine!'
 
     def test_render_image_region_incomplete_request(self):
         image_id = self.createTestImage(sizeC=1, session=self.sf).id.val

--- a/components/tools/OmeroWeb/test/integration/weblibrary.py
+++ b/components/tools/OmeroWeb/test/integration/weblibrary.py
@@ -74,6 +74,20 @@ class IWebTest(lib.ITest):
         cls.django_clients.append(django_client)
         return django_client
 
+    @classmethod
+    def new_django_client_from_session_id(cls, session_id):
+        django_client = Client(enforce_csrf_checks=True)
+        index_url = reverse('webindex')
+
+        data = {
+            'server': 1,
+            'bsession': session_id,
+        }
+        response = django_client.get(index_url, data)
+        assert response.status_code == 200
+        cls.django_clients.append(django_client)
+        return django_client
+
 
 # Helpers
 def _response(django_client, request_url, method, data, status_code=403,


### PR DESCRIPTION
Version of #4832, atop of develop.

When certain request arguments are missing or malformed the
`render_image_region` view allows an exception to bubble up the stack
where it is handled by Django.  As the `BlitzGateway` relies on a
`__del__` destructor to clean up the rendering engine stateful service
this can lead to situations where the destructor is not called.
The rendering engine is then leaked for the duration of the session's
lifetime unless it is explicitly cleaned up by re-instantiating a
proxy to the service and the `close` method is called.

The semantics under which a destructor is called when an exception is
thrown are quite complicated and get into Python interpreter internals.
In short, objects with a `__del__` method are not subject to garbage
collection, they are collected using reference counting.  Raising an
exception may artificially keep objects alive due to the stack traceback
containing references to local variables which were in scope at the
point when the exception was thrown.  This of course increases the
reference count.  The traceback is usually globally accessible until
the next exception is thrown.

It is __essential__ that we not allow view methods which use the
rendering engine in __any way__ to throw exceptions which bubble up
the stack to Django.  We __will__ end up leaking rendering engine
stateful services otherwise.

This PR fixes a series of such conditions in the
`render_image_region` view.  An HTTP status code of 400 has been chosen.
Test cases and an OMERO.web integration test library extensions have
also been added to validate this.

References:
 * http://eli.thegreenplace.net/2009/06/12/safely-using-destructors-in-python/
 * https://mail.python.org/pipermail/python-list/2004-June/240474.html
 * http://python-3-patterns-idioms-test.readthedocs.io/en/latest/InitializationAndCleanup.html
 * https://emptysqua.re/blog/pythons-thread-locals-are-weird/