### PR TITLE
fix minor typo in autogen comment

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -513,7 +513,7 @@ implements java.io.Serializable, IObject
     *
     * will fail. Experimenter has no owner, for obvious reasons.
     *
-    * Note: subclasses of this class will return a subclasse of 
+    * Note: subclasses of this class will return a subclass of
     * the {@link ome.model.internal.Details} type.
     */
     @javax.persistence.Embedded


### PR DESCRIPTION
Just corrects a trivial typo. Everything should just keep on working.