### PR TITLE
Tag removal performance

### DIFF
--- a/components/tests/ui/testcases/web/tagging_test.txt
+++ b/components/tests/ui/testcases/web/tagging_test.txt
@@ -8,36 +8,48 @@ Resource          ../../resources/web/tree.txt
 Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
 Suite Teardown      Close all browsers
 
+*** Keywords ***
+
+Launch Tag Dialog
+    Click Element                           launch_tags_form
+    Wait Until Page Contains Element        id_tag
+    Wait Until Page Contains Element        xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
+
+Check For Tag
+    [Arguments]                             ${tagText}
+    Wait Until Page Contains Element        xpath=//div[@class='tag']/a[contains(text(), '${tagText}')]  10
+
+Check No Tag
+    [Arguments]                             ${tagText}
+    Wait Until Keyword Succeeds             ${TIMEOUT}     ${INTERVAL}     Page Should Not Contain Element         xpath=//div[@class='tag']/a[contains(text(), '${tagText}')]
+
+
 *** Test Cases ***
 
-Test Tag
+Test Tag Dialog
     [Documentation]     Several tests of the Tag dialog for single or batch tagging.
 
     Go To                                       ${WELCOME URL}
     Select Experimenter
     ${projectId}=                               Create Project      robot test tagging_1
     ${pId}=                                     Create Project      robot test tagging_2
-    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
-    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+    Check No Tag                                robotTagTest${pid}TagOne
+    Check No Tag                                robotTagTest${pid}TagTwo
 
     # Tag a single Project
     Click Element                               xpath=//h1[@data-name='tags']
-    Click Element                               launch_tags_form
-    Wait Until Page Contains Element            id_tag
-    Wait Until Page Contains Element            xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
+    Launch Tag Dialog
     Input Text                                  id_tag     robotTagTest${pid}TagOne
     Click Element                               id_add_new_tag
     Click Dialog Button                         Save
-    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
+    Check For Tag                               robotTagTest${pid}TagOne
     # Refresh (select other Project and re-select)
-    ${nodeId}=                                  Select Project By Id                        ${projectId}
+    ${nodeId}=                                  Select Project By Id     ${projectId}
     Wait Until Right Panel Loads                Project                  ${projectId}
     Select Project By Id                        ${pId}
     # Check and add another Tag, remove first one
-    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]  10
-    Click Element                               launch_tags_form
-    Wait Until Page Contains Element            id_tag
-    Wait Until Page Contains Element            xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
+    Check For Tag                               robotTagTest${pid}TagOne
+    Launch Tag Dialog
     # Create a second Tag
     Input Text                                  id_tag     robotTagTest${pid}TagTwo
     Click Element                               id_add_new_tag
@@ -47,19 +59,17 @@ Test Tag
     Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
     # Save - check Tag added and Tag removed
     Click Dialog Button                         Save
-    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]  10
-    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+    Check For Tag                               robotTagTest${pid}TagTwo
+    Check No Tag                                robotTagTest${pid}TagOne
 
 
     # Now select both Projects...
     Meta Click Node                             ${nodeId}
     Wait Until Page Contains Element            id=batch_ann_title
     # Previously added Tag will show up
-    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+    Check For Tag                               robotTagTest${pid}TagTwo
     Wait Until Element Is Visible               launch_tags_form
-    Click Element                               launch_tags_form
-    Wait Until Page Contains Element            id_tag
-    Wait Until Page Contains Element            xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
+    Launch Tag Dialog
 
     # Tags created above should be available to add to second Project
     Wait Until Page Contains Element            xpath=//div[@id='id_all_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
@@ -79,13 +89,11 @@ Test Tag
     Wait Until Page Contains Element            xpath=//span[@class='tooltip_html']/b[contains(text(),'2 objects')]
     # Other tag is still on one Project
     Page Should Contain Element                 xpath=//span[@class='tooltip_html']/b[contains(text(),'1 object')]
-    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
-    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
+    Check For Tag                               robotTagTest${pid}TagOne
+    Check For Tag                               robotTagTest${pid}TagTwo
 
     # Open Tag dialog again...
-    Click Element                               launch_tags_form
-    Wait Until Page Contains Element            id_tag
-    Wait Until Page Contains Element            xpath=//div[contains(@class,'ui-progressbar')][@aria-valuenow='100']    ${WAIT}
+    Launch Tag Dialog
     # Same tag as before should be on right
     Wait Until Page Contains Element            xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagOne')]
     Page Should Not Contain Element             xpath=//div[@id='id_selected_tags']/div[contains(text(),'robotTagTest${pid}TagTwo')]
@@ -101,8 +109,56 @@ Test Tag
     Go To                                       ${WELCOME URL}?show=project-${projectId}|project-${pId}
     Wait Until Element Is Visible               xpath=//h1[@data-name='tags']
     Click Element                               xpath=//h1[@data-name='tags']
