### PR TITLE
populate_metadata: warn on missing image

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -865,20 +865,20 @@ class ParsingContext(object):
                 log.info('Missing well name column, skipping.')
 
             if image_name_column is not None:
+                iid = -1
                 try:
                     iname = image_name_column.values[i]
                     did = None
                     if "Dataset Name" in columns_by_name:  # FIXME
                         did = columns_by_name["Dataset Name"].values[i]
                     iid = self.value_resolver.get_image_id_by_name(iname, did)
-                    assert i == len(image_column.values)
-                    image_column.values.append(iid)
-                    image_name_column.size = max(
-                        image_name_column.size, len(iname))
                 except KeyError:
-                    log.error(
+                    log.warn(
                         "%s not found in image names" % iname)
-                    raise
+                assert i == len(image_column.values)
+                image_column.values.append(iid)
+                image_name_column.size = max(
+                    image_name_column.size, len(iname))
             else:
                 log.info('Missing image name column, skipping.')
 

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -543,6 +543,25 @@ class Dataset2Images(Fixture):
                 assert typ == 'Treatment'
 
 
+class Dataset2Images1Missing(Dataset2Images):
+
+    def __init__(self):
+        super(Dataset2Images1Missing, self).__init__()
+        self.annCount = 1
+
+    def get_target(self):
+        """
+        Temporarily alter self.names so that the super
+        invocation creates fewer images than are expected.
+        """
+        old = self.names
+        try:
+            self.names = old[0:-1]  # Skip last
+            return super(Dataset2Images1Missing, self).get_target()
+        finally:
+            self.names = old
+
+
 class Dataset101Images(Dataset2Images):
 
     def __init__(self):
@@ -664,6 +683,7 @@ class TestPopulateMetadata(lib.ITest):
         Screen2Plates(),
         Plate2Wells(),
         Dataset2Images(),
+        Dataset2Images1Missing(),
         Dataset101Images(),
         Project2Datasets(),
         GZIP(),


### PR DESCRIPTION
# What this PR does

When a well is missing from a plate, a warning is printed. The
same now happens when an image is missing from a dataset. Likely,
a `--strict` argument should be added which will force the existence
of all objects.


# Testing this PR

1. Check all 29 `test/integration/metadata/test_populate.py` tests continue passing.
2. Attempt to annotate idr0023 (cc @eleanorwilliams). All present images should be annotated.

# Related reading

 * https://trello.com/c/q8Fr2ERU/477-in-non-screen-datasets-if-image-file-is-missing-then-bulk-annotation-can-t-be-added-as-gives-error

