### PR TITLE
Arrow shapes (Insight)

### DIFF
--- a/components/blitz/src/omero/gateway/model/ShapeSettingsData.java
+++ b/components/blitz/src/omero/gateway/model/ShapeSettingsData.java
@@ -30,6 +30,7 @@ import omero.RString;
 import omero.rtypes;
 import omero.model.Length;
 import omero.model.LengthI;
+import omero.model.Line;
 import omero.model.Shape;
 import omero.model.enums.UnitsLength;
 
@@ -455,8 +456,13 @@ public class ShapeSettingsData
      *
      * @return See above.
      */
-    public String getMarkerStart()
-    {
+    public String getMarkerStart() {
+        Shape shape = (Shape) asIObject();
+        if (shape instanceof Line) {
+            Line l = (Line) shape;
+            return l.getMarkerStart() != null ? l.getMarkerStart().getValue()
+                    : "";
+        }
         return "";
     }
 
@@ -467,27 +473,41 @@ public class ShapeSettingsData
      */
     public String getMarkerEnd()
     {
+        Shape shape = (Shape) asIObject();
+        if (shape instanceof Line) {
+            Line l = (Line) shape;
+            return l.getMarkerEnd() != null ? l.getMarkerEnd().getValue()
+                    : "";
+        }
         return "";
     }
 
     /**
-     * Returns the marker start.
+     * Sets the marker start.
      *
      * @param start The value to set.
      */
-    public String setMarkerStart(String start)
+    public void setMarkerStart(String start)
     {
-        return "";
+        Shape shape = (Shape) asIObject();
+        if (shape instanceof Line) {
+            Line l = (Line) shape;
+            l.setMarkerStart(rtypes.rstring(start));
+        }
     }
 
     /**
-     * Returns the marker end.
+     * Sets the marker end.
      *
      * @param end The value to set.
      */
-    public String setMarkerEnd(String end)
+    public void setMarkerEnd(String end)
     {
-        return "";
+        Shape shape = (Shape) asIObject();
+        if (shape instanceof Line) {
+            Line l = (Line) shape;
+            l.setMarkerEnd(rtypes.rstring(end));
+        }
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnnotationDescription.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/AnnotationDescription.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.util.AnnotationDescription 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -98,6 +98,8 @@ public class AnnotationDescription
 														"Show Measurement");
 		annotationDescription.put(MeasurementAttributes.SCALE_PROPORTIONALLY,
 				"Scale Proportionally");
+		annotationDescription.put(MeasurementAttributes.START_DECORATION, "Start decoration");
+        annotationDescription.put(MeasurementAttributes.END_DECORATION, "End decoration");
 		annotationDescription.put(AnnotationKeys.TAG, "Tag");
 		annotationDescription.put(AnnotationKeys.FOLDERS, "Folders");
 		}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -28,9 +28,9 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKey;
 import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
-import org.openmicroscopy.shoola.agents.util.EditorUtil;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKey;
@@ -124,13 +124,14 @@ public class FigureTableModel
 				if (key.equals(fieldName.getKey()))
 				{
 				    Object value = figure.getAttribute(key);
-					if (MeasurementAttributes.TEXT.equals(key) ||
-							MeasurementAttributes.WIDTH.equals(key) ||
-							MeasurementAttributes.HEIGHT.equals(key)) {
-						if (figure.isReadOnly())
-							fieldName.setEditable(false);
-						else fieldName.setEditable(figure.canEdit());
-					} else if (AnnotationKeys.TAG.equals(key)) {
+                    if (MeasurementAttributes.TEXT.equals(key)
+                            || MeasurementAttributes.WIDTH.equals(key)
+                            || MeasurementAttributes.HEIGHT.equals(key)) {
+                        if (figure.isReadOnly())
+                            fieldName.setEditable(false);
+                        else
+                            fieldName.setEditable(figure.canEdit());
+                    } else if (AnnotationKeys.TAG.equals(key)) {
 	                    
 	                    StructuredDataResults sd = (StructuredDataResults) figure.getAttribute(key);
 	                    if (sd != null) {
@@ -164,7 +165,18 @@ public class FigureTableModel
 					                value += "; ";
 					        }
 					    }
-					}
+                    } else if (MeasurementAttributes.START_DECORATION
+                            .equals(key)) {
+                        if (value != null) {
+                            if (value instanceof ArrowTip)
+                                value = "Arrow";
+                        }
+                    } else if (MeasurementAttributes.END_DECORATION.equals(key)) {
+                        if (value != null) {
+                            if (value instanceof ArrowTip)
+                                value = "Arrow";
+                        }
+                    }
 					keys.add(key);
 					values.add(value);
 					found = true;
