### PR TITLE
populate metadata using bin/omero

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -87,8 +87,7 @@ done
 bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Use populate_metadata to upload and attach bulk annotation csv
-#PYTHONPATH=./lib/python python lib/python/omero/util/populate_metadata.py -s $HOSTNAME -p $PORT -k $key Plate:$plateid $BULK_ANNOTATION_CSV
-OMERO_DEV_PLUGINS=1 bin/omero metadata populate Plate:$plateid --file bulk_annotation.csv
+OMERO_DEV_PLUGINS=1 bin/omero metadata populate Plate:$plateid --file $BULK_ANNOTATION_CSV
 
 # Import Plate and rename for test ?show=image.name-NAME
 bin/omero import $PLATE_NAME --debug ERROR > show_import.log 2>&1

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -87,7 +87,8 @@ done
 bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 # Use populate_metadata to upload and attach bulk annotation csv
-PYTHONPATH=./lib/python python lib/python/omero/util/populate_metadata.py -s $HOSTNAME -p $PORT -k $key Plate:$plateid $BULK_ANNOTATION_CSV
+#PYTHONPATH=./lib/python python lib/python/omero/util/populate_metadata.py -s $HOSTNAME -p $PORT -k $key Plate:$plateid $BULK_ANNOTATION_CSV
+OMERO_DEV_PLUGINS=1 bin/omero metadata populate Plate:$plateid --file bulk_annotation.csv
 
 # Import Plate and rename for test ?show=image.name-NAME
 bin/omero import $PLATE_NAME --debug ERROR > show_import.log 2>&1


### PR DESCRIPTION
# What this PR does

replace the way populate_metadata.py is run by recommanded `bin/omero metadata populate`

# Testing this PR

CI will test it https://ci.openmicroscopy.org/job/OMERO-DEV-merge-robotframework/

before:
```
20:53:09 + python lib/python/omero/util/populate_metadata.py -s cowfish.openmicroscopy.org -p 24064 -k 24ba5a42-8a1c-463d-84d7-842288057e2a Plate:176 bulk_annotation.csv
20:53:09 INFO:omero.util.Resources:Starting
20:53:09 INFO:omero.util.populate_metadata:Missing image name column, skipping.
20:53:09 INFO:omero.util.populate_metadata:Missing plate name column, skipping.
20:53:09 INFO:omero.util.populate_metadata:Missing image name column, skipping.
20:53:09 INFO:omero.util.populate_metadata:Missing plate name column, skipping.
20:53:15 Traceback (most recent call last):
20:53:15   File "lib/python/omero/util/populate_metadata.py", line 1075, in <module>
20:53:15     ctx.write_to_omero()
20:53:15   File "lib/python/omero/util/populate_metadata.py", line 624, in write_to_omero
20:53:15     "Unable to create table: %s" % name)
20:53:15 __main__.MetadataError: Unable to create table: bulk_annotations
20:53:15 INFO:omero.util.Resources:Halted
20:53:15 Build step 'Execute shell' marked build as failure
20:53:15 Robot results publisher started...
```

now

```
06:14:36 + plateid=201
06:14:36 + OMERO_DEV_PLUGINS=1
06:14:36 + bin/omero metadata populate Plate:201 --file bulk_annotation.csv
06:14:36 ERROR:omero.gateway:No Pillow installed, line plots and split channel will fail!
06:14:36 Using session 4cf1ebfa-2d15-4d52-95f6-0290ec1a6f8d (robot_user-1474607514@cowfish.openmicroscopy.org:24064). Idle timeout: 10 min. Current group: robot_group-1474607514
06:14:36 INFO:omero.util.populate_metadata:Missing image name column, skipping.
06:14:36 INFO:omero.util.populate_metadata:Missing plate name column, skipping.
06:14:36 INFO:omero.util.populate_metadata:Missing image name column, skipping.
06:14:36 INFO:omero.util.populate_metadata:Missing plate name column, skipping.
06:14:41 INFO:omero.util.populate_metadata:Created new table OriginalFile:2279
06:14:41 INFO:omero.util.populate_metadata:Table initialized with 4 columns.
06:14:41 INFO:omero.util.populate_metadata:Added data column data.
```

# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/4765

