### PR TITLE
Output test - put all to default

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -153,12 +153,10 @@ class TestImport(CLITest):
         client_dir = dist_dir / "lib" / "client"
         self.args += ["--clientdir", client_dir]
 
-    def check_other_output(self, out_lines):
+    def check_other_output(self, out):
         """Check the output of the import except Images, Plates and Summary"""
-        assert len(out_lines) == 5
-        assert out_lines[0] == "Other imported objects:"
-        assert out_lines[2] == ''
-        assert out_lines[3] == "==> Summary"
+        assert "Other imported objects:" in out
+        assert "==> Summary" in out
 
     def get_object(self, err, obj_type, query=None):
         if not query:
@@ -847,9 +845,8 @@ class TestImport(CLITest):
 
         # Check the contents of "e"
         # and the existence of the newly created Fileset
-        e_lines = self.parse_imported_objects(e)
         self.get_object(e, 'Fileset')
-        self.check_other_output(e_lines)
+        self.check_other_output(e)
 
         # Parse and check the summary of the import output
         summary = self.parse_summary(e)
@@ -873,9 +870,8 @@ class TestImport(CLITest):
 
         # Check the contents of "e"
         # and the existence of the newly created Fileset
-        e_lines = self.parse_imported_objects(e)
         self.get_object(e, 'Fileset')
-        self.check_other_output(e_lines)
+        self.check_other_output(e)
 
         # Parse and check the summary of the import output
         summary = self.parse_summary(e)

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -164,8 +164,11 @@ class TestImport(CLITest):
             match = re.match(pattern, line)
             if match:
                 break
-        return query.get(obj_type, int(match.group('id')),
+        obj = query.get(obj_type, int(match.group('id')),
                          {"omero.group": "-1"})
+        assert obj
+        assert obj.id.val == int(match.group('id'))
+        return obj
 
     def get_objects(self, err, obj_type, query=None):
         if not query:
@@ -831,18 +834,14 @@ class TestImport(CLITest):
         # Check the contents of "o",
         # and the existence of the newly created image
         assert len(self.parse_imported_objects(o)) == 1
-        image = self.get_object(o, 'Image')
-        assert image
-        assert self.parse_imported_objects(o)[0] == "Image:%s" % image.id.val
+        self.get_object(o, 'Image')
 
         # Check the contents of "e"
         # and the existence of the newly created Fileset
         e_lines = self.parse_imported_objects(e)
+        self.get_object(e, 'Fileset')
         assert len(e_lines) == 5
         assert e_lines[0] == "Other imported objects:"
-        fileset = self.get_object(e, 'Fileset')
-        assert fileset
-        assert e_lines[1] == "Fileset:%s" % fileset.id.val
         assert e_lines[2] == ''
         assert e_lines[3] == "==> Summary"
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -820,7 +820,7 @@ class TestImport(CLITest):
         expected_levels = debug_levels[debug_levels.index(level):]
         assert set(levels) <= set(expected_levels), out
 
-    def testImportOutput(self, tmpdir, capfd):
+    def testImportOutputDefault(self, tmpdir, capfd):
         """Test import output"""
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -165,7 +165,7 @@ class TestImport(CLITest):
             if match:
                 break
         obj = query.get(obj_type, int(match.group('id')),
-                         {"omero.group": "-1"})
+                        {"omero.group": "-1"})
         assert obj
         assert obj.id.val == int(match.group('id'))
         return obj

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -129,8 +129,6 @@ class TestImport(CLITest):
         self.add_client_dir()
 
     def do_import(self, capfd, strip_logs=True):
-        # Temporary fix to pass current tests by getting legacy output
-        # self.args += ["--output", "legacy"]
         try:
             self.cli.invoke(self.args, strict=True)
             o, e = capfd.readouterr()
@@ -349,7 +347,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image')
+        obj = self.get_object(o, 'Image')
         annotations = self.get_linked_annotations(obj.id.val)
 
         assert len(annotations) == fixture.n
