### PR TITLE
test_download: fixture IDs must be strings

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -272,7 +272,7 @@ class TestDownload(CLITest):
         self.do_restrictions(fixture, tmpdir, group)
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
-                             ids=POLICY_FIXTURES)
+                             ids=[str(x) for x in POLICY_FIXTURES])
     def testPolicyGroupRestriction(self, tmpdir, fixture):
         parts = fixture.cfg.split(",")
         config = [NV("omero.policy.binary_access", x) for x in parts]

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -262,7 +262,7 @@ class TestDownload(CLITest):
         assert cfg in [x.cfg for x in self.POLICY_FIXTURES]
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
-                             ids=POLICY_FIXTURES)
+                             ids=[str(x) for x in POLICY_FIXTURES])
     def testPolicyGlobalRestriction(self, tmpdir, fixture):
         # Skip f this isn't a check for this particular
         # config, then skip.


### PR DESCRIPTION
Test failure occurred with pytest-3.0.2 in devspace.