### PR TITLE
Add get_image_rdefs_json method/resource to webgateway

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -413,6 +413,13 @@ Get a json dict of original file paths.
 'client' is a list of paths for original files on the client when imported
 """
 
+get_image_rdefs_json = url(r'^get_image_rdefs_json/(?P<img_id>[0-9]+)/$',
+                           'webgateway.views.get_image_rdefs_json',
+                           name="webgateway_get_image_rdefs_json")
+"""
+This url will retrieve all rendering definitions for a given image (id)
+"""
+
 urlpatterns = patterns(
     '',
     webgateway,
@@ -447,6 +454,7 @@ urlpatterns = patterns(
     # rendering def methods
     save_image_rdef_json,
     get_image_rdef_json,
+    get_image_rdefs_json,
     listLuts_json,
     list_compatible_imgs_json,
     copy_image_rdef_json,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2542,8 +2542,8 @@ def get_image_rdefs_json(request, img_id=None, conn=None, **kwargs):
         img = conn.getObject("Image", img_id)
 
         if img is None:
-            return {'error' : 'No image with id ' + str(img_id)}
+            return {'error': 'No image with id ' + str(img_id)}
 
-        return {'rdefs' : img.getAllRenderingDefs()}
+        return {'rdefs': img.getAllRenderingDefs()}
     except:
-        return {'error' : 'Failed to retrieve rdefs'}
+        return {'error': 'Failed to retrieve rdefs'}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2520,3 +2520,30 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
     tableData['parentId'] = ann['parentId']
     tableData['addedOn'] = ann['addedOn']
     return tableData
+
+
+@login_required()
+@jsonp
+def get_image_rdefs_json(request, img_id=None, conn=None, **kwargs):
+    """
+    Retrieves all rendering definitions for a given image (id).
+
+    Example:  /get_image_rdefs_json/1
+              Returns all rdefs for image with id 1
+
+    @param request:     http request.
+    @param img_id:      the id of the image in question
+    @param conn:        L{omero.gateway.BlitzGateway}
+    @param **kwargs:    unused
+    @return:            A dictionary with key 'rdefs' in the success case,
+                        one with key 'error' if something went wrong
+    """
+    try:
+        img = conn.getObject("Image", img_id)
+
+        if img is None:
+            return {'error' : 'No image with id ' + str(img_id)}
+
+        return {'rdefs' : img.getAllRenderingDefs()}
+    except:
+        return {'error' : 'Failed to retrieve rdefs'}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2546,4 +2546,5 @@ def get_image_rdefs_json(request, img_id=None, conn=None, **kwargs):
 
         return {'rdefs': img.getAllRenderingDefs()}
     except:
+        logger.debug(traceback.format_exc())
         return {'error': 'Failed to retrieve rdefs'}

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -170,8 +170,10 @@ class TestRendering(IWebTest):
         assert image.isGreyscaleRenderingModel() is False
 
         # request the rendering def via the method we want to test
-        request_url = reverse('webgateway.views.get_image_rdefs_json',args=[iid])
-        response = _get_response(self.django_client, request_url, {}, status_code=200)
+        request_url = reverse(
+            'webgateway.views.get_image_rdefs_json', args=[iid])
+        response = _get_response(
+            self.django_client, request_url, {}, status_code=200)
 
         # check expected response
         assert response is not None and response.content is not None

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -197,6 +197,14 @@ class TestRendering(IWebTest):
             assert c['end'] == expChannels[i].getWindowEnd()
             assert c['color'] == expChannels[i].getColor().getHtml()
 
+        # id and owner check
+        assert rdefs[0].get("id") is not None
+        owner = rdefs[0].get("owner")
+        assert isinstance(owner, dict)
+        fullOwner = owner.get("firstName", "") + " " +\
+            owner.get("lastName", "")
+        assert fullOwner == conn.getUser().getFullName()
+
 
 class TestRenderImageRegion(IWebTest):
     """

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -21,6 +21,8 @@
 Tests copying and pasting of rendering settings in webclient
 """
 
+import json
+
 import omero
 import omero.clients
 
@@ -149,6 +151,49 @@ class TestRendering(IWebTest):
         assert old_c1 == new_c2
         # check if image2 rendering model changed from greyscale to color
         assert image2.isGreyscaleRenderingModel() is False
+
+    """
+    Tests retrieving all rendering defs for an image (given id)
+    """
+    def test_all_rendering_defs(self):
+        # Create image with 3 channels
+        iid = self.createTestImage(sizeC=3, session=self.sf).id.val
+
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+
+        image = conn.getObject("Image", iid)
+        image.resetDefaults()
+        image.setColorRenderingModel()
+        image.saveDefaults()
+        image = conn.getObject("Image", iid)
+
+        assert image.isGreyscaleRenderingModel() is False
+
+        # request the rendering def via the method we want to test
+        request_url = reverse('webgateway.views.get_image_rdefs_json',args=[iid])
+        response = _get_response(self.django_client, request_url, {}, status_code=200)
+
+        # check expected response
+        assert response is not None and response.content is not None
+
+        # json => dict for convenience
+        rdefDict = json.loads(response.content)
+        assert isinstance(rdefDict, dict)
+        rdefs = rdefDict.get('rdefs')
+
+        # there has to be one rgb image with 3 channels
+        assert isinstance(rdefs, list) and len(rdefs) == 1
+        assert rdefs[0].get("model") == "rgb"
+        channels = rdefs[0].get("c")
+        assert isinstance(channels, list) and len(channels) == 3
+
+        # channel info is supposed to match
+        expChannels = image.getChannels()
+        for i, c in enumerate(channels):
+            assert c['active'] == expChannels[i].isActive()
+            assert c['start'] == expChannels[i].getWindowStart()
+            assert c['end'] == expChannels[i].getWindowEnd()
+            assert c['color'] == expChannels[i].getColor().getHtml()
 
 
 class TestRenderImageRegion(IWebTest):


### PR DESCRIPTION
# What this PR does

Retrieving all rendering defs for an image is at the moment a 2 step procedure that requires knowing the ids to the rendering defs that have to be retrieved. The present omero web viewer accomplishes the latter task by receiving an html/js response. In specific this is used in the preview section that shows user rendering settings by their respective thumbnails. 

For the purpose of being able to do likewise in the viewer-ng, but really it's useful in any case where that information is needed and cannot be used with an html response as is I propose this simple webgateway extension that will return all rendering settings for a given image as json (and within one request).

# Testing this PR

I have added an integration test in what seemed to me the most appropriate place, namely where copy and paste of the rendering settings are tested.

Of course there is also the "conventional" way of browsing to the corresponding gateway url: _get_image_rdefs_json/img_id_