### PR TITLE
scripts menu duplicate bugfix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -930,7 +930,10 @@ OME.showScriptList = function(event) {
 
             var html = "<ul class='menulist'>" + build_ul(data) + "</ul>";
 
-            $('#scriptList').append($(html));
+            // In case multiple requests are sent at once, don't duplicate menu
+            if ($("#scriptList li").length === 0) {
+                $('#scriptList').append($(html));
+            }
 
             $('#scriptList ul ul').hide();
             $scriptSpinner.hide();


### PR DESCRIPTION
# What this PR does

Fixes duplication of scripts menu - see https://trello.com/c/Gkvvidg9/139-duplication-of-scripts-menu-random-event

# Testing this PR

1. Double-click (or more!) on the scripts menu button.
Shouldn't be possible to get duplication of script menu items.
