### PR TITLE
Reverse intensity (Insight)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -561,11 +561,11 @@ class BrowserControl
         } else if (CellDisplay.DESCRIPTOR_PROPERTY.equals(name)) {
         	CellDisplay node = (CellDisplay) evt.getNewValue();
         	setSelectedCell(node.getLocation(), node);
-        } else if (ColourPicker.COLOUR_PROPERTY.equals(name)) {
+        } else if (ColourPicker.ACCEPT_PROPERTY.equals(name)) {
         	ColourObject co = (ColourObject) evt.getNewValue();
         	if (selectedCell == null) return;
-        	selectedCell.setHighlight(co.getColor());
-        	selectedCell.setDescription(co.getDescription());
+        	selectedCell.setHighlight(co.color);
+        	selectedCell.setDescription(co.description != null ? co.description : "");
         	model.setSelectedCell(selectedCell);
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellsModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -279,27 +279,33 @@ class WellsModel
 			if (cMap.containsKey(column)) {
 				co = cMap.get(column);
 				color = createColor(data);
-				if (!UIUtilities.isSameColors(co.getColor(), color, true) ||
-						!isSameDescription(co.getDescription(), type)) {
-					co.setColor(null);
-					co.setDescription(null);
+				if (!UIUtilities.isSameColors(co.color, color, true) ||
+						!isSameDescription(co.description, type)) {
+					co.color = null;
+					co.description = null;
 					cMap.put(column, co);
 				}
 			} else {
-				cMap.put(column, new ColourObject(createColor(data), type));
+			    ColourObject newco = new ColourObject();
+			    newco.color = createColor(data);
+			    newco.description = type;
+				cMap.put(column, newco);
 			}
 			
 			if (rMap.containsKey(row)) {
 				co = rMap.get(row);
 				color = createColor(data);
-				if (!UIUtilities.isSameColors(co.getColor(), color, true) ||
-						!isSameDescription(co.getDescription(), type)) {
-					co.setColor(null);
-					co.setDescription(null);
+				if (!UIUtilities.isSameColors(co.color, color, true) ||
+						!isSameDescription(co.description, type)) {
+					co.color = null;
+					co.description = null;
 					rMap.put(row, co);
 				}
 			} else {
-				rMap.put(row, new ColourObject(createColor(data), type));
+			    ColourObject newco = new ColourObject();
+                newco.color = createColor(data);
+                newco.description = type;
+				rMap.put(row, newco);
 			}
 			if (row > rows) rows = row;
 			if (column > columns) columns = column;
@@ -362,8 +368,8 @@ class WellsModel
 			cell = new CellDisplay(k-1, columnSequence);
 			co = cMap.get(k-1);
 			if (co != null) {
-				cell.setHighlight(co.getColor());
-				cell.setDescription(co.getDescription());
+				cell.setHighlight(co.color);
+				cell.setDescription(co.description != null ? co.description : "");
 			}
 			//if (!isMac)
 			//samples.add(cell);
@@ -379,8 +385,8 @@ class WellsModel
 			cell = new CellDisplay(k-1, rowSequence, CellDisplay.TYPE_VERTICAL);
 			co = rMap.get(k-1);
 			if (co != null) {
-				cell.setHighlight(co.getColor());
-				cell.setDescription(co.getDescription());
+				cell.setHighlight(co.color);
+				cell.setDescription(co.description != null ? co.description : "");
 			}
 			//if (!isMac)
 			//samples.add(cell);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ControlPane.java
@@ -1261,20 +1261,26 @@ class ControlPane
         ChannelButton button;
         while (i.hasNext()) {
             button = i.next();
-            if (index == button.getChannelIndex())
+            if (index == button.getChannelIndex()) {
                 button.setColor(c);
+                button.setImage(null);
+            }
         }
         i = channelButtonsGrid.iterator();
         while (i.hasNext()) {
             button = i.next();
-            if (index == button.getChannelIndex())
+            if (index == button.getChannelIndex()) {
                 button.setColor(c);
+                button.setImage(null);
+            }
         }
         i = channelButtonsProjection.iterator();
         while (i.hasNext()) {
             button = i.next();
-            if (index == button.getChannelIndex())
+            if (index == button.getChannelIndex()) {
                 button.setColor(c);
+                button.setImage(null);
+            }
         }
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -392,6 +392,19 @@ public interface ImViewer
      */
     public void setLookupTable(int index, String lut, boolean preview);
     
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param index
+     *            The channel index
+     * @param revInt
+     *            The reverse intensity flag
+     * @param preview
+     *            Pass <code>true</code> to indicate that it is a color preview,
+     *            <code>false</code> otherwise.
+     */
+    public void setReverseIntensity(int index, boolean revInt, boolean preview);
+    
 	/**
 	 * Selects or deselects the specified channel.
 	 * The selection process depends on the currently selected color model.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -589,6 +589,15 @@ public interface ImViewer
     public String getLookupTable(int index);
 
     /**
+     * Get the reverse intensity flag for the given channel
+     * 
+     * @param index
+     *            The channel index
+     * @return See above
+     */
+    boolean getReverseIntensity(int index);
+    
+    /**
      * Get all available lookup tables
      * 
      * @return See above

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -1082,6 +1082,33 @@ class ImViewerComponent
     /**
      * Implemented as specified by the {@link ImViewer} interface.
      * 
+     * @see ImViewer#setReverseIntensity(int, boolean, boolean)
+     */
+    public void setReverseIntensity(int index, boolean revInt, boolean preview) {
+        switch (model.getState()) {
+        case NEW:
+        case DISCARDED:
+            throw new IllegalStateException(
+                    "This method can't be invoked in the DISCARDED, "
+                            + "NEW or LOADING_RENDERING_CONTROL state.");
+        }
+
+        try {
+            model.setReverseIntensity(index, revInt);
+        } catch (Exception e) {
+            Registry reg = ImViewerAgent.getRegistry();
+            LogMessage msg = new LogMessage();
+            msg.println("Cannot set the reverse intensity of channel " + index);
+            msg.print(e);
+            reg.getLogger().error(this, msg);
+            reg.getUserNotifier().notifyError("Set reverse intensity",
+                    "Cannot set the reverse intensity of channel " + index, e);
+        }
+    }
+    
+    /**
+     * Implemented as specified by the {@link ImViewer} interface.
+     * 
      * @see ImViewer#resetLookupTable(int)
      */
     public void resetLookupTable(int index) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -1753,6 +1753,16 @@ class ImViewerComponent
     
     /** 
      * Implemented as specified by the {@link ImViewer} interface.
+     * @see ImViewer#getReverseIntensity(int)
+     */
+    public boolean getReverseIntensity(int index) {
+        if (model.getState() == DISCARDED)
+            return false;
+        return model.getReverseIntensity(index);
+    }
+    
+    /** 
+     * Implemented as specified by the {@link ImViewer} interface.
      * @see ImViewer#getAvailableLookupTables()
      */
     public Collection<String> getAvailableLookupTables() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -1206,7 +1206,7 @@ class ImViewerControl
             model.resetLookupTable(index);
             model.setChannelColor(index, null, true);
         } else {
-            if (newLut != null && !ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
+            if (!ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
                 model.setLookupTable(index, newLut, preview);
             } else if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
                 model.setLookupTable(index, null, preview);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -1208,8 +1208,7 @@ class ImViewerControl
         } else {
             if (!ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
                 model.setLookupTable(index, newLut, preview);
-            } else if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
-                model.setLookupTable(index, null, preview);
+            } if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
                 model.setChannelColor(index, newColor, preview);
             } 
             model.setReverseIntensity(index, revInt, preview);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -108,6 +108,7 @@ import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneComponent;
 import org.openmicroscopy.shoola.util.ui.LoadingWindow;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import org.openmicroscopy.shoola.util.ui.colourpicker.ColourObject;
 import org.openmicroscopy.shoola.util.ui.colourpicker.ColourPicker;
 import org.openmicroscopy.shoola.util.ui.colourpicker.ColourPickerUtil;
 import org.openmicroscopy.shoola.util.ui.filechooser.FileChooser;
@@ -738,10 +739,11 @@ class ImViewerControl
 		colorPickerIndex = index;
 		Color c = model.getChannelColor(index);
 		String lut = model.getLookupTable(index);
+		boolean revInt = model.getReverseIntensity(index);
         Collection<String> luts = model.getAvailableLookupTables();
         
 		if(colorPicker == null) {
-            colorPicker = new ColourPicker(view, c, luts, lut);
+            colorPicker = new ColourPicker(view, c, luts, lut, revInt);
             colorPicker.setPreviewVisible(true);
             colorPicker.addPropertyChangeListener(this);
         }
@@ -984,31 +986,13 @@ class ImViewerControl
 			ChannelColorMenuItem.CHANNEL_COLOR_PROPERTY.equals(pName)) {
 			if (view.isSourceDisplayed(pce.getSource()))
 				model.showColorPicker(((Integer) pce.getNewValue()).intValue());
-		} else if (ColourPicker.COLOUR_PROPERTY.equals(pName)
-                || ColourPicker.COLOUR_PREVIEW_PROPERTY.equals(pName)
-                || ColourPicker.LUT_PROPERTY.equals(pName)
-                || ColourPicker.LUT_PREVIEW_PROPERTY.equals(pName)) {
+		} else if (ColourPicker.ACCEPT_PROPERTY.equals(pName)) {
             if (colorPickerIndex != -1) {
 
-                Color newColor = model.getChannelColor(colorPickerIndex);
-                Color oldColor = model.getChannelColor(colorPickerIndex);
-                String newLut = model.getLookupTable(colorPickerIndex);
-                String oldLut = model.getLookupTable(colorPickerIndex);
-
-                if (ColourPicker.COLOUR_PROPERTY.equals(pName)
-                        || ColourPicker.COLOUR_PREVIEW_PROPERTY.equals(pName)) {
-                    newColor = (Color) pce.getNewValue();
-                } else if (ColourPicker.LUT_PROPERTY.equals(pName)
-                        || ColourPicker.LUT_PREVIEW_PROPERTY.equals(pName)) {
-                    newLut = (String) pce.getNewValue();
-                }
-
-                boolean preview = ColourPicker.COLOUR_PREVIEW_PROPERTY
-                        .equals(pName)
-                        || ColourPicker.LUT_PREVIEW_PROPERTY.equals(pName);
-
-                handleColorPicker(false, preview, colorPickerIndex, newColor,
-                        oldColor, newLut, oldLut);
+                ColourObject co = (ColourObject) pce.getNewValue();
+                ColourObject old = (ColourObject) pce.getOldValue();
+                handleColorPicker(false, co.preview, colorPickerIndex, co.color,
+                        old != null ? old.color : null, co.lut, old != null ? old.lut : null);
             }
         } else if (UnitBarSizeDialog.UNIT_BAR_VALUE_PROPERTY.equals(pName)) {
 			double v = ((Double) pce.getNewValue()).doubleValue();
@@ -1217,9 +1201,9 @@ class ImViewerControl
             model.resetLookupTable(index);
             model.setChannelColor(index, null, true);
         } else {
-            if (!ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
+            if (newLut != null && !ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
                 model.setLookupTable(index, newLut, preview);
-            } else if (!ColourPickerUtil.sameColor(newColor, oldColor)) {
+            } else if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
                 model.setLookupTable(index, null, preview);
                 model.setChannelColor(index, newColor, preview);
             } 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerControl.java
@@ -747,6 +747,10 @@ class ImViewerControl
             colorPicker.setPreviewVisible(true);
             colorPicker.addPropertyChangeListener(this);
         }
+		else {
+		    colorPicker.reinit(c, null, lut, revInt);
+		}
+		
         if (!colorPicker.isShowing()) {
             UIUtilities.setLocationRelativeToAndShow(view, colorPicker);
         }
@@ -992,7 +996,7 @@ class ImViewerControl
                 ColourObject co = (ColourObject) pce.getNewValue();
                 ColourObject old = (ColourObject) pce.getOldValue();
                 handleColorPicker(false, co.preview, colorPickerIndex, co.color,
-                        old != null ? old.color : null, co.lut, old != null ? old.lut : null);
+                        old != null ? old.color : null, co.lut, old != null ? old.lut : null, co.revInt);
             }
         } else if (UnitBarSizeDialog.UNIT_BAR_VALUE_PROPERTY.equals(pName)) {
 			double v = ((Double) pce.getNewValue()).doubleValue();
@@ -1194,9 +1198,10 @@ class ImViewerControl
      * @param oldColor The previous Color
      * @param newLut The new lookup table
      * @param oldLut The previous lookup table
+     * @param revInt The reverse intensity flag
      */
     private void handleColorPicker(boolean reset, boolean preview, int index,
-            Color newColor, Color oldColor, String newLut, String oldLut) {
+            Color newColor, Color oldColor, String newLut, String oldLut, boolean revInt) {
         if (reset) {
             model.resetLookupTable(index);
             model.setChannelColor(index, null, true);
@@ -1207,6 +1212,7 @@ class ImViewerControl
                 model.setLookupTable(index, null, preview);
                 model.setChannelColor(index, newColor, preview);
             } 
+            model.setReverseIntensity(index, revInt, preview);
         }
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -1000,6 +1000,20 @@ class ImViewerModel
         return rnd.getLookupTable(index);
 	}
 	
