### PR TITLE
Thumbnails and plate fixes

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -27,7 +27,7 @@
                 <!-- we wrap img with <a> so you can right-click -> open link in new tab -->
                 <a href="<%= webindex %><% if(img.shareId) {print( img.shareId + '/')} %>img_detail/<%= img.id %>/">
                     <img alt="image"
-                         src="<%= webindex %>render_thumbnail/size/96/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>"
+                         src="<%= webindex %>render_thumbnail/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>"
                          title="<%= img.name %>"/>
                 </a>
             </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -97,7 +97,7 @@
                 <tr id="{{ byId.otype }}-{{ c.id }}" class="{{ c.getPermsCss }}">
                     <td class="image">
                         {% if byId.otype == 'image' %}
-                            <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail_resize' 96 c.id  %}" alt="image" title="{{ c.name }}"/>
+                            <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail' c.id  %}" alt="image" title="{{ c.name }}"/>
                         {% elif byId.otype == 'project' %}
                             <img src="{% static "webgateway/img/folder16.png" %}" alt="{{ byId.otype }}" title="{{ c.name }}"/>
                         {% elif byId.otype == 'dataset' %}
@@ -198,7 +198,7 @@
             {% for c in manager.containers.images %}
                 <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
                     <td class="image">
-                        <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail_resize' 96 c.id  %}" alt="image" title="{{ c.name }}"/>
+                        <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail' c.id  %}" alt="image" title="{{ c.name }}"/>
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
                     <td class="date">{{ c.getDate|date:"Y-m-d H:i:s" }}</td>

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -124,7 +124,7 @@ urlpatterns = patterns(
     url(r'^render_thumbnail/(?P<iid>[0-9]+)/'
         r'(?:(?P<share_id>[0-9]+)/)?$',
         webgateway.render_thumbnail,
-        {'w': 80, '_defcb': defaultThumbnail},
+        {'_defcb': defaultThumbnail},
         name="render_thumbnail"),
     url(r'^render_thumbnail/size/(?P<w>[0-9]+)/'
         r'(?P<iid>[0-9]+)/(?:(?P<share_id>[0-9]+)/)?$',

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -102,11 +102,10 @@ jQuery._WeblitzPlateview = function (container, options) {
       baseurl: '',
       width: 64,
       height: 48,
-      size: 96,
       useParentPrefix: true,
     }, options);
 
-  opts.size = opts.size || Math.max(opts.width, opts.height);
+  // if options.size is set, it will be used below, otherwise thumbs will be default size
   this.self = jQuery(container);
   this.self.addClass('weblitz-plateview');
   this.origHTML = this.self.html();
@@ -164,7 +163,11 @@ jQuery._WeblitzPlateview = function (container, options) {
     if (field === undefined) {
       field = 0;
     }
-    gs_json(opts.baseurl+'/plate/'+pid+'/'+field+'/?size='+opts.size, null, _reset);
+    var url = opts.baseurl+'/plate/'+pid+'/'+field+'/';
+    if (opts.size) {
+      url += '?size='+opts.size;
+    }
+    gs_json(url, null, _reset);
   };
 
   this.setFocus = function (elm, evt) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -164,7 +164,7 @@ jQuery._WeblitzPlateview = function (container, options) {
     if (field === undefined) {
       field = 0;
     }
-    gs_json(opts.baseurl+'/plate/'+pid+'/'+field+'/', {size:opts.size}, _reset);
+    gs_json(opts.baseurl+'/plate/'+pid+'/'+field+'/?size='+opts.size, null, _reset);
   };
 
   this.setFocus = function (elm, evt) {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -292,8 +292,6 @@ def render_birds_eye_view(request, iid, size=None,
                         bird's eye view.
     @return:            http response containing jpeg
     """
-    if size is None:
-        size = 96       # Use cached thumbnail
     return render_thumbnail(request, iid, w=size, **kwargs)
 
 
@@ -306,14 +304,14 @@ def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
 
     @param request:     http request
     @param iid:         Image ID
-    @param w:           Thumbnail max width. 64 by default
+    @param w:           Thumbnail max width. 96 by default
     @param h:           Thumbnail max height
     @return:            http response containing jpeg
     """
     server_id = request.session['connector'].server_id
     direct = True
     if w is None:
-        size = (64,)
+        size = (96,)
     else:
         if h is None:
             size = (int(w),)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1371,24 +1371,28 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
     except ValueError:
         field = 0
     prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
-    thumbsize = int(request.GET.get('size', 96))
+    thumbsize = getIntOrDefault(request, 'size', None)
     logger.debug(thumbsize)
     server_id = kwargs['server_id']
 
-    def urlprefix(iid):
-        return reverse(prefix, args=(iid, thumbsize))
+    def get_thumb_url(iid):
+        if thumbsize is not None:
+            return reverse(prefix, args=(iid, thumbsize))
+        return reverse(prefix, args=(iid,))
+
     plateGrid = PlateGrid(conn, pid, field,
-                          kwargs.get('urlprefix', urlprefix))
+                          kwargs.get('urlprefix', get_thumb_url))
     plate = plateGrid.plate
     if plate is None:
         return Http404
 
-    rv = webgateway_cache.getJson(request, server_id, plate,
-                                  'plategrid-%d-%d' % (field, thumbsize))
+    cache_key = 'plategrid-%d-%s' % (field, thumbsize)
+    rv = webgateway_cache.getJson(request, server_id, plate, cache_key)
+
     if rv is None:
         rv = plateGrid.metadata
         webgateway_cache.setJson(request, server_id, plate, json.dumps(rv),
-                                 'plategrid-%d-%d' % (field, thumbsize))
+                                 cache_key)
     else:
         rv = json.loads(rv)
     return rv

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -290,8 +290,12 @@ class TestPlateGrid(object):
                 well_metadata = grid[well.row.val][well.column.val]
                 well_samples = well.copyWellSamples()
                 if len(well_samples) > field:
-                    assert well_metadata['name'] ==\
-                        well_samples[field].getImage().name.val
+                    img = well_samples[field].getImage()
+                    assert well_metadata['name'] == img.name.val
+                    # expect default thumbnail (no size specified)
+                    assert well_metadata['thumb_url'] ==\
+                        reverse('webgateway.views.render_thumbnail',
+                                args=[img.id.val])
 
     def test_instantiation(self, plate_wells, conn):
         """

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests rendering of thumbnails."""
+
+from weblibrary import IWebTest
+from weblibrary import _get_response
+
+from cStringIO import StringIO
+import pytest
+from django.core.urlresolvers import reverse
+try:
+    from PIL import Image
+except:
+    import Image
+
+
+class TestThumbnails(IWebTest):
+    """Tests loading of thumbnails."""
+
+    @pytest.mark.parametrize("size", [None, 100])
+    def test_default_thumb_size(self, size):
+        """
+        Test that the default size of thumbnails is correct.
+
+        Default size is 96.
+        """
+        # Create a square image
+        iId = self.createTestImage(sizeX=125, sizeY=125,
+                                   session=self.sf).id.val
+        args = [iId]
+        if size is not None:
+            args.append(size)
+        request_url = reverse('webgateway.views.render_thumbnail', args=args)
+        rsp = _get_response(self.django_client, request_url, {},
+                            status_code=200)
+
+        thumb = Image.open(StringIO(rsp.content))
+        # Should be 96 on both sides
+        if size is None:
+            assert thumb.size == (96, 96)
+        else:
+            assert thumb.size == (size, size)


### PR DESCRIPTION
This PR is the same as https://github.com/openmicroscopy/openmicroscopy/pull/4687 and https://github.com/openmicroscopy/openmicroscopy/pull/4718

---
# What this PR does

This changes the default size for webgateway thumbnails from 64 to 96, which
can then use the cached thumbnails from OMERO.
# Testing this PR
- go to: `/webgateway/render_thumbnail/<imageId>/`
- Should get a thumbnail that is 96 long on longest side.
- `webgateway/render_birds_eye_view/<imageId>/` should continue to give size 96 thumbnail as before (no change).
- Dataset thumbnails no-longer have size specified (now use default size). Right-click on thumbnail and "Open image in new tab". Url should be webclient/render_thumbnail/<imageId>/ with no '96' size.
- Do the same for SPW thumbnails.
- Check test is green at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/350/testReport/OmeroWeb.test.integration.test_plategrid/TestPlateGrid/test_get_plate_grid_metadata/
# Related reading

See https://trello.com/c/abPmgATV/90-thumbnail-96-by-default
