### PR TITLE
disable testPopulateMetadataPlate

### DIFF
--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -154,8 +154,10 @@ class TestPopulateMetadata(BasePopulate):
         except Exception:
             skip("PyYAML not installed.")
         self._test_parsing_context()
-        self._test_bulk_to_map_annotation_context()
-        self._test_delete_map_annotation_context()
+        # Adding map annotations to wells AND images is currently disabled
+        # in commit d3a0b362 because they are duplicated in UI.
+        # self._test_bulk_to_map_annotation_context()
+        # self._test_delete_map_annotation_context()
 
     def _test_parsing_context(self):
         """


### PR DESCRIPTION
This turns off the breaking parts of testPopulateMetadataPlate, which is broken due to https://github.com/openmicroscopy/openmicroscopy/commit/d3a0b36208b84 

https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/384/testReport/junit/OmeroPy.test.integration.metadata.test_populate/TestPopulateMetadata/testPopulateMetadataPlate/

cc @joshmoore @manics 
