### PR TITLE
LUT image within slider knobs

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
@@ -156,6 +156,12 @@ public class TwoKnobsSlider
 	/** The background image */
 	private BufferedImage      image;
 
+    /**
+     * Flag to indicate that the background image should be only drawn within
+     * the start and end slider knob
+     */
+    private boolean squeezeImage = true;
+	
 	/** Computes the preferred size of this component. */
 	private void calculatePreferredSize()
 	{
@@ -727,10 +733,25 @@ public class TwoKnobsSlider
 	 */
 	Color[] getGradientColors() { return gradients; }
 	
-	BufferedImage getImage() {
-	    return this.image;
-	}
+    /**
+     * Get the background image
+     * 
+     * @return The current background image
+     */
+    BufferedImage getImage() {
+        return this.image;
+    }
 	
+    /**
+     * Returns if the background image is supposed to be only drawn within the
+     * start and end slider knob (instead of the full range)
+     * 
+     * @return See above.
+     */
+    boolean isSqueezeImage() {
+        return squeezeImage;
+    }
+    
 	/**
 	 * Returns <code>True</code> if the color gradient is set,
 	 * <code>false</code> otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSlider.java
@@ -157,10 +157,10 @@ public class TwoKnobsSlider
 	private BufferedImage      image;
 
     /**
-     * Flag to indicate that the background image should be only drawn within
-     * the start and end slider knob
+     * Flag to indicate that the background image/color should be only drawn
+     * within the start and end slider knob
      */
-    private boolean squeezeImage = true;
+    private boolean squeezeBackground = true;
 	
 	/** Computes the preferred size of this component. */
 	private void calculatePreferredSize()
@@ -743,13 +743,13 @@ public class TwoKnobsSlider
     }
 	
     /**
-     * Returns if the background image is supposed to be only drawn within the
-     * start and end slider knob (instead of the full range)
+     * Returns if the background image/color is supposed to be only drawn within
+     * the start and end slider knob (instead of the full range)
      * 
      * @return See above.
      */
-    boolean isSqueezeImage() {
-        return squeezeImage;
+    boolean isSqueezeBackground() {
+        return squeezeBackground;
     }
     
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
@@ -350,12 +350,21 @@ class TwoKnobsSliderUI
 	{
 		int l = xPositionForValue(model.getStartValue());
 		int r = xPositionForValue(model.getEndValue());
-		if ( component.getImage() != null ){
-            g2D.drawImage(component.getImage(), trackRect.x, trackRect.y, trackRect.width, trackRect.height-9, null);
-            
+		
+		int w  = component.getKnobWidth();
+        int h = component.getKnobHeight();
+        
+        if (component.getImage() != null) {
+            if (component.isSqueezeImage())
+                g2D.drawImage(component.getImage(), r, trackRect.y, (l - r),
+                        trackRect.height - 9, null);
+            else
+                g2D.drawImage(component.getImage(), trackRect.x, trackRect.y,
+                        trackRect.width, trackRect.height - 9, null);
+
             g2D.drawRect(trackRect.x, trackRect.y, trackRect.width,
-                    trackRect.height-8);
-		}
+                    trackRect.height - 8);
+        }
 		else {
 		    if (!component.getColourGradient())
 	        {
@@ -385,8 +394,6 @@ class TwoKnobsSliderUI
 	        }
 		}
 		//Draw the knobs
-		int w  = component.getKnobWidth();
-		int h = component.getKnobHeight();
 		Image img;
 		int offset = 0;
 		if (!component.getColourGradient()) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/slider/TwoKnobsSliderUI.java
@@ -355,8 +355,8 @@ class TwoKnobsSliderUI
         int h = component.getKnobHeight();
         
         if (component.getImage() != null) {
-            if (component.isSqueezeImage())
-                g2D.drawImage(component.getImage(), r, trackRect.y, (l - r),
+            if (component.isSqueezeBackground())
+                g2D.drawImage(component.getImage(), l, trackRect.y, (r - l),
                         trackRect.height - 9, null);
             else
                 g2D.drawImage(component.getImage(), trackRect.x, trackRect.y,
@@ -373,7 +373,7 @@ class TwoKnobsSliderUI
 	                trackRect.y+trackRect.height-10,
 	                UIUtilities.TRACK_GRADIENT_END, false);
 	            g2D.setPaint(paint);
-	            g2D.fillRoundRect(trackRect.x, trackRect.y+3, trackRect.width,
+	            g2D.fillRoundRect(l, trackRect.y+3, (r - l),
 	                    trackRect.height-12, trackRect.height/3, 
 	                    trackRect.height/3);
 	            g2D.setColor(TRACK_COLOR);
@@ -381,11 +381,11 @@ class TwoKnobsSliderUI
 	                    trackRect.height-11, trackRect.height/3, trackRect.height/3);
 	        } else {
 	            Color[] colors = component.getGradientColors();
-	            Paint paint = new GradientPaint(trackRect.x,
-	                    trackRect.y-2,  colors[0], trackRect.width,
+	            Paint paint = new GradientPaint(l,
+	                    trackRect.y-2,  colors[0], r,
 	                    trackRect.height+2, colors[1], false);
 	            g2D.setPaint(paint);
-	            g2D.fillRoundRect(trackRect.x, trackRect.y+2, trackRect.width,
+	            g2D.fillRoundRect(l, trackRect.y+2, (r - l),
 	                    trackRect.height-10, trackRect.height/3, 
 	                    trackRect.height/3);
 	            g2D.setColor(Color.black);


### PR DESCRIPTION
# What this PR does

With this PR the color gradient background (or lookup table image) on channel sliders is only drawn within the knobs (instead of across the full slider/range like it was before).

# Testing this PR

See above.

# Related reading

https://trello.com/c/h8OylVrf/209-lut-follow-up

