### PR TITLE
have graph path report include new EveryObjectOverview.inc file

### DIFF
--- a/components/server/src/ome/services/graphs/GraphPathReport.java
+++ b/components/server/src/ome/services/graphs/GraphPathReport.java
@@ -177,6 +177,7 @@ public class GraphPathReport {
         out.write("===================================\n\n");
         out.write("Overview\n");
         out.write("--------\n\n");
+        out.write(".. include:: EveryObjectOverview.inc\n\n");
         out.write("Reference\n");
         out.write("---------\n\n");
         final SortedMap<String, String> classNames = new TreeMap<String, String>();


### PR DESCRIPTION
# What this PR does

This makes the `GraphPathReport` model object glossary generation procedure generate a glossary page that matches what is now in our documentation.

# Testing this PR

Use the class' documentation at http://downloads.openmicroscopy.org/omero/5.2.5/api/ome/services/graphs/GraphPathReport.html to see how to test it and check that it generates an `EveryObject.txt` matching https://github.com/openmicroscopy/ome-documentation/blob/develop/omero/developers/Model/EveryObject.txt exactly. E.g., with a server with this PR configured but not running, check out the current `develop` branch of our docs and from the server's top directory do,
```shell
$ java -cp lib/server/\* `bin/omero config get | awk '{print"-D"$1}'` ome.services.graphs.GraphPathReport /tmp/EveryObject.txt
$ diff /tmp/EveryObject.txt /my/repos/ome-documentation/omero/developers/Model/EveryObject.txt
```

# Related reading

https://github.com/openmicroscopy/ome-documentation/pull/1525