### PR TITLE
test that ISession.createUserSession cannot be used from sudo

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -332,14 +332,21 @@ class TestISession(lib.ITest):
 
     # Test that ISession.createUserSession cannot be used from a session that
     # is a sudo from somebody else.
-    def testCreateUserSessionFromSudo(self):
-        iSessionRoot = self.root.sf.getSessionService()
-
+    @pytest.mark.parametrize("to_root", [True, False])
+    def testCreateUserSessionFromSudo(self, to_root):
         principal = omero.sys.Principal()
-        principal.name = self.ctx.userName
-        principal.group = self.ctx.groupName
         principal.eventType = "Test"
 
+        if to_root:
+            iAdminRoot = self.root.sf.getAdminService()
+            ctx_root = iAdminRoot.getEventContext()
+            principal.name = ctx_root.userName
+            principal.group = ctx_root.groupName
+        else:
+            principal.name = self.ctx.userName
+            principal.group = self.ctx.groupName
+
+        iSessionRoot = self.root.sf.getSessionService()
         sudoSession = iSessionRoot.createSessionWithTimeout(
             principal, 10 * 1000)
 

--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -338,20 +338,20 @@ class TestISession(lib.ITest):
         principal.eventType = "Test"
 
         if to_root:
-            iAdminRoot = self.root.sf.getAdminService()
-            ctx_root = iAdminRoot.getEventContext()
+            iAdmin_root = self.root.sf.getAdminService()
+            ctx_root = iAdmin_root.getEventContext()
             principal.name = ctx_root.userName
             principal.group = ctx_root.groupName
         else:
             principal.name = self.ctx.userName
             principal.group = self.ctx.groupName
 
-        iSessionRoot = self.root.sf.getSessionService()
-        sudoSession = iSessionRoot.createSessionWithTimeout(
+        iSession_root = self.root.sf.getSessionService()
+        sudo_session = iSession_root.createSessionWithTimeout(
             principal, 10 * 1000)
 
         c = omero.client(self.client.getPropertyMap())
-        c.joinSession(sudoSession.uuid.val)
+        c.joinSession(sudo_session.uuid.val)
 
         iSession = c.sf.getSessionService()
         with pytest.raises(omero.SecurityViolation):


### PR DESCRIPTION
# What this PR does

This PR adds integration testing ensuring that, while `ISession.createUserSession` can be used from a normal session, it cannot be used from a sudo'd session.
# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.test_isession/TestISession/ should be green.
# Related reading

This closes one of the paths by which the "light administrators" of https://trello.com/c/t0nT7KYa/133-new-role could have broken out of their restrictions.
