### PR TITLE
Luts2

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7978,7 +7978,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             for w in waves:
                 color = ColorHolder.fromRGBA(
                     w.getRed().val, w.getGreen().val, w.getBlue().val, 255)
-                d['c'].append({
+                r = {
                     'active': w.getActive().val,
                     'start': w.getInputStart().val,
                     'end': w.getInputEnd().val,
@@ -7986,7 +7986,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     'rgb': {'red': w.getRed().val,
                             'green': w.getGreen().val,
                             'blue': w.getBlue().val}
-                    })
+                    }
+                lut = unwrap(w.getLookupTable())
+                if lut is not None and len(lut) > 0:
+                    r['lut'] = lut
+                d['c'].append(r)
             rv.append(d)
         return rv
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -238,6 +238,7 @@ class TestRDefs (object):
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
         self.image = gatewaywrapper.getTestImage()
         self.image.setGreyscaleRenderingModel()
+        self.image.setActiveChannels([1], colors=['cool.lut'])
         self.image.saveDefaults()
 
         # Author saves Rdef (color)
@@ -245,6 +246,7 @@ class TestRDefs (object):
         authorId = gatewaywrapper.gateway.getUserId()
         self.image = gatewaywrapper.getTestImage()
         self.image.setColorRenderingModel()
+        self.image.setActiveChannels([1], colors=['FF0000'])
         self.image.saveDefaults()
 
         rdefs = self.image.getAllRenderingDefs()
@@ -256,9 +258,12 @@ class TestRDefs (object):
             if r['owner']['id'] == adminId:
                 adminRdefId = r['id']
                 assert r['model'] == 'greyscale'
+                assert r['c'][0]['lut'] == 'cool.lut'
             elif r['owner']['id'] == authorId:
                 authorRdefId = r['id']
                 assert r['model'] == 'rgb'
+                assert 'lut' not in r['c'][0]
+                assert r['c'][0]['color'] == 'FF0000'
 
         assert adminRdefId is not None
         assert authorRdefId is not None

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1599,8 +1599,9 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
             act = "-"
             if c['active']:
                 act = ""
+            color = c['lut'] if 'lut' in c else c['color']
             chs.append('%s%s|%d:%d$%s'
-                       % (act, i+1, c['start'], c['end'], c['color']))
+                       % (act, i+1, c['start'], c['end'], color))
         rdefQueries.append({
             'id': r['id'],
             'owner': r['owner'],

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.colorbtn.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.colorbtn.js
@@ -106,6 +106,7 @@ $.fn.colorbtn = function(cfg) {
           picker = jQuery.farbtastic("#"+this.cfg.prefix);
         }
       }
+      var currColor = self.attr('data-color');
 
       // lookup LUTs
       var $luts = $("#" + this.cfg.prefix + "-luts");
@@ -132,6 +133,7 @@ $.fn.colorbtn = function(cfg) {
           });
           var html = '<div>' + colorRows.join("") + lutRows.join("") + '</div>';
           $luts.html(html);
+          $("label[for='" + currColor + "']").css('background', '#cddcfc');
         });
       }
 
@@ -139,6 +141,9 @@ $.fn.colorbtn = function(cfg) {
       $('.cpickerPane').hide();
       $luts.show();
       $('.showColorPicker a').html('Show Color Picker');
+      // Highlight current color/lut
+      $("label", $luts).css('background', 'none');
+      $("label[for='" + currColor + "']", $luts).css('background', '#cddcfc')
 
       // bind appropriate handler (wraps ref to button)
       $("#cbpicker-OK-btn").unbind('click').bind('click', ok_callback)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -173,13 +173,14 @@
     };
 
     function getLutBgPos(color) {
-        var css = {};
         if (color.endsWith('.lut')) {
             var lutIndex = OME.LUT_NAMES.indexOf(color);
-            return '0px -' + (lutIndex * 20) + 'px';
-        } else {
-            return '0px 100px';  // hide by offsetting
+            if (lutIndex > -1) {
+                return '0px -' + (lutIndex * 20) + 'px';
+            }
         }
+        // Not found...
+        return '0px 100px';  // hide by offsetting
     }
 
     window.syncRDCW = function(viewport) {


### PR DESCRIPTION
# What this PR does

Fixes a few outstanding issues from [first LUTs PR](https://github.com/openmicroscopy/openmicroscopy/pull/4767) , as mentioned in https://trello.com/c/9iAe3Sg9/95-lut-support

# Testing this PR

 - Add a new 'unknown' LUT to the server. E.g. copy a LUT from dist/lib/scripts/lut/ put it in another luts directory and rename it. Then:

``` $ omero script upload luts/a_test_will.lut --official ```

Check that Channel button and slider are grey when LUT is selected
 - When clicking on the users' rendering def thumbnails at bottom of Preview panel, picking those with LUTs saved should display the LUT in the Preview viewer.
 - The currently selected LUT or color should be highlighted in the color-picker list (light blue background).

![screen shot 2016-10-03 at 15 11 02](https://cloud.githubusercontent.com/assets/900055/19042044/66ffa03c-8982-11e6-920e-080dceddcf12.png)

