### PR TITLE
name-restriction

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/proj/ProjSavingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/util/proj/ProjSavingDialog.java
@@ -60,8 +60,8 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import info.clearthought.layout.TableLayout;
-import org.apache.commons.collections.CollectionUtils;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.openmicroscopy.shoola.agents.imviewer.IconManager;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.util.ComboBoxToolTipRenderer;
@@ -70,6 +70,7 @@ import org.openmicroscopy.shoola.agents.util.ViewerSorter;
 import org.openmicroscopy.shoola.agents.util.browser.DataNode;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ProjectionParam;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.TitlePanel;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.openmicroscopy.shoola.util.ui.filechooser.CreateFolderDialog;
@@ -542,13 +543,7 @@ public class ProjSavingDialog
 	/** Sets the enabled flag of the {@link #projectButton}. */
     private void enableSave()
     {
-    	String name = nameField.getText();
-    	if (name == null) projectButton.setEnabled(false);
-    	else {
-    		name = name.trim();
-        	int l = name.length();
-        	projectButton.setEnabled(l > 0 && l < 256);
-    	}
+        projectButton.setEnabled(CommonsLangUtils.isNotBlank(nameField.getText()));
     }
     
     /** Projects the image. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelEditUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/ChannelEditUI.java
@@ -149,7 +149,7 @@ class ChannelEditUI
         Iterator k = channels.keySet().iterator();
         while (k.hasNext()) {
             channel = (ChannelData) k.next();
-            field = new TextFieldLimit(EditorUtil.MAX_CHAR-1);
+            field = new JTextField();
             field.setBackground(UIUtilities.BACKGROUND_COLOR);
             field.setText(channel.getChannelLabeling());
             field.getDocument().addDocumentListener(this);


### PR DESCRIPTION
# What this PR does

No longer check if the length is greater than 255.

Add support for name with length > 255 see https://github.com/openmicroscopy/openmicroscopy/pull/4882

Remove the 2 remaining constraints in the client
# Testing this PR

test 1

Projection new image image:
- Open an image with multi z in viewer
- Go to the projection preview
- project the image
- Check that the save button is enabled even for name with length > 255
- Save the image. 

test 2:

Channel name:
- select an image
- edit the channel name. Enter a name length > 255
- save
# Related reading

Link to cards, tickets, other PRs:

See https://github.com/openmicroscopy/openmicroscopy/pull/4882 for DB changes

--depends-on 4882

cc @mtbc @dominikl @pwalczysko  

It is probably good to keep an eye for other "name"
