### PR TITLE
tag removal test wait

### DIFF
--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -379,21 +379,21 @@ Test Key Word Search
     Clear Search Text Field
     Input Text     name=query           ${Search_Query1}
     Click Button    id=search_button
-    Wait Until Page Contains Element  id=dataTable  1
+    Wait Until Page Contains Element  id=dataTable  ${TIMEOUT}
     Page Should Contain Element         ${XpathTable}
     ${rows}=        Get Matching XPath Count    xpath=//table[@id='dataTable']/tbody/tr
 
     Clear Search Text Field
     Input Text     name=query           ${Search_Query1}*
     Click Button    id=search_button
-    Wait Until Page Contains Element  id=dataTable  1
+    Wait Until Page Contains Element  id=dataTable  ${TIMEOUT}
     Page Should Contain Element         ${XpathTable}
     ${rows1}=        Get Matching XPath Count    xpath=//table[@id='dataTable']/tbody/tr
 
     Clear Search Text Field
     Input Text     name=query           *${Search_Query1}*
     Click Button    id=search_button
-    Wait Until Page Contains Element  id=dataTable  1
+    Wait Until Page Contains Element  id=dataTable  ${TIMEOUT}
     Page Should Contain Element         ${XpathTable}
     ${rows2}=        Get Matching XPath Count    xpath=//table[@id='dataTable']/tbody/tr
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -804,7 +804,7 @@ class BaseContainer(BaseController):
                 linksByType[objType] = []
             linksByType[objType].append(obj.id.val)
         for linkType, ids in linksByType.items():
-            self.conn.deleteObjects(linkType, ids, wait=False)
+            self.conn.deleteObjects(linkType, ids, wait=True)
         if len(notFound) > 0:
             raise AttributeError("Attribute not specified. Cannot be removed.")
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
@@ -80,18 +80,13 @@ var TagPane = function TagPane($element, opts) {
     });
     $('#add_tags_form').ajaxForm({
         beforeSubmit: function(data) {
-            $("#tagann_spinner").show();
-            // $("#add_tags_form").dialog( "close" );
+            showSpinner();
         },
         success: function(data) {
-            // hide in case it was submitted via 'Enter'
-            $("#add_tags_form").dialog( "close" );
             // update the list of tags: Re-render tag pane...
             self.render();
-            // show_batch_msg("Tags added to Objects");
         },
         error: function(data) {
-            $("#tagann_spinner").hide();
         }
     });
 
@@ -106,6 +101,11 @@ var TagPane = function TagPane($element, opts) {
 
     var compareParentName = function(a, b){
         return a.parent.name.toLowerCase() > b.parent.name.toLowerCase() ? 1 : -1;
+    };
+
+    var showSpinner = function() {
+        // added to $tags_container, so will get removed on render();
+        $tags_container.append('<img src="' + WEBCLIENT.URLS.static_webgateway + 'img/spinner.gif">');
     };
 
     this.render = function render() {

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1012,7 +1012,7 @@ def _api_links_DELETE(conn, json_data):
                 linkType, links = objLnks
                 linkIds = [r.id.val for r in links]
                 logger.info("api_link: Deleting %s links" % len(linkIds))
-                conn.deleteObjects(linkType, linkIds)
+                conn.deleteObjects(linkType, linkIds, wait=True)
                 # webclient needs to know what is orphaned
                 linkType, remainingLinks = get_object_links(conn,
                                                             parent_type,

--- a/components/tools/OmeroWeb/test/integration/test_tags.py
+++ b/components/tools/OmeroWeb/test/integration/test_tags.py
@@ -167,7 +167,7 @@ class TestTags(IWebTest):
         _post_response(self.django_client, request_url, data)
         _csrf_post_response(self.django_client, request_url, data)
         # Check that tag is removed - short delay to allow async delete
-        sleep(0.1)
+        sleep(1)
         request_url = reverse("api_annotations")
         data = {'image': img.id.val, 'type': 'tag'}
         data = _get_response_json(self.django_client, request_url, data)


### PR DESCRIPTION
# What this PR does

This reverts async removal of tags (deletion of tag links).
Now we wait for tags to be removed before updating tags in web UI.

Also updates tests accordingly.

To test:
 - Select a large number E.g > 100 objects P/D/I.
 - Add tags, then remove them via Tag dialog
 - Check that when tag is removed, it disappears from lists of tags in right panel
 - Also check that removing via (-) on Tag itself still works as expected.
 - Check that tests are passing.
