### PR TITLE
preserve objective settings on moves and chowns

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -136,9 +136,9 @@
 
         <!-- Move settings if underlying object is moved. -->
 
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[ED].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[ED].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[ED].objective = [I]" p:changes="S:[I]"/>
 
         <!-- Images may be moved only if doing so would not remove an imaging environment from any of them. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -156,9 +156,9 @@
 
         <!-- Give settings if underlying object is given. -->
 
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].detector = [I]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].lightSource = [I]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].objective = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[ED].detector = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[ED].lightSource = [I]" p:changes="S:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[ED].objective = [I]" p:changes="S:[I]"/>
 
         <!-- Images may be given only if doing so would not remove an imaging environment from any of them. -->
 

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -142,7 +142,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         final Chgrp2 dc = Requests.chgrp().target(savedImage).toGroup(targetGroup).build();
         callback(true, client, dc);
 
-        // check if the image have been moved.
+        // check if the image has been moved.
         Image returnedSourceImage = getImageWithId(originalImageId);
         Assert.assertNull(returnedSourceImage);
 

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -135,7 +135,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
 
         Image savedImage = (Image) iUpdate.saveAndReturnObject(sourceImage);
         long originalImageId = savedImage.getId().getValue();
-        final long objectiveId = savedImage.getObjectiveSettings().getObjective().getId().getValue();
+        final long originalObjectiveId = savedImage.getObjectiveSettings().getObjective().getId().getValue();
 
         // make sure we are in the source group
         loginUser(sourceGroup);
@@ -177,7 +177,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         final Objective returnedObjective = (Objective) iQuery.findByQuery(
                 "SELECT i.objectiveSettings.objective FROM Image i WHERE i.id = :id",
                 new ParametersI().addId(originalImageId));
-        Assert.assertEquals(returnedObjective.getId().getValue(), objectiveId);
+        Assert.assertEquals(returnedObjective.getId().getValue(), originalObjectiveId);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -37,6 +37,7 @@ import omero.model.Image;
 import omero.model.Instrument;
 import omero.model.Laser;
 import omero.model.LightSource;
+import omero.model.Objective;
 import omero.model.Pixels;
 import omero.sys.ParametersI;
 
@@ -134,6 +135,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
 
         Image savedImage = (Image) iUpdate.saveAndReturnObject(sourceImage);
         long originalImageId = savedImage.getId().getValue();
+        final long objectiveId = savedImage.getObjectiveSettings().getObjective().getId().getValue();
 
         // make sure we are in the source group
         loginUser(sourceGroup);
@@ -170,6 +172,12 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
             if (lightSource instanceof Laser)
                 validateLaser((Laser) lightSource, xmlLaser);
         }
+
+        // check that the objective and settings moved
+        final Objective returnedObjective = (Objective) iQuery.findByQuery(
+                "SELECT i.objectiveSettings.objective FROM Image i WHERE i.id = :id",
+                new ParametersI().addId(originalImageId));
+        Assert.assertEquals(returnedObjective.getId().getValue(), objectiveId);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -24,7 +24,6 @@ package integration.chgrp;
 import integration.AbstractServerTest;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 import ome.specification.XMLMockObjects;
@@ -135,8 +134,6 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
 
         Image savedImage = (Image) iUpdate.saveAndReturnObject(sourceImage);
         long originalImageId = savedImage.getId().getValue();
-        List<Long> imageIds = new ArrayList<Long>(1);
-        imageIds.add(originalImageId);
 
         // make sure we are in the source group
         loginUser(sourceGroup);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveImageWithAcquisitionDataTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -98,9 +98,9 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
     /**
      * Test moving data as the data owner from a private to a private group
      *
-     * @throws Exception
+     * @throws Exception unexpected
      */
-    @Test(groups = "broken")
+    @Test
     public void moveImageRWtoRW() throws Exception {
         moveImageBetweenPermissionGroups("rw----", "rw----");
     }
@@ -201,7 +201,7 @@ public class HierarchyMoveImageWithAcquisitionDataTest extends
         Assert.assertEquals(laser.getModel().getValue(), xml.getModel());
         Assert.assertEquals(laser.getSerialNumber().getValue(), xml.getSerialNumber());
         Assert.assertEquals(laser.getLotNumber().getValue(), xml.getLotNumber());
-        Assert.assertEquals(laser.getPower().getValue(), xml.getPower());
+        Assert.assertEquals(laser.getPower().getValue(), xml.getPower().value());
         Assert.assertEquals(laser.getType().getValue().getValue(),
                 XMLMockObjects.LASER_TYPE.getValue());
     }


### PR DESCRIPTION
# What this PR does

This PR resurrects and extends `HierarchyMoveImageWithAcquisitionDataTest` to check that objective settings move along with images and fixes the graph policy rules so that they actually do.

# Testing this PR

CI suffices, especially https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.chgrp/HierarchyMoveImageWithAcquisitionDataTest/