### PR TITLE
tables data on images

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -368,7 +368,7 @@ class ValueResolver(object):
             try:
                 return images_by_id[long(value)].id.val
             except KeyError:
-                log.debug('Image Id: %i not found!' % (value))
+                log.error('Image Id: %s not found!' % (value))
                 return -1L
             return
         if WellColumn is column_class:

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -346,41 +346,12 @@
                     {% if manager.well %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}";
+                    var query = "Well-{{ manager.well.id }}";
                     {% elif manager.image %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
-                        plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    var query = "Image-{{ manager.image.id }}";
                     {% endif %}
-
-
-                    var wellId;
-                    {% if manager.well %}
-                        wellId = {{ manager.well.id }};
-                    {% endif %}
-
-                    // Since we may not have the WellId in hand (if we're an image)
-                    // this returns a Promise() that will return wellId on resolve();
-                    var getWellId = function() {
-                        var d = $.Deferred();
-                        if (wellId) {
-                            // If we have it already, resolve immediately
-                            d.resolve(wellId);
-                        } else {
-                            // Otherwise, get paths to Image which may include SPW path...
-                            $.getJSON(WEBCLIENT.URLS.api_paths_to_object+'?image={{ manager.image.id }}', function(data){
-                                if (data.paths && data.paths.length > 0) {
-                                    wellId = data.paths[0].reduce(function(prev, node){
-                                        if (node.type === "well") {
-                                            return node.id;
-                                        }
-                                        return prev;
-                                    }, undefined);
-                                }
-                                d.resolve(wellId);
-                            });
-                        }
-                        return d.promise();
-
-                    }
 
                     var showBulkAnnTooltip = function(data) {
                         var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
@@ -415,11 +386,8 @@
                         OME.setPaneExpanded('tables', expanded);
 
                         if (expanded && $("#bulk_annotations_table").is(":empty")) {
-                            getWellId().done(function(wId){
-                                if (!wId) return;
-                                loadBulkAnnotations(screenQuery, wId, showBulkAnnTooltip);
-                                loadBulkAnnotations(plateQuery, wId, showBulkAnnTooltip);
-                            });
+                            loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
                         }
                     });
 
@@ -429,15 +397,8 @@
                             .toggleClass('closed')
                             .next().slideToggle();
                         if ($("#bulk_annotations_table").is(":empty")) {
-                            getWellId().done(function(wId){
-                                if (!wId) {
-                                    // Close tab so we don't keep querying for Well.
-                                    OME.setPaneExpanded('tables', false);
-                                    return;
-                                }
-                                loadBulkAnnotations(screenQuery, wId, showBulkAnnTooltip);
-                                loadBulkAnnotations(plateQuery, wId, showBulkAnnTooltip);
-                            });
+                            loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
                         }
                     }
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -300,9 +300,9 @@
 
 
     // Used in the Image viewer and in metadata general panel
-    window.loadBulkAnnotations = function(url, wellId, callback) {
+    window.loadBulkAnnotations = function(url, query, callback) {
         // Load bulk annotations for screen or plate
-        $.getJSON(url + '?query=Well-' + wellId + '&callback=?',
+        $.getJSON(url + '?query=' + query + '&callback=?',
             function(result) {
                 if (result.data && result.data.rows) {
                     var table = $("#bulk-annotations").show().next().show().children("table");


### PR DESCRIPTION
# OMERO.tables data for Images in Wells

Previously webclient has only tried to show the OMERO.tables data for Wells (not other objects).
E.g. Browse SPW -> show Well in right panel -> expand 'Tables' panel
This was in contrast to other annotations E.g. Tags etc that could only be applied to Images in Wells.

When images were shown "out of SPW context", (e.g. result of image search) we have tried to check whether the image is in a Well, then query for parent Screen/Plate table with row that matches that Well. (see https://github.com/openmicroscopy/openmicroscopy/pull/4774)

Now, we have changed the UI for SPW, such that right panel shows Well OR Image, but not both. https://github.com/openmicroscopy/openmicroscopy/pull/4863
This allows us to only show annotations on the Well OR Image (not show Image annotations for Well or Well annotations for Image).
Therefore, this PR reverts the behaviour of #4774 but adds support for querying Image rows of tables.
When Image OR Well is shown in right panel, we query Screen and Plate parents for OMERO.tables then query OMERO.table rows that match Image-id or Well-id.

# Testing this PR

1. Test Image
    - Create a csv file with an Image column that contains Image IDs (Images within a Screen & Plate). Just select a few images from Plate (not all)! E.g.
```
Image, Well Type, Drug, Concentration
63009, Control, DMSO, 0
63010, Treatment, Toxin, 5
63011, Treatment, Taxol, 10
```
    - Attach this to the parent Screen
    - Click the scripts button above annotations, check the checkbox for csv and run Populate_metadata script
    - When done, click the Well then select Image from bottom panel.
    - Image in right panel, expand the 'Tables' pane. Should see corresponding data from table.

2. Test Well
    - Create similar csv with ```Well``` column instead of ```Image```, using ```A1, A2``` etc instead of IDs.
    - Attach this to the Plate from above.
    - Run the populat_metadata script with this csv on Plate.
    - Browse to Wells in that plate and check 'Tables' tab for data.

3. Test wrong image ID
    - Use an invalid Image ID in the csv file with Image column
    - Attach and run the populate_metadata as before
    - Error output from script should contain:
```ERROR:omero.util.populate_metadata:Image Id: 630010 not found!```

NB: Since we only query a single OMERO.tables file at a time, we ONLY show the most recent. Therefore it's not possible to have E.g. one table with Image column and one table with Well column, both on the same Plate and both being displayed on child Images & Wells.
In the test scenario above, we attach one table to Screen and one to Plate to avoid this clash.
In future, we should probably try to show data from ALL OMERO.tables on the parent.

NB: This means that search results of Images (from within Wells) won't now show OMERO.tables data that is on the parent Well. Searching for Wells themselves is on the trello card below.

NB: I haven't added Robot tests for Images because it is much harder to create a csv file with Image IDs than to create one with Well positions. Would be nice if populate_metadata supported Image Name column or Well + field?

# Related reading

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-October/006232.html
which was added to card: https://trello.com/c/GxqDnD0P/211-spw-follow-up

cc @joshmoore @manics 