@@ -378,7 +376,7 @@ class TestImport(CLITest):
         print self.args
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image')
+        obj = self.get_object(o, 'Image')
         annotations = self.get_linked_annotations(obj.id.val)
 
         assert len(annotations) == fixture.n
@@ -522,10 +520,10 @@ class TestImport(CLITest):
     def parse_container(self, spw, capfd):
         o, e = self.do_import(capfd)
         if spw:
-            obj = self.get_object(e, 'Plate')
+            obj = self.get_object(o, 'Plate')
             container = self.get_screen(obj.id.val)
         else:
-            obj = self.get_object(e, 'Image')
+            obj = self.get_object(o, 'Image')
             container = self.get_dataset(obj.id.val)
 
         assert container
@@ -699,7 +697,7 @@ class TestImport(CLITest):
         # containers are created and used.
         o, e = self.do_import(capfd)
 
-        objs = self.get_objects(e, importType)
+        objs = self.get_objects(o, importType)
         assert len(objs) == 2
         container1 = self.get_container(objs[0].id.val, spw=spw)
         container2 = self.get_container(objs[1].id.val, spw=spw)
@@ -780,7 +778,7 @@ class TestImport(CLITest):
         # Now, run the import and check that the imported object
         # is not in a container.
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, importType)
+        obj = self.get_object(o, importType)
         container = self.get_container(obj.id.val, spw=spw)
         assert container is None
 
@@ -902,7 +900,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image', query=client.sf.getQueryService())
+        obj = self.get_object(o, 'Image', query=client.sf.getQueryService())
         assert obj.details.owner.id.val == user.id.val
 
     def testImportMultiGroup(self, tmpdir, capfd):
@@ -924,7 +922,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image', query=client.sf.getQueryService())
+        obj = self.get_object(o, 'Image', query=client.sf.getQueryService())
         assert obj.details.owner.id.val == user.id.val
         assert obj.details.group.id.val == group2.id.val
 
@@ -947,7 +945,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image', query=client.sf.getQueryService())
+        obj = self.get_object(o, 'Image', query=client.sf.getQueryService())
         assert obj.details.owner.id.val == user.id.val
         assert obj.details.group.id.val == group2.id.val
 
@@ -969,7 +967,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, fixture.obj_type)
+        obj = self.get_object(o, fixture.obj_type)
 
         if fixture.name_arg:
             assert obj.getName().val == 'name'
@@ -988,7 +986,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         out, err = self.do_import(capfd)
-        image = self.get_object(err, 'Image')
+        image = self.get_object(out, 'Image')
 
         # Check no thumbnails
         assert self.get_thumbnail(image.id.val) is None
@@ -1007,7 +1005,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         out, err = self.do_import(capfd)
-        image = self.get_object(err, 'Image')
+        image = self.get_object(out, 'Image')
 
         # Check min/max calculation
         query = ("select p from Pixels p left outer "
@@ -1045,7 +1043,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image')
+        obj = self.get_object(o, 'Image')
 
         assert obj
 
@@ -1074,7 +1072,7 @@ class TestImport(CLITest):
 
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
-        obj = self.get_object(e, 'Image')
+        obj = self.get_object(o, 'Image')
         assert obj.details.group.id.val == new_group.id.val
 
     @pytest.mark.parametrize("container,filename,arg", target_fixtures)


### PR DESCRIPTION
# What this PR does
As the output form of import commands changed in https://github.com/openmicroscopy/openmicroscopy/pull/4812, this PR is adjusting the import integration tests in such a manner that the new Default output is being tested in all tests. Also, 2 new explicit tests have been added, for the default option output (single image and single and multiple plates).

Give this PR a descriptive title then expand on that here.


# Testing this PR

Check the integration tests are passing.
Check the sensibility of the test additions here.


# Related reading

Note that follow-up PR(s) will add new tests for the 2 new non-default options introduced by the https://github.com/openmicroscopy/openmicroscopy/pull/4812 - A) yaml and B) legacy
