### PR TITLE
have OMERO server populate database with missing enumeration values

### DIFF
--- a/components/model/resources/ome/util/actions/psql.properties
+++ b/components/model/resources/ome/util/actions/psql.properties
@@ -3,6 +3,7 @@ sql_action.check_units=SELECT CAST('Å' AS UnitsLength)
 sql_action.curr_val=select next_val from seq_table where sequence_name = ?
 sql_action.db_version=select currentversion, currentpatch from dbpatch order by id desc limit 1
 sql_action.get_pixels_name_path_repo=select name, path, repo from pixels where id = ?
+sql_action.insert_format=insert into format (id,permissions,value) select ome_nextval('seq_format'),-35,?
 sql_action.insert_session=insert into session (id,permissions,timetoidle,timetolive,started,closed,defaulteventtype,uuid,owner,node) values (:sid,-35,:ttl,:tti,:start,null,:type,:uuid,:owner,:node)
 sql_action.next_session=select ome_nextval('seq_session'::text)
 sql_action.next_val=select ome_nextval(?,?)

--- a/components/model/resources/ome/util/actions/psql.properties
+++ b/components/model/resources/ome/util/actions/psql.properties
@@ -3,7 +3,6 @@ sql_action.check_units=SELECT CAST('Å' AS UnitsLength)
 sql_action.curr_val=select next_val from seq_table where sequence_name = ?
 sql_action.db_version=select currentversion, currentpatch from dbpatch order by id desc limit 1
 sql_action.get_pixels_name_path_repo=select name, path, repo from pixels where id = ?
