### PR TITLE
adjust how Java clients have Blitz close sessions (rebased from develop)

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -66,6 +66,7 @@ import omero.util.Resources;
 import omero.util.Resources.Entry;
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+import Glacier2.SessionNotExistException;
 import Ice.Current;
 
 /**
@@ -941,6 +942,7 @@ public class client {
         try {
             if (oldSf != null && !fast) {
                 oldSf = ServiceFactoryPrxHelper.uncheckedCast(oldSf.ice_oneway());
+                getRouter(oldIc).destroySession();
             }
         } catch (Ice.ConnectionLostException cle) {
             // ok. Exception will always be thrown
@@ -952,6 +954,8 @@ public class client {
             // ok. client is having network issues
         } catch (Ice.SocketException se) {
             // ok. client is having network issues
+        } catch (SessionNotExistException e) {
+            // ok. we don't want the session to exist
         } finally {
             try {
                 if (oldIc != null && !fast) {

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -942,7 +942,9 @@ public class client {
         try {
             if (oldSf != null && !fast) {
                 oldSf = ServiceFactoryPrxHelper.uncheckedCast(oldSf.ice_oneway());
-                getRouter(oldIc).destroySession();
+                if (oldIc != null) {
+                    getRouter(oldIc).destroySession();
+                }
             }
         } catch (Ice.ConnectionLostException cle) {
             // ok. Exception will always be thrown

--- a/components/tools/OmeroJava/test/integration/ClientUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/ClientUsageTest.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -29,6 +27,8 @@ import omero.model.PermissionsI;
 import omero.sys.EventContext;
 
 import org.testng.annotations.Test;
+
+import Ice.UserException;
 
 /**
  * Various uses of the {@link omero.client} object. All configuration comes from
@@ -161,8 +161,11 @@ public class ClientUsageTest extends AbstractServerTest {
         sf.setSecurityContext(new omero.model.ExperimenterGroupI(1L, false));
     }
 
+    /**
+     * Test that {@link client#joinSession(String)} fails after the client is disconnected.
+     * @throws Exception unexpected
+     */
     public void testJoinSession() throws Exception {
-        
         //create a new user.
         EventContext ec = newUserAndGroup("rw----", true);
         String session = ec.sessionUuid;
@@ -171,14 +174,9 @@ public class ClientUsageTest extends AbstractServerTest {
         client c = new client();
         try {
             c.joinSession(session);
-            if (Ice.Util.intVersion() >= 30600) {
-                fail("The session should have been deleted");
-            }
-        } catch (Exception e) {
-            if (Ice.Util.intVersion() < 30600) {
-                fail("Ice 3.5 do not close the session."
-                        + "An error should not have been thrown");
-            }
+            fail("The session should have been deleted");
+        } catch (UserException e) {
+            /* expected because the client is disconnected */
         }
     }
 }

--- a/components/tools/OmeroJava/test/integration/ClientUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/ClientUsageTest.java
@@ -171,6 +171,13 @@ public class ClientUsageTest extends AbstractServerTest {
         String session = ec.sessionUuid;
         //delete the active client
         disconnect();
+        
+        try {
+            // wait a bit before trying to join the session
+            Thread.sleep(2000);
+        } catch (Exception e1) {
+        }
+        
         client c = new client();
         try {
             c.joinSession(session);


### PR DESCRIPTION
This PR has the client's `closeSession()` also destroy the session via the router as already occurs in Python. See https://trello.com/c/NWT3qUma/172-client-del-session-still-alive for more specific discussion.

--rebased-from #4817