### PR TITLE
Include hyphen syntax in graph command help

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -26,8 +26,9 @@ Examples:
     omero chgrp 101 Image:1
     omero chgrp Group:101 Image:2
     omero chgrp ExperimenterGroup:101 Image:3
-    # Move three images to the group named "My Lab"
-    omero chgrp "My Lab" Image:51,52,53
+    # In both cases move five images to the group named "My Lab"
+    omero chgrp "My Lab" Image:51,52,53,54,56
+    omero chgrp "My Lab" Image:51-54,56
 
     # Move a plate but leave all images in the original group
     omero chgrp 201 Plate:1 --exclude Image

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -36,8 +36,9 @@ Examples:
     omero chown 101 Image:1
     omero chown User:101 Image:2
     omero chown Experimenter:101 Image:3
-    # Transfer three images to the user named jane
-    omero chown jane Image:51,52,53
+    # In both cases transfer five images to the user named jane
+    omero chown jane Image:51,52,53,54,56
+    omero chown jane Image:51-54,56
 
     # Transfer a plate but leave all images with the original owner
     omero chown 201 Plate:1 --exclude Image

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -30,6 +30,8 @@ Examples:
 
     # Delete three images and two datasets including their contents
     omero delete  omero delete Image:101,102,103 Dataset:201,202
+    # Delete five images and four datasets including their contents
+    omero delete  omero delete Image:106-110 Dataset:203-205,207
     # Delete a project excluding contained datasets and linked annotations
     omero delete Project:101 --exclude Dataset,Annotation
 

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -29,9 +29,9 @@ Examples:
     omero delete Image:52 --include Annotation
 
     # Delete three images and two datasets including their contents
-    omero delete  omero delete Image:101,102,103 Dataset:201,202
+    omero delete Image:101,102,103 Dataset:201,202
     # Delete five images and four datasets including their contents
-    omero delete  omero delete Image:106-110 Dataset:203-205,207
+    omero delete Image:106-110 Dataset:203-205,207
     # Delete a project excluding contained datasets and linked annotations
     omero delete Project:101 --exclude Dataset,Annotation
 


### PR DESCRIPTION
# What this PR does

This PR adds examples to the help for `delete`, `chgrp` and `chown` that use the hyphen syntax for specifying id ranges. See gh-4707. This form of input is only currently available for the `GraphControl` commands, hence this PR's limited scope.

# Testing this PR

Check that the command line help for the above commands makes sense.