### PR TITLE
Use jinja2 when populating metadata maps

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_utils.py
@@ -30,6 +30,13 @@ from collections import deque
 from omero.constants import namespaces
 import re
 
+# TODO: Make jinja2 mandatory?
+try:
+    import jinja2
+    JINJA2_ENABLED = True
+except ImportError:
+    JINJA2_ENABLED = False
+
 
 # Namespace for Bulk-Annotations configuration files
 NSBULKANNOTATIONSCONFIG = namespaces.NSBULKANNOTATIONS + "/config"
@@ -357,6 +364,10 @@ class KeyValueListTransformer(object):
         """
 
         def valuesub(v, cv):
+            if JINJA2_ENABLED:
+                t = jinja2.Template(cv)
+                return t.render(value=v)
+            # Fallback to previous implementation
             return re.sub("\{\{\s*value\s*\}\}", v, cv)
 
         key = cfg["name"]

--- a/components/tools/OmeroPy/src/omero/util/metadata_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_utils.py
@@ -33,9 +33,9 @@ import re
 # TODO: Make jinja2 mandatory?
 try:
     import jinja2
-    JINJA2_ENABLED = True
-except ImportError:
-    JINJA2_ENABLED = False
+    JINJA2_MISSING = None
+except ImportError as j2exc:
+    JINJA2_MISSING = j2exc
 
 
 # Namespace for Bulk-Annotations configuration files
@@ -364,11 +364,10 @@ class KeyValueListTransformer(object):
         """
 
         def valuesub(v, cv):
-            if JINJA2_ENABLED:
-                t = jinja2.Template(cv)
-                return t.render(value=v)
-            # Fallback to previous implementation
-            return re.sub("\{\{\s*value\s*\}\}", v, cv)
+            if JINJA2_MISSING:
+                raise JINJA2_MISSING
+            t = jinja2.Template(cv)
+            return t.render(value=v)
 
         key = cfg["name"]
         if cfg["clientname"]:

--- a/components/tools/OmeroPy/test/unit/test_metadata_utils.py
+++ b/components/tools/OmeroPy/test/unit/test_metadata_utils.py
@@ -25,11 +25,16 @@ Test of metadata_utils classes
 
 
 import pytest
-from pytest import skip
 
 from omero.util.metadata_utils import (
     BulkAnnotationConfiguration, GroupConfig, KeyValueListPassThrough,
     KeyValueGroupList, KeyValueListTransformer)
+
+try:
+    import jinja2  # noqa
+    JINJA2_MISSING = None
+except ImportError as j2exc:
+    JINJA2_MISSING = j2exc
 
 
 def expected(**kwargs):
@@ -287,6 +292,7 @@ class TestKeyValueGroupList(object):
             (expected(name="a1"), 0), (expected(name="a3"), 2)]
 
 
+@pytest.mark.skipif(JINJA2_MISSING, reason="Requires Jinja2")
 class TestKeyValueListTransformer(object):
 
     def test_transform1_default(self):
@@ -316,10 +322,6 @@ class TestKeyValueListTransformer(object):
 
     # TODO: Can we assume jinja2 is always installed on test systems?
     def test_transformj2(self):
-        try:
-            import jinja2  # noqa
-        except ImportError:
-            skip("jinja2 not found")
         cfg = expected(name="a1", clientvalue="http://{{ value | urlencode }}")
         assert KeyValueListTransformer.transform1("a b", cfg) == (
             "a1", ["http://a%20b"])

--- a/components/tools/OmeroPy/test/unit/test_metadata_utils.py
+++ b/components/tools/OmeroPy/test/unit/test_metadata_utils.py
@@ -25,6 +25,7 @@ Test of metadata_utils classes
 
 
 import pytest
+from pytest import skip
 
 from omero.util.metadata_utils import (
     BulkAnnotationConfiguration, GroupConfig, KeyValueListPassThrough,
@@ -312,6 +313,16 @@ class TestKeyValueListTransformer(object):
     def test_transform1(self, inout):
         cfg = expected(name="a1", **inout[1])
         assert KeyValueListTransformer.transform1(inout[0], cfg) == inout[2]
+
+    # TODO: Can we assume jinja2 is always installed on test systems?
+    def test_transformj2(self):
+        try:
+            import jinja2  # noqa
+        except ImportError:
+            skip("jinja2 not found")
+        cfg = expected(name="a1", clientvalue="http://{{ value | urlencode }}")
+        assert KeyValueListTransformer.transform1("a b", cfg) == (
+            "a1", ["http://a%20b"])
 
     def test_transform(self):
         headers = ["a2", "a4", "a3", "a1"]


### PR DESCRIPTION
# What this PR does

The IDR bulk-annotation -> map-annotations process involves building URLs. Previously these were simple identifiers, but now they may include phrases including characters which need to be escaped when used in a URL. This PR now uses the Jinja templating module if it's installed, so standard Jinja2 filters such as `{{ value | urlencode }}` can be used.
# Testing this PR

Current use case: Mapr @aleksandra-tarkowska which creates mapr URLs with spaces.
# Potential issues

This adds a new optional dependency, `jinja2`, to OMERO.py. Should it be made mandatory along with yaml in order to keep things clearer?
