### PR TITLE
Bug fixes oct 2016

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -128,7 +128,7 @@ $(function() {
         var dryRunUrl = webindex_url + "chgrpDryRun/",
             data = $.extend({}, targetObjects, {'group_id': groupId});
         // Show message and start dry-run
-        var msg = "<p style='margin-bottom:0'><img alt='Loading' src='" + static_url + "/../webgateway/img/spinner.gif'> " +
+        var msg = "<p style='margin-bottom:0'><img alt='Loading' src='" + static_url + "../webgateway/img/spinner.gif'> " +
                   "Checking which linked objects will be moved...</p>";
         var $dryRunSpinner = $(msg).appendTo($group_chooser);
         $group_chooser.append('<hr>');
@@ -145,7 +145,7 @@ $(function() {
                             // More assertive error message
                             errMsg = errMsg.replace("may not move", "Cannot move");
                             var errHtml = "<img style='vertical-align: middle; position:relative; top:-3px' src='" +
-                                static_url + "/../webgateway/img/failed.png'> ";
+                                static_url + "../webgateway/img/failed.png'> ";
                             // In messages, replace Image[123] with link to image
                             var getLinkHtml = function(imageId) {
                                 var id = imageId.replace("Image[", "").replace("]", "");
@@ -233,7 +233,8 @@ $(function() {
 
         // Remove all groups (except the chosen one)
         $(".chgrpGroup").remove();
-        $group_chooser.append($this);
+        // We remove .chgrpGroup to avoid clicking again on .chgrpGroup
+        $group_chooser.append($this.removeClass('chgrpGroup'));
 
         // Add hidden inputs to include 'group_id' in the POST data
         $("<input name='group_id' value='"+ gid +"'/>")

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -162,6 +162,7 @@ $(function() {
                         var traverse = function(index, parentNode) {
                             // Get this path component
                             var comp = path[index];
+                            var lastIndex = path.length - 1;
                             // Get the node for this path component
                             var node = inst.locate_node(comp.type + '-' + comp.id, parentNode)[0];
 
@@ -204,7 +205,6 @@ $(function() {
                     var i;
                     for (i=0; i < (data.length); i++) {
                         var path = data[i];
-                        var lastIndex = path.length - 1;
                         var traverse = getTraverse(path)
                         // Start traversing at the start of the path with no parent node
                         try {


### PR DESCRIPTION
# What this PR does

A couple of minor bug fixes:

# Testing this PR

1. See https://trello.com/c/GEK62sim/195-move-dialog-double-click-bug In the "Move To Group" (chgrp) dialog, click a target group.
    - Check that the spinner shows up while the 'dry run' is performed
    - Check that clicking again on the group (or double-clicking) doesn't repeat the dry-run and display the results multiple times.

2. Place an image in 2 Datasets, and place one of the Datasets in a Project (the other Dataset is orphaned). Copy the link to the image ```webclient/?show=image-123``` and visit that url in the browser. 
    - Both of the 'paths' to the image should be expanded (both Datasets opened) and the image should be selected in one of the Datasets.
