### PR TITLE
allow customizing django apps using AppConfig (rebased onto metadata52)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -80,8 +80,13 @@ for app in settings.ADDITIONAL_APPS:
         urlmodule = 'omeroweb.%s.urls' % app
     else:
         urlmodule = '%s.urls' % app
-    regex = '^(?i)%s/' % label
-    urlpatterns += patterns('', (regex, include(urlmodule)),)
+    try:
+        __import__(urlmodule)
+    except ImportError:
+        pass
+    else:
+        regex = '^(?i)%s/' % label
+        urlpatterns += patterns('', (regex, include(urlmodule)),)
 
 urlpatterns += patterns(
     '',

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -24,6 +24,7 @@
 #
 
 from django.conf import settings
+from django.apps import AppConfig
 from django.conf.urls import url, patterns, include
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
@@ -67,13 +68,19 @@ def redirect_urlpatterns():
 urlpatterns = patterns('',)
 
 for app in settings.ADDITIONAL_APPS:
+    if isinstance(app, AppConfig):
+        app_config = app
+    else:
+        app_config = AppConfig.create(app)
+    label = app_config.label
+
     # Depending on how we added the app to INSTALLED_APPS in settings.py,
     # include the urls the same way
     if 'omeroweb.%s' % app in settings.INSTALLED_APPS:
         urlmodule = 'omeroweb.%s.urls' % app
     else:
         urlmodule = '%s.urls' % app
-    regex = '^(?i)%s/' % app
+    regex = '^(?i)%s/' % label
     urlpatterns += patterns('', (regex, include(urlmodule)),)
 
 urlpatterns += patterns(


### PR DESCRIPTION
This is the same as gh-4843 but rebased onto metadata52.

---
# What this PR does

allows to customize app urls regardless of original web app name is and allow loading apps that has no urls.py

if the app urls need to be different then package name, custom app would have to provide `label` value using AppConfig, see https://github.com/openmicroscopy/weberror/pull/9 as an example

```
from django.apps import AppConfig
class MyWebAppConfig(AppConfig):
    name = "module_name"
    label = "custom_label"  # this is used by urls
```
# Testing this PR

To test this PR is required to have a basic understanding of web deployment including nginx and Django.

**testing matrix: Python2.7 Django 1.8.(latest)**
- test custom label
  
  install omeroweb http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/install-web/install-web-trial.html or use https://github.com/ome/omeroweb-install Do not use development server!
  
  ```
  # App with AppConfig
  pip install "git+git://github.com/aleksandra-tarkowska/omero-mapr.git@maps"
  
  bin/omero config append --set omero.web.apps '"omero_mapr"'
  ```
  
  test urls:
  - http://host/mapr/
# Related reading

Django doc https://docs.djangoproject.com/en/1.8/ref/applications/#application-configuration
