### PR TITLE
have disk usage plugin cope with multiple IDs given for same class

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1850,10 +1850,7 @@ class GraphControl(CmdControl):
         elif len(others) > 1:
             for req in others[1:]:
                 type, ids = req.targetObjects.items()[0]
-                if type in others[0].targetObjects:
-                    others[0].targetObjects[type].extend(ids)
-                else:
-                    others[0].targetObjects[type] = ids
+                others[0].targetObjects.setdefault(type, []).extend(ids)
             rv.append(others[0])
 
         # Group skipheads by their startFrom attribute.

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -840,10 +840,7 @@ Examples:
                 else:
                     ids = parts[1].split(",")
                     ids = map(long, ids)
-                    if klass in objects:
-                        objects[klass].extend(ids)
-                    else:
-                        objects[klass] = ids
+                    objects.setdefault(klass, []).extend(ids)
             except:
                 raise ValueError("Bad object: ", o)
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -840,7 +840,10 @@ Examples:
                 else:
                     ids = parts[1].split(",")
                     ids = map(long, ids)
-                    objects[klass] = ids
+                    if klass in objects:
+                        objects[klass].extend(ids)
+                    else:
+                        objects[klass] = ids
             except:
                 raise ValueError("Bad object: ", o)
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -838,8 +838,7 @@ Examples:
                 if '*' in parts[1]:
                     classes.add(klass)
                 else:
-                    ids = parts[1].split(",")
-                    ids = map(long, ids)
+                    ids = [long(id) for id in parts[1].split(",")]
                     objects.setdefault(klass, []).extend(ids)
             except:
                 raise ValueError("Bad object: ", o)


### PR DESCRIPTION
# What this PR does

@joshmoore [found that](https://openmicroscopy.slack.com/archives/general/p1478000835010648) `bin/omero fs usage` ignores all but the last of arguments of the form Class:X Class:Y Class:Z so that for identical classes "Class" only the Z is targeted.

# Testing this PR

Check that the `usage` feature of the `fs` CLI plugin now gives sensible results when the same class is mentioned multiple times on the command line.