+    /**
+     * Return the reverse intensity flag for the given channel
+     * 
+     * @param index
+     *            The channel index
+     * @return See above
+     */
+    boolean getReverseIntensity(int index) {
+        Renderer rnd = metadataViewer.getRenderer();
+        if (rnd == null)
+            return false;
+        return rnd.getReverseIntensity(index);
+    }
+	
 	/**
 	 * Returns <code>true</code> if the channel is mapped, <code>false</code>
 	 * otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -1265,6 +1265,21 @@ class ImViewerModel
         rnd.setLookupTable(index, lut, false);
     }
 
+    /**
+     * Sets reverse intensity flag for the specified channel.
+     * 
+     * @param index
+     *            The channel's index.
+     * @param revInt
+     *            The reverse intensity flag
+     */
+    void setReverseIntensity(int index, boolean revInt) {
+        Renderer rnd = metadataViewer.getRenderer();
+        if (rnd == null)
+            return;
+        rnd.setReverseIntensity(index, revInt, false);
+    }
+    
 	/**
 	 * Sets the channel active.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -59,7 +59,6 @@ import org.jhotdraw.draw.FigureListener;
 import org.jhotdraw.draw.FigureSelectionEvent;
 import org.jhotdraw.draw.FigureSelectionListener;
 import org.jhotdraw.draw.AttributeKey;
-
 import org.openmicroscopy.shoola.agents.events.measurement.SelectChannel;
 import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.agents.measurement.actions.CreateFigureAction;
@@ -84,6 +83,7 @@ import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes
 import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 import org.openmicroscopy.shoola.util.ui.LoadingWindow;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+import org.openmicroscopy.shoola.util.ui.colourpicker.ColourObject;
 import org.openmicroscopy.shoola.util.ui.colourpicker.ColourPicker;
 
 import omero.gateway.model.AnnotationData;
@@ -433,7 +433,7 @@ class MeasurementViewerControl
     {
 		if (color == null) return;
 		ColourPicker picker = new ColourPicker(view, color);
-		picker.addPropertyChangeListener(ColourPicker.COLOUR_PROPERTY, this);
+		picker.addPropertyChangeListener(ColourPicker.ACCEPT_PROPERTY, this);
 		UIUtilities.setLocationRelativeTo(view, picker);
 	}
     
@@ -487,8 +487,10 @@ class MeasurementViewerControl
 	public void propertyChange(PropertyChangeEvent evt)
 	{
 		String name = evt.getPropertyName();
-		if (ColourPicker.COLOUR_PROPERTY.equals(name))
-			view.setCellColor((Color) evt.getNewValue());
+		if (ColourPicker.ACCEPT_PROPERTY.equals(name)) {
+		    ColourObject co = (ColourObject) evt.getNewValue();
+			view.setCellColor(co.color);
+		}
 		else if (LoadingWindow.CLOSED_PROPERTY.equals(name)) 
             model.discard();
 		else if (PermissionMenu.SELECTED_LEVEL_PROPERTY.equals(name)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -412,6 +412,15 @@ public interface Renderer
     String getLookupTable(int index);
     
     /**
+     * Return the reverse intensity flag for the given channel
+     * 
+     * @param index
+     *            The channel index
+     * @return See above
+     */
+    boolean getReverseIntensity(int index);
+    
+    /**
      * Returns <code>true</code> if the channel is mapped, <code>false</code>
      * otherwise.
      * 
@@ -831,6 +840,19 @@ public interface Renderer
      */
     void setLookupTable(int index, String lut, boolean preview);
 
+    /**
+     * Set the reverse intensity flag for the specified channel
+     * 
+     * @param index
+     *            The channel index
+     * @param revInt
+     *            The reverse intensity flag
+     * @param preview
+     *            Pass <code>true</code> to indicate that it is a color preview,
+     *            <code>false</code> otherwise.
+     */
+    void setReverseIntensity(int index, boolean revInt, boolean preview);
+    
     /**
      * Resets a previously previewed lookup table
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererComponent.java
@@ -35,7 +35,6 @@ import javax.swing.SwingUtilities;
 import omero.romio.PlaneDef;
 
 import org.openmicroscopy.shoola.agents.events.iviewer.RendererUnloadedEvent;
-import org.openmicroscopy.shoola.agents.events.iviewer.RndSettingsChanged;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
 import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
 import org.openmicroscopy.shoola.agents.metadata.MetadataViewerAgent;
@@ -533,6 +532,23 @@ class RendererComponent
         }
     }
     
+    /**
+     * Implemented as specified by the {@link Renderer} interface.
+     * 
+     * @see Renderer#setReverseIntensity(int, boolean, boolean)
+     */
+    public void setReverseIntensity(int index, boolean revInt, boolean preview) {
+        try {
+            makeHistorySnapshot();
+            model.setReverseIntensity(index, revInt);
+            firePropertyChange(CHANNEL_COLOR_PROPERTY, -1, index);
+            firePropertyChange(RENDER_PLANE_PROPERTY, Boolean.valueOf(false),
+                    Boolean.valueOf(true));
+        } catch (Exception e) {
+            handleException(e);
+        }
+    }
+    
     /** 
      * Implemented as specified by the {@link Renderer} interface.
      * @see Renderer#setChannelColor(int, Color, boolean)
@@ -727,7 +743,7 @@ class RendererComponent
 
     /** 
      * Implemented as specified by the {@link Renderer} interface.
-     * @see Renderer#onSettingsApplied()
+     * @see Renderer#onSettingsApplied(RenderingControl)
      */
 	public void onSettingsApplied(RenderingControl rndControl)
 	{ 
@@ -816,6 +832,14 @@ class RendererComponent
     public String getLookupTable(int index)
     {
         return model.getLookupTable(index);
+    }
+    
+    /** 
+     * Implemented as specified by the {@link Renderer} interface.
+     * @see Renderer#getReverseIntensity(int)
+     */
+    public boolean getReverseIntensity(int index) {
+        return model.getReverseIntensity(index);
     }
     
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -490,6 +490,7 @@ class RendererControl
      * @param oldColor The previous Color
      * @param newLut The new lookup table
      * @param oldLut The previous lookup table
+     * @param revInt Reverse intensity flag
      */
     private void handleColorPicker(boolean reset, boolean preview, int index,
             Color newColor, Color oldColor, String newLut, String oldLut, boolean revInt) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -236,6 +236,9 @@ class RendererControl
     		colorPicker.setPreviewVisible(true);
     		colorPicker.addPropertyChangeListener(this);
 		}
+		else {
+		    colorPicker.reinit(c, null, lut, revInt);
+		}
 		if (!colorPicker.isShowing()) {
     		if (location == null)
     		    UIUtilities.centerAndShow(colorPicker);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -499,8 +499,7 @@ class RendererControl
         } else {
             if (!ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
                 model.setLookupTable(index, newLut, preview);
-            } else if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
-                model.setLookupTable(index, null, preview);
+            } if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
                 model.setChannelColor(index, newColor, preview);
             } 
             model.setReverseIntensity(index, revInt, preview);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererControl.java
@@ -497,7 +497,7 @@ class RendererControl
             model.resetLookupTable(index);
             model.setChannelColor(index, null, true);
         } else {
-            if (newLut != null && !ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
+            if (!ColourPickerUtil.sameLookuptable(newLut, oldLut)) {
                 model.setLookupTable(index, newLut, preview);
             } else if (newColor != null && !ColourPickerUtil.sameColor(newColor, oldColor)) {
                 model.setLookupTable(index, null, preview);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -1787,4 +1787,36 @@ class RendererModel
             MetadataViewerAgent.getRegistry().getLogger().error(this, msg);
         }
     }
+    
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param index
+     *            The channel index
+     * @param revInt
+     *            The reverse intensity flag
+     */
+    public void setReverseIntensity(int index, boolean revInt) {
+        try {
+            rndControl.setReverseIntensity(index, revInt);
+        } catch (Exception e) {
+            LogMessage msg = new LogMessage();
+            msg.append("Error while setting reverse intensity.");
+            msg.print(e);
+            MetadataViewerAgent.getRegistry().getLogger().error(this, msg);
+        }
+    }
+
+    /**
+     * Get the reverse intensity flag
+     * 
+     * @param index
+     *            The channel index
+     * @return See above.
+     */
+    public boolean getReverseIntensity(int index) {
+        if (rndControl == null)
+            return false;
+        return rndControl.getReverseIntensity(index);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererUI.java
@@ -267,6 +267,17 @@ class RendererUI
     }
 
     /**
+     * Returns the reverse intensity flag associated to the channel.
+     *
+     * @param channel
+     *            The index of the channel.
+     * @return See above.
+     */
+    boolean getReverseIntensity(int channel) {
+        return model.getReverseIntensity(channel);
+    };
+    
+    /**
      * Updates UI components when a new z-section is selected.
      *
      * @param z The selected z-section.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/ChannelBindingsProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/ChannelBindingsProxy.java
@@ -76,6 +76,9 @@ class ChannelBindingsProxy
     /** The lookup table */
     private String lookupTable;
     
+    /** The reverse intensity flag */
+    private boolean revInt;
+    
     /** Creates a new instance. */
     ChannelBindingsProxy()
     {
@@ -235,6 +238,7 @@ class ChannelBindingsProxy
     			this.isNoiseReduction());
     	copy.setRGBA(this.getRGBA());
     	copy.setLookupTable(this.getLookupTable());
+    	copy.setReverseIntensity(this.getReverseIntensity());
     	return copy;
     }
 
@@ -243,7 +247,7 @@ class ChannelBindingsProxy
      * 
      * @return See above
      */
