### PR TITLE
Deprecate enum

### DIFF
--- a/components/blitz/resources/omero/api/IPixels.ice
+++ b/components/blitz/resources/omero/api/IPixels.ice
@@ -145,6 +145,7 @@ module omero {
                  * @param value Enumeration string value.
                  * @return Enumeration object.
                  **/
+                 ["deprecated:Use ITypes#getEnumeration(string, string) instead."]
                 idempotent omero::model::IObject getEnumeration(string enumClass, string value) throws ServerError;
 
                 /**
@@ -155,6 +156,7 @@ module omero {
                  * @return List of all enumeration objects for the
                  *         <i>enumClass</i>.
                  **/
+                 ["deprecated:Use ITypes#allEnumerations(string) instead."]
                 idempotent IObjectList getAllEnumerations(string enumClass) throws ServerError;
 
                 /**

--- a/components/blitz/src/omero/gateway/Connector.java
+++ b/components/blitz/src/omero/gateway/Connector.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Multimap;
@@ -74,6 +73,8 @@ import omero.api.IRoiPrxHelper;
 import omero.api.IScriptPrx;
 import omero.api.IScriptPrxHelper;
 import omero.api.ISessionPrx;
+import omero.api.ITypesPrx;
+import omero.api.ITypesPrxHelper;
 import omero.api.IUpdatePrx;
 import omero.api.IUpdatePrxHelper;
 import omero.api.RawFileStorePrx;
@@ -481,6 +482,20 @@ class Connector
                 get(omero.constants.PIXELSSERVICE.value,
                         unsecureClient == null));
     }
+
+     /**
+      * Returns the {@link ITypesPrx} service.
+      * 
+      * @return See above.
+      * @throws Throwable Thrown if the service cannot be initialized.
+      */
+      ITypesPrx getTypesService()
+             throws DSOutOfServiceException
+     {
+         return ITypesPrxHelper.uncheckedCast(
+                 get(omero.constants.TYPESSERVICE.value,
+                         unsecureClient == null));
+     }
 
     /**
      * Returns the {@link SearchPrx} service.

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -56,6 +56,7 @@ import omero.api.IRenderingSettingsPrx;
 import omero.api.IRepositoryInfoPrx;
 import omero.api.IRoiPrx;
 import omero.api.IScriptPrx;
+import omero.api.ITypesPrx;
 import omero.api.IUpdatePrx;
 import omero.api.RawFileStorePrx;
 import omero.api.RawPixelsStorePrx;
@@ -1535,6 +1536,23 @@ public class Gateway {
         }
     }
 
+    /**
+     * Returns the {@link ITypesPrx} service.
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @return See above.
+     * @throws DSOutOfServiceException
+     *             Thrown if the service cannot be initialized.
+     */
+    public ITypesPrx getTypesService(SecurityContext ctx)
+            throws DSOutOfServiceException {
+        Connector c = getConnector(ctx, true, false);
+        if (c != null)
+            return c.getTypesService();
+        return null;
+    }
+    
     /**
      * Create a {@link Connector} for a particular {@link SecurityContext}
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -125,6 +125,7 @@ import omero.api.IRenderingSettingsPrx;
 import omero.api.IRepositoryInfoPrx;
 import omero.api.IRoiPrx;
 import omero.api.IScriptPrx;
+import omero.api.ITypesPrx;
 import omero.api.IUpdatePrx;
 import omero.api.RawFileStorePrx;
 import omero.api.RawPixelsStorePrx;
@@ -5195,8 +5196,8 @@ class OMEROGateway
 	{
 	   
 		try {
-		    IQueryPrx service = gw.getQueryService(ctx);
-			return service.findByString(klass.getName(), "value", value);
+		    ITypesPrx service = gw.getTypesService(ctx);
+		    return service.getEnumeration(klass.getName(), value);
 		} catch (Exception e) {
 			handleException(e, "Cannot find the enumeration's value.");
 		}
@@ -5222,10 +5223,10 @@ class OMEROGateway
 	   
 		List<EnumerationObject> r;
 		try {
-		    IPixelsPrx service = gw.getPixelsService(ctx);
+		    ITypesPrx service = gw.getTypesService(ctx);
 			r = enumerations.get(klassName);
 			if (r != null) return r;
-			List<IObject> l = service.getAllEnumerations(klassName);
+			List<IObject> l = service.allEnumerations(klassName);
 			r = new ArrayList<EnumerationObject>();
 			if (l == null) return r;
 			Iterator<IObject> i = l.iterator();

--- a/components/server/src/ome/logic/PixelsImpl.java
+++ b/components/server/src/ome/logic/PixelsImpl.java
@@ -310,11 +310,13 @@ public class PixelsImpl extends AbstractLevel2Service implements IPixels {
 	}
 
 	@RolesAllowed("user")
+	@Deprecated
 	public <T extends IObject> T getEnumeration(Class<T> klass, String value) {
 		return iQuery.findByString(klass, "value", value);
 	}
 
 	@RolesAllowed("user")
+	@Deprecated
 	public <T extends IObject> List<T> getAllEnumerations(Class<T> klass) {
 		return iQuery.findAll(klass, null);
 	}


### PR DESCRIPTION
Noticed when writing following the formats enum Db patch,


# What this PR does
Mark 2 methods in IPixels as deprecated
Remove usage of the methods in insight


# Testing this PR
Check that insight can start.
Enum are loaded at start up.

cc @mtbc 