@@ -219,7 +231,7 @@ public class FigureTableModel
 	public int getRowCount()
 	{
 		return keys.size();
-	}
+	} 
 	
 	/**
 	 * Returns the value of the specified cell.
@@ -281,6 +293,18 @@ public class FigureTableModel
 				}
 			}
 		}
+		else if (MeasurementAttributes.START_DECORATION.equals(key)) {
+		    if("Arrow".equals(value)) 
+		        figure.setAttribute(key, new ArrowTip());
+		    else
+                figure.setAttribute(key, null);
+		}
+		else if (MeasurementAttributes.END_DECORATION.equals(key)) {
+            if("Arrow".equals(value)) 
+                figure.setAttribute(key, new ArrowTip());
+            else
+                figure.setAttribute(key, null);
+        }
 		else  
 			figure.setAttribute(key, value);
 		values.set(row, value);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -28,10 +28,11 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKey;
+import org.jhotdraw.draw.LineDecoration;
 import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.env.data.util.StructuredDataResults;
+import org.openmicroscopy.shoola.util.roi.figures.Cap;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKey;
 import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
@@ -167,14 +168,16 @@ public class FigureTableModel
 					    }
                     } else if (MeasurementAttributes.START_DECORATION
                             .equals(key)) {
-                        if (value != null) {
-                            if (value instanceof ArrowTip)
-                                value = "Arrow";
+                        if (value instanceof LineDecoration) {
+                            Cap c = Cap.findByPrototype((LineDecoration) value);
+                            if (c != null)
+                                value = c.getValue();
                         }
                     } else if (MeasurementAttributes.END_DECORATION.equals(key)) {
-                        if (value != null) {
-                            if (value instanceof ArrowTip)
-                                value = "Arrow";
+                        if (value instanceof LineDecoration) {
+                            Cap c = Cap.findByPrototype((LineDecoration) value);
+                            if (c != null)
+                                value = c.getValue();
                         }
                     }
 					keys.add(key);
@@ -231,7 +234,7 @@ public class FigureTableModel
 	public int getRowCount()
 	{
 		return keys.size();
-	} 
+	}
 	
 	/**
 	 * Returns the value of the specified cell.
@@ -294,16 +297,20 @@ public class FigureTableModel
 			}
 		}
 		else if (MeasurementAttributes.START_DECORATION.equals(key)) {
-		    if("Arrow".equals(value)) 
-		        figure.setAttribute(key, new ArrowTip());
-		    else
-                figure.setAttribute(key, null);
+            LineDecoration dec = null;
+            Cap c = Cap.findByValue(value.toString());
+            if (c != null) {
+                dec = c.newLineDecorationInstance();
+            }
+            figure.setAttribute(key, dec);
 		}
 		else if (MeasurementAttributes.END_DECORATION.equals(key)) {
-            if("Arrow".equals(value)) 
-                figure.setAttribute(key, new ArrowTip());
-            else
-                figure.setAttribute(key, null);
+		    LineDecoration dec = null;
+            Cap c = Cap.findByValue(value.toString());
+            if (c != null) {
+                dec = c.newLineDecorationInstance();
+            }
+            figure.setAttribute(key, dec);
         }
 		else  
 			figure.setAttribute(key, value);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/InspectorCellRenderer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/ui/InspectorCellRenderer.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.util.InspectorCellRenderer 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -26,6 +26,7 @@ package org.openmicroscopy.shoola.agents.measurement.util.ui;
 import java.awt.Color;
 import java.awt.Component;
 import java.util.List;
+
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -129,13 +130,14 @@ public class InspectorCellRenderer
 				for (int i = 0 ; i < valueRange.size(); i++)
 				{
 					comboBox.addItem(valueRange.get(i));
-					if (value.equals(valueRange.get(i)))
+					if (valueRange.get(i).equals(value))
 						index = i;
 				}
 				comboBox.setSelectedIndex(index);
 			}
 			thisComponent = comboBox;
 		}
+		
 		return thisComponent;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.measurement.view.ObjectInspector 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -133,6 +133,12 @@ class ObjectInspector
             attributeFields.add(new AttributeField(MeasurementAttributes.HEIGHT,
                     AnnotationDescription.annotationDescription
                             .get(AnnotationKeys.HEIGHT), true));
+            attributeFields.add(new AttributeField(MeasurementAttributes.START_DECORATION,
+                    AnnotationDescription.annotationDescription
+                    .get(MeasurementAttributes.START_DECORATION), true));
+            attributeFields.add(new AttributeField(MeasurementAttributes.END_DECORATION,
+                    AnnotationDescription.annotationDescription
+                    .get(MeasurementAttributes.END_DECORATION), true));
             attributeFields.add(new AttributeField(MeasurementAttributes.SHOWTEXT,
                     "Show Comment", false));
             attributeFields.add(new AttributeField(MeasurementAttributes.SHOWMEASUREMENT,
@@ -243,7 +249,12 @@ class ObjectInspector
                     }
                 } catch (Exception e) {
                 }
-            }
+            } else if (attr.equals(MeasurementAttributes.START_DECORATION)) {
+                figure.setAttribute(MeasurementAttributes.START_DECORATION, text);
+            } 
+            else if (attr.equals(MeasurementAttributes.END_DECORATION)) {
+                figure.setAttribute(MeasurementAttributes.END_DECORATION, text);
+            } 
             model.getDrawingView().repaint();
         }
         

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -51,6 +51,7 @@ import org.openmicroscopy.shoola.agents.measurement.util.model.AttributeField;
 import org.openmicroscopy.shoola.agents.measurement.util.model.FigureTableModel;
 import org.openmicroscopy.shoola.agents.measurement.util.model.ValueType;
 import org.openmicroscopy.shoola.agents.measurement.util.ui.FigureTable;
+import org.openmicroscopy.shoola.util.roi.figures.Cap;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureEllipseFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureLineConnectionFigure;
@@ -111,8 +112,9 @@ class ObjectInspector
     /** Possible values for start/end line decorations */
     private static final List<String> LINE_DECORATION_VALUES = new ArrayList<String>();
     static {
-        LINE_DECORATION_VALUES.add("None");
-        LINE_DECORATION_VALUES.add("Arrow");
+        for(Cap c : Cap.values()) {
+            LINE_DECORATION_VALUES.add(c.getValue());
+        }
     }
 	
 	/** Statically initialize the AttributeFields to be shown;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ObjectInspector.java
@@ -49,6 +49,7 @@ import org.openmicroscopy.shoola.agents.measurement.MeasurementAgent;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AnnotationDescription;
 import org.openmicroscopy.shoola.agents.measurement.util.model.AttributeField;
 import org.openmicroscopy.shoola.agents.measurement.util.model.FigureTableModel;
+import org.openmicroscopy.shoola.agents.measurement.util.model.ValueType;
 import org.openmicroscopy.shoola.agents.measurement.util.ui.FigureTable;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureEllipseFigure;
@@ -107,6 +108,13 @@ class ObjectInspector
 		COLUMN_NAMES.add("Value");
 	}
 	
+    /** Possible values for start/end line decorations */
+    private static final List<String> LINE_DECORATION_VALUES = new ArrayList<String>();
+    static {
+        LINE_DECORATION_VALUES.add("None");
+        LINE_DECORATION_VALUES.add("Arrow");
+    }
+	
 	/** Statically initialize the AttributeFields to be shown;
 	 *  The order in the list reflects the order they are shown in the table
          */
