### PR TITLE
Filter images by name only

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -367,6 +367,7 @@ $(document).ready(function() {
             'delay': 300,
             'bind': 'keyup',
             'loader': 'span.loading',
+            'selector': '.hidden_sort_text',
             onAfter: function(){
                 // onAfter can get triggered without text change, E.g. by tree selection!
                 var new_txt = $filter_input.val();


### PR DESCRIPTION
This fixes the filtering of images by name, as reported by @pwalczysko: https://github.com/openmicroscopy/openmicroscopy/pull/4694#issuecomment-251083417

To test:
- Filter images in a Dataset using the filter input above thumbnails.
- If any characters are entered that are not in the image's name, that image should be filtered out.