-sql_action.insert_format=insert into format (id,permissions,value) select ome_nextval('seq_format'),-35,?
 sql_action.insert_session=insert into session (id,permissions,timetoidle,timetolive,started,closed,defaulteventtype,uuid,owner,node) values (:sid,-35,:ttl,:tti,:start,null,:type,:uuid,:owner,:node)
 sql_action.next_session=select ome_nextval('seq_session'::text)
 sql_action.next_val=select ome_nextval(?,?)

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -332,6 +332,8 @@ public interface SqlAction {
 
     long countFormat(String name);
 
+    int insertFormat(String name);
+
     int closeSessions(String uuid);
 
     int closeNodeSessions(String uuid);

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -332,8 +332,6 @@ public interface SqlAction {
 
     long countFormat(String name);
 
-    int insertFormat(String name);
-
     int closeSessions(String uuid);
 
     int closeNodeSessions(String uuid);

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -332,6 +332,7 @@ public interface SqlAction {
 
     long countFormat(String name);
 
+    @Deprecated  // use ome.services.util.EnsureEnum
     int insertFormat(String name);
 
     int closeSessions(String uuid);

--- a/components/model/src/ome/util/actions/PostgresSqlAction.java
+++ b/components/model/src/ome/util/actions/PostgresSqlAction.java
@@ -127,14 +127,6 @@ public class PostgresSqlAction extends SqlAction.Impl {
         return _jdbc().queryForLong(_lookup("count_format"), name); //$NON-NLS-1$
     }
 
-    // Copied from data.vm
-    public final static String insertFormatSql = PsqlStrings
-            .getString("sql_action.insert_format"); //$NON-NLS-1$
-
-    public int insertFormat(String name) {
-        return _jdbc().update(insertFormatSql, name);
-    }
-
     public int closeSessions(String uuid) {
         return _jdbc().update(_lookup("update_session"), uuid); //$NON-NLS-1$
     }

--- a/components/model/src/ome/util/actions/PostgresSqlAction.java
+++ b/components/model/src/ome/util/actions/PostgresSqlAction.java
@@ -128,9 +128,11 @@ public class PostgresSqlAction extends SqlAction.Impl {
     }
 
     // Copied from data.vm
+    @Deprecated  // use ome.services.util.EnsureEnum
     public final static String insertFormatSql = PsqlStrings
             .getString("sql_action.insert_format"); //$NON-NLS-1$
 
+    @Deprecated  // use ome.services.util.EnsureEnum
     public int insertFormat(String name) {
         return _jdbc().update(insertFormatSql, name);
     }

--- a/components/model/src/ome/util/actions/PostgresSqlAction.java
+++ b/components/model/src/ome/util/actions/PostgresSqlAction.java
@@ -127,6 +127,14 @@ public class PostgresSqlAction extends SqlAction.Impl {
         return _jdbc().queryForLong(_lookup("count_format"), name); //$NON-NLS-1$
     }
 
+    // Copied from data.vm
+    public final static String insertFormatSql = PsqlStrings
+            .getString("sql_action.insert_format"); //$NON-NLS-1$
+
+    public int insertFormat(String name) {
+        return _jdbc().update(insertFormatSql, name);
+    }
+
     public int closeSessions(String uuid) {
         return _jdbc().update(_lookup("update_session"), uuid); //$NON-NLS-1$
     }

--- a/components/server/resources/ome/services/startup.xml
+++ b/components/server/resources/ome/services/startup.xml
@@ -41,8 +41,16 @@
      lazy-init="false">
   </bean>
 
-  <bean id="dbEnumerationCheck"
+  <bean id="dbFormatEnumerationCheck"
      class="ome.services.util.DBEnumCheck"
+     init-method="start" lazy-init="false">
+     <constructor-arg ref="executor"/>
+     <constructor-arg ref="preferenceContext"/>
+     <constructor-arg ref="ensureEnum"/>
+  </bean>
+
+  <bean id="dbMappedEnumerationCheck"
+     class="ome.services.util.DBMappedEnumCheck"
      init-method="start" lazy-init="false">
      <constructor-arg ref="executor"/>
      <constructor-arg ref="preferenceContext"/>

--- a/components/server/resources/ome/services/startup.xml
+++ b/components/server/resources/ome/services/startup.xml
@@ -46,6 +46,7 @@
      init-method="start" lazy-init="false">
      <constructor-arg ref="executor"/>
      <constructor-arg ref="preferenceContext"/>
+     <constructor-arg ref="ensureEnum"/>
   </bean>
 
   <bean id="ensureEnum"

--- a/components/server/resources/ome/services/startup.xml
+++ b/components/server/resources/ome/services/startup.xml
@@ -48,6 +48,13 @@
      <constructor-arg ref="preferenceContext"/>
   </bean>
 
+  <bean id="ensureEnum"
+     class="ome.services.util.EnsureEnum">
+     <constructor-arg ref="executor"/>
+     <constructor-arg ref="uuid"/>
+     <constructor-arg ref="roles"/>
+  </bean>
+
   <bean id="dbUnicodeUnitsCheck" depends-on="dbPatchCheck"
      class="ome.services.util.DBUnicodeUnitsCheck"
      init-method="start" lazy-init="false">

--- a/components/server/src/ome/logic/TypesImpl.java
+++ b/components/server/src/ome/logic/TypesImpl.java
@@ -166,10 +166,11 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
     public <T extends IEnum> List<T> getOriginalEnumerations() {
         List<IEnum> original = new ArrayList<IEnum>();
         InputStream in = null;
+        JarFile jarFile = null;
         try {
             URL file = ResourceUtils.getURL("classpath:enums.properties");
             URL jar = ResourceUtils.extractJarFileURL(file);
-            JarFile jarFile = new JarFile(jar.getPath());
+            jarFile = new JarFile(jar.getPath());
             JarEntry entry = jarFile.getJarEntry("enums.properties");
             in = jarFile.getInputStream(entry);
             Properties property = new Properties();
@@ -212,7 +213,8 @@ public class TypesImpl extends AbstractLevel2Service implements ITypes {
             throw new RuntimeException("No such method. " + e.getMessage());
         } finally {
             try {
-                in.close();
+                if (in != null) in.close();
+                if (jarFile != null) jarFile.close();
             } catch (IOException e) {
             }
         }

--- a/components/server/src/ome/services/util/BaseDBCheck.java
+++ b/components/server/src/ome/services/util/BaseDBCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -41,9 +41,7 @@ abstract class BaseDBCheck {
     private final String version;
     private final int patch;
 
-    private final String configKey = "DB check " + getClass().getSimpleName();
-    private final String configValue = getCheckDone();
-    private final String configKeyValue = configKey + ": " + configValue;
+    private final String configKey, configValue, configKeyValue;
 
     /**
      * @param executor executor to use for configuration map check
@@ -52,6 +50,11 @@ abstract class BaseDBCheck {
         this.executor = executor;
         this.version = preferences.getProperty("omero.db.version");
         this.patch = Integer.parseInt(preferences.getProperty("omero.db.patch"));
+
+        /* these values may depend upon version and patch above */
+        configKey = "DB check " + getClass().getSimpleName();
+        configValue = getCheckDone();
+        configKeyValue = configKey + ": " + configValue;
     }
 
     /**

--- a/components/server/src/ome/services/util/BaseDBCheck.java
+++ b/components/server/src/ome/services/util/BaseDBCheck.java
@@ -125,4 +125,11 @@ abstract class BaseDBCheck {
     protected String getCheckDone() {
         return "done";
     }
+
+    /**
+     * @return a string representing the version and patch of this server
+     */
+    protected String getOmeroVersion() {
+        return version + "__" + patch;
+    }
 }

--- a/components/server/src/ome/services/util/DBEnumCheck.java
+++ b/components/server/src/ome/services/util/DBEnumCheck.java
@@ -6,20 +6,16 @@
 package ome.services.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
-import ome.conditions.InternalException;
+
+import ome.model.enums.Format;
 import ome.system.PreferenceContext;
-import ome.util.SqlAction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Hook run by the context to guarantee that various enumerations are up to
@@ -29,124 +25,37 @@ import org.springframework.transaction.annotation.Transactional;
  * greatest without a database upgrade.
  * 
  * @author Josh Moore, josh at glencoesoftware.com
+ * @author m.t.b.carroll@dundee.ac.uk
  * @since Beta4.1.1
  */
 public class DBEnumCheck extends BaseDBCheck {
 
     public final static Logger log = LoggerFactory.getLogger(DBEnumCheck.class);
 
-    public final static Pattern readerClass = Pattern
-            .compile("^.*?[.]?([^.]+)Reader$");
+    private final EnsureEnum ensureEnum;
 
-    /**
-     * Hard-coded list of formats missing from 4.1 which should have a
-     * "Companion/<reader>" value in the database. Temporary until bio-formats
-     * provides inspection on this information.
-     */
-    final private static List<String> companionful = Arrays.asList("Analyze",
-            "APL", "L2D", "Nifti", "TillVision", "Scanr");
-
-    /**
-     * Hard-coded list of formats missing from 4.1 which should NOT have a
-     * "Companion/<reader>" value in the database. Temporary until bio-formats
-     * provides inspection on this information.
-     */
-    final private static List<String> companionless = Arrays.asList("Zip",
-            "APNG", "PCX", "Ivision", "FEI", "NAF", "MINC", "MRW", "ARF",
-            "Cellomics", "LiFlim", "Amira");
-
-    /**
-     * Hard-coded list of formats missing from 4.1 which should NOT have a
-     * "Companion/<reader>" NOR a format at all. Temporary until bio-formats
-     * provides inspection on this information.
-     */
-    final private static List<String> omitlist = Arrays.asList("Fake");
-
-    public static List<String> getReaderNames() {
-        List<String> rv = new ArrayList<String>();
-        IFormatReader[] readers = new ImageReader().getReaders();
-        for (IFormatReader formatReader : readers) {
-
-            String name = formatReader.getClass().getSimpleName();
-            Matcher matcher = readerClass.matcher(name);
-            if (!matcher.matches()) {
-                log.warn("Reader doesn't match: " + name);
-                continue;
-            }
-
-            rv.add(matcher.group(1));
-        }
-        return rv;
-    }
-
-    public static boolean requiresCompanion(String name) {
-        return companionful.contains(name);
-    }
-
-    public static boolean shouldBeOmitted(String name) {
-        return omitlist.contains(name);
-    }
-
-    public DBEnumCheck(Executor executor, PreferenceContext preferences) {
+    public DBEnumCheck(Executor executor, PreferenceContext preferences, EnsureEnum ensureEnum) {
         super(executor, preferences);
+        this.ensureEnum = ensureEnum;
     }
 
     @Override
     protected void doCheck() {
-        try {
-            executor.executeSql(new Executor.SimpleSqlWork(this,
-                    "DBEnumCheck") {
-                @Transactional(readOnly = false)
-                public Object doWork(SqlAction sql) {
-                    for (String name : getReaderNames()) {
-                        addFormat(sql, name);
-                        if (requiresCompanion(name)) {
-                            addFormat(sql, "Companion/" + name);
-                        }
-                    }
-                    return null;
+        final List<String> formatNames = new ArrayList<String>();
+        for (final IFormatReader formatReader : new ImageReader().getReaders()) {
+            String name = formatReader.getClass().getSimpleName();
+            if (name.endsWith("Reader")) {
+                name = name.substring(0, name.length() - 6);
+                if ("Fake".equals(name)) {
+                    continue;
                 }
-
-            });
-        } catch (Exception e) {
-            final String msg = "Error synchronizing enumerations";
-            log.error(msg, e); // slf4j migration: fatal() to error()
-            InternalException ie = new InternalException(msg);
-            throw ie;
+                formatNames.add(name);
+                if (formatReader.hasCompanionFiles()) {
+                    formatNames.add("Companion/" + name);
+                }
+            }
         }
-    }
-
-    /**
-     * Adds an ome.model.enums.Format object if 1) the format value is not
-     * omitted, 2) it doesn't already exist.
-     * 
-     * @param jdbc
-     * @param name
-     * @return true if the format was added.
-     */
-    private boolean addFormat(SqlAction sql, String name) {
-
-        if (shouldBeOmitted(name)) {
-            log.debug("Omitting: " + name);
-            return false;
-        }
-
-        long count = sql.countFormat(name);
-
-        if (count > 0) {
-            log.debug("Found reader: " + name);
-            return false;
-        }
-
-        int inserts = sql.insertFormat(name);
-        if (inserts != 1) {
-            throw new InternalException("Expected 1 insert. Found " + inserts
-                    + " while adding: " + name);
-        }
-
-        log.info("Added format: " + name);
-        return true;
-
+        ensureEnum.ensure(Format.class, formatNames);
     }
 
     @Override

--- a/components/server/src/ome/services/util/DBMappedEnumCheck.java
+++ b/components/server/src/ome/services/util/DBMappedEnumCheck.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ResourceUtils;
+
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
+
+import ome.model.IEnum;
+import ome.model.IGlobal;
+import ome.system.PreferenceContext;
+
+/**
+ * When a new version of the OMERO server starts up check that the database
+ * includes an enumeration instance for every value mapped for code generation.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.3.0
+ */
+public class DBMappedEnumCheck extends BaseDBCheck {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DBMappedEnumCheck.class);
+
+    private static final Pattern ENUMERATION_PATTERN = Pattern.compile("(ome\\.model\\.enums\\.[A-Za-z\\.]+)\\.\\d+\\:(\\S*)");
+
+    private EnsureEnum ensureEnum;
+
+    protected DBMappedEnumCheck(Executor executor, PreferenceContext preferences, EnsureEnum ensureEnum) {
+        super(executor, preferences);
+        this.ensureEnum = ensureEnum;
+    }
+
+    @Override
+    protected void doCheck() {
+        final SetMultimap<String, String> enums = getEnums();
+        if (enums != null) {
+            ensureEnums(enums);
+        }
+    }
+
+    /**
+     * @return the enumeration classes and values from the generated {@code enums.properties} file,
+     * or {@code null} if it the file not be read
+     */
+    private SetMultimap<String, String> getEnums() {
+        JarFile jarFile = null;
+        InputStream enums = null;
+        final SetMultimap<String, String> enumValues = LinkedHashMultimap.create();
+        try {
+            try {
+                final URL file = ResourceUtils.getURL("classpath:enums.properties");
+                jarFile = new JarFile(ResourceUtils.extractJarFileURL(file).getPath());
+                enums = jarFile.getInputStream(jarFile.getJarEntry("enums.properties"));
+            } catch (IOException ioe) {
+                LOGGER.warn("could not locate mapped enumerations", ioe);
+                return null;
+            }
+            try (final BufferedReader in = new BufferedReader(new InputStreamReader(enums))) {
+                String line;
+                while ((line = in.readLine()) != null) {
+                    final Matcher matcher = ENUMERATION_PATTERN.matcher(line);
+                    if (matcher.matches()) {
+                        enumValues.put(matcher.group(1), matcher.group(2));
+                    }
+                }
+            } catch (IOException ioe) {
+                LOGGER.warn("could not read mapped enumerations", ioe);
+                return null;
+            }
+        } finally {
+            try {
+                if (jarFile != null) {
+                    jarFile.close();
+                }
+                if (enums != null) {
+                    enums.close();
+                }
+            } catch (IOException ioe) {
+                LOGGER.warn("failed to close input handle", ioe);
+            }
+        }
+        return enumValues;
+    }
+
+    /**
+     * @param className the name of an enumeration class
+     * @return the corresponding class
+     * @throws ClassNotFoundException if the class could not be found
+     */
+    @SuppressWarnings("unchecked")
+    private static <C extends IEnum & IGlobal> Class<C> getEnumClassForName(String className) throws ClassNotFoundException {
+        return (Class<C>) Class.forName(className);
+    }
+
+    /**
+     * Ensure that the given enumeration values exist as instances in the database.
+     * @param enumValues the enumeration classes and their values
+     */
+    private void ensureEnums(SetMultimap<String, String> enumValues) {
+        for (final Map.Entry<String, Collection<String>> valuesForClass : enumValues.asMap().entrySet()) {
+            try {
+                ensureEnum.ensure(getEnumClassForName(valuesForClass.getKey()), valuesForClass.getValue());
+            } catch (ClassNotFoundException cnfe) {
+                LOGGER.warn("cannot find class", cnfe);
+                continue;
+            }
+        }
+    }
+
+    @Override
+    protected String getCheckDone() {
+        return "done for OMERO version " + getOmeroVersion();
+    }
+}

--- a/components/server/src/ome/services/util/EnsureEnum.java
+++ b/components/server/src/ome/services/util/EnsureEnum.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import ome.model.IEnum;
+import ome.model.IGlobal;
+import ome.system.Login;
+import ome.system.Principal;
+import ome.system.Roles;
+import ome.system.ServiceFactory;
+
+import org.hibernate.Session;
+import org.hibernate.criterion.Restrictions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Utility bean for ensuring that enumeration values do exist in the database.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class EnsureEnum {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnsureEnum.class);
+
+    private final Executor executor;
+    private final Principal principal;
+    private final Map<String, String> callContext;
+
+    /**
+     * Construct a new enumeration ensurer. Expected to be instantiated via Spring.
+     * @param executor the internal task executor
+     * @param uuid a UUID suitable for constructing a privileged principal
+     * @param roles information about the system roles
+     */
+    public EnsureEnum(Executor executor, String uuid, Roles roles) {
+        this.executor = executor;
+        this.principal = new Principal(uuid, roles.getSystemGroupName(), "Internal");
+        this.callContext = ImmutableMap.of(Login.OMERO_GROUP, Long.toString(roles.getUserGroupId()));
+    }
+
+    /**
+     * Ensure that the given enumeration exists.
+     * @param enumClass the model class of the enumeration
+     * @param enumValue the name of the enumeration (case-sensitive)
+     * @return the ID of the enumeration, or {@code null} if it did not exist and could not be created
+     */
+    private <E extends IEnum & IGlobal> Long ensure(Session session, Class<E> enumClass, String enumValue) {
+        IEnum instance = (IEnum) session.createCriteria(enumClass).add(Restrictions.eq("value", enumValue)).uniqueResult();
+        if (instance != null) {
+            return instance.getId();
+        }
+        final String prettyEnum = enumClass.getSimpleName() + '.' + enumValue;
+        try {
+            instance = enumClass.getConstructor(String.class).newInstance(enumValue);
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
+            LOGGER.error("failed to create enumeration value " + prettyEnum, e);
+            return null;
+        }
+        LOGGER.info("adding to database new enumeration value " + prettyEnum);
+        return (Long) session.save(instance);
+    }
+
+    /**
+     * Ensure that the given enumerations exist.
+     * @param enumClass the model class of the enumeration
+     * @param enumValues the names of the enumerations (case-sensitive)
+     * @return the IDs of the enumerations, with {@code null} for any that did not exist and could not be created
+     */
+    @SuppressWarnings("unchecked")
+    public <E extends IEnum & IGlobal> List<Long> ensure(final Class<E> enumClass, final Collection<String> enumValues) {
+        if (enumValues.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return (List<Long>) executor.execute(callContext, principal, new Executor.Work<List<Long>>() {
+            @Override
+            public String description() {
+                return "ensure enum values";
+            }
+
+            @Override
+            @Transactional(readOnly = false)
+            public List<Long> doWork(Session session, ServiceFactory sf) {
+                final List<Long> enumIds = new ArrayList<Long>(enumValues.size());
+                for (final String enumValue : enumValues) {
+                    enumIds.add(ensure(session, enumClass, enumValue));
+                }
+                return enumIds;
+            }
+        });
+    }
+}


### PR DESCRIPTION
# What this PR does

When a new version of OMERO.server starts up (minor or major) it reviews the enumeration values defined in `<enum>` tags in `components/model/resources/mappings/` and ensures that all those strings exist in the corresponding database tables.

# Testing this PR

In an older version of OMERO delete a few enumeration values from the database. Upgrade to and start up the latest version of OMERO with this PR included and see if those values are added back.

Additionally the `format` table should continue to be populated with new image formats as reported by Bio-Formats readers whenever a new version of Bio-Formats is detected so in the above testing maybe also delete a few formats too that you know should be there (beyond just those listed in `acquisition.ome.xml`).

# Related reading

https://trello.com/c/0zNp8HvU/167-enumerations-addition