@@ -133,12 +141,16 @@ class ObjectInspector
             attributeFields.add(new AttributeField(MeasurementAttributes.HEIGHT,
                     AnnotationDescription.annotationDescription
                             .get(AnnotationKeys.HEIGHT), true));
-            attributeFields.add(new AttributeField(MeasurementAttributes.START_DECORATION,
+            attributeFields.add(new AttributeField(
+                    MeasurementAttributes.START_DECORATION,
                     AnnotationDescription.annotationDescription
-                    .get(MeasurementAttributes.START_DECORATION), true));
-            attributeFields.add(new AttributeField(MeasurementAttributes.END_DECORATION,
+                            .get(MeasurementAttributes.START_DECORATION), true,
+                    LINE_DECORATION_VALUES, ValueType.ENUM));
+            attributeFields.add(new AttributeField(
+                    MeasurementAttributes.END_DECORATION,
                     AnnotationDescription.annotationDescription
-                    .get(MeasurementAttributes.END_DECORATION), true));
+                            .get(MeasurementAttributes.END_DECORATION), true,
+                    LINE_DECORATION_VALUES, ValueType.ENUM));
             attributeFields.add(new AttributeField(MeasurementAttributes.SHOWTEXT,
                     "Show Comment", false));
             attributeFields.add(new AttributeField(MeasurementAttributes.SHOWMEASUREMENT,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/view/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -48,10 +48,10 @@ import javax.swing.event.ChangeListener;
 
 import org.jhotdraw.draw.AttributeKey;
 import org.jhotdraw.draw.DrawingEditor;
-
 import org.openmicroscopy.shoola.agents.measurement.IconManager;
 import org.openmicroscopy.shoola.agents.measurement.actions.DrawingAction;
 import org.openmicroscopy.shoola.agents.util.ui.PermissionMenu;
+import org.openmicroscopy.shoola.util.roi.figures.MeasureArrowFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureEllipseFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureLineConnectionFigure;
@@ -67,7 +67,6 @@ import org.openmicroscopy.shoola.util.ui.drawingtools.attributes.FigurePropertie
 import org.openmicroscopy.shoola.util.ui.drawingtools.creationtools.DrawingBezierTool;
 import org.openmicroscopy.shoola.util.ui.drawingtools.creationtools.DrawingConnectionTool;
 import org.openmicroscopy.shoola.util.ui.drawingtools.creationtools.DrawingObjectCreationTool;
-import org.openmicroscopy.shoola.util.ui.drawingtools.creationtools.DrawingPointCreationTool;
 import org.openmicroscopy.shoola.util.ui.drawingtools.creationtools.DrawingToolBarButtonFactory;
 import org.openmicroscopy.shoola.util.ui.drawingtools.figures.FigureUtil;
 
@@ -163,6 +162,9 @@ class ToolBar
     /** The line creation tool. */
     private DrawingObjectCreationTool	lineTool;
     
+    /** The arrow creation tool. */
+    private DrawingObjectCreationTool   arrowTool;
+    
     /** The text creation tool. */
     private DrawingObjectCreationTool	textTool;
 
@@ -253,6 +255,8 @@ class ToolBar
 				new MeasureTextFigure(false, true), p);
 		lineTool = new DrawingObjectCreationTool(
 				new MeasureLineFigure(false, true, true, true, true), p);
+		arrowTool = new DrawingObjectCreationTool(
+                new MeasureArrowFigure(false, true, true, true, true), p);
 		Map<AttributeKey, Object> m = lineConnectionProperties.getProperties();
 		m.put(MeasurementAttributes.FONT_SIZE, value);
 		connectionTool = new DrawingConnectionTool(
@@ -306,6 +310,12 @@ class ToolBar
 		if (component instanceof JToggleButton)
 			setUpToggleButton((JToggleButton) component);
 		
+		DrawingToolBarButtonFactory.addToolTo(toolBar, editor, arrowTool, 
+                CREATE_KEY+FigureUtil.ARROW_TYPE);
+        component = toolBar.getComponent(toolBar.getComponentCount()-1);
+        if (component instanceof JToggleButton)
+            setUpToggleButton((JToggleButton) component);
+    
 		if (addPolyline)
 		{
 			DrawingToolBarButtonFactory.addToolTo(toolBar, editor, polylineTool, 
@@ -463,6 +473,7 @@ class ToolBar
 		rectTool.setResetToSelect(option);
 		textTool.setResetToSelect(option); 
 		lineTool.setResetToSelect(option); 
+		arrowTool.setResetToSelect(option); 
 		// TODO : connectionTool.setResetToSelect(option);
 		pointTool.setResetToSelect(option);
 	    if (addPolygon)
@@ -533,6 +544,7 @@ class ToolBar
         ellipseTool.setAttributes(p);
         pointTool.setAttributes(p);
         lineTool.setAttributes(p);
+        arrowTool.setAttributes(p);
         textTool.setAttributes(p);
         polygonTool.setAttributes(p);
         polylineTool.setAttributes(p);

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/ROIComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/ROIComponent.java
@@ -133,6 +133,8 @@ public class ROIComponent
 				ShapeSettingsData.DEFAULT_FILL_COLOUR);
 		AttributeKeys.STROKE_COLOR.set(fig, 
 				ShapeSettingsData.DEFAULT_STROKE_COLOUR);
+        MeasurementAttributes.START_DECORATION.set(fig, null);
+        MeasurementAttributes.END_DECORATION.set(fig, null);
     }
         
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/ROIComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/ROIComponent.java
@@ -30,10 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKeys;
 import org.openmicroscopy.shoola.util.roi.exception.NoSuchROIException;
 import org.openmicroscopy.shoola.util.roi.exception.ParsingException;
 import org.openmicroscopy.shoola.util.roi.exception.ROICreationException;
+import org.openmicroscopy.shoola.util.roi.figures.MeasureArrowFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.io.ServerROIStrategy;
@@ -134,7 +136,8 @@ public class ROIComponent
 		AttributeKeys.STROKE_COLOR.set(fig, 
 				ShapeSettingsData.DEFAULT_STROKE_COLOUR);
         MeasurementAttributes.START_DECORATION.set(fig, null);
-        MeasurementAttributes.END_DECORATION.set(fig, null);
+        MeasurementAttributes.END_DECORATION.set(fig,
+                (fig instanceof MeasureArrowFigure) ? new ArrowTip() : null);
     }
         
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/Cap.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/Cap.java
@@ -1,0 +1,139 @@
+/*
+ * org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.util.roi.figures;
+
+import org.jhotdraw.draw.ArrowTip;
+import org.jhotdraw.draw.LineDecoration;
+
+/**
+ * Maps OMERO shape attributes for start/end markers to the corresponding
+ * JHotDraw {@link LineDecoration}s.
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public enum Cap {
+
+    /** No decoration */
+    NONE("None", null),
+
+    /** Arrow */
+    ARROW("Arrow", ArrowTip.class);
+
+    private String value = null;
+    private Class<? extends LineDecoration> type = null;
+
+    private Cap(String value, Class<? extends LineDecoration> type) {
+        this.value = value;
+        this.type = type;
+    }
+
+    /**
+     * Get the OMERO shape attribute value
+     * 
+     * @return See above.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Get the JHotDraw {@link LineDecoration} class
+     * 
+     * @return See above.
+     */
+    public Class<? extends LineDecoration> getType() {
+        return type;
+    }
+
+    /**
+     * Creates a new JHotDraw {@link LineDecoration} instance
+     * 
+     * @return See above.
+     */
+    public <T extends LineDecoration> T newLineDecorationInstance() {
+        if (type == null)
+            return null;
+
+        T obj = null;
+        try {
+            obj = (T) type.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not instantiate " + type, e);
+        }
+        return obj;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    /**
+     * Find the specific Cap with the given value
+     * 
+     * @param value
+     *            The value to look for
+     * @return See above.
+     */
+    public static Cap findByValue(String value) {
+        for (Cap c : values()) {
+            if (c.getValue().equalsIgnoreCase(value))
+                return c;
+        }
+        return null;
+    }
+
+    /**
+     * Find the specific Cap with the given {@link LineDecoration} class
+     * 
+     * @param type
+     *            The class to look for
+     * @return See above.
+     */
+    public static Cap findByType(Class<? extends LineDecoration> type) {
+        for (Cap c : values()) {
+            if (c.getType() != null && c.getType().equals(type))
+                return c;
+        }
+        return null;
+    }
+
+    /**
+     * Find the specific Cap with the given {@link LineDecoration} instance
+     * 
+     * @param type
+     *            The {@link LineDecoration} instance to look for
+     * @return See above.
+     */
+    public static <T extends LineDecoration> Cap findByPrototype(T type) {
+        if (type != null) {
+            for (Cap c : values()) {
+                if (c.getType() != null
+                        && c.getType().isAssignableFrom(type.getClass()))
+                    return c;
+            }
+        }
+        return null;
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
@@ -1,24 +1,20 @@
 /*
- * org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure 
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
  *
- *------------------------------------------------------------------------------
- *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *  
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *------------------------------------------------------------------------------
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 package org.openmicroscopy.shoola.util.roi.figures;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
@@ -38,7 +38,7 @@ public class MeasureArrowFigure extends MeasureLineFigure {
      * See {@link MeasureLineFigure}
      */
     public MeasureArrowFigure() {
-        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+        setAttribute(MeasurementAttributes.END_DECORATION, Cap.ARROW.newLineDecorationInstance());
     }
 
     /**
@@ -48,7 +48,7 @@ public class MeasureArrowFigure extends MeasureLineFigure {
     public MeasureArrowFigure(boolean readOnly, boolean clientObject,
             boolean editable, boolean deletable, boolean annotatable) {
         super(readOnly, clientObject, editable, deletable, annotatable);
-        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+        setAttribute(MeasurementAttributes.END_DECORATION, Cap.ARROW.newLineDecorationInstance());
     }
 
     /**
@@ -59,7 +59,7 @@ public class MeasureArrowFigure extends MeasureLineFigure {
             boolean clientObject, boolean editable, boolean deletable,
             boolean annotatable) {
         super(text, readOnly, clientObject, editable, deletable, annotatable);
-        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+        setAttribute(MeasurementAttributes.END_DECORATION, Cap.ARROW.newLineDecorationInstance());
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureArrowFigure.java
@@ -1,0 +1,65 @@
+/*
+ * org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure 
+ *
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.util.roi.figures;
+
+import org.jhotdraw.draw.ArrowTip;
+import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
+
+/**
+ * {@link MeasureLineFigure} with an {@link ArrowTip} as default line end
+ * decoration
+ *
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class MeasureArrowFigure extends MeasureLineFigure {
+
+    /**
+     * See {@link MeasureLineFigure}
+     */
+    public MeasureArrowFigure() {
+        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+    }
+
+    /**
+     * See
+     * {@link MeasureLineFigure#MeasureLineFigure(boolean, boolean, boolean, boolean, boolean)}
+     */
+    public MeasureArrowFigure(boolean readOnly, boolean clientObject,
+            boolean editable, boolean deletable, boolean annotatable) {
+        super(readOnly, clientObject, editable, deletable, annotatable);
+        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+    }
+
+    /**
+     * See
+     * {@link MeasureLineFigure#MeasureLineFigure(String, boolean, boolean, boolean, boolean, boolean)}
+     */
+    public MeasureArrowFigure(String text, boolean readOnly,
+            boolean clientObject, boolean editable, boolean deletable,
+            boolean annotatable) {
+        super(text, readOnly, clientObject, editable, deletable, annotatable);
+        setAttribute(MeasurementAttributes.END_DECORATION, new ArrowTip());
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -122,6 +122,9 @@ public class MeasureLineFigure
 	/** Flag indicating if the user can move or resize the shape.*/
 	private boolean interactable;
 	
+	/** Flat indicating if the user can split the line */
+	private boolean allowSplitSegment = false;
+	
 	/**
 	 * Returns the point i in pixels or microns depending on the units used.
 	 * 
@@ -828,7 +831,8 @@ public class MeasureLineFigure
 	 */
 	public int splitSegment(Point2D.Double split) 
 	{
-		if (isReadOnly() || !interactable) return -1;
+		if (isReadOnly() || !interactable || !allowSplitSegment)
+		    return -1;
 		this.setObjectDirty(true);
 		return super.splitSegment(split);
 	}
@@ -840,7 +844,8 @@ public class MeasureLineFigure
 	 */
 	public int splitSegment(Point2D.Double split, float tolerance) 
 	{
-		if (isReadOnly() || !interactable) return -1;
+		if (isReadOnly() || !interactable || !allowSplitSegment)
+		    return -1;
 		this.setObjectDirty(true);
 		return super.splitSegment(split, tolerance);
 	}
@@ -852,7 +857,8 @@ public class MeasureLineFigure
 	 */
 	public int joinSegments(Point2D.Double join, float tolerance) 
 	{
-		if (isReadOnly() || !interactable) return -1;
+		if (isReadOnly() || !interactable || !allowSplitSegment)
+		    return -1;
 		this.setObjectDirty(true);
 		return super.joinSegments(join, tolerance);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -831,7 +831,7 @@ public class MeasureLineFigure
 	 */
 	public int splitSegment(Point2D.Double split) 
 	{
-		if (isReadOnly() || !interactable || !allowSplitSegment)
+	    if (!canBeSplit())
 		    return -1;
 		this.setObjectDirty(true);
 		return super.splitSegment(split);
@@ -844,7 +844,7 @@ public class MeasureLineFigure
 	 */
 	public int splitSegment(Point2D.Double split, float tolerance) 
 	{
-		if (isReadOnly() || !interactable || !allowSplitSegment)
+	    if (!canBeSplit())
 		    return -1;
 		this.setObjectDirty(true);
 		return super.splitSegment(split, tolerance);
@@ -857,11 +857,20 @@ public class MeasureLineFigure
 	 */
 	public int joinSegments(Point2D.Double join, float tolerance) 
 	{
-		if (isReadOnly() || !interactable || !allowSplitSegment)
+		if (!canBeSplit())
 		    return -1;
 		this.setObjectDirty(true);
 		return super.joinSegments(join, tolerance);
 	}
+	
+    /**
+     * Checks if the line can be split into segments (polyline)
+     * 
+     * @return See above.
+     */
+    private boolean canBeSplit() {
+        return !isReadOnly() && interactable && allowSplitSegment;
+    }
 	
 	/**
 	 * Overridden to mark the object has dirty.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -123,7 +123,7 @@ public class MeasureLineFigure
 	private boolean interactable;
 	
 	/** Flat indicating if the user can split the line */
-	private boolean allowSplitSegment = false;
+	private boolean allowSplitSegment = true;
 	
 	/**
 	 * Returns the point i in pixels or microns depending on the units used.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/figures/MeasureLineFigure.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -174,6 +174,8 @@ public class MeasureLineFigure
 		setAttribute(MeasurementAttributes.FONT_FACE, DEFAULT_FONT);
 		setAttribute(MeasurementAttributes.FONT_SIZE, new Double(FONT_SIZE));
         setAttribute(MeasurementAttributes.SCALE_PROPORTIONALLY, Boolean.FALSE);
+        setAttribute(MeasurementAttributes.START_DECORATION, null);
+        setAttribute(MeasurementAttributes.END_DECORATION, null);
 		boundsArray = new ArrayList<Rectangle2D>();
 		lengthArray = new ArrayList<Length>();
 		angleArray = new ArrayList<Double>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -43,8 +43,8 @@ import static org.jhotdraw.draw.AttributeKeys.STROKE_COLOR;
 import static org.jhotdraw.draw.AttributeKeys.TEXT_COLOR;
 import static org.jhotdraw.draw.AttributeKeys.STROKE_WIDTH;
 
-import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKey;
+import org.jhotdraw.draw.LineDecoration;
 import org.jhotdraw.geom.BezierPath.Node;
 
 import omero.model.Length;
@@ -54,6 +54,7 @@ import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.roi.ROIComponent;
 import org.openmicroscopy.shoola.util.roi.exception.NoSuchROIException;
 import org.openmicroscopy.shoola.util.roi.exception.ROICreationException;
+import org.openmicroscopy.shoola.util.roi.figures.Cap;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureEllipseFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureLineFigure;
@@ -530,14 +531,20 @@ class InputServerStrategy
 		TEXT_COLOR.set(figure, data.getStroke());
 		
         if (CommonsLangUtils.isNotBlank(data.getMarkerStart())) {
-            if (data.getMarkerStart().equalsIgnoreCase("Arrow"))
-                MeasurementAttributes.START_DECORATION.set(figure,
-                        new ArrowTip());
+            LineDecoration dec = null;
+            Cap c = Cap.findByValue(data.getMarkerStart());
+            if (c != null) {
+                dec = c.newLineDecorationInstance();
+            }
+            MeasurementAttributes.START_DECORATION.set(figure, dec);
         }
         if (CommonsLangUtils.isNotBlank(data.getMarkerEnd())) {
-            if (data.getMarkerEnd().equalsIgnoreCase("Arrow"))
-                MeasurementAttributes.END_DECORATION
-                        .set(figure, new ArrowTip());
+            LineDecoration dec = null;
+            Cap c = Cap.findByValue(data.getMarkerEnd());
+            if (c != null) {
+                dec = c.newLineDecorationInstance();
+            }
+            MeasurementAttributes.END_DECORATION.set(figure, dec);
         }
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/InputServerStrategy.java
@@ -43,12 +43,14 @@ import static org.jhotdraw.draw.AttributeKeys.STROKE_COLOR;
 import static org.jhotdraw.draw.AttributeKeys.TEXT_COLOR;
 import static org.jhotdraw.draw.AttributeKeys.STROKE_WIDTH;
 
+import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKey;
 import org.jhotdraw.geom.BezierPath.Node;
 
 import omero.model.Length;
 import omero.model.enums.UnitsLength;
 
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.roi.ROIComponent;
 import org.openmicroscopy.shoola.util.roi.exception.NoSuchROIException;
 import org.openmicroscopy.shoola.util.roi.exception.ROICreationException;
@@ -526,6 +528,17 @@ class InputServerStrategy
 		FONT_ITALIC.set(figure, data.isFontItalic());
 		FONT_BOLD.set(figure, data.isFontBold());
 		TEXT_COLOR.set(figure, data.getStroke());
+		
+        if (CommonsLangUtils.isNotBlank(data.getMarkerStart())) {
+            if (data.getMarkerStart().equalsIgnoreCase("Arrow"))
+                MeasurementAttributes.START_DECORATION.set(figure,
+                        new ArrowTip());
+        }
+        if (CommonsLangUtils.isNotBlank(data.getMarkerEnd())) {
+            if (data.getMarkerEnd().equalsIgnoreCase("Arrow"))
+                MeasurementAttributes.END_DECORATION
+                        .set(figure, new ArrowTip());
+        }
 	}
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/OutputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/OutputServerStrategy.java
@@ -30,12 +30,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 
-import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKeys;
 import org.jhotdraw.draw.LineDecoration;
 import org.jhotdraw.geom.BezierPath;
 import org.openmicroscopy.shoola.util.roi.ROIComponent;
 import org.openmicroscopy.shoola.util.roi.exception.ParsingException;
+import org.openmicroscopy.shoola.util.roi.figures.Cap;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureEllipseFigure;
 import org.openmicroscopy.shoola.util.roi.figures.MeasurePointFigure;
@@ -543,13 +543,19 @@ public class OutputServerStrategy
 			}
 		} else settings.setFontStyle(ShapeSettingsData.FONT_REGULAR);
 		
-		LineDecoration ld = MeasurementAttributes.START_DECORATION.get(fig);
-        if (ld instanceof ArrowTip)
-            settings.setMarkerStart("Arrow");
-
+        LineDecoration ld = MeasurementAttributes.START_DECORATION.get(fig);
+        Cap c = Cap.findByPrototype(ld);
+        if (c != null)
+            settings.setMarkerStart(c.getValue());
+        else
+            settings.setMarkerStart("");
+        
         ld = MeasurementAttributes.END_DECORATION.get(fig);
-        if (ld instanceof ArrowTip)
-            settings.setMarkerEnd("Arrow");
+        c = Cap.findByPrototype(ld);
+        if (c != null)
+            settings.setMarkerEnd(c.getValue());
+        else
+            settings.setMarkerEnd("");
 	}
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/OutputServerStrategy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/io/OutputServerStrategy.java
@@ -30,9 +30,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 
+import org.jhotdraw.draw.ArrowTip;
 import org.jhotdraw.draw.AttributeKeys;
+import org.jhotdraw.draw.LineDecoration;
 import org.jhotdraw.geom.BezierPath;
-
 import org.openmicroscopy.shoola.util.roi.ROIComponent;
 import org.openmicroscopy.shoola.util.roi.exception.ParsingException;
 import org.openmicroscopy.shoola.util.roi.figures.MeasureBezierFigure;
@@ -45,10 +46,10 @@ import org.openmicroscopy.shoola.util.roi.figures.MeasureTextFigure;
 import org.openmicroscopy.shoola.util.roi.figures.ROIFigure;
 import org.openmicroscopy.shoola.util.roi.model.ROI;
 import org.openmicroscopy.shoola.util.roi.model.ROIShape;
-import org.openmicroscopy.shoola.util.roi.model.annotation.AnnotationKeys;
 import org.openmicroscopy.shoola.util.roi.model.annotation.MeasurementAttributes;
 import org.openmicroscopy.shoola.util.roi.model.util.Coord3D;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
 import omero.gateway.model.EllipseData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.LineData;
@@ -541,6 +542,14 @@ public class OutputServerStrategy
 				} else settings.setFontStyle(ShapeSettingsData.FONT_REGULAR);
 			}
 		} else settings.setFontStyle(ShapeSettingsData.FONT_REGULAR);
+		
+		LineDecoration ld = MeasurementAttributes.START_DECORATION.get(fig);
+        if (ld instanceof ArrowTip)
+            settings.setMarkerStart("Arrow");
+
+        ld = MeasurementAttributes.END_DECORATION.get(fig);
+        if (ld instanceof ArrowTip)
+            settings.setMarkerEnd("Arrow");
 	}
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/FigureUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/drawingtools/figures/FigureUtil.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.drawingtools.figures.FigureUtil 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -68,6 +68,9 @@ public class FigureUtil
 	
 	/** Identifies the <code>Line</code> type. */
 	public static final String LINE_TYPE = "Line";
+	
+	/** Identifies the <code>Line</code> type. */
+    public static final String ARROW_TYPE = "Arrow";
 	
 	/** Identifies the <code>LineConnection</code> type. */
 	public static final String LINE_CONNECTION_TYPE = "LineConnection";


### PR DESCRIPTION
# What this PR does

Corresponding Insight PR to #4690 .
Adds the possibility to specify Arrows as start and/or end of a Line ROI.
# Testing this PR

Draw some lines, add Arrows as MarkerStart/MarkerEnd, compare to the corresponding Web PR.
# Related reading

![screen shot 2016-10-12 at 10 25 06](https://cloud.githubusercontent.com/assets/6575139/19304904/688fa65a-9066-11e6-8977-3312137e3db1.png)
