### PR TITLE
Fixed ClassCastException in ChannelMetadataLoader

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ChannelMetadataLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ChannelMetadataLoader.java
@@ -74,6 +74,7 @@ public class ChannelMetadataLoader
             {
                 OmeroMetadataService os = context.getMetadataService();
                 List l = os.getChannelsMetadata(ctx, pixelsID);
+                
                 if (userID >= 0) { //load the rendering settings.
                 	OmeroImageService svc = context.getImageService();
                 	List rnd = svc.getRenderingSettingsFor(ctx,
@@ -99,7 +100,13 @@ public class ChannelMetadataLoader
                 	}
                 	
                 	results = channels;
-                } else results = l;
+                } 
+                else {
+                    results = new HashMap();
+                    for (Object o : l) {
+                        ((Map) results).put(o, null);
+                    }
+                }
             }
         };
     }


### PR DESCRIPTION
# What this PR does

Tiny bug fix (ClassCastException). Noticed that bug when testing something else. Can be triggered by selecting image 42401 (user-3 on eel), which triggers the metadata loading.

# Testing this PR

Select above mentioned image (without PR that already crashed Insight), browse the metadata.


