### PR TITLE
JSON table CLI output

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -376,9 +376,10 @@ class SessionsControl(BaseControl):
                             else:
                                 rv = store.attach(*previous[:-1])
                                 return self.handle(rv, "Using")
-                        self.ctx.out("Previously logged in to %s:%s as %s"
-                                     % (previous[0], previous[3],
-                                        previous[1]))
+                        if not self.ctx.isquiet:
+                            self.ctx.out("Previously logged in to %s:%s as %s"
+                                         % (previous[0], previous[3],
+                                            previous[1]))
                     except Exception, e:
                         self.ctx.out("Previous session expired for %s on"
                                      " %s:%s" % (previous[1], previous[0],

--- a/components/tools/OmeroPy/src/omero/util/text.py
+++ b/components/tools/OmeroPy/src/omero/util/text.py
@@ -12,6 +12,8 @@
 # http://code.activestate.com/recipes/577202-render-tables-for-text-interface/
 #
 
+import json
+
 
 class Style(object):
 
@@ -89,6 +91,26 @@ class CSVStyle(PlainStyle):
             yield row
 
 
+class JSONStyle(Style):
+
+    NAME = "json"
+
+    def format(self, width, align):
+        return '%s'
+
+    def get_rows(self, table):
+        headers = list(table.get_row(None))
+
+        if table.length == 0:
+            yield '[]'
+
+        for i in range(0, table.length):
+            prefix = '[' if i == 0 else ''
+            suffix = ']' if i == table.length - 1 else ','
+            d = dict(zip(headers, table.get_row(i)))
+            yield prefix + json.dumps(d) + suffix
+
+
 class StyleRegistry(dict):
 
     def __init__(self):
@@ -96,6 +118,7 @@ class StyleRegistry(dict):
         self["csv"] = CSVStyle()
         self["sql"] = SQLStyle()
         self["plain"] = PlainStyle()
+        self["json"] = JSONStyle()
 
 
 STYLE_REGISTRY = StyleRegistry()

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -84,7 +84,7 @@ class TestUser(CLITest):
             sorted_list = sorted(self.users, key=lambda x: x.id.val)
         assert ids == [user.id.val for user in sorted_list]
 
-    @pytest.mark.parametrize("style", [None, "sql", "csv", "plain"])
+    @pytest.mark.parametrize("style", [None, "sql", "csv", "plain", "json"])
     def testListWithStyles(self, capsys, style):
         self.args += ["list"]
         if style:


### PR DESCRIPTION
# What this PR does

Adds `json` to the available tabular output styles for the CLI. Also suppresses the `Previously logged in to` CLI message in quiet mode. This means the `json` table output can be piped to other processes.
# Testing this PR

Test CLI commands that have tabular output, e.g.
- `omero hql --style json ...`
- `omero user list --style json`

Try piping the `json` output into other commands, for example `jq` (The JSON version of `sed`/xpath):
- `omero user list -q --style json`
  
  ```
  [{"admin": "Yes", "last name": "root", "email": "", "owner of": "", "first name": "root", "member of": "", "ldap": "False", "active": "Yes", "login": "root", "id": "0"},
  {"admin": "", "last name": "Account", "email": "", "owner of": "", "first name": "Guest", "member of": "2", "ldap": "False", "active": "", "login": "guest", "id": "1"},
  ...
  ```
- `omero user list --style json | jq 'map(select(.["admin"]=="Yes"))'`
  
  ```
  [
    {
      "admin": "Yes",
      "last name": "root",
      "email": "",
      "owner of": "",
      "first name": "root",
      "member of": "",
      "ldap": "False",
      "active": "Yes",
      "login": "root",
      "id": "0"
    }
  ]
  ```

Read the output directly into an Ansible variable, for example this will create the Ansible variable `omero_user_list` containing a list of dictionaries with OMERO users:

```
- name: omero user | current user list
  become: yes
  become_user: "{{ omero_user_system }}"
  command: >
    {{ omero_serverdir }}/{{ omero_server_symlink }}/bin/omero user
    -s localhost
    -u {{ omero_user_admin_user }}
    -w {{ omero_user_admin_pass }}
    list
    -q
    --style json
  register: usercmd
  always_run: yes
  changed_when: False

- set_fact:
    omero_user_list: "{{ usercmd.stdout | from_json }}"
```
# Problems
- [x] `unit/test_util.py::TestJSONSTyle.testPlainModuleParsing` fails with unicode values, but I don't know whether that's a bug in the test framework, JSON, or the `TableBuilder`.
