### PR TITLE
Script dialog bugfix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -284,7 +284,7 @@ public class ScriptingDialog
     private void canRunScript()
     {
         Iterator<Entry<String, ScriptComponent>>
-        i = components.entrySet().iterator();
+        i = componentsAll.entrySet().iterator();
         Entry<String, ScriptComponent> entry;
         ScriptComponent c;
         int required = 0;


### PR DESCRIPTION
# What this PR does

Tiny bug fix, which makes sure the "Run script" button is disabled when not all required fields are set.
# Testing this PR

1) Upload a script with a non-optional parameter in a specific grouping , e. g. use example script https://gist.github.com/dominikl/e64b6ef335288177175fc979a988b713 
2) Open the scripting dialog for this script in Insight.
3) Make sure the "Run script" button is disabled when the required field is empty.
# Related reading

[Ticket 13305](https://trac.openmicroscopy.org/ome/ticket/13305)