-    public String getLookupTable() {
+    String getLookupTable() {
         return lookupTable;
     }
 
@@ -253,9 +257,27 @@ class ChannelBindingsProxy
      * @param lookupTable
      *            The lookup table
      */
-    public void setLookupTable(String lookupTable) {
+    void setLookupTable(String lookupTable) {
         this.lookupTable = lookupTable;
     }
-       
-    
+     
+    /**
+     * Get the reverse intensity flag
+     * 
+     * @return See above
+     */
+    boolean getReverseIntensity() {
+        return revInt;
+    }
+
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param revInt
+     *            The reverse intensity flag
+     */
+    void setReverseIntensity(boolean revInt) {
+        this.revInt = revInt;
+    }
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -150,7 +150,7 @@ public class PixelsServicesFactory
                 
                 cb.setReverseIntensity(false);
                 List<CodomainMapContext> cdctx = c.copySpatialDomainEnhancement();
-                for(CodomainMapContext cd : cdctx) {
+                for (CodomainMapContext cd : cdctx) {
                     if(cd instanceof ReverseIntensityContext) {
                         cb.setReverseIntensity(true);
                         break;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -35,9 +35,11 @@ import java.util.Map.Entry;
 
 import omero.api.RenderingEnginePrx;
 import omero.model.ChannelBinding;
+import omero.model.CodomainMapContext;
 import omero.model.Pixels;
 import omero.model.QuantumDef;
 import omero.model.RenderingDef;
+import omero.model.ReverseIntensityContext;
 import omero.romio.PlaneDef;
 
 import org.openmicroscopy.shoola.env.Container;
@@ -145,6 +147,15 @@ public class PixelsServicesFactory
 						c.getNoiseReduction().getValue());
                 if (c.getLookupTable() != null)
                     cb.setLookupTable(c.getLookupTable().getValue());
+                
+                cb.setReverseIntensity(false);
+                List<CodomainMapContext> cdctx = c.copySpatialDomainEnhancement();
+                for(CodomainMapContext cd : cdctx) {
+                    if(cd instanceof ReverseIntensityContext) {
+                        cb.setReverseIntensity(true);
+                        break;
+                    }
+                }
 			}		
 			i++;
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -288,7 +288,7 @@ public interface RenderingControl
     /**
      * Sets the values used during the mapping of the specified wavelength.
      * 
-     * @param w                 The index of the channel.
+     * @param index                 The index of the channel.
      * @param family            The mapping family.
      * @param coefficient       The coefficient identifying a curve in the
      *                          family.
@@ -299,7 +299,7 @@ public interface RenderingControl
      * 										the value.       
      * @throws DSOutOfServiceException  	If the connection is broken.                   
      */ 
-    public void setQuantizationMap(int w, String family, double coefficient, 
+    public void setQuantizationMap(int index, String family, double coefficient, 
                                     boolean noiseReduction)
     	throws RenderingServiceException, DSOutOfServiceException;
     
@@ -307,102 +307,102 @@ public interface RenderingControl
      * Returns the family used to map the specified channel onto the device
      * space.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return See above.
      */
-    public String getChannelFamily(int w);
+    public String getChannelFamily(int index);
     
     /**
      * Returns <code>true</code> is the <code>NoiseReduction</code> algorithm
      * is used when mapping the specified channel.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return See above.
      */
-    public boolean getChannelNoiseReduction(int w);
+    public boolean getChannelNoiseReduction(int index);
 
     /**
      * Returns the coefficient that identifies a curve in the family of curves.
      *      
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return  See above.
      * @see #getChannelFamily(int)
      */
-    public double getChannelCurveCoefficient(int w);
+    public double getChannelCurveCoefficient(int index);
     
     /**
      * Sets the size of the pixel intensity interval for the specified channel.
      * 
-     * @param w     The index of the channel.
+     * @param index     The index of the channel.
      * @param start The lower bound of the interval.
      * @param end   The upper bound of the interval.
      * @throws RenderingServiceException 	If an error occurred while setting 
      * 										the value.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
-    public void setChannelWindow(int w, double start, double end)
+    public void setChannelWindow(int index, double start, double end)
     	throws RenderingServiceException, DSOutOfServiceException;
     
     /**
      * Returns the lower bound of the pixel intensity interval.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return See above.
      * @see #setChannelWindow(int, double, double)
      */
-    public double getChannelWindowStart(int w);
+    public double getChannelWindowStart(int index);
     
     /**
      * Returns the upper bound of the pixel intensity interval.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return See above.
      * @see #setChannelWindow(int, double, double)
      */
-    public double getChannelWindowEnd(int w);
+    public double getChannelWindowEnd(int index);
     
     /**
      * Sets the color on which the specified channel is mapped onto.
      * 
-     * @param w     The index of the channel.
+     * @param index     The index of the channel.
      * @param color The color to set.
      * @throws RenderingServiceException 	If an error occurred while setting 
      * 										the value. 
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
-    public void setRGBA(int w, Color color)
+    public void setRGBA(int index, Color color)
     	throws RenderingServiceException, DSOutOfServiceException;
     
     /**
      * Returns the color the channel is mapped onto.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return  See above.
      */
-    public Color getRGBA(int w);
+    public Color getRGBA(int index);
     
     /**
      * Sets the flag to map the channel, passed <code>true</code> to map the
      * channel, <code>false</code> otherwise.
      * 
-     * @param w         The index of the channel.
+     * @param index         The index of the channel.
      * @param active    Pass <code>true</code> to map the channel, 
      *                  <code>false</code> otherwise.
      * @throws RenderingServiceException 	If an error occurred while setting 
      * 										the value.  
      * @throws DSOutOfServiceException  	If the connection is broken.               
      */
-    public void setActive(int w, boolean active)
+    public void setActive(int index, boolean active)
     	throws RenderingServiceException, DSOutOfServiceException;
     
     /**
      * Returns <code>true</code> if the channel is mapped, <code>false</code>
      * otherwise.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @return  See above.
      */
-    public boolean isActive(int w);
+    public boolean isActive(int index);
     
     /**
      * Adds the <code>CodomainMapContext</code> to the list of transformations.
@@ -411,45 +411,36 @@ public interface RenderingControl
      * managing the codomain transformations is rebuilt. 
      *
      * @param mapCtx The context to add.
-     * @param w The channel to add the context to.
-     * @throws RenderingServiceException If an error occurred while setting the value.
+     * @param index The channel to add the context to.
+     * @throws RenderingServiceException If an error occurred while adding the CodomainMapContext.
      * @throws DSOutOfServiceException If the connection is broken.
      */
-    public void addCodomainMap(CodomainMapContext mapCtx, int w)
+    public void addCodomainMap(CodomainMapContext mapCtx, int index)
             throws RenderingServiceException, DSOutOfServiceException;
-    
-    /**
-     * Updates the specified <code>CodomainMapContext</code>.
-     * The transformation associated should already be in the transformations.
-     * 
-     * @param mapCtx The context to update.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
-     * @throws DSOutOfServiceException  	If the connection is broken.
-     */
-    //public void updateCodomainMap(CodomainMapContext mapCtx)
-    //	throws RenderingServiceException, DSOutOfServiceException;
     
     /**
      * Removed the <code>CodomainMapContext</code> from the list of
      * transformations.
      * 
      * @param mapCtx The context to remove.
-     * @param w The channel to remove the context from.
-     * @throws RenderingServiceException If an error occurred while setting the value.
+     * @param index The channel to remove the context from.
+     * @throws RenderingServiceException If an error occurred while removing the CodomainMapContext.
      * @throws DSOutOfServiceException If the connection is broken.
      */
-    public void removeCodomainMap(CodomainMapContext mapCtx, int w)
+    public void removeCodomainMap(CodomainMapContext mapCtx, int index)
             throws RenderingServiceException, DSOutOfServiceException;
 
     /**
      * Returns a read-only list of <code>CodomainMapContext</code>s using during
      * the mapping process in the device space.
      *
-     * @param w The channel
+     * @param index The channel
      * @return See above.
+     * @throws RenderingServiceException    If an error occurred while getting 
+     *                                      the value.
+     * @throws DSOutOfServiceException      If the connection is broken. 
      */
-    public List<CodomainMapContext> getCodomainMaps(int w)
+    public List<CodomainMapContext> getCodomainMaps(int index)
         throws RenderingServiceException, DSOutOfServiceException;
 
     /**
@@ -487,10 +478,10 @@ public interface RenderingControl
      * Returns the <code>ChannelMetadata</code> object specified
      * by the passed index.
      * 
-     * @param w The channel index.
+     * @param index The channel index.
      * @return See above.
      */
-    public ChannelData getChannelData(int w);
+    public ChannelData getChannelData(int index);
     
     /**
      * Returns an array of <code>ChannelMetadata</code> objects.
@@ -595,19 +586,19 @@ public interface RenderingControl
      * Returns the minimum value for that channels depending on the pixels
      * type and the original range.
      * 
-     * @param w The channel's index.
+     * @param index The channel's index.
      * @return See above.
      */
-	public double getPixelsTypeLowerBound(int w);
+	public double getPixelsTypeLowerBound(int index);
 
 	/**
      * Returns the maximum value for that channels depending on the pixels
      * type and the original range.
      * 
-     * @param w The channel's index.
+     * @param index The channel's index.
      * @return See above.
      */
-	public double getPixelsTypeUpperBound(int w);
+	public double getPixelsTypeUpperBound(int index);
 	
 	/**
 	 * Controls if the passed set of pixels is compatible
@@ -766,6 +757,9 @@ public interface RenderingControl
      * @param tableID  The id of the table.
      * @param overlays The overlays to set, or <code>null</code> to turn 
      * the overlays off.
+     * @throws RenderingServiceException    If an error occurred while setting 
+     *                                      the value.
+     * @throws DSOutOfServiceException      If the connection is broken. 
      */
     public void setOverlays(long tableID, Map<Long, Integer> overlays)
     	throws RenderingServiceException, DSOutOfServiceException;
@@ -814,8 +808,6 @@ public interface RenderingControl
 	 * otherwise.
 	 * 
 	 * @return See above.
-	 * @throws RenderingServiceException
-	 * @throws DSOutOfServiceException
 	 */
 	public boolean isBigImage();
 	
@@ -839,6 +831,9 @@ public interface RenderingControl
 	 * Returns the list of the levels.
 	 * 
 	 * @return See above.
+	 * @throws RenderingServiceException   If an error occurred while getting 
+     *                                      the value.
+     * @throws DSOutOfServiceException      If the connection is broken.
 	 */
 	List<ResolutionLevel> getResolutionDescriptions()
 		throws RenderingServiceException, DSOutOfServiceException;
@@ -853,21 +848,24 @@ public interface RenderingControl
     /**
      * Get the lookup table
      * 
-     * @param w
+     * @param index
      *            The channel index
      * @return See above
      */
-    String getLookupTable(int w);
+    String getLookupTable(int index);
 
     /**
      * Set the lookup table
      * 
-     * @param w
+     * @param index
      *            The channel index
      * @param lut
      *            The lookup table
+     * @throws RenderingServiceException    If an error occurred while setting 
+     *                                      the value.
+     * @throws DSOutOfServiceException      If the connection is broken. 
      */
-    void setLookupTable(int w, String lut) throws RenderingServiceException,
+    void setLookupTable(int index, String lut) throws RenderingServiceException,
             DSOutOfServiceException;
 
     /**
@@ -881,21 +879,24 @@ public interface RenderingControl
     /**
      * Set the reverse intensity flag
      * 
-     * @param w
+     * @param index
      *            The channel index
      * @param revInt
      *            The reverse intensity flag
+     * @throws RenderingServiceException    If an error occurred while setting 
+     *                                      the value.
+     * @throws DSOutOfServiceException      If the connection is broken. 
      */
-    void setReverseIntensity(int w, boolean revInt)
+    void setReverseIntensity(int index, boolean revInt)
             throws RenderingServiceException, DSOutOfServiceException;
 
     /**
      * Get the reverse intensity flag
      * 
-     * @param w
+     * @param index
      *            The channel index
      * @return See above
      */
-    boolean getReverseIntensity(int w);
+    boolean getReverseIntensity(int index);
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -877,4 +877,25 @@ public interface RenderingControl
      *            The lookup tables
      */
     void setAvailableLookupTables(Collection<String> lookupTables);
+
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param w
+     *            The channel index
+     * @param revInt
+     *            The reverse intensity flag
+     */
+    void setReverseIntensity(int w, boolean revInt)
+            throws RenderingServiceException, DSOutOfServiceException;
+
+    /**
+     * Get the reverse intensity flag
+     * 
+     * @param w
+     *            The channel index
+     * @return See above
+     */
+    boolean getReverseIntensity(int w);
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControl.java
@@ -185,8 +185,7 @@ public interface RenderingControl
      * mapped onto a color space.
      * 
      * @param model Identifies the color space model.
-     * @throws RenderingServiceException	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setModel(String model)
@@ -221,8 +220,7 @@ public interface RenderingControl
      * This index is used to define a default plane.
      *  
      * @param z The stack index.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
 	 * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setDefaultZ(int z)
@@ -233,8 +231,7 @@ public interface RenderingControl
      * This index is used to define a default plane.
      * 
      * @param t The time-point index.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken. 
      */
     public void setDefaultT(int t)
@@ -244,8 +241,7 @@ public interface RenderingControl
      * Sets the mapping strategy used during the mapping process.
      * 
      * @param bitResolution The depth, in bits, of the rendered image.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value. 
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setQuantumStrategy(int bitResolution)
@@ -257,8 +253,7 @@ public interface RenderingControl
      * 
      * @param start The lower bound of the interval.
      * @param end   The upper bound of the interval.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setCodomainInterval(int start, int end)
@@ -295,8 +290,7 @@ public interface RenderingControl
      * @param noiseReduction    Pass <code>true</code> to select the 
      *                          mapping <code>NoiseReduction</code> algorithm,
      *                          <code>false</code> otherwise.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.       
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.                   
      */ 
     public void setQuantizationMap(int index, String family, double coefficient, 
@@ -336,8 +330,7 @@ public interface RenderingControl
      * @param index     The index of the channel.
      * @param start The lower bound of the interval.
      * @param end   The upper bound of the interval.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setChannelWindow(int index, double start, double end)
@@ -366,8 +359,7 @@ public interface RenderingControl
      * 
      * @param index     The index of the channel.
      * @param color The color to set.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value. 
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setRGBA(int index, Color color)
@@ -388,8 +380,7 @@ public interface RenderingControl
      * @param index         The index of the channel.
      * @param active    Pass <code>true</code> to map the channel, 
      *                  <code>false</code> otherwise.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.  
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.               
      */
     public void setActive(int index, boolean active)
@@ -412,7 +403,7 @@ public interface RenderingControl
      *
      * @param mapCtx The context to add.
      * @param index The channel to add the context to.
-     * @throws RenderingServiceException If an error occurred while adding the CodomainMapContext.
+     * @throws RenderingServiceException If an error occurred.
      * @throws DSOutOfServiceException If the connection is broken.
      */
     public void addCodomainMap(CodomainMapContext mapCtx, int index)
@@ -424,7 +415,7 @@ public interface RenderingControl
      * 
      * @param mapCtx The context to remove.
      * @param index The channel to remove the context from.
-     * @throws RenderingServiceException If an error occurred while removing the CodomainMapContext.
+     * @throws RenderingServiceException If an error occurred.
      * @throws DSOutOfServiceException If the connection is broken.
      */
     public void removeCodomainMap(CodomainMapContext mapCtx, int index)
@@ -436,8 +427,7 @@ public interface RenderingControl
      *
      * @param index The channel
      * @return See above.
-     * @throws RenderingServiceException    If an error occurred while getting 
-     *                                      the value.
+     * @throws RenderingServiceException    If an error occurred.
      * @throws DSOutOfServiceException      If the connection is broken. 
      */
     public List<CodomainMapContext> getCodomainMaps(int index)
@@ -456,8 +446,7 @@ public interface RenderingControl
      * Returns the copy of the saved rendering data.
      *  
      * @return See above.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public RndProxyDef saveCurrentSettings()
@@ -467,8 +456,7 @@ public interface RenderingControl
      * Resets the original default values. 
      * The default values aren't values previously saved.
      * 
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void resetDefaults()
@@ -552,8 +540,7 @@ public interface RenderingControl
      * Resets the rendering settings.
      * (Does not reset Z and T settings)
      * @param settings The settings to set.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void resetSettings(RndProxyDef settings)
@@ -566,10 +553,8 @@ public interface RenderingControl
      *            The settings to set.
      * @param includeZT Pass <code>true</code> to also reset Z and T setting,
      *         <code>false</code> to ignore Z and T
-     * @throws RenderingServiceException
-     *             If an error occurred while setting the value.
-     * @throws DSOutOfServiceException
-     *             If the connection is broken.
+     * @throws RenderingServiceException If an error occurred.
+     * @throws DSOutOfServiceException If the connection is broken.
      */
     public void resetSettings(RndProxyDef rndDef, boolean includeZT)
             throws RenderingServiceException, DSOutOfServiceException;
@@ -630,8 +615,7 @@ public interface RenderingControl
 	 * 
 	 * @param pDef   Information about the plane to render.
 	 * @return See above.
-	 * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+	 * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
 	 */
 	public BufferedImage render(PlaneDef pDef)
@@ -643,8 +627,7 @@ public interface RenderingControl
 	 * @param pDef 	 Information about the plane to render.
 	 * @param compression The compression level.
 	 * @return See above.
-	 * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+	 * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
 	 */
 	public BufferedImage render(PlaneDef pDef, int compression)
@@ -660,8 +643,7 @@ public interface RenderingControl
 	/** 
      * Sets the original rendering settings. 
      * 
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void setOriginalRndSettings()
@@ -677,8 +659,7 @@ public interface RenderingControl
      * @param type 	   One of the projection type defined by this class.
      * @param channels The collection of channels to project.
      * @return See above.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public BufferedImage renderProjected(int startZ, int endZ, int stepping, 
@@ -692,8 +673,7 @@ public interface RenderingControl
      * @param rndToCopy The rendering settings to copy.
      * @param indexes   Collection of channel's indexes. 
      * 					Mustn't be <code>null</code>.
-     * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+     * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
      */
     public void copyRenderingSettings(RndProxyDef rndToCopy, 
@@ -757,8 +737,7 @@ public interface RenderingControl
      * @param tableID  The id of the table.
      * @param overlays The overlays to set, or <code>null</code> to turn 
      * the overlays off.
-     * @throws RenderingServiceException    If an error occurred while setting 
-     *                                      the value.
+     * @throws RenderingServiceException    If an error occurred.
      * @throws DSOutOfServiceException      If the connection is broken. 
      */
     public void setOverlays(long tableID, Map<Long, Integer> overlays)
@@ -785,8 +764,7 @@ public interface RenderingControl
 	 * large images.
 	 * 
 	 * @param level The value to set.
-	 * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+	 * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
 	 */
 	public void setSelectedResolutionLevel(int level)
@@ -796,8 +774,7 @@ public interface RenderingControl
 	 * Returns the dimension of a tile.
 	 * 
 	 * @return See above.
-	 * @throws RenderingServiceException 	If an error occurred while setting 
-     * 										the value.
+	 * @throws RenderingServiceException 	If an error occurred.
      * @throws DSOutOfServiceException  	If the connection is broken.
 	 */
 	public Dimension getTileSize()
@@ -831,8 +808,7 @@ public interface RenderingControl
 	 * Returns the list of the levels.
 	 * 
 	 * @return See above.
-	 * @throws RenderingServiceException   If an error occurred while getting 
-     *                                      the value.
+	 * @throws RenderingServiceException   If an error occurred.
      * @throws DSOutOfServiceException      If the connection is broken.
 	 */
 	List<ResolutionLevel> getResolutionDescriptions()
@@ -861,8 +837,7 @@ public interface RenderingControl
      *            The channel index
      * @param lut
      *            The lookup table
-     * @throws RenderingServiceException    If an error occurred while setting 
-     *                                      the value.
+     * @throws RenderingServiceException    If an error occurred.
      * @throws DSOutOfServiceException      If the connection is broken. 
      */
     void setLookupTable(int index, String lut) throws RenderingServiceException,
@@ -883,8 +858,7 @@ public interface RenderingControl
      *            The channel index
      * @param revInt
      *            The reverse intensity flag
-     * @throws RenderingServiceException    If an error occurred while setting 
-     *                                      the value.
+     * @throws RenderingServiceException    If an error occurred.
      * @throws DSOutOfServiceException      If the connection is broken. 
      */
     void setReverseIntensity(int index, boolean revInt)

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -1925,6 +1925,9 @@ class RenderingControlProxy
 			if (rgba[1] != color.getGreen()) return false;
 			if (rgba[2] != color.getBlue()) return false;
 			if (rgba[3] != color.getAlpha()) return false;
+			
+            if (channel.getReverseIntensity() != getReverseIntensity(i))
+                return false;
 		}
 		return true;
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -522,22 +522,22 @@ class RenderingControlProxy
     /** 
      * Sets the color.
      * 
-     * @param w The index of the channel.
+     * @param index The index of the channel.
      * @param rgba The color to set.
      * @throws RenderingServiceException If an error occurred while setting
      * the value.
      * @throws DSOutOfServiceException If the connection is broken.
      * @see RenderingControl#setRGBA(int, Color)
      */
-    private void setRGBA(int w, int[] rgba)
+    private void setRGBA(int index, int[] rgba)
     	throws RenderingServiceException, DSOutOfServiceException
     {
     	try {
-    		servant.setRGBA(w, rgba[0], rgba[1], rgba[2], rgba[3]);
-    		rndDef.getChannel(w).setRGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
+    		servant.setRGBA(index, rgba[0], rgba[1], rgba[2], rgba[3]);
+    		rndDef.getChannel(index).setRGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
     		invalidateCache();
 		} catch (Exception e) {
-			handleException(e, ERROR+"color for: "+w+".");
+			handleException(e, ERROR+"color for: "+index+".");
 		}
     }
 
@@ -1110,7 +1110,7 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#setQuantizationMap(int, String, double, boolean)
      */
-    public void setQuantizationMap(int w, String value, double coefficient,
+    public void setQuantizationMap(int index, String value, double coefficient,
                                     boolean noiseReduction)
     	throws RenderingServiceException, DSOutOfServiceException
     {
@@ -1122,16 +1122,16 @@ class RenderingControlProxy
             while (i.hasNext()) {
                 family = (Family) i.next();
                 if (family.getValue().getValue().equals(value)) {
-                    servant.setQuantizationMap(w, family, coefficient,
+                    servant.setQuantizationMap(index, family, coefficient,
                                                 noiseReduction);
-                    rndDef.getChannel(w).setQuantization(value, coefficient,
+                    rndDef.getChannel(index).setQuantization(value, coefficient,
                                                 noiseReduction);
                     invalidateCache();
                 }
             }
             Iterator<RenderingControl> j = slaves.iterator();
 			while (j.hasNext())
-				j.next().setQuantizationMap(w, value, coefficient,
+				j.next().setQuantizationMap(index, value, coefficient,
 						noiseReduction);
 		} catch (Exception e) {
 			handleException(e, ERROR+"quantization map.");
@@ -1142,20 +1142,20 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getChannelFamily(int)
      */
-    public String getChannelFamily(int w)
+    public String getChannelFamily(int index)
     { 
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return "";
-        return rndDef.getChannel(w).getFamily();
+        return rndDef.getChannel(index).getFamily();
     }
 
     /** 
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getChannelNoiseReduction(int)
      */
-    public boolean getChannelNoiseReduction(int w)
+    public boolean getChannelNoiseReduction(int index)
     {
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return false;
         return channel.isNoiseReduction();
     }
@@ -1164,9 +1164,9 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}. 
      * @see RenderingControl#getChannelCurveCoefficient(int)
      */
-    public double getChannelCurveCoefficient(int w)
+    public double getChannelCurveCoefficient(int index)
     {
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return 1;
         return channel.getCurveCoefficient();
     }
@@ -1175,19 +1175,19 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#setChannelWindow(int, double, double)
      */
-    public void setChannelWindow(int w, double start, double end)
+    public void setChannelWindow(int index, double start, double end)
     	throws RenderingServiceException, DSOutOfServiceException
     {
     	isSessionAlive();
     	try {
-    		servant.setChannelWindow(w, start, end);
-            rndDef.getChannel(w).setInterval(start, end);
+    		servant.setChannelWindow(index, start, end);
+            rndDef.getChannel(index).setInterval(start, end);
             Iterator<RenderingControl> i = slaves.iterator();
     		while (i.hasNext())
-    			i.next().setChannelWindow(w, start, end);
+    			i.next().setChannelWindow(index, start, end);
             invalidateCache();
 		} catch (Exception e) {
-			handleException(e, ERROR+"input channel for: "+w+".");
+			handleException(e, ERROR+"input channel for: "+index+".");
 		}  
     }
 
@@ -1195,9 +1195,9 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getChannelWindowStart(int)
      */
-    public double getChannelWindowStart(int w)
+    public double getChannelWindowStart(int index)
     {
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return 0;
         return channel.getInputStart();
     }
@@ -1206,9 +1206,9 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getChannelWindowEnd(int)
      */
-    public double getChannelWindowEnd(int w)
+    public double getChannelWindowEnd(int index)
     {
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return 0;
         return channel.getInputEnd();
     }
@@ -1217,21 +1217,21 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}. 
      * @see RenderingControl#setRGBA(int, Color)
      */
-    public void setRGBA(int w, Color c)
+    public void setRGBA(int index, Color c)
     	throws RenderingServiceException, DSOutOfServiceException
     {
     	isSessionAlive();
     	try {
-    		servant.setRGBA(w, c.getRed(), c.getGreen(), c.getBlue(),
+    		servant.setRGBA(index, c.getRed(), c.getGreen(), c.getBlue(),
     						c.getAlpha());
-    		rndDef.getChannel(w).setRGBA(c.getRed(), c.getGreen(), c.getBlue(),
+    		rndDef.getChannel(index).setRGBA(c.getRed(), c.getGreen(), c.getBlue(),
     						c.getAlpha());
     		invalidateCache();
     		Iterator<RenderingControl> j = slaves.iterator();
 			while (j.hasNext())
-				j.next().setRGBA(w, c);
+				j.next().setRGBA(index, c);
 		} catch (Exception e) {
-			handleException(e, ERROR+"color for: "+w+".");
+			handleException(e, ERROR+"color for: "+index+".");
 		}
     }
 
@@ -1239,9 +1239,9 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getRGBA(int)
      */
-    public Color getRGBA(int w)
+    public Color getRGBA(int index)
     {
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return Color.black;
         int[] rgba = channel.getRGBA();
         return new Color(rgba[0], rgba[1], rgba[2], rgba[3]);
@@ -1251,19 +1251,19 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}. 
      * @see RenderingControl#setActive(int, boolean)
      */
-    public void setActive(int w, boolean active)
+    public void setActive(int index, boolean active)
     	throws RenderingServiceException, DSOutOfServiceException
     { 
     	isSessionAlive();
     	try {
-    		servant.setActive(w, active);
-            rndDef.getChannel(w).setActive(active);
+    		servant.setActive(index, active);
+            rndDef.getChannel(index).setActive(active);
             Iterator<RenderingControl> i = slaves.iterator();
     		while (i.hasNext())
-    			i.next().setActive(w, active);
+    			i.next().setActive(index, active);
             invalidateCache();
 		} catch (Exception e) {
-			handleException(e, ERROR+"active channel for: "+w+".");
+			handleException(e, ERROR+"active channel for: "+index+".");
 		}
     }
 
@@ -1271,9 +1271,9 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#isActive(int)
      */
-    public boolean isActive(int w)
+    public boolean isActive(int index)
     { 
-    	ChannelBindingsProxy channel = rndDef.getChannel(w);
+    	ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return false;
         return channel.isActive();
     }
@@ -1282,7 +1282,7 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#addCodomainMap(CodomainMapContext, int)
      */
-    public void addCodomainMap(CodomainMapContext mapCtx, int w)
+    public void addCodomainMap(CodomainMapContext mapCtx, int index)
             throws RenderingServiceException, DSOutOfServiceException
     {
         if (!(mapCtx instanceof ReverseIntensityContext)){
@@ -1291,7 +1291,7 @@ class RenderingControlProxy
         isSessionAlive();
         try {
             omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
-            servant.addCodomainMapToChannel(c, w);
+            servant.addCodomainMapToChannel(c, index);
             invalidateCache();
         } catch (Exception e) {
             handleException(e, ERROR+"cannot set the map context.");
@@ -1315,7 +1315,7 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#removeCodomainMap(CodomainMapContext, int)
      */
-    public void removeCodomainMap(CodomainMapContext mapCtx, int w)
+    public void removeCodomainMap(CodomainMapContext mapCtx, int index)
         throws RenderingServiceException, DSOutOfServiceException
     {
         if (!(mapCtx instanceof ReverseIntensityContext)){
@@ -1324,7 +1324,7 @@ class RenderingControlProxy
         isSessionAlive();
         try {
             omero.romio.ReverseIntensityMapContext c = new omero.romio.ReverseIntensityMapContext();
-            servant.removeCodomainMapFromChannel(c, w);
+            servant.removeCodomainMapFromChannel(c, index);
             invalidateCache();
         } catch (Exception e) {
             handleException(e, ERROR+"cannot set the map context.");
@@ -1335,13 +1335,13 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getCodomainMaps()
      */
-    public List<CodomainMapContext> getCodomainMaps(int w)
+    public List<CodomainMapContext> getCodomainMaps(int index)
             throws RenderingServiceException, DSOutOfServiceException
     {
         isSessionAlive();
         List<CodomainMapContext> l = new ArrayList<CodomainMapContext>();
         try {
-            List<IObject> ll = servant.getCodomainMapContext(w);
+            List<IObject> ll = servant.getCodomainMapContext(index);
             Iterator<IObject> i = ll.iterator();
             while (i.hasNext()) {
                 l.add((CodomainMapContext) i.next());
@@ -1485,7 +1485,7 @@ class RenderingControlProxy
      * Implemented as specified by {@link RenderingControl}.
      * @see RenderingControl#getChannelData(int)
      */
-    public ChannelData getChannelData(int w) { return metadata[w]; }
+    public ChannelData getChannelData(int index) { return metadata[index]; }
     
     /** 
      * Implemented as specified by {@link RenderingControl}.
@@ -1613,9 +1613,9 @@ class RenderingControlProxy
 	 * Implemented as specified by {@link RenderingControl}.
 	 * @see RenderingControl#getPixelsTypeLowerBound(int)
 	 */
-	public double getPixelsTypeLowerBound(int w)
+	public double getPixelsTypeLowerBound(int index)
 	{
-		ChannelBindingsProxy channel = rndDef.getChannel(w);
+		ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return 0;
 		return channel.getLowerBound();
 	}
@@ -1624,9 +1624,9 @@ class RenderingControlProxy
 	 * Implemented as specified by {@link RenderingControl}.
 	 * @see RenderingControl#getPixelsTypeUpperBound(int)
 	 */
-	public double getPixelsTypeUpperBound(int w)
+	public double getPixelsTypeUpperBound(int index)
 	{
-		ChannelBindingsProxy channel = rndDef.getChannel(w);
+		ChannelBindingsProxy channel = rndDef.getChannel(index);
     	if (channel == null) return 0;
 		return channel.getUpperBound();
 	}
@@ -2141,8 +2141,8 @@ class RenderingControlProxy
      * @see RenderingControl#getLookupTable(int)
      */
     @Override
-    public String getLookupTable(int w) {
-        ChannelBindingsProxy channel = rndDef.getChannel(w);
+    public String getLookupTable(int index) {
+        ChannelBindingsProxy channel = rndDef.getChannel(index);
         if (channel == null)
             return null;
         return channel.getLookupTable();
@@ -2154,8 +2154,8 @@ class RenderingControlProxy
      * @see RenderingControl#getReverseIntensity(int)
      */
     @Override
-    public boolean getReverseIntensity(int w) {
-        ChannelBindingsProxy channel = rndDef.getChannel(w);
+    public boolean getReverseIntensity(int index) {
+        ChannelBindingsProxy channel = rndDef.getChannel(index);
         if (channel == null)
             return false;
         return channel.getReverseIntensity();
@@ -2167,12 +2167,12 @@ class RenderingControlProxy
      * @see RenderingControl#setReverseIntensity(int, boolean)
      */
     @Override
-    public void setReverseIntensity(int w, boolean revInt)
+    public void setReverseIntensity(int index, boolean revInt)
             throws RenderingServiceException, DSOutOfServiceException {
         isSessionAlive();
         try {
             boolean currentRevInt = false;
-            List<IObject> cdctx = servant.getCodomainMapContext(w);
+            List<IObject> cdctx = servant.getCodomainMapContext(index);
             for (IObject cd : cdctx) {
                 if (cd instanceof ReverseIntensityContext) {
                     currentRevInt = true;
@@ -2185,21 +2185,21 @@ class RenderingControlProxy
 
             if (revInt)
                 servant.addCodomainMapToChannel(
-                        new ReverseIntensityMapContext(), w);
+                        new ReverseIntensityMapContext(), index);
             else
                 servant.removeCodomainMapFromChannel(
-                        new ReverseIntensityMapContext(), w);
+                        new ReverseIntensityMapContext(), index);
 
             Iterator<RenderingControl> i = slaves.iterator();
             while (i.hasNext())
-                i.next().setReverseIntensity(w, revInt);
+                i.next().setReverseIntensity(index, revInt);
             invalidateCache();
-            ChannelBindingsProxy channel = rndDef.getChannel(w);
+            ChannelBindingsProxy channel = rndDef.getChannel(index);
             if (channel != null)
                 channel.setReverseIntensity(revInt);
         } catch (Exception e) {
             handleException(e, ERROR
-                    + " setting reverse intensity for channel: " + w + ".");
+                    + " setting reverse intensity for channel: " + index + ".");
         }
     }
     
@@ -2209,20 +2209,20 @@ class RenderingControlProxy
      * @see RenderingControl#setLookupTable(int, String)
      */
     @Override
-    public void setLookupTable(int w, String lut)
+    public void setLookupTable(int index, String lut)
             throws RenderingServiceException, DSOutOfServiceException {
         isSessionAlive();
         try {
-            servant.setChannelLookupTable(w, lut);
+            servant.setChannelLookupTable(index, lut);
             Iterator<RenderingControl> i = slaves.iterator();
             while (i.hasNext())
-                i.next().setLookupTable(w, lut);
+                i.next().setLookupTable(index, lut);
             invalidateCache();
-            ChannelBindingsProxy channel = rndDef.getChannel(w);
+            ChannelBindingsProxy channel = rndDef.getChannel(index);
             if (channel != null)
                 channel.setLookupTable(lut);
         } catch (Exception e) {
-            handleException(e, ERROR + " lookup up table for channel: " + w
+            handleException(e, ERROR + " lookup up table for channel: " + index
                     + ".");
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourIcon.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourIcon.java
@@ -35,7 +35,7 @@ import javax.swing.Icon;
 //Application-internal dependencies
 
 /** 
- * ColourIcon used in the {@link ColourListRenderer} to paint the colours next
+ * ColourIcon used in the ColourListRenderer to paint the colours next
  * to the colour names.
  *
  * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourObject.java
@@ -22,12 +22,7 @@
  */
 package org.openmicroscopy.shoola.util.ui.colourpicker;
 
-//Java imports
 import java.awt.Color;
-
-//Third-party libraries
-
-//Application-internal dependencies
 
 /**
  * Utility object.
@@ -111,6 +106,15 @@ public class ColourObject {
         return true;
     }
 
+    /**
+     * Checks if the given {@link Color} is the same color as this
+     * {@link ColourObject}'s {@link Color}, by comparing the RGB and alpha
+     * values.
+     * 
+     * @param c
+     *            The {@link Color} to check
+     * @return See above.
+     */
     private boolean isSameColor(Color c) {
         return (c.getRed() == color.getRed()
                 && c.getGreen() == color.getGreen()
@@ -118,6 +122,13 @@ public class ColourObject {
                 .getAlpha());
     }
 
+    /**
+     * Calculates a hash code based on the {@link Color}'s RGB and alpha value
+     * 
+     * @param c
+     *            The {@link Color} to calculate the hash code for
+     * @return See above
+     */
     private int colorHashcode(Color c) {
         final int prime = 31;
         int result = 1;

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourObject.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.colourpicker.ColourObject 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,6 @@
  */
 package org.openmicroscopy.shoola.util.ui.colourpicker;
 
-
 //Java imports
 import java.awt.Color;
 
@@ -30,69 +29,103 @@ import java.awt.Color;
 
 //Application-internal dependencies
 
-/** 
+/**
  * Utility object.
  *
- * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
- * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
+ * @version 3.0 <small> (<b>Internal version:</b> $Revision: $Date: $) </small>
  * @since 3.0-Beta4
  */
-public class ColourObject
-{
+public class ColourObject {
+    
+    /** The color */
+    public Color color;
+    
+    /** The description */
+    public String description;
+    
+    /** The lookup table */
+    public String lut;
+    
+    /** The reverse intensity flag */
+    public boolean revInt;
+    
+    /** The preview flag */
+    public boolean preview;
+    
+    /**
+     * Creates a new instance.
+     */
+    public ColourObject() {
+    }
 
-	/** The selected color. */
-	private Color color;
-	
-	/** The description associated to it. */
-	private String description;
-	
-	/**
-	 * Creates a new instance.
-	 * 
-	 * @param color		  The color to set.
-	 * @param description The description associated to the color.
-	 */
-	public ColourObject(Color color, String description)
-	{
-		this.color = color;
-		this.description = description;
-	}
-	
-	/**
-	 * Sets the color.
-	 * 
-	 * @param color The value to set.
-	 */
-	public void setColor(Color color) { this.color = color; }
-	
-	/**
-	 * Sets the description.
-	 * 
-	 * @param description The value to set.
-	 */
-	public void setDescription(String description)
-	{ 
-		this.description = description;
-	}
-	
-	/**
-	 * Returns the color.
-	 * 
-	 * @return See above.
-	 */
-	public Color getColor() { return color; }
-	
-	/**
-	 * Returns the description.
-	 * 
-	 * @return See above.
-	 */
-	public String getDescription() { return description; }
-	
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((color == null) ? 0 : colorHashcode(color));
+        result = prime * result
+                + ((description == null) ? 0 : description.hashCode());
+        result = prime * result
+                + ((lut == null) ? 0 : lut.trim().toLowerCase().hashCode());
+        result = prime * result + (revInt ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ColourObject other = (ColourObject) obj;
+        if (color == null) {
+            if (other.color != null)
+                return false;
+        } else if (!isSameColor(other.color))
+            return false;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
+        if (lut == null) {
+            if (other.lut != null)
+                return false;
+        } else if (other.lut == null) {
+            if (lut != null)
+                return false;
+        } else if (lut != null
+                && other.lut != null
+                && !lut.trim().toLowerCase()
+                        .equals(other.lut.trim().toLowerCase()))
+            return false;
+        if (revInt != other.revInt)
+            return false;
+        return true;
+    }
+
+    private boolean isSameColor(Color c) {
+        return (c.getRed() == color.getRed()
+                && c.getGreen() == color.getGreen()
+                && c.getBlue() == color.getBlue() && c.getAlpha() == color
+                .getAlpha());
+    }
+
+    private int colorHashcode(Color c) {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + c.getRed();
+        result = prime * result + c.getGreen();
+        result = prime * result + c.getBlue();
+        result = prime * result + c.getAlpha();
+        return result;
+    }
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
@@ -37,6 +37,7 @@ import javax.swing.WindowConstants;
 
 //Third-party libraries
 
+
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.NotificationDialog;
@@ -181,6 +182,22 @@ public class ColourPicker
         oldColor.revInt = model.getOriginalReversetIntensity();
         
     	firePropertyChange(ACCEPT_PROPERTY, null,oldColor);
+    }
+    
+    /**
+     * Reinitializes the ColourPicker with the given values
+     * @param c The color
+     * @param desc The description
+     * @param lut The lookup table
+     * @param revInt The reverse intensity flag
+     */
+    public void reinit(Color c, String desc, String lut, boolean revInt) {
+        this.model.setColour(c, true);
+        if (desc != null)
+            tabbedPane.setColorDescription(desc);
+        this.model.setLUT(lut, true);
+        this.model.setReverseIntensity(revInt, true);
+        tabbedPane.stateChanged(null);
     }
     
 	/** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
@@ -141,8 +141,8 @@ public class ColourPicker
         newColor.lut = model.getLUT();
         oldColor.lut = model.getOriginalLUT();
         
-        newColor.revInt = model.getReversetIntensity();
-        oldColor.revInt = model.getOriginalReversetIntensity();
+        newColor.revInt = model.getReverseIntensity();
+        oldColor.revInt = model.getOriginalReverseIntensity();
         
         newColor.description = tabbedPane.getDescription();
         
@@ -163,8 +163,8 @@ public class ColourPicker
         newColor.lut = model.getLUT();
         oldColor.lut = model.getOriginalLUT();
         
-        newColor.revInt = model.getReversetIntensity();
-        oldColor.revInt = model.getOriginalReversetIntensity();
+        newColor.revInt = model.getReverseIntensity();
+        oldColor.revInt = model.getOriginalReverseIntensity();
         
         newColor.description = tabbedPane.getDescription();
         
@@ -179,7 +179,7 @@ public class ColourPicker
         ColourObject oldColor = new ColourObject();
         oldColor.color = model.getOriginalColor();
         oldColor.lut = model.getOriginalLUT();
-        oldColor.revInt = model.getOriginalReversetIntensity();
+        oldColor.revInt = model.getOriginalReverseIntensity();
         
     	firePropertyChange(ACCEPT_PROPERTY, null,oldColor);
     }
@@ -270,6 +270,7 @@ public class ColourPicker
      *              the default color.
      * @param luts The available lookup tables
      * @param selectedLUT The selected lookup table
+	 * @param revInt  The reverse intensity flag
      */
     public ColourPicker(JFrame owner, Color color, Collection<String> luts, String selectedLUT, boolean revInt)
     {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourPicker.java
@@ -68,17 +68,8 @@ public class ColourPicker
     /** The default height of the component. */
     public static final int     DEFAULT_HEIGHT = 310;
     
-    /** Bounds property indicating that a new lookup table is selected. */
-    public static final String LUT_PROPERTY = "lut";
-    
-    /** Bounds property indicating that a new lookup table is selected. */
-    public static final String LUT_PREVIEW_PROPERTY = "lutPreview";
-    
     /** Bounds property indicating that a new color is selected. */
-    public static final String COLOUR_PROPERTY = "colour";
-    
-    /** Bounds property indicating that a new color is selected. */
-    public static final String COLOUR_PREVIEW_PROPERTY = "colourPreview";
+    public static final String ACCEPT_PROPERTY = "colour";
     
     /** Bounds property indicating to cancel the dialog. */
     public static final String CANCEL_PROPERTY = "cancelColourPicker";
@@ -139,20 +130,22 @@ public class ColourPicker
 
     /** Returns the current colour to the user. */
     void accept() {
-        Color c = model.getColour();
-        String description = tabbedPane.getDescription();
-        if (model.isOriginalColor(model.getColour())
-                && model.isOriginalLut(model.getLUT()) && description == null)
-            return;
-        if (!model.isOriginalLut(model.getLUT())) 
-            firePropertyChange(LUT_PROPERTY, model.getOriginalLUT(),
-                    model.getLUT());
         
-        if (description == null)
-            firePropertyChange(COLOUR_PROPERTY, model.getOriginalColor(), c);
-        else
-            firePropertyChange(COLOUR_PROPERTY, null, new ColourObject(c,
-                    description));
+        ColourObject newColor = new ColourObject();
+        ColourObject oldColor = new ColourObject();
+        
+        newColor.color = model.getColour();
+        oldColor.color = model.getOriginalColor();
+        
+        newColor.lut = model.getLUT();
+        oldColor.lut = model.getOriginalLUT();
+        
+        newColor.revInt = model.getReversetIntensity();
+        oldColor.revInt = model.getOriginalReversetIntensity();
+        
+        newColor.description = tabbedPane.getDescription();
+        
+        firePropertyChange(ACCEPT_PROPERTY, oldColor, newColor);
         
         setVisible(false);
         firePropertyChange(CLOSE, false, true);
@@ -160,25 +153,34 @@ public class ColourPicker
     
     /** Returns the current colour to the user. */
     void preview() {
-        Color c = model.getColour();
-        String description = tabbedPane.getDescription();
-        if (!model.isOriginalLut(model.getLUT()))
-            firePropertyChange(LUT_PREVIEW_PROPERTY, model.getOriginalLUT(),
-                    model.getLUT());
-        else if (model.isOriginalColor(model.getColour())
-                && description == null)
-            return;
-
-        else
-            firePropertyChange(COLOUR_PREVIEW_PROPERTY,
-                    model.getOriginalColor(), c);
+        ColourObject newColor = new ColourObject();
+        ColourObject oldColor = new ColourObject();
+        
+        newColor.color = model.getColour();
+        oldColor.color = model.getOriginalColor();
+        
+        newColor.lut = model.getLUT();
+        oldColor.lut = model.getOriginalLUT();
+        
+        newColor.revInt = model.getReversetIntensity();
+        oldColor.revInt = model.getOriginalReversetIntensity();
+        
+        newColor.description = tabbedPane.getDescription();
+        
+        newColor.preview = true;
+        
+        firePropertyChange(ACCEPT_PROPERTY, oldColor, newColor);
     }
     
     /** Resets the color to the original.*/
     void reset()
     {
-    	firePropertyChange(COLOUR_PROPERTY, null, model.getOriginalColor());
-    	firePropertyChange(LUT_PROPERTY, null, model.getOriginalLUT());
+        ColourObject oldColor = new ColourObject();
+        oldColor.color = model.getOriginalColor();
+        oldColor.lut = model.getOriginalLUT();
+        oldColor.revInt = model.getOriginalReversetIntensity();
+        
+    	firePropertyChange(ACCEPT_PROPERTY, null,oldColor);
     }
     
 	/** 
@@ -190,16 +192,17 @@ public class ColourPicker
      * @param field		Pass <code>true</code> to add a field, 
      * 					<code>false</code> otherwise.       
 	 * @param luts      The selected lookup table
+	 * @param revInt    The reverse intensity flag
 	 * @param selectedLUT  All available lookup tables
      */
-	public ColourPicker(JFrame owner, Color color, boolean field, Collection<String> luts, String selectedLUT)
+	public ColourPicker(JFrame owner, Color color, boolean field, Collection<String> luts, String selectedLUT, boolean revInt)
 	{
 	    super(owner);
 	    if (color == null) color = DEFAULT_COLOR;
         setWindowProperties();
         float[] vals = new float[4];
         vals = color.getComponents(vals);
-        model = new RGBModel(vals[0], vals[1], vals[2], vals[3], selectedLUT, luts);
+        model = new RGBModel(vals[0], vals[1], vals[2], vals[3], selectedLUT, luts, revInt);
         RGBControl control = new RGBControl(model);
         
         tabbedPane = new TabbedPaneUI(this, control, field);
@@ -223,7 +226,7 @@ public class ColourPicker
 	 */
 	public ColourPicker(JFrame owner, Color color)
 	{
-		this(owner, color, false, null, null);
+		this(owner, color, false, null, null, false);
 	}
 	
     /**
@@ -239,7 +242,7 @@ public class ColourPicker
      *            otherwise.
      */
     public ColourPicker(JFrame owner, Color color, boolean field) {
-        this(owner, color, field, null, null);
+        this(owner, color, field, null, null, false);
     }
 	
 	/** 
@@ -251,9 +254,9 @@ public class ColourPicker
      * @param luts The available lookup tables
      * @param selectedLUT The selected lookup table
      */
-    public ColourPicker(JFrame owner, Color color, Collection<String> luts, String selectedLUT)
+    public ColourPicker(JFrame owner, Color color, Collection<String> luts, String selectedLUT, boolean revInt)
     {
-        this(owner, color, false, luts, selectedLUT);
+        this(owner, color, false, luts, selectedLUT, revInt);
     }
     
 	/** 
@@ -263,7 +266,7 @@ public class ColourPicker
 	 */
 	public ColourPicker(JFrame owner)
 	{
-		this(owner, null, false, null, null);
+		this(owner, null, false, null, null, false);
 	}
 	
 	/** 
@@ -275,7 +278,7 @@ public class ColourPicker
 	 */
 	public ColourPicker(JFrame owner, boolean field)
 	{
-		this(owner, null, field, null, null);
+		this(owner, null, field, null, null, false);
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourSwatchUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/ColourSwatchUI.java
@@ -169,6 +169,7 @@ public class ColourSwatchUI
 	
     /**
      * Create the color items
+     * @return See above.
      */
     private LookupTableItem[] createColours() {
         LookupTableItem[] result = new LookupTableItem[RGBControl.PREDEFINED_COLORS
@@ -206,6 +207,7 @@ public class ColourSwatchUI
     /**
      * Finds the item index which has to be selected according to the
      * current control's state
+     * @return See above.
      */
     private int findIndex() {
         if (CommonsLangUtils.isNotEmpty(control.getLUT())) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/LookupTableListRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/LookupTableListRenderer.java
@@ -45,6 +45,7 @@ import javax.swing.border.Border;
  */
 public class LookupTableListRenderer extends JLabel implements ListCellRenderer {
 
+    /** The icon dimension */
     private static final Dimension ICON_DIM = new Dimension(96, 24);
 
     /** Create the colouricon which will hold the colours. */
@@ -57,6 +58,7 @@ public class LookupTableListRenderer extends JLabel implements ListCellRenderer 
     /** Border colour of the cell when the icon is not selected. */
     private Border emptyBorder = BorderFactory.createEmptyBorder(2, 2, 2, 2);
 
+    /** Default renderer */
     protected DefaultListCellRenderer defaultRenderer = new DefaultListCellRenderer();
 
     public Component getListCellRendererComponent(JList list, Object value,

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/PaintPotUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/PaintPotUI.java
@@ -23,17 +23,14 @@
 
 package org.openmicroscopy.shoola.util.ui.colourpicker;
 
-//Java imports
 import java.awt.Color;
 import java.awt.Graphics;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.JComponent;
 
+import org.apache.commons.lang.StringUtils;
 
-//Third-party libraries
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.PaintPot;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -80,7 +77,8 @@ class PaintPotUI
 	    if (c == null)
 	        throw new NullPointerException("No control.");
 		
-        image = LookupTableIconUtil.getLUTIconImage(lut);
+        image = StringUtils.isBlank(lut) ? null : LookupTableIconUtil
+                .getLUTIconImage(lut);
 		
 		control = c;
 		control.addPropertyChangeListener(COLOUR_CHANGED_PROPERTY, this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
@@ -336,12 +336,42 @@ class RGBControl
     }
 
     /**
+     * Set the reverse intensity
+     * 
+     * @param revInt
+     *            The reverse intensity
+     */
+    void setReverseIntensity(boolean revInt) {
+        model.setReverseIntensity(revInt);
+        fireChangeEvent(true);
+    }
+
+    /**
+     * Get the reverse intensity
+     * 
+     * @return See above
+     */
+    boolean getReverseIntensity() {
+        return model.getReversetIntensity();
+    }
+
+    
+    /**
      * Check if the lookup table has been changed
      * 
      * @return <code>true</code> if it has not, <code>false</code> if it has
      */
     boolean isOriginalLut() {
         return model.isOriginalLut(getLUT());
+    }
+    
+    /**
+     * Check if the reverse intensity has been changed
+     * 
+     * @return <code>true</code> if it has not, <code>false</code> if it has
+     */
+    boolean isOriginalRevInt() {
+        return model.getOriginalReversetIntensity() == getReverseIntensity();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
@@ -352,7 +352,7 @@ class RGBControl
      * @return See above
      */
     boolean getReverseIntensity() {
-        return model.getReversetIntensity();
+        return model.getReverseIntensity();
     }
 
     
@@ -371,7 +371,7 @@ class RGBControl
      * @return <code>true</code> if it has not, <code>false</code> if it has
      */
     boolean isOriginalRevInt() {
-        return model.getOriginalReversetIntensity() == getReverseIntensity();
+        return model.getOriginalReverseIntensity() == getReverseIntensity();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBControl.java
@@ -323,7 +323,7 @@ class RGBControl
      */
     void setLUT(String lut) {
         model.setLUT(lut);
-        fireChangeEvent(true);
+        fireChangeEvent(PaintPotUI.LUT_PROPERTY);
     }
 
     /**
@@ -343,7 +343,7 @@ class RGBControl
      */
     void setReverseIntensity(boolean revInt) {
         model.setReverseIntensity(revInt);
-        fireChangeEvent(true);
+        fireChangeEvent(null);
     }
 
     /**
@@ -392,25 +392,28 @@ class RGBControl
 	
     /** Fires Changed event to all listeners stating the model has changed. */
     void fireChangeEvent() {
-        fireChangeEvent(false);
+        fireChangeEvent(PaintPotUI.COLOUR_CHANGED_PROPERTY);
     }
 
     /**
      * Fires Changed event to all listeners stating the model has changed.
      * 
-     * @param lut
-     *            Pass <code>true</code> if only the lookup table has changed
+     * @param property
+     *            An optional property to fire (see {@link
+     *            PaintPotUI#LUT_PROPERTY} ,
+     *            {@link PaintPotUI#COLOUR_CHANGED_PROPERTY}
      */
-    void fireChangeEvent(boolean lut) {
+    void fireChangeEvent(String property) {
         ChangeListener e;
         for (int i = 0; i < listeners.size(); i++) {
             e = listeners.get(i);
             e.stateChanged(new ColourChangedEvent(this));
         }
-        if (lut)
+
+        if (PaintPotUI.LUT_PROPERTY.equals(property))
             firePropertyChange(PaintPotUI.LUT_PROPERTY, null, model.getLUT());
 
-        else
+        else if (PaintPotUI.COLOUR_CHANGED_PROPERTY.equals(property))
             firePropertyChange(PaintPotUI.COLOUR_CHANGED_PROPERTY, null,
                     model.getColour());
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
@@ -25,6 +25,7 @@ package org.openmicroscopy.shoola.util.ui.colourpicker;
 
 import java.awt.Color;
 import java.util.Collection;
+
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /** 
@@ -87,7 +88,7 @@ class RGBModel
      * 
      * @param v value.
      */
-    private void setV(float v)
+    private void setV(float v, boolean reset)
     {
         float []vals = RGBtoHSV();
         vals[2] = v;
@@ -95,6 +96,12 @@ class RGBModel
         red = rgb[0];
         green = rgb[1];
         blue = rgb[2];
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+            originalAlpha = alpha;
+        }
     }
     
     /**
@@ -102,7 +109,7 @@ class RGBModel
      * 
      * @param h hue.
      */
-    private void setH(float h)
+    private void setH(float h, boolean reset)
     {
         float []vals = RGBtoHSV();
         vals[0] = h;
@@ -110,6 +117,11 @@ class RGBModel
         red = rgb[0];
         green = rgb[1];
         blue = rgb[2];
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+        }
     }
     
     /**
@@ -117,7 +129,7 @@ class RGBModel
      * 
      * @param s saturation.
      */
-    private void setS(float s)
+    private void setS(float s, boolean reset)
     {
         float[] vals = RGBtoHSV();
         vals[1] = s;
@@ -125,6 +137,11 @@ class RGBModel
         red = rgb[0];
         green = rgb[1];
         blue = rgb[2];
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+        }
     }
     
 	/**
@@ -220,61 +237,140 @@ class RGBModel
 	 * Sets the value of the model (HSV) to v.
 	 * 
 	 * @param v  value.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setValue(float v) { setV(v); }
+	void setValue(float v, boolean reset) { setV(v, reset); }
+	
+	/**
+     * Sets the value of the model (HSV) to v.
+     * 
+     * @param v  value.
+     */
+	void setValue(float v) { setValue(v, false); }
 	
 	/**
 	 * Sets the hue of the model to h.
 	 * 
 	 * @param h hue.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setHue(float h) { setH(h); }
+	void setHue(float h, boolean reset) { setH(h, reset); }
+	
+	/**
+     * Sets the hue of the model to h.
+     * 
+     * @param h hue.
+     */
+	void setHue(float h) { setH(h, false); }
 	
 	/**
 	 * Sets the saturation of the model to s.
 	 * 
 	 * @param s saturation.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setSaturation(float s) { setS(s); }
+	void setSaturation(float s, boolean reset) { setS(s, reset); }
+	
+	/**
+     * Sets the saturation of the model to s.
+     * 
+     * @param s saturation.
+     */
+	void setSaturation(float s) { setSaturation(s, false); }
 	
 	/**
 	 * Sets the red channel of the model to r.
 	 * 
 	 * @param r red.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setRed(float r) { red = r; }
+	void setRed(float r, boolean reset) { red = r; if (reset) originalRed = red;}
+	
+	/**
+     * Sets the red channel of the model to r.
+     * 
+     * @param r red.
+     */
+	void setRed(float r) {
+	    setRed(r, false);
+	}
 	
 	/**
 	 * Sets the green channel of the model to g.
 	 * 
 	 * @param g green.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setGreen(float g) { green = g; }
+	void setGreen(float g, boolean reset) { green = g; if (reset) originalGreen = green;}
+	
+	/**
+     * Sets the green channel of the model to g.
+     * 
+     * @param g green.
+     */
+	void setGreen(float g) {
+	    setGreen(g, false);
+	}
 	
 	/**
 	 * Sets the blue channel of the model to b.
 	 * 
 	 * @param b blue.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setBlue(float b) { blue = b; }
+	void setBlue(float b, boolean reset) { blue = b; if (reset) originalBlue = blue;}
+	
+	/**
+     * Sets the blue channel of the model to b.
+     * 
+     * @param b blue.
+     */
+    void setBlue(float b) {
+        setBlue(b, false);
+    }
 	
 	/**
 	 * Sets the alpha of the model to a.
 	 * 
 	 * @param a alpha.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setAlpha(float a) { alpha = a; }
+	void setAlpha(float a, boolean reset) { alpha = a; if (reset) originalAlpha = alpha;}
+	
+	/**
+     * Sets the alpha of the model to a.
+     * 
+     * @param a alpha.
+     */
+    void setAlpha(float a) {
+        setAlpha(a, false);
+    }
 	
 	/**
 	 * Sets the colour to the new Color c.
 	 * 
 	 * @param c new Colour.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setColour(Color c)
+	void setColour(Color c, boolean reset)
 	{
 		red = (c.getRed()/255.0f);
 		green = (c.getGreen()/255.0f);
 		blue = (c.getBlue()/255.0f);
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+        }
+	}
+	
+	/**
+     * Sets the colour to the new Color c.
+     * 
+     * @param c new Colour.
+     */
+	void setColour(Color c) {
+	    setColour(c, false);
 	}
 	
 	/** 
@@ -285,13 +381,33 @@ class RGBModel
 	 * @param g green.
 	 * @param b blue.
 	 * @param a alpha.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setRGBColour(float r, float g, float b, float a)
+	void setRGBColour(float r, float g, float b, float a, boolean reset)
 	{
 		red = r;
 		green = g;
 		blue = b;
 		alpha = a;
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+            originalAlpha = alpha;
+        }
+	}
+	
+	/** 
+     * Sets the colour of the model based on the rgb values r, b, g and alpha 
+     * (a).
+     * 
+     * @param r red.
+     * @param g green.
+     * @param b blue.
+     * @param a alpha.
+     */
+	void setRGBColour(float r, float g, float b, float a) {
+	    setRGBColour(r, g, b, a, false);
 	}
 	
 	/**
@@ -301,14 +417,33 @@ class RGBModel
 	 * @param s saturation.
 	 * @param v value.
 	 * @param a alpha.
+	 * @param reset Pass <code>true</code> to also reset the original value
 	 */
-	void setHSVColour(float h, float s, float v, float a)
+	void setHSVColour(float h, float s, float v, float a, boolean reset)
 	{
 		float[] rgb = HSVtoRGB(h,s,v);
 		red = rgb[0];
 		green = rgb[1];
 		blue = rgb[2];
 		alpha = a;
+        if (reset) {
+            originalRed = red;
+            originalGreen = green;
+            originalBlue = blue;
+            originalAlpha = alpha;
+        }
+	}
+	
+	/**
+     * Sets the colour of the model based on the hsv values h, s, v and alpha a.
+     * 
+     * @param h hue.
+     * @param s saturation.
+     * @param v value.
+     * @param a alpha.
+     */
+	void setHSVColour(float h, float s, float v, float a) {
+	    setHSVColour(h, s, v, a, false);
 	}
 
 	/**
@@ -485,6 +620,7 @@ class RGBModel
 		blue = originalBlue;
 		alpha = originalAlpha;
 		lut = originalLut;
+		revInt = originalRevInt;
 	}
 	
 	/**
@@ -508,11 +644,25 @@ class RGBModel
      * 
      * @param lut
      *            The lookup table
+     *  @param reset 
+     *            Pass <code>true</code> to also reset the original value
      */
-    void setLUT(String lut) {
+    void setLUT(String lut, boolean reset) {
         this.lut = lut;
+        if (reset)
+            originalLut = lut;
     }
 
+    /**
+     * Set the lookup table
+     * 
+     * @param lut
+     *            The lookup table
+     */
+    void setLUT(String lut) {
+        setLUT(lut, false);
+    }
+    
     /**
      * Get the lookup table
      * 
@@ -536,9 +686,24 @@ class RGBModel
      * 
      * @param revInt
      *            The reverse intensity flag
+     * @param reset
+     *            Pass <code>true</code> to also reset the original value
+     */
+    void setReverseIntensity(boolean revInt, boolean reset) {
+        this.revInt = revInt;
+        if (reset)
+            originalRevInt = revInt;
+    }
+    
+
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param revInt
+     *            The reverse intensity flag
      */
     void setReverseIntensity(boolean revInt) {
-        this.revInt = revInt;
+        setReverseIntensity(revInt, false);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
@@ -86,7 +86,11 @@ class RGBModel
     /**
      * Sets the value of the model to v without firing an event.
      * 
-     * @param v value.
+     * @param v
+     *            value.
+     * @param reset
+     *            Pass <code>true</code> to also overwrite the original color
+     *            values (see {@link #revert()})
      */
     private void setV(float v, boolean reset)
     {
@@ -108,6 +112,9 @@ class RGBModel
      * Sets the hue of the model to h without firing an event.
      * 
      * @param h hue.
+     * @param reset
+     *            Pass <code>true</code> to also overwrite the original color
+     *            values (see {@link #revert()})
      */
     private void setH(float h, boolean reset)
     {
@@ -128,6 +135,9 @@ class RGBModel
      * Sets the saturation of the model to S without firing an event.
      * 
      * @param s saturation.
+     * @param reset
+     *            Pass <code>true</code> to also overwrite the original color
+     *            values (see {@link #revert()})
      */
     private void setS(float s, boolean reset)
     {
@@ -728,7 +738,7 @@ class RGBModel
      * Check if the provided lookup table is the same as the original lookup
      * table
      * 
-     * @param The
+     * @param lut The
      *            lookup table
      * @return <code>true</code> if it is, <code>false</code> if it is not
      */
@@ -743,6 +753,7 @@ class RGBModel
 
     /**
      * Get all available lookup tables
+     * @return See above
      */
     Collection<String> getAvailableLookupTables() {
         return availableLUTs;

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
@@ -721,7 +721,7 @@ class RGBModel
      * 
      * @return See above
      */
-    boolean getReversetIntensity() {
+    boolean getReverseIntensity() {
         return revInt;
     }
 
@@ -730,7 +730,7 @@ class RGBModel
      * 
      * @return See above
      */
-    boolean getOriginalReversetIntensity() {
+    boolean getOriginalReverseIntensity() {
         return originalRevInt;
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/RGBModel.java
@@ -76,6 +76,11 @@ class RGBModel
 	/** The lookup table */
 	private String lut;
 	
+	/** The reverse intensity flag */
+	private boolean revInt;
+	
+	/** The original reverse intensity flag */
+	private boolean originalRevInt;
 	
     /**
      * Sets the value of the model to v without firing an event.
@@ -131,8 +136,9 @@ class RGBModel
 	 * @param a  alpha channel.
 	 * @param lut lookup table
 	 * @param availableLUTs available lookup tables
+	 * @param revInt reverse intensity flag
 	 */
-	RGBModel(float r, float g, float b, float a, String lut, Collection<String> availableLUTs)
+	RGBModel(float r, float g, float b, float a, String lut, Collection<String> availableLUTs, boolean revInt)
 	{
 		originalRed = r;
 		originalGreen = g;
@@ -145,6 +151,8 @@ class RGBModel
 		alpha = a;
 		this.lut = lut;
 		this.availableLUTs = availableLUTs;
+		this.revInt = revInt;
+		this.originalRevInt = revInt;
 	}
 	
 	/**
@@ -523,6 +531,34 @@ class RGBModel
         return originalLut;
     }
 
+    /**
+     * Set the reverse intensity flag
+     * 
+     * @param revInt
+     *            The reverse intensity flag
+     */
+    void setReverseIntensity(boolean revInt) {
+        this.revInt = revInt;
+    }
+
+    /**
+     * Get the reverse intensity flag
+     * 
+     * @return See above
+     */
+    boolean getReversetIntensity() {
+        return revInt;
+    }
+
+    /**
+     * Get the original reverse intensity flag
+     * 
+     * @return See above
+     */
+    boolean getOriginalReversetIntensity() {
+        return originalRevInt;
+    }
+    
     /**
      * Check if the provided lookup table is the same as the original lookup
      * table

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -35,6 +35,7 @@ import javax.swing.AbstractAction;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
@@ -52,7 +53,6 @@ import info.clearthought.layout.TableLayout;
 //Third-party libraries
 
 //Application-internal dependencies
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -114,6 +114,9 @@ class TabbedPaneUI
 	
 	/** Button to choose colour swatch panel. */
 	private JToggleButton		colourSwatchButton;
+	
+	/** Button to reverse intensity. */
+	private JCheckBox           revIntButton;
 	
 	/** Accept the current colour choice. */
 	private JButton				acceptButton;
@@ -203,11 +206,17 @@ class TabbedPaneUI
             }
         };
         colourSwatchButton.addActionListener(action);
-                
+        
+        revIntButton = new JCheckBox("Reverse Intensity");
+        revIntButton.setToolTipText("Reverse this channel's intensity");
+        
         toolbar.setFloatable(false);
         toolbar.setRollover(true);
+        toolbar.setLayout(new BoxLayout(toolbar, BoxLayout.LINE_AXIS));
         toolbar.add(colourSwatchButton);
         toolbar.add(colourWheelButton);
+        toolbar.add(Box.createHorizontalGlue());
+        toolbar.add(revIntButton);
     }
     
     /** 
@@ -281,7 +290,7 @@ class TabbedPaneUI
                 
         JPanel container = new JPanel();
         container.setLayout(new BorderLayout());
-        container.add(toolbar, BorderLayout.WEST);
+        container.add(toolbar, BorderLayout.CENTER);
           
         this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         add(container);
@@ -410,6 +419,16 @@ class TabbedPaneUI
 		return text.trim();
 	}
 	
+	/** 
+     * Returns the reverse intensity.
+     * 
+     * @return See above.
+     */
+    boolean getReverseIntensity()
+    {
+        return revIntButton.isSelected();
+    }
+    
 	/**
 	 * Sets the description associated to the color.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -483,6 +483,7 @@ class TabbedPaneUI
 					|| !control.isOriginalLut() 
 					|| !control.isOriginalRevInt());
 		}
+		revIntButton.setSelected(control.getReverseIntensity());
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -209,7 +209,13 @@ class TabbedPaneUI
         
         revIntButton = new JCheckBox("Reverse Intensity");
         revIntButton.setToolTipText("Reverse this channel's intensity");
-        
+        revIntButton.setSelected(control.getReverseIntensity());
+        revIntButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                control.setReverseIntensity(revIntButton.isSelected());
+            }
+        });
         toolbar.setFloatable(false);
         toolbar.setRollover(true);
         toolbar.setLayout(new BoxLayout(toolbar, BoxLayout.LINE_AXIS));
@@ -416,7 +422,10 @@ class TabbedPaneUI
 		if (fieldDescription == null) return null;
 		String text = fieldDescription.getText();
 		if (text == null) return null;
-		return text.trim();
+		text = text.trim();
+		if(text.length()==0)
+		    return null;
+		return text;
 	}
 	
 	/** 
@@ -465,12 +474,14 @@ class TabbedPaneUI
 			swatchPane.refresh();
 		if (fieldDescription == null)
 			setButtonsEnabled(!control.isOriginalColour()
-			        || !control.isOriginalLut());
+			        || !control.isOriginalLut() 
+			        || !control.isOriginalRevInt());
 		else {
 			String text = fieldDescription.getText();
 			setButtonsEnabled(!text.equals(originalDescription) 
 					|| !control.isOriginalColour() 
-					|| !control.isOriginalLut());
+					|| !control.isOriginalLut() 
+					|| !control.isOriginalRevInt());
 		}
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -23,7 +23,6 @@
 
 package org.openmicroscopy.shoola.util.ui.colourpicker;
 
-//Java imports
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
@@ -47,14 +46,10 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
-import info.clearthought.layout.TableLayout; 
-
-
-//Third-party libraries
-
+import info.clearthought.layout.TableLayout;
 
 import org.apache.commons.lang.StringUtils;
-//Application-internal dependencies
+
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -52,6 +52,8 @@ import info.clearthought.layout.TableLayout;
 
 //Third-party libraries
 
+
+import org.apache.commons.lang.StringUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
@@ -365,8 +367,6 @@ class TabbedPaneUI
 	 * 
      * @param parent  The parent of this component. Mustn't be <code>null</code>.
 	 * @param control Reference to the control. Mustn't be <code>null</code>.
-	 * @param luts The available lookup tables
-	 * @param selectedLUT The selected lookup table
 	 * @param field	  Pass <code>true</code> to add a field, 
 	 * 				  <code>false</code> otherwise. 
 	 */
@@ -421,9 +421,7 @@ class TabbedPaneUI
 	{
 		if (fieldDescription == null) return null;
 		String text = fieldDescription.getText();
-		if (text == null) return null;
-		text = text.trim();
-		if(text.length()==0)
+		if (StringUtils.isBlank(text))
 		    return null;
 		return text;
 	}


### PR DESCRIPTION
# What this PR does

Adds the reverse intensity functionality to Insight.
# Testing this PR

In preview and full viewer: Open the color picker for a channel, reverse the intensity by ticking the checkbox in the upper right corner of the color picker.
