### PR TITLE
dataset_thumb_drag_select_fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -1412,6 +1412,8 @@
         top: 0; 
         left: 0;
         position: relative;
+        width: 100%;
+        height: 100%;
     }
 
 


### PR DESCRIPTION
# What this PR does
Fixes the drag-select of Dataset thumbnails, allowing you to start the drag from anywhere in the centre panel (don't need to start dragging on a thumbnail).
cc @pwalczysko 

# Testing this PR

1. Drag select Dataset thumbnails with OR without starting on a thumbnail.

