### PR TITLE
use only pytest < 3

### DIFF
--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -33,4 +33,4 @@ setup(name="OmeroFS",
       package_dir={"": "target"},
       packages=[''],
       cmdclass={'test': PyTest},
-      tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'])
+      tests_require=['pytest<3'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -67,4 +67,4 @@ setup(
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
     cmdclass={'test': PyTest},
-    tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'])
+    tests_require=['pytest<3'])

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -272,7 +272,7 @@ class TestDownload(CLITest):
         self.do_restrictions(fixture, tmpdir, group)
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
-                             ids=POLICY_FIXTURES)
+                             ids=[str(x) for x in POLICY_FIXTURES])
     def testPolicyGroupRestriction(self, tmpdir, fixture):
         parts = fixture.cfg.split(",")
         config = [NV("omero.policy.binary_access", x) for x in parts]

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -262,7 +262,7 @@ class TestDownload(CLITest):
         assert cfg in [x.cfg for x in self.POLICY_FIXTURES]
 
     @pytest.mark.parametrize('fixture', POLICY_FIXTURES,
-                             ids=POLICY_FIXTURES)
+                             ids=[str(x) for x in POLICY_FIXTURES])
     def testPolicyGlobalRestriction(self, tmpdir, fixture):
         # Skip f this isn't a check for this particular
         # config, then skip.

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -51,5 +51,5 @@ OmeroWeb is the container of the web clients for OMERO."
       packages=[''],
       test_suite='test.suite',
       cmdclass={'test': PyTest},
-      tests_require=['pytest != 3.0.0, != 3.0.1, != 3.0.2'],
+      tests_require=['pytest<3'],
       )


### PR DESCRIPTION
# What this PR does

try to fix pytest version
# Testing this PR

go to:
- https://ci.openmicroscopy.org/job/OMERO-DEV-breaking-integration-Python27
- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27

and check which version is used when tests are run, it is listed in:

```
05:24:34 ============================= test session starts ==============================
05:24:34 platform linux2 -- Python 2.7.5, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 ...
```
# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/4826

LIMITATIONS:

for some reason merge build has pytest-2.8.1 installed, that is not very clear to me where  is that exactly. This PR run on merge didn't change anything, see https://github.com/openmicroscopy/openmicroscopy/pull/4886#issuecomment-252831924
