### PR TITLE
Cap pytest to below 3.0 (rebased onto metadata52)

### DIFF
--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -33,4 +33,4 @@ setup(name="OmeroFS",
       package_dir={"": "target"},
       packages=[''],
       cmdclass={'test': PyTest},
-      tests_require=['pytest<3.0.0'])
+      tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'])

--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-   Copyright 2008 Glencoe Software, Inc. All rights reserved.
+   Copyright 2008-2016 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -33,4 +33,4 @@ setup(name="OmeroFS",
       package_dir={"": "target"},
       packages=[''],
       cmdclass={'test': PyTest},
-      tests_require=['pytest'])
+      tests_require=['pytest<3.0.0'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -67,4 +67,4 @@ setup(
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
     cmdclass={'test': PyTest},
-    tests_require=['pytest<3.0.0'])
+    tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -67,4 +67,4 @@ setup(
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
     cmdclass={'test': PyTest},
-    tests_require=['pytest'])
+    tests_require=['pytest<3.0.0'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -26,7 +26,7 @@
       ./setup.py test --pdb
 
 
-   Copyright 2007-2013 Glencoe Software, Inc. All rights reserved.
+   Copyright 2007-2016 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -51,5 +51,5 @@ OmeroWeb is the container of the web clients for OMERO."
       packages=[''],
       test_suite='test.suite',
       cmdclass={'test': PyTest},
-      tests_require=['pytest'],
+      tests_require=['pytest<3.0.0'],
       )

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -51,5 +51,5 @@ OmeroWeb is the container of the web clients for OMERO."
       packages=[''],
       test_suite='test.suite',
       cmdclass={'test': PyTest},
-      tests_require=['pytest<3.0.0'],
+      tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'],
       )

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-   Copyright 2008 Glencoe Software, Inc. All rights reserved.
+   Copyright 2008-2016 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """


### PR DESCRIPTION

This is the same as gh-4826 but rebased onto metadata52.

----

# What this PR does

This PR caps the  `pytest` version to below `3.0.0` due to the bug at: https://github.com/pytest-dev/pytest/issues/1905 

# Testing this PR

The test previously failing at https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-breaking-integration-Python27/26/testReport/OmeroPy.test.integration.clitest/test_download/TestDownload/ should pass.

When the issue above if resolved the commit in this PR should be reverted or otherwise amended.

See: https://trello.com/c/FjmLqCum/709-uncap-pytest

--rebased-to #4848 

                