### PR TITLE
Yaml and legacy output tests

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -163,8 +163,8 @@ class TestImport(CLITest):
             assert "Other imported objects:" in out
         elif import_type == 'yaml':
             assert "Imported objects:" in out
-        elif import_type == 'legacy':
-            assert 'Imported Pixels:' in out
+        if import_type == 'legacy':
+            assert "Imported pixels:" in out
 
     def get_object(self, err, obj_type, query=None):
         """Retrieve the created object by parsing the stderr output"""


### PR DESCRIPTION
# What this PR does

A follow-up pf https://github.com/openmicroscopy/openmicroscopy/pull/4873 where the tests for import output in case `--legacy` flag and `--yaml` flag are being passed.

As the output form of import commands changed in https://github.com/openmicroscopy/openmicroscopy/pull/4812, this PR is adjusting the import integration tests in such a manner that the new flag options ``--legacy` and `--yaml` are being tested.
# Testing this PR

Check the integration tests are passing.
Check the sensibility of the test additions here.

yaml library is necessary for these tests to pass, thank you @joshmoore 

@mtbc @jburel 