-    Wait Until Page Contains Element            xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagThree')]  10
-    Page Should Contain Element                 xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagTwo')]
-    Page Should Not Contain Element             xpath=//div[@class='tag']/a[contains(text(), 'robotTagTest${pid}TagOne')]
+    Check For Tag                               robotTagTest${pid}TagThree
+    Check For Tag                               robotTagTest${pid}TagTwo
+    Check No Tag                                robotTagTest${pid}TagOne
 
 
+Test Tag Removal
+    [Documentation]     Tests the removal of tags by clicking on the Tag (-) button
+
+    Go To                                       ${WELCOME URL}
+    Select Experimenter
+    ${projectId}=                               Create Project      robot test tag remove_1
+    ${pId}=                                     Create Project      robot test tag remove_2
+    # Tag a single Project
+    Click Element                               xpath=//h1[@data-name='tags']
+    Launch Tag Dialog
+    Input Text                                  id_tag     removeTest${pid}One
+    Click Element                               id_add_new_tag
+    Click Dialog Button                         Save
+    Check For Tag                               removeTest${pid}One
+    # Click (-) button on Tag to remove
+    Click Element                               xpath=//div[@class='tag'][descendant::a[contains(text(), 'removeTest${pid}One')]]/span[@title='Remove Tag']
+    Click Dialog Button                         OK
+    Check No Tag                                removeTest${pid}One
+
+    # Batch Tag 2 Projects
+    ${pNodeId}=                                 Select Project By Id    ${pId}
+    ${projectNodeId}=                           Select Project By Id    ${projectId}
+    Meta Click Node                             ${pNodeId}
+    Wait Until Page Contains Element            id=batch_ann_title
+    Launch Tag Dialog
+    # Add 2 Tags to both Projects...
+    Input Text                                  id_tag     removeTest${pid}Two
+    Click Element                               id_add_new_tag
+    Input Text                                  id_tag     removeTest${pid}Three
+    Click Element                               id_add_new_tag
+    Click Dialog Button                         Save
+    Check For Tag                               removeTest${pid}Two
+    # Click (-) button on Tag to remove
+    Click Element                               xpath=//div[@class='tag'][descendant::a[contains(text(), 'removeTest${pid}Two')]]/span[@title='Remove Tag']
+    Click Dialog Button                         OK
+    Check No Tag                                removeTest${pid}Two
+
+    # Select each Project in turn, check tags One and Two are gone (but Three remains)
+    Select Project By Id                        ${projectId}
+    Wait Until Page Contains                    robot test tag remove_1
+    Check For Tag                               removeTest${pid}Three
+    Check No Tag                                removeTest${pid}One
+    Check No Tag                                removeTest${pid}Two
+    Select Project By Id                        ${pId}
+    Wait Until Page Contains                    robot test tag remove_2
+    Check For Tag                               removeTest${pid}Three
+    Check No Tag                                removeTest${pid}One
+    Check No Tag                                removeTest${pid}Two

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -751,6 +751,8 @@ class BaseContainer(BaseController):
 
         @param parents:     List of parent IDs, E.g. ['image-123']
         """
+        toDelete = []
+        notFound = []
         for p in parents:
             parent = p.split('-')
             dtype = str(parent[0])
@@ -766,35 +768,45 @@ class BaseContainer(BaseController):
                     if (al is not None and al.canDelete() and (
                             tag_owner_id is None or
                             unwrap(al.details.owner.id) == tag_owner_id)):
-                        self.conn.deleteObject(al._obj)
+                        toDelete.append(al._obj)
             elif self.file:
                 for al in self.file.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
-                        self.conn.deleteObject(al._obj)
+                        toDelete.append(al._obj)
             elif self.comment:
                 # remove the comment from specified parent
                 # the comment is automatically deleted when orphaned
                 for al in self.comment.getParentLinks(dtype, [parentId]):
                     if al is not None and al.canDelete():
-                        self.conn.deleteObject(al._obj)
+                        toDelete.append(al._obj)
             elif self.dataset is not None:
                 if dtype == 'project':
                     for pdl in self.dataset.getParentLinks([parentId]):
                         if pdl is not None:
-                            self.conn.deleteObject(pdl._obj)
+                            toDelete.append(pdl._obj)
             elif self.plate is not None:
                 if dtype == 'screen':
                     for spl in self.plate.getParentLinks([parentId]):
                         if spl is not None:
-                            self.conn.deleteObject(spl._obj)
+                            toDelete.append(spl._obj)
             elif self.image is not None:
                 if dtype == 'dataset':
                     for dil in self.image.getParentLinks([parentId]):
                         if dil is not None:
-                            self.conn.deleteObject(dil._obj)
+                            toDelete.append(dil._obj)
             else:
-                raise AttributeError(
-                    "Attribute not specified. Cannot be removed.")
+                notFound.append(p)
+        # Need to group objects by class then batch delete
+        linksByType = {}
+        for obj in toDelete:
+            objType = obj.__class__.__name__.rstrip('I')
+            if (objType not in linksByType):
+                linksByType[objType] = []
+            linksByType[objType].append(obj.id.val)
+        for linkType, ids in linksByType.items():
+            self.conn.deleteObjects(linkType, ids, wait=False)
+        if len(notFound) > 0:
+            raise AttributeError("Attribute not specified. Cannot be removed.")
 
     ##########################################################
     # Delete

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
@@ -121,7 +121,10 @@ var TagPane = function TagPane($element, opts) {
             });
             request = request.join("&");
 
-            $.getJSON(WEBCLIENT.URLS.webindex + "api/annotations/?type=tag&" + request, function(data){
+            var annsUrl = WEBCLIENT.URLS.webindex + "api/annotations/?type=tag&" + request
+            // set high limit on number of results (default is 200)
+            annsUrl += '&limit=10000'
+            $.getJSON(annsUrl, function(data){
 
                 // manipulate data...
                 // make an object of eid: experimenter

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
@@ -194,7 +194,7 @@ var tagging_form = function(
         var num_desc_callbacks = 0;
 
         var load = function(mode, callback, offset, limit) {
-            var url = WEBCLIENT.URLS.webindex + "marshal_tagging_form_data";
+            var url = WEBCLIENT.URLS.webindex + "marshal_tagging_form_data/";
             url = url + "?jsonmode=" + mode +
                         "&group=" + WEBCLIENT.active_group_id;
             if (offset !== undefined && limit !== undefined) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2435,6 +2435,8 @@ def annotate_tags(request, conn=None, **kwargs):
         selected_tags.append(
             (tag['id'], self_id, ownerName, canDelete, created, linkOwned))
 
+    # selected_tags is really a list of tag LINKS.
+    # May be several links per tag.id
     selected_tags.sort(key=lambda x: x[0])
 
     initial = {
@@ -2458,7 +2460,8 @@ def annotate_tags(request, conn=None, **kwargs):
             # filter down previously selected tags to the ones linked by
             # current user
             selected_tag_ids = [stag[0] for stag in selected_tags if stag[5]]
-            # added_tags = [stag[0] for stag in selected_tags if not stag[5]]
+            # Remove duplicates from tag IDs
+            selected_tag_ids = list(set(selected_tag_ids))
             post_tags = form_tags.cleaned_data['tags']
             tags = [tag for tag in post_tags
                     if tag not in selected_tag_ids]

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1187,6 +1187,8 @@ def api_annotations(request, conn=None, **kwargs):
     screen_ids = r.getlist('screen')
     plate_ids = r.getlist('plate')
     run_ids = r.getlist('acquisition')
+    page = get_long_or_default(request, 'page', 1)
+    limit = get_long_or_default(request, 'limit', settings.PAGE)
 
     ann_type = r.get('type', None)
 
@@ -1196,7 +1198,9 @@ def api_annotations(request, conn=None, **kwargs):
                                           screen_ids=screen_ids,
                                           plate_ids=plate_ids,
                                           run_ids=run_ids,
-                                          ann_type=ann_type)
+                                          ann_type=ann_type,
+                                          page=page,
+                                          limit=limit)
 
     return HttpJsonResponse({'annotations': anns, 'experimenters': exps})
 
@@ -2403,7 +2407,9 @@ def annotate_tags(request, conn=None, **kwargs):
         screen_ids=selected['screens'],
         plate_ids=selected['plates'],
         run_ids=selected['acquisitions'],
-        ann_type='tag')
+        ann_type='tag',
+        # If we reach this limit we'll get some tags not removed
+        limit=100000)
 
     userMap = {}
     for exp in users:

--- a/components/tools/OmeroWeb/test/integration/test_annotate.py
+++ b/components/tools/OmeroWeb/test/integration/test_annotate.py
@@ -24,6 +24,7 @@ Tests adding & removing annotations
 import omero
 import json
 import omero.clients
+from time import sleep
 
 from weblibrary import IWebTest
 from weblibrary import _csrf_post_response, _get_response
@@ -110,6 +111,9 @@ class TestTagging(IWebTest):
         # E.g. move from Right to Left column in the UI
         self.annotate_dataset(django_client1, ds.id.val, [tag2.id.val])
 
+        # Since tag link deletion is async, we need to wait to be sure that
+        # tag is removed.
+        sleep(1)
         rsp = _get_response_json(django_client1, request_url, data)
         tagIds = [t['id'] for t in rsp['annotations']]
         assert tag.id.val not in tagIds

--- a/components/tools/OmeroWeb/test/integration/test_tags.py
+++ b/components/tools/OmeroWeb/test/integration/test_tags.py
@@ -188,7 +188,6 @@ class TestTags(IWebTest):
     def test_add_remove_tags(self):
         # Test performance with lots of tags.
         # See https://github.com/openmicroscopy/openmicroscopy/pull/4842
-        img = self.make_image()
         img_count = 200
         tag_count = 10
         iids = [self.make_image().id.val for i in range(img_count)]

--- a/components/tools/OmeroWeb/test/integration/test_tags.py
+++ b/components/tools/OmeroWeb/test/integration/test_tags.py
@@ -166,10 +166,10 @@ class TestTags(IWebTest):
         }
         _post_response(self.django_client, request_url, data)
         _csrf_post_response(self.django_client, request_url, data)
-        # Check that tag is removed - sort delay to allow async delete
+        # Check that tag is removed - short delay to allow async delete
         sleep(0.1)
         request_url = reverse("api_annotations")
-        data = {'image': img.id.val}
+        data = {'image': img.id.val, 'type': 'tag'}
         data = _get_response_json(self.django_client, request_url, data)
         assert len(data['annotations']) == 1
 
@@ -179,11 +179,71 @@ class TestTags(IWebTest):
         _post_response(self.django_client, request_url, {})
         _csrf_post_response(self.django_client, request_url, {})
         # Check that tag is deleted from image
-        sleep(0.1)
+        sleep(1)
         request_url = reverse("api_annotations")
-        data = {'image': img.id.val}
-        data = _get_response_json(self.django_client, request_url, data)
-        assert len(data['annotations']) == 0
+        data = {'image': img.id.val, 'type': 'tag'}
+        rsp = _get_response_json(self.django_client, request_url, data)
+        assert len(rsp['annotations']) == 0
+
+    def test_add_remove_tags(self):
+        # Test performance with lots of tags.
+        # See https://github.com/openmicroscopy/openmicroscopy/pull/4842
+        img = self.make_image()
+        img_count = 200
+        tag_count = 10
+        iids = [self.make_image().id.val for i in range(img_count)]
+        tagIds = [str(self.new_tag().id.val) for i in range(tag_count)]
+        tagIds = ",".join(tagIds)
+        request_url = reverse('annotate_tags')
+        data = {
+            'image': iids,
+            'filter_mode': 'any',
+            'filter_owner_mode': 'all',
+            'index': 0,
+            'newtags-INITIAL_FORMS': 0,
+            'newtags-MAX_NUM_FORMS': 1000,
+            'newtags-TOTAL_FORMS': 0,
+            'tags': tagIds
+        }
+        _post_response(self.django_client, request_url, data)
+        rsp = _csrf_post_response(self.django_client, request_url, data)
+        rspJson = json.loads(rsp.content)
+        assert len(rspJson['added']) == tag_count
+        # Check that tags are added to all images
+        anns_url = reverse("api_annotations")
+        query_string = '&'.join(['image=%s' % i for i in iids])
+        query_string += '&type=tag'
+        query_string += '&page=0'  # disable pagination
+        print query_string
+        rsp = self.django_client.get('%s?%s' % (anns_url, query_string))
+        rspJson = json.loads(rsp.content)
+        assert len(rspJson['annotations']) == img_count * tag_count
+
+        # Remove tags
+        data = {
+            'image': iids,
+            'filter_mode': 'any',
+            'filter_owner_mode': 'all',
+            'index': 0,
+            'newtags-INITIAL_FORMS': 0,
+            'newtags-MAX_NUM_FORMS': 1000,
+            'newtags-TOTAL_FORMS': 0,
+            'tags': ''
+        }
+        _post_response(self.django_client, request_url, data)
+        rsp = _csrf_post_response(self.django_client, request_url, data)
+        rspJson = json.loads(rsp.content)
+
+        # Async delete - Keep checking until all removed
+        completed = False
+        for t in range(10):
+            rsp = self.django_client.get('%s?%s' % (anns_url, query_string))
+            rspJson = json.loads(rsp.content)
+            if len(rspJson['annotations']) == 0:
+                completed = True
+                break
+            sleep(1)
+        assert completed
 
 
 def _get_response_json(django_client, request_url, query_string):


### PR DESCRIPTION
# What this PR does

A couple of performance improvements for removing tags from images.
See https://trello.com/c/gPkTUuw5/23-tags-removal-takes-too-long-on-200-images

We now use the batch ```conn.deleteObjects()``` with ```wait=False``` to not wait on async delete, instead of doing a single ```conn.deleteObject()``` for each link in turn.

# Testing this PR

1. Select many images, add Tag to all of them and Save.
2. Remove tag either with (-) icon on tag itself OR via Tag dialog (moving tag into left column)
3. In both cases this should be much improved performance.
