### PR TITLE
Update bioformats version to 5.2.2

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -904,7 +904,7 @@ versions.asm=1.5.3
 versions.axis=1.4
 versions.backport=3.1
 versions.batik=1.8pre-jdk6
-versions.bioformats=5.1.9
+versions.bioformats=5.2.2
 versions.btm=2.1.3
 versions.cglib=2.2
 versions.checkstyle=4.3
@@ -976,6 +976,3 @@ versions.bufr=1.1.00
 ###
 ### Appended Values
 ###
-
-# Override BIo-Formats version for the model work
-versions.bioformats=5.2.0-SNAPSHOT


### PR DESCRIPTION
# What this PR does

Updates the version of the bioformats component to 5.2.2.  It was using an old 5.2.0-SNAPSHOT version, which seems odd given that there have been three stable releases since then.
# Testing this PR

Check builds are green
I'm not sure what specifically needs checking here; if there were any fundamental API changes then the build would break.  If there are more subtle behavioural changes, that might need testing but I'm not aware of anything specific

--breaking
