### PR TITLE
getProjectedThumbnail bugfix (rebased onto dev_5_2)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7366,6 +7366,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             else:
                 w = w * size[0] / h
                 h = size[0]
+        elif len(size) == 2:
+            w, h = size
         img = img.resize((w, h), Image.NEAREST)
         rv = StringIO()
         img.save(rv, 'jpeg', quality=70)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -59,6 +59,12 @@ class TestImage (object):
         thumb.verify()  # Raises if invalid
         assert thumb.format == 'JPEG'
         assert thumb.size == (64, 64)
+        # Projection
+        self.image.setProjection('intmax')
+        pThumb = self.image.getThumbnail()
+        ptfile = StringIO(pThumb)
+        pthumb = Image.open(ptfile)  # Raises if invalid
+        pthumb.verify()  # Raises if invalid
 
     def testRenderingModels(self):
         # default is color model


### PR DESCRIPTION

This is the same as gh-4841 but rebased onto dev_5_2.

----

# What this PR does

Fixes error in logs on getProjectedThumbnail.
See https://trello.com/c/gl6sfCdI/146-getprojectedthumbnail-bug

# Testing this PR

1. Need to check web logs:  ```$ tail -f dist/var/log/OMEROweb.log```
2. Pick a Z-stack image, open in full web image viewer, turn Projection ON.
3. Save rendering settings (may need to tweak sliders to enable Save button)
4. Logs should not show any error on Save (see trello card exception).


                